### PR TITLE
fix(scripts): bind livetest cleanup to allocated home

### DIFF
--- a/scripts/tool_search_livetest.py
+++ b/scripts/tool_search_livetest.py
@@ -298,6 +298,11 @@ def setup_isolated_home(enabled: bool, listing: str = "off",
     return hermes_home
 
 
+def cleanup_isolated_home(hermes_home: Path) -> None:
+    """Remove the temporary root that produced ``hermes_home``."""
+    shutil.rmtree(hermes_home.parent, ignore_errors=True)
+
+
 def _yaml_dump(obj: Any) -> str:
     try:
         import yaml
@@ -443,8 +448,7 @@ def run_one_scenario(scenario: Dict[str, Any], enabled: bool, out_dir: Path) -> 
     out_path = out_dir / f"{scenario['id']}__{suffix}.json"
     out_path.write_text(json.dumps(record, indent=2, default=str), encoding="utf-8")
 
-    # Cleanup
-    shutil.rmtree(home.parent, ignore_errors=True)
+    cleanup_isolated_home(home)
     return record
 
 

--- a/scripts/tool_search_livetest2.py
+++ b/scripts/tool_search_livetest2.py
@@ -11,7 +11,7 @@ Runs each scenario N_REPS times in each mode (on/off). Output:
 """
 from __future__ import annotations
 
-import json, os, shutil, sys, tempfile, time, traceback
+import json, os, sys, tempfile, time, traceback
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -188,7 +188,7 @@ def run_one(scenario: Dict[str, Any], mode: str, rep: int, out_dir: Path) -> Dic
     }
     out_path = out_dir / f"{scenario['id']}__{'enabled' if enabled else 'disabled'}__rep{rep}.json"
     out_path.write_text(json.dumps(rec, indent=1), encoding="utf-8")
-    shutil.rmtree(Path(os.environ["HERMES_HOME"]).parent, ignore_errors=True)
+    base.cleanup_isolated_home(hermes_home)
     return rec
 
 

--- a/scripts/tool_search_livetest_ue.py
+++ b/scripts/tool_search_livetest_ue.py
@@ -18,7 +18,7 @@ Env: TS_BENCH_REPS (default 2), TS_UE_MODES, TS_UE_SCALE, TS_UE_SUMMARY.
 """
 from __future__ import annotations
 
-import json, os, re, shutil, sys, time, traceback
+import json, os, re, sys, time, traceback
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -265,7 +265,7 @@ def run_one(scenario, mode, scale, rep, out_dir: Path):
         "final_response": base._redact_secrets(final_response)[:400],
     }
     (out_dir / f"{scenario['id']}__{mode}__{scale}__rep{rep}.json").write_text(json.dumps(rec, indent=1), encoding="utf-8")
-    shutil.rmtree(Path(os.environ["HERMES_HOME"]).parent, ignore_errors=True)
+    base.cleanup_isolated_home(hermes_home)
     return rec
 
 

--- a/scripts/tool_search_livetest_ue_disc.py
+++ b/scripts/tool_search_livetest_ue_disc.py
@@ -19,7 +19,7 @@ Scoring per family:
 """
 from __future__ import annotations
 
-import json, os, shutil, sys, time, traceback
+import json, os, sys, time, traceback
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -208,7 +208,7 @@ def run_one(scenario, mode, rep, out_dir: Path):
         "final_response": base._redact_secrets(final_response)[:400],
     }
     (out_dir / f"{scenario['id']}__{mode}__rep{rep}.json").write_text(json.dumps(rec, indent=1), encoding="utf-8")
-    shutil.rmtree(Path(os.environ["HERMES_HOME"]).parent, ignore_errors=True)
+    base.cleanup_isolated_home(hermes_home)
     return rec
 
 

--- a/scripts/tool_search_livetest_ue_hard.py
+++ b/scripts/tool_search_livetest_ue_hard.py
@@ -22,7 +22,7 @@ Env: TS_UE_MODEL, TS_BENCH_REPS, TS_UE_MODES (eager,bridge,listing),
 """
 from __future__ import annotations
 
-import json, os, re, shutil, sys, time, traceback
+import json, os, re, sys, time, traceback
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -281,7 +281,7 @@ def run_one(scenario, mode, rep, out_dir: Path):
         "final_response": base._redact_secrets(final_response)[:300],
     }
     (out_dir / f"{scenario['id']}__{mode}__rep{rep}.json").write_text(json.dumps(rec, indent=1), encoding="utf-8")
-    shutil.rmtree(Path(os.environ["HERMES_HOME"]).parent, ignore_errors=True)
+    base.cleanup_isolated_home(hermes_home)
     return rec
 
 

--- a/tests/scripts/test_tool_search_livetest_cleanup.py
+++ b/tests/scripts/test_tool_search_livetest_cleanup.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS_PATH = REPO_ROOT / "scripts" / "tool_search_livetest.py"
+
+
+def _load_harness():
+    spec = importlib.util.spec_from_file_location("tool_search_livetest_cleanup_test", HARNESS_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cleanup_uses_allocated_home_not_mutable_environment(tmp_path, monkeypatch):
+    harness = _load_harness()
+    allocated_root = tmp_path / "allocated"
+    allocated_home = allocated_root / ".hermes"
+    allocated_home.mkdir(parents=True)
+    (allocated_home / "config.yaml").write_text("test: true\n", encoding="utf-8")
+
+    unrelated_root = tmp_path / "unrelated"
+    unrelated_home = unrelated_root / ".hermes"
+    unrelated_home.mkdir(parents=True)
+    sentinel = unrelated_root / "keep.txt"
+    sentinel.write_text("keep\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(unrelated_home))
+
+    harness.cleanup_isolated_home(allocated_home)
+
+    assert not allocated_root.exists()
+    assert sentinel.read_text(encoding="utf-8") == "keep\n"


### PR DESCRIPTION
## What does this PR do?

Binds tool-search livetest cleanup to the temporary home path returned by `setup_isolated_home()` instead of re-reading `HERMES_HOME` from mutable process-global state at teardown.

Four sibling benchmark harnesses currently derive a recursive-delete target from:

```python
Path(os.environ["HERMES_HOME"]).parent
```

If that value differs at teardown, cleanup can remove an unrelated parent while leaving the allocated temporary root behind. This was discovered after a cleanup run selected the real Hermes home as its `rm -rf` target, turning the mutable-path hazard into a concrete data-loss risk rather than a theoretical edge case. The harness already retains the allocation path locally, so this PR makes that retained path the cleanup authority.

A shared `cleanup_isolated_home()` helper now handles cleanup for the base harness and all four sibling scripts. The regression test changes `HERMES_HOME` to an unrelated directory and proves cleanup still removes only the allocated root.

### Why this belongs upstream

These benchmark harnesses are tracked upstream contributor tooling, copy real credentials into disposable homes, and perform recursive deletion after live agent runs. Cleanup aimed by mutable global state is therefore an upstream correctness and safety footgun, not a local configuration concern.

The change fixes the complete sibling bug class with a small scripts-only patch. It adds no production-agent behavior, dependency, configuration, environment variable, or core/tool-schema surface, while preventing an unrelated directory tree from becoming the cleanup target.

## Related Issue

No related issue found. Searches covered open, closed, and merged PRs/issues for combinations of `tool_search_livetest`, `HERMES_HOME`, `rmtree`, and cleanup. PR #71286 is related uninstall cleanup work but does not touch these benchmark harnesses or this cleanup-authority contract.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `cleanup_isolated_home(hermes_home)` beside `setup_isolated_home()` in `scripts/tool_search_livetest.py`.
- Use the retained `home` / `hermes_home` allocation in the base harness and all four sibling tool-search livetests.
- Remove the sibling scripts' now-unused `shutil` imports.
- Add `tests/scripts/test_tool_search_livetest_cleanup.py`, a real-filesystem invariant test that proves environment mutation cannot redirect deletion.

## How to Test

1. Run the focused scripts suite:
   ```bash
   scripts/run_tests.sh tests/scripts -q
   ```
   Result: **23 passed, 0 failed**.
2. Run the changed-file checks:
   ```bash
   python3 scripts/check-windows-footguns.py \
     scripts/tool_search_livetest.py \
     scripts/tool_search_livetest2.py \
     scripts/tool_search_livetest_ue.py \
     scripts/tool_search_livetest_ue_disc.py \
     scripts/tool_search_livetest_ue_hard.py \
     tests/scripts/test_tool_search_livetest_cleanup.py

   uv run ruff check \
     scripts/tool_search_livetest.py \
     scripts/tool_search_livetest2.py \
     scripts/tool_search_livetest_ue.py \
     scripts/tool_search_livetest_ue_disc.py \
     scripts/tool_search_livetest_ue_hard.py \
     tests/scripts/test_tool_search_livetest_cleanup.py
   ```
   Result: both passed; `git diff --check` also passed.
3. Full `scripts/run_tests.sh` result on the exact PR head: **22,887 passed, 2 failed**. Both failures are outside this PR's files and reproduce identically on the unmodified parent commit `3735ccee2`:
   - `tests/agent/test_credential_pool_routing.py::TestFailureAttribution::test_unmatched_key_does_not_retry_only_pool_entry`
   - `tests/tools/test_execution_flag_detection.py::test_real_binaries_execute_leading_dash_program_payload[sort-args2-{bulk}-False]`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite was run; the two failures above reproduce on the unmodified base
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 LTS, Python 3.13.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing behavior or configuration changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — existing `pathlib.Path`/`shutil.rmtree` behavior is preserved; Windows-footgun scan passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. This is a contributor-script filesystem cleanup fix; verification results are included above.