### PR TITLE
fix(desktop): preserve local pin clicks during server sync

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -59,6 +59,35 @@ describe('watchSessionPins', () => {
     expect(patch).toHaveBeenCalledWith('b', false, undefined)
   })
 
+  it('does not let a stale pinned=true row undo a user unpin', async () => {
+    $sessions.set([row('user-unpin', { pinned: true })])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('user-unpin')
+    patch.mockClear()
+
+    // The click changes local state before the PATCH response can be reflected
+    // in the next session-list page. The still-true row must not re-add it.
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('user-unpin')
+    expect(patch).toHaveBeenCalledWith('user-unpin', false, undefined)
+  })
+
+  it('does not let a stale pinned=false row undo a user pin', async () => {
+    $sessions.set([row('user-pin', { pinned: false })])
+    await flush()
+    patch.mockClear()
+
+    // The list page predates the user's click. The local write must be
+    // registered before remote reconciliation consults that stale row.
+    $pinnedSessionIds.set(['user-pin'])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toContain('user-pin')
+    expect(patch).toHaveBeenCalledWith('user-pin', true, undefined)
+  })
+
   it('defers a pin whose row is not loaded, then flushes once it appears', async () => {
     $pinnedSessionIds.set(['c'])
     await flush()

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -82,24 +82,23 @@ function pullRemotePins(): void {
     }
 
     if (row.pinned && !heldLocally) {
-      pinSession(pinId)
       // Already true server-side; record it so the push pass doesn't re-PATCH.
       mirrored.add(pinId)
+      pinSession(pinId)
     } else if (!row.pinned && heldLocally) {
-      unpinSession(local.has(pinId) ? pinId : row.id)
       mirrored.delete(pinId)
       mirrored.delete(row.id)
+      unpinSession(local.has(pinId) ? pinId : row.id)
     }
   }
 }
 
-function reconcile(): void {
+/** Push local membership changes to the backend. */
+function pushLocalPins(): void {
   // Config/session REST is only reachable through the Electron bridge.
   if (!window.hermesDesktop) {
     return
   }
-
-  pullRemotePins()
 
   const current = new Set($pinnedSessionIds.get())
 
@@ -138,9 +137,22 @@ function reconcile(): void {
   }
 }
 
-// Sync once, then re-sync on pin-set and session-list changes. Call once per app.
+/** Pull a fresh server page, then flush any local pins that became resolvable. */
+function reconcileRemotePins(): void {
+  if (!window.hermesDesktop) {
+    return
+  }
+
+  pullRemotePins()
+  pushLocalPins()
+}
+
+// Sync once, then push clicks and pull server refreshes through separate paths.
+// A local click must register its PATCH before any stale list row is consulted;
+// otherwise pinned=true immediately resurrects an unpin (and pinned=false
+// immediately cancels a pin) before `unconfirmed` can guard the write.
 export function watchSessionPins(): void {
-  reconcile()
-  $pinnedSessionIds.listen(reconcile)
-  $sessions.listen(reconcile)
+  reconcileRemotePins()
+  $pinnedSessionIds.listen(pushLocalPins)
+  $sessions.listen(reconcileRemotePins)
 }


### PR DESCRIPTION
## Summary

- separate local pin-click pushes from server session-list pulls
- register local pin/unpin intent before stale server rows can reconcile it away
- update mirrored state before applying remote changes to avoid echo writes
- add regression coverage for both stale `pinned: true` and stale `pinned: false` rows

## Root cause

The server-owned pin sync introduced in #74234 called `pullRemotePins()` at the start of the same reconciliation pass used for local pin-list changes. Immediately after a user click, `$sessions` still carries the pre-PATCH server value:

- stale `pinned: true` resurrected a just-unpinned session
- stale `pinned: false` removed a just-pinned session

Because the pull ran before `writePin()` recorded the desired value in `unconfirmed`, the existing in-flight-write guard could not protect the click.

The fix gives local pin-list changes a push-only path. Session-list refreshes retain the pull-then-push path, so remote changes are still adopted while local clicks are registered first.

## Verification

- Regression tests fail before the fix in both directions
- `npx vitest run src/store/session-pin-sync.test.ts` — 13 passed
- `npm run typecheck` — passed
- macOS Desktop live test against a remote Hermes backend:
  - unpin removed the row immediately
  - backend `sessions.pinned` changed from `1` to `0`
  - cold restart did not resurrect the removed pin

Follow-up to #74234.
