### PR TITLE
fix: classify hard quota 429s as billing + prevent writer thread leak under 429 storms

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -783,6 +783,33 @@ def _run_review_in_thread(
                     _pref_val = getattr(agent, _pref_attr, None)
                     if _pref_val:
                         _fork_kwargs[_pref_attr] = _pref_val
+            # Inherit the parent's fallback provider chain so the review fork
+            # can recover from quota exhaustion / rate-limits exactly like the
+            # top-level agent and subagent forks do (delegate_tool.py passes
+            # the same parameter).  Without this the fork's _fallback_chain is
+            # empty, a hard-quota 429 on the review's model aborts instead of
+            # switching to the configured fallback — the same bug class as the
+            # main-conversation path this PR already fixes.
+            #
+            # Unlike reasoning_config (gated by ``not _routed`` above because
+            # a routed model may 400 on the parent's effort vocabulary),
+            # fallback entries are API parameters, not request payloads:
+            # try_activate_fallback resolves each entry independently and
+            # skips any whose provider/model is not locally usable, so an
+            # inherited entry can never cause a malformed request.  In the
+            # worst case the fork tries a fallback entry that is not configured
+            # for its routed provider; that entry is skipped and the next one
+            # (or graceful failure) takes over — strictly better than the
+            # pre-fix behavior of aborting with no fallback at all.
+            #
+            # On the same-model path, fallback activation does break the
+            # warm-cache prefix (the fallback model cannot reuse the primary's
+            # cached prefix), but that is the correct tradeoff: losing one
+            # turn of cache warmth is better than the review silently aborting
+            # on every request until the quota window resets.  The chain list
+            # is shared by reference with the parent, matching delegate_tool.py
+            # — the fallback path only reads entries (.get()), never writes.
+            parent_fallback = getattr(agent, "_fallback_chain", None) or None
             review_agent = AIAgent(
                 model=_rt.get("model") or agent.model,
                 max_iterations=16,
@@ -798,6 +825,7 @@ def _run_review_in_thread(
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 skip_memory=True,
+                fallback_model=parent_fallback,
                 **_fork_kwargs,
             )
             review_agent._memory_write_origin = "background_review"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3854,6 +3854,30 @@ def run_conversation(
                 if recovered_with_pool:
                     continue
 
+                # Terminal quota/billing errors have already had their chance
+                # to rotate credentials. Do not let the eager rate-limit gate
+                # below suppress a configured fallback merely because the pool
+                # reports an available entry. Successful rotation returns
+                # above, so transient rate-limit handling is unchanged.
+                fallback_attempted = False
+                if (
+                    classified.reason == FailoverReason.billing
+                    and classified.should_fallback
+                    and agent._has_pending_fallback()
+                ):
+                    fallback_attempted = True
+                    agent._buffer_status(
+                        "⚠️ Billing or credits exhausted — trying fallback provider..."
+                    )
+                    if agent._try_activate_fallback(reason=classified.reason):
+                        active_system_prompt = _sync_failover_system_message(
+                            agent, api_messages, active_system_prompt
+                        )
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        continue
+
                 # Image-too-large recovery: shrink oversized native image
                 # parts in-place and retry once.  Triggered by Anthropic's
                 # per-image 5 MB ceiling (400 with "image exceeds 5 MB
@@ -4413,7 +4437,11 @@ def run_conversation(
                     is_rate_limited
                     or (_is_transport_failure and retry_count >= 2)
                 )
-                if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
+                if (
+                    _should_fallback
+                    and not fallback_attempted
+                    and agent._fallback_index < len(agent._fallback_chain)
+                ):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool exception.  Fixes #11314.
@@ -5046,14 +5074,18 @@ def run_conversation(
                     # exists; otherwise "trying fallback..." is a lie and the
                     # session looks like it's recovering when it's about to
                     # abort silently (#35314, #17446).
-                    if agent._has_pending_fallback():
+                    if not fallback_attempted and agent._has_pending_fallback():
                         if classified.reason == FailoverReason.content_policy_blocked:
                             agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
                         elif classified.reason == FailoverReason.ssl_cert_verification:
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if (
+                        not fallback_attempted
+                        and agent._has_pending_fallback()
+                        and agent._try_activate_fallback()
+                    ):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -209,6 +209,10 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "resets at",
     "resets in",  # (#63021) "Your limit resets in 4hr 5min"
     "reset in",
+    "reset after",
+    "available in",
+    "per minute",
+    "per second",
     "wait",
     "requests remaining",
     "periodic",
@@ -222,6 +226,7 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
 _EXPLICIT_RATE_LIMIT_PATTERNS = [
     "rate limit",
     "rate-limit",
+    "rate_limit",
     "ratelimit",
 ]
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -207,11 +207,22 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "try again",
     "retry",
     "resets at",
+    "resets in",  # (#63021) "Your limit resets in 4hr 5min"
     "reset in",
     "wait",
     "requests remaining",
     "periodic",
     "window",
+]
+
+# Explicit rate-limit wording that must always stay retryable rate_limit, even
+# when it co-occurs with a usage-limit phrase.  Without this guard, a broad
+# "limit exceeded" usage-limit pattern would capture ordinary "rate limit
+# exceeded" 429s and misclassify them as terminal billing. (#61123)
+_EXPLICIT_RATE_LIMIT_PATTERNS = [
+    "rate limit",
+    "rate-limit",
+    "ratelimit",
 ]
 
 # Payload-too-large patterns detected from message text (no status_code attr).
@@ -1109,6 +1120,34 @@ def _classify_by_status(
                 should_rotate_credential=False,
                 should_fallback=True,
                 error_context=ctx,
+            )
+        # Message-aware quota/billing detection on the remaining 429s.  A hard
+        # quota/usage-limit 429 (e.g. Z.AI "Usage limit reached for 5 hour") is
+        # terminal exhaustion of the current window — the credential is valid
+        # but cannot serve any request until the window resets, so retrying the
+        # same key only burns the turn and never recovers.  Classify it as
+        # billing so the configured fallback activates immediately instead of
+        # being gated behind pool-recovery. (#39441, #36276)
+        #
+        # Guard order matters:
+        #   1. Explicit rate-limit wording ("rate limit exceeded") stays
+        #      retryable rate_limit even if a broad usage-limit pattern also
+        #      matches — otherwise ordinary throttling would be promoted to
+        #      terminal billing. (#61123)
+        #   2. A usage-limit phrase with a transient signal ("try again",
+        #      "resets in") is a periodic quota that will lift, so keep it as
+        #      retryable rate_limit. (#63021)
+        #   3. A usage-limit phrase with no transient signal and no explicit
+        #      rate-limit wording is hard quota exhaustion → billing.
+        has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
+        has_transient_signal = any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS)
+        has_explicit_rate_limit = any(p in error_msg for p in _EXPLICIT_RATE_LIMIT_PATTERNS)
+        if has_usage_limit and not has_transient_signal and not has_explicit_rate_limit:
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
             )
         return result_fn(
             FailoverReason.rate_limit,

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -392,6 +392,8 @@ class MemoryManager:
         # a bounded FIFO drain, then explicitly report anything abandoned.
         self._background_futures: Dict[Future, str] = {}
         self._shutting_down = False
+        self._shutdown_all_lock = threading.Lock()
+        self._shutdown_all_complete = False
         self._shutdown_drain_state: Dict[str, Any] = {
             "status": "not_started",
             "abandoned_writes": 0,
@@ -1150,15 +1152,24 @@ class MemoryManager:
         daemon, so anything still wedged past the drain window dies with
         the interpreter rather than blocking exit.
         """
-        self._drain_sync_executor()
-        for provider in reversed(self._providers):
+        with self._shutdown_all_lock:
+            if self._shutdown_all_complete:
+                return
             try:
-                provider.shutdown()
-            except Exception as e:
-                logger.warning(
-                    "Memory provider '%s' shutdown failed: %s",
-                    provider.name, e,
-                )
+                self._drain_sync_executor()
+                for provider in reversed(self._providers):
+                    try:
+                        provider.shutdown()
+                    except Exception as e:
+                        logger.warning(
+                            "Memory provider '%s' shutdown failed: %s",
+                            provider.name, e,
+                        )
+            finally:
+                # Mark complete even when one provider raises: shutdown is a
+                # best-effort terminal boundary and a concurrent/repeated
+                # caller must not invoke already-partially-torn-down providers.
+                self._shutdown_all_complete = True
 
     @property
     def shutdown_drain_state(self) -> Dict[str, Any]:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -65,6 +65,8 @@ _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # overwrites prior turns server-side, so we keep the per-process
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
+_CIRCUIT_BREAKER_THRESHOLD = 3  # consecutive failures before opening circuit
+_CIRCUIT_BREAKER_COOLDOWN = 60.0  # seconds before half-open retry
 _VALID_BUDGETS = {"low", "mid", "high"}
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
@@ -747,6 +749,8 @@ class HindsightMemoryProvider(MemoryProvider):
         # Legacy alias — older tests/callers reference _sync_thread directly.
         # Points at _writer_thread once the writer is running.
         self._sync_thread = None
+        self._circuit_breaker_failures = 0
+        self._circuit_breaker_open_until = 0.0
         self._session_id = ""
         self._parent_session_id = ""
         self._document_id = ""
@@ -1155,18 +1159,34 @@ class HindsightMemoryProvider(MemoryProvider):
         """Schedule *coro* on the shared loop using the configured timeout."""
         return _run_sync(coro, timeout=self._timeout)
 
-    def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
-        """Return True for stale embedded-daemon connection failures."""
-        if self._mode != "local_embedded":
-            return False
+    def _check_circuit_breaker(self):
+        """Fast-fail if the backend has failed repeatedly."""
+        if self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD:
+            if time.monotonic() < self._circuit_breaker_open_until:
+                raise RuntimeError(
+                    "Hindsight circuit breaker open: backend failed %d consecutive times; "
+                    "will retry after cooldown" % self._circuit_breaker_failures
+                )
+            # Cooldown elapsed — half-open: allow one attempt
+            logger.info("[CB-HS] Hindsight circuit breaker half-open: allowing retry after cooldown")
+            self._circuit_breaker_failures = 0
+
+    def _is_retriable_connection_error(self, exc: Exception) -> bool:
+        """Return True for retriable connection failures across all modes."""
         text = f"{type(exc).__name__}: {exc}".lower()
         return any(
             marker in text
             for marker in (
-                "cannot connect to host",
+                # local_external / cloud connection errors
+                "server disconnected",
+                "connection reset",
+                "timed out",
                 "connection refused",
-                "connect call failed",
+                "cannot connect to host",
                 "clientconnectorerror",
+                # local_embedded daemon lifecycle errors
+                "failed to start daemon",
+                "after it has been closed",
             )
         )
 
@@ -1402,20 +1422,61 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def _run_hindsight_operation(self, operation):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
+        self._check_circuit_breaker()
+        logger.debug(
+            "[CB-HS] Hindsight operation starting (circuit failures: %d/%d)",
+            self._circuit_breaker_failures,
+            _CIRCUIT_BREAKER_THRESHOLD,
+        )
         client = self._get_client()
         try:
-            return self._run_sync(operation(client))
+            result = self._run_sync(operation(client))
+            if self._circuit_breaker_failures > 0:
+                logger.info(
+                    "[CB-HS] Hindsight circuit breaker CLOSED: operation succeeded, counter reset from %d",
+                    self._circuit_breaker_failures,
+                )
+            self._circuit_breaker_failures = 0
+            return result
         except Exception as exc:
-            if not self._is_retriable_embedded_connection_error(exc):
+            if not self._is_retriable_connection_error(exc):
+                self._circuit_breaker_failures += 1
+                self._circuit_breaker_open_until = time.monotonic() + _CIRCUIT_BREAKER_COOLDOWN
+                if self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD:
+                    logger.warning(
+                        "[CB-HS] Hindsight circuit breaker OPENED after %d consecutive failures; "
+                        "fast-failing for %.0fs cooldown",
+                        self._circuit_breaker_failures,
+                        _CIRCUIT_BREAKER_COOLDOWN,
+                    )
                 raise
             logger.info(
-                "Hindsight embedded daemon appears unreachable; recreating client and retrying once: %s",
+                "Hindsight backend appears unreachable; recreating client and retrying once: %s",
                 exc,
             )
             self._client = None
-            client = self._get_client()
-            self._client = client
-            return self._run_sync(operation(client))
+            try:
+                client = self._get_client()
+                self._client = client
+                result = self._run_sync(operation(client))
+                if self._circuit_breaker_failures > 0:
+                    logger.info(
+                        "[CB-HS] Hindsight circuit breaker CLOSED: operation succeeded, counter reset from %d",
+                        self._circuit_breaker_failures,
+                    )
+                self._circuit_breaker_failures = 0
+                return result
+            except Exception:
+                self._circuit_breaker_failures += 1
+                self._circuit_breaker_open_until = time.monotonic() + _CIRCUIT_BREAKER_COOLDOWN
+                if self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD:
+                    logger.warning(
+                        "[CB-HS] Hindsight circuit breaker OPENED after %d consecutive failures; "
+                        "fast-failing for %.0fs cooldown",
+                        self._circuit_breaker_failures,
+                        _CIRCUIT_BREAKER_COOLDOWN,
+                    )
+                raise
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
@@ -1872,6 +1933,10 @@ class HindsightMemoryProvider(MemoryProvider):
             return
         if self._shutting_down.is_set():
             logger.debug("sync_turn: skipped (shutting down)")
+            return
+        if (self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD
+                and time.monotonic() < self._circuit_breaker_open_until):
+            logger.debug("sync_turn: skipped (circuit breaker open)")
             return
 
         if session_id:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -751,6 +751,8 @@ class HindsightMemoryProvider(MemoryProvider):
         self._sync_thread = None
         self._circuit_breaker_failures = 0
         self._circuit_breaker_open_until = 0.0
+        self._circuit_breaker_half_open_probe = False
+        self._circuit_breaker_lock = threading.Lock()
         self._session_id = ""
         self._parent_session_id = ""
         self._document_id = ""
@@ -1159,34 +1161,85 @@ class HindsightMemoryProvider(MemoryProvider):
         """Schedule *coro* on the shared loop using the configured timeout."""
         return _run_sync(coro, timeout=self._timeout)
 
-    def _check_circuit_breaker(self):
-        """Fast-fail if the backend has failed repeatedly."""
-        if self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD:
-            if time.monotonic() < self._circuit_breaker_open_until:
+    def _check_circuit_breaker(self) -> bool:
+        """Check the breaker and reserve the sole HALF-OPEN probe, if needed.
+
+        Returns whether this call owns a half-open probe.  Every compound state
+        transition is protected by ``_circuit_breaker_lock``; callers that do
+        not own the probe must fail fast while it is in flight.
+        """
+        now = time.monotonic()
+        with self._circuit_breaker_lock:
+            failures = self._circuit_breaker_failures
+            if failures < _CIRCUIT_BREAKER_THRESHOLD:
+                return False
+            if now < self._circuit_breaker_open_until:
                 raise RuntimeError(
                     "Hindsight circuit breaker open: backend failed %d consecutive times; "
-                    "will retry after cooldown" % self._circuit_breaker_failures
+                    "will retry after cooldown" % failures
                 )
-            # Cooldown elapsed — half-open: allow one attempt
-            logger.info("[CB-HS] Hindsight circuit breaker half-open: allowing retry after cooldown")
+            if self._circuit_breaker_half_open_probe:
+                raise RuntimeError(
+                    "Hindsight circuit breaker half-open probe in flight; fast-failing"
+                )
+            self._circuit_breaker_half_open_probe = True
+            logger.info(
+                "[CB-HS] Hindsight circuit breaker HALF-OPEN: allowing one probe after cooldown"
+            )
+            return True
+
+    def _circuit_breaker_success(self, *, probe: bool) -> None:
+        with self._circuit_breaker_lock:
+            previous = self._circuit_breaker_failures
             self._circuit_breaker_failures = 0
+            self._circuit_breaker_open_until = 0.0
+            if probe:
+                self._circuit_breaker_half_open_probe = False
+        if previous:
+            logger.info(
+                "[CB-HS] Hindsight circuit breaker CLOSED: operation succeeded, counter reset from %d",
+                previous,
+            )
+
+    def _circuit_breaker_failure(self, exc: Exception, *, probe: bool) -> None:
+        """Record only backend/connection/timeout failures."""
+        if not self._is_retriable_connection_error(exc):
+            if probe:
+                with self._circuit_breaker_lock:
+                    self._circuit_breaker_half_open_probe = False
+            return
+        with self._circuit_breaker_lock:
+            self._circuit_breaker_failures += 1
+            self._circuit_breaker_open_until = time.monotonic() + _CIRCUIT_BREAKER_COOLDOWN
+            failures = self._circuit_breaker_failures
+            if probe:
+                self._circuit_breaker_half_open_probe = False
+        if failures >= _CIRCUIT_BREAKER_THRESHOLD:
+            logger.warning(
+                "[CB-HS] Hindsight circuit breaker OPENED after %d consecutive failures; "
+                "fast-failing for %.0fs cooldown",
+                failures,
+                _CIRCUIT_BREAKER_COOLDOWN,
+            )
+
+    def _circuit_breaker_is_open(self) -> bool:
+        with self._circuit_breaker_lock:
+            return (
+                self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD
+                and time.monotonic() < self._circuit_breaker_open_until
+            )
 
     def _is_retriable_connection_error(self, exc: Exception) -> bool:
-        """Return True for retriable connection failures across all modes."""
+        """Return True only for backend, connection, and timeout failures."""
+        if isinstance(exc, (ConnectionError, TimeoutError, asyncio.TimeoutError)):
+            return True
         text = f"{type(exc).__name__}: {exc}".lower()
         return any(
             marker in text
             for marker in (
-                # local_external / cloud connection errors
-                "server disconnected",
-                "connection reset",
-                "timed out",
-                "connection refused",
-                "cannot connect to host",
-                "clientconnectorerror",
-                # local_embedded daemon lifecycle errors
-                "failed to start daemon",
-                "after it has been closed",
+                "server disconnected", "connection reset", "timed out",
+                "connection refused", "cannot connect to host", "clientconnectorerror",
+                "failed to start daemon", "after it has been closed",
             )
         )
 
@@ -1421,62 +1474,46 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("Hindsight atexit shutdown failed: %s", exc)
 
     def _run_hindsight_operation(self, operation):
-        """Run an async Hindsight client operation, retrying once after idle shutdown."""
-        self._check_circuit_breaker()
+        """Run an operation with one backend retry and circuit protection."""
+        probe = self._check_circuit_breaker()
+        with self._circuit_breaker_lock:
+            failures = self._circuit_breaker_failures
         logger.debug(
             "[CB-HS] Hindsight operation starting (circuit failures: %d/%d)",
-            self._circuit_breaker_failures,
-            _CIRCUIT_BREAKER_THRESHOLD,
+            failures, _CIRCUIT_BREAKER_THRESHOLD,
         )
-        client = self._get_client()
+        failure_recorded = False
         try:
-            result = self._run_sync(operation(client))
-            if self._circuit_breaker_failures > 0:
-                logger.info(
-                    "[CB-HS] Hindsight circuit breaker CLOSED: operation succeeded, counter reset from %d",
-                    self._circuit_breaker_failures,
-                )
-            self._circuit_breaker_failures = 0
-            return result
-        except Exception as exc:
-            if not self._is_retriable_connection_error(exc):
-                self._circuit_breaker_failures += 1
-                self._circuit_breaker_open_until = time.monotonic() + _CIRCUIT_BREAKER_COOLDOWN
-                if self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD:
-                    logger.warning(
-                        "[CB-HS] Hindsight circuit breaker OPENED after %d consecutive failures; "
-                        "fast-failing for %.0fs cooldown",
-                        self._circuit_breaker_failures,
-                        _CIRCUIT_BREAKER_COOLDOWN,
-                    )
-                raise
-            logger.info(
-                "Hindsight backend appears unreachable; recreating client and retrying once: %s",
-                exc,
-            )
-            self._client = None
+            client = self._get_client()
             try:
+                result = self._run_sync(operation(client))
+            except Exception as exc:
+                if not self._is_retriable_connection_error(exc):
+                    self._circuit_breaker_failure(exc, probe=probe)
+                    failure_recorded = True
+                    raise
+                logger.info(
+                    "Hindsight backend appears unreachable; recreating client and retrying once: %s",
+                    exc,
+                )
+                self._client = None
                 client = self._get_client()
                 self._client = client
-                result = self._run_sync(operation(client))
-                if self._circuit_breaker_failures > 0:
-                    logger.info(
-                        "[CB-HS] Hindsight circuit breaker CLOSED: operation succeeded, counter reset from %d",
-                        self._circuit_breaker_failures,
-                    )
-                self._circuit_breaker_failures = 0
-                return result
-            except Exception:
-                self._circuit_breaker_failures += 1
-                self._circuit_breaker_open_until = time.monotonic() + _CIRCUIT_BREAKER_COOLDOWN
-                if self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD:
-                    logger.warning(
-                        "[CB-HS] Hindsight circuit breaker OPENED after %d consecutive failures; "
-                        "fast-failing for %.0fs cooldown",
-                        self._circuit_breaker_failures,
-                        _CIRCUIT_BREAKER_COOLDOWN,
-                    )
-                raise
+                try:
+                    result = self._run_sync(operation(client))
+                except Exception as retry_exc:
+                    self._circuit_breaker_failure(retry_exc, probe=probe)
+                    failure_recorded = True
+                    raise
+            self._circuit_breaker_success(probe=probe)
+            return result
+        except Exception as exc:
+            # Client creation can itself fail before the operation coroutine is
+            # entered. It is a breaker failure only when classified as a
+            # backend/connection/timeout error; all other errors stay visible.
+            if not failure_recorded:
+                self._circuit_breaker_failure(exc, probe=probe)
+            raise
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
@@ -1934,8 +1971,7 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._shutting_down.is_set():
             logger.debug("sync_turn: skipped (shutting down)")
             return
-        if (self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD
-                and time.monotonic() < self._circuit_breaker_open_until):
+        if self._circuit_breaker_is_open():
             logger.debug("sync_turn: skipped (circuit breaker open)")
             return
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4179,6 +4179,32 @@ class AIAgent:
         except Exception:
             pass
 
+        # 3. Shut down memory providers WITHOUT on_session_end().
+        #
+        # Each memory provider instance (notably Hindsight) spawns its own
+        # background writer thread.  When an agent is soft-evicted from the
+        # LRU cache, those writer threads are never terminated — they pile
+        # up as zombie daemons, one per evicted agent.  Under a 128-entry
+        # cache with heavy turnover (e.g. concurrent 429 retry storms), this
+        # produces dozens of leaked threads, each holding stack memory and
+        # references to Hindsight clients/queues/loops that prevent GC.
+        #
+        # shutdown_memory_provider() calls on_session_end() first — too heavy
+        # for soft eviction (it triggers end-of-session extraction; a
+        # resumed session would re-extract).  Instead, call shutdown_all()
+        # directly on the memory manager: this drains the sync executor and
+        # terminates writer threads (Hindsight sends _WRITER_SENTINEL, joins
+        # the thread) without the extraction side-effect.
+        #
+        # Safe because a resumed session's freshly-built AIAgent creates a
+        # new MemoryManager with fresh provider instances.
+        try:
+            _mm = getattr(self, "_memory_manager", None)
+            if _mm is not None and not getattr(_mm, "_shutting_down", False):
+                _mm.shutdown_all()
+        except Exception:
+            pass
+
     def close(self) -> None:
         """Release all resources held by this agent instance.
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -234,6 +234,27 @@ class TestClassifyApiError:
 
     # ── Rate limit ──
 
+    def test_429_usage_limit_transient_window_wording_stays_rate_limit(self):
+        """Periodic quota wording must not become terminal billing."""
+        messages = [
+            "Your API usage limit quota allows 60 requests per minute",
+            "Usage limit exceeded per minute quota",
+            "Quota available in 5 minutes",
+            "Requests per second limit exceeded",
+            "Usage limit will be reset after cooldown period",
+        ]
+        for message in messages:
+            result = classify_api_error(MockAPIError(message, status_code=429))
+            assert result.reason == FailoverReason.rate_limit, message
+            assert result.retryable is True, message
+
+    def test_429_underscore_rate_limit_stays_rate_limit(self):
+        result = classify_api_error(
+            MockAPIError("rate_limit exceeded", status_code=429)
+        )
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
     def test_429_rate_limit(self):
         e = MockAPIError("Too Many Requests", status_code=429)
         result = classify_api_error(e)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1049,4 +1049,98 @@ class TestExpandedOverflowPatterns:
         assert result.reason == FailoverReason.context_overflow
 
 
+# ── Test: Message-aware quota/billing classification for HTTP 429 ─────────
+# A hard quota/usage-limit 429 (e.g. Z.AI "Usage limit reached for 5 hour") is
+# terminal exhaustion of the current window — retrying the same key never
+# recovers.  Classify it as billing so the configured fallback activates
+# immediately instead of being gated behind pool-recovery. (#39441, #36276,
+# #61123, #63021)
+
+class TestQuotaBillingClassification:
+    """Message-aware 429 disambiguation: terminal quota vs transient rate limit."""
+
+    def test_zai_usage_limit_reached_is_billing_not_rate_limit(self):
+        """The exact production incident: Z.AI HTTP 429 with a hard 5-hour usage
+        limit.  Must classify as terminal billing (non-retryable, fallback
+        enabled) so the configured fallback chain activates immediately
+        instead of burning retries against an exhausted window."""
+        e = MockAPIError(
+            "Usage limit reached for 5 hour. "
+            "Your limit will reset at 2026-07-30 17:31:59",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="zai", model="glm-5.2")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_kimi_billing_cycle_quota_is_billing(self):
+        """Kimi-style monthly/billing-cycle quota exhaustion.  A hard plan
+        limit with no transient signal must be billing."""
+        e = MockAPIError(
+            "usage limit for this billing cycle has been reached",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="moonshot", model="kimi")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_transient_usage_limit_with_try_again_is_rate_limit(self):
+        """A usage-limit 429 with a transient signal ('try again') is a
+        periodic quota that will lift — keep it as retryable rate_limit."""
+        e = MockAPIError(
+            "usage limit reached, please try again in 60 seconds",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="zai")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.should_fallback is True
+
+    def test_transient_usage_limit_with_resets_in_is_rate_limit(self):
+        """'resets in' is a transient signal (#63021): 'Your limit resets in
+        4hr 5min' is a periodic quota, not terminal billing."""
+        e = MockAPIError(
+            "usage limit reached. your limit resets in 4hr 5min",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="zai")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_ordinary_rate_limit_exceeded_stays_rate_limit(self):
+        """Guard (#61123): ordinary 'Rate limit exceeded' must stay retryable
+        rate_limit even though 'limit exceeded' matches a usage-limit pattern.
+        Without the explicit-rate-limit guard, this would regress to terminal
+        billing."""
+        e = MockAPIError(
+            "Rate limit exceeded: too many requests", status_code=429
+        )
+        result = classify_api_error(e, provider="zai")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+        assert result.should_rotate_credential is True
+
+    def test_openrouter_upstream_429_unaffected_by_quota_logic(self):
+        """Guard: an OpenRouter upstream-model 429 must still classify as
+        upstream_rate_limit, not get captured by the new billing detection.
+        Proves the insertion ordering is correct — the OpenRouter branch runs
+        before the quota/billing branch."""
+        e = MockAPIError(
+            "Provider returned error: 429 rate_limit_error",
+            status_code=429,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"raw": {"provider_name": "DeepSeek"}},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="deepseek/deepseek-chat")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.should_rotate_credential is False
+
+
 

--- a/tests/agent/test_memory_manager_shutdown.py
+++ b/tests/agent/test_memory_manager_shutdown.py
@@ -1,0 +1,68 @@
+"""Regression tests for synchronized MemoryManager shutdown."""
+
+import threading
+
+from agent.memory_manager import MemoryManager
+from agent.memory_provider import MemoryProvider
+
+
+class _ShutdownProvider(MemoryProvider):
+    @property
+    def name(self):
+        return "shutdown-test"
+
+    def __init__(self, entered=None, release=None):
+        self.shutdown_calls = 0
+        self.entered = entered
+        self.release = release
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        pass
+
+    def get_tool_schemas(self):
+        return []
+
+    def shutdown(self):
+        self.shutdown_calls += 1
+        if self.entered:
+            self.entered.set()
+        if self.release:
+            assert self.release.wait(timeout=2)
+
+
+def test_shutdown_all_is_idempotent():
+    manager = MemoryManager()
+    provider = _ShutdownProvider()
+    manager.add_provider(provider)
+
+    manager.shutdown_all()
+    manager.shutdown_all()
+
+    assert provider.shutdown_calls == 1
+
+
+def test_shutdown_all_serializes_concurrent_callers():
+    entered = threading.Event()
+    release = threading.Event()
+    manager = MemoryManager()
+    provider = _ShutdownProvider(entered, release)
+    manager.add_provider(provider)
+
+    first = threading.Thread(target=manager.shutdown_all)
+    second = threading.Thread(target=manager.shutdown_all)
+    first.start()
+    assert entered.wait(timeout=2)
+    second.start()
+    # The second caller must wait for the first, rather than invoking the
+    # provider concurrently while its resources are being torn down.
+    assert second.is_alive()
+    release.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert provider.shutdown_calls == 1

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -636,6 +636,61 @@ class TestAgentCacheIdleResume:
             f"tabs and cookies gone on resume. Calls: {browser_calls}"
         )
 
+    def test_release_clients_shuts_down_memory_provider(self):
+        """release_clients() must call shutdown_all() on the memory manager.
+
+        Memory providers (notably Hindsight) spawn background writer threads.
+        Without shutdown on soft eviction, these threads pile up as zombies
+        — one per evicted agent — eventually causing thread/memory exhaustion
+        and gateway liveness crashes.
+
+        This test verifies that release_clients() calls shutdown_all() on the
+        memory manager without calling on_session_end() (which would trigger
+        end-of-session extraction, too heavy for a soft-evicted session that
+        may resume).
+        """
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4", api_key="test",
+            base_url="https://openrouter.ai/api/v1", provider="openrouter",
+            max_iterations=5, quiet_mode=True,
+            skip_context_files=True, skip_memory=True,
+            session_id="mem-provider-evict-test",
+        )
+
+        class _MockMM:
+            def __init__(self):
+                self.shutdown_all_calls = 0
+                self.on_session_end_calls = 0
+            def shutdown_all(self):
+                self.shutdown_all_calls += 1
+            def on_session_end(self, messages):
+                self.on_session_end_calls += 1
+
+        mock_mm = _MockMM()
+        agent._memory_manager = mock_mm
+
+        try:
+            agent.release_clients()
+        except Exception:
+            pass
+        finally:
+            try:
+                agent.close()
+            except Exception:
+                pass
+
+        assert mock_mm.shutdown_all_calls >= 1, (
+            "release_clients() must call shutdown_all() to terminate memory "
+            "provider writer threads. Leaked threads cause thread proliferation "
+            "under cache turnover."
+        )
+        assert mock_mm.on_session_end_calls == 0, (
+            "release_clients() must NOT call on_session_end() — that triggers "
+            "end-of-session extraction, too heavy for a soft-evicted session."
+        )
+
 
     def test_close_vs_release_full_teardown_difference(self, monkeypatch):
         """close() tears down task state; release_clients() does not.

--- a/tests/plugins/memory/test_hindsight_circuit_breaker.py
+++ b/tests/plugins/memory/test_hindsight_circuit_breaker.py
@@ -59,16 +59,66 @@ def provider_external(tmp_path, monkeypatch):
 
 class TestCircuitBreaker:
 
-    def test_opens_after_threshold_failures(self, provider):
-        """Circuit opens after _CIRCUIT_BREAKER_THRESHOLD consecutive non-retriable failures."""
-        provider._client.arecall = AsyncMock(side_effect=RuntimeError("database migration failed"))
+    def test_opens_after_threshold_connection_failures(self, provider):
+        """Only backend connection failures open the circuit."""
+        provider._client.arecall = AsyncMock(side_effect=RuntimeError("server disconnected"))
 
         for _ in range(_CIRCUIT_BREAKER_THRESHOLD):
-            with pytest.raises(RuntimeError, match="database migration failed"):
+            with pytest.raises(RuntimeError, match="server disconnected"):
                 provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
 
         with pytest.raises(RuntimeError, match="circuit breaker open"):
             provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
+
+    @pytest.mark.parametrize("message", [
+        "authentication failed", "invalid request", "unsupported operation",
+        "database migration failed",
+    ])
+    def test_non_backend_errors_do_not_open_circuit(self, provider, message):
+        provider._client.arecall = AsyncMock(side_effect=RuntimeError(message))
+
+        for _ in range(_CIRCUIT_BREAKER_THRESHOLD + 1):
+            with pytest.raises(RuntimeError, match=message):
+                provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
+
+        assert provider._circuit_breaker_failures == 0
+
+    def test_half_open_probe_is_single_flight(self, provider):
+        """After cooldown, one caller probes and concurrent callers fail fast."""
+        import threading
+
+        provider._circuit_breaker_failures = _CIRCUIT_BREAKER_THRESHOLD
+        provider._circuit_breaker_open_until = time.monotonic() - 1
+        started = threading.Event()
+        release = threading.Event()
+        results = []
+
+        def run_sync(_operation):
+            started.set()
+            assert release.wait(timeout=2)
+            return SimpleNamespace(results=[])
+
+        provider._run_sync = run_sync
+
+        def caller():
+            try:
+                provider._run_hindsight_operation(lambda c: "probe")
+                results.append("success")
+            except RuntimeError as exc:
+                results.append(str(exc))
+
+        first = threading.Thread(target=caller)
+        first.start()
+        assert started.wait(timeout=2)
+        second = threading.Thread(target=caller)
+        second.start()
+        second.join(timeout=2)
+        release.set()
+        first.join(timeout=2)
+
+        assert any("half-open probe in flight" in result for result in results)
+        assert results.count("success") == 1
+        assert provider._circuit_breaker_failures == 0
 
     def test_resets_after_cooldown(self, provider):
         """After cooldown, circuit allows a retry (half-open)."""

--- a/tests/plugins/memory/test_hindsight_circuit_breaker.py
+++ b/tests/plugins/memory/test_hindsight_circuit_breaker.py
@@ -1,0 +1,173 @@
+"""Tests for Hindsight circuit breaker behaviour.
+
+Adapted from PR #17416 (kagura-agent) with local_external mode support.
+"""
+
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from plugins.memory.hindsight import (
+    HindsightMemoryProvider,
+    _CIRCUIT_BREAKER_COOLDOWN,
+    _CIRCUIT_BREAKER_THRESHOLD,
+)
+
+
+def _make_provider(tmp_path, monkeypatch, mode="local_embedded"):
+    """Create a provider with a mock client for the given mode."""
+    config = {
+        "mode": mode,
+        "bank_id": "test-bank",
+        "budget": "mid",
+        "memory_mode": "hybrid",
+    }
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config))
+    monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+
+    p = HindsightMemoryProvider()
+    p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+    client = MagicMock()
+    client.aretain = AsyncMock(return_value=SimpleNamespace(ok=True))
+    client.arecall = AsyncMock(
+        return_value=SimpleNamespace(results=[SimpleNamespace(text="m1")])
+    )
+    client.aretain_batch = AsyncMock()
+    client.aclose = AsyncMock()
+    p._client = client
+    # Stub _get_client so it never tries to create a real connection
+    p._get_client = lambda: client
+    return p
+
+
+@pytest.fixture()
+def provider(tmp_path, monkeypatch):
+    return _make_provider(tmp_path, monkeypatch, mode="local_embedded")
+
+
+@pytest.fixture()
+def provider_external(tmp_path, monkeypatch):
+    return _make_provider(tmp_path, monkeypatch, mode="local_external")
+
+
+class TestCircuitBreaker:
+
+    def test_opens_after_threshold_failures(self, provider):
+        """Circuit opens after _CIRCUIT_BREAKER_THRESHOLD consecutive non-retriable failures."""
+        provider._client.arecall = AsyncMock(side_effect=RuntimeError("database migration failed"))
+
+        for _ in range(_CIRCUIT_BREAKER_THRESHOLD):
+            with pytest.raises(RuntimeError, match="database migration failed"):
+                provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
+
+        with pytest.raises(RuntimeError, match="circuit breaker open"):
+            provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
+
+    def test_resets_after_cooldown(self, provider):
+        """After cooldown, circuit allows a retry (half-open)."""
+        provider._circuit_breaker_failures = _CIRCUIT_BREAKER_THRESHOLD
+        provider._circuit_breaker_open_until = time.monotonic() - 1  # expired
+
+        result = provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
+        assert result.results
+        assert provider._circuit_breaker_failures == 0
+
+    def test_success_resets_counter(self, provider):
+        """A successful operation resets the failure counter to 0."""
+        provider._circuit_breaker_failures = 2
+
+        provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
+        assert provider._circuit_breaker_failures == 0
+
+    def test_sync_turn_skips_when_circuit_open(self, provider):
+        """sync_turn returns early without calling aretain_batch when circuit is open."""
+        provider._circuit_breaker_failures = _CIRCUIT_BREAKER_THRESHOLD
+        provider._circuit_breaker_open_until = time.monotonic() + 300
+        provider._auto_retain = True
+        provider._retain_every_n_turns = 1
+
+        provider.sync_turn("hello", "world")
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+
+        provider._client.aretain_batch.assert_not_called()
+
+
+class TestRetriableErrorDetection:
+
+    def test_embedded_mode_markers_still_work(self, provider):
+        """Original local_embedded markers are still detected."""
+        assert provider._is_retriable_connection_error(
+            RuntimeError("Failed to start daemon on port 9999")
+        )
+        assert provider._is_retriable_connection_error(
+            RuntimeError("Cannot use HindsightEmbedded after it has been closed")
+        )
+
+    def test_external_mode_markers(self, provider_external):
+        """local_external mode connection errors are detected as retriable."""
+        assert provider_external._is_retriable_connection_error(
+            RuntimeError("Server disconnected")
+        )
+        assert provider_external._is_retriable_connection_error(
+            RuntimeError("Connection reset by peer")
+        )
+        assert provider_external._is_retriable_connection_error(
+            RuntimeError("Operation timed out")
+        )
+        assert provider_external._is_retriable_connection_error(
+            RuntimeError("Connection refused")
+        )
+        assert provider_external._is_retriable_connection_error(
+            RuntimeError("Cannot connect to host 192.168.10.252:8888")
+        )
+        assert provider_external._is_retriable_connection_error(
+            RuntimeError("ClientConnectorError")
+        )
+
+    def test_non_connection_errors_not_retriable(self, provider_external):
+        """Genuine non-connection errors are NOT retriable."""
+        assert not provider_external._is_retriable_connection_error(
+            RuntimeError("Invalid query syntax")
+        )
+        assert not provider_external._is_retriable_connection_error(
+            ValueError("bad argument")
+        )
+
+
+class TestLocalExternalCircuitBreaker:
+    """Verify the circuit breaker works end-to-end in local_external mode
+    (our production configuration)."""
+
+    def test_circuit_opens_on_server_disconnected(self, provider_external):
+        """The exact error we see in production ('Server disconnected') trips the circuit.
+
+        'Server disconnected' is retriable, so each call attempts a retry.
+        The circuit opens once failures reach the threshold.
+        """
+        provider_external._client.arecall = AsyncMock(
+            side_effect=RuntimeError("Server disconnected")
+        )
+
+        # Keep calling until the circuit opens
+        circuit_opened = False
+        for i in range(10):
+            try:
+                provider_external._run_hindsight_operation(
+                    lambda c: c.arecall(bank_id="b", query="q")
+                )
+            except RuntimeError as e:
+                if "circuit breaker open" in str(e).lower():
+                    circuit_opened = True
+                    break
+            except Exception:
+                pass
+
+        assert circuit_opened, "Circuit breaker should have opened after repeated Server disconnected errors"

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -21,6 +21,9 @@ def _bare_agent() -> AIAgent:
     agent._memory_enabled = True
     agent._user_profile_enabled = False
     agent._cached_system_prompt = "test-cached-system-prompt"
+    agent._fallback_chain = [
+        {"provider": "copilot", "model": "gpt-5.6-luna"},
+    ]
     import datetime as _dt
     agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
     agent._MEMORY_REVIEW_PROMPT = "review memory"
@@ -118,6 +121,229 @@ def test_background_review_fork_opts_out_of_session_finalization(monkeypatch):
 
     assert seen.get("end_session_on_close") is False
     assert seen.get("at_run_time") is False
+
+
+def test_background_review_fork_inherits_parent_fallback_chain(monkeypatch):
+    """The review fork must inherit the parent's fallback chain so a hard-quota
+    429 on the review's model switches to the configured fallback instead of
+    aborting.  Regression for the same bug class as the main-conversation
+    Z.AI hard-quota fallback path (sibling fork path: delegate_tool.py already
+    inherits _fallback_chain for subagents; background_review did not).
+    """
+    captured = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured["init_kwargs"] = kwargs
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    init_kwargs = captured.get("init_kwargs", {})
+    assert "fallback_model" in init_kwargs, "fallback_model not passed to review fork"
+    expected = [{"provider": "copilot", "model": "gpt-5.6-luna"}]
+    assert init_kwargs["fallback_model"] == expected, (
+        f"review fork fallback_model={init_kwargs['fallback_model']!r}, "
+        f"expected {expected!r}"
+    )
+
+
+def test_background_review_fork_fallback_none_when_parent_has_no_chain(monkeypatch):
+    """When the parent has no fallback chain, the review fork should pass
+    ``fallback_model=None`` (matching AIAgent's default) rather than crashing
+    or synthesizing an empty list.
+    """
+    captured = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured["init_kwargs"] = kwargs
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._fallback_chain = []  # no fallback configured
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    init_kwargs = captured.get("init_kwargs", {})
+    assert init_kwargs.get("fallback_model") is None, (
+        f"expected fallback_model=None when parent has no chain, got "
+        f"{init_kwargs.get('fallback_model')!r}"
+    )
+
+
+def test_background_review_fork_inherits_multi_entry_fallback_chain(monkeypatch):
+    """Multi-entry fallback chains must be passed through intact, preserving
+    ordering.  The review fork's _has_pending_fallback() and
+    try_activate_fallback() walk the list in order, so any truncation or
+    reordering would break the fallback sequence.
+    """
+    captured = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured["init_kwargs"] = kwargs
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    multi_chain = [
+        {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        {"provider": "copilot", "model": "gpt-5.6-luna"},
+    ]
+    agent._fallback_chain = multi_chain
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    init_kwargs = captured.get("init_kwargs", {})
+    assert init_kwargs["fallback_model"] == multi_chain, (
+        f"multi-entry chain not passed intact: {init_kwargs.get('fallback_model')!r}"
+    )
+
+
+def test_background_review_fork_does_not_mutate_parent_fallback_chain(monkeypatch):
+    """The review fork's fallback operations (index advancement, key tracking)
+    must not mutate the parent's _fallback_chain list or its dict entries.
+    This guards against shared-reference bugs if future code writes to chain
+    entries.  The fallback path currently only reads entries, but this test
+    locks that contract.
+    """
+    import copy as _copy
+
+    captured = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured["init_kwargs"] = kwargs
+            self._session_messages = []
+            # Simulate fallback activation: advance index on the fork's chain
+            fb = kwargs.get("fallback_model")
+            if isinstance(fb, list) and fb:
+                # try_activate_fallback reads entries — never writes.
+                _ = fb[0].get("provider")
+                _ = fb[0].get("model")
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    original_chain = [
+        {"provider": "copilot", "model": "gpt-5.6-luna"},
+    ]
+    original_snapshot = _copy.deepcopy(original_chain)
+    agent._fallback_chain = original_chain
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert agent._fallback_chain == original_snapshot, (
+        "parent _fallback_chain was mutated by the review fork"
+    )
+
+
+def test_background_review_fork_chain_enables_has_pending_fallback(monkeypatch):
+    """Behavioral test: prove the inherited chain makes the fork's
+    _has_pending_fallback() return True — the actual gate that decides whether
+    fallback is attempted.  This goes beyond kwarg-plumbing: it verifies the
+    chain flows through agent_init.py's list comprehension and produces a
+    usable _fallback_chain on the constructed agent.
+
+    Uses a real AIAgent via __new__ to exercise the _has_pending_fallback
+    method directly, simulating what agent_init.py would produce.
+    """
+    import run_agent as run_agent_module
+
+    # Simulate what agent_init.py does with fallback_model=[...]
+    fallback_model = [{"provider": "copilot", "model": "gpt-5.6-luna"}]
+    # agent_init.py: [f for f in fallback_model if isinstance(f, dict) and f.get("provider") and f.get("model")]
+    chain = [
+        f for f in fallback_model
+        if isinstance(f, dict) and f.get("provider") and f.get("model")
+    ]
+
+    # Build a bare agent the way _has_pending_fallback reads it
+    agent = object.__new__(run_agent_module.AIAgent)
+    agent._fallback_chain = chain
+    agent._fallback_index = 0
+
+    # The actual method from run_agent.py:5905
+    assert agent._has_pending_fallback() is True, (
+        "fork with inherited chain should report a pending fallback"
+    )
+
+    # Simulate exhausting the chain (index advanced past all entries)
+    agent._fallback_index = len(chain)
+    assert agent._has_pending_fallback() is False, (
+        "fork with exhausted index should report no pending fallback"
+    )
+
+    # Prove an empty chain (pre-fix behavior) reports False
+    agent._fallback_chain = []
+    agent._fallback_index = 0
+    assert agent._has_pending_fallback() is False, (
+        "fork with empty chain (pre-fix) should report no pending fallback"
+    )
 
 
 

--- a/tests/run_agent/test_zai_quota_fallback.py
+++ b/tests/run_agent/test_zai_quota_fallback.py
@@ -1,0 +1,224 @@
+"""Regression coverage for terminal Z.AI quota fallback."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.error_classifier import FailoverReason
+from run_agent import AIAgent
+
+
+class _ZaiQuotaError(Exception):
+    status_code = 429
+
+
+def _response(content="fallback selected"):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        output=[
+            SimpleNamespace(
+                type="message",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=content)],
+            )
+        ],
+        output_text=content,
+        status="completed",
+        model="copilot/model",
+    )
+
+
+def _agent(fallback_model=None):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="zai-key",
+            base_url="https://api.z.ai/api/paas/v4",
+            provider="zai",
+            api_mode="chat_completions",
+            model="glm-5.2",
+            fallback_model=fallback_model,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    return agent
+
+
+def test_zai_terminal_quota_rotates_then_selects_copilot_fallback():
+    agent = _agent({"provider": "copilot", "model": "gpt-5"})
+    quota_error = _ZaiQuotaError("Usage limit reached for 5 hour.")
+    relay_attempts = []
+
+    def execute(request, callback, **kwargs):
+        relay_attempts.append((request, kwargs))
+        if len(relay_attempts) == 1:
+            raise quota_error
+        return _response()
+
+    fallback_client = MagicMock()
+    fallback_client.api_key = "copilot-key"
+    fallback_client.base_url = "https://api.githubcopilot.com"
+    with (
+        patch.object(agent, "_recover_with_credential_pool", return_value=(False, False)) as rotate,
+        patch("run_agent._pool_may_recover_from_rate_limit", return_value=True),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, "gpt-5"),
+        ) as resolve,
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("agent.relay_llm.execute", side_effect=execute),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    rotate.assert_called_once()
+    resolve.assert_called_once()
+    assert agent._fallback_index == 1
+    assert agent.provider == "copilot"
+    assert agent.model == "gpt-5"
+    assert agent.client is fallback_client
+    assert len(relay_attempts) == 2
+    assert relay_attempts[0][1]["name"] == "zai"
+    assert relay_attempts[1][1]["name"] == "copilot"
+    assert result["completed"] is True
+    assert result["final_response"] == "fallback selected"
+
+
+def test_zai_terminal_quota_without_fallback_remains_terminal():
+    agent = _agent()
+    quota_error = _ZaiQuotaError("Usage limit reached for 5 hour.")
+
+    with (
+        patch.object(agent, "_recover_with_credential_pool", return_value=(False, False)),
+        patch.object(agent, "_try_activate_fallback", return_value=False) as activate,
+        patch("agent.relay_llm.execute", side_effect=quota_error),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    activate.assert_not_called()
+    assert result["failed"] is True
+
+
+def test_successful_credential_rotation_skips_fallback():
+    agent = _agent({"provider": "copilot", "model": "gpt-5"})
+    quota_error = _ZaiQuotaError("Usage limit reached for 5 hour.")
+    attempts = []
+
+    def execute(request, callback, **kwargs):
+        attempts.append(kwargs["name"])
+        if len(attempts) == 1:
+            raise quota_error
+        return _response("recovered by rotated credential")
+
+    with (
+        patch.object(agent, "_recover_with_credential_pool", side_effect=[(True, False)]) as recover,
+        patch.object(agent, "_try_activate_fallback") as activate,
+        patch("agent.relay_llm.execute", side_effect=execute),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    recover.assert_called_once()
+    activate.assert_not_called()
+    assert attempts == ["zai", "zai"]
+    assert result["completed"] is True
+    assert result["final_response"] == "recovered by rotated credential"
+
+
+def test_transient_rate_limit_stays_on_pool_recovery_path():
+    agent = _agent({"provider": "copilot", "model": "gpt-5"})
+    rate_limit = _ZaiQuotaError("rate limit exceeded; retry later")
+    attempts = []
+
+    def execute(request, callback, **kwargs):
+        attempts.append(kwargs["name"])
+        if len(attempts) == 1:
+            raise rate_limit
+        return _response("recovered after transient limit")
+
+    with (
+        patch.object(agent, "_recover_with_credential_pool", side_effect=[(True, False)]) as recover,
+        patch("run_agent._pool_may_recover_from_rate_limit", return_value=True),
+        patch.object(agent, "_try_activate_fallback") as activate,
+        patch("agent.relay_llm.execute", side_effect=execute),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    recover.assert_called_once()
+    activate.assert_not_called()
+    assert attempts == ["zai", "zai"]
+    assert result["completed"] is True
+
+
+def test_fallback_chain_skips_unusable_entry_and_activates_second():
+    agent = _agent(
+        [
+            {"provider": "unconfigured", "model": "missing"},
+            {"provider": "copilot", "model": "gpt-5"},
+        ]
+    )
+    fallback_client = MagicMock()
+    fallback_client.api_key = "copilot-key"
+    fallback_client.base_url = "https://api.githubcopilot.com"
+
+    with (
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=[(None, None), (fallback_client, "gpt-5")],
+        ) as resolve,
+        patch("agent.credential_pool.load_pool", return_value=None),
+    ):
+        assert agent._try_activate_fallback(reason=FailoverReason.billing) is True
+
+    assert [call.args[0] for call in resolve.call_args_list] == [
+        "unconfigured",
+        "copilot",
+    ]
+    assert agent._fallback_index == 2
+    assert agent.provider == "copilot"
+    assert agent.model == "gpt-5"
+    assert agent.client is fallback_client
+
+
+def test_failed_fallback_activation_does_not_start_duplicate_outer_traversal():
+    agent = _agent({"provider": "unconfigured", "model": "missing"})
+    quota_error = _ZaiQuotaError("Usage limit reached for 5 hour.")
+
+    with (
+        patch.object(agent, "_recover_with_credential_pool", return_value=(False, False)),
+        patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)) as resolve,
+        patch("agent.relay_llm.execute", side_effect=quota_error) as execute,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    # The candidate is attempted once; the failed activation must not fall
+    # through to the generic non-retryable branch and traverse the chain again.
+    resolve.assert_called_once()
+    execute.assert_called_once()
+    assert agent._fallback_index == 1
+    assert result["failed"] is True


### PR DESCRIPTION
## What does this PR do?

Fixes three root-cause paths where Hermes fails to activate the configured provider fallback when a hard billing-quota 429 is returned (e.g. Z.AI `Usage limit reached for 5 hour`). In each case, the turn burns retries or leaks resources instead of switching to the fallback provider.

**1. Classifier: hard-quota 429s classified as retryable `rate_limit` instead of terminal `billing`** (`agent/error_classifier.py`)

A provider 429 with usage-limit wording (e.g. `Usage limit reached for 5 hour`) and no transient signal was classified as generic `rate_limit`, causing Hermes to retry/pool-recover against an exhausted billing window instead of activating the configured provider fallback. The turn would burn retries and fail without a visible fallback switch.

Now classified as terminal `billing` (non-retryable, fallback enabled). Guard order in the 429 branch preserves existing behavior for:
- Explicit rate-limit wording (`rate limit exceeded`) → stays `rate_limit` (#61123)
- Usage-limit + transient signal (`try again`, `resets in`) → stays `rate_limit` (#63021)
- Usage-limit without transient/rate-limit signals → `billing` (#39441, #36276)

Also adds `resets in` to transient signals.

**2. Gateway: leaked memory provider writer threads on soft eviction** (`run_agent.py`, `agent/memory_manager.py`)

`release_clients()` did not shut down memory providers, leaking one hindsight-writer daemon thread per evicted agent. Under sustained quota pressure this accumulates leaked threads (observed 57 leaked writer threads out of 99 total in a crash dump), driving memory growth that can kill the liveness watchdog (exit 75).

Fix: call `shutdown_all()` on the memory manager from `release_clients()`, which drains the executor and terminates writer threads. Does NOT call `on_session_end()` to avoid triggering end-of-session extraction on a session that may resume — a resumed session creates fresh providers anyway.

**3. Hindsight plugin: circuit breaker for connection failures** (`plugins/memory/hindsight/__init__.py`)

When the Hindsight backend drops connections (`Server disconnected`), `_run_sync()` blocks the calling thread for the configured timeout. Multiple concurrent blocked calls starve the gateway event loop, triggering the shutdown watchdog (exit 75), which kills sessions mid-stream and causes resume-list pruning.

Fix: circuit breaker in `_run_hindsight_operation()` — after 3 consecutive failures, fast-fails for 60s cooldown (half-open retry after). Also renames `_is_retriable_embedded_connection_error()` → `_is_retriable_connection_error()` and removes the mode check so it works across `local_embedded` AND `local_external` modes (production config). Adapted from PR #17416 by @kagura-agent (closed without review).

**4. Background-review fork: inherits parent fallback chain** (`agent/background_review.py`)

The background-review fork creates an AIAgent without passing `fallback_model`, leaving `_fallback_chain` empty. When the review's model hits a hard-quota 429, the error is classified correctly as `billing` but `_has_pending_fallback()` returns False, so the fork aborts instead of switching to the configured fallback — the same bug class as the main-conversation path. Subagent delegation (`tools/delegate_tool.py:1461`) already inherits the parent fallback chain; `background_review` was the one fork path that dropped it.

Fix: pass the parent's `_fallback_chain` as `fallback_model` to the review fork AIAgent, identical to the `delegate_tool.py` pattern. Applies on both the same-model (auto) and routed (explicit aux) paths — fallback is resilience, not cache parity. The fallback path only reads chain entries (never mutates), matching the `delegate_tool.py` shallow-reference convention.

## Related Issue

Closes #17403 (Hindsight connection-failure circuit breaker). Refs: #41590, #36276, #39441, #61123, #63021.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` — classify hard-quota 429s (usage-limit, no transient signal) as `billing` to enable immediate fallback; preserve periodic quota rate limits
- `agent/conversation_loop.py` — activate billing fallback after rotation failure
- `agent/background_review.py` — inherit parent fallback chain on review fork (sibling path: bg-review was the one fork that dropped the fallback chain, unlike `delegate_tool.py`)
- `run_agent.py` — terminate memory provider writer threads on soft eviction via `shutdown_all()`
- `agent/memory_manager.py` — expose `shutdown_all()` for clean eviction shutdown
- `plugins/memory/hindsight/__init__.py` — circuit breaker + observability for connection failures; cross-mode connection error detection

**Tests added (9 files, +911 lines):**
- `tests/agent/test_error_classifier.py` (+115) — hard-quota vs transient-quota classification, failed-fallback paths
- `tests/agent/test_memory_manager_shutdown.py` (+68) — eviction shutdown contract
- `tests/gateway/test_agent_cache.py` (+55) — writer thread termination on eviction
- `tests/plugins/memory/test_hindsight_circuit_breaker.py` (+223) — breaker open/half-open/closed transitions, local_external e2e
- `tests/run_agent/test_background_review.py` (+226) — fallback chain inheritance, multi-entry, no-mutation, behavioral gate test
- `tests/run_agent/test_zai_quota_fallback.py` (+224) — end-to-end quota fallback activation

## How to Test

1. **Classifier unit tests**: `pytest tests/agent/test_error_classifier.py -v`
2. **Memory shutdown tests**: `pytest tests/agent/test_memory_manager_shutdown.py tests/gateway/test_agent_cache.py -v`
3. **Hindsight circuit breaker**: `pytest tests/plugins/memory/test_hindsight_circuit_breaker.py -v`
4. **Background review fallback**: `pytest tests/run_agent/test_background_review.py -v`
5. **E2E quota fallback**: `pytest tests/run_agent/test_zai_quota_fallback.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal fix, no user-facing config changes)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (provider error classification, no file I/O or terminal handling)
- [x] I've updated tool descriptions/schemas — N/A (no tool changes)
