### PR TITLE
fix: preserve Codex compaction continuity

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -969,9 +969,15 @@ def run_codex_app_server_turn(
         getattr(agent, "_iters_since_skill", 0) + turn.tool_iterations
     )
     _record_codex_app_server_compaction(agent, turn)
-    # Startup/lease failures return a TurnResult without a Codex turn id.
-    # They sent no model request and must not inflate API-call accounting.
-    api_calls = 1 if getattr(turn, "turn_id", None) else 0
+    # Startup/lease failures occur before turn/start and count zero. Once the
+    # turn/start request is attempted, count it even if the JSON-RPC response
+    # times out, is rejected, or is malformed and therefore yields no turn id.
+    # A turn id is also incontrovertible post-hoc evidence for compatibility
+    # with older transport stubs/results that predate turn_start_attempted.
+    api_calls = 1 if (
+        getattr(turn, "turn_start_attempted", False)
+        or getattr(turn, "turn_id", None)
+    ) else 0
     usage_result = (
         _record_codex_app_server_usage(agent, turn)
         if api_calls

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -60,15 +60,6 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
 
     usage = getattr(turn, "token_usage_last", None)
     if not isinstance(usage, dict) or not usage:
-        compressor = getattr(agent, "context_compressor", None)
-        if (
-            compressor is not None
-            and getattr(compressor, "awaiting_real_usage_after_compression", False)
-        ):
-            # No usage means this turn cannot adjudicate the pending compaction.
-            # Consume the marker so a later unrelated reading is not charged to
-            # it and preflight deferral cannot stay latched indefinitely.
-            compressor.update_from_response({})
         if agent._session_db and agent.session_id:
             try:
                 if not agent._session_db_created:
@@ -124,7 +115,12 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     compressor = getattr(agent, "context_compressor", None)
     if compressor is not None:
         try:
-            compressor.update_from_response(usage_dict)
+            # ``thread/tokenUsage/updated`` is a sibling notification and can
+            # contain a partial/empty latest bucket.  A completed compaction
+            # remains pending until a real prompt count arrives; otherwise an
+            # empty usage update would erase its effectiveness verdict.
+            if prompt_tokens > 0:
+                compressor.update_from_response(usage_dict)
             context_window = getattr(turn, "model_context_window", None)
             if isinstance(context_window, int) and context_window > 0:
                 compressor.context_length = context_window
@@ -242,7 +238,17 @@ def _record_codex_app_server_compaction(
             record_boundary(compressor, used_fallback=False)
         elif hasattr(compressor, "_verify_compaction_cleared_threshold"):
             compressor._verify_compaction_cleared_threshold = True
-        if not getattr(turn, "token_usage_last", None):
+        last_usage = getattr(turn, "token_usage_last", None)
+        # A non-empty sibling usage object is still not a compaction verdict
+        # unless it contains the input side of the request.  Codex can emit a
+        # partial ``last`` bucket (for example output/total only) before the
+        # prompt-size update arrives.
+        has_real_prompt_tokens = isinstance(last_usage, dict) and (
+            _coerce_usage_int(last_usage.get("inputTokens"))
+            + _coerce_usage_int(last_usage.get("cachedInputTokens"))
+            > 0
+        )
+        if not has_real_prompt_tokens:
             compressor.last_prompt_tokens = -1
             compressor.last_completion_tokens = 0
             compressor.awaiting_real_usage_after_compression = True

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+import uuid
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
@@ -200,7 +201,12 @@ def _record_codex_app_server_compaction(
     rewrite local transcript rows here; state.db records the boundary via the
     session event/usage counters while preserving the visible transcript.
     """
-    if not force and not getattr(turn, "compacted", False):
+    # A successful JSON-RPC response and even turn/completed are not proof of
+    # compaction. The app-server contract requires a contextCompaction item;
+    # fail closed if that authoritative lifecycle signal was not projected.
+    # ``force`` only distinguishes a user-requested boundary from an automatic
+    # one for status reporting—it must never manufacture a success.
+    if not getattr(turn, "compacted", False):
         return False
 
     thread_id = getattr(turn, "thread_id", None) or ""
@@ -679,6 +685,142 @@ def run_codex_app_server_turn(
                 exc_info=True,
             )
 
+        # Codex owns its native compacted context inside the app-server thread
+        # rollout. Persist that thread id separately from Hermes' messaging
+        # origin thread_id, then resume it whenever this in-process adapter is
+        # recreated after a crash, timeout, auth refresh, or app restart.
+        resume_thread_id = None
+        on_thread_ready = None
+        lease_acquire = None
+        lease_refresh = None
+        lease_release = None
+        session_db = getattr(agent, "_session_db", None)
+        session_id = str(getattr(agent, "session_id", None) or "").strip()
+        if session_db is None or not session_id:
+            error = (
+                "Codex app-server has no durable Hermes session store, "
+                "so Hermes refused to start a new thread."
+            )
+            logger.warning(
+                "codex app-server: durable session store unavailable "
+                "(has_db=%s, has_session_id=%s); refusing to start a new "
+                "Codex thread",
+                session_db is not None,
+                bool(session_id),
+            )
+            return {
+                "final_response": error,
+                "messages": messages,
+                "api_calls": 0,
+                "completed": False,
+                "partial": True,
+                "interrupted": False,
+                "error": error,
+            }
+
+        if session_db is not None and session_id:
+            try:
+                if not getattr(agent, "_session_db_created", False):
+                    agent._ensure_db_session()
+                if not getattr(agent, "_session_db_created", False):
+                    raise RuntimeError(
+                        "Hermes session row could not be created"
+                    )
+                if session_db.get_session(session_id) is None:
+                    raise RuntimeError(
+                        "Hermes session row is unavailable"
+                    )
+                resume_thread_id = session_db.get_codex_thread_id(session_id)
+            except Exception as exc:
+                logger.warning(
+                    "codex app-server: could not load persisted thread binding "
+                    "for session=%s; refusing to start a new Codex thread",
+                    session_id,
+                    exc_info=True,
+                )
+                error = (
+                    "Codex app-server could not verify the persisted thread "
+                    "binding, so Hermes refused to start a new thread."
+                )
+                return {
+                    "final_response": error,
+                    "messages": messages,
+                    "api_calls": 0,
+                    "completed": False,
+                    "partial": True,
+                    "interrupted": False,
+                    "error": error,
+                }
+
+            lease_holder = str(uuid.uuid4())
+            lease_state = {"thread_id": resume_thread_id}
+
+            def _acquire_codex_turn_lease(
+                *,
+                _db=session_db,
+                _session_id=session_id,
+                _holder=lease_holder,
+            ) -> bool:
+                return _db.try_acquire_codex_turn_lease(
+                    _session_id,
+                    _holder,
+                    codex_thread_id=lease_state["thread_id"],
+                    ttl_seconds=300.0,
+                )
+
+            def _persist_codex_thread_binding(
+                thread_id: str,
+                *,
+                _db=session_db,
+                _session_id=session_id,
+                _holder=lease_holder,
+            ) -> None:
+                if _db.bind_codex_thread_under_lease(
+                    _session_id,
+                    _holder,
+                    thread_id,
+                ):
+                    lease_state["thread_id"] = thread_id
+                    return
+                existing = _db.get_codex_thread_id(_session_id)
+                if existing and existing != thread_id:
+                    raise RuntimeError(
+                        "Hermes session is already bound to a different "
+                        f"Codex thread ({existing})"
+                    )
+                raise RuntimeError(
+                    "Hermes session row is unavailable for Codex thread binding"
+                )
+
+            def _refresh_codex_turn_lease(
+                *,
+                _db=session_db,
+                _session_id=session_id,
+                _holder=lease_holder,
+            ) -> bool:
+                return _db.refresh_codex_turn_lease(
+                    _session_id,
+                    _holder,
+                    codex_thread_id=lease_state["thread_id"],
+                    ttl_seconds=300.0,
+                )
+
+            def _release_codex_turn_lease(
+                *,
+                _db=session_db,
+                _session_id=session_id,
+                _holder=lease_holder,
+            ) -> bool:
+                return _db.release_codex_turn_lease(
+                    _session_id,
+                    _holder,
+                )
+
+            on_thread_ready = _persist_codex_thread_binding
+            lease_acquire = _acquire_codex_turn_lease
+            lease_refresh = _refresh_codex_turn_lease
+            lease_release = _release_codex_turn_lease
+
         # Bridge codex JSON-RPC notifications (item/started, item/completed,
         # item/agentMessage/delta, ...) into Hermes' gateway UI callbacks
         # (tool_progress_callback, _fire_stream_delta,
@@ -694,6 +836,12 @@ def run_codex_app_server_turn(
                 auto_approve_apply_patch=auto_approve_requests,
             ),
             on_event=make_codex_app_server_event_bridge(agent),
+            resume_thread_id=resume_thread_id,
+            on_thread_ready=on_thread_ready,
+            lease_acquire=lease_acquire,
+            lease_refresh=lease_refresh,
+            lease_release=lease_release,
+            lease_refresh_interval=60.0,
         )
 
     # NOTE: the user message is ALREADY appended to messages by the
@@ -821,8 +969,14 @@ def run_codex_app_server_turn(
         getattr(agent, "_iters_since_skill", 0) + turn.tool_iterations
     )
     _record_codex_app_server_compaction(agent, turn)
-    usage_result = _record_codex_app_server_usage(agent, turn)
-    api_calls = 1
+    # Startup/lease failures return a TurnResult without a Codex turn id.
+    # They sent no model request and must not inflate API-call accounting.
+    api_calls = 1 if getattr(turn, "turn_id", None) else 0
+    usage_result = (
+        _record_codex_app_server_usage(agent, turn)
+        if api_calls
+        else {}
+    )
 
     # Now check the skill nudge AFTER iters were incremented — same
     # pattern the chat_completions path uses (line ~15432).

--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -131,6 +131,7 @@ def compute_session_context_breakdown(
     context_max = int(getattr(comp, "context_length", 0) or 0) if comp else 0
     measured_used = int(getattr(comp, "last_prompt_tokens", 0) or 0) if comp else 0
     context_used = measured_used if measured_used > 0 else estimated_total
+    context_used_estimated = measured_used <= 0
     context_percent = (
         max(0, min(100, round(context_used / context_max * 100)))
         if context_max
@@ -151,6 +152,7 @@ def compute_session_context_breakdown(
         "context_max": context_max,
         "context_percent": context_percent,
         "context_used": context_used,
+        "context_used_estimated": context_used_estimated,
         "estimated_total": estimated_total,
         "model": getattr(agent, "model", "") or "",
     }

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -16,6 +16,7 @@ Improvements over v2:
   - Richer tool call/result detail in summarizer input
 """
 
+import copy
 import hashlib
 import json
 import logging
@@ -1534,6 +1535,179 @@ class ContextCompressor(ContextEngine):
         self._load_fallback_compression_streak()
         self._load_ineffective_compression_count()
 
+    def checkpoint_compression_transaction(self) -> Dict[str, Any]:
+        """Capture all compressor state that a not-yet-durable rewrite may change.
+
+        ``compress()`` can update iterative-summary state, switch away from a
+        failing auxiliary summary model, and clear a persisted failure cooldown
+        before the caller publishes its rewritten transcript.  A failed
+        publication must not leave any of those speculative changes behind.
+        Keep this ownership here rather than making callers maintain a brittle
+        list of compressor internals.
+        """
+        state = {
+            key: copy.deepcopy(value)
+            for key, value in vars(self).items()
+            # SessionDB owns locks/connections and is deliberately retained by
+            # identity; all other mutable compressor values are copied.
+            if key != "_session_db"
+        }
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        durable: Dict[str, Any] = {
+            "session_id": session_id,
+            "cooldown": None,
+            "fallback_streak": None,
+            "ineffective_count": None,
+        }
+        if session_db and session_id:
+            try:
+                durable["cooldown"] = copy.deepcopy(
+                    session_db.get_compression_failure_cooldown(session_id)
+                )
+                durable["fallback_streak"] = (
+                    session_db.get_compression_fallback_streak(session_id)
+                )
+                durable["ineffective_count"] = (
+                    session_db.get_compression_ineffective_count(session_id)
+                )
+            except Exception as exc:
+                # An unknown durable baseline is unsafe: rollback would treat
+                # it as empty/zero and could erase a cooldown or guard that
+                # predates this attempted compression. Fail before compress()
+                # mutates anything instead of manufacturing a partial
+                # checkpoint.
+                logger.error(
+                    "compression transaction checkpoint persistence read failed "
+                    "for session=%s; aborting before compression",
+                    session_id,
+                    exc_info=True,
+                )
+                raise RuntimeError(
+                    "compression transaction checkpoint persistence read failed"
+                ) from exc
+        return {"state": state, "durable": durable}
+
+    def rollback_compression_transaction(
+        self,
+        checkpoint: Dict[str, Any],
+        *,
+        preserve_failure_outcome: bool = False,
+    ) -> None:
+        """Restore state after an unpublished rewrite.
+
+        ``preserve_failure_outcome`` is used only when summary generation
+        itself aborted. The transcript rewrite is still speculative and must
+        roll back, but the observed failure/backoff is a real outcome: callers
+        need ``_last_compress_aborted`` for correct feedback and the persisted
+        cooldown to prevent an immediate cross-turn retry loop.
+        """
+        state = checkpoint.get("state") if isinstance(checkpoint, dict) else None
+        if not isinstance(state, dict):
+            raise ValueError("invalid compression transaction checkpoint")
+
+        failure_outcome = None
+        if preserve_failure_outcome:
+            outcome_fields = (
+                "_last_compress_aborted",
+                "_last_summary_error",
+                "_last_summary_auth_failure",
+                "_last_summary_network_failure",
+                "_last_summary_dropped_count",
+                "_last_summary_fallback_used",
+                "_last_aux_model_failure_error",
+                "_last_aux_model_failure_model",
+                "_last_compression_made_progress",
+                "_summary_failure_cooldown_until",
+                "_cooldown_persist_failed",
+                "_consecutive_timeout_failures",
+                "_last_compression_telemetry",
+            )
+            failure_outcome = {
+                key: copy.deepcopy(getattr(self, key))
+                for key in outcome_fields
+                if hasattr(self, key)
+            }
+
+        # Remove speculative fields added during compress(), then replace every
+        # captured value.  Keep the SessionDB object by identity.
+        for key in tuple(vars(self)):
+            if key != "_session_db" and key not in state:
+                delattr(self, key)
+        for key, value in state.items():
+            setattr(self, key, copy.deepcopy(value))
+
+        durable = checkpoint.get("durable", {})
+        session_db = getattr(self, "_session_db", None)
+        session_id = durable.get("session_id") if isinstance(durable, dict) else ""
+        if not session_db or not session_id:
+            if failure_outcome is not None:
+                for key, value in failure_outcome.items():
+                    setattr(self, key, copy.deepcopy(value))
+            return
+        failures: list[tuple[str, Exception]] = []
+
+        def _restore(name: str, operation) -> None:
+            try:
+                operation()
+            except Exception as exc:
+                failures.append((name, exc))
+
+        # In preserve mode the post-summary cooldown is already a committed
+        # failure outcome. Never clear/recreate it as two separate DB writes:
+        # a crash or second-write failure between those operations would lose
+        # the backoff and revive the cross-turn compression loop.
+        if not preserve_failure_outcome:
+            cooldown = durable.get("cooldown")
+            if cooldown:
+                _restore(
+                    "cooldown",
+                    lambda: session_db.record_compression_failure_cooldown(
+                        session_id,
+                        cooldown["cooldown_until"],
+                        cooldown.get("error"),
+                        raise_on_error=True,
+                    ),
+                )
+            else:
+                _restore(
+                    "cooldown",
+                    lambda: session_db.clear_compression_failure_cooldown(
+                        session_id,
+                        raise_on_error=True,
+                    ),
+                )
+        if durable.get("fallback_streak") is not None:
+            _restore(
+                "fallback_streak",
+                lambda: session_db.set_compression_fallback_streak(
+                    session_id, durable["fallback_streak"]
+                ),
+            )
+        if durable.get("ineffective_count") is not None:
+            _restore(
+                "ineffective_count",
+                lambda: session_db.set_compression_ineffective_count(
+                    session_id, durable["ineffective_count"]
+                ),
+            )
+        if not failures and failure_outcome is not None:
+            for key, value in failure_outcome.items():
+                setattr(self, key, copy.deepcopy(value))
+        if failures:
+            failed_steps = ", ".join(name for name, _exc in failures)
+            logger.error(
+                "compression transaction rollback persistence partially failed "
+                "for session=%s (steps=%s)",
+                session_id,
+                failed_steps,
+                exc_info=(type(failures[0][1]), failures[0][1], failures[0][1].__traceback__),
+            )
+            raise RuntimeError(
+                "compression rollback persistence restore failed "
+                f"(steps={failed_steps})"
+            ) from failures[0][1]
+
     def on_session_start(self, session_id: str, **kwargs) -> None:
         """Bind session-scoped compression state for a new or resumed session."""
         super().on_session_start(session_id, **kwargs)
@@ -2214,10 +2388,29 @@ class ContextCompressor(ContextEngine):
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
-        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        reported_prompt_tokens = _safe_int(usage.get("prompt_tokens"))
+        has_real_prompt_tokens = bool(
+            reported_prompt_tokens is not None and reported_prompt_tokens > 0
+        )
+
+        # A completed compaction has no meaningful verdict until the provider
+        # reports the prompt size of the compacted request.  In particular, do
+        # not turn the post-compaction ``-1`` sentinel into zero here: callers
+        # use it to avoid treating a rough estimate as a second compaction
+        # trigger while the real reading is still outstanding.
+        if (
+            not has_real_prompt_tokens
+            and (
+                self.awaiting_real_usage_after_compression
+                or self._verify_compaction_cleared_threshold
+            )
+        ):
+            return
+
+        self.last_prompt_tokens = reported_prompt_tokens or 0
         self.last_completion_tokens = usage.get("completion_tokens", 0)
         self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
-        if self.last_prompt_tokens > 0:
+        if has_real_prompt_tokens:
             self.last_real_prompt_tokens = self.last_prompt_tokens
             if self.last_prompt_tokens < self.threshold_tokens:
                 if self.awaiting_real_usage_after_compression and self.last_compression_rough_tokens > 0:
@@ -2264,9 +2457,9 @@ class ContextCompressor(ContextEngine):
                         )
                 else:
                     self._record_ineffective_compression_verdict(0)
-        # Consume the pending-verification flag once real usage arrives, whether
-        # or not prompt_tokens was reported, so a usage-less response can't leave
-        # it armed for a later, unrelated reading.
+        # Only a real provider prompt count can adjudicate a compaction.  Empty
+        # usage is common on interrupted/streaming responses and must not spend
+        # this one-shot verdict or re-open the host retry budget.
         self._verify_compaction_cleared_threshold = False
         self.awaiting_real_usage_after_compression = False
 
@@ -3006,6 +3199,7 @@ class ContextCompressor(ContextEngine):
         tool_actions: list[str] = []
         relevant_files: list[str] = []
         blockers: list[str] = []
+        failed_attempts: list[str] = []
         last_dropped_turns: list[str] = []
 
         def _compact_fallback_turn(value: Any) -> str:
@@ -3091,15 +3285,32 @@ class ContextCompressor(ContextEngine):
             elif role == "tool":
                 call_id = str(msg.get("tool_call_id") or "")
                 tool_name, tool_args = call_id_to_tool.get(call_id, ("unknown", ""))
-                tool_actions.append(
-                    _summarize_tool_result(tool_name, tool_args, text or "")
+                tool_summary = _summarize_tool_result(
+                    tool_name, tool_args, text or ""
+                )
+                tool_actions.append(tool_summary)
+                # Successful test/build output routinely contains phrases such
+                # as "0 failed" or "no errors". Remove only those explicit
+                # zero-failure counters before looking for a real failure
+                # signal; otherwise the handoff marks a successful command as
+                # unsafe to repeat.
+                failure_probe = re.sub(
+                    r"\b(?:0|no)\s+(?:errors?|failures?|failed)\b",
+                    "",
+                    text,
+                    flags=re.I,
                 )
                 if re.search(
                     r"\b(error|failed|exception|traceback|timeout|timed out|fatal)\b",
-                    text,
+                    failure_probe,
                     re.I,
                 ):
                     blockers.append(text[:500])
+                    failed_attempts.append(
+                        f"{tool_summary} Exact failure: {text[:500]} "
+                        "Cause unknown; do not repeat the same "
+                        "call unchanged until current state and inputs are verified."
+                    )
 
         def _bullets(items: list[str], limit: int = 8) -> str:
             unique: list[str] = []
@@ -3155,6 +3366,12 @@ Recovered from a deterministic fallback because the LLM context summarizer was u
 
 ## Active State
 Unknown from deterministic fallback. Inspect current repository/session state if needed.
+
+## Failed Attempts
+{_bullets(failed_attempts, limit=5)}
+
+## Next Safe Step
+Verify the current repository/session state and the latest real user request before continuing. Do not replay completed actions merely because they appear in this historical fallback.
 
 ## Blocked
 {_bullets(blockers, limit=5)}
@@ -3478,6 +3695,16 @@ Be specific with file paths, commands, line numbers, and results.]
 - Any running processes or servers
 - Environment details that matter]
 
+## Failed Attempts
+[Each unsuccessful approach — include the action/tool, exact failure, likely
+cause if known, what state changed, and whether/when it is safe to retry.
+Write "Do not repeat unchanged" when the same preconditions would produce the
+same failure. Do not invent a root cause.]
+
+## Next Safe Step
+[The single safest next action based on Active State. Verify current state
+before mutating or retrying. Write "None" when there is no active task.]
+
 ## Blocked
 [Any blockers, errors, or issues not yet resolved. Include exact error messages.]
 
@@ -3524,7 +3751,7 @@ PREVIOUS SUMMARY:
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}{_memory_section}
 
-Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
+Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Preserve failed approaches under "Failed Attempts" so they are not retried unchanged, and revise "Next Safe Step" to one state-verified action. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Historical Task Snapshot" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
 
 {_template_sections}"""
         else:
@@ -3650,6 +3877,40 @@ This compaction should PRIORITISE preserving all information related to the focu
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
             summary = _redact_compaction_text(content.strip())
+            # Prompts are not an output contract: weaker/local summarizers can
+            # return fluent prose while omitting the two recovery anchors that
+            # prevent a resumed agent from blindly replaying a failed action.
+            # Fill only missing sections from the deterministic parser so we
+            # keep the richer LLM summary while preserving exact observed tool
+            # errors and a state-verification step.
+            missing_handoff_sections = [
+                heading
+                for heading in ("## Failed Attempts", "## Next Safe Step")
+                if heading not in summary
+            ]
+            if missing_handoff_sections:
+                fallback = self._strip_summary_prefix(
+                    self._build_static_fallback_summary(
+                        turns_to_summarize,
+                        reason="LLM summary omitted required recovery sections",
+                    )
+                )
+                for heading in missing_handoff_sections:
+                    # The deterministic fallback may embed the previous summary
+                    # as a snapshot, including headings with the same names.
+                    # Select its own final top-level section, not the stale
+                    # embedded copy.
+                    start = fallback.rfind(heading)
+                    if start < 0:
+                        continue
+                    next_heading = fallback.find("\n## ", start + len(heading))
+                    section = (
+                        fallback[start:next_heading]
+                        if next_heading >= 0
+                        else fallback[start:]
+                    ).strip()
+                    if section:
+                        summary = f"{summary.rstrip()}\n\n{section}"
             # P2 ghost-skill defense (#32106): deterministically restore any
             # [SKILL_PRUNED: ...] marker the summarizer paraphrased away.
             summary = _reinject_pruned_skill_markers(summary, _pruned_skill_names)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2702,6 +2702,16 @@ def _compress_context_via_codex_app_server(
         _complete_compaction_lifecycle()
         raise
 
+    if (
+        not getattr(result, "interrupted", False)
+        and not getattr(result, "error", None)
+        and not getattr(result, "compacted", False)
+    ):
+        result.error = (
+            "Codex completed the compact turn without the required "
+            "contextCompaction event"
+        )
+
     if getattr(result, "interrupted", False) or getattr(result, "error", None):
         _activity_heartbeat.stop("context compression failed")
     else:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1341,26 +1341,65 @@ def compress_context(
     # the app server does not expose its native summary prompt, so there is no
     # truthful injection point for ``on_pre_compress()`` return text here.
     if getattr(agent, "api_mode", None) == "codex_app_server":
-        _codex_fence_entered = False
-        if commit_fence is not None:
-            _codex_fence_entered = commit_fence.begin_commit()
-            if not _codex_fence_entered:
-                existing_prompt = getattr(agent, "_cached_system_prompt", None)
-                if not existing_prompt:
-                    existing_prompt = agent._build_system_prompt(system_message)
-                return messages, existing_prompt
-        try:
-            return _compress_context_via_codex_app_server(
-                agent,
-                messages,
-                system_message,
-                approx_tokens=approx_tokens,
-                task_id=task_id,
-                force=force,
+        _auto_mode = str(
+            getattr(agent, "codex_app_server_auto_compaction", "native")
+            or "native"
+        ).lower()
+        if _auto_mode not in {"native", "hermes", "off"}:
+            _auto_mode = "native"
+
+        # Native/off mode leaves automatic compaction to Codex. Manual
+        # compression still routes to the active Codex thread below.
+        if not force and _auto_mode in {"native", "off"}:
+            logger.info(
+                "codex app-server compaction skipped: mode=%s force=false "
+                "(session=%s messages=%d tokens=~%s)",
+                _auto_mode,
+                getattr(agent, "session_id", None) or "none",
+                len(messages),
+                f"{approx_tokens:,}" if approx_tokens else "unknown",
             )
-        finally:
-            if _codex_fence_entered:
-                commit_fence.finish_commit()
+            existing_prompt = getattr(agent, "_cached_system_prompt", None)
+            if not existing_prompt:
+                existing_prompt = agent._build_system_prompt(system_message)
+            return messages, existing_prompt
+
+        if getattr(agent, "_codex_session", None) is not None:
+            _codex_fence_entered = False
+            if commit_fence is not None:
+                _codex_fence_entered = commit_fence.begin_commit()
+                if not _codex_fence_entered:
+                    existing_prompt = getattr(agent, "_cached_system_prompt", None)
+                    if not existing_prompt:
+                        existing_prompt = agent._build_system_prompt(system_message)
+                    return messages, existing_prompt
+            try:
+                return _compress_context_via_codex_app_server(
+                    agent,
+                    messages,
+                    system_message,
+                    approx_tokens=approx_tokens,
+                    task_id=task_id,
+                    force=force,
+                )
+            finally:
+                if _codex_fence_entered:
+                    commit_fence.finish_commit()
+
+        # Hermes mode without an active Codex thread occurs during preflight,
+        # session hygiene, and some manual /compress paths. Falling through
+        # lets the built-in compressor shrink the durable transcript instead
+        # of silently counting a no-op as a successful attempt (#73503,
+        # upstream PR #73715).
+        logger.info(
+            "codex app-server: no active codex thread (session=%s); "
+            "falling through to Hermes compression "
+            "(mode=%s messages=%d tokens=~%s)",
+            getattr(agent, "session_id", None) or "none",
+            _auto_mode,
+            len(messages),
+            f"{approx_tokens:,}" if approx_tokens else "unknown",
+        )
 
     # Every automatic entrypoint must honor compressor-owned cooldown and
     # breaker state. Gateway hygiene constructs a fresh AIAgent, so the
@@ -1691,6 +1730,7 @@ def compress_context(
             return messages, existing_prompt
 
     _activity_heartbeat: Optional[_CompressionActivityHeartbeat] = None
+    _rollback_unpublished_compression = None
     try:
         if _lock_holder is not None:
             _lock_refresher = _CompressionLockLeaseRefresher(
@@ -1781,7 +1821,98 @@ def compress_context(
                     engine_name,
                 )
 
+        # A summary attempt mutates iterative compressor state before either
+        # durable rewrite is attempted. The built-in compressor owns a complete
+        # checkpoint (including its persisted cooldown); plugin compressors
+        # that do not expose this optional API simply retain their historical
+        # behavior.
+        _checkpoint_compressor = getattr(
+            type(agent.context_compressor), "checkpoint_compression_transaction", None
+        )
+        _rollback_compressor = getattr(
+            type(agent.context_compressor), "rollback_compression_transaction", None
+        )
+        _compression_transaction = (
+            _checkpoint_compressor(agent.context_compressor)
+            if callable(_checkpoint_compressor) and callable(_rollback_compressor)
+            else None
+        )
+
         messages_before_compression = copy.deepcopy(messages)
+        # The in-place flush baseline is identity-based. Preserve the caller's
+        # original dict objects as well as their value snapshot: an abort that
+        # did not mutate messages must not replace those objects with deep
+        # copies, or a prior compacted baseline will append them again.
+        _messages_before_compression_identities = list(messages)
+        _rollback_attempted = False
+        _rollback_failure: Optional[RuntimeError] = None
+
+        def _rollback_unpublished_compression(
+            *, preserve_failure_outcome: bool = False
+        ) -> None:
+            """Undo speculative compression state before a durable boundary.
+
+            A failed rollback is not a no-op: callers must stop rather than
+            continue with unknown compressor/cooldown state.
+            """
+            nonlocal _rollback_attempted, _rollback_failure
+            if _rollback_attempted:
+                if _rollback_failure is not None:
+                    raise _rollback_failure
+                return
+            _rollback_attempted = True
+            # Restore values *into* the original objects before restoring the
+            # original list references. Flush baselines deliberately compare
+            # message identities after an in-place compaction; replacing a
+            # polluted compacted dict with a deep copy would make its already
+            # durable row look new and append it a second time. Dict/list
+            # message shapes are recoverable in place; uncommon scalar/custom
+            # entries fall back to a copied snapshot at that position.
+            restored_refs = []
+            for original, snapshot in zip(
+                _messages_before_compression_identities,
+                messages_before_compression,
+            ):
+                if isinstance(original, dict) and isinstance(snapshot, dict):
+                    original.clear()
+                    original.update(copy.deepcopy(snapshot))
+                    restored_refs.append(original)
+                elif isinstance(original, list) and isinstance(snapshot, list):
+                    original[:] = copy.deepcopy(snapshot)
+                    restored_refs.append(original)
+                else:
+                    restored_refs.append(copy.deepcopy(snapshot))
+            messages[:] = restored_refs
+            if _compression_transaction is None:
+                return
+            try:
+                _rollback_kwargs = {}
+                try:
+                    if (
+                        preserve_failure_outcome
+                        and "preserve_failure_outcome"
+                        in inspect.signature(_rollback_compressor).parameters
+                    ):
+                        _rollback_kwargs["preserve_failure_outcome"] = True
+                except (TypeError, ValueError):
+                    pass
+                _rollback_compressor(
+                    agent.context_compressor,
+                    _compression_transaction,
+                    **_rollback_kwargs,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Compression rollback failed; refusing to claim a no-op "
+                    "for session=%s",
+                    agent.session_id or "none",
+                    exc_info=True,
+                )
+                _rollback_failure = RuntimeError(
+                    "compression rollback failed; compressor state may be stale"
+                )
+                raise _rollback_failure from exc
+
         _activity_heartbeat = _CompressionActivityHeartbeat(agent).start()
         # Publish forward progress to the commit fence while the summary LLM
         # call streams. Async hosts (gateway session hygiene) poll
@@ -1813,6 +1944,19 @@ def compress_context(
         if _activity_heartbeat is not None:
             _activity_heartbeat.stop("context compression failed")
             _activity_heartbeat = None
+        if _rollback_unpublished_compression is not None:
+            try:
+                _rollback_unpublished_compression()
+            except RuntimeError:
+                _release_lock()
+                _emit_compression_attempt_telemetry(
+                    agent,
+                    started_at=_attempt_started_at,
+                    commit_status="rollback_failed",
+                    split_status="aborted",
+                    failure_class="rollback_failed",
+                )
+                raise
         _release_lock()
         _emit_compression_attempt_telemetry(
             agent,
@@ -1847,6 +1991,9 @@ def compress_context(
         if getattr(agent.context_compressor, "_last_compress_aborted", False):
             try:
                 _err = getattr(agent.context_compressor, "_last_summary_error", None) or "unknown error"
+                _rollback_unpublished_compression(
+                    preserve_failure_outcome=True
+                )
                 if getattr(agent, "_last_compression_summary_warning", None) != _err:
                     agent._last_compression_summary_warning = _err
                     agent._emit_warning(
@@ -1876,8 +2023,7 @@ def compress_context(
         # the live list while returning an unchanged snapshot. Neither case may
         # rotate or rewrite the session.
         if compressed == messages_before_compression:
-            if messages != messages_before_compression:
-                messages[:] = copy.deepcopy(messages_before_compression)
+            _rollback_unpublished_compression()
             logger.info(
                 "Compression made no progress (session=%s) — skipping boundary rewrite.",
                 agent.session_id or "none",
@@ -1901,6 +2047,7 @@ def compress_context(
                 "rotate session=%s so the parent remains resumable",
                 agent.session_id or "none",
             )
+            _rollback_unpublished_compression()
             try:
                 agent._emit_warning(
                     "⚠ Compression returned an empty transcript. "
@@ -1922,6 +2069,7 @@ def compress_context(
                     "(session=%s).",
                     agent.session_id or "none",
                 )
+                _rollback_unpublished_compression()
                 agent._last_compaction_in_place = False
                 _existing_sp = getattr(agent, "_cached_system_prompt", None)
                 if not _existing_sp:
@@ -2015,6 +2163,12 @@ def compress_context(
         _ensure_compressed_has_user_turn(messages, compressed)
 
         cached_system_prompt = agent._cached_system_prompt
+        _cached_system_prompt_static = getattr(
+            agent, "_cached_system_prompt_static", None
+        )
+        _static_rebuild_failed_for = getattr(
+            agent, "_static_rebuild_failed_for", None
+        )
         agent._invalidate_system_prompt()
 
         # Built-in memory is the only system-prompt input that a normal
@@ -2056,12 +2210,6 @@ def compress_context(
         if agent._session_db:
             split_status = "pending"
             try:
-                # Trigger memory extraction on the current session before the
-                # transcript is rewritten (runs in BOTH modes — the logical
-                # conversation's pre-compaction turns are about to be summarized
-                # away regardless of whether the id rotates).
-                agent.commit_memory_session(messages)
-
                 if in_place:
                     # ── In-place compaction: keep the same session_id ──────────
                     # No end_session, no new row, no parent_session_id, no title
@@ -2081,8 +2229,25 @@ def compress_context(
                     # for search/recovery (Teknium review — keep one durable id
                     # WITHOUT destroying history, unlike a hard replace_messages).
                     # See #38763.
-                    agent._session_db.archive_and_compact(agent.session_id, compressed)
+                    agent._session_db.archive_and_compact(
+                        agent.session_id,
+                        compressed,
+                        system_prompt=new_system_prompt,
+                    )
+                    # The atomic rewrite is the durable commit point. Do not
+                    # notify memory providers before it succeeds: their
+                    # on_session_end hooks can have irreversible side effects,
+                    # so a failed archive must remain a complete no-op.
                     split_status = "in_place_committed"
+                    _session_commit_succeeded = True
+                    try:
+                        agent.commit_memory_session(messages)
+                    except Exception:
+                        # The durable boundary already exists. Memory hooks are
+                        # external side effects and cannot roll it back.
+                        logger.exception(
+                            "memory commit failed after durable in-place compaction"
+                        )
                     # Reset the flush identity set so the next turn's appends are
                     # diffed against the COMPACTED transcript: the compacted dicts
                     # are passed as conversation_history next turn and skipped by
@@ -2158,6 +2323,19 @@ def compress_context(
                         compression_lock_holder=_lock_holder,
                         require_compression_lease=_lock_holder is not None,
                     )
+                    # Publication is the rotation's durable commit point.
+                    # Commit the old logical session while its id is still
+                    # current, so memory providers see the same old-SID
+                    # semantics as a normal session end. In particular, do
+                    # not invoke on_session_end if publication rolls back.
+                    try:
+                        agent.commit_memory_session(messages)
+                    except Exception:
+                        # Publication already committed atomically; do not
+                        # misclassify it as an aborted rotation.
+                        logger.exception(
+                            "memory commit failed after durable compression rotation"
+                        )
                     agent.session_id = new_session_id
                     try:
                         from gateway.session_context import set_current_session_id
@@ -2190,12 +2368,9 @@ def compress_context(
                         except (ValueError, Exception) as e:
                             logger.debug("Could not propagate title on compression: %s", e)
 
-                # In-place mode still updates/replaces the current row here.
-                # Rotation already published prompt + compacted handoff atomically.
+                # Rotation already published prompt + compacted handoff atomically;
+                # in-place did the same in archive_and_compact's transaction.
                 if in_place:
-                    agent._session_db.update_system_prompt(
-                        agent.session_id, new_system_prompt
-                    )
                     agent._last_flushed_db_idx = 0
                 else:
                     agent._last_flushed_db_idx = len(compressed)
@@ -2235,6 +2410,33 @@ def compress_context(
                     )
                 else:
                     logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
+
+        if split_status in {"aborted", "failed_not_indexed"} and not _session_commit_succeeded:
+            # Neither archive-and-compact nor child publication committed. A
+            # failed rewrite is a complete no-op: restore caller-visible
+            # messages, prompt cache, compressor runtime/durable state, and
+            # return before every boundary callback, event, usage latch, and
+            # file-dedup reset.
+            _rollback_unpublished_compression()
+            compressed = messages
+            _compression_made_progress = False
+            agent._cached_system_prompt = cached_system_prompt
+            agent._cached_system_prompt_static = _cached_system_prompt_static
+            agent._static_rebuild_failed_for = _static_rebuild_failed_for
+            _emit_compression_attempt_telemetry(
+                agent,
+                started_at=_attempt_started_at,
+                commit_status="aborted",
+                split_status="aborted",
+                failure_class=(
+                    "session_split_failed" if not in_place else "in_place_compaction_failed"
+                ),
+            )
+            return messages, (
+                cached_system_prompt
+                if cached_system_prompt is not None
+                else new_system_prompt
+            )
 
         # Compaction-boundary bookkeeping, computed once. `old_session_id` is only
         # bound in the rotation branch; in-place leaves it unset. `_boundary_parent`
@@ -2379,6 +2581,35 @@ def compress_context(
             ),
         )
         return compressed, new_system_prompt
+    except BaseException as _precommit_exc:
+        # Anything after the checkpoint but before a durable transcript
+        # boundary (prompt assembly, todo injection, callback preparation,
+        # etc.) must not leak speculative compressor state. Once durable,
+        # external bookkeeping errors cannot honestly roll the transcript back.
+        if not locals().get("_session_commit_succeeded", False):
+            try:
+                _rollback_unpublished_compression()
+            except RuntimeError:
+                _emit_compression_attempt_telemetry(
+                    agent,
+                    started_at=_attempt_started_at,
+                    commit_status="rollback_failed",
+                    split_status="aborted",
+                    failure_class="rollback_failed",
+                )
+                raise
+            if "cached_system_prompt" in locals():
+                agent._cached_system_prompt = cached_system_prompt
+                agent._cached_system_prompt_static = _cached_system_prompt_static
+                agent._static_rebuild_failed_for = _static_rebuild_failed_for
+            _emit_compression_attempt_telemetry(
+                agent,
+                started_at=_attempt_started_at,
+                commit_status="aborted",
+                split_status="aborted",
+                failure_class=f"exception:{type(_precommit_exc).__name__}",
+            )
+        raise
     finally:
         # Release the lock on the OLD session_id only AFTER rotation completed
         # and all post-rotation bookkeeping (memory manager, context engine,
@@ -2508,10 +2739,10 @@ def _compress_context_via_codex_app_server(
             approx_tokens=approx_tokens,
             force=True,
         )
-        # An empty usage report must consume the pending post-compaction verdict
-        # rather than leaving preflight deferral armed until some unrelated later
-        # Codex turn supplies usage. Minimal external test engines may not expose
-        # the ContextEngine update hook; preserve their existing bookkeeping.
+        # Keep the post-compaction verdict pending across empty/partial usage:
+        # only a later real positive prompt count can prove whether compaction
+        # restored the window below threshold. Minimal external test engines may
+        # not expose the ContextEngine update hook; preserve their bookkeeping.
         if hasattr(agent.context_compressor, "update_from_response"):
             _record_codex_app_server_usage(agent, result)
     except Exception:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -16,6 +16,7 @@ resolved through :func:`_ra` so those patches keep working.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -58,6 +59,16 @@ from agent.message_sanitization import (
     _strip_images_from_messages,
     _strip_non_ascii,
 )
+
+
+def _request_local_llama_cpp_tools(
+    tools: List[Dict[str, Any]],
+) -> tuple[List[Dict[str, Any]], int]:
+    """Return llama.cpp-compatible tools without mutating the agent registry."""
+    from tools.schema_sanitizer import strip_pattern_and_format
+
+    request_tools = copy.deepcopy(tools)
+    return strip_pattern_and_format(request_tools)
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     _estimate_tools_tokens_rough,
@@ -2001,6 +2012,12 @@ def run_conversation(
         api_kwargs = None  # Guard against UnboundLocalError in except handler
         api_request_id = f"{turn_id}:api:{api_call_count}"
         agent._current_api_request_id = api_request_id
+        # A llama.cpp grammar rejection is recovered with a sanitized copy for
+        # this route only.  Never mutate ``agent.tools``: it is the canonical
+        # per-session registry and must remain byte-stable across retries,
+        # provider failover, and later turns.
+        _llama_cpp_tools_override: Optional[List[Dict[str, Any]]] = None
+        _llama_cpp_tools_route: Optional[tuple[str, str, str, str]] = None
 
         while retry_count < max_retries:
             # ── Nous Portal rate limit guard ──────────────────────
@@ -2076,6 +2093,25 @@ def run_conversation(
                     )
                 )
                 api_kwargs = agent._build_api_kwargs(api_messages)
+                if _llama_cpp_tools_override is not None:
+                    _current_tool_route = (
+                        str(getattr(agent, "provider", "") or ""),
+                        str(getattr(agent, "base_url", "") or ""),
+                        str(getattr(agent, "model", "") or ""),
+                        str(getattr(agent, "api_mode", "") or ""),
+                    )
+                    if _current_tool_route == _llama_cpp_tools_route:
+                        # Middleware and provider adapters may sanitize request
+                        # dictionaries in place, so each retry receives its own
+                        # copy of the already-sanitized route-local schema.
+                        api_kwargs["tools"] = copy.deepcopy(
+                            _llama_cpp_tools_override
+                        )
+                    else:
+                        # A fallback/model switch must rebuild from the full
+                        # canonical tool registry for the new route.
+                        _llama_cpp_tools_override = None
+                        _llama_cpp_tools_route = None
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)
                 if agent.api_mode == "codex_responses":
@@ -3137,7 +3173,75 @@ def run_conversation(
                         "cache_write_tokens": canonical_usage.cache_write_tokens,
                         "reasoning_tokens": canonical_usage.reasoning_tokens,
                     }
-                    agent.context_compressor.update_from_response(usage_dict)
+                    # Capture this before update_from_response() consumes it.
+                    # Only a completed compaction boundary arms the latch, so
+                    # an unrelated low-usage response after a failed/no-op
+                    # attempt cannot reopen the retry budget.
+                    _awaiting_compaction_verdict = bool(
+                        getattr(
+                            agent.context_compressor,
+                            "awaiting_real_usage_after_compression",
+                            False,
+                        )
+                    )
+                    # Let the engine observe the armed latch while it processes
+                    # the provider's real usage.  The built-in compressor uses
+                    # that edge to retain the rough-token baseline that proved
+                    # to fit; clearing it first loses the baseline and makes
+                    # hgfast/preflight deferral regress into repeated
+                    # compaction.  A zero/missing prompt count is not a verdict:
+                    # keep the latch armed until the provider supplies a real
+                    # prompt size, including for third-party engines.
+                    # Do not even forward an empty/zero prompt reading to a
+                    # plug-in compressor: unlike the built-in engine, an
+                    # arbitrary ContextEngine may consume its latch whenever
+                    # update_from_response() is called. Session accounting and
+                    # context-length discovery below still process the response.
+                    if prompt_tokens > 0:
+                        agent.context_compressor.update_from_response(usage_dict)
+                        if (
+                            _awaiting_compaction_verdict
+                            and getattr(
+                                agent.context_compressor,
+                                "awaiting_real_usage_after_compression",
+                                False,
+                            )
+                        ):
+                            agent.context_compressor.awaiting_real_usage_after_compression = False
+
+                    # ``compression_attempts`` is a consecutive-recovery
+                    # backstop, not a lifetime quota for the whole tool turn.
+                    # A long-running turn may legitimately regrow past the
+                    # threshold several times. Once the provider proves that a
+                    # completed compaction restored the real prompt below the
+                    # threshold, give a later regrowth a fresh retry budget.
+                    # Without this reset, three effective compactions early in
+                    # a 100-iteration turn permanently disable compression and
+                    # the request can grow into the hard context limit.
+                    _effective_threshold = int(
+                        getattr(
+                            agent.context_compressor,
+                            "threshold_tokens",
+                            0,
+                        )
+                        or 0
+                    )
+                    if (
+                        compression_attempts > 0
+                        and _awaiting_compaction_verdict
+                        and prompt_tokens > 0
+                        and _effective_threshold > 0
+                        and prompt_tokens < _effective_threshold
+                    ):
+                        logger.info(
+                            "Compression retry budget reset after provider "
+                            "confirmed prompt recovery: %s < %s tokens",
+                            f"{prompt_tokens:,}",
+                            f"{_effective_threshold:,}",
+                        )
+                        compression_attempts = 0
+                        _preflight_compression_blocked = False
+                        _last_preflight_pressure = None
 
                     # Stash this response's canonical usage so the post-turn
                     # on_turn_complete() observation hook can forward it (the
@@ -3146,18 +3250,6 @@ def run_conversation(
                     # of interest is the cost/size of the latest assembled
                     # request, so we keep the most recent call's usage.
                     agent._last_turn_usage = dict(usage_dict)
-                elif getattr(
-                    agent.context_compressor,
-                    "awaiting_real_usage_after_compression",
-                    False,
-                ):
-                    # A response with no usage cannot adjudicate whether the
-                    # prior compaction cleared the threshold. Consume the pending
-                    # verdict now so a much later, unrelated reading is not
-                    # charged to that old compaction, and so preflight deferral
-                    # does not remain latched indefinitely.
-                    agent.context_compressor.update_from_response({})
-
                 if hasattr(response, 'usage') and response.usage:
                     # Cache discovered context length after successful call.
                     # Only persist limits confirmed by the provider (parsed
@@ -4004,8 +4096,8 @@ def run_conversation(
                 # regex escape classes (``\d``, ``\w``, ``\s``) and most
                 # ``format`` values in tool schemas.  MCP servers emit
                 # these routinely for date/phone/email params.  Recovery:
-                # strip ``pattern``/``format`` from ``agent.tools`` and
-                # retry once.  We keep the keywords by default so cloud
+                # strip ``pattern``/``format`` from a request-local copy and
+                # retry once.  We keep the canonical registry intact so cloud
                 # providers get the full prompting hints; this branch
                 # fires only for users on llama.cpp's OAI server.
                 if (
@@ -4014,13 +4106,23 @@ def run_conversation(
                 ):
                     _retry.llama_cpp_grammar_retry_attempted = True
                     try:
-                        from tools.schema_sanitizer import strip_pattern_and_format
-                        _, _stripped = strip_pattern_and_format(agent.tools)
+                        (
+                            _llama_cpp_tools_override,
+                            _stripped,
+                        ) = _request_local_llama_cpp_tools(agent.tools)
+                        _llama_cpp_tools_route = (
+                            str(getattr(agent, "provider", "") or ""),
+                            str(getattr(agent, "base_url", "") or ""),
+                            str(getattr(agent, "model", "") or ""),
+                            str(getattr(agent, "api_mode", "") or ""),
+                        )
                     except Exception as _strip_exc:  # pragma: no cover — defensive
                         logger.warning(
                             "%sllama.cpp grammar recovery: strip helper failed: %s",
                             agent.log_prefix, _strip_exc,
                         )
+                        _llama_cpp_tools_override = None
+                        _llama_cpp_tools_route = None
                         _stripped = 0
                     if _stripped:
                         agent._vprint(
@@ -4030,7 +4132,7 @@ def run_conversation(
                         )
                         logger.warning(
                             "%sllama.cpp grammar recovery: stripped %d "
-                            "pattern/format keyword(s) from tool schemas",
+                            "pattern/format keyword(s) from request-local tool schemas",
                             agent.log_prefix, _stripped,
                         )
                         continue

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -7,6 +7,7 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 import json
 import logging
 import os
+import stat
 import sys
 import threading
 import contextvars
@@ -27,9 +28,11 @@ from agent.skill_utils import (
     extract_skill_description,
     get_all_skills_dirs,
     get_disabled_skill_names,
+    get_skill_environment_fingerprint,
     iter_skill_index_files,
     org_id_of_path,
     parse_frontmatter,
+    read_strict_skill_index_file,
     read_active_org_id,
     skill_matches_environment,
     skill_matches_platform,
@@ -1346,9 +1349,9 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-# v2: entries gained org provenance fields (org_id/org_author/rel_dir) for M2
-# org-shared skills; older snapshots are discarded and rebuilt.
-_SKILLS_SNAPSHOT_VERSION = 2
+# v3 retains org provenance fields and adds strict scan semantics; older
+# snapshots are discarded and rebuilt.
+_SKILLS_SNAPSHOT_VERSION = 3
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1366,7 +1369,7 @@ def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
             logger.debug("Could not remove skills prompt snapshot: %s", e)
 
 
-def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
+def _build_skills_manifest(skills_dir: Path, *, on_error=None) -> dict[str, list[int]]:
     """Build an mtime/size manifest of all SKILL.md and DESCRIPTION.md files.
 
     Org mirrors (M2): only the ACTIVE org's mirror participates, and the
@@ -1387,7 +1390,7 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
         ]
     except OSError:
         pass
-    for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
+    for root, dirs, files in os.walk(skills_dir_str, followlinks=True, onerror=on_error):
         has_skill_md = "SKILL.md" in files
         if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
             dirs.remove(ORG_MIRROR_DIR_NAME)
@@ -1402,16 +1405,19 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
         for filename in ("SKILL.md", "DESCRIPTION.md"):
             if filename not in files:
                 continue
-            path = os.path.join(root, filename)
+            path = Path(os.path.join(root, filename))
             try:
-                st = os.stat(path)
-            except OSError:
+                st = path.stat()
+                relative_path = path.relative_to(skills_dir).as_posix()
+            except (OSError, ValueError) as exc:
+                if on_error is not None:
+                    on_error(exc)
                 continue
-            manifest[path[prefix_len:]] = [st.st_mtime_ns, st.st_size]
+            manifest[relative_path] = [st.st_mtime_ns, st.st_size]
     return manifest
 
 
-def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
+def _load_skills_snapshot(skills_dir: Path, *, on_error=None) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
     if not snapshot_path.exists():
@@ -1424,7 +1430,25 @@ def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
         return None
     if snapshot.get("version") != _SKILLS_SNAPSHOT_VERSION:
         return None
-    if snapshot.get("manifest") != _build_skills_manifest(skills_dir):
+    # A profile can switch its skills root without changing HERMES_HOME. Never
+    # reuse the prior root's snapshot merely because a transient scan error
+    # made its manifest unknowable.
+    if snapshot.get("skills_dir") != str(skills_dir):
+        return None
+    scan_errors: list[Exception] = []
+
+    def _record(error) -> None:
+        scan_errors.append(error)
+        if on_error is not None:
+            on_error(error)
+
+    manifest = _build_skills_manifest(skills_dir, on_error=_record)
+    if scan_errors:
+        # The on-disk data is a same-scope, previously complete snapshot. It
+        # is safer than committing or rendering a newly discovered partial
+        # catalog while a directory/file is temporarily unreadable.
+        return snapshot
+    if snapshot.get("manifest") != manifest:
         return None
     return snapshot
 
@@ -1438,6 +1462,7 @@ def _write_skills_snapshot(
     """Persist skill metadata to disk for fast cold-start reuse."""
     payload = {
         "version": _SKILLS_SNAPSHOT_VERSION,
+        "skills_dir": str(skills_dir),
         "manifest": manifest,
         "skills": skill_entries,
         "category_descriptions": category_descriptions,
@@ -1476,6 +1501,9 @@ def _build_snapshot_entry(
     platforms = frontmatter.get("platforms") or []
     if isinstance(platforms, str):
         platforms = [platforms]
+    environments = frontmatter.get("environments") or []
+    if not isinstance(environments, list):
+        environments = [environments]
 
     entry = {
         "skill_name": skill_name,
@@ -1483,6 +1511,11 @@ def _build_snapshot_entry(
         "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
+        "environments": [
+            str(environment).strip()
+            for environment in environments
+            if str(environment).strip()
+        ],
         "conditions": extract_skill_conditions(frontmatter),
     }
     if org_id:
@@ -1507,15 +1540,18 @@ def _build_snapshot_entry(
 # Skills index
 # =========================================================================
 
-def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
+def _parse_skill_file(
+    skill_file: Path, *, on_error=None, fail_closed: bool = False
+) -> tuple[bool, dict | None, str]:
     """Read a SKILL.md once and return platform compatibility, frontmatter, and description.
 
-    Returns (is_compatible, frontmatter, description). On any error, returns
-    (True, {}, "") to err on the side of showing the skill.
+    Returns (is_compatible, frontmatter, description). Direct callers retain
+    the historic permissive error value; active discovery passes
+    ``fail_closed=True`` so malformed fenced YAML and canonical-entry
+    symlinks cannot be advertised or saved in a prompt snapshot.
     """
     try:
-        raw = skill_file.read_text(encoding="utf-8")
-        frontmatter, _ = parse_frontmatter(raw)
+        _, frontmatter, _ = read_strict_skill_index_file(skill_file)
 
         if not skill_matches_platform(frontmatter):
             return False, frontmatter, ""
@@ -1530,7 +1566,9 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
         return True, frontmatter, extract_skill_description(frontmatter)
     except Exception as e:
         logger.warning("Failed to parse skill file %s: %s", skill_file, e)
-        return True, {}, ""
+        if on_error is not None:
+            on_error(e)
+        return (False, None, "") if fail_closed else (True, {}, "")
 
 
 def _skill_should_show(
@@ -1584,6 +1622,7 @@ def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
+    prompt_index_mode: str = "full",
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1604,11 +1643,41 @@ def build_skills_system_prompt(
     the rendered index. Nothing is ever hidden: every skill name stays
     visible and loadable via ``skill_view`` / ``skills_list``; only the
     descriptions are dropped, and a footer note explains the demotion.
+
+    ``prompt_index_mode="category_compact"`` applies that treatment to every
+    category while preserving category descriptions and the full
+    ``hermes-agent`` routing anchor. This keeps all skill names discoverable
+    without injecting every long description into every conversation.
     """
+    prompt_index_mode = str(prompt_index_mode or "full").strip().lower()
+    if prompt_index_mode not in {"full", "category_compact"}:
+        logger.warning(
+            "Unknown skills.prompt_index_mode=%r; using full",
+            prompt_index_mode,
+        )
+        prompt_index_mode = "full"
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
 
-    if not skills_dir.exists() and not external_dirs:
+    # Do not use ``Path.exists()`` for a selected root: it suppresses
+    # PermissionError and can make an incomplete catalog look like a valid
+    # empty one.  A missing local root is the ordinary first-run case; a
+    # missing configured external root is handled below once the full cache
+    # scope has been assembled.
+    try:
+        local_root_stat = skills_dir.stat()
+    except FileNotFoundError:
+        local_root_missing = True
+    except OSError as exc:
+        logger.debug("Local skills root is inaccessible: %s", exc)
+        return ""
+    else:
+        if not stat.S_ISDIR(local_root_stat.st_mode):
+            logger.debug("Local skills root is not a directory: %s", skills_dir)
+            return ""
+        local_root_missing = False
+
+    if local_root_missing and not external_dirs:
         return ""
 
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
@@ -1622,17 +1691,53 @@ def build_skills_system_prompt(
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
+        get_skill_environment_fingerprint(),
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        prompt_index_mode,
     )
+
+    # External roots are part of the cache scope.  Validate them before an LRU
+    # lookup so a root deleted after a prior complete render cannot return a
+    # stale local+external prompt.  Treat FileNotFoundError as incomplete too:
+    # the root was present when this scope was resolved, and omitting it would
+    # turn the result into a silently partial catalog.
+    root_error = None
+    for external_dir in external_dirs:
+        try:
+            external_stat = external_dir.stat()
+        except OSError as exc:
+            root_error = exc
+            break
+        if not stat.S_ISDIR(external_stat.st_mode):
+            root_error = NotADirectoryError(
+                f"External skills root is not a directory: {external_dir}"
+            )
+            break
+    if root_error is not None:
+        logger.debug("External skills root is inaccessible: %s", root_error)
+        with _SKILLS_PROMPT_CACHE_LOCK:
+            _SKILLS_PROMPT_CACHE.pop(cache_key, None)
+        return ""
+
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
         if cached is not None:
             _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
             return cached
 
+    # Every cacheable scan reports traversal, stat, read, and parse errors.
+    # A scan that has omitted even one path is not a valid replacement for a
+    # previous catalog: do not write it to disk or the in-process LRU.
+    scan_incomplete = False
+
+    def _mark_scan_incomplete(error) -> None:
+        nonlocal scan_incomplete
+        scan_incomplete = True
+        logger.debug("Skills prompt scan incomplete: %s", error)
+
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    snapshot = _load_skills_snapshot(skills_dir, on_error=_mark_scan_incomplete)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
@@ -1651,6 +1756,10 @@ def build_skills_system_prompt(
             platforms = entry.get("platforms") or []
             if not skill_matches_platform_list(platforms):
                 continue
+            if not skill_matches_environment(
+                {"environments": entry.get("environments") or []}
+            ):
+                continue
             if frontmatter_name in disabled or skill_name in disabled:
                 continue
             if not _skill_should_show(
@@ -1666,9 +1775,24 @@ def build_skills_system_prompt(
         }
     else:
         # Cold path: full filesystem scan + write snapshot for next time
-        for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
-            is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
-            entry = _build_snapshot_entry(skill_file, skills_dir, frontmatter, desc)
+        skill_entries: list[dict] = []
+        for skill_file in iter_skill_index_files(
+            skills_dir, "SKILL.md", on_error=_mark_scan_incomplete
+        ):
+            try:
+                is_compatible, frontmatter, desc = _parse_skill_file(
+                    skill_file, on_error=_mark_scan_incomplete, fail_closed=True
+                )
+                entry = _build_snapshot_entry(
+                    skill_file, skills_dir, frontmatter or {}, desc
+                )
+            except Exception as exc:
+                _mark_scan_incomplete(exc)
+                continue
+            if frontmatter is None:
+                # Strict read/parse failure: it is not a valid snapshot entry
+                # and must not become visible on the next cache hit.
+                continue
             skill_entries.append(entry)
             if not is_compatible:
                 continue
@@ -1714,7 +1838,9 @@ def build_skills_system_prompt(
     if snapshot is None:
         # (continuation of the cold path below: category descriptions + write)
         # Read category-level DESCRIPTION.md files
-        for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
+        for desc_file in iter_skill_index_files(
+            skills_dir, "DESCRIPTION.md", on_error=_mark_scan_incomplete
+        ):
             try:
                 content = desc_file.read_text(encoding="utf-8")
                 fm, _ = parse_frontmatter(content)
@@ -1726,13 +1852,24 @@ def build_skills_system_prompt(
                 category_descriptions[cat] = str(cat_desc).strip().strip("'\"")
             except Exception as e:
                 logger.debug("Could not read skill description %s: %s", desc_file, e)
+                _mark_scan_incomplete(e)
 
-        _write_skills_snapshot(
-            skills_dir,
-            _build_skills_manifest(skills_dir),
-            skill_entries,
-            category_descriptions,
+        manifest = _build_skills_manifest(
+            skills_dir, on_error=_mark_scan_incomplete
         )
+        if scan_incomplete:
+            # No prior valid snapshot exists (otherwise _load would have used
+            # it). Do not let a transient permissions/race failure create a
+            # partial prompt catalog.
+            skills_by_category = {}
+            category_descriptions = {}
+        else:
+            _write_skills_snapshot(
+                skills_dir,
+                manifest,
+                skill_entries,
+                category_descriptions,
+            )
 
     # ── External skill directories ─────────────────────────────────────
     # Scan external dirs directly (no snapshot caching — they're read-only
@@ -1743,12 +1880,43 @@ def build_skills_system_prompt(
         for name, _desc in cat_skills:
             seen_skill_names.add(name)
 
+    external_skills: dict[str, list[tuple[str, str]]] = {}
+    external_descriptions: dict[str, str] = {}
+
+    def _mark_external_scan_incomplete(error) -> None:
+        _mark_scan_incomplete(error)
+
     for ext_dir in external_dirs:
-        if not ext_dir.exists():
+        try:
+            external_stat = ext_dir.stat()
+        except FileNotFoundError:
+            # The configured root was selected into this scope but disappeared
+            # during the scan.  Do not let the local snapshot masquerade as a
+            # complete local+external index; a later config resolution with a
+            # new root set can safely build a new scope.
+            _mark_external_scan_incomplete(
+                FileNotFoundError(f"External skills root disappeared: {ext_dir}")
+            )
             continue
-        for skill_file in iter_skill_index_files(ext_dir, "SKILL.md"):
+        except OSError as exc:
+            _mark_external_scan_incomplete(exc)
+            continue
+        if not stat.S_ISDIR(external_stat.st_mode):
+            _mark_external_scan_incomplete(
+                NotADirectoryError(
+                    f"External skills root is not a directory: {ext_dir}"
+                )
+            )
+            continue
+        for skill_file in iter_skill_index_files(
+            ext_dir, "SKILL.md", on_error=_mark_external_scan_incomplete
+        ):
             try:
-                is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
+                is_compatible, frontmatter, desc = _parse_skill_file(
+                    skill_file,
+                    on_error=_mark_external_scan_incomplete,
+                    fail_closed=True,
+                )
                 if not is_compatible:
                     continue
                 entry = _build_snapshot_entry(skill_file, ext_dir, frontmatter, desc)
@@ -1765,14 +1933,17 @@ def build_skills_system_prompt(
                 ):
                     continue
                 seen_skill_names.add(frontmatter_name)
-                skills_by_category.setdefault(entry["category"], []).append(
+                external_skills.setdefault(entry["category"], []).append(
                     (frontmatter_name, entry["description"])
                 )
             except Exception as e:
                 logger.debug("Error reading external skill %s: %s", skill_file, e)
+                _mark_external_scan_incomplete(e)
 
         # External category descriptions
-        for desc_file in iter_skill_index_files(ext_dir, "DESCRIPTION.md"):
+        for desc_file in iter_skill_index_files(
+            ext_dir, "DESCRIPTION.md", on_error=_mark_external_scan_incomplete
+        ):
             try:
                 content = desc_file.read_text(encoding="utf-8")
                 fm, _ = parse_frontmatter(content)
@@ -1781,9 +1952,28 @@ def build_skills_system_prompt(
                     continue
                 rel = desc_file.relative_to(ext_dir)
                 cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
-                category_descriptions.setdefault(cat, str(cat_desc).strip().strip("'\""))
+                external_descriptions.setdefault(cat, str(cat_desc).strip().strip("'\""))
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
+                _mark_external_scan_incomplete(e)
+
+    # External directories have no disk snapshot. Keep their changes staged
+    # until every configured external scan is complete so a failed directory
+    # cannot create a partial prompt or poison its LRU entry.
+    if not scan_incomplete:
+        for category, entries in external_skills.items():
+            skills_by_category.setdefault(category, []).extend(entries)
+        for category, description in external_descriptions.items():
+            category_descriptions.setdefault(category, description)
+    elif external_dirs:
+        # The disk snapshot deliberately covers only the writable local root.
+        # If an external root fails, rendering that local snapshot alone would
+        # still be a partial result for this full (local + external) scope.
+        # An exact full-scope LRU entry would already have been returned above;
+        # with no such entry, fail closed instead of advertising a catalog that
+        # silently omitted externally configured skills.
+        skills_by_category = {}
+        category_descriptions = {}
 
     # Posture-driven category demotion (e.g. non-coding skills while pairing
     # on code). Demoted categories stay in the index as a single names-only
@@ -1794,13 +1984,23 @@ def build_skills_system_prompt(
     # what the index stops showing them. Match on the top-level category
     # segment so nested categories ("social-media/twitter") are demoted with
     # their parent.
-    demoted = frozenset(
-        cat for cat in skills_by_category
-        if cat.split("/", 1)[0] in (compact_categories or frozenset())
-    )
+    if prompt_index_mode == "category_compact":
+        demoted = frozenset(skills_by_category)
+    else:
+        demoted = frozenset(
+            cat for cat in skills_by_category
+            if cat.split("/", 1)[0] in (compact_categories or frozenset())
+        )
 
     hidden_note = ""
-    if demoted:
+    if prompt_index_mode == "category_compact" and demoted:
+        hidden_note = (
+            "\n(The skill index is category-compact: every skill name remains "
+            "visible, while ordinary descriptions load on demand. Use "
+            "skills_list(category='...') to inspect a category, then "
+            "skill_view(name='...') before following a skill.)"
+        )
+    elif demoted:
         hidden_note = (
             "\n(Categories marked [names only] are outside the current coding "
             "context, so their descriptions are omitted — the skills work "
@@ -1815,8 +2015,32 @@ def build_skills_system_prompt(
             # Deduplicate and sort skills within each category
             seen = set()
             if category in demoted:
-                names = sorted({name for name, _ in skills_by_category[category]})
-                index_lines.append(f"  {category} [names only]: {', '.join(names)}")
+                entries = sorted(
+                    set(skills_by_category[category]), key=lambda item: item[0]
+                )
+                if prompt_index_mode == "category_compact":
+                    cat_desc = category_descriptions.get(category, "")
+                    index_lines.append(
+                        f"  {category}:"
+                        + (f" {cat_desc}" if cat_desc else "")
+                    )
+                    ordinary_names = [
+                        name for name, _ in entries if name != "hermes-agent"
+                    ]
+                    if ordinary_names:
+                        index_lines.append(
+                            f"    [names only]: {', '.join(ordinary_names)}"
+                        )
+                    for name, desc in entries:
+                        if name == "hermes-agent":
+                            index_lines.append(
+                                f"    - {name}" + (f": {desc}" if desc else "")
+                            )
+                else:
+                    names = [name for name, _ in entries]
+                    index_lines.append(
+                        f"  {category} [names only]: {', '.join(names)}"
+                    )
                 continue
             cat_desc = category_descriptions.get(category, "")
             if cat_desc:
@@ -1831,6 +2055,15 @@ def build_skills_system_prompt(
                     index_lines.append(f"    - {name}: {desc}")
                 else:
                     index_lines.append(f"    - {name}")
+
+        maintenance_guidance = ""
+        if available_tools is None or "skill_manage" in available_tools:
+            maintenance_guidance = (
+                "If a skill has issues, fix it with skill_manage(action='patch').\n"
+                "After difficult/iterative tasks, offer to save as a skill. "
+                "If a skill you loaded was missing steps, had wrong commands, or needed "
+                "pitfalls you discovered, update it before finishing.\n"
+            )
 
         result = (
             "## Skills (mandatory)\n"
@@ -1849,25 +2082,23 @@ def build_skills_system_prompt(
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
             "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
             "`hermes setup`) so you don't have to guess or invent workarounds.\n"
-            "If a skill has issues, fix it with skill_manage(action='patch').\n"
-            "After difficult/iterative tasks, offer to save as a skill. "
-            "If a skill you loaded was missing steps, had wrong commands, or needed "
-            "pitfalls you discovered, update it before finishing.\n"
-            "\n"
-            "<available_skills>\n"
+            + maintenance_guidance
+            + "\n"
+            + "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            + "</available_skills>\n"
+            + "\n"
+            + "Only proceed without loading a skill if genuinely none are relevant to the task."
             + hidden_note
         )
 
     # ── Store in LRU cache ────────────────────────────────────────────
-    with _SKILLS_PROMPT_CACHE_LOCK:
-        _SKILLS_PROMPT_CACHE[cache_key] = result
-        _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
-        while len(_SKILLS_PROMPT_CACHE) > _SKILLS_PROMPT_CACHE_MAX:
-            _SKILLS_PROMPT_CACHE.popitem(last=False)
+    if not scan_incomplete:
+        with _SKILLS_PROMPT_CACHE_LOCK:
+            _SKILLS_PROMPT_CACHE[cache_key] = result
+            _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
+            while len(_SKILLS_PROMPT_CACHE) > _SKILLS_PROMPT_CACHE_MAX:
+                _SKILLS_PROMPT_CACHE.popitem(last=False)
 
     return result
 

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -8,6 +8,8 @@ import json
 import logging
 import os
 import re
+import stat
+import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -22,6 +24,16 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+_skill_commands_environment: tuple[tuple[str, bool], ...] | None = None
+# The catalog also depends on the active profile's local skills root and its
+# configured external roots.  Keep that part separate from the historical
+# platform/environment fields so older integrations that inspect those fields
+# retain their meaning.
+_skill_commands_roots: tuple[str, ...] | None = None
+# A gateway can serve distinct profile ContextVars concurrently.  Serialise the
+# resolve -> walk -> commit sequence so one request cannot commit a catalog
+# under another request's scope while it is still scanning.
+_skill_commands_lock = threading.RLock()
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -189,6 +201,86 @@ def _resolve_skill_commands_platform() -> Optional[str]:
         resolved_platform = os.getenv("HERMES_PLATFORM")
     return resolved_platform or None
 
+
+def _resolve_skill_commands_environment() -> tuple[tuple[str, bool], ...]:
+    """Return the offer-time environment state used by the slash catalog."""
+    try:
+        from agent.skill_utils import get_skill_environment_fingerprint
+
+        return get_skill_environment_fingerprint()
+    except Exception:
+        return ()
+
+
+def _canonical_skill_root(path: Path) -> str:
+    """Return a stable, comparison-safe spelling of a configured root."""
+    try:
+        return str(path.expanduser().resolve())
+    except (OSError, RuntimeError):
+        return str(path.expanduser().absolute())
+
+
+def _resolve_skill_command_roots() -> tuple[Path, tuple[Path, ...], tuple[str, ...]]:
+    """Snapshot the live local and external roots for one catalog scan.
+
+    ``tools.skills_tool.SKILLS_DIR`` is a legacy import-time compatibility
+    attribute.  Its ``_skills_dir()`` helper resolves the active
+    profile/HERMES_HOME at call time (while continuing to honour patched
+    ``SKILLS_DIR`` in tests and integrations), so slash discovery must use it
+    too.  Return the actual paths alongside their fingerprint to ensure the
+    scan walks exactly the roots it compared and later commits.
+    """
+    from agent.skill_utils import get_external_skills_dirs
+    from tools.skills_tool import _skills_dir
+
+    primary_root = Path(_skills_dir())
+    external_roots = tuple(Path(path) for path in get_external_skills_dirs())
+    roots = (primary_root, *external_roots)
+    return primary_root, external_roots, tuple(
+        _canonical_skill_root(root) for root in roots
+    )
+
+
+def _skill_command_roots_are_accessible(
+    primary_root: Path, external_roots: tuple[Path, ...]
+) -> bool:
+    """Return whether a cached catalog can still describe this exact root scope.
+
+    A missing *primary* root is the normal empty-local-skills case.  Every
+    other error, and a missing configured external root, means this call cannot
+    prove that its catalog is complete.  In particular, ``Path.exists()`` is
+    deliberately not used here because it turns permission failures into
+    ``False`` and would let an external-only catalog replace or reuse a
+    complete one.
+    """
+    try:
+        primary_stat = primary_root.stat()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("Primary skill root is inaccessible: %s", exc)
+        return False
+    else:
+        if not stat.S_ISDIR(primary_stat.st_mode):
+            logger.warning("Primary skill root is not a directory: %s", primary_root)
+            return False
+
+    for external_root in external_roots:
+        try:
+            external_stat = external_root.stat()
+        except OSError as exc:
+            # An external root was part of this resolved scope.  Treat removal
+            # the same as denial: returning a cached map would advertise skills
+            # that may no longer be available.
+            logger.warning("External skill root is inaccessible: %s", exc)
+            return False
+        if not stat.S_ISDIR(external_stat.st_mode):
+            logger.warning(
+                "External skill root is not a directory: %s", external_root
+            )
+            return False
+    return True
+
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
     """Load a skill by name/path and return (loaded_payload, skill_dir, display_name)."""
     raw_identifier = (skill_identifier or "").strip()
@@ -196,14 +288,17 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         return None
 
     try:
-        from tools.skills_tool import SKILLS_DIR, skill_view
+        from tools.skills_tool import _skills_dir, skill_view
         from agent.skill_utils import normalize_skill_lookup_name
 
         normalized = normalize_skill_lookup_name(raw_identifier)
 
-        loaded_skill = json.loads(
-            skill_view(normalized, task_id=task_id, preprocess=False)
-        )
+        # ``skill_view`` owns the package snapshot for every modern skill.
+        # Keep preprocessing there too: it can expand inline shell while its
+        # dirfd still names the inspected package.  Re-rendering below with a
+        # ``Path`` would reopen a directory an attacker could replace after
+        # this call returned (slash, stacked, and preload all use this path).
+        loaded_skill = json.loads(skill_view(normalized, task_id=task_id))
     except Exception:
         return None
 
@@ -222,7 +317,7 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         skill_dir = Path(abs_skill_dir)
     elif skill_path:
         try:
-            skill_dir = SKILLS_DIR / Path(skill_path).parent
+            skill_dir = _skills_dir() / Path(skill_path).parent
         except Exception:
             skill_dir = None
 
@@ -277,25 +372,27 @@ def _build_skill_message(
     session_id: str | None = None,
 ) -> str:
     """Format a loaded skill into a user/system message payload."""
-    from tools.skills_tool import SKILLS_DIR
+    from tools.skills_tool import _skills_dir
 
     content = str(loaded_skill.get("content") or "")
 
-    # ── Template substitution and inline-shell expansion ──
-    # Done before anything else so downstream blocks (setup notes,
-    # supporting-file hints) see the expanded content.
-    skills_cfg = _load_skills_config()
-    if skills_cfg.get("template_vars", True):
-        content = _substitute_template_vars(content, skill_dir, session_id)
-    if skills_cfg.get("inline_shell", False):
-        timeout = int(skills_cfg.get("inline_shell_timeout", 10) or 10)
-        content = _expand_inline_shell(content, skill_dir, timeout)
+    # Modern skill_view payloads were rendered while their package dirfd was
+    # bound to the discovery snapshot.  Do not use the returned path to run
+    # inline shell after that fd has been closed.  Keep this legacy fallback
+    # for integrations which construct a payload directly.
+    if not loaded_skill.get("preprocessed"):
+        skills_cfg = _load_skills_config()
+        if skills_cfg.get("template_vars", True):
+            content = _substitute_template_vars(content, skill_dir, session_id)
+        if skills_cfg.get("inline_shell", False):
+            timeout = int(skills_cfg.get("inline_shell_timeout", 10) or 10)
+            content = _expand_inline_shell(content, skill_dir, timeout)
 
     parts = [activation_note, "", content.strip()]
 
     # ── Inject the absolute skill directory so the agent can reference
     #    bundled scripts without an extra skill_view() round-trip. ──
-    if skill_dir:
+    if skill_dir and not loaded_skill.get("package_bound"):
         parts.append("")
         parts.append(f"[Skill directory: {skill_dir}]")
         parts.append(
@@ -335,18 +432,56 @@ def _build_skill_message(
         if isinstance(entries, list):
             supporting.extend(entries)
 
-    if not supporting and skill_dir:
-        for subdir in ("references", "templates", "scripts", "assets"):
-            subdir_path = skill_dir / subdir
-            if subdir_path.exists():
-                for f in sorted(subdir_path.rglob("*")):
-                    if f.is_file() and not f.is_symlink():
-                        rel = str(f.relative_to(skill_dir))
-                        supporting.append(rel)
+    if not supporting and skill_dir and not loaded_skill.get("package_bound"):
+        try:
+            from tools.skills_tool import build_linked_files_manifest
+
+            linked_files, fallback_summary = build_linked_files_manifest(skill_dir)
+            for entries in linked_files.values():
+                supporting.extend(entries)
+            if not loaded_skill.get("linked_files_summary"):
+                loaded_skill["linked_files_summary"] = fallback_summary
+        except Exception:
+            logger.debug(
+                "Could not build linked-file manifest for %s",
+                skill_dir,
+                exc_info=True,
+            )
 
     if supporting and skill_dir:
+        # A bound package must not advertise mutable absolute paths for direct
+        # execution.  Support files remain readable through a fresh, checked
+        # skill_view request, which binds its own package snapshot.
+        if loaded_skill.get("package_bound"):
+            skill_view_target = str(
+                loaded_skill.get("lookup_name") or loaded_skill.get("name") or "skill"
+            )
+            parts.append("")
+            parts.append("[This skill has supporting files:]")
+            for sf in supporting:
+                parts.append(f"- {sf}")
+            parts.append(
+                f'\nLoad any of these with skill_view(name="{skill_view_target}", '
+                'file_path="<path>").'
+            )
+            linked_summary = loaded_skill.get("linked_files_summary") or {}
+            if linked_summary.get("truncated"):
+                categories = ", ".join(linked_summary.get("truncated_categories") or [])
+                suffix = f" ({categories})" if categories else ""
+                parts.append(
+                    "[Supporting-file preview truncated"
+                    f"{suffix}; use skill_view with an explicit file_path for files "
+                    "not shown.]"
+                )
+            if user_instruction:
+                parts.append("")
+                parts.append(f"The user has provided the following instruction alongside the skill invocation: {user_instruction}")
+            if runtime_note:
+                parts.append("")
+                parts.append(f"[Runtime note: {runtime_note}]")
+            return "\n".join(parts)
         try:
-            skill_view_target = str(skill_dir.relative_to(SKILLS_DIR))
+            skill_view_target = str(skill_dir.relative_to(_skills_dir()))
         except ValueError:
             # Skill is from an external dir — use the skill name instead
             skill_view_target = skill_dir.name
@@ -359,6 +494,15 @@ def _build_skill_message(
             f'file_path="<path>"), or run scripts directly by absolute path '
             f"(e.g. `node {skill_dir}/scripts/foo.js`)."
         )
+        linked_summary = loaded_skill.get("linked_files_summary") or {}
+        if linked_summary.get("truncated"):
+            categories = ", ".join(linked_summary.get("truncated_categories") or [])
+            suffix = f" ({categories})" if categories else ""
+            parts.append(
+                "[Supporting-file preview truncated"
+                f"{suffix}; use skill_view with an explicit file_path for files "
+                "not shown.]"
+            )
 
     if user_instruction:
         parts.append("")
@@ -377,109 +521,206 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands, _skill_commands_platform
-    _skill_commands_platform = _resolve_skill_commands_platform()
-    _skill_commands = {}
-    try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
-        from hermes_cli.commands import resolve_command
-        disabled = _get_disabled_skill_names()
-        seen_names: set = set()
+    global _skill_commands, _skill_commands_platform, _skill_commands_environment, _skill_commands_roots
+    with _skill_commands_lock:
+        resolved_platform = _resolve_skill_commands_platform()
+        resolved_environment = _resolve_skill_commands_environment()
+        try:
+            primary_root, external_roots, resolved_roots = _resolve_skill_command_roots()
+        except Exception:
+            logger.warning(
+                "Skill command root resolution failed; refusing a stale catalog",
+                exc_info=True,
+            )
+            return {}
 
-        # Scan local dir first, then external dirs
-        dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
-        dirs_to_scan.extend(get_external_skills_dirs())
+        previous_scope_matches = (
+            _skill_commands_platform == resolved_platform
+            and _skill_commands_environment == resolved_environment
+            and _skill_commands_roots == resolved_roots
+        )
+        new_commands: Dict[str, Dict[str, Any]] = {}
+        scan_incomplete = False
+        root_scan_failed = False
 
-        for scan_dir in dirs_to_scan:
-            for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
-                    continue
+        def mark_scan_incomplete(error: OSError) -> None:
+            nonlocal scan_incomplete
+            scan_incomplete = True
+            logger.warning("Skill command directory scan was incomplete: %s", error)
+
+        try:
+            from tools.skills_tool import (
+                _get_disabled_skill_names,
+                skill_matches_environment,
+                skill_matches_platform,
+            )
+            from agent.skill_utils import (
+                iter_skill_index_files,
+                read_strict_skill_index_file,
+            )
+            from hermes_cli.commands import resolve_command
+
+            disabled = _get_disabled_skill_names()
+            seen_names: set = set()
+            dirs_to_scan = []
+            try:
+                primary_stat = primary_root.stat()
+            except FileNotFoundError:
+                # A first-run profile need not have created its local skills
+                # directory yet; it is an empty local root, not a partial scan.
+                primary_stat = None
+            except OSError as exc:
+                root_scan_failed = True
+                mark_scan_incomplete(exc)
+                primary_stat = None
+            if primary_stat is not None and stat.S_ISDIR(primary_stat.st_mode):
+                dirs_to_scan.append(primary_root)
+            elif primary_stat is not None:
+                root_scan_failed = True
+                mark_scan_incomplete(
+                    NotADirectoryError(
+                        f"Primary skill root is not a directory: {primary_root}"
+                    )
+                )
+
+            for external_root in external_roots:
                 try:
-                    content = skill_md.read_text(encoding='utf-8')
-                    frontmatter, body = _parse_frontmatter(content)
-                    # Skip skills incompatible with the current OS platform
-                    if not skill_matches_platform(frontmatter):
-                        continue
-                    # Skip skills not relevant to the current runtime env
-                    # (kanban/docker/s6). Offer-time only; explicit load bypasses.
-                    if not skill_matches_environment(frontmatter):
-                        continue
-                    name = frontmatter.get('name', skill_md.parent.name)
-                    if name in seen_names:
-                        continue
-                    # Respect user's disabled skills config
-                    if name in disabled:
-                        continue
-                    description = frontmatter.get('description', '')
-                    if not description:
-                        for line in body.strip().split('\n'):
-                            line = line.strip()
-                            if line and not line.startswith('#'):
-                                description = line[:80]
-                                break
-                    seen_names.add(name)
-                    # Normalize to hyphen-separated slug, stripping
-                    # non-alnum chars (e.g. +, /) to avoid invalid
-                    # Telegram command names downstream.
-                    cmd_name = name.lower().replace(' ', '-').replace('_', '-')
-                    cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)
-                    cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
-                    if not cmd_name:
-                        continue
-                    # Skip if this skill's auto-generated /command collides
-                    # with a core Hermes slash command (name or alias). The
-                    # skill remains fully loadable via /skill <name>.
-                    # Uses resolve_command() so aliases and case variants are
-                    # covered without maintaining a separate cache.
-                    if resolve_command(cmd_name) is not None:
-                        logger.warning(
-                            "Skill %r generates slash command '/%s' which "
-                            "collides with a core Hermes command; skipping "
-                            "auto-registration. Use '/skill %s' instead.",
-                            name, cmd_name, name,
-                        )
-                        continue
-                    # Dedup on the resolved slug, not just the raw name: two
-                    # distinct frontmatter names can normalize to the same
-                    # slug (e.g. "git_helper" vs "git-helper"). First-wins
-                    # preserves local-before-external precedence.
-                    cmd_key = f"/{cmd_name}"
-                    if cmd_key in _skill_commands:
-                        logger.warning(
-                            "Skill %r maps to slash command %s already claimed "
-                            "by %r; keeping the first and skipping this one.",
-                            name, cmd_key, _skill_commands[cmd_key]["name"],
-                        )
-                        continue
-                    _skill_commands[cmd_key] = {
-                        "name": name,
-                        "description": description or f"Invoke the {name} skill",
-                        "skill_md_path": str(skill_md),
-                        "skill_dir": str(skill_md.parent),
-                    }
-                except Exception:
+                    external_stat = external_root.stat()
+                except OSError as exc:
+                    # This path has already been selected into the scope.  A
+                    # concurrent deletion is just as incomplete as a permission
+                    # failure: do not publish an external-only subset.
+                    root_scan_failed = True
+                    mark_scan_incomplete(exc)
                     continue
-    except Exception:
-        pass
-    return _skill_commands
+                if stat.S_ISDIR(external_stat.st_mode):
+                    dirs_to_scan.append(external_root)
+                else:
+                    root_scan_failed = True
+                    mark_scan_incomplete(
+                        NotADirectoryError(
+                            f"External skill root is not a directory: {external_root}"
+                        )
+                    )
+
+            # Walk the exact root snapshot that forms this cache scope.  A
+            # subsequent request with another profile cannot interleave here:
+            # the lock covers both this walk and the final global commit.
+            for scan_dir in dirs_to_scan:
+                for skill_md in iter_skill_index_files(
+                    scan_dir, "SKILL.md", on_error=mark_scan_incomplete
+                ):
+                    if any(
+                        part in {".git", ".github", ".hub", ".archive"}
+                        for part in skill_md.parts
+                    ):
+                        continue
+                    try:
+                        _, frontmatter, body = read_strict_skill_index_file(skill_md)
+                        if not skill_matches_platform(frontmatter):
+                            continue
+                        if not skill_matches_environment(frontmatter):
+                            continue
+                        name = frontmatter.get("name", skill_md.parent.name)
+                        if name in seen_names or name in disabled:
+                            continue
+                        description = frontmatter.get("description", "")
+                        if not description:
+                            for line in body.strip().split("\n"):
+                                line = line.strip()
+                                if line and not line.startswith("#"):
+                                    description = line[:80]
+                                    break
+                        seen_names.add(name)
+                        cmd_name = name.lower().replace(" ", "-").replace("_", "-")
+                        cmd_name = _SKILL_INVALID_CHARS.sub("", cmd_name)
+                        cmd_name = _SKILL_MULTI_HYPHEN.sub("-", cmd_name).strip("-")
+                        if not cmd_name:
+                            continue
+                        if resolve_command(cmd_name) is not None:
+                            logger.warning(
+                                "Skill %r generates slash command '/%s' which "
+                                "collides with a core Hermes command; skipping "
+                                "auto-registration. Use '/skill %s' instead.",
+                                name,
+                                cmd_name,
+                                name,
+                            )
+                            continue
+                        cmd_key = f"/{cmd_name}"
+                        if cmd_key in new_commands:
+                            logger.warning(
+                                "Skill %r maps to slash command %s already claimed "
+                                "by %r; keeping the first and skipping this one.",
+                                name,
+                                cmd_key,
+                                new_commands[cmd_key]["name"],
+                            )
+                            continue
+                        new_commands[cmd_key] = {
+                            "name": name,
+                            "description": description or f"Invoke the {name} skill",
+                            "skill_md_path": str(skill_md),
+                            "skill_dir": str(skill_md.parent),
+                        }
+                    except Exception:
+                        scan_incomplete = True
+                        logger.warning(
+                            "Skipping unreadable skill command source %s",
+                            skill_md,
+                            exc_info=True,
+                        )
+        except Exception:
+            logger.warning(
+                "Skill command scan failed; keeping the previous catalog",
+                exc_info=True,
+            )
+            return _skill_commands if previous_scope_matches else {}
+
+        if root_scan_failed:
+            logger.warning(
+                "Skill command root scan was incomplete; refusing the cached catalog"
+            )
+            return {}
+
+        if scan_incomplete:
+            logger.warning("Skill command scan was incomplete; keeping the previous catalog")
+            return _skill_commands if previous_scope_matches else {}
+
+        _skill_commands = new_commands
+        _skill_commands_platform = resolved_platform
+        _skill_commands_environment = resolved_environment
+        _skill_commands_roots = resolved_roots
+        return _skill_commands
 
 
 def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     """Return the current skill commands mapping (scan first if empty).
 
-    Rescans when the active platform scope changes (e.g. a gateway
-    process serving Telegram and Discord concurrently) so each platform
-    sees its own ``skills.platform_disabled`` view (#14536).
+    Rescans when the active platform scope or offer-time runtime environment
+    changes, so long-lived processes do not retain a stale filtered view.
     """
-    if (
-        not _skill_commands
-        or _skill_commands_platform != _resolve_skill_commands_platform()
-    ):
-        scan_skill_commands()
-    return _skill_commands
+    with _skill_commands_lock:
+        try:
+            primary_root, external_roots, resolved_roots = _resolve_skill_command_roots()
+        except Exception:
+            logger.warning(
+                "Skill command root resolution failed; refusing a stale catalog",
+                exc_info=True,
+            )
+            return {}
+        if not _skill_command_roots_are_accessible(primary_root, external_roots):
+            # Re-run the protected scanner so it records the failure under the
+            # same lock and declines a stale exact-scope cache.
+            return scan_skill_commands()
+        if (
+            not _skill_commands
+            or _skill_commands_platform != _resolve_skill_commands_platform()
+            or _skill_commands_environment != _resolve_skill_commands_environment()
+            or _skill_commands_roots != resolved_roots
+        ):
+            return scan_skill_commands()
+        return _skill_commands
 
 
 def reload_skills() -> Dict[str, Any]:

--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -20,6 +20,8 @@ _INLINE_SHELL_RE = re.compile(r"!`([^`\n]+)`")
 
 # Cap inline-shell output so a runaway command can't blow out the context.
 _INLINE_SHELL_MAX_OUTPUT = 4000
+_INLINE_SHELL_DEFAULT_TIMEOUT = 10
+_INLINE_SHELL_MAX_TIMEOUT = 60
 
 
 def load_skills_config() -> dict:
@@ -36,9 +38,28 @@ def load_skills_config() -> dict:
     return {}
 
 
+def normalize_preprocessing_config(
+    skills_cfg: dict | None,
+) -> tuple[bool, bool, int]:
+    """Return strict, fail-closed preprocessing switches and timeout."""
+    cfg = skills_cfg if isinstance(skills_cfg, dict) else {}
+    template_vars = cfg.get("template_vars", True) is True
+    inline_shell = cfg.get("inline_shell", False) is True
+    raw_timeout = cfg.get(
+        "inline_shell_timeout", _INLINE_SHELL_DEFAULT_TIMEOUT
+    )
+    if isinstance(raw_timeout, bool) or not isinstance(raw_timeout, int):
+        timeout = _INLINE_SHELL_DEFAULT_TIMEOUT
+    else:
+        timeout = max(
+            1, min(raw_timeout, _INLINE_SHELL_MAX_TIMEOUT)
+        )
+    return template_vars, inline_shell, timeout
+
+
 def substitute_template_vars(
     content: str,
-    skill_dir: Path | None,
+    skill_dir: Path | str | None,
     session_id: str | None,
 ) -> str:
     """Replace ${HERMES_SKILL_DIR} / ${HERMES_SESSION_ID} in skill content.
@@ -136,9 +157,11 @@ def preprocess_skill_content(
         return content
 
     cfg = skills_cfg if isinstance(skills_cfg, dict) else load_skills_config()
-    if cfg.get("template_vars", True):
+    template_vars, inline_shell, timeout = normalize_preprocessing_config(
+        cfg
+    )
+    if template_vars:
         content = substitute_template_vars(content, skill_dir, session_id)
-    if cfg.get("inline_shell", False):
-        timeout = int(cfg.get("inline_shell_timeout", 10) or 10)
+    if inline_shell:
         content = expand_inline_shell(content, skill_dir, timeout)
     return content

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -8,9 +8,10 @@ tool registration or provider resolution.
 import logging
 import os
 import re
+import stat
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_config_path, get_skills_dir, is_termux
 
@@ -220,6 +221,99 @@ def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     return frontmatter, body
 
 
+def parse_strict_fenced_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
+    """Parse canonical fenced YAML frontmatter without the legacy fallback.
+
+    Active skill discovery treats a leading, exact ``---`` fence as a
+    declaration boundary.  Such a fence must close and contain a YAML mapping;
+    otherwise a malformed skill could silently claim a directory-derived name
+    and shadow a legitimate package in another root.  Markdown with no exact
+    opening fence remains a supported legacy skill and returns empty metadata.
+
+    ``parse_frontmatter`` intentionally keeps a permissive key/value fallback
+    for compatibility in non-discovery consumers.  Do not use it to decide
+    whether a filesystem entry is an active skill.
+    """
+    if content.startswith("\ufeff"):
+        content = content[1:]
+
+    opening = re.match(r"---[ \t]*\r?\n", content)
+    if opening is None:
+        return {}, content
+
+    remainder = content[opening.end():]
+    closing = re.search(r"\r?\n---[ \t]*(?:\r?\n|$)", remainder)
+    if closing is None:
+        raise ValueError("frontmatter fence is not closed")
+
+    parsed = yaml_load(remainder[:closing.start()])
+    if not isinstance(parsed, dict):
+        raise ValueError("frontmatter is not a mapping")
+    return parsed, remainder[closing.end():]
+
+
+def read_strict_skill_index_file(skill_file: Path) -> Tuple[str, Dict[str, Any], str]:
+    """Open one canonical SKILL.md without following an entry-file symlink.
+
+    Discovery may traverse configured category symlinks, but the canonical
+    entry file itself must be a regular file in the selected package.  Opening
+    it with ``O_NOFOLLOW`` prevents an attacker from redirecting only
+    ``SKILL.md`` outside that package after the directory has been accepted.
+    """
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import open_directory, read_regular_file
+
+        # Configured roots and category links are an existing compatibility
+        # feature. Resolve that package alias once, then bind the resulting
+        # physical directory with the NT no-reparse open; the canonical file
+        # itself is still opened handle-relative and can never be a symlink.
+        package_path = skill_file.parent.resolve(strict=True)
+        with open_directory(package_path, writable=False) as package:
+            payload, _metadata = read_regular_file(package, skill_file.name)
+        content = payload.decode("utf-8")
+        frontmatter, body = parse_strict_fenced_frontmatter(content)
+        return content, frontmatter, body
+
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise OSError("secure SKILL.md opens are unsupported on this platform")
+
+    flags = os.O_RDONLY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    fd = os.open(skill_file, flags)
+    try:
+        before = os.fstat(fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise ValueError("SKILL.md is not a regular file")
+        chunks: List[bytes] = []
+        while True:
+            chunk = os.read(fd, 64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after = os.fstat(fd)
+        if (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+            before.st_ctime_ns,
+        ) != (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_ctime_ns,
+        ):
+            raise RuntimeError("SKILL.md changed during discovery")
+    finally:
+        os.close(fd)
+
+    content = b"".join(chunks).decode("utf-8")
+    frontmatter, body = parse_strict_fenced_frontmatter(content)
+    return content, frontmatter, body
+
+
 # ── Platform matching ─────────────────────────────────────────────────────
 
 
@@ -280,7 +374,10 @@ def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
 # never need it — but it can ALWAYS still be loaded explicitly (``skill_view``,
 # ``--skills``), because an explicit request is explicit consent.
 #
-# Detection is cached for the process lifetime via ``_ENV_DETECT_CACHE``.
+# Container/supervisor detection is stable for the process lifetime and is
+# cached via ``_ENV_DETECT_CACHE``. Kanban relevance is intentionally dynamic:
+# a long-lived gateway can move between ordinary sessions, dispatcher workers,
+# and profiles with the kanban toolset without restarting.
 _KNOWN_ENVIRONMENTS = frozenset({"kanban", "docker", "s6"})
 
 _ENV_DETECT_CACHE: Dict[str, bool] = {}
@@ -289,10 +386,12 @@ _ENV_DETECT_CACHE: Dict[str, bool] = {}
 def _detect_environment(env: str) -> bool:
     """Return True when the named runtime environment is currently active.
 
-    Cached per process. Unknown env names return True (fail-open: never hide a
-    skill because of a tag we don't understand).
+    Stable process environments are cached. Kanban is evaluated on every call
+    because its env/profile signals can change in a long-lived process.
+    Unknown env names return True (fail-open: never hide a skill because of a
+    tag we don't understand).
     """
-    if env in _ENV_DETECT_CACHE:
+    if env != "kanban" and env in _ENV_DETECT_CACHE:
         return _ENV_DETECT_CACHE[env]
 
     result = True
@@ -328,8 +427,21 @@ def _detect_environment(env: str) -> bool:
             "/package/admin/s6-overlay"
         )
 
-    _ENV_DETECT_CACHE[env] = result
+    if env != "kanban":
+        _ENV_DETECT_CACHE[env] = result
     return result
+
+
+def get_skill_environment_fingerprint() -> Tuple[Tuple[str, bool], ...]:
+    """Return the current offer-time environment state for cache keys.
+
+    Discovery, slash-command, and system-prompt caches all filter skills via
+    :func:`skill_matches_environment`. Sharing one fingerprint keeps those
+    surfaces coherent when a process enters or leaves dynamic Kanban mode.
+    """
+    return tuple(
+        (env, _detect_environment(env)) for env in sorted(_KNOWN_ENVIRONMENTS)
+    )
 
 
 def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
@@ -377,43 +489,93 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
 _RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}
 
 
+class SkillsConfigError(RuntimeError):
+    """The configured skills scope could not be determined safely."""
+
+
 def _raw_config_cache_clear() -> None:
     """Test hook — drop the shared raw config cache."""
     _RAW_CONFIG_CACHE.clear()
 
 
-def _load_raw_config() -> Dict[str, Any]:
+def _stat_skills_config(
+    config_path: Path,
+) -> Tuple[Optional[Any], Optional[str]]:
+    """Stat config while distinguishing absence from a dangling path entry."""
+    try:
+        return config_path.stat(), None
+    except FileNotFoundError as exc:
+        # stat() follows symlinks, so a dangling config symlink raises the same
+        # exception as a genuinely absent path. lstat() preserves that
+        # distinction for strict mutation/collision callers.
+        try:
+            config_path.lstat()
+        except FileNotFoundError:
+            return None, None
+        except OSError as lstat_exc:
+            return (
+                None,
+                f"Could not inspect skills config {config_path}: {lstat_exc}",
+            )
+        return (
+            None,
+            f"Could not resolve skills config {config_path}: {exc}",
+        )
+    except OSError as exc:
+        return None, f"Could not stat skills config {config_path}: {exc}"
+
+
+def _load_raw_config_with_error(
+    *, use_cache: bool = True
+) -> Tuple[Dict[str, Any], Optional[str]]:
     """Read config.yaml with a shared mtime+size keyed cache.
 
     This module intentionally avoids importing ``hermes_cli.config`` on the
     skill prompt/build path. A tiny local cache gives the same repeated-read
     win without pulling the heavier CLI config stack into startup.
+
+    The second return value distinguishes a genuinely absent/empty config from
+    a config that exists but could not be read or parsed.  Ordinary discovery
+    remains best-effort through :func:`_load_raw_config`; mutation collision
+    scans use this status to fail closed instead of silently forgetting
+    configured external roots.
     """
     config_path = get_config_path()
-    if not config_path.exists():
-        return {}
-    try:
-        stat = config_path.stat()
-        cache_key = (str(config_path), stat.st_mtime_ns, stat.st_size)
-    except OSError:
-        cache_key = None
+    config_stat, stat_error = _stat_skills_config(config_path)
+    if stat_error is not None:
+        return {}, stat_error
+    if config_stat is None:
+        return {}, None
+    cache_key = (
+        str(config_path),
+        config_stat.st_mtime_ns,
+        config_stat.st_size,
+    )
 
-    if cache_key is not None:
+    if use_cache:
         cached = _RAW_CONFIG_CACHE.get(cache_key)
         if cached is not None:
-            return cached
+            return cached, None
 
     try:
         parsed = yaml_load(config_path.read_text(encoding="utf-8"))
     except Exception as e:
         logger.debug("Could not read skill config %s: %s", config_path, e)
-        return {}
+        return {}, f"Could not read or parse skills config {config_path}: {e}"
+    if parsed is None:
+        parsed = {}
     if not isinstance(parsed, dict):
-        return {}
+        return {}, f"Skills config {config_path} must contain a YAML mapping"
 
-    if cache_key is not None:
+    if use_cache:
         _RAW_CONFIG_CACHE.clear()
         _RAW_CONFIG_CACHE[cache_key] = parsed
+    return parsed, None
+
+
+def _load_raw_config() -> Dict[str, Any]:
+    """Best-effort compatibility view of ``config.yaml``."""
+    parsed, _error = _load_raw_config_with_error()
     return parsed
 
 
@@ -480,46 +642,90 @@ def _external_dirs_cache_clear() -> None:
     _raw_config_cache_clear()
 
 
-def get_external_skills_dirs() -> List[Path]:
-    """Read ``skills.external_dirs`` from config.yaml and return validated paths.
+def _configured_skill_root(path: Path) -> Path:
+    """Return an absolute, comparison-safe spelling without requiring I/O.
+
+    ``Path.resolve()`` normally gives the best deduplication behavior, but it
+    can fail for an inaccessible path or a symlink loop.  A configured root is
+    still part of the discovery scope in those cases, so fall back to a purely
+    lexical absolute path instead of dropping it.
+    """
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return path.absolute()
+
+
+def _resolve_external_skills_dirs(
+    *, require_valid_config: bool = False
+) -> List[Path]:
+    """Read ``skills.external_dirs`` and return every configured root.
 
     Each entry is expanded (``~`` and ``${VAR}``) and resolved to an absolute
-    path.  Only directories that actually exist are returned.  Duplicates and
-    paths that resolve to the local ``~/.hermes/skills/`` are silently skipped.
+    path.  Roots are intentionally retained when they are missing,
+    inaccessible, or not directories: configuration defines discovery scope,
+    while callers separately decide which roots are currently scannable.
+    Duplicates and paths that resolve to the local ``~/.hermes/skills/`` are
+    silently skipped.
 
     Cached in-process, keyed on ``config.yaml`` mtime — the function is
     called once per skill during banner / tool-registry scans, and YAML
     parsing a non-trivial config dominates ``hermes`` cold-start time
     when the cache is absent.
+
+    ``require_valid_config=True`` is reserved for mutation/collision scans.
+    It bypasses successful parse caches and raises :class:`SkillsConfigError`
+    when an existing config cannot be read, parsed, or interpreted.  This
+    prevents an unreadable config from masquerading as ``external_dirs: []``
+    while preserving the historical best-effort result for ordinary callers.
     """
     config_path = get_config_path()
-    if not config_path.exists():
-        return []
 
     # Cache key: (absolute path, mtime_ns).  stat() is ~2us vs ~85ms for
     # the full YAML parse, so the fast path is nearly free.
-    try:
-        stat = config_path.stat()
-        cache_key: Tuple[str, int] = (str(config_path), stat.st_mtime_ns)
-    except OSError:
-        cache_key = None  # type: ignore[assignment]
+    config_stat, stat_error = _stat_skills_config(config_path)
+    if stat_error is None and config_stat is not None:
+        cache_key: Optional[Tuple[str, int]] = (
+            str(config_path),
+            config_stat.st_mtime_ns,
+        )
+    elif stat_error is None:
+        return []
+    else:
+        if require_valid_config:
+            raise SkillsConfigError(stat_error)
+        return []
 
-    if cache_key is not None:
+    if not require_valid_config:
         cached = _EXTERNAL_DIRS_CACHE.get(cache_key)
         if cached is not None:
             # Return a copy so callers can't mutate the cached list.
             return list(cached)
 
-    parsed = _load_raw_config()
-    if not parsed:
+    parsed, config_error = _load_raw_config_with_error(
+        use_cache=not require_valid_config
+    )
+    if config_error is not None:
+        if require_valid_config:
+            raise SkillsConfigError(config_error)
         return []
 
     skills_cfg = parsed.get("skills")
+    if skills_cfg is None:
+        return []
     if not isinstance(skills_cfg, dict):
+        if require_valid_config:
+            raise SkillsConfigError(
+                f"Skills config {config_path} field 'skills' must be a mapping"
+            )
         return []
 
     raw_dirs = skills_cfg.get("external_dirs")
-    if not raw_dirs:
+    if raw_dirs is None or (
+        isinstance(raw_dirs, str) and not raw_dirs.strip()
+    ) or (
+        isinstance(raw_dirs, list) and not raw_dirs
+    ):
         result: List[Path] = []
         if cache_key is not None:
             _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
@@ -527,50 +733,107 @@ def get_external_skills_dirs() -> List[Path]:
     if isinstance(raw_dirs, str):
         raw_dirs = [raw_dirs]
     if not isinstance(raw_dirs, list):
+        if require_valid_config:
+            raise SkillsConfigError(
+                f"Skills config {config_path} field "
+                "'skills.external_dirs' must be a string or list"
+            )
         return []
 
     from hermes_constants import get_hermes_home
 
     hermes_home = get_hermes_home()
-    local_skills = get_skills_dir().resolve()
+    local_skills = _configured_skill_root(get_skills_dir())
     seen: Set[Path] = set()
     result = []
 
     for entry in raw_dirs:
+        if require_valid_config and not isinstance(entry, str):
+            raise SkillsConfigError(
+                f"Skills config {config_path} field "
+                "'skills.external_dirs' entries must be strings"
+            )
         entry = str(entry).strip()
         if not entry:
+            if require_valid_config:
+                raise SkillsConfigError(
+                    f"Skills config {config_path} field "
+                    "'skills.external_dirs' entries must be non-empty strings"
+                )
             continue
         # Expand ~ and environment variables
         expanded = os.path.expanduser(os.path.expandvars(entry))
         p = Path(expanded)
         # Resolve relative paths against HERMES_HOME, not cwd
         if not p.is_absolute():
-            p = (hermes_home / p).resolve()
-        else:
-            p = p.resolve()
+            p = hermes_home / p
+        p = _configured_skill_root(p)
         if p == local_skills:
             continue
         if p in seen:
             continue
-        if p.is_dir():
-            seen.add(p)
-            result.append(p)
-        else:
-            logger.debug("External skills dir does not exist, skipping: %s", p)
+        seen.add(p)
+        result.append(p)
 
     if cache_key is not None:
         _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
     return result
 
 
-def get_all_skills_dirs() -> List[Path]:
-    """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
+def get_external_skills_dirs() -> List[Path]:
+    """Return configured external skill roots using compatibility semantics.
+
+    Read-only/discovery callers historically receive an empty list when
+    ``config.yaml`` is unavailable or malformed. Keep this public no-argument
+    contract stable; security-sensitive callers use
+    ``get_all_skills_dirs(require_valid_config=True)``.
+    """
+    return _resolve_external_skills_dirs()
+
+
+def get_scannable_external_skills_dirs(
+    *, on_error: Optional[Callable[[OSError], None]] = None
+) -> List[Path]:
+    """Return configured external roots that currently stat as directories.
+
+    This is the explicit best-effort view for non-catalog maintenance callers.
+    Catalog and cache builders should use :func:`get_external_skills_dirs`
+    directly so an unavailable configured root remains in their scope identity
+    and can make the scan fail closed.
+    """
+    result: List[Path] = []
+    for root in get_external_skills_dirs():
+        try:
+            root_stat = root.stat()
+        except OSError as exc:
+            if on_error is not None:
+                on_error(exc)
+            continue
+        if not stat.S_ISDIR(root_stat.st_mode):
+            error = NotADirectoryError(f"External skills root is not a directory: {root}")
+            if on_error is not None:
+                on_error(error)
+            continue
+        result.append(root)
+    return result
+
+
+def get_all_skills_dirs(
+    *, require_valid_config: bool = False
+) -> List[Path]:
+    """Return the complete configured skill-root scope, local first.
 
     The local dir is always first (and always included even if it doesn't exist
-    yet — callers handle that).  External dirs follow in config order.
+    yet — callers handle that). Configured external roots follow in config
+    order even when they cannot currently be scanned. Mutation/collision scans
+    pass ``require_valid_config=True`` so a broken config cannot shrink that
+    security boundary to the local root.
     """
     dirs = [get_skills_dir()]
-    dirs.extend(get_external_skills_dirs())
+    if require_valid_config:
+        dirs.extend(_resolve_external_skills_dirs(require_valid_config=True))
+    else:
+        dirs.extend(get_external_skills_dirs())
     return dirs
 
 
@@ -591,15 +854,14 @@ def normalize_skill_lookup_name(identifier: str) -> str:
     if not identifier_path.is_absolute():
         return raw_identifier.lstrip("/")
 
-    # Look the primary skills root up on tools.skills_tool at CALL time
-    # (not via get_skills_dir()): callers and tests patch
-    # ``tools.skills_tool.SKILLS_DIR`` and skill_view() itself resolves
-    # against that module attribute, so normalization must agree with the
-    # exact root skill_view() will enforce.  Import deferred to avoid a
-    # module cycle (tools.skills_tool imports agent.skill_utils).
+    # Look the primary skills root up at CALL time. ``_skills_dir()`` resolves
+    # the active profile/HERMES_HOME, while retaining the legacy patched
+    # ``SKILLS_DIR`` behavior used by callers and tests. This must agree with
+    # the exact root ``skill_view()`` enforces, otherwise a slash command from
+    # one profile can be normalised relative to another profile's root.
     try:
         from tools import skills_tool as _skills_tool
-        primary_root = Path(_skills_tool.SKILLS_DIR)
+        primary_root = Path(_skills_tool._skills_dir())
     except Exception:
         primary_root = get_skills_dir()
 
@@ -748,20 +1010,70 @@ def discover_all_skill_config_vars() -> List[Dict[str, Any]]:
     a deduplicated list of config var dicts.  Each dict also includes a
     ``skill`` key with the skill name for attribution.
 
-    Disabled and platform-incompatible skills are excluded.
+    Disabled, platform-incompatible, and environment-incompatible skills are
+    excluded. Any unreadable or malformed candidate makes the entire result
+    unsafe to use, so discovery fails closed instead of returning a partial
+    configuration prompt.
     """
     all_vars: List[Dict[str, Any]] = []
     seen_keys: set = set()
 
     disabled = get_disabled_skill_names()
-    for skills_dir in get_all_skills_dirs():
-        if not skills_dir.is_dir():
+    scan_errors: List[OSError] = []
+    skills_dirs: List[Path] = []
+    local_skills_dir = get_skills_dir()
+    try:
+        local_stat = local_skills_dir.stat()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        scan_errors.append(exc)
+    else:
+        if stat.S_ISDIR(local_stat.st_mode):
+            skills_dirs.append(local_skills_dir)
+        else:
+            scan_errors.append(
+                NotADirectoryError(
+                    f"Local skills root is not a directory: {local_skills_dir}"
+                )
+            )
+
+    try:
+        configured_external_dirs = _resolve_external_skills_dirs(
+            require_valid_config=True
+        )
+    except SkillsConfigError as exc:
+        scan_errors.append(exc)
+        configured_external_dirs = []
+    for root in configured_external_dirs:
+        try:
+            root_stat = root.stat()
+        except OSError as exc:
+            scan_errors.append(exc)
             continue
-        for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
+        if not stat.S_ISDIR(root_stat.st_mode):
+            scan_errors.append(
+                NotADirectoryError(
+                    f"External skills root is not a directory: {root}"
+                )
+            )
+            continue
+        skills_dirs.append(root)
+    if scan_errors:
+        logger.warning(
+            "Skill config discovery is incomplete; refusing a partial result: %s",
+            scan_errors[0],
+        )
+        return []
+
+    for skills_dir in skills_dirs:
+        for skill_file in iter_skill_index_files(
+            skills_dir, "SKILL.md", on_error=scan_errors.append
+        ):
             try:
-                raw = skill_file.read_text(encoding="utf-8")
-                frontmatter, _ = parse_frontmatter(raw)
-            except Exception:
+                _, frontmatter, _ = read_strict_skill_index_file(skill_file)
+            except Exception as exc:
+                scan_errors.append(exc)
                 continue
 
             skill_name = frontmatter.get("name") or skill_file.parent.name
@@ -769,13 +1081,23 @@ def discover_all_skill_config_vars() -> List[Dict[str, Any]]:
                 continue
             if not skill_matches_platform(frontmatter):
                 continue
+            if not skill_matches_environment(frontmatter):
+                continue
 
             config_vars = extract_skill_config_vars(frontmatter)
             for var in config_vars:
                 if var["key"] not in seen_keys:
-                    var["skill"] = str(skill_name)
-                    all_vars.append(var)
+                    entry = dict(var)
+                    entry["skill"] = str(skill_name)
+                    all_vars.append(entry)
                     seen_keys.add(var["key"])
+
+    if scan_errors:
+        logger.warning(
+            "Skill config discovery is incomplete; refusing a partial result: %s",
+            scan_errors[0],
+        )
+        return []
 
     return all_vars
 
@@ -858,7 +1180,12 @@ def is_skill_description_truncated_for_prompt(frontmatter: Dict[str, Any]) -> bo
 # ── File iteration ────────────────────────────────────────────────────────
 
 
-def iter_skill_index_files(skills_dir: Path, filename: str):
+def iter_skill_index_files(
+    skills_dir: Path,
+    filename: str,
+    *,
+    on_error: Optional[Callable[[OSError], None]] = None,
+):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
     Excludes Hermes metadata, VCS, virtualenv/dependency, cache, and skill
@@ -872,12 +1199,42 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     every other ``_org/<id>/`` (stale mirror from a previous org, or no
     marker at all) is pruned — leave an org and its skills stop resolving,
     without any manual cleanup.
+
+    Directory traversal errors are skipped for best-effort callers and reported
+    through ``on_error`` when supplied. Catalog builders that cache the result
+    must provide this callback so a partial walk is never committed as a
+    complete snapshot.
     """
     skills_dir_str = str(skills_dir)
     active_org = read_active_org_id(skills_dir)
     org_root = os.path.join(skills_dir_str, ORG_MIRROR_DIR_NAME)
     matches: list[str] = []
-    for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
+
+    def report_error(error: OSError) -> None:
+        if on_error is not None:
+            on_error(error)
+
+    # ``followlinks=True`` is required for supported symlinked skill roots, but
+    # os.walk does not detect directory cycles. Track physical directories so a
+    # ``loop -> ..`` link cannot make startup/indexing recurse forever.
+    visited_dirs: set[tuple[int, int]] = set()
+    for root, dirs, files in os.walk(
+        skills_dir_str,
+        followlinks=True,
+        onerror=report_error,
+    ):
+        try:
+            stat = os.stat(root, follow_symlinks=True)
+            identity = (stat.st_dev, stat.st_ino)
+        except OSError as exc:
+            report_error(exc)
+            dirs[:] = []
+            continue
+        if identity in visited_dirs:
+            dirs[:] = []
+            continue
+        visited_dirs.add(identity)
+
         has_skill_md = "SKILL.md" in files
         if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
             dirs.remove(ORG_MIRROR_DIR_NAME)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -318,10 +318,28 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             )
         except Exception:
             _compact_cats = frozenset()
+        _prompt_index_mode = "full"
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            _skills_cfg = (load_config_readonly().get("skills") or {})
+            _configured_mode = str(
+                _skills_cfg.get("prompt_index_mode", "full") or "full"
+            ).strip().lower()
+            if _configured_mode in {"full", "category_compact"}:
+                _prompt_index_mode = _configured_mode
+            else:
+                logger.warning(
+                    "Unknown skills.prompt_index_mode=%r; using full",
+                    _configured_mode,
+                )
+        except Exception:
+            pass
         skills_prompt = _r.build_skills_system_prompt(
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
+            prompt_index_mode=_prompt_index_mode,
         )
     else:
         skills_prompt = ""

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -91,6 +91,18 @@ class TurnResult:
 # normal completion path fires. Mirrors openclaw beta.8 fix.
 _TURN_ABORTED_MARKERS = ("<turn_aborted>", "<turn_aborted/>")
 
+# Since Hermes requires codex >= 0.125, lifecycle and accounting
+# notifications always carry both threadId and turnId.  Treat these events as
+# security boundaries: an unscoped/stale notification must never finish the
+# active turn, update its usage, or claim a compaction succeeded.
+_EXACT_SCOPE_METHODS = {
+    "turn/started",
+    "turn/completed",
+    "turn/diff/updated",
+    "thread/tokenUsage/updated",
+    "thread/compacted",
+}
+
 
 def _notification_scope_ids(
     note: dict,
@@ -140,25 +152,48 @@ def _notification_belongs_to_turn(
     Codex app-server can carry parent and hosted subagent threads over one
     JSON-RPC connection.  An explicitly foreign child or
     stale-turn event must not mutate the active parent's transcript or mark
-    its turn complete.  Unscoped notifications remain accepted for protocol
-    compatibility.
+    its turn complete.  Lifecycle/accounting/compaction notifications use the
+    strict codex >= 0.125 contract and must carry exact thread and turn ids.
+    Non-critical display events retain compatibility with older producers.
     """
     if not isinstance(note, dict):
         return False
 
     observed_thread_id, observed_turn_id = _notification_scope_ids(note)
+    method = str(note.get("method") or "")
+    exact_thread_and_turn_required = (
+        method in _EXACT_SCOPE_METHODS
+        or method.startswith("turn/")
+        or method.startswith("item/")
+    )
 
+    if exact_thread_and_turn_required and (
+        observed_thread_id is None or observed_turn_id is None
+    ):
+        return False
     if (
         thread_id is not None
-        and observed_thread_id is not None
-        and str(observed_thread_id) != str(thread_id)
+        and (
+            (exact_thread_and_turn_required and observed_thread_id is None)
+            or (
+                observed_thread_id is not None
+                and str(observed_thread_id) != str(thread_id)
+            )
+        )
     ):
         return False
 
     if (
         turn_id is not None
-        and observed_turn_id is not None
-        and str(observed_turn_id) != str(turn_id)
+        and (
+            (
+                exact_thread_and_turn_required and observed_turn_id is None
+            )
+            or (
+                observed_turn_id is not None
+                and str(observed_turn_id) != str(turn_id)
+            )
+        )
     ):
         return False
 
@@ -280,6 +315,12 @@ class CodexAppServerSession:
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
+        resume_thread_id: Optional[str] = None,
+        on_thread_ready: Optional[Callable[[str], None]] = None,
+        lease_acquire: Optional[Callable[[], bool]] = None,
+        lease_refresh: Optional[Callable[[], bool]] = None,
+        lease_release: Optional[Callable[[], bool]] = None,
+        lease_refresh_interval: float = 60.0,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
     ) -> None:
@@ -294,6 +335,19 @@ class CodexAppServerSession:
         )
         self._approval_callback = approval_callback
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
+        self._resume_thread_id = str(resume_thread_id or "").strip() or None
+        self._on_thread_ready = on_thread_ready
+        self._lease_acquire = lease_acquire
+        self._lease_refresh = lease_refresh
+        self._lease_release = lease_release
+        self._lease_refresh_interval = max(
+            float(lease_refresh_interval), 0.05
+        )
+        self._lease_acquired = False
+        self._lease_lost = threading.Event()
+        self._lease_stop = threading.Event()
+        self._lease_thread: Optional[threading.Thread] = None
+        self._lifecycle_lock = threading.Lock()
         self._routing = request_routing or _ServerRequestRouting()
         self._client_factory = client_factory or CodexAppServerClient
 
@@ -317,16 +371,36 @@ class CodexAppServerSession:
         thread. Returns the codex thread id. Idempotent — repeated calls
         return the same thread id."""
         if self._thread_id is not None:
+            if self._lease_lost.is_set():
+                raise CodexAppServerError(
+                    code=-32603,
+                    message="Codex turn lease was lost; refusing thread reuse",
+                )
             return self._thread_id
+        self._ensure_lease_acquired()
         if self._client is None:
-            self._client = self._client_factory(
-                codex_bin=self._codex_bin, codex_home=self._codex_home
+            try:
+                self._client = self._client_factory(
+                    codex_bin=self._codex_bin, codex_home=self._codex_home
+                )
+            except BaseException:
+                self.close()
+                raise
+        try:
+            capabilities = (
+                {"experimentalApi": True}
+                if self._resume_thread_id is not None
+                else None
             )
-        self._client.initialize(
-            client_name="hermes",
-            client_title="Hermes Agent",
-            client_version=_get_hermes_version(),
-        )
+            self._client.initialize(
+                client_name="hermes",
+                client_title="Hermes Agent",
+                client_version=_get_hermes_version(),
+                capabilities=capabilities,
+            )
+        except BaseException:
+            self.close()
+            raise
         # Permission selection is intentionally NOT sent on thread/start.
         # Two reasons (live-tested against codex 0.130.0):
         #   1. `thread/start.permissions` is gated behind the experimentalApi
@@ -342,40 +416,157 @@ class CodexAppServerSession:
         # codex CLI workflow and avoids fighting codex's own validation.
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
-        params: dict[str, Any] = {"cwd": self._cwd}
-        result = self._client.request("thread/start", params, timeout=15)
+        if self._resume_thread_id is not None:
+            method = "thread/resume"
+            params: dict[str, Any] = {
+                "threadId": self._resume_thread_id,
+                # Hermes owns its own projected transcript and only needs the
+                # resumed thread identity/state. Codex exposes this field on
+                # the experimental app-server surface, so ensure_started()
+                # opts this resume connection into experimentalApi during the
+                # one allowed initialize handshake. This keeps long rollouts
+                # from materializing every prior turn in a response that
+                # Hermes immediately discards.
+                "excludeTurns": True,
+            }
+        else:
+            method = "thread/start"
+            params = {"cwd": self._cwd}
+        try:
+            result = self._client.request(method, params, timeout=15)
+        except BaseException:
+            self.close()
+            raise
         # Cross-fill thread.id/sessionId — different codex versions have
-        # serialized this under either key. Mirrors openclaw beta.8's
-        # tolerance fix so future codex drops/renames don't KeyError us
-        # at handshake time.
+        # serialized start responses under either key. A resume response must
+        # return the official nested thread.id, or the older top-level
+        # result.threadId compatibility field with the exact requested value.
+        # thread.sessionId is the conversation tree root and can differ after
+        # a fork, so accepting it here could attach Hermes to the wrong rollout.
         thread_obj = result.get("thread") or {}
-        thread_id = (
-            thread_obj.get("id")
-            or thread_obj.get("sessionId")
-            or result.get("sessionId")
-            or result.get("threadId")
-        )
+        if self._resume_thread_id is not None:
+            thread_id = thread_obj.get("id") or result.get("threadId")
+        else:
+            thread_id = (
+                thread_obj.get("id")
+                or thread_obj.get("sessionId")
+                or result.get("sessionId")
+                or result.get("threadId")
+            )
         if not thread_id:
+            self.close()
             raise CodexAppServerError(
                 code=-32603,
                 message=(
-                    "codex thread/start returned no thread id "
+                    f"codex {method} returned no thread id "
                     f"(payload keys: {sorted(result.keys())})"
                 ),
             )
+        thread_id = str(thread_id)
+        if (
+            self._resume_thread_id is not None
+            and thread_id != self._resume_thread_id
+        ):
+            self.close()
+            raise CodexAppServerError(
+                code=-32603,
+                message=(
+                    "codex thread/resume returned a different thread id "
+                    f"(requested={self._resume_thread_id}, returned={thread_id})"
+                ),
+            )
+        if self._on_thread_ready is not None:
+            try:
+                self._on_thread_ready(thread_id)
+            except Exception as exc:
+                self.close()
+                raise CodexAppServerError(
+                    code=-32603,
+                    message=(
+                        "could not persist the Codex thread binding; "
+                        "refusing to run an unresumable turn"
+                    ),
+                ) from exc
         self._thread_id = thread_id
         logger.info(
-            "codex app-server thread started: id=%s profile=%s cwd=%s",
+            "codex app-server thread %s: id=%s profile=%s cwd=%s",
+            "resumed" if self._resume_thread_id is not None else "started",
             self._thread_id[:8],
             self._permission_profile,
             self._cwd,
         )
         return self._thread_id
 
-    def close(self) -> None:
-        if self._closed:
+    def _ensure_lease_acquired(self) -> None:
+        """Acquire the cross-process writer lease before spawning Codex."""
+        if self._lease_acquire is None:
             return
-        self._closed = True
+        with self._lifecycle_lock:
+            if self._lease_acquired:
+                if self._lease_lost.is_set():
+                    raise CodexAppServerError(
+                        code=-32603,
+                        message="Codex turn lease was lost",
+                    )
+                return
+            if self._closed:
+                raise CodexAppServerError(
+                    code=-32603,
+                    message="Codex app-server session is closed",
+                )
+            try:
+                acquired = bool(self._lease_acquire())
+            except Exception:
+                acquired = False
+                logger.warning(
+                    "Codex turn lease acquisition raised; failing closed",
+                    exc_info=True,
+                )
+            if not acquired:
+                raise CodexAppServerError(
+                    code=-32603,
+                    message=(
+                        "another Hermes/Codex client owns this session; "
+                        "refusing concurrent thread access"
+                    ),
+                )
+            self._lease_acquired = True
+            if self._lease_refresh is not None:
+                self._lease_thread = threading.Thread(
+                    target=self._refresh_lease_loop,
+                    name="codex-turn-lease-refresh",
+                    daemon=True,
+                )
+                self._lease_thread.start()
+
+    def _refresh_lease_loop(self) -> None:
+        while not self._lease_stop.wait(self._lease_refresh_interval):
+            try:
+                refreshed = bool(
+                    self._lease_refresh is not None
+                    and self._lease_refresh()
+                )
+            except Exception:
+                refreshed = False
+                logger.warning(
+                    "Codex turn lease refresh raised; marking lease lost",
+                    exc_info=True,
+                )
+            if not refreshed:
+                self._lease_lost.set()
+                self._interrupt_event.set()
+                return
+
+    def _lease_is_lost(self) -> bool:
+        return self._lease_acquired and self._lease_lost.is_set()
+
+    def close(self) -> None:
+        with self._lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
+            lease_acquired = self._lease_acquired
+            self._lease_acquired = False
         with self._active_turn_lock:
             self._active_turn_id = None
         if self._client is not None:
@@ -385,6 +576,57 @@ class CodexAppServerSession:
                 pass
             self._client = None
         self._thread_id = None
+        self._lease_stop.set()
+        lease_thread = self._lease_thread
+        if (
+            lease_thread is not None
+            and lease_thread is not threading.current_thread()
+        ):
+            lease_thread.join(timeout=max(self._lease_refresh_interval, 1.0))
+        self._lease_thread = None
+        if lease_acquired and self._lease_release is not None:
+            release_callback = self._lease_release
+            try:
+                released = bool(release_callback())
+                if not released:
+                    logger.warning(
+                        "Codex turn lease release failed; scheduling bounded "
+                        "background retries"
+                    )
+            except Exception:
+                released = False
+                logger.warning(
+                    "Codex turn lease release raised; scheduling bounded "
+                    "background retries",
+                    exc_info=True,
+                )
+            if not released:
+                threading.Thread(
+                    target=self._retry_lease_release,
+                    args=(release_callback,),
+                    name="codex-turn-lease-release-retry",
+                    daemon=True,
+                ).start()
+
+    @staticmethod
+    def _retry_lease_release(
+        release_callback: Callable[[], bool],
+    ) -> None:
+        """Retry transient DB release failures after the client is closed."""
+        for delay in (0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0):
+            time.sleep(delay)
+            try:
+                if release_callback():
+                    return
+            except Exception:
+                logger.debug(
+                    "Codex turn lease background release retry raised",
+                    exc_info=True,
+                )
+        logger.error(
+            "Codex turn lease could not be released after bounded retries; "
+            "access remains fail-closed until process exit or manual recovery"
+        )
 
     def __enter__(self) -> "CodexAppServerSession":
         return self
@@ -402,7 +644,7 @@ class CodexAppServerSession:
     def request_steer(self, text: str) -> bool:
         """Append user guidance to the active Codex turn via ``turn/steer``."""
         cleaned = str(text or "").strip()
-        if not cleaned:
+        if not cleaned or self._lease_is_lost():
             return False
         with self._active_turn_lock:
             turn_id = self._active_turn_id
@@ -474,6 +716,7 @@ class CodexAppServerSession:
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
         post_tool_quiet_timeout: float = 90.0,
+        interrupt_grace_timeout: float = 5.0,
     ) -> TurnResult:
         """Send a user message and block until turn/completed, while
         forwarding server-initiated approval requests and projecting items
@@ -500,6 +743,7 @@ class CodexAppServerSession:
             # Subprocess almost certainly unhealthy — retire so the next
             # turn re-spawns cleanly.
             result.should_retire = True
+            self.close()
             self._interrupt_event.clear()
             return result
         assert self._client is not None and self._thread_id is not None
@@ -510,6 +754,10 @@ class CodexAppServerSession:
         # Codex turn instead of erasing the signal.
         if self._interrupt_event.is_set():
             result.interrupted = True
+            if self._lease_is_lost():
+                result.error = "Codex turn lease was lost before turn/start"
+                result.should_retire = True
+                self.close()
             self._interrupt_event.clear()
             return result
         projector = CodexEventProjector()
@@ -557,20 +805,101 @@ class CodexAppServerSession:
             return result
 
         result.turn_id = (ts.get("turn") or {}).get("id")
+        if not result.turn_id:
+            result.error = self._format_error_with_stderr(
+                "turn/start returned no turn id"
+            )
+            result.should_retire = True
+            self.close()
+            self._interrupt_event.clear()
+            return result
         with self._active_turn_lock:
             self._active_turn_id = result.turn_id
         deadline = time.monotonic() + turn_timeout
         turn_complete = False
+        interrupt_requested = False
+        interrupt_sent = False
+        interrupt_deadline: Optional[float] = None
         # Post-tool watchdog state. last_tool_completion_at is set whenever
         # a tool-shaped item completes; if no further notification arrives
         # within post_tool_quiet_timeout and the turn hasn't completed, we
         # fast-fail and retire the session.
         last_tool_completion_at: Optional[float] = None
 
-        while time.monotonic() < deadline and not turn_complete:
-            if self._interrupt_event.is_set():
-                self._issue_interrupt(result.turn_id)
+        def record_turn_completion(note: dict) -> None:
+            """Apply one already scope-validated terminal notification."""
+            nonlocal turn_complete
+            turn_complete = True
+            turn_obj = (note.get("params") or {}).get("turn") or {}
+            turn_status = turn_obj.get("status")
+            if turn_status == "interrupted":
                 result.interrupted = True
+            elif turn_status and turn_status != "completed":
+                err_obj = turn_obj.get("error")
+                if err_obj:
+                    err_msg = _format_responses_error(
+                        err_obj,
+                        str(turn_status),
+                    )
+                    stderr_blob = "\n".join(self._client.stderr_tail(40))
+                    hint = _classify_oauth_failure(err_msg, stderr_blob)
+                    if hint is not None:
+                        result.error = hint
+                        result.should_retire = True
+                    else:
+                        result.error = self._format_error_with_stderr(
+                            f"turn ended status={turn_status}",
+                            err_msg,
+                        )
+
+        while not turn_complete:
+            now = time.monotonic()
+            if not interrupt_requested and now >= deadline:
+                # A completed assistant message is still useful when a codex
+                # build omits turn/completed and then goes quiet.
+                if result.final_text and result.error is None:
+                    logger.warning(
+                        "codex app-server turn reached deadline after a "
+                        "completed assistant message but before "
+                        "turn/completed; accepting the assistant text as the "
+                        "terminal response"
+                    )
+                    turn_complete = True
+                    break
+                interrupt_requested = True
+                result.interrupted = True
+                result.should_retire = True
+                result.error = self._format_error_with_stderr(
+                    f"turn timed out after {turn_timeout}s"
+                )
+
+            if self._lease_is_lost():
+                result.interrupted = True
+                result.error = (
+                    "Codex turn lease refresh failed; retiring the "
+                    "app-server session"
+                )
+                result.should_retire = True
+                self.close()
+                break
+            if self._interrupt_event.is_set():
+                interrupt_requested = True
+                result.interrupted = True
+                result.should_retire = True
+                self._interrupt_event.clear()
+
+            if interrupt_requested and not interrupt_sent:
+                self._issue_interrupt(result.turn_id)
+                interrupt_sent = True
+                interrupt_deadline = (
+                    time.monotonic() + max(0.0, interrupt_grace_timeout)
+                )
+
+            if (
+                interrupt_requested
+                and interrupt_deadline is not None
+                and time.monotonic() >= interrupt_deadline
+            ):
                 break
 
             # Detect a dead subprocess between iterations. If codex exited
@@ -594,11 +923,13 @@ class CodexAppServerSession:
             # signal and codex has been silent past the quiet timeout, give
             # up on this turn instead of waiting for the outer deadline.
             if (
+                not interrupt_requested
+                and
                 last_tool_completion_at is not None
                 and (time.monotonic() - last_tool_completion_at)
                     > post_tool_quiet_timeout
             ):
-                self._issue_interrupt(result.turn_id)
+                interrupt_requested = True
                 result.interrupted = True
                 result.error = (
                     f"codex went silent for "
@@ -606,7 +937,8 @@ class CodexAppServerSession:
                     f"retiring app-server session."
                 )
                 result.should_retire = True
-                break
+                last_tool_completion_at = None
+                continue
 
             # Drain any server-initiated requests (approvals) before
             # reading notifications, so the codex side isn't blocked.
@@ -656,14 +988,25 @@ class CodexAppServerSession:
                         last_tool_completion_at = time.monotonic()
                     if proj.final_text is not None:
                         result.final_text = proj.final_text
-                        if _has_turn_aborted_marker(proj.final_text):
+                        if (
+                            not interrupt_requested
+                            and _has_turn_aborted_marker(proj.final_text)
+                        ):
                             turn_complete = True
                             result.interrupted = True
                             result.error = (
                                 result.error
                                 or "codex reported turn_aborted"
                             )
-                self._handle_server_request(sreq)
+                    if pending.get("method") == "turn/completed":
+                        record_turn_completion(pending)
+                        break
+                # Codex resolves outstanding approvals while unwinding an
+                # interrupted turn.  If the matching interrupted terminal was
+                # already drained, the locally queued request is stale and
+                # must not reopen an approval prompt after the user stopped.
+                if not turn_complete:
+                    self._handle_server_request(sreq)
                 # Activity counts as live signal — reset the post-tool
                 # quiet timer so an approval round-trip doesn't trip it.
                 last_tool_completion_at = None
@@ -724,7 +1067,10 @@ class CodexAppServerSession:
                 # `<turn_aborted>` marker in the agent message text and
                 # never sending turn/completed. Treat the marker itself
                 # as terminal so we don't burn the full deadline.
-                if _has_turn_aborted_marker(projection.final_text):
+                if (
+                    not interrupt_requested
+                    and _has_turn_aborted_marker(projection.final_text)
+                ):
                     turn_complete = True
                     result.interrupted = True
                     result.error = (
@@ -732,56 +1078,19 @@ class CodexAppServerSession:
                     )
 
             if method == "turn/completed":
-                turn_complete = True
-                turn_status = (
-                    (note.get("params") or {}).get("turn") or {}
-                ).get("status")
-                if turn_status and turn_status not in {"completed", "interrupted"}:
-                    err_obj = (
-                        (note.get("params") or {}).get("turn") or {}
-                    ).get("error")
-                    if err_obj:
-                        err_msg = _format_responses_error(err_obj, str(turn_status))
-                        # If the turn failed for an auth/refresh reason,
-                        # rewrite the error into a re-auth hint AND mark
-                        # the session for retirement.
-                        stderr_blob = "\n".join(
-                            self._client.stderr_tail(40)
-                        )
-                        hint = _classify_oauth_failure(err_msg, stderr_blob)
-                        if hint is not None:
-                            result.error = hint
-                            result.should_retire = True
-                        else:
-                            result.error = self._format_error_with_stderr(
-                                f"turn ended status={turn_status}", err_msg
-                            )
+                record_turn_completion(note)
 
-        if (
-            not turn_complete
-            and not result.interrupted
-            and result.final_text
-            and result.error is None
-        ):
-            logger.warning(
-                "codex app-server turn reached deadline after a completed "
-                "assistant message but before turn/completed; accepting "
-                "the assistant text as the terminal response"
-            )
-            turn_complete = True
-
-        if not turn_complete and not result.interrupted:
-            # Hit the deadline. Issue interrupt to stop wasted compute, and
-            # tell the caller to retire the session — a turn that never
-            # finished is a strong sign codex is wedged in a way the next
-            # turn shouldn't inherit.
-            self._issue_interrupt(result.turn_id)
+        if interrupt_requested:
             result.interrupted = True
-            if not result.error:
-                result.error = self._format_error_with_stderr(
-                    f"turn timed out after {turn_timeout}s"
-                )
             result.should_retire = True
+            if not turn_complete and not result.error:
+                result.error = self._format_error_with_stderr(
+                    "turn interrupt was not confirmed by turn/completed"
+                )
+            # Close only after the matching terminal notification was drained,
+            # or after the bounded grace period expired.  The interrupt RPC's
+            # empty response merely acknowledges the request.
+            self.close()
 
         with self._active_turn_lock:
             self._active_turn_id = None
@@ -793,6 +1102,7 @@ class CodexAppServerSession:
         *,
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
+        interrupt_grace_timeout: float = 5.0,
     ) -> TurnResult:
         """Trigger Codex-native history compaction for the current thread.
 
@@ -809,11 +1119,27 @@ class CodexAppServerSession:
                 "codex app-server startup failed", exc
             )
             result.should_retire = True
+            self.close()
+            self._interrupt_event.clear()
             return result
 
         assert self._client is not None and self._thread_id is not None
         result.thread_id = self._thread_id
-        self._interrupt_event.clear()
+
+        # A stop can arrive while ensure_started() is spawning, initializing,
+        # or resuming the app-server. Honor it before starting compaction;
+        # clearing it here would launch background work after the caller
+        # already asked us to stop.
+        if self._interrupt_event.is_set():
+            result.interrupted = True
+            if self._lease_is_lost():
+                result.error = (
+                    "Codex turn lease was lost before compaction started"
+                )
+                result.should_retire = True
+                self.close()
+            self._interrupt_event.clear()
+            return result
         projector = CodexEventProjector()
 
         try:
@@ -832,6 +1158,7 @@ class CodexAppServerSession:
                 result.error = self._format_error_with_stderr(
                     "thread/compact/start failed", exc
                 )
+            self._interrupt_event.clear()
             return result
         except TimeoutError as exc:
             stderr_blob = "\n".join(self._client.stderr_tail(40))
@@ -840,15 +1167,58 @@ class CodexAppServerSession:
                 "thread/compact/start timed out", exc
             )
             result.should_retire = True
+            self._interrupt_event.clear()
             return result
 
         deadline = time.monotonic() + turn_timeout
         turn_complete = False
+        interrupt_requested = False
+        interrupt_sent = False
+        interrupt_deadline: Optional[float] = None
 
-        while time.monotonic() < deadline and not turn_complete:
-            if self._interrupt_event.is_set():
-                self._issue_interrupt(result.turn_id)
+        while not turn_complete:
+            now = time.monotonic()
+            if not interrupt_requested and now >= deadline:
+                interrupt_requested = True
                 result.interrupted = True
+                result.should_retire = True
+                result.error = self._format_error_with_stderr(
+                    f"compact turn timed out after {turn_timeout}s"
+                )
+
+            if self._lease_is_lost():
+                result.interrupted = True
+                result.error = (
+                    "Codex turn lease refresh failed during compaction; "
+                    "retiring the app-server session"
+                )
+                result.should_retire = True
+                self.close()
+                break
+            if self._interrupt_event.is_set():
+                interrupt_requested = True
+                result.interrupted = True
+                result.should_retire = True
+                self._interrupt_event.clear()
+
+            if interrupt_requested and interrupt_deadline is None:
+                interrupt_deadline = (
+                    time.monotonic() + max(0.0, interrupt_grace_timeout)
+                )
+
+            if (
+                interrupt_requested
+                and result.turn_id is not None
+                and not interrupt_sent
+            ):
+                self._issue_interrupt(result.turn_id)
+                interrupt_sent = True
+
+            if (
+                interrupt_requested
+                and interrupt_deadline is not None
+                and time.monotonic() >= interrupt_deadline
+            ):
                 break
 
             if not self._client.is_alive():
@@ -879,28 +1249,23 @@ class CodexAppServerSession:
             observed_thread_id, observed_turn_id = _notification_scope_ids(note)
             if result.turn_id is None:
                 if method == "turn/started":
-                    if (
-                        observed_thread_id is not None
-                        and str(observed_thread_id) != str(self._thread_id)
+                    if not _notification_belongs_to_turn(
+                        note,
+                        thread_id=self._thread_id,
+                        turn_id=None,
                     ):
                         logger.debug(
-                            "ignoring foreign compact turn/started: thread=%s",
+                            "ignoring unscoped/foreign compact turn/started: "
+                            "thread=%s",
                             observed_thread_id,
                         )
                         continue
-                    if observed_turn_id is None:
-                        logger.debug(
-                            "ignoring compact turn/started without a turn id"
-                        )
-                        continue
                     result.turn_id = str(observed_turn_id)
-                elif observed_turn_id is not None or method in {
-                    "item/completed",
-                    "turn/completed",
-                }:
+                else:
                     # thread/compact/start does not return a turn id. Until the
-                    # new turn/started arrives, any terminal/projectable event
-                    # is stale or cannot be safely attributed to this compaction.
+                    # matching turn/started arrives, every other event is stale
+                    # or cannot be safely attributed to this compaction. This
+                    # includes the deprecated unscoped thread/compacted event.
                     logger.debug(
                         "ignoring codex notification before compact turn start: "
                         "method=%s",
@@ -935,7 +1300,10 @@ class CodexAppServerSession:
                 result.tool_iterations += 1
             if projection.final_text is not None:
                 result.final_text = projection.final_text
-                if _has_turn_aborted_marker(projection.final_text):
+                if (
+                    not interrupt_requested
+                    and _has_turn_aborted_marker(projection.final_text)
+                ):
                     turn_complete = True
                     result.interrupted = True
                     result.error = (
@@ -967,21 +1335,29 @@ class CodexAppServerSession:
                             err_msg,
                         )
 
-        if not turn_complete and not result.interrupted:
-            self._issue_interrupt(result.turn_id)
+        if interrupt_requested:
             result.interrupted = True
-            if not result.error:
-                result.error = self._format_error_with_stderr(
-                    f"compact turn timed out after {turn_timeout}s"
-                )
             result.should_retire = True
+            if not turn_complete and not result.error:
+                result.error = self._format_error_with_stderr(
+                    "compact interrupt was not confirmed by turn/completed"
+                )
+            # `turn/interrupt` acknowledges the request; only the matching
+            # terminal notification confirms Codex has finished unwinding.
+            self.close()
 
+        self._interrupt_event.clear()
         return result
 
     # ---------- internals ----------
 
     def _issue_interrupt(self, turn_id: Optional[str]) -> None:
-        if self._client is None or self._thread_id is None or turn_id is None:
+        if (
+            self._lease_is_lost()
+            or self._client is None
+            or self._thread_id is None
+            or turn_id is None
+        ):
             return
         try:
             self._client.request(
@@ -1007,7 +1383,7 @@ class CodexAppServerSession:
                                                   permission profile in
                                                   ~/.codex/config.toml).
         """
-        if self._client is None:
+        if self._client is None or self._lease_is_lost():
             return
         method = req.get("method", "")
         rid = req.get("id")
@@ -1229,7 +1605,10 @@ def _apply_compaction_notification(result: TurnResult, note: dict) -> None:
         result.turn_id = params.get("turnId") or result.turn_id
         return
 
-    if method not in {"item/started", "item/completed"}:
+    # item/started is only intent/progress. item/completed is the
+    # authoritative execution boundary; counting the started event would turn
+    # a later failed/interrupted compaction into a false success.
+    if method != "item/completed":
         return
 
     item = params.get("item") or {}

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -72,6 +72,10 @@ class TurnResult:
     error: Optional[str] = None  # Set if turn ended in a non-recoverable error
     turn_id: Optional[str] = None
     thread_id: Optional[str] = None
+    # True once Hermes has entered the turn/start JSON-RPC attempt.  A timed
+    # out or rejected request may never yield a turn id, but it still crossed
+    # the model-request boundary and must count as an API-call attempt.
+    turn_start_attempted: bool = False
     token_usage_last: Optional[dict[str, Any]] = None
     token_usage_total: Optional[dict[str, Any]] = None
     model_context_window: Optional[int] = None
@@ -100,7 +104,6 @@ _EXACT_SCOPE_METHODS = {
     "turn/completed",
     "turn/diff/updated",
     "thread/tokenUsage/updated",
-    "thread/compacted",
 }
 
 
@@ -766,6 +769,7 @@ class CodexAppServerSession:
 
         # Send turn/start with the user input. Text-only for now (codex
         # supports rich content but Hermes' text path is the common case).
+        result.turn_start_attempted = True
         try:
             ts = self._client.request(
                 "turn/start",
@@ -803,8 +807,26 @@ class CodexAppServerSession:
             result.should_retire = True
             self._interrupt_event.clear()
             return result
+        except RuntimeError as exc:
+            # CodexAppServerError is a RuntimeError subclass and is handled
+            # above. Reaching this branch means the local JSON-RPC transport
+            # failed after Hermes entered the turn/start attempt (for example,
+            # a broken/closed app-server stdin). Retire the process and return
+            # the explicit attempted boundary so accounting cannot report a
+            # misleading zero-call turn.
+            result.error = self._format_error_with_stderr(
+                "turn/start transport failed", exc
+            )
+            result.should_retire = True
+            self.close()
+            self._interrupt_event.clear()
+            return result
 
-        result.turn_id = (ts.get("turn") or {}).get("id")
+        ts_obj = ts if isinstance(ts, dict) else {}
+        turn_obj = ts_obj.get("turn")
+        if not isinstance(turn_obj, dict):
+            turn_obj = {}
+        result.turn_id = turn_obj.get("id") or ts_obj.get("turnId")
         if not result.turn_id:
             result.error = self._format_error_with_stderr(
                 "turn/start returned no turn id"
@@ -1588,21 +1610,16 @@ def _apply_token_usage_notification(result: TurnResult, note: dict) -> None:
 def _apply_compaction_notification(result: TurnResult, note: dict) -> None:
     """Capture Codex-native context compaction boundaries.
 
-    Recent app-server builds expose compaction as a ContextCompaction item.
-    Older builds also emit the deprecated thread/compacted notification. Both
-    mean the underlying Codex thread history has been compacted.
+    A completed ContextCompaction item is the sole authoritative execution
+    boundary.  The deprecated ``thread/compacted`` notification is ignored:
+    its historical ordering/completion semantics are not strong enough to
+    persist a successful Hermes compaction checkpoint.
     """
     if not isinstance(note, dict):
         return
     method = note.get("method") or ""
     params = note.get("params") or {}
     if not isinstance(params, dict):
-        return
-
-    if method == "thread/compacted":
-        result.compacted = True
-        result.thread_id = params.get("threadId") or result.thread_id
-        result.turn_id = params.get("turnId") or result.turn_id
         return
 
     # item/started is only intent/progress. item/completed is the

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -719,12 +719,23 @@ describe('usePromptActions /compress', () => {
     )
   })
 
-  it('surfaces the RPC error verbatim (e.g. the busy guard) instead of a routing error', async () => {
+  it('interrupts a busy turn and retries compression instead of surfacing the busy guard', async () => {
     const seeds: Record<string, unknown>[] = []
+    let compressAttempts = 0
 
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.compress') {
-        throw new Error('session busy — /interrupt the current turn before /compress')
+        compressAttempts += 1
+
+        if (compressAttempts === 1) {
+          throw new Error('session busy — /interrupt the current turn before /compress')
+        }
+
+        return { removed: 3 } as never
+      }
+
+      if (method === 'session.interrupt') {
+        return { status: 'interrupted' } as never
       }
 
       return {} as never
@@ -743,7 +754,16 @@ describe('usePromptActions /compress', () => {
     await handle!.submitText('/compress')
 
     const texts = renderedSeedTexts(seeds)
-    expect(texts.some(text => text.includes('session busy'))).toBe(true)
+    expect(requestGateway.mock.calls.map(([method]) => method)).toEqual([
+      'session.compress',
+      'session.interrupt',
+      'session.compress'
+    ])
+    expect(requestGateway).toHaveBeenCalledWith('session.interrupt', {
+      session_id: RUNTIME_SESSION_ID
+    })
+    expect(texts.some(text => text.includes('compressed 3 messages'))).toBe(true)
+    expect(texts.some(text => text.includes('session busy'))).toBe(false)
     expect(texts.some(text => text.includes('not a quick/plugin/skill command'))).toBe(false)
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -57,12 +57,14 @@ import type {
 import { resolveTargetSessionId } from './resolve-target-session'
 import {
   type GatewayRequest,
+  isSessionBusyError,
   isSessionIdCandidate,
   isTargetSessionBusy,
   renderCommandsCatalog,
   renderRpcResult,
   slashStatusText,
-  type SubmitTextOptions
+  type SubmitTextOptions,
+  withSessionBusyRetry
 } from './utils'
 
 // Manual compression is LLM-bound and routinely outlives the desktop's 30s
@@ -518,14 +520,41 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           })
 
           try {
-            const result = await requestGateway<SessionCompressResponse>(
-              'session.compress',
-              {
-                session_id: sessionId,
-                ...(focusTopic ? { focus_topic: focusTopic } : {})
-              },
-              SESSION_COMPRESS_TIMEOUT_MS
-            )
+            const compress = () =>
+              requestGateway<SessionCompressResponse>(
+                'session.compress',
+                {
+                  session_id: sessionId,
+                  ...(focusTopic ? { focus_topic: focusTopic } : {})
+                },
+                SESSION_COMPRESS_TIMEOUT_MS
+              )
+
+            let result: SessionCompressResponse
+
+            try {
+              result = await compress()
+            } catch (err) {
+              if (!isSessionBusyError(err)) {
+                throw err
+              }
+
+              // A manual compression request is an explicit request to create
+              // a context boundary now. If a turn is still running, stop it
+              // first and wait for the gateway's running flag/history flush to
+              // settle before retrying. Rewind/edit already use this same
+              // bounded busy-retry contract; without it Desktop merely echoed
+              // "session busy — /interrupt..." and made the user issue two
+              // more commands by hand.
+              notify({
+                durationMs: 0,
+                id: noticeId,
+                kind: 'info',
+                message: 'interrupting the current turn before compression...'
+              })
+              await requestGateway('session.interrupt', { session_id: sessionId })
+              result = await withSessionBusyRetry(compress)
+            }
 
             // Replace the transcript with the post-compress history so the
             // summarized bubbles actually disappear. `messages` is the same

--- a/apps/desktop/src/app/shell/context-usage-panel.test.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.test.tsx
@@ -21,6 +21,7 @@ const breakdown: ContextBreakdown = {
   context_max: 272_000,
   context_percent: 89,
   context_used: 241_400,
+  context_used_estimated: false,
   estimated_total: 286_600,
   model: 'test-model'
 }
@@ -89,5 +90,48 @@ describe('ContextUsagePanel', () => {
     rerender(<ContextUsagePanel currentUsage={initialUsage} requestGateway={secondGateway} sessionId="runtime-2" />)
 
     await waitFor(() => expect(secondGateway).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not replace measured statusbar usage with a rough breakdown estimate', async () => {
+    const requestGateway = vi.fn().mockResolvedValue({
+      ...breakdown,
+      context_percent: 100,
+      context_used: 300_600,
+      context_used_estimated: true
+    })
+
+    const published = vi.fn()
+
+    render(
+      <ContextUsagePanel
+        currentUsage={initialUsage}
+        onUsageSnapshot={published}
+        requestGateway={requestGateway}
+        sessionId="runtime-1"
+      />
+    )
+
+    await waitFor(() => {
+      expect(published).toHaveBeenCalledWith({ context_max: 272_000 })
+    })
+  })
+
+  it('treats a legacy payload without an estimate marker conservatively', async () => {
+    const { context_used_estimated: _marker, ...legacyBreakdown } = breakdown
+    const requestGateway = vi.fn().mockResolvedValue(legacyBreakdown)
+    const published = vi.fn()
+
+    render(
+      <ContextUsagePanel
+        currentUsage={initialUsage}
+        onUsageSnapshot={published}
+        requestGateway={requestGateway}
+        sessionId="runtime-1"
+      />
+    )
+
+    await waitFor(() => {
+      expect(published).toHaveBeenCalledWith({ context_max: 272_000 })
+    })
   })
 })

--- a/apps/desktop/src/app/shell/context-usage-panel.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.tsx
@@ -40,11 +40,19 @@ export function ContextUsagePanel({
       .then(data => {
         if (!cancelled) {
           setBreakdown(data)
-          onUsageSnapshotRef.current?.({
-            context_max: data.context_max,
-            context_percent: data.context_percent,
-            context_used: data.context_used
-          })
+          // The breakdown falls back to a rough request-size estimate while
+          // compaction is waiting for the provider's next real usage report.
+          // Keep rendering that useful estimate in this panel, but do not let
+          // it replace the statusbar's last measured provider usage.
+          onUsageSnapshotRef.current?.(
+            data.context_used_estimated === false
+              ? {
+                  context_max: data.context_max,
+                  context_percent: data.context_percent,
+                  context_used: data.context_used
+                }
+              : { context_max: data.context_max }
+          )
         }
       })
       .catch(() => {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -693,6 +693,7 @@ export interface ContextBreakdown {
   context_max: number
   context_percent: number
   context_used: number
+  context_used_estimated?: boolean
   estimated_total: number
   model?: string
 }

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -777,6 +777,11 @@ streaming:
 # also create new skills after completing complex tasks.
 #
 skills:
+  # Skill metadata injected into every system prompt.
+  # "full" keeps all descriptions. "category_compact" keeps every category
+  # and skill name visible but loads ordinary descriptions only on demand.
+  prompt_index_mode: full
+
   # Nudge the agent to create skills after complex tasks.
   # Every N tool-calling iterations, remind the model to consider saving a skill.
   # Set to 0 to disable.

--- a/cli.py
+++ b/cli.py
@@ -4177,6 +4177,25 @@ class _VoiceInputMessage:
         return self.text
 
 
+class _ProcessNotificationInput:
+    """A queued notification whose durable claim follows the actual turn.
+
+    Keeping the raw event in the CLI queue avoids acknowledging it merely
+    because ``_pending_input.put`` succeeded. The process loop claims just
+    before the synthetic turn and acknowledges only after that turn completes
+    successfully, matching the TUI delivery lifetime.
+    """
+
+    __slots__ = ("text", "event", "consumer", "claim_id", "durable")
+
+    def __init__(self, text: str, event: dict, consumer: str):
+        self.text = text
+        self.event = event
+        self.consumer = consumer
+        self.claim_id = ""
+        self.durable = False
+
+
 class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     """
     Interactive CLI for the Hermes Agent.
@@ -10314,24 +10333,139 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         ``process_registry`` restores durable delegation completions into every
         process using the same Hermes profile.  Always pass this CLI's stable
         session identity when draining so another window cannot claim and mark
-        delivered a completion that belongs to this one.
+        delivered a completion that belongs to this one. The queued envelope
+        is claimed by ``process_loop`` immediately before its agent turn, not
+        here, so a process crash between drain and turn cannot lose the event.
         """
         from tools.process_registry import process_registry
-        from tools.async_delegation import (
-            claim_event_delivery,
-            complete_event_delivery,
-        )
-
         session_key = getattr(self, "session_id", "") or ""
         for event, synthetic_message in process_registry.drain_notifications(
             session_key=session_key,
             owns_event=self._owns_process_notification,
         ):
-            claim = claim_event_delivery(event, consumer)
-            if claim is None:
-                continue
-            self._pending_input.put(synthetic_message)
-            complete_event_delivery(event, claim)
+            self._pending_input.put(
+                _ProcessNotificationInput(synthetic_message, event, consumer)
+            )
+
+    @staticmethod
+    def _requeue_process_notification_if_pending(
+        notification: _ProcessNotificationInput,
+    ) -> None:
+        """Release a failed claim and preserve only a still-live event."""
+        from tools.async_delegation import (
+            DELIVERY_BUSY_PENDING,
+            DELIVERY_TERMINAL_CONSUMED,
+            inspect_event_delivery_state,
+            release_event_delivery,
+        )
+        from tools.process_registry import process_registry
+
+        if notification.claim_id:
+            try:
+                release_event_delivery(
+                    notification.event, notification.claim_id
+                )
+            except Exception:
+                logger.warning(
+                    "CLI notification delivery release failed",
+                    exc_info=True,
+                )
+        try:
+            state = inspect_event_delivery_state(notification.event)
+        except Exception:
+            # A state-store read failure is not proof that another consumer
+            # terminally accepted the event. Preserve it for a later pass.
+            logger.warning(
+                "CLI notification delivery state inspection failed",
+                exc_info=True,
+            )
+            state = DELIVERY_BUSY_PENDING
+        # Terminal is the only positive proof that retry would duplicate an
+        # already-consumed event. A failure while classifying a legacy event
+        # has not run its turn, so it remains retryable too.
+        if state != DELIVERY_TERMINAL_CONSUMED:
+            process_registry.completion_queue.put(notification.event)
+
+    def _claim_process_notification(
+        self, notification: _ProcessNotificationInput
+    ) -> bool:
+        """Claim immediately before the synthetic turn becomes visible."""
+        from tools.async_delegation import (
+            DELIVERY_BUSY_PENDING,
+            DELIVERY_CLAIMED,
+            DELIVERY_LEGACY_NON_DURABLE,
+            DELIVERY_TERMINAL_CONSUMED,
+            claim_event_delivery_state,
+        )
+        from tools.process_registry import process_registry
+
+        try:
+            result = claim_event_delivery_state(
+                notification.event, notification.consumer
+            )
+        except Exception:
+            logger.warning(
+                "CLI notification delivery claim failed",
+                exc_info=True,
+            )
+            self._requeue_process_notification_if_pending(notification)
+            return False
+        if result.state == DELIVERY_BUSY_PENDING:
+            process_registry.completion_queue.put(notification.event)
+            return False
+        if result.state == DELIVERY_TERMINAL_CONSUMED:
+            return False
+        if result.state == DELIVERY_LEGACY_NON_DURABLE:
+            notification.durable = False
+            return True
+        if result.state != DELIVERY_CLAIMED or not result.claim_id:
+            self._requeue_process_notification_if_pending(notification)
+            return False
+        notification.claim_id = result.claim_id
+        notification.durable = True
+        return True
+
+    def _settle_process_notification(
+        self,
+        notification: _ProcessNotificationInput,
+        succeeded: bool,
+    ) -> None:
+        """Acknowledge only a successful terminal turn; otherwise retry."""
+        if not notification.durable:
+            if not succeeded:
+                from tools.process_registry import process_registry
+
+                process_registry.completion_queue.put(notification.event)
+            return
+        acknowledged = False
+        if succeeded:
+            try:
+                from tools.async_delegation import complete_event_delivery
+
+                acknowledged = bool(
+                    complete_event_delivery(
+                        notification.event, notification.claim_id
+                    )
+                )
+            except Exception:
+                logger.warning(
+                    "CLI notification delivery completion failed",
+                    exc_info=True,
+                )
+        if not acknowledged:
+            self._requeue_process_notification_if_pending(notification)
+
+    @staticmethod
+    def _process_notification_turn_succeeded(result: Any) -> bool:
+        """Return whether an agent result is safe to acknowledge durably."""
+        return bool(
+            isinstance(result, dict)
+            and result.get("completed") is True
+            and not result.get("interrupted")
+            and not result.get("error")
+            and not result.get("failed")
+            and not result.get("partial")
+        )
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
         """Move stray messages from ``_interrupt_queue`` into ``_pending_input``.
@@ -13333,6 +13467,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # this to True. Early returns (credential refresh failure, etc.)
         # leave it False, which is correct — those aren't user interrupts.
         self._last_turn_interrupted = False
+        # Notification delivery uses this stricter terminal outcome instead
+        # of treating any return value (including an error string) as success.
+        self._last_turn_succeeded = False
 
         # Refresh provider credentials if needed (handles key rotation transparently)
         if not self._ensure_runtime_credentials():
@@ -14124,6 +14261,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
                 self._pending_input.put(_leftover_steer)
 
+            self._last_turn_succeeded = (
+                self._process_notification_turn_succeeded(result)
+            )
             return response
             
         except Exception as e:
@@ -16777,6 +16917,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Background thread to process inputs and run agent
         def process_loop():
             while not self._should_exit:
+                notification_input = None
                 try:
                     # Check for pending input with timeout
                     try:
@@ -16792,6 +16933,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             except Exception:
                                 pass
                         continue
+
+                    if isinstance(user_input, _ProcessNotificationInput):
+                        notification_input = user_input
+                        if not self._claim_process_notification(
+                            notification_input
+                        ):
+                            notification_input = None
+                            continue
+                        user_input = notification_input.text
 
                     # Voice-transcribed messages arrive wrapped in a sentinel
                     # so only genuine STT output gets the voice prefix (#65827).
@@ -16902,8 +17052,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     app.invalidate()  # Refresh status line
 
                     try:
+                        self._last_turn_succeeded = False
                         self.chat(user_input, images=submit_images or None, voice_input=is_voice_input)
                     finally:
+                        if notification_input is not None:
+                            notification_to_settle = notification_input
+                            notification_input = None
+                            try:
+                                self._settle_process_notification(
+                                    notification_to_settle,
+                                    bool(
+                                        getattr(
+                                            self,
+                                            "_last_turn_succeeded",
+                                            False,
+                                        )
+                                    ),
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "CLI notification settlement failed",
+                                    exc_info=True,
+                                )
                         self._agent_running = False
                         self._spinner_text = ""
                         self._tool_start_time = 0.0
@@ -16979,6 +17149,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
                 except Exception as e:
                     logger.warning("process_loop unhandled error (msg may be lost): %s", e)
+                finally:
+                    if notification_input is not None:
+                        notification_to_settle = notification_input
+                        notification_input = None
+                        try:
+                            self._settle_process_notification(
+                                notification_to_settle, False
+                            )
+                        except Exception:
+                            logger.warning(
+                                "CLI notification rollback failed",
+                                exc_info=True,
+                            )
         
         # Start processing thread
         process_thread = threading.Thread(target=process_loop, daemon=True)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5693,6 +5693,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._completion_delivery_lock = threading.Lock()
         self._completion_deliveries_inflight: set[tuple[str, str, object]] = set()
         self._completion_deliveries_delivered: "OrderedDict[tuple[str, str, object], None]" = OrderedDict()
+        # Adapter acceptance is irreversible even when its durable CAS is
+        # temporarily uncertain. Keep those identities outside the bounded
+        # delivered-LRU so retention pressure cannot permit reinjection.
+        self._completion_deliveries_settlement_pending: set[
+            tuple[str, str, object]
+        ] = set()
         self._completion_delivery_retention = 2048
 
         # Cache AIAgent instances per session to preserve prompt caching.
@@ -21001,10 +21007,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> Optional[bool]:
         """Deliver once per live gateway, or return False for a retry.
 
-        ``True`` means this caller reached adapter acceptance, ``False`` means
-        injection failed and the claim was released for retry, and ``None``
-        means either another same-lifecycle caller owns/delivered the producer
-        event or the event has no gateway route. No cross-process exactly-once
+        ``True`` means adapter acceptance and durable settlement both
+        completed. ``False`` means injection or settlement must be retried,
+        and ``None`` means another same-lifecycle caller owns/consumed the
+        event or it has no gateway route. Once an adapter accepts, retries in
+        this process are settlement-only; no cross-process exactly-once
         guarantee is claimed.
         """
         identity = self._completion_delivery_identity(evt)
@@ -21014,13 +21021,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             durable_delegation_id = str(evt.get("delegation_id") or "")
             if durable_delegation_id:
                 try:
-                    from tools.async_delegation import claim_completion_delivery
+                    from tools.async_delegation import (
+                        DELIVERY_BUSY_PENDING,
+                        DELIVERY_CLAIMED,
+                        DELIVERY_TERMINAL_CONSUMED,
+                        claim_event_delivery_state,
+                    )
 
-                    durable_claim_id = f"gateway:{id(self)}:{__import__('uuid').uuid4().hex}"
-                    if not claim_completion_delivery(
-                        durable_delegation_id, durable_claim_id,
-                    ):
+                    claim = claim_event_delivery_state(evt, "gateway")
+                    if claim.state == DELIVERY_TERMINAL_CONSUMED:
+                        if identity is not None:
+                            with self._completion_delivery_lock:
+                                self._completion_deliveries_settlement_pending.discard(
+                                    identity
+                                )
+                                self._completion_deliveries_delivered[identity] = None
+                                while (
+                                    len(self._completion_deliveries_delivered)
+                                    > self._completion_delivery_retention
+                                ):
+                                    self._completion_deliveries_delivered.popitem(
+                                        last=False
+                                    )
                         return None
+                    if claim.state == DELIVERY_BUSY_PENDING:
+                        # A live claimant may be injecting, or its lease may
+                        # be approaching rollover. Keep the queue item so a
+                        # successor can observe the eventual terminal state.
+                        return False
+                    if claim.state == DELIVERY_CLAIMED:
+                        durable_claim_id = claim.claim_id
                 except Exception as exc:
                     logger.warning(
                         "Could not claim durable async completion %s: %s",
@@ -21070,12 +21100,120 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 exc_info=True,
                             )
                     return False
+
+        # An adapter acceptance cannot be revoked.  If a previous pass got
+        # that far but its durable settlement was uncertain, a replay in this
+        # gateway must retry only the compare-and-set acknowledgement, never
+        # inject the same delegation into the adapter again.
+        previously_accepted = False
+        if identity is not None:
+            with self._completion_delivery_lock:
+                previously_accepted = (
+                    identity in self._completion_deliveries_settlement_pending
+                )
+
+        def _remember_durable_settlement_pending() -> None:
+            if identity is None:
+                return
+            with self._completion_delivery_lock:
+                self._completion_deliveries_inflight.discard(identity)
+                self._completion_deliveries_settlement_pending.add(identity)
+
+        def _mark_durable_settlement_terminal() -> None:
+            if identity is None:
+                return
+            with self._completion_delivery_lock:
+                self._completion_deliveries_settlement_pending.discard(identity)
+                # Keep ordinary same-lifecycle deduplication after the
+                # durable ledger has converged (including a successor's
+                # delivered/dropped/pruned terminal disposition).
+                self._completion_deliveries_delivered[identity] = None
+                while (
+                    len(self._completion_deliveries_delivered)
+                    > self._completion_delivery_retention
+                ):
+                    self._completion_deliveries_delivered.popitem(last=False)
+
+        def _settle_durable_acceptance() -> Optional[bool]:
+            """Commit adapter acceptance, retrying safely when CAS is uncertain."""
+            if not durable_claim_id:
+                return True
+            try:
+                from tools.async_delegation import (
+                    DELIVERY_TERMINAL_CONSUMED,
+                    complete_completion_delivery,
+                    inspect_event_delivery_state,
+                    release_completion_delivery,
+                )
+
+                if complete_completion_delivery(
+                    durable_delegation_id, durable_claim_id,
+                ):
+                    _mark_durable_settlement_terminal()
+                    return True
+                logger.warning(
+                    "Durable async completion settlement CAS lost for %s",
+                    durable_delegation_id,
+                )
+            except Exception:
+                logger.warning(
+                    "Could not acknowledge durable async completion %s",
+                    durable_delegation_id, exc_info=True,
+                )
+                try:
+                    from tools.async_delegation import (
+                        DELIVERY_TERMINAL_CONSUMED,
+                        inspect_event_delivery_state,
+                        release_completion_delivery,
+                    )
+                except Exception:
+                    return False
+
+            # A failed CAS is not durable success. Re-read the authoritative
+            # row: a stale claimant must consume a successor's terminal
+            # delivered/dropped/pruned outcome, while a still-pending row is
+            # released and retried through the bounded claim-attempt policy.
+            try:
+                state = inspect_event_delivery_state(evt)
+            except Exception:
+                logger.debug(
+                    "Could not inspect durable completion settlement %s",
+                    durable_delegation_id, exc_info=True,
+                )
+                state = None
+            if state == DELIVERY_TERMINAL_CONSUMED:
+                _mark_durable_settlement_terminal()
+                return None
+            try:
+                release_completion_delivery(durable_delegation_id, durable_claim_id)
+            except Exception:
+                logger.debug("Could not release durable completion claim", exc_info=True)
+            return False
+
+        if previously_accepted:
+            # This invocation owns a fresh durable claim, but not a fresh
+            # adapter delivery.  It is a settlement retry only.
+            return _settle_durable_acceptance()
+
         if identity is not None:
             with self._completion_delivery_lock:
                 if (
                     identity in self._completion_deliveries_inflight
+                    or identity in self._completion_deliveries_settlement_pending
                     or identity in self._completion_deliveries_delivered
                 ):
+                    if durable_claim_id:
+                        try:
+                            from tools.async_delegation import release_completion_delivery
+
+                            release_completion_delivery(
+                                durable_delegation_id, durable_claim_id,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Could not release duplicate durable completion claim",
+                                exc_info=True,
+                            )
                     return None
                 self._completion_deliveries_inflight.add(identity)
 
@@ -21087,31 +21225,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             accepted = True
 
             if identity is not None:
-                with self._completion_delivery_lock:
-                    self._completion_deliveries_inflight.discard(identity)
-                    self._completion_deliveries_delivered[identity] = None
-                    while (
-                        len(self._completion_deliveries_delivered)
-                        > self._completion_delivery_retention
-                    ):
-                        self._completion_deliveries_delivered.popitem(last=False)
+                if durable_claim_id:
+                    _remember_durable_settlement_pending()
+                else:
+                    _mark_durable_settlement_terminal()
 
-            # If the durable async-delegation producer branch is present, its
-            # SQLite row remains the authoritative replay state. Acknowledge it
-            # after adapter acceptance; this gateway keeps no parallel ledger.
-            if durable_claim_id:
-                try:
-                    from tools.async_delegation import complete_completion_delivery
-
-                    complete_completion_delivery(
-                        durable_delegation_id, durable_claim_id,
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        "Could not acknowledge durable async completion %s: %s",
-                        durable_delegation_id, exc,
-                    )
-            return True
+            return _settle_durable_acceptance()
         finally:
             if identity is not None and not accepted:
                 with self._completion_delivery_lock:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2445,9 +2445,10 @@ class GatewaySlashCommandsMixin:
             /codex-runtime codex_app_server — codex subprocess runtime
             /codex-runtime on / off         — synonyms
 
-        On change, the cached agent for this session is evicted so the next
-        message creates a fresh AIAgent with the new api_mode wired in
-        (avoids prompt-cache invalidation mid-session)."""
+        Runtime changes are persisted for the next conversation boundary.
+        The current cached agent must keep its original runtime so a config
+        toggle cannot replace its model-visible context mid-session. Users
+        apply the new runtime explicitly with /new or /reset."""
         from hermes_cli import codex_runtime_switch as crs
 
         raw_args = event.get_command_args().strip() if event else ""
@@ -2467,16 +2468,6 @@ class GatewaySlashCommandsMixin:
             new_value,
             persist_callback=(save_config if new_value is not None else None),
         )
-
-        # On a real change, evict the cached agent so the new runtime takes
-        # effect on the next message rather than waiting for cache TTL.
-        if result.success and new_value is not None and result.requires_new_session:
-            try:
-                session_key = self._session_key_for_source(event.source)
-                self._evict_cached_agent(session_key)
-            except Exception:
-                logger.debug("could not evict cached agent after codex-runtime change",
-                             exc_info=True)
 
         prefix = "✓" if result.success else "✗"
         return f"{prefix} {result.message}"

--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -263,13 +263,13 @@ def apply(
             "(terminal/file ops/patching inside Codex; "
             "Hermes tools available via MCP callback)."
         )
-        msg_lines.append(
-            "Effective on next session — current cached agent keeps "
-            "the prior runtime to preserve prompt cache."
-        )
     else:
         msg_lines.append("OpenAI/Codex turns will use the default Hermes runtime.")
-        msg_lines.append("Effective on next session.")
+    msg_lines.append(
+        "Saved for the next session — the current Hermes session keeps "
+        "its existing runtime to preserve prompt cache and conversation "
+        "continuity. Run `/new` or `/reset` to apply this change."
+    )
     return CodexRuntimeStatus(
         success=True,
         new_value=new_value,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1681,6 +1681,11 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # System-prompt skill index:
+        #   full             — include every skill description (legacy default)
+        #   category_compact — keep every category/name visible, load ordinary
+        #                      descriptions on demand with skills_list/skill_view
+        "prompt_index_mode": "full",
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -25,6 +25,7 @@ import sqlite3
 import sys
 import threading
 import time
+import uuid
 from collections import deque
 from contextlib import contextmanager
 from pathlib import Path
@@ -127,6 +128,91 @@ def _compression_lock_holder_process_is_dead(holder: str) -> bool:
     except (PermissionError, OSError, OverflowError):
         return False
     return False
+
+
+def _codex_turn_lease_process_start_time(pid: int) -> Optional[int]:
+    """Return a stable start-time fingerprint for ``pid``, or ``None``.
+
+    A PID alone is not an ownership identity because operating systems reuse
+    PIDs. Linux exposes field 22 of ``/proc/<pid>/stat``; macOS and Windows
+    use psutil's process creation time, quantized to centiseconds. Any probe
+    doubt is reported as ``None`` so lease acquisition/recovery can fail
+    closed instead of guessing that an owner died.
+    """
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return None
+    if pid <= 0:
+        return None
+
+    try:
+        stat_text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+        # proc_pid_stat(5) encloses comm in parentheses, and comm itself may
+        # contain spaces or ')'. Parse fields only after the final ')' so field
+        # 22 (starttime) remains stable; a naïve split shifts the index.
+        comm_end = stat_text.rfind(")")
+        if comm_end < 0:
+            raise ValueError("malformed /proc stat")
+        fields_after_comm = stat_text[comm_end + 1 :].strip().split()
+        # The suffix begins at field 3 (state), so field 22 is index 19.
+        return int(fields_after_comm[19])
+    except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        # Do not mix Linux /proc starttime ticks with psutil epoch seconds.
+        # Comparing fingerprints from different units can make a live owner
+        # look like a reused PID and permit an unsafe stale-lease takeover.
+        # On Linux, an unreadable /proc identity is therefore inconclusive.
+        if sys.platform.startswith("linux"):
+            return None
+
+    if psutil is None:
+        return None
+    try:
+        return int(round(psutil.Process(pid).create_time() * 100))
+    except Exception:
+        return None
+
+
+def _codex_turn_lease_owner_is_alive(
+    owner_pid: Any,
+    owner_started_at: Any,
+) -> Optional[bool]:
+    """Return ``True``/``False`` only when lease-owner identity is provable.
+
+    ``None`` means the process probe was inconclusive. Callers must treat that
+    as alive and keep the lease: a false-death decision can put two app-server
+    clients on one Codex thread, while a conservative keep merely delays
+    recovery until process identity can be checked again.
+    """
+    try:
+        pid = int(owner_pid)
+        expected_start = int(owner_started_at)
+    except (TypeError, ValueError):
+        return None
+    if pid <= 0 or expected_start <= 0:
+        return None
+
+    current_start = _codex_turn_lease_process_start_time(pid)
+    if current_start is not None:
+        return current_start == expected_start
+
+    # A missing start-time probe can mean either "gone" or "unreadable".
+    # psutil.pid_exists is the cross-platform discriminator; unlike
+    # os.kill(pid, 0), it is safe on native Windows.
+    if psutil is None:
+        return None
+    try:
+        return bool(psutil.pid_exists(pid))
+    except Exception:
+        return None
+
+
+def _normalize_codex_turn_lease_holder(holder_uuid: Any) -> Optional[str]:
+    """Return a canonical UUID string for a lease holder."""
+    try:
+        return str(uuid.UUID(str(holder_uuid or "").strip()))
+    except (AttributeError, TypeError, ValueError):
+        return None
 
 
 def _scrub_surrogates(value: Any) -> Any:
@@ -738,6 +824,26 @@ def apply_wal_with_fallback(
             raise WalUnsupportedError(str(exc)) from exc
         _log_wal_fallback_once(db_label, exc)
         return _set_delete_journal_mode(conn, reason="fallback")
+
+
+def _set_delete_journal_mode(
+    conn: sqlite3.Connection,
+    *,
+    reason: str,
+) -> str:
+    """Switch to DELETE mode and verify SQLite accepted the transition."""
+    row = conn.execute("PRAGMA journal_mode=DELETE").fetchone()
+    actual = (
+        str(row[0]).strip().lower()
+        if row and row[0] is not None
+        else ""
+    )
+    if actual != "delete":
+        raise sqlite3.OperationalError(
+            "could not set journal_mode=delete during "
+            f"{reason} (got {actual or 'no result'})"
+        )
+    return actual
 
 
 def _apply_delete_for_wal_reset_bug(
@@ -1526,6 +1632,10 @@ class CompressionSessionClosedError(RuntimeError):
 
 class CompressionSessionBusyError(RuntimeError):
     """A non-owner tried to write while compression owns the session."""
+
+
+class _CodexTurnLeaseBindConflict(RuntimeError):
+    """Abort an atomic Codex thread bind without committing partial state."""
 
 
 def _connect_tracked_db(path, tracking_path=None, **kwargs):
@@ -3238,6 +3348,547 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (session_id,),
             )
         self._execute_write(_do)
+
+    def get_codex_thread_id(self, session_id: str) -> Optional[str]:
+        """Return the Codex app-server thread bound to a Hermes session.
+
+        ``sessions.thread_id`` is reserved for the messaging origin
+        (Telegram topic, Discord thread, and similar gateway routing). Codex's
+        app-server thread is a separate persistence domain whose rollout owns
+        native compaction state, so it must never reuse that routing column.
+        """
+        if not session_id:
+            return None
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT codex_thread_id FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        value = (
+            row["codex_thread_id"]
+            if isinstance(row, sqlite3.Row)
+            else row[0]
+        )
+        value = str(value or "").strip()
+        return value or None
+
+    def bind_codex_thread_id(self, session_id: str, thread_id: str) -> bool:
+        """Atomically bind one canonical Codex thread to a Hermes session.
+
+        The first writer wins. Rebinding the same value is idempotent, while a
+        different existing value or a thread already bound to another session
+        is rejected. BEGIN IMMEDIATE serializes the application-level global
+        uniqueness check with the update.
+        """
+        session_id = str(session_id or "").strip()
+        thread_id = str(thread_id or "").strip()
+        if not session_id or not thread_id:
+            return False
+
+        def _do(conn):
+            duplicate = conn.execute(
+                "SELECT id FROM sessions "
+                "WHERE codex_thread_id = ? AND id != ? LIMIT 1",
+                (thread_id, session_id),
+            ).fetchone()
+            if duplicate is not None:
+                return False
+            cursor = conn.execute(
+                "UPDATE sessions SET codex_thread_id = ? "
+                "WHERE id = ? AND (codex_thread_id IS NULL "
+                "OR codex_thread_id = '' OR codex_thread_id = ?)",
+                (thread_id, session_id, thread_id),
+            )
+            return cursor.rowcount == 1
+
+        return bool(self._execute_write(_do))
+
+    # ──────────────────────────────────────────────────────────────────
+    # Codex app-server turn leases
+    # ──────────────────────────────────────────────────────────────────
+    # Codex currently assumes that only one app-server client drives a
+    # persisted thread at a time. The API server and CLI can otherwise create
+    # separate app-server processes that both resume the same thread and start
+    # concurrent turns. These state.db leases are therefore a correctness
+    # boundary, not a throughput hint: every error returns False and the caller
+    # must refuse to start/resume/compact the Codex thread.
+
+    def bind_codex_thread_under_lease(
+        self,
+        session_id: str,
+        holder_uuid: str,
+        thread_id: str,
+    ) -> bool:
+        """Atomically bind a newly-started Codex thread under its lease.
+
+        The session's first-writer-wins binding and the provisional lease's
+        nullable thread ID are updated in the same BEGIN IMMEDIATE transaction.
+        The exact holder UUID, PID, and process-start fingerprint must still
+        own the lease. The thread must not be bound to any other session or
+        lease. Any conflict, SQLite error, or timeout rolls back both updates
+        and returns ``False``.
+        """
+        session_id = str(session_id or "").strip()
+        thread_id = str(thread_id or "").strip()
+        holder = _normalize_codex_turn_lease_holder(holder_uuid)
+        if not session_id or not thread_id or holder is None:
+            return False
+
+        owner_pid = os.getpid()
+        owner_started_at = _codex_turn_lease_process_start_time(owner_pid)
+        if owner_started_at is None:
+            return False
+
+        def _do(conn):
+            lease = conn.execute(
+                "SELECT codex_thread_id FROM codex_turn_leases "
+                "WHERE session_id = ? AND holder_uuid = ? AND owner_pid = ? "
+                "AND owner_started_at = ?",
+                (session_id, holder, owner_pid, owner_started_at),
+            ).fetchone()
+            if lease is None:
+                return False
+            leased_thread_id = str(lease["codex_thread_id"] or "").strip()
+            if leased_thread_id and leased_thread_id != thread_id:
+                return False
+
+            session = conn.execute(
+                "SELECT codex_thread_id FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if session is None:
+                return False
+            bound_thread_id = str(session["codex_thread_id"] or "").strip()
+            if bound_thread_id and bound_thread_id != thread_id:
+                return False
+
+            duplicate_session = conn.execute(
+                "SELECT id FROM sessions "
+                "WHERE codex_thread_id = ? AND id != ? LIMIT 1",
+                (thread_id, session_id),
+            ).fetchone()
+            duplicate_lease = conn.execute(
+                "SELECT session_id FROM codex_turn_leases "
+                "WHERE codex_thread_id = ? AND session_id != ? LIMIT 1",
+                (thread_id, session_id),
+            ).fetchone()
+            if duplicate_session is not None or duplicate_lease is not None:
+                return False
+
+            bound = conn.execute(
+                "UPDATE sessions SET codex_thread_id = ? "
+                "WHERE id = ? AND (codex_thread_id IS NULL "
+                "OR codex_thread_id = '' OR codex_thread_id = ?)",
+                (thread_id, session_id, thread_id),
+            )
+            if bound.rowcount != 1:
+                raise _CodexTurnLeaseBindConflict
+
+            attached = conn.execute(
+                "UPDATE codex_turn_leases SET codex_thread_id = ? "
+                "WHERE session_id = ? AND holder_uuid = ? AND owner_pid = ? "
+                "AND owner_started_at = ? AND (codex_thread_id IS NULL "
+                "OR codex_thread_id = ?)",
+                (
+                    thread_id,
+                    session_id,
+                    holder,
+                    owner_pid,
+                    owner_started_at,
+                    thread_id,
+                ),
+            )
+            if attached.rowcount != 1:
+                raise _CodexTurnLeaseBindConflict
+            return True
+
+        try:
+            return bool(self._execute_write(_do, patience_s=2.0))
+        except (_CodexTurnLeaseBindConflict, sqlite3.Error, TimeoutError) as exc:
+            logger.warning(
+                "bind_codex_thread_under_lease(%s, %s) failed closed: %s",
+                session_id,
+                thread_id,
+                exc,
+            )
+            return False
+
+    def try_acquire_codex_turn_lease(
+        self,
+        session_id: str,
+        holder_uuid: str,
+        *,
+        codex_thread_id: Optional[str] = None,
+        ttl_seconds: float = 300.0,
+    ) -> bool:
+        """Atomically acquire exclusive use of one Hermes/Codex turn.
+
+        ``session_id`` is the primary lease identity because ``thread/start``
+        must acquire before Codex has returned a thread ID. If the session is
+        already bound, the durable binding is copied into the lease. A
+        supplied ``codex_thread_id`` is accepted only when it exactly matches
+        that binding; the nullable UNIQUE column then also prevents two Hermes
+        sessions from driving the same known Codex thread.
+
+        A stale row is reclaimed only when BOTH conditions hold:
+
+        * its TTL has expired; and
+        * its ``(owner_pid, owner_started_at)`` identity is provably dead or
+          the PID has been reused.
+
+        Probe doubt and a live process both keep the row. In particular, a
+        slow refresher in this process cannot let a sibling holder steal an
+        otherwise live lease merely because the TTL elapsed.
+
+        ``holder_uuid`` is normalized and must be a valid UUID. The owner PID
+        and process-start fingerprint are captured internally so callers
+        cannot accidentally create a lease that they cannot refresh/release.
+        All SQLite, lock-timeout, and process-identity failures return
+        ``False`` (fail closed).
+        """
+        session_id = str(session_id or "").strip()
+        requested_thread_id = str(codex_thread_id or "").strip() or None
+        holder = _normalize_codex_turn_lease_holder(holder_uuid)
+        try:
+            ttl = float(ttl_seconds)
+        except (TypeError, ValueError):
+            return False
+        if (
+            not session_id
+            or holder is None
+            or not (ttl > 0.0)
+            or ttl == float("inf")
+        ):
+            return False
+
+        owner_pid = os.getpid()
+        owner_started_at = _codex_turn_lease_process_start_time(owner_pid)
+        if owner_started_at is None:
+            logger.error(
+                "codex turn lease: could not fingerprint owner process; "
+                "refusing acquisition for session=%s",
+                session_id,
+            )
+            return False
+
+        now = time.time()
+        expires_at = now + ttl
+
+        def _do(conn):
+            binding = conn.execute(
+                "SELECT codex_thread_id FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if binding is None:
+                return False
+            bound_thread_id = str(
+                (
+                    binding["codex_thread_id"]
+                    if isinstance(binding, sqlite3.Row)
+                    else binding[0]
+                )
+                or ""
+            ).strip()
+            bound_thread_id = bound_thread_id or None
+            if (
+                requested_thread_id is not None
+                and bound_thread_id != requested_thread_id
+            ):
+                return False
+            effective_thread_id = requested_thread_id or bound_thread_id
+            if effective_thread_id is not None:
+                duplicate_binding = conn.execute(
+                    "SELECT id FROM sessions "
+                    "WHERE codex_thread_id = ? AND id != ? LIMIT 1",
+                    (effective_thread_id, session_id),
+                ).fetchone()
+                if duplicate_binding is not None:
+                    return False
+
+            if effective_thread_id is None:
+                rows = conn.execute(
+                    "SELECT session_id, codex_thread_id, holder_uuid, owner_pid, "
+                    "owner_started_at, acquired_at, refreshed_at, expires_at "
+                    "FROM codex_turn_leases WHERE session_id = ?",
+                    (session_id,),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT session_id, codex_thread_id, holder_uuid, owner_pid, "
+                    "owner_started_at, acquired_at, refreshed_at, expires_at "
+                    "FROM codex_turn_leases "
+                    "WHERE session_id = ? OR codex_thread_id = ?",
+                    (session_id, effective_thread_id),
+                ).fetchall()
+            # Two rows can only arise from a damaged/manually-edited database
+            # where each unique key points at a different lease. Never choose
+            # a winner heuristically.
+            if len(rows) > 1:
+                return False
+
+            if rows:
+                row = rows[0]
+                existing_session_id = str(row["session_id"])
+                existing_thread_id = (
+                    str(row["codex_thread_id"]).strip()
+                    if row["codex_thread_id"] is not None
+                    else None
+                )
+                existing_holder = str(row["holder_uuid"])
+                existing_pid = int(row["owner_pid"])
+                existing_started_at = int(row["owner_started_at"])
+                existing_expires_at = float(row["expires_at"])
+
+                same_owner = (
+                    existing_session_id == session_id
+                    and existing_holder == holder
+                    and existing_pid == owner_pid
+                    and existing_started_at == owner_started_at
+                )
+                if same_owner:
+                    if (
+                        existing_thread_id is not None
+                        and existing_thread_id != effective_thread_id
+                    ):
+                        return False
+                    cursor = conn.execute(
+                        "UPDATE codex_turn_leases "
+                        "SET codex_thread_id = COALESCE(codex_thread_id, ?), "
+                        "refreshed_at = ?, expires_at = ? "
+                        "WHERE session_id = ? "
+                        "AND holder_uuid = ? AND owner_pid = ? "
+                        "AND owner_started_at = ?",
+                        (
+                            effective_thread_id,
+                            now,
+                            expires_at,
+                            session_id,
+                            holder,
+                            owner_pid,
+                            owner_started_at,
+                        ),
+                    )
+                    return cursor.rowcount == 1
+
+                if existing_expires_at >= now:
+                    return False
+                owner_alive = _codex_turn_lease_owner_is_alive(
+                    existing_pid,
+                    existing_started_at,
+                )
+                if owner_alive is not False:
+                    return False
+
+                deleted = conn.execute(
+                    "DELETE FROM codex_turn_leases "
+                    "WHERE session_id = ? AND holder_uuid = ? AND owner_pid = ? "
+                    "AND owner_started_at = ? AND expires_at = ?",
+                    (
+                        existing_session_id,
+                        existing_holder,
+                        existing_pid,
+                        existing_started_at,
+                        existing_expires_at,
+                    ),
+                )
+                if deleted.rowcount != 1:
+                    return False
+
+            try:
+                inserted = conn.execute(
+                    "INSERT INTO codex_turn_leases "
+                    "(session_id, codex_thread_id, holder_uuid, owner_pid, "
+                    "owner_started_at, acquired_at, refreshed_at, expires_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        session_id,
+                        effective_thread_id,
+                        holder,
+                        owner_pid,
+                        owner_started_at,
+                        now,
+                        now,
+                        expires_at,
+                    ),
+                )
+            except sqlite3.IntegrityError:
+                # A binding/uniqueness race or missing session row is ordinary
+                # lease contention from the caller's perspective: fail closed.
+                return False
+            return inserted.rowcount == 1
+
+        try:
+            return bool(self._execute_write(_do, patience_s=2.0))
+        except (sqlite3.Error, TimeoutError) as exc:
+            logger.warning(
+                "try_acquire_codex_turn_lease(%s, thread=%s) failed closed: %s",
+                session_id,
+                requested_thread_id,
+                exc,
+            )
+            return False
+
+    def refresh_codex_turn_lease(
+        self,
+        session_id: str,
+        holder_uuid: str,
+        *,
+        codex_thread_id: Optional[str] = None,
+        ttl_seconds: float = 300.0,
+    ) -> bool:
+        """Extend an owned lease and attach its durable Codex ID when known."""
+        session_id = str(session_id or "").strip()
+        requested_thread_id = str(codex_thread_id or "").strip() or None
+        holder = _normalize_codex_turn_lease_holder(holder_uuid)
+        try:
+            ttl = float(ttl_seconds)
+        except (TypeError, ValueError):
+            return False
+        if (
+            not session_id
+            or holder is None
+            or not (ttl > 0.0)
+            or ttl == float("inf")
+        ):
+            return False
+
+        owner_pid = os.getpid()
+        owner_started_at = _codex_turn_lease_process_start_time(owner_pid)
+        if owner_started_at is None:
+            return False
+        now = time.time()
+
+        def _do(conn):
+            binding = conn.execute(
+                "SELECT codex_thread_id FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if binding is None:
+                return False
+            bound_thread_id = str(
+                (
+                    binding["codex_thread_id"]
+                    if isinstance(binding, sqlite3.Row)
+                    else binding[0]
+                )
+                or ""
+            ).strip() or None
+            if (
+                requested_thread_id is not None
+                and bound_thread_id != requested_thread_id
+            ):
+                return False
+            effective_thread_id = requested_thread_id or bound_thread_id
+
+            lease = conn.execute(
+                "SELECT codex_thread_id FROM codex_turn_leases "
+                "WHERE session_id = ? AND holder_uuid = ? AND owner_pid = ? "
+                "AND owner_started_at = ?",
+                (session_id, holder, owner_pid, owner_started_at),
+            ).fetchone()
+            if lease is None:
+                return False
+            leased_thread_id = (
+                str(lease["codex_thread_id"]).strip()
+                if lease["codex_thread_id"] is not None
+                else None
+            )
+            if (
+                leased_thread_id is not None
+                and leased_thread_id != effective_thread_id
+            ):
+                return False
+
+            cursor = conn.execute(
+                "UPDATE codex_turn_leases "
+                "SET codex_thread_id = COALESCE(codex_thread_id, ?), "
+                "refreshed_at = ?, expires_at = ? "
+                "WHERE session_id = ? AND holder_uuid = ? AND owner_pid = ? "
+                "AND owner_started_at = ?",
+                (
+                    effective_thread_id,
+                    now,
+                    now + ttl,
+                    session_id,
+                    holder,
+                    owner_pid,
+                    owner_started_at,
+                ),
+            )
+            return cursor.rowcount == 1
+
+        try:
+            return bool(self._execute_write(_do, patience_s=2.0))
+        except (sqlite3.Error, TimeoutError) as exc:
+            logger.warning(
+                "refresh_codex_turn_lease(%s, thread=%s) failed closed: %s",
+                session_id,
+                requested_thread_id,
+                exc,
+            )
+            return False
+
+    def release_codex_turn_lease(
+        self,
+        session_id: str,
+        holder_uuid: str,
+    ) -> bool:
+        """Release the lease iff this exact UUID and process identity owns it."""
+        session_id = str(session_id or "").strip()
+        holder = _normalize_codex_turn_lease_holder(holder_uuid)
+        if not session_id or holder is None:
+            return False
+
+        owner_pid = os.getpid()
+        owner_started_at = _codex_turn_lease_process_start_time(owner_pid)
+        if owner_started_at is None:
+            return False
+
+        def _do(conn):
+            cursor = conn.execute(
+                "DELETE FROM codex_turn_leases "
+                "WHERE session_id = ? AND holder_uuid = ? AND owner_pid = ? "
+                "AND owner_started_at = ?",
+                (
+                    session_id,
+                    holder,
+                    owner_pid,
+                    owner_started_at,
+                ),
+            )
+            return cursor.rowcount == 1
+
+        try:
+            return bool(self._execute_write(_do, patience_s=2.0))
+        except (sqlite3.Error, TimeoutError) as exc:
+            logger.warning(
+                "release_codex_turn_lease(%s) failed closed: %s",
+                session_id,
+                exc,
+            )
+            return False
+
+    def get_codex_turn_lease(
+        self,
+        session_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the stored Codex turn lease for diagnostics."""
+        session_id = str(session_id or "").strip()
+        if not session_id:
+            return None
+        try:
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT session_id, codex_thread_id, holder_uuid, owner_pid, "
+                    "owner_started_at, acquired_at, refreshed_at, expires_at "
+                    "FROM codex_turn_leases WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+        except (sqlite3.Error, TimeoutError):
+            return None
+        return dict(row) if row is not None else None
 
     def promote_to_session_reset(
         self, session_id: str, reason: str = "session_reset"

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -737,8 +737,7 @@ def apply_wal_with_fallback(
             # Caller mandates WAL — fail loudly instead of degrading to DELETE.
             raise WalUnsupportedError(str(exc)) from exc
         _log_wal_fallback_once(db_label, exc)
-        conn.execute("PRAGMA journal_mode=DELETE")
-        return "delete"
+        return _set_delete_journal_mode(conn, reason="fallback")
 
 
 def _apply_delete_for_wal_reset_bug(
@@ -3353,8 +3352,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         cooldown_until: float,
         error: Optional[str] = None,
+        *,
+        raise_on_error: bool = False,
     ) -> None:
-        """Persist the active compression-failure cooldown for a session."""
+        """Persist the active compression-failure cooldown for a session.
+
+        The default remains best-effort for ordinary compressor failure
+        handling.  A transaction rollback passes ``raise_on_error=True`` so
+        it never claims that its durable checkpoint was restored when SQLite
+        rejected the write.
+        """
         if not session_id:
             return
 
@@ -3372,6 +3379,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "record_compression_failure_cooldown(%s) failed: %s",
                 session_id, exc,
             )
+            if raise_on_error:
+                raise
 
     def get_compression_failure_cooldown(
         self,
@@ -3410,8 +3419,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             "error": error,
         }
 
-    def clear_compression_failure_cooldown(self, session_id: str) -> None:
-        """Clear any persisted compression-failure cooldown for a session."""
+    def clear_compression_failure_cooldown(
+        self,
+        session_id: str,
+        *,
+        raise_on_error: bool = False,
+    ) -> None:
+        """Clear any persisted compression-failure cooldown for a session.
+
+        ``raise_on_error`` is reserved for transactional rollback, where a
+        swallowed SQLite error would leave the durable cooldown divergent from
+        the restored in-memory compressor state.
+        """
         if not session_id:
             return
 
@@ -3429,6 +3448,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "clear_compression_failure_cooldown(%s) failed: %s",
                 session_id, exc,
             )
+            if raise_on_error:
+                raise
 
     def get_compression_fallback_streak(self, session_id: str) -> int:
         """Return the persisted deterministic-fallback streak."""
@@ -6025,7 +6046,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return cursor.fetchone() is not None
 
     def archive_and_compact(
-        self, session_id: str, compacted_messages: List[Dict[str, Any]]
+        self,
+        session_id: str,
+        compacted_messages: List[Dict[str, Any]],
+        *,
+        system_prompt: Optional[str] = None,
     ) -> int:
         """Non-destructive in-place compaction for a single durable session id.
 
@@ -6068,10 +6093,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             # message_count / tool_call_count reflect the LIVE (active) set —
             # the archived rows are still on disk but not part of the live count.
-            conn.execute(
-                "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
-                (inserted, tool_calls_total, session_id),
-            )
+            if system_prompt is None:
+                conn.execute(
+                    "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+                    (inserted, tool_calls_total, session_id),
+                )
+            else:
+                # The active transcript and assembled prompt describe one
+                # compaction boundary. Keep them in this same transaction so
+                # a prompt-write error rolls the archive/insert back too.
+                conn.execute(
+                    "UPDATE sessions SET message_count = ?, tool_call_count = ?, "
+                    "system_prompt = ? WHERE id = ?",
+                    (inserted, tool_calls_total, system_prompt, session_id),
+                )
             return inserted
 
         return self._execute_write(_do)

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -102,7 +102,7 @@ def _ephemeral_child_sql(alias: str = "s") -> str:
     )
 
 
-SCHEMA_VERSION = 23
+SCHEMA_VERSION = 25
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -145,6 +145,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     chat_id TEXT,
     chat_type TEXT,
     thread_id TEXT,
+    codex_thread_id TEXT,
     display_name TEXT,
     origin_json TEXT,
     expiry_finalized INTEGER DEFAULT 0,
@@ -257,6 +258,17 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS codex_turn_leases (
+    session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    codex_thread_id TEXT UNIQUE,
+    holder_uuid TEXT NOT NULL,
+    owner_pid INTEGER NOT NULL,
+    owner_started_at INTEGER NOT NULL,
+    acquired_at REAL NOT NULL,
+    refreshed_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -284,6 +296,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_codex_turn_leases_expires ON codex_turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery

--- a/model_tools.py
+++ b/model_tools.py
@@ -24,6 +24,7 @@ import os
 import json
 import re
 import asyncio
+import copy
 import logging
 import threading
 import time
@@ -340,9 +341,10 @@ def get_tool_definitions(
             # consistent state even on a cache hit.
             global _last_resolved_tool_names
             _last_resolved_tool_names = [t["function"]["name"] for t in cached]
-            # Return a shallow copy of the list but share the dict references —
-            # schemas are treated as read-only by all known callers.
-            return list(cached)
+            # Provider recovery paths sanitize nested schemas in-place. Return
+            # a deep copy so one agent cannot weaken the canonical cache entry
+            # (and therefore every later agent) through those mutations.
+            return copy.deepcopy(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
                                        skip_tool_search_assembly=skip_tool_search_assembly)
@@ -359,8 +361,9 @@ def get_tool_definitions(
         # toolset/config fingerprints it sees over its lifetime (#19251).
         if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX:
             _tool_defs_cache.pop(next(iter(_tool_defs_cache)))  # evict oldest
-        _tool_defs_cache[cache_key] = result
-        return list(result)
+        canonical = copy.deepcopy(result)
+        _tool_defs_cache[cache_key] = canonical
+        return copy.deepcopy(canonical)
     return result
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3890,6 +3890,22 @@ class AIAgent:
         except Exception:
             pass
 
+    def _close_codex_app_server_session(self) -> None:
+        """Close and detach the cached Codex app-server subprocess.
+
+        The canonical thread id is persisted in SessionDB, so a rebuilt agent
+        can resume the rollout. Detach before closing to make repeated or
+        re-entrant cleanup idempotent even if the transport close path raises.
+        """
+        codex_session = getattr(self, "_codex_session", None)
+        self._codex_session = None
+        if codex_session is None:
+            return
+        try:
+            codex_session.close()
+        except Exception:
+            pass
+
     def release_clients(self) -> None:
         """Release LLM client resources WITHOUT tearing down session tool state.
 
@@ -3906,6 +3922,8 @@ class AIAgent:
         We DO close:
           - OpenAI/httpx client pool (big chunk of held memory + sockets;
             the rebuilt agent gets a fresh client anyway)
+          - Codex app-server subprocess (its persisted thread is resumed by
+            the rebuilt agent)
           - Active child subagents (per-turn artefacts; safe to drop)
 
         Safe to call multiple times.  Distinct from close() — which is the
@@ -3950,6 +3968,12 @@ class AIAgent:
         except Exception:
             pass
 
+        # A soft cache eviction discards this AIAgent instance. Keeping its
+        # app-server child alive would leak a subprocess and two competing
+        # owners could later drive the same Hermes session. The durable
+        # codex_thread_id binding lets the replacement resume safely.
+        self._close_codex_app_server_session()
+
     def close(self) -> None:
         """Release all resources held by this agent instance.
 
@@ -3965,6 +3989,10 @@ class AIAgent:
         independently guarded so a failure in one does not prevent the rest.
         """
         task_id = getattr(self, "session_id", None) or ""
+
+        # 0. Retire the per-agent Codex app-server subprocess. Its thread
+        # binding remains durable for explicit session resume.
+        self._close_codex_app_server_session()
 
         # 1. Kill background processes for this task
         try:

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -347,9 +347,16 @@ class TestBridgeWiredInRuntime:
             FakeSession,
         )
 
+        session_db = SimpleNamespace(
+            get_session=lambda session_id: {"id": session_id},
+            get_codex_thread_id=lambda _session_id: None,
+            bind_codex_thread_id=lambda _session_id, _thread_id: True,
+        )
+
         # Minimal stub agent — the runtime only touches a handful of
         # attributes and we mock the heavy ones to keep the test fast.
         agent = SimpleNamespace(
+            session_id="bridge-session",
             session_cwd=None,
             _codex_session=None,
             tool_progress_callback=MagicMock(),
@@ -370,7 +377,8 @@ class TestBridgeWiredInRuntime:
             session_total_tokens=0,
             context_compressor=None,
             event_callback=None,
-            _session_db=None,
+            _session_db=session_db,
+            _session_db_created=True,
         )
 
         codex_runtime.run_codex_app_server_turn(

--- a/tests/agent/test_compaction_anti_thrash.py
+++ b/tests/agent/test_compaction_anti_thrash.py
@@ -168,7 +168,64 @@ class TestFutilityGuard:
 
 
 
+    def test_usage_less_response_keeps_pending_verdict_until_real_prompt(self):
+        cc = _compressor(threshold_tokens=24_576)
+        cc._verify_compaction_cleared_threshold = True
+        cc.awaiting_real_usage_after_compression = True
+        cc.last_prompt_tokens = -1
 
+        cc.update_from_response({})
+
+        assert cc._verify_compaction_cleared_threshold is True
+        assert cc.awaiting_real_usage_after_compression is True
+        assert cc.last_prompt_tokens == -1
+
+        cc.update_from_response({"prompt_tokens": 20_000})
+
+        assert cc._verify_compaction_cleared_threshold is False
+        assert cc.awaiting_real_usage_after_compression is False
+        assert cc._ineffective_compression_count == 0
+
+    def test_fallback_streak_survives_ordinary_fitting_responses(self):
+        cc = _compressor(threshold_tokens=24_576)
+
+        cc.record_completed_compaction(used_fallback=True)
+        cc.update_from_response({"prompt_tokens": 20_000})
+        assert cc._fallback_compression_streak == 1
+
+        # Context regrows through ordinary successful turns before the next
+        # fallback boundary. Those turns reset real-usage effectiveness, not
+        # the independent summary-quality breaker.
+        cc.update_from_response({"prompt_tokens": 20_000})
+        cc.record_completed_compaction(used_fallback=True)
+        cc.update_from_response({"prompt_tokens": 20_000})
+
+        assert cc._fallback_compression_streak == 2
+        assert not cc.should_compress(33_564)
+
+    def test_usage_less_fallback_boundary_waits_for_real_prompt(self):
+        cc = _compressor(threshold_tokens=24_576)
+
+        cc.record_completed_compaction(used_fallback=True)
+        cc.awaiting_real_usage_after_compression = True
+        cc.update_from_response({})
+
+        assert cc._fallback_compression_streak == 1
+        assert cc._verify_compaction_cleared_threshold is True
+        assert cc.awaiting_real_usage_after_compression is True
+
+        cc.update_from_response({"prompt_tokens": 20_000})
+
+        assert cc._verify_compaction_cleared_threshold is False
+        assert cc.awaiting_real_usage_after_compression is False
+
+    def test_healthy_boundary_resets_only_fallback_streak(self):
+        cc = _compressor(threshold_tokens=24_576)
+        cc.record_completed_compaction(used_fallback=True)
+        cc.record_completed_compaction(used_fallback=False)
+
+        assert cc._fallback_compression_streak == 0
+        assert cc._verify_compaction_cleared_threshold is True
 
     def test_model_switch_resets_and_persists_fallback_streak(self, tmp_path):
         from hermes_state import SessionDB

--- a/tests/agent/test_context_breakdown.py
+++ b/tests/agent/test_context_breakdown.py
@@ -48,8 +48,18 @@ def test_breakdown_includes_major_categories():
     assert {"system_prompt", "tool_definitions", "rules", "skills", "mcp", "subagent_definitions", "conversation"} <= ids
     assert data["context_max"] == 200_000
     assert data["estimated_total"] > 0
+    assert data["context_used_estimated"] is True
 
 
+def test_breakdown_uses_measured_context_when_available():
+    agent, parts = _make_agent(last_prompt_tokens=42_000)
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        data = compute_session_context_breakdown(agent, [])
+
+    assert data["context_used"] == 42_000
+    assert data["context_percent"] == 21
+    assert data["context_used_estimated"] is False
 
 # ── /context renderers (pure functions over the payload) ────────────────────
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -98,6 +98,23 @@ class TestUpdateFromResponse:
         compressor.update_from_response({})
         assert compressor.last_prompt_tokens == 0
 
+    def test_zero_prompt_keeps_post_compaction_verdict_pending(self, compressor):
+        """A normalised zero is indistinguishable from missing provider usage."""
+        compressor.awaiting_real_usage_after_compression = True
+        compressor._verify_compaction_cleared_threshold = True
+        compressor.last_prompt_tokens = -1
+
+        compressor.update_from_response({"prompt_tokens": 0})
+
+        assert compressor.last_prompt_tokens == -1
+        assert compressor.awaiting_real_usage_after_compression is True
+        assert compressor._verify_compaction_cleared_threshold is True
+
+        compressor.update_from_response({"prompt_tokens": 5_000})
+
+        assert compressor.awaiting_real_usage_after_compression is False
+        assert compressor._verify_compaction_cleared_threshold is False
+
 class TestPreflightDeferral:
 
     def test_does_not_defer_when_rough_growth_is_large(self, compressor):
@@ -163,6 +180,134 @@ class TestCompress:
             f"active_task line should appear at most once (was triplicated in "
             f"#49307), found {count}x:\n{summary}"
         )
+
+    def test_fallback_preserves_failed_attempt_and_safe_resume_step(self):
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=100000,
+        ):
+            c = ContextCompressor(model="test/model", quiet_mode=True)
+
+        turns = [
+            {"role": "user", "content": "run the migration"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command":"migrate"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": "ERROR: migration timed out",
+            },
+        ]
+
+        summary = c._build_static_fallback_summary(
+            turns, reason="provider down"
+        )
+
+        assert "## Failed Attempts" in summary
+        assert "migration timed out" in summary
+        assert "do not repeat the same call unchanged" in summary
+        assert "## Next Safe Step" in summary
+        assert "Verify the current repository/session state" in summary
+
+    def test_static_fallback_ignores_explicit_zero_failure_counters(self):
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=100000,
+        ):
+            c = ContextCompressor(model="test/model", quiet_mode=True)
+
+        summary = c._build_static_fallback_summary(
+            [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "function": {
+                                "name": "terminal",
+                                "arguments": '{"command":"pytest -q"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-1",
+                    "content": "1312 passed, 0 failed, no errors",
+                },
+            ]
+        )
+
+        failed_section = summary.split("## Failed Attempts", 1)[1].split(
+            "## Next Safe Step", 1
+        )[0]
+        assert failed_section.strip() == "None."
+
+    def test_iterative_prompt_pins_failed_attempts_and_next_safe_step(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=100000,
+        ):
+            c = ContextCompressor(model="test/model", quiet_mode=True)
+        c._previous_summary = (
+            "## Historical Task Snapshot\nold task\n\n"
+            "## Failed Attempts\n- old failed call"
+        )
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=mock_response,
+        ) as mock_call:
+            summary = c._generate_summary(
+                [
+                    {"role": "user", "content": "continue safely"},
+                    {"role": "assistant", "content": "checking state"},
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "terminal",
+                                    "arguments": '{"command":"migrate"}',
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call-1",
+                        "content": "ERROR: migration timed out",
+                    },
+                ]
+            )
+
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert "## Failed Attempts" in prompt
+        assert "## Next Safe Step" in prompt
+        assert "Preserve failed approaches" in prompt
+        assert "Do not repeat unchanged" in prompt
+        assert 'Move items from "In Progress"' not in prompt
+        assert "## Failed Attempts" in summary
+        assert "migration timed out" in summary
+        assert "do not repeat the same call unchanged" in summary
+        assert "## Next Safe Step" in summary
+        assert "Verify the current repository/session state" in summary
 
     def test_threshold_below_window_at_minimum_ctx(self):
         """Regression for #14690: at context_length == MINIMUM_CONTEXT_LENGTH
@@ -464,7 +609,9 @@ class TestNonStringContent:
 
         assert summary.startswith(f"{SUMMARY_PREFIX}\n{HISTORICAL_TASK_HEADING}\n")
         assert "do something" in summary
-        assert summary.endswith("plain summary text")
+        assert "plain summary text" in summary
+        assert "## Failed Attempts" in summary
+        assert "## Next Safe Step" in summary
 
 
 
@@ -2693,4 +2840,3 @@ class TestContextLengthSetterCoherence:
         assert c.threshold_percent == 0.75
         # ...and budgets recompute from the same window+percent.
         assert c.threshold_tokens == 150_000
-

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -184,10 +184,12 @@ def test_resume_handoff_after_default_protected_head_decays_initial_turns():
     assert "original answer before first compaction" in prompt
     assert "original follow-up before first compaction" in prompt
     assert f"[ASSISTANT]: {SUMMARY_PREFIX}" not in prompt
-    # Grounding (761a0b124e) may prepend a deterministic task-snapshot
-    # section — pin the contract, not the exact stored string.
+    # Grounding may prepend a deterministic task snapshot. Pin continuity
+    # rather than the exact stored string.
     stored_summary = compressor._previous_summary or ""
-    assert stored_summary.endswith("fresh summary")
+    assert stored_summary.count("fresh summary") == 1
+    assert "## Failed Attempts" in stored_summary
+    assert "## Next Safe Step" in stored_summary
     assert old_summary not in stored_summary
     assert all(
         "original task before first compaction" not in str(msg.get("content", ""))

--- a/tests/agent/test_conversation_loop_request_local_tools.py
+++ b/tests/agent/test_conversation_loop_request_local_tools.py
@@ -1,0 +1,34 @@
+from copy import deepcopy
+
+from agent.conversation_loop import _request_local_llama_cpp_tools
+
+
+def test_llama_cpp_grammar_recovery_keeps_canonical_tools_unchanged():
+    canonical = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "email": {
+                            "type": "string",
+                            "format": "email",
+                            "pattern": r"^\S+@\S+$",
+                        }
+                    },
+                },
+            },
+        }
+    ]
+    before = deepcopy(canonical)
+
+    request_tools, stripped = _request_local_llama_cpp_tools(canonical)
+
+    assert stripped == 2
+    assert canonical == before
+    assert request_tools is not canonical
+    email_schema = request_tools[0]["function"]["parameters"]["properties"]["email"]
+    assert "format" not in email_schema
+    assert "pattern" not in email_schema

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -31,7 +31,9 @@ def hermes_home(tmp_path):
 
 class TestGetExternalSkillsDirs:
     def test_empty_config(self, hermes_home):
-        (hermes_home / "config.yaml").write_text("skills:\n  external_dirs: []\n")
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  external_dirs: []\n", encoding="utf-8"
+        )
         with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
             from agent.skill_utils import get_external_skills_dirs
             result = get_external_skills_dirs()

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -36,6 +37,37 @@ class TestGetExternalSkillsDirs:
             result = get_external_skills_dirs()
         assert result == []
 
+    def test_nonexistent_dir_remains_in_configured_scope(self, hermes_home):
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  external_dirs:\n    - /nonexistent/path\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import get_external_skills_dirs
+            result = get_external_skills_dirs()
+        assert result == [Path("/nonexistent/path")]
+
+    def test_non_directory_remains_configured_but_is_not_scannable(
+        self, hermes_home, tmp_path
+    ):
+        configured_file = tmp_path / "not-a-skills-dir"
+        configured_file.write_text("not a directory", encoding="utf-8")
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {configured_file}\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import (
+                get_external_skills_dirs,
+                get_scannable_external_skills_dirs,
+            )
+
+            errors = []
+            configured = get_external_skills_dirs()
+            scannable = get_scannable_external_skills_dirs(on_error=errors.append)
+
+        assert configured == [configured_file.resolve()]
+        assert scannable == []
+        assert len(errors) == 1
+        assert isinstance(errors[0], NotADirectoryError)
 
     def test_valid_dir_returned(self, hermes_home, external_skills_dir):
         (hermes_home / "config.yaml").write_text(

--- a/tests/agent/test_external_skills_dirs_cache.py
+++ b/tests/agent/test_external_skills_dirs_cache.py
@@ -48,6 +48,38 @@ def hermes_home_with_config(tmp_path, monkeypatch):
 
 
 
+def test_cold_cache_retains_missing_configured_root(tmp_path, monkeypatch):
+    """Root availability must not erase the configured discovery scope."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    missing = tmp_path / "not-created-yet"
+    (home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {missing}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _external_dirs_cache_clear()
+
+    assert get_external_skills_dirs() == [missing.resolve()]
+    assert get_external_skills_dirs() == [missing.resolve()]
+
+
+def test_cache_reuses_result_without_reparsing(hermes_home_with_config):
+    """Subsequent calls hit the cache and skip YAML parsing entirely."""
+    _home, _external, _cfg = hermes_home_with_config
+
+    # Prime cache
+    get_external_skills_dirs()
+
+    # Patch yaml_load to raise — if cache works, it's never called again.
+    with patch.object(
+        skill_utils,
+        "yaml_load",
+        side_effect=AssertionError("yaml_load should not run on cache hit"),
+    ):
+        # Many calls, none should trigger the patched yaml_load.
+        for _ in range(100):
+            get_external_skills_dirs()
 
 
 def test_cache_invalidates_on_mtime_change(hermes_home_with_config):

--- a/tests/agent/test_org_skill_namespace.py
+++ b/tests/agent/test_org_skill_namespace.py
@@ -108,7 +108,7 @@ class TestListingCollisionsAndLabels:
         skills.mkdir(parents=True, exist_ok=True)
         monkeypatch.setattr(pb, "get_skills_dir", lambda: skills, raising=True)
         monkeypatch.setattr(
-            pb, "get_all_skills_dirs", lambda: [skills], raising=True
+            pb, "get_all_skills_dirs", lambda **_kwargs: [skills], raising=True
         )
         monkeypatch.setattr(pb, "get_disabled_skill_names", lambda *a, **k: set())
         monkeypatch.setattr(
@@ -171,7 +171,7 @@ class TestOrgSkillsAreEditableInPlace:
         _mark_active(skills, "org-1")
         monkeypatch.setattr(smt, "_skills_dir", lambda: skills)
         monkeypatch.setattr(
-            _sku, "get_all_skills_dirs", lambda: [skills], raising=True
+            _sku, "get_all_skills_dirs", lambda **_kwargs: [skills], raising=True
         )
         return smt, skills, d
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,8 @@ import builtins
 import importlib
 import logging
 import sys
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -234,7 +236,7 @@ class TestParseSkillFile:
         def boom(*args, **kwargs):
             raise OSError("read exploded")
 
-        monkeypatch.setattr(type(skill_file), "read_text", boom)
+        monkeypatch.setattr("agent.prompt_builder.read_strict_skill_index_file", boom)
         with caplog.at_level(logging.DEBUG, logger="agent.prompt_builder"):
             is_compat, frontmatter, desc = _parse_skill_file(skill_file)
 
@@ -282,6 +284,358 @@ class TestBuildSkillsSystemPrompt:
 
 
 
+    @pytest.mark.parametrize(
+        "broken",
+        (
+            "---\nname: steals-valid\n# no closing fence\n",
+            "---\n- steals-valid\n---\n",
+        ),
+        ids=("unclosed-fence", "non-mapping-yaml"),
+    )
+    def test_invalid_fenced_skill_refuses_partial_system_prompt(
+        self, monkeypatch, tmp_path, broken
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        valid = tmp_path / "skills" / "general" / "valid" / "SKILL.md"
+        corrupt = tmp_path / "skills" / "general" / "corrupt" / "SKILL.md"
+        valid.parent.mkdir(parents=True)
+        corrupt.parent.mkdir(parents=True)
+        valid.write_text(
+            "---\nname: valid\ndescription: valid skill\n---\n", encoding="utf-8"
+        )
+        corrupt.write_text(broken, encoding="utf-8")
+
+        result = build_skills_system_prompt()
+
+        assert result == ""
+        assert not (tmp_path / ".skills_prompt_snapshot.json").exists()
+
+    def test_snapshot_manifest_breaks_symlink_cycles(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+        try:
+            (skill_dir / "loop").symlink_to(
+                tmp_path / "skills", target_is_directory=True
+            )
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+
+        first = build_skills_system_prompt()
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        clear_skills_system_prompt_cache()
+        second = build_skills_system_prompt()
+
+        assert first == second
+        assert first.count("- python-debug") == 1
+
+    def test_walk_error_uses_same_scope_snapshot_without_caching_partial_result(
+        self, monkeypatch, tmp_path
+    ):
+        """A failed walk must retain the prior complete snapshot, never a subset."""
+        prompt_builder = sys.modules[build_skills_system_prompt.__module__]
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            prompt_builder, "get_all_skills_dirs", lambda: [tmp_path / "skills"]
+        )
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+        complete = build_skills_system_prompt()
+        snapshot_path = tmp_path / ".skills_prompt_snapshot.json"
+        snapshot_before = snapshot_path.read_bytes()
+        prompt_builder.clear_skills_system_prompt_cache()
+
+        def denied_walk(*_args, **kwargs):
+            kwargs["onerror"](OSError("simulated walk denial"))
+            return []
+
+        monkeypatch.setattr("agent.skill_utils.os.walk", denied_walk)
+        recovered = build_skills_system_prompt()
+
+        assert recovered == complete
+        assert snapshot_path.read_bytes() == snapshot_before
+        assert prompt_builder._SKILLS_PROMPT_CACHE == {}
+
+    def test_file_read_error_never_overwrites_snapshot_or_lru(
+        self, monkeypatch, tmp_path
+    ):
+        """A file that fails after enumeration invalidates the whole cold scan."""
+        prompt_builder = sys.modules[build_skills_system_prompt.__module__]
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        good_dir = tmp_path / "skills" / "coding" / "good"
+        good_dir.mkdir(parents=True)
+        (good_dir / "SKILL.md").write_text(
+            "---\nname: good\ndescription: Complete catalog entry\n---\n"
+        )
+        assert "good" in build_skills_system_prompt()
+        snapshot_path = tmp_path / ".skills_prompt_snapshot.json"
+        snapshot_before = snapshot_path.read_bytes()
+        prompt_builder.clear_skills_system_prompt_cache()
+
+        bad_file = tmp_path / "skills" / "coding" / "bad" / "SKILL.md"
+        bad_file.parent.mkdir()
+        bad_file.write_text("---\nname: bad\ndescription: unreadable\n---\n")
+        original_reader = prompt_builder.read_strict_skill_index_file
+
+        def fail_only_bad_file(path, *args, **kwargs):
+            if path == bad_file:
+                raise OSError("simulated file read denial")
+            return original_reader(path, *args, **kwargs)
+
+        monkeypatch.setattr(
+            prompt_builder, "read_strict_skill_index_file", fail_only_bad_file
+        )
+        build_skills_system_prompt()
+        assert snapshot_path.read_bytes() == snapshot_before
+        assert prompt_builder._SKILLS_PROMPT_CACHE == {}
+
+    def test_external_walk_error_does_not_render_local_only_snapshot(
+        self, monkeypatch, tmp_path
+    ):
+        """A local snapshot is not a valid full-scope fallback with externals."""
+        prompt_builder = sys.modules[build_skills_system_prompt.__module__]
+        from agent import skill_utils
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        local_root = tmp_path / "skills"
+        external_root = tmp_path / "external-skills"
+        local_skill = local_root / "local" / "SKILL.md"
+        external_skill = external_root / "external" / "SKILL.md"
+        local_skill.parent.mkdir(parents=True)
+        external_skill.parent.mkdir(parents=True)
+        local_skill.write_text(
+            "---\nname: local\ndescription: Local skill\n---\n"
+        )
+        external_skill.write_text(
+            "---\nname: external\ndescription: External skill\n---\n"
+        )
+        monkeypatch.setattr(
+            prompt_builder,
+            "get_all_skills_dirs",
+            lambda: [local_root, external_root],
+        )
+        complete = build_skills_system_prompt()
+        assert "- local:" in complete
+        assert (tmp_path / ".skills_prompt_snapshot.json").exists()
+        prompt_builder.clear_skills_system_prompt_cache()
+
+        original_walk = skill_utils.os.walk
+
+        walked_external = []
+
+        def fail_external_walk(top, *args, **kwargs):
+            if Path(top).resolve() == external_root.resolve():
+                walked_external.append(top)
+                kwargs["onerror"](OSError("simulated external walk denial"))
+                return []
+            return original_walk(top, *args, **kwargs)
+
+        monkeypatch.setattr(skill_utils.os, "walk", fail_external_walk)
+        result = build_skills_system_prompt()
+        assert walked_external, "external directory was not scanned"
+        assert result == ""
+        assert [Path(path).resolve() for path in walked_external] == [
+            external_root.resolve(),
+            external_root.resolve(),
+        ]
+        assert prompt_builder._SKILLS_PROMPT_CACHE == {}
+
+    def test_external_root_stat_error_does_not_render_local_snapshot(
+        self, monkeypatch, tmp_path
+    ):
+        """Path.exists must not silently turn an inaccessible external into empty."""
+        prompt_builder = sys.modules[build_skills_system_prompt.__module__]
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        local_root = tmp_path / "skills"
+        external_root = tmp_path / "external-skills"
+        local_skill = local_root / "local" / "SKILL.md"
+        external_skill = external_root / "external" / "SKILL.md"
+        local_skill.parent.mkdir(parents=True)
+        external_skill.parent.mkdir(parents=True)
+        local_skill.write_text("---\nname: local\ndescription: Local skill\n---\n")
+        external_skill.write_text(
+            "---\nname: external\ndescription: External skill\n---\n"
+        )
+        monkeypatch.setattr(
+            prompt_builder,
+            "get_all_skills_dirs",
+            lambda: [local_root, external_root],
+        )
+        assert "- external:" in build_skills_system_prompt()
+        prompt_builder.clear_skills_system_prompt_cache()
+
+        original_stat = Path.stat
+
+        def fail_external_root(path, *args, **kwargs):
+            if path == external_root:
+                raise PermissionError("simulated external root denial")
+            return original_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", fail_external_root)
+        assert build_skills_system_prompt() == ""
+        assert prompt_builder._SKILLS_PROMPT_CACHE == {}
+
+    @pytest.mark.parametrize("root_kind", ["missing", "file"])
+    def test_cold_start_invalid_configured_external_root_fails_closed(
+        self, monkeypatch, tmp_path, root_kind
+    ):
+        """A configured root is scope even before it becomes scannable."""
+        prompt_builder = sys.modules[build_skills_system_prompt.__module__]
+        from agent import skill_utils
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        local_skill = tmp_path / "skills" / "local" / "SKILL.md"
+        local_skill.parent.mkdir(parents=True)
+        local_skill.write_text(
+            "---\nname: local\ndescription: Local skill\n---\n",
+            encoding="utf-8",
+        )
+        external_root = tmp_path / "configured-external"
+        if root_kind == "file":
+            external_root.write_text("not a directory", encoding="utf-8")
+        (tmp_path / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_root}\n",
+            encoding="utf-8",
+        )
+        skill_utils._external_dirs_cache_clear()
+        prompt_builder.clear_skills_system_prompt_cache()
+
+        assert skill_utils.get_all_skills_dirs() == [
+            tmp_path / "skills",
+            external_root.resolve(),
+        ]
+        assert build_skills_system_prompt() == ""
+        assert prompt_builder._SKILLS_PROMPT_CACHE == {}
+
+    def test_first_scan_external_root_permission_failure_is_not_cached_and_retries(
+        self, monkeypatch, tmp_path
+    ):
+        """A selected-but-unreadable external root must not create local-only LRU."""
+        prompt_builder = sys.modules[build_skills_system_prompt.__module__]
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        local_root = tmp_path / "skills"
+        external_root = tmp_path / "external-skills"
+        local_skill = local_root / "local" / "SKILL.md"
+        external_skill = external_root / "external" / "SKILL.md"
+        local_skill.parent.mkdir(parents=True)
+        external_skill.parent.mkdir(parents=True)
+        local_skill.write_text("---\nname: local\ndescription: Local skill\n---\n")
+        external_skill.write_text(
+            "---\nname: external\ndescription: External skill\n---\n"
+        )
+        monkeypatch.setattr(
+            prompt_builder,
+            "get_all_skills_dirs",
+            lambda: [local_root, external_root],
+        )
+
+        original_stat = Path.stat
+        deny_external = True
+
+        def deny_external_root(path, *args, **kwargs):
+            if deny_external and path == external_root:
+                raise PermissionError("simulated first-scan external denial")
+            return original_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", deny_external_root)
+        assert build_skills_system_prompt() == ""
+        assert prompt_builder._SKILLS_PROMPT_CACHE == {}
+
+        deny_external = False
+        result = build_skills_system_prompt()
+        assert "- local:" in result
+        assert "- external:" in result
+
+    def test_external_root_deleted_after_scope_resolution_returns_empty_until_new_scope(
+        self, monkeypatch, tmp_path
+    ):
+        """A deleted configured root invalidates its old local+external scope."""
+        prompt_builder = sys.modules[build_skills_system_prompt.__module__]
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        local_root = tmp_path / "skills"
+        external_root = tmp_path / "external-skills"
+        local_skill = local_root / "local" / "SKILL.md"
+        external_skill = external_root / "external" / "SKILL.md"
+        local_skill.parent.mkdir(parents=True)
+        external_skill.parent.mkdir(parents=True)
+        local_skill.write_text("---\nname: local\ndescription: Local skill\n---\n")
+        external_skill.write_text(
+            "---\nname: external\ndescription: External skill\n---\n"
+        )
+
+        roots = [local_root, external_root]
+        monkeypatch.setattr(prompt_builder, "get_all_skills_dirs", lambda: roots)
+        complete = build_skills_system_prompt()
+        assert "- local:" in complete
+        assert "- external:" in complete
+        assert prompt_builder._SKILLS_PROMPT_CACHE
+
+        external_skill.unlink()
+        external_skill.parent.rmdir()
+        external_root.rmdir()
+        assert build_skills_system_prompt() == ""
+        assert prompt_builder._SKILLS_PROMPT_CACHE == {}
+
+        # The next config/root resolution creates a different scope and may
+        # safely render the local snapshot again.
+        roots[:] = [local_root]
+        rebuilt = build_skills_system_prompt()
+        assert "- local:" in rebuilt
+        assert "external" not in rebuilt
+
+    def test_omits_manage_instructions_when_tool_is_unavailable(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts.\n---\n"
+        )
+
+        read_only = build_skills_system_prompt(
+            available_tools={"skills_list", "skill_view"}
+        )
+        writable = build_skills_system_prompt(
+            available_tools={"skills_list", "skill_view", "skill_manage"}
+        )
+
+        assert "skill_manage" not in read_only
+        assert "skill_manage" in writable
+
+    def test_rebuilds_for_dynamic_kanban_environment(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+        skill_dir = tmp_path / "skills" / "workflow" / "kanban-only"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: kanban-only\ndescription: Manage board work.\n"
+            "environments: [kanban]\n---\n"
+        )
+
+        with patch(
+            "tools.kanban_tools._profile_has_kanban_toolset",
+            return_value=False,
+        ):
+            assert "kanban-only" not in build_skills_system_prompt()
+            monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+            assert "kanban-only" in build_skills_system_prompt()
+            monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+            assert "kanban-only" not in build_skills_system_prompt()
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"
@@ -313,6 +667,43 @@ class TestBuildSkillsSystemPrompt:
         # Unfiltered call must not be served from the compacted cache entry.
         full = build_skills_system_prompt()
         assert "Write threads" in full
+
+    def test_category_compact_keeps_names_and_hermes_anchor(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        entries = [
+            ("hermes-agent", "Canonical Hermes setup and troubleshooting."),
+            ("long-workflow", "ordinary workflow " * 40),
+            ("another-skill", "another workflow " * 40),
+            *[
+                (f"workflow-{index}", f"workflow {index} details " * 40)
+                for index in range(8)
+            ],
+        ]
+        for name, description in entries:
+            skill_dir = tmp_path / "skills" / "operations" / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {description}\n---\n"
+            )
+
+        compact = build_skills_system_prompt(
+            prompt_index_mode="category_compact"
+        )
+        full = build_skills_system_prompt(prompt_index_mode="full")
+
+        assert "hermes-agent" in compact
+        assert "long-workflow" in compact
+        assert "another-skill" in compact
+        assert all(name in compact for name, _ in entries)
+        assert "Canonical Hermes setup and troubleshooting." in compact
+        assert "ordinary workflow ordinary workflow" not in compact
+        assert "another workflow another workflow" not in compact
+        assert "skills_list(category='...')" in compact
+        assert len(compact) < len(full)
+        # The rendering mode is part of the cache key.
+        assert "ordinary workflow ordinary workflow" in full
 
 
 
@@ -919,5 +1310,3 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -223,7 +223,9 @@ class TestParseSkillFile:
     def test_long_description_truncated(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
         long_desc = "A" * 100
-        skill_file.write_text(f"---\ndescription: {long_desc}\n---\n")
+        skill_file.write_text(
+            f"---\ndescription: {long_desc}\n---\n", encoding="utf-8"
+        )
         _, _, desc = _parse_skill_file(skill_file)
         assert len(desc) <= 60
         assert desc.endswith("...")
@@ -231,7 +233,9 @@ class TestParseSkillFile:
 
     def test_logs_parse_failures_and_returns_defaults(self, tmp_path, monkeypatch, caplog):
         skill_file = tmp_path / "SKILL.md"
-        skill_file.write_text("---\nname: broken\n---\n")
+        skill_file.write_text(
+            "---\nname: broken\n---\n", encoding="utf-8"
+        )
 
         def boom(*args, **kwargs):
             raise OSError("read exploded")
@@ -383,7 +387,10 @@ class TestBuildSkillsSystemPrompt:
 
         bad_file = tmp_path / "skills" / "coding" / "bad" / "SKILL.md"
         bad_file.parent.mkdir()
-        bad_file.write_text("---\nname: bad\ndescription: unreadable\n---\n")
+        bad_file.write_text(
+            "---\nname: bad\ndescription: unreadable\n---\n",
+            encoding="utf-8",
+        )
         original_reader = prompt_builder.read_strict_skill_index_file
 
         def fail_only_bad_file(path, *args, **kwargs):
@@ -462,7 +469,10 @@ class TestBuildSkillsSystemPrompt:
         external_skill = external_root / "external" / "SKILL.md"
         local_skill.parent.mkdir(parents=True)
         external_skill.parent.mkdir(parents=True)
-        local_skill.write_text("---\nname: local\ndescription: Local skill\n---\n")
+        local_skill.write_text(
+            "---\nname: local\ndescription: Local skill\n---\n",
+            encoding="utf-8",
+        )
         external_skill.write_text(
             "---\nname: external\ndescription: External skill\n---\n"
         )
@@ -529,7 +539,10 @@ class TestBuildSkillsSystemPrompt:
         external_skill = external_root / "external" / "SKILL.md"
         local_skill.parent.mkdir(parents=True)
         external_skill.parent.mkdir(parents=True)
-        local_skill.write_text("---\nname: local\ndescription: Local skill\n---\n")
+        local_skill.write_text(
+            "---\nname: local\ndescription: Local skill\n---\n",
+            encoding="utf-8",
+        )
         external_skill.write_text(
             "---\nname: external\ndescription: External skill\n---\n"
         )
@@ -568,7 +581,10 @@ class TestBuildSkillsSystemPrompt:
         external_skill = external_root / "external" / "SKILL.md"
         local_skill.parent.mkdir(parents=True)
         external_skill.parent.mkdir(parents=True)
-        local_skill.write_text("---\nname: local\ndescription: Local skill\n---\n")
+        local_skill.write_text(
+            "---\nname: local\ndescription: Local skill\n---\n",
+            encoding="utf-8",
+        )
         external_skill.write_text(
             "---\nname: external\ndescription: External skill\n---\n"
         )
@@ -642,7 +658,9 @@ class TestBuildSkillsSystemPrompt:
         for subdir in ["search", "search"]:
             d = cat_dir / subdir
             d.mkdir(parents=True, exist_ok=True)
-            (d / "SKILL.md").write_text("---\ndescription: Search stuff\n---\n")
+            (d / "SKILL.md").write_text(
+                "---\ndescription: Search stuff\n---\n", encoding="utf-8"
+            )
         result = build_skills_system_prompt()
         # "search" should appear only once per category
         assert result.count("- search") == 1
@@ -835,7 +853,9 @@ class TestBuildContextFilesPrompt:
         assert "Hermes Agent" in result
 
     def test_loads_agents_md(self, tmp_path):
-        (tmp_path / "AGENTS.md").write_text("Use Ruff for linting.")
+        (tmp_path / "AGENTS.md").write_text(
+            "Use Ruff for linting.", encoding="utf-8"
+        )
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Ruff for linting" in result
         assert "Project Context" in result
@@ -848,7 +868,9 @@ class TestBuildContextFilesPrompt:
         import agent.runtime_cwd as rt
 
         monkeypatch.setattr(rt, "_PACKAGE_ROOT", tmp_path.resolve())
-        (tmp_path / "AGENTS.md").write_text("Never give up on the right solution.")
+        (tmp_path / "AGENTS.md").write_text(
+            "Never give up on the right solution.", encoding="utf-8"
+        )
         monkeypatch.chdir(tmp_path)
         result = build_context_files_prompt(cwd=None, skip_soul=True)
         assert "Never give up" not in result
@@ -883,7 +905,9 @@ class TestBuildContextFilesPrompt:
 
 
     def test_loads_claude_md(self, tmp_path):
-        (tmp_path / "CLAUDE.md").write_text("Use type hints everywhere.")
+        (tmp_path / "CLAUDE.md").write_text(
+            "Use type hints everywhere.", encoding="utf-8"
+        )
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "type hints" in result
         assert "CLAUDE.md" in result
@@ -897,8 +921,8 @@ class TestBuildContextFilesPrompt:
     def test_claude_md_uppercase_takes_priority(self, tmp_path):
         uppercase = tmp_path / "CLAUDE.md"
         lowercase = tmp_path / "claude.md"
-        uppercase.write_text("From uppercase.")
-        lowercase.write_text("From lowercase.")
+        uppercase.write_text("From uppercase.", encoding="utf-8")
+        lowercase.write_text("From lowercase.", encoding="utf-8")
         if uppercase.samefile(lowercase):
             pytest.skip("filesystem is case-insensitive")
         result = build_context_files_prompt(cwd=str(tmp_path))
@@ -916,14 +940,16 @@ class TestBuildContextFilesPrompt:
 
 class TestFindHermesMd:
     def test_finds_in_cwd(self, tmp_path):
-        (tmp_path / ".hermes.md").write_text("rules")
+        (tmp_path / ".hermes.md").write_text("rules", encoding="utf-8")
         assert _find_hermes_md(tmp_path) == tmp_path / ".hermes.md"
 
 
 
     def test_walks_to_git_root(self, tmp_path):
         (tmp_path / ".git").mkdir()
-        (tmp_path / ".hermes.md").write_text("root rules")
+        (tmp_path / ".hermes.md").write_text(
+            "root rules", encoding="utf-8"
+        )
         sub = tmp_path / "a" / "b"
         sub.mkdir(parents=True)
         assert _find_hermes_md(sub) == tmp_path / ".hermes.md"
@@ -941,7 +967,9 @@ class TestFindHermesMd:
 
         parent = tmp_path / "parent"
         parent.mkdir()
-        (parent / ".hermes.md").write_text("planted by another user")
+        (parent / ".hermes.md").write_text(
+            "planted by another user", encoding="utf-8"
+        )
         cwd = parent / "work"
         cwd.mkdir()
         # No git root anywhere up the tree.

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -37,7 +37,7 @@ description: Description for {name}.
 
 {body}
 """
-    (skill_dir / "SKILL.md").write_text(content)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir
 
 
@@ -963,7 +963,9 @@ class TestBuildSkillInvocationMessage:
             skill_dir = _make_skill(tmp_path, "test-skill")
             references = skill_dir / "references"
             references.mkdir()
-            (references / "api.md").write_text("reference")
+            (references / "api.md").write_text(
+                "reference", encoding="utf-8"
+            )
             scan_skill_commands()
             msg = build_skill_invocation_message("/test-skill", "do stuff")
 
@@ -988,7 +990,9 @@ class TestSkillDirectoryHeader:
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skill_dir = _make_skill(tmp_path, "scripted-skill")
             (skill_dir / "scripts").mkdir()
-            (skill_dir / "scripts" / "run.js").write_text("console.log('hi')")
+            (skill_dir / "scripts" / "run.js").write_text(
+                "console.log('hi')", encoding="utf-8"
+            )
             scan_skill_commands()
             msg = build_skill_invocation_message("/scripted-skill")
 
@@ -1007,7 +1011,9 @@ class TestSkillDirectoryHeader:
             assets = skill_dir / "assets"
             assets.mkdir()
             for index in range(limit + 5):
-                (assets / f"{index:03d}.txt").write_text("asset")
+                (assets / f"{index:03d}.txt").write_text(
+                    "asset", encoding="utf-8"
+                )
             scan_skill_commands()
             msg = build_skill_invocation_message("/asset-heavy")
 
@@ -1308,4 +1314,3 @@ class TestStackedSkillCommands:
         assert loaded == ["skill-a"]
         assert missing == ["gone"]
         assert "Skills missing (skipped): gone" in msg
-

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -1,7 +1,9 @@
 """Tests for agent/skill_commands.py — skill slash command scanning and platform filtering."""
 
 import os
+import threading
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -10,6 +12,7 @@ import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
+    get_skill_commands,
     resolve_skill_command_key,
     scan_skill_commands,
 )
@@ -51,8 +54,491 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
 
 
 class TestScanSkillCommands:
+    def test_live_profile_root_and_external_dirs_are_part_of_catalog_scope(
+        self, tmp_path
+    ):
+        """A long-lived process must not reuse another profile's slash map."""
+        import agent.skill_commands as sc_mod
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        external_a = tmp_path / "external-a"
+        external_b = tmp_path / "external-b"
+        for home, external, local_name, external_name in (
+            (home_a, external_a, "a-local", "a-external"),
+            (home_b, external_b, "b-local", "b-external"),
+        ):
+            _make_skill(home / "skills", local_name)
+            _make_skill(external, external_name)
+            (home / "config.yaml").write_text(
+                f"skills:\n  external_dirs:\n    - {external}\n", encoding="utf-8"
+            )
 
+        with (
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_environment", None),
+            patch.object(sc_mod, "_skill_commands_roots", None),
+            patch.object(sc_mod, "_resolve_skill_commands_platform", return_value=None),
+            patch.object(sc_mod, "_resolve_skill_commands_environment", return_value=()),
+        ):
+            token = set_hermes_home_override(str(home_a))
+            try:
+                commands_a = dict(get_skill_commands())
+            finally:
+                reset_hermes_home_override(token)
+
+            token = set_hermes_home_override(str(home_b))
+            try:
+                commands_b = dict(get_skill_commands())
+            finally:
+                reset_hermes_home_override(token)
+
+            token = set_hermes_home_override(str(home_a))
+            try:
+                commands_a_again = dict(get_skill_commands())
+            finally:
+                reset_hermes_home_override(token)
+
+        assert set(commands_a) == {"/a-local", "/a-external"}
+        assert set(commands_b) == {"/b-local", "/b-external"}
+        assert commands_a_again == commands_a
+
+    def test_failed_scan_in_another_profile_never_returns_or_commits_old_catalog(
+        self, tmp_path
+    ):
+        import agent.skill_commands as sc_mod
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        _make_skill(home_a / "skills", "a-only")
+        _make_skill(home_b / "skills", "b-only")
+
+        with (
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_environment", None),
+            patch.object(sc_mod, "_skill_commands_roots", None),
+            patch.object(sc_mod, "_resolve_skill_commands_platform", return_value=None),
+            patch.object(sc_mod, "_resolve_skill_commands_environment", return_value=()),
+        ):
+            token = set_hermes_home_override(str(home_a))
+            try:
+                commands_a = dict(get_skill_commands())
+            finally:
+                reset_hermes_home_override(token)
+
+            token = set_hermes_home_override(str(home_b))
+            try:
+                with patch(
+                    "agent.skill_utils.iter_skill_index_files",
+                    side_effect=OSError("temporary profile-b failure"),
+                ):
+                    assert get_skill_commands() == {}
+            finally:
+                reset_hermes_home_override(token)
+
+            # The global cache remains the known-good profile-A snapshot, but
+            # the profile-B request was deliberately denied that stale value.
+            assert sc_mod._skill_commands == commands_a
+            token = set_hermes_home_override(str(home_a))
+            try:
+                assert dict(get_skill_commands()) == commands_a
+            finally:
+                reset_hermes_home_override(token)
+
+    def test_concurrent_profile_scans_do_not_cross_commit_catalogs(self, tmp_path):
+        """Context-local profiles may race, but each caller receives its own map."""
+        import agent.skill_commands as sc_mod
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        _make_skill(home_a / "skills", "a-only")
+        _make_skill(home_b / "skills", "b-only")
+        results = {}
+        errors = []
+
+        def load_for_profile(label, home):
+            token = set_hermes_home_override(str(home))
+            try:
+                results[label] = dict(get_skill_commands())
+            except BaseException as exc:  # assert after both workers join
+                errors.append(exc)
+            finally:
+                reset_hermes_home_override(token)
+
+        with (
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_environment", None),
+            patch.object(sc_mod, "_skill_commands_roots", None),
+            patch.object(sc_mod, "_resolve_skill_commands_platform", return_value=None),
+            patch.object(sc_mod, "_resolve_skill_commands_environment", return_value=()),
+        ):
+            workers = [
+                threading.Thread(target=load_for_profile, args=("a", home_a)),
+                threading.Thread(target=load_for_profile, args=("b", home_b)),
+            ]
+            for worker in workers:
+                worker.start()
+            for worker in workers:
+                worker.join()
+
+        assert errors == []
+        assert set(results["a"]) == {"/a-only"}
+        assert set(results["b"]) == {"/b-only"}
+
+    def test_finds_skills(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "my-skill")
+            result = scan_skill_commands()
+        assert "/my-skill" in result
+        assert result["/my-skill"]["name"] == "my-skill"
+
+    @pytest.mark.parametrize(
+        "broken",
+        (
+            "---\nname: steals-valid\n# no closing fence\n",
+            "---\n- steals-valid\n---\n",
+        ),
+        ids=("unclosed-fence", "non-mapping-yaml"),
+    )
+    def test_invalid_fenced_skill_refuses_partial_slash_catalog(self, tmp_path, broken):
+        """A corrupt package cannot claim a name or hide a complete scan."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "valid")
+            corrupt = _make_skill(tmp_path, "corrupt") / "SKILL.md"
+            corrupt.write_text(broken, encoding="utf-8")
+            result = scan_skill_commands()
+
+        assert result == {}
+        assert "/steals-valid" not in result
+        assert "/valid" not in result
+
+    def test_empty_dir(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            result = scan_skill_commands()
+        assert result == {}
+
+    def test_root_scan_failure_preserves_last_good_catalog(self, tmp_path, caplog):
+        import agent.skill_commands as sc_mod
+
+        previous = {
+            "/stable": {
+                "name": "stable",
+                "description": "Stable.",
+                "skill_md_path": "/stable/SKILL.md",
+                "skill_dir": "/stable",
+            }
+        }
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch.object(sc_mod, "_skill_commands", previous),
+            patch.object(sc_mod, "_skill_commands_roots", (str(tmp_path.resolve()),)),
+            patch(
+                "agent.skill_utils.iter_skill_index_files",
+                side_effect=OSError("temporary scan failure"),
+            ),
+            caplog.at_level("WARNING", logger="agent.skill_commands"),
+        ):
+            result = scan_skill_commands()
+
+        assert result == previous
+        assert any("keeping the previous catalog" in r.message for r in caplog.records)
+
+    def test_first_scan_primary_root_permission_failure_retries_without_external_subset(
+        self, monkeypatch, tmp_path
+    ):
+        """``stat`` errors on the primary root are not silently treated as empty."""
+        import agent.skill_commands as sc_mod
+
+        primary_root = tmp_path / "skills"
+        external_root = tmp_path / "external"
+        _make_skill(primary_root, "local")
+        _make_skill(external_root, "external")
+        roots = (str(primary_root.resolve()), str(external_root.resolve()))
+
+        monkeypatch.setattr(
+            sc_mod,
+            "_resolve_skill_command_roots",
+            lambda: (primary_root, (external_root,), roots),
+        )
+        original_stat = Path.stat
+        deny_primary = True
+
+        def deny_primary_root(path, *args, **kwargs):
+            if deny_primary and path == primary_root:
+                raise PermissionError("simulated primary root denial")
+            return original_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", deny_primary_root)
+        monkeypatch.setattr(sc_mod, "_skill_commands", {})
+        monkeypatch.setattr(sc_mod, "_skill_commands_platform", None)
+        monkeypatch.setattr(sc_mod, "_skill_commands_environment", None)
+        monkeypatch.setattr(sc_mod, "_skill_commands_roots", None)
+        monkeypatch.setattr(sc_mod, "_resolve_skill_commands_platform", lambda: None)
+        monkeypatch.setattr(sc_mod, "_resolve_skill_commands_environment", lambda: ())
+
+        assert get_skill_commands() == {}
+        assert sc_mod._skill_commands == {}
+
+        deny_primary = False
+        assert set(get_skill_commands()) == {"/local", "/external"}
+
+    @pytest.mark.parametrize("root_kind", ["missing", "file"])
+    def test_cold_start_invalid_external_root_refuses_local_only_catalog(
+        self, monkeypatch, tmp_path, root_kind
+    ):
+        import agent.skill_commands as sc_mod
+
+        primary_root = tmp_path / "skills"
+        external_root = tmp_path / "configured-external"
+        _make_skill(primary_root, "local")
+        if root_kind == "file":
+            external_root.write_text("not a directory", encoding="utf-8")
+        roots = (str(primary_root.resolve()), str(external_root.resolve()))
+
+        monkeypatch.setattr(
+            sc_mod,
+            "_resolve_skill_command_roots",
+            lambda: (primary_root, (external_root,), roots),
+        )
+        monkeypatch.setattr(sc_mod, "_skill_commands", {})
+        monkeypatch.setattr(sc_mod, "_skill_commands_platform", None)
+        monkeypatch.setattr(sc_mod, "_skill_commands_environment", None)
+        monkeypatch.setattr(sc_mod, "_skill_commands_roots", None)
+        monkeypatch.setattr(sc_mod, "_resolve_skill_commands_platform", lambda: None)
+        monkeypatch.setattr(sc_mod, "_resolve_skill_commands_environment", lambda: ())
+
+        assert get_skill_commands() == {}
+        assert sc_mod._skill_commands == {}
+        assert sc_mod._skill_commands_roots is None
+
+    def test_deleted_external_root_refuses_old_scope_then_rebuilds_new_scope(
+        self, monkeypatch, tmp_path
+    ):
+        """A removed configured external root cannot be hidden by a cached map."""
+        import agent.skill_commands as sc_mod
+
+        primary_root = tmp_path / "skills"
+        external_root = tmp_path / "external"
+        _make_skill(primary_root, "local")
+        external_skill_dir = _make_skill(external_root, "external")
+        current_external_roots = (external_root,)
+
+        def resolve_roots():
+            roots = (primary_root, *current_external_roots)
+            return (
+                primary_root,
+                current_external_roots,
+                tuple(str(root.resolve()) for root in roots),
+            )
+
+        monkeypatch.setattr(sc_mod, "_resolve_skill_command_roots", resolve_roots)
+        monkeypatch.setattr(sc_mod, "_skill_commands", {})
+        monkeypatch.setattr(sc_mod, "_skill_commands_platform", None)
+        monkeypatch.setattr(sc_mod, "_skill_commands_environment", None)
+        monkeypatch.setattr(sc_mod, "_skill_commands_roots", None)
+        monkeypatch.setattr(sc_mod, "_resolve_skill_commands_platform", lambda: None)
+        monkeypatch.setattr(sc_mod, "_resolve_skill_commands_environment", lambda: ())
+
+        assert set(get_skill_commands()) == {"/local", "/external"}
+
+        (external_skill_dir / "SKILL.md").unlink()
+        external_skill_dir.rmdir()
+        external_root.rmdir()
+        assert get_skill_commands() == {}
+        assert set(sc_mod._skill_commands) == {"/local", "/external"}
+
+        # The following root-config resolution defines a new scope.  It can
+        # build the still-available local root without reusing old external
+        # entries.
+        current_external_roots = ()
+        assert set(get_skill_commands()) == {"/local"}
+
+    def test_unreadable_skill_preserves_last_good_catalog(
+        self, tmp_path, caplog
+    ):
+        import agent.skill_commands as sc_mod
+
+        previous = {
+            "/stable": {
+                "name": "stable",
+                "description": "Stable.",
+                "skill_md_path": "/stable/SKILL.md",
+                "skill_dir": "/stable",
+            }
+        }
+        unreadable = tmp_path / "missing" / "SKILL.md"
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch.object(sc_mod, "_skill_commands", previous),
+            patch.object(sc_mod, "_skill_commands_roots", (str(tmp_path.resolve()),)),
+            patch(
+                "agent.skill_utils.iter_skill_index_files",
+                return_value=iter([unreadable]),
+            ),
+            caplog.at_level("WARNING", logger="agent.skill_commands"),
+        ):
+            result = scan_skill_commands()
+
+        assert result == previous
+        assert any("scan was incomplete" in r.message for r in caplog.records)
+
+    def test_incomplete_first_scan_does_not_cache_partial_catalog(
+        self, tmp_path, caplog
+    ):
+        import agent.skill_commands as sc_mod
+
+        readable = _make_skill(tmp_path, "readable")
+        unreadable = tmp_path / "missing" / "SKILL.md"
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch(
+                "agent.skill_utils.iter_skill_index_files",
+                return_value=iter([readable, unreadable]),
+            ),
+            caplog.at_level("WARNING", logger="agent.skill_commands"),
+        ):
+            result = scan_skill_commands()
+
+        assert result == {}
+        assert any("scan was incomplete" in r.message for r in caplog.records)
+
+    @pytest.mark.parametrize(
+        ("old_platform", "new_platform", "old_environment", "new_environment"),
+        [
+            ("telegram", "discord", (), ()),
+            (
+                None,
+                None,
+                (("kanban", True),),
+                (("kanban", False),),
+            ),
+        ],
+    )
+    def test_failed_cross_scope_scan_never_returns_stale_catalog(
+        self,
+        tmp_path,
+        old_platform,
+        new_platform,
+        old_environment,
+        new_environment,
+    ):
+        import agent.skill_commands as sc_mod
+
+        previous = {
+            "/scope-only": {
+                "name": "scope-only",
+                "description": "Only valid in the previous scope.",
+                "skill_md_path": "/old/SKILL.md",
+                "skill_dir": "/old",
+            }
+        }
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch.object(sc_mod, "_skill_commands", previous),
+            patch.object(sc_mod, "_skill_commands_platform", old_platform),
+            patch.object(
+                sc_mod,
+                "_skill_commands_environment",
+                old_environment,
+            ),
+            patch.object(
+                sc_mod,
+                "_resolve_skill_commands_platform",
+                return_value=new_platform,
+            ),
+            patch.object(
+                sc_mod,
+                "_resolve_skill_commands_environment",
+                return_value=new_environment,
+            ),
+            patch(
+                "agent.skill_utils.iter_skill_index_files",
+                side_effect=OSError("temporary scan failure"),
+            ),
+        ):
+            result = get_skill_commands()
+            assert sc_mod._skill_commands == previous
+            assert sc_mod._skill_commands_platform == old_platform
+            assert sc_mod._skill_commands_environment == old_environment
+
+        assert result == {}
+
+    def test_partial_walk_failure_is_not_cached_and_retries_cross_scope(
+        self, tmp_path, monkeypatch
+    ):
+        import agent.skill_commands as sc_mod
+        from agent import skill_utils
+
+        good = _make_skill(tmp_path, "good")
+        bad = tmp_path / "bad"
+        bad.mkdir()
+        previous = {
+            "/scope-only": {
+                "name": "scope-only",
+                "description": "Only valid in the previous scope.",
+                "skill_md_path": "/old/SKILL.md",
+                "skill_dir": "/old",
+            }
+        }
+        bad_stat_attempts = 0
+
+        def fake_walk(root, *, followlinks, onerror):
+            assert root == str(tmp_path)
+            assert followlinks is True
+            assert callable(onerror)
+            yield str(tmp_path), ["good", "bad"], []
+            yield str(good), [], ["SKILL.md"]
+            yield str(bad), [], []
+
+        def fake_stat(path, *, follow_symlinks):
+            nonlocal bad_stat_attempts
+            if path == str(bad):
+                bad_stat_attempts += 1
+                raise OSError("temporary subtree failure")
+            return os.stat(path, follow_symlinks=follow_symlinks)
+
+        monkeypatch.setattr(
+            skill_utils,
+            "os",
+            SimpleNamespace(walk=fake_walk, stat=fake_stat, path=os.path),
+        )
+        monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", tmp_path)
+        monkeypatch.setattr(sc_mod, "_skill_commands", previous)
+        monkeypatch.setattr(sc_mod, "_skill_commands_platform", "telegram")
+        monkeypatch.setattr(sc_mod, "_skill_commands_environment", ())
+        monkeypatch.setattr(
+            sc_mod, "_resolve_skill_commands_platform", lambda: "discord"
+        )
+        monkeypatch.setattr(
+            sc_mod, "_resolve_skill_commands_environment", lambda: ()
+        )
+
+        assert get_skill_commands() == {}
+        assert get_skill_commands() == {}
+        assert bad_stat_attempts == 2
+        assert sc_mod._skill_commands == previous
+        assert sc_mod._skill_commands_platform == "telegram"
+        assert sc_mod._skill_commands_environment == ()
+
+    def test_excludes_incompatible_platform(self, tmp_path):
+        """macOS-only skills should not register slash commands on Linux."""
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("agent.skill_utils.sys") as mock_sys,
+        ):
+            mock_sys.platform = "linux"
+            _make_skill(tmp_path, "imessage", frontmatter_extra="platforms: [macos]\n")
+            _make_skill(tmp_path, "web-search")
+            result = scan_skill_commands()
+        assert "/web-search" in result
+        assert "/imessage" not in result
 
 
 
@@ -236,6 +722,37 @@ class TestScanSkillCommands:
             assert "/telegram-only" in bare_commands
             assert sc_mod._skill_commands_platform is None
 
+
+    def test_get_skill_commands_rescans_when_kanban_environment_changes(
+        self, tmp_path, monkeypatch
+    ):
+        import agent.skill_commands as sc_mod
+        from agent.skill_commands import get_skill_commands
+
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch.object(sc_mod, "_skill_commands", {}),
+            patch.object(sc_mod, "_skill_commands_platform", None),
+            patch.object(sc_mod, "_skill_commands_environment", None),
+            patch(
+                "tools.kanban_tools._profile_has_kanban_toolset",
+                return_value=False,
+            ),
+        ):
+            _make_skill(
+                tmp_path,
+                "kanban-only",
+                frontmatter_extra="environments: [kanban]\n",
+            )
+            assert "/kanban-only" not in get_skill_commands()
+
+            monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+            assert "/kanban-only" in get_skill_commands()
+
+            monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+            assert "/kanban-only" not in get_skill_commands()
 
 
 
@@ -455,9 +972,7 @@ class TestBuildSkillInvocationMessage:
 
 
 class TestSkillDirectoryHeader:
-    """The activation message must expose the absolute skill directory and
-    explain how to resolve relative paths, so skills with bundled scripts
-    don't force the agent into a second ``skill_view()`` round-trip."""
+    """Bound slash payloads must not advertise a mutable executable path."""
 
     def test_header_contains_absolute_skill_dir(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -466,8 +981,8 @@ class TestSkillDirectoryHeader:
             msg = build_skill_invocation_message("/abs-dir-skill", "go")
 
         assert msg is not None
-        assert f"[Skill directory: {skill_dir}]" in msg
-        assert "Resolve any relative paths" in msg
+        assert f"[Skill directory: {skill_dir}]" not in msg
+        assert "Resolve any relative paths" not in msg
 
     def test_supporting_files_shown_with_absolute_paths(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -478,12 +993,28 @@ class TestSkillDirectoryHeader:
             msg = build_skill_invocation_message("/scripted-skill")
 
         assert msg is not None
-        # The supporting-files block must emit both the relative form (so the
-        # agent can call skill_view on it) and the absolute form (so it can
-        # run the script directly via terminal).
+        # Bound packages expose only relative support paths.  A subsequent
+        # skill_view request obtains a fresh checked snapshot rather than
+        # executing a path that may have been replaced since activation.
         assert "scripts/run.js" in msg
-        assert str(skill_dir / "scripts" / "run.js") in msg
-        assert f"node {skill_dir}/scripts/foo.js" in msg
+        assert str(skill_dir / "scripts" / "run.js") not in msg
+        assert f"node {skill_dir}/scripts/foo.js" not in msg
+
+    def test_supporting_file_preview_is_bounded(self, tmp_path):
+        limit = skills_tool_module.MAX_LINKED_FILES_PER_CATEGORY
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "asset-heavy")
+            assets = skill_dir / "assets"
+            assets.mkdir()
+            for index in range(limit + 5):
+                (assets / f"{index:03d}.txt").write_text("asset")
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/asset-heavy")
+
+        assert msg is not None
+        assert "Supporting-file preview truncated" in msg
+        assert f"assets/{limit - 1:03d}.txt" in msg
+        assert f"assets/{limit + 4:03d}.txt" not in msg
 
 
 class TestTemplateVarSubstitution:
@@ -511,7 +1042,7 @@ class TestTemplateVarSubstitution:
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch(
-                "agent.skill_commands._load_skills_config",
+                "agent.skill_preprocessing.load_skills_config",
                 return_value={"template_vars": False},
             ),
         ):
@@ -529,17 +1060,59 @@ class TestTemplateVarSubstitution:
 
 
 class TestInlineShellExpansion:
-    """Inline ``!`cmd`` snippets in SKILL.md run before the agent sees the
-    content — but only when the user has opted in via config."""
+    def test_quoted_false_does_not_enable_inline_shell(self):
+        from agent.skill_preprocessing import preprocess_skill_content
 
+        result = preprocess_skill_content(
+            "Value: !`printf EXECUTED`",
+            None,
+            skills_cfg={"inline_shell": "false"},
+        )
 
+        assert result == "Value: !`printf EXECUTED`"
+
+    def test_inline_shell_is_off_by_default(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "dyn-default-off",
+                body="Today is !`echo INLINE_RAN`.",
+            )
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/dyn-default-off")
+
+        assert msg is not None
+        # Default config has inline_shell=False — snippet must stay literal.
+        assert "!`echo INLINE_RAN`" in msg
+        assert "Today is INLINE_RAN." not in msg
+
+    def test_inline_shell_runs_when_enabled(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_preprocessing.load_skills_config",
+                return_value={"template_vars": True, "inline_shell": True,
+                              "inline_shell_timeout": 5},
+            ),
+        ):
+            _make_skill(
+                tmp_path,
+                "dyn-on",
+                body="Marker: !`echo INLINE_RAN`.",
+            )
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/dyn-on")
+
+        assert msg is not None
+        assert "Marker: INLINE_RAN." in msg
+        assert "!`echo INLINE_RAN`" not in msg
 
     def test_inline_shell_runs_in_skill_directory(self, tmp_path):
         """Inline snippets get the skill dir as CWD so relative paths work."""
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch(
-                "agent.skill_commands._load_skills_config",
+                "agent.skill_preprocessing.load_skills_config",
                 return_value={"template_vars": True, "inline_shell": True,
                               "inline_shell_timeout": 5},
             ),
@@ -559,7 +1132,7 @@ class TestInlineShellExpansion:
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch(
-                "agent.skill_commands._load_skills_config",
+                "agent.skill_preprocessing.load_skills_config",
                 return_value={"template_vars": True, "inline_shell": True,
                               "inline_shell_timeout": 1},
             ),
@@ -579,6 +1152,108 @@ class TestInlineShellExpansion:
         # The command's intended stdout never made it through — only the
         # timeout marker (which echoes the command text) survives.
         assert "DYN_MARKER" not in msg.replace("sleep 5 && printf DYN_MARKER", "")
+
+
+class TestBoundInvocationRendering:
+    """Slash-family callers must never re-open a package by its old path."""
+
+    def _make_swappable_skill(self, tmp_path, name="bound"):
+        skills_root = tmp_path / "skills"
+        packages = tmp_path / "packages"
+        original_category = packages / "original"
+        replacement_category = packages / "replacement"
+        skills_root.mkdir()
+        original = _make_skill(
+            original_category, name, body="Marker: !`cat marker.txt`"
+        )
+        replacement = replacement_category / name
+        replacement.mkdir(parents=True)
+        # Same SKILL.md identity keeps discovery stable; only the package
+        # support file differs, which is what the inline shell observes.
+        os.link(original / "SKILL.md", replacement / "SKILL.md")
+        (original / "marker.txt").write_text("ORIGINAL", encoding="utf-8")
+        (replacement / "marker.txt").write_text("REPLACEMENT", encoding="utf-8")
+        category_link = skills_root / "linked"
+        try:
+            category_link.symlink_to(original_category, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+        return skills_root, category_link, replacement_category
+
+    def _swap_config(self, category_link, replacement_category):
+        swapped = False
+
+        def config():
+            nonlocal swapped
+            if not swapped:
+                swapped = True
+                category_link.unlink()
+                category_link.symlink_to(replacement_category, target_is_directory=True)
+            return {
+                "template_vars": True,
+                "inline_shell": True,
+                "inline_shell_timeout": 5,
+            }
+
+        return config, lambda: swapped
+
+    def test_slash_inline_shell_stays_in_discovered_package(self, tmp_path):
+        skills_root, category_link, replacement_category = self._make_swappable_skill(
+            tmp_path, "slash-bound"
+        )
+        config, was_swapped = self._swap_config(category_link, replacement_category)
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_root),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+            patch("agent.skill_preprocessing.load_skills_config", side_effect=config),
+        ):
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/slash-bound")
+
+        assert was_swapped() is True
+        assert "Marker: ORIGINAL" in msg
+        assert "REPLACEMENT" not in msg
+
+    def test_stacked_inline_shell_stays_in_discovered_package(self, tmp_path):
+        from agent.skill_commands import build_stacked_skill_invocation_message
+
+        skills_root, category_link, replacement_category = self._make_swappable_skill(
+            tmp_path, "stacked-bound"
+        )
+        _make_skill(skills_root, "plain", body="Plain guidance.")
+        config, was_swapped = self._swap_config(category_link, replacement_category)
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_root),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+            patch("agent.skill_preprocessing.load_skills_config", side_effect=config),
+        ):
+            scan_skill_commands()
+            result = build_stacked_skill_invocation_message(
+                ["/stacked-bound", "/plain"]
+            )
+
+        assert result is not None
+        assert was_swapped() is True
+        assert "Marker: ORIGINAL" in result[0]
+        assert "REPLACEMENT" not in result[0]
+
+    def test_preload_inline_shell_stays_in_discovered_package(self, tmp_path):
+        skills_root, category_link, replacement_category = self._make_swappable_skill(
+            tmp_path, "preload-bound"
+        )
+        config, was_swapped = self._swap_config(category_link, replacement_category)
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_root),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+            patch("agent.skill_preprocessing.load_skills_config", side_effect=config),
+        ):
+            prompt, loaded, missing = build_preloaded_skills_prompt(["preload-bound"])
+
+        assert was_swapped() is True
+        assert loaded == ["preload-bound"]
+        assert missing == []
+        assert "Marker: ORIGINAL" in prompt
+        assert "REPLACEMENT" not in prompt
 
 
 class TestStackedSkillCommands:
@@ -633,6 +1308,4 @@ class TestStackedSkillCommands:
         assert loaded == ["skill-a"]
         assert missing == ["gone"]
         assert "Skills missing (skipped): gone" in msg
-
-
 

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,8 +1,15 @@
 """Tests for agent/skill_utils.py."""
 
+import os
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from agent.skill_utils import (
+    SkillsConfigError,
+    discover_all_skill_config_vars,
     extract_skill_config_vars,
     extract_skill_conditions,
     get_disabled_skill_names,
@@ -18,6 +25,146 @@ from agent.skill_utils import (
 )
 
 
+def _write_config_skill(
+    root: Path,
+    name: str,
+    *,
+    platforms: str = "",
+    environments: str = "",
+) -> Path:
+    """Create a minimal, valid skill that declares one config variable."""
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Test skill\n"
+        f"{platforms}"
+        f"{environments}"
+        "metadata:\n"
+        "  hermes:\n"
+        "    config:\n"
+        f"      - key: {name}.token\n"
+        "        description: A test token\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    return skill_dir / "SKILL.md"
+
+
+def _configure_local_config_discovery(monkeypatch, skills_dir: Path) -> None:
+    monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr(
+        "agent.skill_utils.get_scannable_external_skills_dirs", lambda **_: []
+    )
+    monkeypatch.setattr("agent.skill_utils.get_disabled_skill_names", lambda: set())
+
+
+def test_discover_config_vars_refuses_partial_result_for_malformed_skill(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / "skills"
+    _write_config_skill(skills_dir, "valid")
+    malformed_dir = skills_dir / "malformed"
+    malformed_dir.mkdir(parents=True)
+    (malformed_dir / "SKILL.md").write_text(
+        "---\nname: malformed\n", encoding="utf-8"
+    )
+    _configure_local_config_discovery(monkeypatch, skills_dir)
+
+    assert discover_all_skill_config_vars() == []
+
+
+def test_discover_config_vars_refuses_canonical_skill_symlink(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    _write_config_skill(skills_dir, "valid")
+    outside = _write_config_skill(tmp_path / "outside", "linked")
+    link_dir = skills_dir / "linked"
+    link_dir.mkdir()
+    try:
+        (link_dir / "SKILL.md").symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable on this platform")
+    _configure_local_config_discovery(monkeypatch, skills_dir)
+
+    assert discover_all_skill_config_vars() == []
+
+
+def test_discover_config_vars_applies_platform_and_environment_gates(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / "skills"
+    _write_config_skill(skills_dir, "available")
+    _write_config_skill(skills_dir, "other-platform", platforms="platforms: [windows]\n")
+    _write_config_skill(skills_dir, "other-environment", environments="environments: [kanban]\n")
+    _configure_local_config_discovery(monkeypatch, skills_dir)
+    monkeypatch.setattr("agent.skill_utils.sys.platform", "linux")
+    monkeypatch.setattr("agent.skill_utils.is_termux", lambda: False)
+    monkeypatch.setattr("agent.skill_utils._detect_environment", lambda _: False)
+
+    assert [item["key"] for item in discover_all_skill_config_vars()] == [
+        "available.token"
+    ]
+
+
+def test_discover_config_vars_refuses_partial_result_on_reader_error(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / "skills"
+    _write_config_skill(skills_dir, "valid")
+    broken = _write_config_skill(skills_dir, "broken")
+    _configure_local_config_discovery(monkeypatch, skills_dir)
+
+    from agent import skill_utils
+
+    real_reader = skill_utils.read_strict_skill_index_file
+
+    def fail_for_broken(path):
+        if path == broken:
+            raise OSError("simulated read failure")
+        return real_reader(path)
+
+    monkeypatch.setattr(skill_utils, "read_strict_skill_index_file", fail_for_broken)
+
+    assert discover_all_skill_config_vars() == []
+
+
+def test_discover_config_vars_refuses_malformed_external_scope(
+    tmp_path, monkeypatch
+):
+    skills_dir = tmp_path / "skills"
+    _write_config_skill(skills_dir, "valid")
+    monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr(
+        "agent.skill_utils._resolve_external_skills_dirs",
+        lambda **_: (_ for _ in ()).throw(
+            SkillsConfigError("malformed skills.external_dirs")
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.skill_utils.get_disabled_skill_names", lambda: set()
+    )
+
+    assert discover_all_skill_config_vars() == []
+
+
+def test_metadata_as_dict_with_hermes():
+    """Normal case: metadata is a dict containing hermes keys."""
+    frontmatter = {
+        "metadata": {
+            "hermes": {
+                "fallback_for_toolsets": ["toolset_a"],
+                "requires_toolsets": ["toolset_b"],
+                "fallback_for_tools": ["tool_x"],
+                "requires_tools": ["tool_y"],
+            }
+        }
+    }
+    result = extract_skill_conditions(frontmatter)
+    assert result["fallback_for_toolsets"] == ["toolset_a"]
+    assert result["requires_toolsets"] == ["toolset_b"]
+    assert result["fallback_for_tools"] == ["tool_x"]
+    assert result["requires_tools"] == ["tool_y"]
 
 
 
@@ -26,6 +173,69 @@ from agent.skill_utils import (
 
 
 
+
+
+def test_iter_skill_index_files_breaks_directory_symlink_cycles(tmp_path):
+    skill = tmp_path / "real-skill"
+    skill.mkdir()
+    skill_md = skill / "SKILL.md"
+    skill_md.write_text("---\nname: real-skill\n---\n", encoding="utf-8")
+    try:
+        (skill / "loop").symlink_to(tmp_path, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        return
+
+    assert list(iter_skill_index_files(tmp_path, "SKILL.md")) == [skill_md]
+
+
+def test_iter_skill_index_files_reports_walk_and_stat_errors(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    walk_error = OSError("walk failed")
+    stat_error = OSError("stat failed")
+    errors = []
+
+    def fake_walk(root, *, followlinks, onerror):
+        assert root == str(tmp_path)
+        assert followlinks is True
+        onerror(walk_error)
+        yield str(tmp_path / "unreadable"), [], []
+
+    def fake_stat(path, *, follow_symlinks):
+        assert path == str(tmp_path / "unreadable")
+        assert follow_symlinks is True
+        raise stat_error
+
+    monkeypatch.setattr(
+        skill_utils,
+        "os",
+        SimpleNamespace(walk=fake_walk, stat=fake_stat, path=os.path),
+    )
+
+    assert list(
+        iter_skill_index_files(tmp_path, "SKILL.md", on_error=errors.append)
+    ) == []
+    assert errors == [walk_error, stat_error]
+
+
+def test_skill_environment_fingerprint_tracks_dynamic_kanban_env(monkeypatch):
+    from agent.skill_utils import get_skill_environment_fingerprint
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    with patch(
+        "tools.kanban_tools._profile_has_kanban_toolset",
+        return_value=False,
+    ):
+        initial = dict(get_skill_environment_fingerprint())
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+        active = dict(get_skill_environment_fingerprint())
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        restored = dict(get_skill_environment_fingerprint())
+
+    assert initial["kanban"] is False
+    assert active["kanban"] is True
+    assert restored["kanban"] is False
 
 
 def test_skill_config_helpers_share_raw_config_parse_cache(tmp_path, monkeypatch):
@@ -73,6 +283,149 @@ skills:
 
 
 
+def test_strict_skills_scope_rejects_malformed_config_but_ordinary_lookup_is_compatible(
+    tmp_path, monkeypatch
+):
+    """Mutation scans can detect config loss without breaking read-only callers."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "skills:\n  external_dirs: [\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+
+    # Historical best-effort callers retain their empty-list behavior.
+    assert skill_utils.get_external_skills_dirs() == []
+    with pytest.raises(skill_utils.SkillsConfigError, match="config.yaml"):
+        skill_utils.get_all_skills_dirs(require_valid_config=True)
+
+
+def test_strict_skills_scope_rejects_unreadable_config(tmp_path, monkeypatch):
+    """A stat-able config that cannot be read must not look like no externals."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text("skills: {}\n", encoding="utf-8")
+    real_read_text = Path.read_text
+
+    def deny_config_read(path, *args, **kwargs):
+        if path == config_path:
+            raise PermissionError("permission denied")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+    monkeypatch.setattr(Path, "read_text", deny_config_read)
+
+    assert skill_utils.get_external_skills_dirs() == []
+    with pytest.raises(skill_utils.SkillsConfigError, match="permission denied"):
+        skill_utils.get_all_skills_dirs(require_valid_config=True)
+
+
+@pytest.mark.parametrize(
+    "yaml_value",
+    [
+        "false",
+        "0",
+        "{}",
+        "[false]",
+        "['']",
+    ],
+)
+def test_strict_skills_scope_rejects_falsey_non_path_types(
+    tmp_path, monkeypatch, yaml_value
+):
+    """Falsey YAML scalars/mappings must not collapse to an empty strict scope."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs: {yaml_value}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+
+    # Ordinary discovery keeps its historical best-effort result, including
+    # stringifying legacy list entries. Only strict mutation scope hardens it.
+    expected_ordinary = (
+        [hermes_home / "False"] if yaml_value == "[false]" else []
+    )
+    assert skill_utils.get_external_skills_dirs() == expected_ordinary
+    with pytest.raises(skill_utils.SkillsConfigError, match="external_dirs"):
+        skill_utils.get_all_skills_dirs(require_valid_config=True)
+
+
+def test_strict_skills_scope_rejects_dangling_config_symlink(
+    tmp_path, monkeypatch
+):
+    """A dangling config entry exists and cannot mean an absent configuration."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    try:
+        config_path.symlink_to(hermes_home / "missing-config.yaml")
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation is unavailable")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+
+    assert skill_utils.get_external_skills_dirs() == []
+    with pytest.raises(skill_utils.SkillsConfigError, match="config.yaml"):
+        skill_utils.get_all_skills_dirs(require_valid_config=True)
+
+
+@pytest.mark.parametrize("yaml_value", ["null", "''", "[]"])
+def test_strict_skills_scope_accepts_explicit_empty_values(
+    tmp_path, monkeypatch, yaml_value
+):
+    """Only the documented null/empty-string/empty-list forms mean no externals."""
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs: {yaml_value}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+
+    assert skill_utils.get_all_skills_dirs(require_valid_config=True) == [
+        hermes_home / "skills"
+    ]
+
+
+def test_is_external_skill_path_matches_configured_external_dir(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    local_skills = hermes_home / "skills"
+    external = tmp_path / "external-skills"
+    local_skills.mkdir(parents=True)
+    external.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {external}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+
+    assert is_external_skill_path(external / "team-skill" / "SKILL.md") is True
+    assert is_external_skill_path(local_skills / "local-skill" / "SKILL.md") is False
 
 
 def test_iter_skill_index_files_prunes_skill_support_dirs(tmp_path):
@@ -187,6 +540,30 @@ class TestSkillMatchesPlatformTermux:
 
 
 class TestNormalizeSkillLookupName:
+    def test_active_profile_root_is_resolved_at_call_time(self, tmp_path):
+        from agent.skill_utils import normalize_skill_lookup_name
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        skill_a = home_a / "skills" / "a-skill"
+        skill_b = home_b / "skills" / "b-skill"
+        skill_a.mkdir(parents=True)
+        skill_b.mkdir(parents=True)
+
+        token = set_hermes_home_override(str(home_a))
+        try:
+            assert normalize_skill_lookup_name(str(skill_a)) == "a-skill"
+        finally:
+            reset_hermes_home_override(token)
+
+        token = set_hermes_home_override(str(home_b))
+        try:
+            assert normalize_skill_lookup_name(str(skill_b)) == "b-skill"
+            assert normalize_skill_lookup_name(str(skill_a)) == str(skill_a)
+        finally:
+            reset_hermes_home_override(token)
+
     def test_relative_path_unchanged(self, tmp_path, monkeypatch):
         from agent.skill_utils import normalize_skill_lookup_name
 
@@ -301,4 +678,3 @@ class TestBOMToleranceSiblingSites:
         fm = _split_frontmatter("\ufeff---\nname: bp\n---\nbody")
         assert fm is not None
         assert fm.get("name") == "bp"
-

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -130,6 +130,31 @@ def test_build_system_prompt_records_stable_prefix():
     assert prompt[len(agent._cached_system_prompt_static):].startswith("\n\ncontext")
 
 
+def test_skills_prompt_index_mode_is_wired_from_config():
+    agent = _make_agent(valid_tool_names=["skills_list", "skill_view"])
+    captured = {}
+
+    def fake_skills_prompt(**kwargs):
+        captured.update(kwargs)
+        return "SKILLS"
+
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+        patch("run_agent.build_skills_system_prompt", side_effect=fake_skills_prompt),
+        patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"skills": {"prompt_index_mode": "category_compact"}},
+        ),
+    ):
+        stable = build_system_prompt_parts(agent)["stable"]
+
+    assert "SKILLS" in stable
+    assert captured["prompt_index_mode"] == "category_compact"
+
+
 def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
     """The cache split must not reorder the stored coding prompt."""
     import agent.system_prompt as system_prompt

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -24,6 +24,7 @@ def _make_agent(**overrides):
         platform="",
         pass_session_id=False,
         session_id="",
+        _emit_status=lambda _message: None,
     )
     base.update(overrides)
     return SimpleNamespace(**base)
@@ -88,7 +89,7 @@ def _init_code_repo(path):
     import subprocess
 
     subprocess.run(["git", "-C", str(path), "init", "-q"], check=True)
-    (path / "main.py").write_text("print('hi')\n")
+    (path / "main.py").write_text("print('hi')\n", encoding="utf-8")
 
 
 class TestCodingContextBlock:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -7,8 +7,9 @@ deadline timeouts. These tests pin all of that without spawning real codex.
 
 from __future__ import annotations
 
+import threading
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from typing import Any, Optional
 
 import pytest
@@ -16,7 +17,9 @@ import pytest
 import agent.transports.codex_app_server_session as session_mod
 from agent.transports.codex_app_server_session import (
     CodexAppServerSession,
+    TurnResult,
     _ServerRequestRouting,
+    _apply_compaction_notification,
     _approval_choice_to_codex_decision,
     _coerce_turn_input_text,
 )
@@ -38,9 +41,11 @@ class FakeClient:
         self._notifications: list[dict] = []
         self._server_requests: list[dict] = []
         self._request_handler = None  # Optional[Callable[[str, dict], dict]]
+        self.initialize_kwargs: dict[str, Any] = {}
 
     # API matching CodexAppServerClient
     def initialize(self, **kwargs):
+        self.initialize_kwargs = dict(kwargs)
         self._initialized = True
         return {"userAgent": "fake/0.0.0", "codexHome": "/tmp",
                 "platformOs": "linux", "platformFamily": "unix"}
@@ -53,6 +58,13 @@ class FakeClient:
         if method == "thread/start":
             return {"thread": {"id": "thread-fake-001"},
                     "activePermissionProfile": {"id": "workspace-write"}}
+        if method == "thread/resume":
+            return {
+                "thread": {
+                    "id": (params or {}).get("threadId"),
+                    "sessionId": "thread-tree-root",
+                }
+            }
         if method == "turn/start":
             return {"turn": {"id": "turn-fake-001"}}
         if method == "turn/interrupt":
@@ -126,6 +138,21 @@ def make_session(client: FakeClient, **kwargs) -> CodexAppServerSession:
     )
 
 
+def queue_completion_after_response(client: FakeClient) -> None:
+    """Model the official ordering: approval response precedes terminal."""
+    original_respond = client.respond
+
+    def respond(request_id, result):
+        original_respond(request_id, result)
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+    client.respond = respond
+
+
 # ---- choice mapping ----
 
 class TestApprovalChoiceMapping:
@@ -152,6 +179,124 @@ class TestTurnInputCoercion:
 # ---- lifecycle ----
 
 class TestLifecycle:
+    def test_lease_contention_fails_before_client_construction(self):
+        client_factory = MagicMock(
+            side_effect=AssertionError("client must not be constructed")
+        )
+        session = CodexAppServerSession(
+            cwd="/tmp",
+            client_factory=client_factory,
+            lease_acquire=lambda: False,
+        )
+
+        result = session.run_turn("blocked", turn_timeout=0.1)
+
+        assert result.should_retire is True
+        assert result.error and "another Hermes/Codex client" in result.error
+        client_factory.assert_not_called()
+
+    def test_lease_heartbeat_and_close_release_are_ordered_and_idempotent(self):
+        client = FakeClient()
+        order = []
+        refresh_seen = threading.Event()
+        original_close = client.close
+
+        def close_client():
+            order.append("client-close")
+            original_close()
+
+        def refresh():
+            order.append("refresh")
+            refresh_seen.set()
+            return True
+
+        def release():
+            assert client._closed is True
+            order.append("release")
+            return True
+
+        client.close = close_client
+        session = make_session(
+            client,
+            lease_acquire=lambda: order.append("acquire") or True,
+            lease_refresh=refresh,
+            lease_release=release,
+            lease_refresh_interval=0.01,
+        )
+
+        assert session.ensure_started() == "thread-fake-001"
+        assert refresh_seen.wait(timeout=1.0)
+        session.close()
+        session.close()
+
+        assert order[0] == "acquire"
+        assert order.count("release") == 1
+        assert order.index("client-close") < order.index("release")
+
+    def test_lease_refresh_failure_retires_active_turn(self):
+        client = FakeClient()
+        released = []
+        session = make_session(
+            client,
+            lease_acquire=lambda: True,
+            lease_refresh=lambda: False,
+            lease_release=lambda: released.append(True) or True,
+            lease_refresh_interval=0.01,
+        )
+
+        result = session.run_turn(
+            "wait for lease failure",
+            turn_timeout=1.0,
+            notification_poll_timeout=0.01,
+        )
+
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert result.error and "lease refresh failed" in result.error
+        assert client._closed is True
+        assert released == [True]
+
+    def test_transient_lease_release_failure_is_retried(self):
+        client = FakeClient()
+        released = threading.Event()
+        attempts = []
+
+        def release():
+            attempts.append(len(attempts) + 1)
+            if len(attempts) == 1:
+                return False
+            released.set()
+            return True
+
+        session = make_session(
+            client,
+            lease_acquire=lambda: True,
+            lease_release=release,
+        )
+        session.ensure_started()
+
+        session.close()
+
+        assert released.wait(timeout=1.0)
+        assert attempts == [1, 2]
+
+    def test_thread_binding_failure_closes_client_and_releases_lease(self):
+        client = FakeClient()
+        released = []
+        session = make_session(
+            client,
+            on_thread_ready=MagicMock(side_effect=RuntimeError("db failed")),
+            lease_acquire=lambda: True,
+            lease_release=lambda: released.append(True) or True,
+        )
+
+        result = session.run_turn("must fail", turn_timeout=0.1)
+
+        assert result.should_retire is True
+        assert result.error and "could not persist" in result.error
+        assert client._closed is True
+        assert released == [True]
+
     def test_ensure_started_is_idempotent(self):
         client = FakeClient()
         s = make_session(client)
@@ -174,6 +319,132 @@ class TestLifecycle:
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
 
+    def test_thread_resume_skips_full_turn_history_and_is_idempotent(self):
+        client = FakeClient()
+        s = make_session(client, resume_thread_id="thread-saved-001")
+
+        assert s.ensure_started() == "thread-saved-001"
+        assert s.ensure_started() == "thread-saved-001"
+        assert client.initialize_kwargs["capabilities"] == {
+            "experimentalApi": True
+        }
+        assert [
+            request for request in client.requests
+            if request[0] == "thread/resume"
+        ] == [
+            (
+                "thread/resume",
+                {
+                    "threadId": "thread-saved-001",
+                    "excludeTurns": True,
+                },
+            )
+        ]
+        assert not any(method == "thread/start" for method, _ in client.requests)
+
+    def test_thread_start_does_not_opt_into_experimental_api(self):
+        client = FakeClient()
+        s = make_session(client)
+
+        assert s.ensure_started() == "thread-fake-001"
+        assert client.initialize_kwargs["capabilities"] is None
+
+    def test_thread_resume_accepts_exact_top_level_thread_id_compatibility(self):
+        client = FakeClient()
+        client._request_handler = lambda method, params: {
+            "threadId": params["threadId"]
+        }
+        s = make_session(client, resume_thread_id="thread-saved-001")
+
+        assert s.ensure_started() == "thread-saved-001"
+        assert client.requests == [
+            (
+                "thread/resume",
+                {
+                    "threadId": "thread-saved-001",
+                    "excludeTurns": True,
+                },
+            )
+        ]
+        assert not any(method == "thread/start" for method, _ in client.requests)
+
+    def test_thread_resume_rejects_canonical_id_mismatch(self):
+        client = FakeClient()
+
+        def mismatched_resume(method, params):
+            assert method == "thread/resume"
+            return {
+                "thread": {
+                    "id": "thread-other",
+                    "sessionId": params["threadId"],
+                }
+            }
+
+        client._request_handler = mismatched_resume
+        s = make_session(client, resume_thread_id="thread-saved-001")
+
+        with pytest.raises(session_mod.CodexAppServerError, match="different thread id"):
+            s.ensure_started()
+        assert not any(method == "thread/start" for method, _ in client.requests)
+
+    def test_thread_resume_does_not_accept_session_id_as_thread_id(self):
+        client = FakeClient()
+        client._request_handler = lambda method, params: {
+            "thread": {"sessionId": params["threadId"]}
+        }
+        s = make_session(client, resume_thread_id="thread-saved-001")
+
+        with pytest.raises(session_mod.CodexAppServerError, match="no thread id"):
+            s.ensure_started()
+        assert not any(method == "thread/start" for method, _ in client.requests)
+
+    def test_thread_ready_callback_runs_once_before_first_turn(self):
+        client = FakeClient()
+        order = []
+
+        def request_handler(method, params):
+            order.append(method)
+            if method == "thread/start":
+                return {"thread": {"id": "thread-new"}}
+            if method == "turn/start":
+                return {"turn": {"id": "turn-new"}}
+            return {}
+
+        client._request_handler = request_handler
+        s = make_session(
+            client,
+            on_thread_ready=lambda thread_id: order.append(
+                f"persist:{thread_id}"
+            ),
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-new",
+            turn={"id": "turn-new", "status": "completed", "error": None},
+        )
+
+        s.run_turn("hello", turn_timeout=2.0)
+
+        assert order[:3] == [
+            "thread/start",
+            "persist:thread-new",
+            "turn/start",
+        ]
+        assert order.count("persist:thread-new") == 1
+
+    def test_thread_ready_callback_failure_blocks_first_turn(self):
+        client = FakeClient()
+
+        def fail_binding(_thread_id):
+            raise RuntimeError("database unavailable")
+
+        s = make_session(client, on_thread_ready=fail_binding)
+        result = s.run_turn("hello", turn_timeout=2.0)
+
+        assert result.should_retire is True
+        assert "startup failed" in result.error
+        assert not any(method == "turn/start" for method, _ in client.requests)
+
     def test_close_idempotent(self):
         client = FakeClient()
         s = make_session(client)
@@ -186,6 +457,26 @@ class TestLifecycle:
 # ---- turn loop ----
 
 class TestRunTurn:
+    def test_resume_failure_returns_retiring_error_without_new_thread(self):
+        client = FakeClient()
+
+        def fail_resume(method, params):
+            assert method == "thread/resume"
+            raise session_mod.CodexAppServerError(
+                code=-32000,
+                message="stored rollout unavailable",
+            )
+
+        client._request_handler = fail_resume
+        s = make_session(client, resume_thread_id="thread-saved-001")
+
+        result = s.run_turn("hello", turn_timeout=2.0)
+
+        assert result.should_retire is True
+        assert "stored rollout unavailable" in result.error
+        assert not any(method == "thread/start" for method, _ in client.requests)
+        assert not any(method == "turn/start" for method, _ in client.requests)
+
     def test_simple_text_turn_returns_final_message(self):
         client = FakeClient()
         client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})
@@ -208,6 +499,166 @@ class TestRunTurn:
                    for m in r.projected_messages)
         # turn_id propagated for downstream session-DB linkage
         assert r.turn_id == "turn-fake-001"
+
+    def test_interrupt_waits_for_matching_terminal_before_close(self):
+        client = FakeClient()
+        events = []
+        session = make_session(client)
+        original_close = client.close
+        original_take_notification = client.take_notification
+
+        def close():
+            events.append("closed")
+            original_close()
+
+        def request_handler(method: str, params: dict) -> dict:
+            if method == "thread/start":
+                return {
+                    "thread": {"id": "thread-fake-001"},
+                    "activePermissionProfile": {"id": "workspace-write"},
+                }
+            if method == "turn/start":
+                session.request_interrupt()
+                return {"turn": {"id": "turn-fake-001"}}
+            if method == "turn/interrupt":
+                events.append("interrupt_rpc_response")
+                client.queue_notification(
+                    "turn/completed",
+                    threadId="thread-fake-001",
+                    turn={
+                        "id": "turn-fake-001",
+                        "status": "interrupted",
+                        "error": None,
+                    },
+                )
+                client.queue_notification(
+                    "item/completed",
+                    threadId="thread-fake-001",
+                    turnId="turn-next-001",
+                    item={
+                        "type": "agentMessage",
+                        "id": "next-message",
+                        "text": "must remain queued",
+                    },
+                )
+                return {}
+            return {}
+
+        def take_notification(timeout: float = 0.0):
+            note = original_take_notification(timeout)
+            if note is not None and note.get("method") == "turn/completed":
+                events.append("terminal_seen")
+            return note
+
+        client.close = close
+        client._request_handler = request_handler
+        client.take_notification = take_notification
+
+        result = session.run_turn(
+            "stop",
+            turn_timeout=2.0,
+            interrupt_grace_timeout=0.2,
+        )
+
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert events == [
+            "interrupt_rpc_response",
+            "terminal_seen",
+            "closed",
+        ]
+        assert client._notifications[0]["params"]["turnId"] == "turn-next-001"
+
+    def test_interrupt_drops_stale_approval_after_terminal(self):
+        client = FakeClient()
+        approval_calls = []
+        session = make_session(
+            client,
+            approval_callback=lambda *args, **kwargs: approval_calls.append(
+                (args, kwargs)
+            )
+            or "once",
+        )
+
+        def request_handler(method: str, params: dict) -> dict:
+            if method == "thread/start":
+                return {
+                    "thread": {"id": "thread-fake-001"},
+                    "activePermissionProfile": {"id": "workspace-write"},
+                }
+            if method == "turn/start":
+                session.request_interrupt()
+                return {"turn": {"id": "turn-fake-001"}}
+            if method == "turn/interrupt":
+                client.queue_server_request(
+                    "item/commandExecution/requestApproval",
+                    request_id="stale-approval",
+                    threadId="thread-fake-001",
+                    turnId="turn-fake-001",
+                    command="echo stale",
+                    cwd="/tmp",
+                )
+                client.queue_notification(
+                    "turn/completed",
+                    threadId="thread-fake-001",
+                    turn={
+                        "id": "turn-fake-001",
+                        "status": "interrupted",
+                        "error": None,
+                    },
+                )
+                return {}
+            return {}
+
+        client._request_handler = request_handler
+
+        result = session.run_turn(
+            "stop",
+            turn_timeout=2.0,
+            interrupt_grace_timeout=0.2,
+        )
+
+        assert result.interrupted is True
+        assert client._closed is True
+        assert approval_calls == []
+        assert client.responses == []
+
+    def test_unscoped_turn_items_terminal_and_usage_are_ignored(self):
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "stale", "text": "stale"},
+        )
+        client.queue_notification(
+            "thread/tokenUsage/updated",
+            tokenUsage={"last": {"totalTokens": 999}},
+        )
+        client.queue_notification(
+            "turn/completed",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-fake-001",
+            turnId="turn-fake-001",
+            item={"type": "agentMessage", "id": "m1", "text": "current"},
+        )
+        client.queue_notification(
+            "thread/tokenUsage/updated",
+            threadId="thread-fake-001",
+            turnId="turn-fake-001",
+            tokenUsage={"last": {"totalTokens": 12}},
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+
+        result = make_session(client).run_turn("hi", turn_timeout=2.0)
+
+        assert result.final_text == "current"
+        assert result.token_usage_last == {"totalTokens": 12}
 
 
 
@@ -392,6 +843,214 @@ class TestRunTurn:
 
 
 class TestCompactThread:
+    def test_compaction_started_is_not_a_completed_boundary(self):
+        result = TurnResult()
+        started = {
+            "method": "item/started",
+            "params": {
+                "threadId": "thread-fake-001",
+                "turnId": "compact-turn-1",
+                "item": {
+                    "type": "contextCompaction",
+                    "id": "compact-item-1",
+                },
+            },
+        }
+
+        _apply_compaction_notification(result, started)
+
+        assert result.compacted is False
+
+        completed = {
+            **started,
+            "method": "item/completed",
+        }
+        _apply_compaction_notification(result, completed)
+        assert result.compacted is True
+
+    def test_compact_thread_honors_interrupt_before_rpc(self):
+        client = FakeClient()
+        session = make_session(client)
+        session.request_interrupt()
+
+        result = session.compact_thread(turn_timeout=2.0)
+
+        assert result.interrupted is True
+        assert result.should_retire is False
+        assert not any(
+            method == "thread/compact/start"
+            for method, _params in client.requests
+        )
+
+    def test_compact_thread_lease_lost_during_startup_retires(self):
+        client = FakeClient()
+        refresh_failed = threading.Event()
+
+        def refresh():
+            refresh_failed.set()
+            return False
+
+        def request_handler(method: str, params: dict) -> dict:
+            if method == "thread/start":
+                assert refresh_failed.wait(timeout=1.0)
+                return {
+                    "thread": {"id": "thread-fake-001"},
+                    "activePermissionProfile": {"id": "workspace-write"},
+                }
+            return {}
+
+        client._request_handler = request_handler
+        released = []
+        session = make_session(
+            client,
+            lease_acquire=lambda: True,
+            lease_refresh=refresh,
+            lease_release=lambda: released.append(True) or True,
+            lease_refresh_interval=0.01,
+        )
+
+        result = session.compact_thread(turn_timeout=0.1)
+
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert result.error and "lease was lost" in result.error
+        assert client._closed is True
+        assert released == [True]
+        assert not any(
+            method == "thread/compact/start"
+            for method, _params in client.requests
+        )
+
+    def test_compact_thread_interrupt_before_turn_id_drains_terminal(self):
+        client = FakeClient()
+        session = make_session(client)
+
+        def request_handler(method: str, params: dict) -> dict:
+            if method == "thread/start":
+                return {
+                    "thread": {"id": "thread-fake-001"},
+                    "activePermissionProfile": {"id": "workspace-write"},
+                }
+            if method == "thread/compact/start":
+                session.request_interrupt()
+                client.queue_notification(
+                    "turn/started",
+                    threadId="thread-fake-001",
+                    turn={"id": "compact-turn-1"},
+                )
+                return {}
+            if method == "turn/interrupt":
+                client.queue_notification(
+                    "turn/completed",
+                    threadId="thread-fake-001",
+                    turn={
+                        "id": "compact-turn-1",
+                        "status": "interrupted",
+                        "error": None,
+                    },
+                )
+                return {}
+            return {}
+
+        client._request_handler = request_handler
+
+        result = session.compact_thread(
+            turn_timeout=2.0,
+            interrupt_grace_timeout=0.2,
+        )
+
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert result.error == "compact turn interrupted"
+        assert client._closed is True
+        assert (
+            "turn/interrupt",
+            {
+                "threadId": "thread-fake-001",
+                "turnId": "compact-turn-1",
+            },
+        ) in client.requests
+
+    def test_compact_thread_interrupt_after_turn_id_retires_client(self):
+        client = FakeClient()
+        session = make_session(client)
+        client.queue_notification(
+            "turn/started",
+            threadId="thread-fake-001",
+            turn={"id": "compact-turn-1"},
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "compact-turn-1",
+                "status": "interrupted",
+                "error": None,
+            },
+        )
+
+        original_take_notification = client.take_notification
+
+        def take_notification(timeout: float = 0.0):
+            note = original_take_notification(timeout)
+            if note is not None and note.get("method") == "turn/started":
+                session.request_interrupt()
+            return note
+
+        client.take_notification = take_notification
+
+        result = session.compact_thread(
+            turn_timeout=2.0,
+            interrupt_grace_timeout=0.2,
+        )
+
+        assert result.interrupted is True
+        assert result.should_retire is True
+        assert client._closed is True
+        assert (
+            "turn/interrupt",
+            {
+                "threadId": "thread-fake-001",
+                "turnId": "compact-turn-1",
+            },
+        ) in client.requests
+
+    def test_compact_thread_rejects_unscoped_boundary_and_terminal(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/started",
+            threadId="thread-fake-001",
+            turn={"id": "compact-turn-1"},
+        )
+        client.queue_notification(
+            "item/completed",
+            item={"type": "contextCompaction", "id": "stale-boundary"},
+        )
+        client.queue_notification(
+            "turn/completed",
+            turn={"id": "compact-turn-1", "status": "completed", "error": None},
+        )
+        client.queue_notification(
+            "item/completed",
+            threadId="thread-fake-001",
+            turnId="compact-turn-1",
+            item={"type": "contextCompaction", "id": "current-boundary"},
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "compact-turn-1",
+                "status": "completed",
+                "error": None,
+            },
+        )
+
+        result = make_session(client).compact_thread(turn_timeout=2.0)
+
+        assert result.compacted is True
+        assert result.error is None
+
     def test_compact_thread_sends_rpc_and_waits_for_completion(self):
         client = FakeClient()
         client.queue_notification(
@@ -437,6 +1096,32 @@ class TestCompactThread:
         assert r.final_text == "compacted"
         assert r.token_usage_last["totalTokens"] == 12
         assert r.model_context_window == 200000
+
+    def test_compact_thread_ignores_stale_unscoped_deprecated_boundary(self):
+        client = FakeClient()
+        client.queue_notification(
+            "thread/compacted",
+            threadId="thread-fake-001",
+        )
+        client.queue_notification(
+            "turn/started",
+            threadId="thread-fake-001",
+            turn={"id": "compact-turn-current"},
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "compact-turn-current",
+                "status": "completed",
+                "error": None,
+            },
+        )
+
+        result = make_session(client).compact_thread(turn_timeout=2.0)
+
+        assert result.turn_id == "compact-turn-current"
+        assert result.compacted is False
 
     def test_compact_thread_ignores_foreign_child_completion(self):
         client = FakeClient()
@@ -511,15 +1196,27 @@ class TestServerRequestRouting:
     def test_unknown_server_request_replied_with_error(self):
         client = FakeClient()
         client.queue_server_request("totally/unknown", request_id="req-3")
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
+        original_respond_error = client.respond_error
+
+        def respond_error(request_id, code, message, data=None):
+            original_respond_error(request_id, code, message, data)
+            client.queue_notification(
+                "turn/completed",
+                threadId="t",
+                turn={"id": "tu1", "status": "completed", "error": None},
+            )
+
+        client.respond_error = respond_error
         s = make_session(client)
-        s.run_turn("hi", turn_timeout=1.0)
+        result = s.run_turn("hi", turn_timeout=0.05)
         assert any(
             rid == "req-3" and code == -32601
             for (rid, code, _msg) in client.error_responses
+        )
+        assert result.error is None
+        assert result.interrupted is False
+        assert not any(
+            method == "turn/interrupt" for method, _params in client.requests
         )
 
     def test_on_event_fires_during_approval_drain(self):
@@ -538,6 +1235,8 @@ class TestServerRequestRouting:
         # request — the session sees both during a single drain loop.
         client.queue_notification(
             "item/started",
+            threadId="thread-fake-001",
+            turnId="turn-fake-001",
             item={
                 "type": "commandExecution",
                 "id": "exec-1",
@@ -586,10 +1285,7 @@ class TestServerRequestRouting:
         client = FakeClient()
         client.queue_server_request("item/commandExecution/requestApproval", request_id="r1",
                                     command="ls", cwd="/")
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
+        queue_completion_after_response(client)
         # No callback, but routing says auto-approve. Should approve.
         s = make_session(client, request_routing=_ServerRequestRouting(
             auto_approve_exec=True))
@@ -612,10 +1308,7 @@ class TestApprovalPromptEnrichment:
             "item/commandExecution/requestApproval", request_id="r1",
             command="ls",  # no cwd
         )
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
+        queue_completion_after_response(client)
         captured = {}
         def cb(command, description, *, allow_permanent=True):
             captured["description"] = description
@@ -646,10 +1339,7 @@ class TestApprovalPromptEnrichment:
             startedAtMs=1234567890,
             reason="add and update files",
         )
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
+        queue_completion_after_response(client)
         captured = {}
         def cb(command, description, *, allow_permanent=True):
             captured["command"] = command
@@ -674,10 +1364,7 @@ class TestApprovalPromptEnrichment:
             startedAtMs=1234567890,
             reason="apply some changes",
         )
-        client.queue_notification(
-            "turn/completed", threadId="t",
-            turn={"id": "tu1", "status": "completed", "error": None},
-        )
+        queue_completion_after_response(client)
         captured = {}
         def cb(command, description, *, allow_permanent=True):
             captured["command"] = command
@@ -746,16 +1433,21 @@ class TestSessionRetirement:
         )
         s = make_session(client)
         monotonic_values = iter([1000.0, 999.0, 999.0, 999.0, 1000.2])
+
+        def monotonic_clock():
+            return next(monotonic_values, 1000.2)
+
         with patch.object(
             session_mod.time,
             "monotonic",
-            side_effect=lambda: next(monotonic_values),
+            side_effect=monotonic_clock,
         ):
             r = s.run_turn(
                 "tool then silence",
                 turn_timeout=5.0,
                 notification_poll_timeout=0.0,
                 post_tool_quiet_timeout=0.15,
+                interrupt_grace_timeout=0.0,
             )
         assert r.interrupted is True
         assert r.should_retire is True
@@ -895,4 +1587,3 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -192,6 +192,7 @@ class TestLifecycle:
         result = session.run_turn("blocked", turn_timeout=0.1)
 
         assert result.should_retire is True
+        assert result.turn_start_attempted is False
         assert result.error and "another Hermes/Codex client" in result.error
         client_factory.assert_not_called()
 
@@ -494,6 +495,7 @@ class TestRunTurn:
         r = s.run_turn("hi", turn_timeout=2.0)
         assert r.final_text == "hello world"
         assert r.interrupted is False
+        assert r.turn_start_attempted is True
         assert r.error is None
         assert any(m["role"] == "assistant" and m.get("content") == "hello world"
                    for m in r.projected_messages)
@@ -793,6 +795,7 @@ class TestRunTurn:
         assert "sk-live-deadbeefdeadbeef" not in r.error
         # Non-OAuth → should NOT retire (subprocess JSON-RPC is still healthy).
         assert r.should_retire is False
+        assert r.turn_start_attempted is True
 
     def test_turn_start_timeout_attaches_redacted_stderr_tail(self):
         """A non-OAuth TimeoutError on turn/start surfaces with codex stderr
@@ -816,6 +819,57 @@ class TestRunTurn:
         assert "provider request stalled" in r.error
         assert "sk-stalled-secret-abc123" not in r.error
         assert r.should_retire is True
+        assert r.turn_start_attempted is True
+
+    def test_turn_start_transport_failure_is_attempted_and_retires(self):
+        client = FakeClient()
+
+        def broken_transport(method, params):
+            if method == "turn/start":
+                raise RuntimeError("app-server stdin closed")
+            return {
+                "thread": {"id": "t"},
+                "activePermissionProfile": {"id": "x"},
+            }
+
+        client._request_handler = broken_transport
+        result = make_session(client).run_turn("hi", turn_timeout=2.0)
+
+        assert result.turn_start_attempted is True
+        assert result.should_retire is True
+        assert "turn/start transport failed" in (result.error or "")
+        assert client._closed is True
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            {},
+            {"turn": {}},
+            None,
+            {"turn": "bad"},
+        ],
+    )
+    def test_turn_start_missing_id_fails_immediately_after_attempt(
+        self, response
+    ):
+        client = FakeClient()
+
+        def missing_id(method, params):
+            if method == "turn/start":
+                return response
+            return {
+                "thread": {"id": "t"},
+                "activePermissionProfile": {"id": "x"},
+            }
+
+        client._request_handler = missing_id
+        result = make_session(client).run_turn("hi", turn_timeout=2.0)
+
+        assert result.turn_start_attempted is True
+        assert result.turn_id is None
+        assert result.should_retire is True
+        assert "returned no turn id" in (result.error or "")
+        assert client._closed is True
 
 
 
@@ -867,6 +921,25 @@ class TestCompactThread:
         }
         _apply_compaction_notification(result, completed)
         assert result.compacted is True
+
+    def test_deprecated_thread_compacted_is_never_a_success_boundary(self):
+        result = TurnResult(
+            thread_id="thread-fake-001",
+            turn_id="compact-turn-1",
+        )
+
+        _apply_compaction_notification(
+            result,
+            {
+                "method": "thread/compacted",
+                "params": {
+                    "threadId": "thread-fake-001",
+                    "turnId": "compact-turn-1",
+                },
+            },
+        )
+
+        assert result.compacted is False
 
     def test_compact_thread_honors_interrupt_before_rpc(self):
         client = FakeClient()
@@ -1107,6 +1180,33 @@ class TestCompactThread:
             "turn/started",
             threadId="thread-fake-001",
             turn={"id": "compact-turn-current"},
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={
+                "id": "compact-turn-current",
+                "status": "completed",
+                "error": None,
+            },
+        )
+
+        result = make_session(client).compact_thread(turn_timeout=2.0)
+
+        assert result.turn_id == "compact-turn-current"
+        assert result.compacted is False
+
+    def test_compact_thread_ignores_exact_scoped_deprecated_boundary(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/started",
+            threadId="thread-fake-001",
+            turn={"id": "compact-turn-current"},
+        )
+        client.queue_notification(
+            "thread/compacted",
+            threadId="thread-fake-001",
+            turnId="compact-turn-current",
         )
         client.queue_notification(
             "turn/completed",

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -1,55 +1,361 @@
 """Regression coverage for CLI async-delegation completion ownership."""
 
 import queue
+import sqlite3
+from types import SimpleNamespace
 
-from cli import HermesCLI
+import pytest
+
+from cli import HermesCLI, _ProcessNotificationInput
 
 
-def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
-    """A CLI window must not claim another window's restored completion."""
+def _cli(session_id="visible-session"):
     cli = HermesCLI.__new__(HermesCLI)
-    cli.session_id = "visible-session"
+    cli.session_id = session_id
     cli._pending_input = queue.Queue()
+    return cli
 
+
+class _Registry:
+    def __init__(self, event, text="completion payload"):
+        self.event = event
+        self.text = text
+        self.calls = []
+        self.completion_queue = queue.Queue()
+
+    def drain_notifications(self, *, session_key="", owns_event=None):
+        self.calls.append((session_key, owns_event(self.event)))
+        return [(self.event, self.text)]
+
+
+def _claim(state, claim_id=""):
+    return SimpleNamespace(state=state, claim_id=claim_id)
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (None, False),
+        ({"completed": False}, False),
+        ({"completed": True}, True),
+        ({"completed": True, "interrupted": True}, False),
+        ({"completed": True, "error": "provider failed"}, False),
+        ({"completed": True, "failed": True}, False),
+        ({"completed": True, "partial": True}, False),
+    ],
+)
+def test_cli_notification_ack_requires_genuinely_completed_turn(result, expected):
+    assert HermesCLI._process_notification_turn_succeeded(result) is expected
+
+
+def test_cli_completion_drain_uses_visible_session_identity_without_early_ack(
+    monkeypatch,
+):
+    """Queueing alone must not acknowledge a turn the agent has not run."""
+    cli = _cli()
     event = {
         "type": "async_delegation",
         "delegation_id": "deleg_visible",
         "session_key": "visible-session",
     }
+    registry = _Registry(event)
     calls = []
 
-    class FakeRegistry:
-        def drain_notifications(self, *, session_key="", owns_event=None):
-            calls.append((session_key, owns_event(event)))
-            return [(event, "completion payload")]
-
-    claimed = []
-    completed = []
-
+    monkeypatch.setattr("tools.process_registry.process_registry", registry)
     monkeypatch.setattr(
-        "tools.process_registry.process_registry",
-        FakeRegistry(),
-    )
-    monkeypatch.setattr(
-        "tools.async_delegation.claim_event_delivery",
-        lambda evt, consumer: claimed.append((evt, consumer)) or "claim-token",
+        "tools.async_delegation.claim_event_delivery_state",
+        lambda evt, consumer: (
+            calls.append(("claim", evt, consumer))
+            or _claim("claimed", "claim-token")
+        ),
     )
     monkeypatch.setattr(
         "tools.async_delegation.complete_event_delivery",
-        lambda evt, token: completed.append((evt, token)),
+        lambda evt, token: calls.append(("complete", evt, token)) or True,
     )
 
     cli._drain_process_notifications("cli-idle")
 
-    assert calls == [("visible-session", True)]
-    assert cli._pending_input.get_nowait() == "completion payload"
-    assert claimed == [(event, "cli-idle")]
-    assert completed == [(event, "claim-token")]
+    assert registry.calls == [("visible-session", True)]
+    notification = cli._pending_input.get_nowait()
+    assert isinstance(notification, _ProcessNotificationInput)
+    assert notification.text == "completion payload"
+    assert calls == []
+
+    assert cli._claim_process_notification(notification)
+    calls.append(("turn", notification.text))
+    cli._settle_process_notification(notification, True)
+    assert calls == [
+        ("claim", event, "cli-idle"),
+        ("turn", "completion payload"),
+        ("complete", event, "claim-token"),
+    ]
+    assert registry.completion_queue.empty()
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_message", "expected_requeue"),
+    [
+        ("busy_pending", None, True),
+        ("terminal_consumed", None, False),
+        ("legacy_non_durable", "completion payload", False),
+    ],
+)
+def test_cli_completion_drain_honors_non_claimed_states(
+    monkeypatch, state, expected_message, expected_requeue
+):
+    cli = _cli()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-state",
+        "session_key": cli.session_id,
+    }
+    registry = _Registry(event)
+    completed = []
+    monkeypatch.setattr("tools.process_registry.process_registry", registry)
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery_state",
+        lambda *_args: _claim(state),
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda *args: completed.append(args) or True,
+    )
+
+    cli._drain_process_notifications("cli-idle")
+    notification = cli._pending_input.get_nowait()
+    should_run = cli._claim_process_notification(notification)
+
+    if expected_message is None:
+        assert not should_run
+    else:
+        assert should_run
+        assert notification.text == expected_message
+        cli._settle_process_notification(notification, True)
+    if expected_requeue:
+        assert registry.completion_queue.get_nowait() is event
+    assert registry.completion_queue.empty()
+    assert completed == []
+
+
+@pytest.mark.parametrize(
+    ("durable_state", "expected_requeue"),
+    [
+        ("busy_pending", True),
+        ("terminal_consumed", False),
+    ],
+)
+def test_cli_false_ack_never_consumes_and_only_requeues_live_state(
+    monkeypatch, durable_state, expected_requeue
+):
+    cli = _cli()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-false-ack",
+        "session_key": cli.session_id,
+    }
+    registry = _Registry(event)
+    released = []
+    monkeypatch.setattr("tools.process_registry.process_registry", registry)
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery_state",
+        lambda *_args: _claim("claimed", "claim-token"),
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda *_args: False,
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.release_event_delivery",
+        lambda *args: released.append(args) or False,
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.inspect_event_delivery_state",
+        lambda _event: durable_state,
+    )
+
+    notification = _ProcessNotificationInput("completion payload", event, "cli-idle")
+    assert cli._claim_process_notification(notification)
+    cli._settle_process_notification(notification, True)
+
+    assert released == [(event, "claim-token")]
+    if expected_requeue:
+        assert registry.completion_queue.get_nowait() is event
+    assert registry.completion_queue.empty()
+
+
+def test_cli_failed_durable_turn_releases_without_ack_and_requeues(monkeypatch):
+    cli = _cli()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-turn-failed",
+        "session_key": cli.session_id,
+    }
+    registry = _Registry(event)
+    completed = []
+    released = []
+    monkeypatch.setattr("tools.process_registry.process_registry", registry)
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery_state",
+        lambda *_args: _claim("claimed", "claim-token"),
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda *args: completed.append(args) or True,
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.release_event_delivery",
+        lambda *args: released.append(args) or True,
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.inspect_event_delivery_state",
+        lambda _event: "busy_pending",
+    )
+
+    notification = _ProcessNotificationInput("completion payload", event, "cli-idle")
+    assert cli._claim_process_notification(notification)
+    cli._settle_process_notification(notification, False)
+
+    assert completed == []
+    assert released == [(event, "claim-token")]
+    assert registry.completion_queue.get_nowait() is event
+    assert registry.completion_queue.empty()
+
+
+def test_cli_failed_legacy_turn_requeues_without_durable_ack(monkeypatch):
+    cli = _cli()
+    event = {"type": "completion", "session_id": "legacy-process"}
+    registry = _Registry(event)
+    completed = []
+    monkeypatch.setattr("tools.process_registry.process_registry", registry)
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery_state",
+        lambda *_args: _claim("legacy_non_durable"),
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda *args: completed.append(args) or True,
+    )
+
+    notification = _ProcessNotificationInput("completion payload", event, "cli-idle")
+    assert cli._claim_process_notification(notification)
+    cli._settle_process_notification(notification, False)
+
+    assert completed == []
+    assert registry.completion_queue.get_nowait() is event
+    assert registry.completion_queue.empty()
+
+
+def test_cli_claim_exception_preserves_live_event_without_injection(monkeypatch):
+    cli = _cli()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-claim-error",
+        "session_key": cli.session_id,
+    }
+    registry = _Registry(event)
+    monkeypatch.setattr("tools.process_registry.process_registry", registry)
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery_state",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("claim unavailable")),
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.inspect_event_delivery_state",
+        lambda _event: "busy_pending",
+    )
+
+    notification = _ProcessNotificationInput("completion payload", event, "cli-idle")
+    assert not cli._claim_process_notification(notification)
+
+    assert registry.completion_queue.get_nowait() is event
+    assert registry.completion_queue.empty()
+
+
+def test_cli_ack_exception_releases_and_preserves_live_event(monkeypatch):
+    cli = _cli()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-ack-error",
+        "session_key": cli.session_id,
+    }
+    registry = _Registry(event)
+    released = []
+    monkeypatch.setattr("tools.process_registry.process_registry", registry)
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery_state",
+        lambda *_args: _claim("claimed", "claim-token"),
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("ack unavailable")),
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.release_event_delivery",
+        lambda *args: released.append(args) or True,
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.inspect_event_delivery_state",
+        lambda _event: "busy_pending",
+    )
+
+    notification = _ProcessNotificationInput("completion payload", event, "cli-idle")
+    assert cli._claim_process_notification(notification)
+    cli._settle_process_notification(notification, True)
+
+    assert released == [(event, "claim-token")]
+    assert registry.completion_queue.get_nowait() is event
+    assert registry.completion_queue.empty()
+
+
+def test_cli_real_stale_claim_converges_after_successor_ack(monkeypatch, tmp_path):
+    """A stale in-memory event must not replay after a real SQLite rollover."""
+    from tools import async_delegation
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cli = _cli("rollover-owner")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "cli-real-rollover",
+        "_durable_delivery": True,
+        "session_key": cli.session_id,
+        "status": "completed",
+        "completed_at": 2.0,
+    }
+    async_delegation._persist_dispatch(
+        {
+            "delegation_id": event["delegation_id"],
+            "session_key": event["session_key"],
+            "origin_ui_session_id": "",
+            "parent_session_id": None,
+            "dispatched_at": 1.0,
+        }
+    )
+    async_delegation._persist_completion(
+        event, {"status": "completed", "summary": "done"}
+    )
+    stale_claim = async_delegation.claim_event_delivery(event, "stale-cli")
+    assert stale_claim
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        conn.execute(
+            """UPDATE async_delegations SET delivery_claimed_at=0
+               WHERE delegation_id=?""",
+            (event["delegation_id"],),
+        )
+    successor = async_delegation.claim_event_delivery_state(event, "successor")
+    assert successor.state == "claimed"
+    assert async_delegation.complete_event_delivery(event, successor.claim_id)
+
+    registry = _Registry(event)
+    monkeypatch.setattr("tools.process_registry.process_registry", registry)
+    notification = _ProcessNotificationInput("completion payload", event, "cli-idle")
+    assert not cli._claim_process_notification(notification)
+
+    assert registry.completion_queue.empty()
+    assert async_delegation.inspect_event_delivery_state(event) == "terminal_consumed"
 
 
 def test_cli_completion_ownership_rejects_foreign_session():
-    cli = HermesCLI.__new__(HermesCLI)
-    cli.session_id = "visible-session"
+    cli = _cli()
     cli._session_db = None
 
     assert not cli._owns_process_notification(
@@ -58,8 +364,7 @@ def test_cli_completion_ownership_rejects_foreign_session():
 
 
 def test_cli_completion_ownership_accepts_compression_lineage():
-    cli = HermesCLI.__new__(HermesCLI)
-    cli.session_id = "visible-session"
+    cli = _cli()
 
     class FakeSessionDB:
         def resolve_resume_session_id(self, session_id):

--- a/tests/gateway/test_codex_runtime_command.py
+++ b/tests/gateway/test_codex_runtime_command.py
@@ -1,0 +1,66 @@
+"""Gateway behavior contracts for the /codex-runtime command."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from hermes_cli import codex_runtime_switch as crs
+
+
+def _make_event(text: str = "/codex-runtime on") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="user-1",
+            chat_id="chat-1",
+            user_name="tester",
+            chat_type="dm",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_change_preserves_cached_agent_until_new_session(monkeypatch):
+    """Persisting a runtime must not replace the current conversation owner."""
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._evict_cached_agent = MagicMock()
+    event = _make_event()
+    session_key = runner._session_key_for_source(event.source)
+    cached_agent = object()
+    runner._agent_cache = {session_key: (cached_agent, 0.0)}
+
+    persisted = []
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.config.save_config",
+        lambda config: persisted.append(config),
+    )
+
+    def fake_apply(config, new_value, *, persist_callback):
+        config["model"] = {"openai_runtime": new_value}
+        persist_callback(config)
+        return crs.CodexRuntimeStatus(
+            success=True,
+            new_value=new_value,
+            old_value="auto",
+            message=(
+                "Saved for the next session. "
+                "Run `/new` or `/reset` to apply this change."
+            ),
+            requires_new_session=True,
+        )
+
+    monkeypatch.setattr(crs, "apply", fake_apply)
+
+    result = await runner._handle_codex_runtime_command(event)
+
+    assert persisted == [{"model": {"openai_runtime": "codex_app_server"}}]
+    runner._evict_cached_agent.assert_not_called()
+    assert runner._agent_cache[session_key][0] is cached_agent
+    assert "/new" in result
+    assert "/reset" in result

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -9,6 +9,7 @@ state (when available) is acknowledged through its authoritative SQLite API.
 import asyncio
 import json
 import queue
+import sqlite3
 from collections import OrderedDict
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -45,6 +46,7 @@ def _runner(adapter, *, origins=None):
     runner._completion_delivery_lock = __import__("threading").Lock()
     runner._completion_deliveries_inflight = set()
     runner._completion_deliveries_delivered = OrderedDict()
+    runner._completion_deliveries_settlement_pending = set()
     runner._completion_delivery_retention = 2048
     return runner
 
@@ -162,7 +164,9 @@ def test_failed_async_injection_is_retried_and_only_success_is_acked(
 ):
     isolated = queue.Queue()
     monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
-    isolated.put(_async_event())
+    event = _async_event()
+    _persist_pending_completion(event)
+    isolated.put(event)
 
     adapter = SimpleNamespace(
         handle_message=AsyncMock(side_effect=[RuntimeError("temporary"), None])
@@ -200,6 +204,416 @@ def _persist_pending_completion(event):
         "status": "completed",
         "summary": event["summary"],
     })
+
+
+def test_compression_parent_delivery_targets_tip_and_is_acked(
+    monkeypatch, isolated_registry,
+):
+    """A compression-rotated parent with a live tip is deliverable + acked."""
+    from tools import async_delegation
+
+    event = _async_event("deleg_compression")
+    event["parent_session_id"] = "sess_parent"
+    _persist_pending_completion(event)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(side_effect=lambda session_id: {
+            "sess_parent": {
+                "id": "sess_parent",
+                "ended_at": "2026-07-16T12:00:00",
+                "end_reason": "compression",
+            },
+            "sess_tip": {"id": "sess_tip", "ended_at": None, "end_reason": None},
+        }.get(session_id)),
+        get_compression_tip=AsyncMock(return_value="sess_tip"),
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is True
+
+    adapter.handle_message.assert_awaited_once()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "delivered"
+
+
+def test_durable_cas_failure_retries_settlement_without_reinjecting_adapter(
+    monkeypatch, isolated_registry,
+):
+    """An accepted adapter turn is never injected again while its CAS retries."""
+    from tools import async_delegation
+
+    event = _async_event("deleg_settlement_retry")
+    _persist_pending_completion(event)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+
+    real_complete = async_delegation.complete_completion_delivery
+    calls = 0
+
+    def _lose_then_complete(delegation_id, claim_id):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return False
+        return real_complete(delegation_id, claim_id)
+
+    monkeypatch.setattr(
+        async_delegation, "complete_completion_delivery", _lose_then_complete,
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is False
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is True
+
+    adapter.handle_message.assert_awaited_once()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "delivered"
+
+
+@pytest.mark.parametrize("terminal_state", ["delivered", "dropped", "pruned"])
+def test_durable_cas_false_rechecks_terminal_successor_without_requeueing(
+    monkeypatch, isolated_registry, terminal_state,
+):
+    """A stale claimant consumes its successor's terminal outcome, not success."""
+    from tools import async_delegation
+
+    event = _async_event("deleg_stale_successor")
+    _persist_pending_completion(event)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+
+    real_complete = async_delegation.complete_completion_delivery
+
+    def _roll_over_claim_and_complete(delegation_id, _stale_claim_id):
+        # The original gateway claim expires while the adapter has already
+        # accepted. A successor wins the row, reaches a terminal disposition,
+        # and leaves this stale CAS false.
+        with async_delegation._DB_LOCK, async_delegation._transaction() as conn:
+            conn.execute(
+                "UPDATE async_delegations SET delivery_claimed_at=0 WHERE delegation_id=?",
+                (delegation_id,),
+            )
+        successor_claim = "successor-claim"
+        assert async_delegation.claim_completion_delivery(
+            delegation_id, successor_claim,
+        )
+        if terminal_state == "dropped":
+            assert async_delegation.drop_completion_delivery(
+                delegation_id, successor_claim,
+            )
+        else:
+            assert real_complete(delegation_id, successor_claim)
+            if terminal_state == "pruned":
+                async_delegation._delete_durable_delegation(delegation_id)
+        return False
+
+    monkeypatch.setattr(
+        async_delegation,
+        "complete_completion_delivery",
+        _roll_over_claim_and_complete,
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is None
+
+    adapter.handle_message.assert_awaited_once()
+    assert ("async_delegation", event["delegation_id"], "") in (
+        runner._completion_deliveries_delivered
+    )
+
+
+def test_durable_cas_exception_rechecks_terminal_successor_without_requeueing(
+    monkeypatch, isolated_registry,
+):
+    """An exception after successor settlement is terminal, not a reinjection."""
+    from tools import async_delegation
+
+    event = _async_event("deleg_exception_successor")
+    _persist_pending_completion(event)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    real_complete = async_delegation.complete_completion_delivery
+
+    def _settle_successor_then_raise(delegation_id, _stale_claim_id):
+        with async_delegation._DB_LOCK, async_delegation._transaction() as conn:
+            conn.execute(
+                "UPDATE async_delegations SET delivery_claimed_at=0 "
+                "WHERE delegation_id=?",
+                (delegation_id,),
+            )
+        assert async_delegation.claim_completion_delivery(
+            delegation_id, "exception-successor"
+        )
+        assert real_complete(delegation_id, "exception-successor")
+        raise sqlite3.OperationalError("ack connection interrupted")
+
+    monkeypatch.setattr(
+        async_delegation,
+        "complete_completion_delivery",
+        _settle_successor_then_raise,
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is None
+    adapter.handle_message.assert_awaited_once()
+
+
+def test_pending_settlement_survives_delivered_retention_pressure(
+    monkeypatch, isolated_registry,
+):
+    """Bounded delivered dedupe must never evict irreversible acceptance."""
+    from tools import async_delegation
+
+    event = _async_event("deleg_pending_retention")
+    _persist_pending_completion(event)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._completion_delivery_retention = 2
+    real_complete = async_delegation.complete_completion_delivery
+    calls = 0
+
+    def _lose_then_complete(delegation_id, claim_id):
+        nonlocal calls
+        calls += 1
+        if delegation_id == event["delegation_id"] and calls == 1:
+            return False
+        return real_complete(delegation_id, claim_id)
+
+    monkeypatch.setattr(
+        async_delegation,
+        "complete_completion_delivery",
+        _lose_then_complete,
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is False
+    pending_identity = ("async_delegation", event["delegation_id"], "")
+    assert pending_identity in runner._completion_deliveries_settlement_pending
+
+    async def _apply_retention_pressure():
+        for started_at in (10.0, 20.0, 30.0):
+            assert await runner._deliver_completion_notification(
+                "process completion",
+                _completion_event(started_at=started_at),
+            ) is True
+
+    asyncio.run(_apply_retention_pressure())
+    assert pending_identity in runner._completion_deliveries_settlement_pending
+    accepted_before_retry = adapter.handle_message.await_count
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is True
+    assert adapter.handle_message.await_count == accepted_before_retry
+    assert pending_identity not in runner._completion_deliveries_settlement_pending
+
+
+def test_explicit_reset_drop_is_terminal_not_falsely_delivered(
+    monkeypatch, isolated_registry,
+):
+    """An explicit /new boundary drop gets a terminal 'dropped' disposition.
+
+    Not 'delivered' (the ack must stay honest — nothing was injected) and not
+    'pending' (restart recovery would replay a completion that is fail-closed
+    dropped again on every boot).
+    """
+    from tools import async_delegation
+
+    event = _async_event("deleg_explicit_new")
+    event["parent_session_id"] = "sess_reset"
+    _persist_pending_completion(event)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(return_value={
+            "id": "sess_reset",
+            "ended_at": "2026-07-16T12:00:00",
+            "end_reason": "session_reset",
+        }),
+        get_compression_tip=AsyncMock(),
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is None
+
+    adapter.handle_message.assert_not_awaited()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "dropped"
+    restored = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(restored) == 0
+
+
+def test_midflight_compression_rotation_stays_pending_for_retry(
+    monkeypatch, isolated_registry,
+):
+    """A rotation without a visible continuation yet is retryable, not dropped."""
+    from tools import async_delegation
+
+    event = _async_event("deleg_midflight")
+    event["parent_session_id"] = "sess_rotating"
+    _persist_pending_completion(event)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(return_value={
+            "id": "sess_rotating",
+            "ended_at": "2026-07-16T12:00:00",
+            "end_reason": "compression",
+        }),
+        get_compression_tip=AsyncMock(return_value=None),
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is False
+
+    adapter.handle_message.assert_not_awaited()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "pending"
+    restored = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(restored) == 1
+    assert restored.get_nowait()["delegation_id"] == event["delegation_id"]
+
+
+def test_retry_attempts_are_capped_to_a_terminal_drop(
+    monkeypatch, isolated_registry,
+):
+    """Endless claim/release churn converges to a terminal 'dropped' state."""
+    from tools import async_delegation
+
+    event = _async_event("deleg_attempt_cap")
+    event["parent_session_id"] = "sess_rotating"
+    _persist_pending_completion(event)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(return_value={
+            "id": "sess_rotating",
+            "ended_at": "2026-07-16T12:00:00",
+            "end_reason": "compression",
+        }),
+        get_compression_tip=AsyncMock(return_value=None),
+    )
+
+    async def _churn():
+        for _ in range(async_delegation._MAX_DELIVERY_ATTEMPTS + 2):
+            await runner._deliver_completion_notification("completion", event)
+
+    asyncio.run(_churn())
+
+    adapter.handle_message.assert_not_awaited()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "dropped"
+    assert durable["delivery_attempts"] <= async_delegation._MAX_DELIVERY_ATTEMPTS
+    restored = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(restored) == 0
+
+
+def test_distinct_process_incarnations_are_not_deduplicated():
+    """Producer spawn time distinguishes a reused process session ID."""
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+
+    async def _exercise():
+        first = await runner._deliver_completion_notification(
+            "first", _completion_event(started_at=10.0)
+        )
+        second = await runner._deliver_completion_notification(
+            "second", _completion_event(started_at=20.0)
+        )
+        return first, second
+
+    assert asyncio.run(_exercise()) == (True, True)
+
+    assert adapter.handle_message.await_count == 2
+
+
+def test_delivered_identity_retention_is_bounded():
+    """Lifecycle dedupe cannot grow without bound in a long-running gateway."""
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._completion_delivery_retention = 2
+    runner._completion_deliveries_delivered = OrderedDict()
+
+    async def _exercise():
+        for index in range(3):
+            await runner._deliver_completion_notification(
+                f"completion {index}",
+                _async_event(f"deleg_retention_{index}"),
+            )
+
+    asyncio.run(_exercise())
+
+    assert len(runner._completion_deliveries_delivered) == 2
+    assert ("async_delegation", "deleg_retention_0", "") not in (
+        runner._completion_deliveries_delivered
+    )
+    assert ("async_delegation", "deleg_retention_2", "") in (
+        runner._completion_deliveries_delivered
+    )
+
+
+def test_delivery_state_is_isolated_per_gateway_profile_lifecycle():
+    """A process-local claim in one profile never suppresses another runner."""
+    default_adapter = SimpleNamespace(handle_message=AsyncMock())
+    profile_adapter = SimpleNamespace(handle_message=AsyncMock())
+    default_runner = _runner(default_adapter)
+    profile_runner = _runner(profile_adapter)
+    event = _async_event("deleg_same_producer_id")
+
+    async def _exercise():
+        first = await default_runner._deliver_completion_notification(
+            "default", dict(event),
+        )
+        second = await profile_runner._deliver_completion_notification(
+            "profile", dict(event),
+        )
+        return first, second
+
+    assert asyncio.run(_exercise()) == (True, True)
+    default_adapter.handle_message.assert_awaited_once()
+    profile_adapter.handle_message.assert_awaited_once()
+
+
+def test_async_completion_uses_canonical_origin_routing(monkeypatch, isolated_registry):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    event = _async_event("deleg_routing")
+    isolated.put(event)
+
+    canonical = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="canonical-chat",
+        chat_type="group",
+        thread_id="canonical-topic",
+    )
+    entry = SimpleNamespace(origin=canonical)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter, origins={event["session_key"]: entry})
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    delivered = adapter.handle_message.await_args.args[0]
+    assert delivered.source == canonical
 
 
 def test_explicit_kill_returns_output_before_consuming_notification(monkeypatch):

--- a/tests/hermes_cli/test_codex_runtime_switch.py
+++ b/tests/hermes_cli/test_codex_runtime_switch.py
@@ -143,6 +143,9 @@ class TestApply:
         assert "Default sandbox: :workspace" in r.message
         # Hermes tool callback announcement
         assert "via MCP" in r.message
+        assert "current Hermes session keeps its existing runtime" in r.message
+        assert "`/new` or `/reset`" in r.message
+        assert r.requires_new_session is True
 
     def test_disable_does_not_trigger_migration(self):
         """Switching back to auto must not write to ~/.codex/."""
@@ -154,6 +157,9 @@ class TestApply:
             r = crs.apply(cfg, "auto")
         assert r.success
         assert not mig.called  # disabling does not migrate
+        assert "current Hermes session keeps its existing runtime" in r.message
+        assert "`/new` or `/reset`" in r.message
+        assert r.requires_new_session is True
 
     def test_migration_failure_does_not_block_enable(self):
         """If MCP migration raises, the runtime change still proceeds —
@@ -168,5 +174,4 @@ class TestApply:
         assert r.new_value == "codex_app_server"
         assert "MCP migration skipped" in r.message
         assert "disk full" in r.message
-
 

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -148,7 +148,10 @@ class TestFindAllSkillsFiltering:
         skill_dir = tmp_path / "my-skill"
         skill_dir.mkdir()
         skill_md = skill_dir / "SKILL.md"
-        skill_md.write_text("---\nname: my-skill\ndescription: A test skill\n---\nContent")
+        skill_md.write_text(
+            "---\nname: my-skill\ndescription: A test skill\n---\nContent",
+            encoding="utf-8",
+        )
         # Point SKILLS_DIR at the real tempdir so iter_skill_index_files
         # (which uses os.walk) can actually find the file.
         import tools.skills_tool as _st

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -93,6 +93,13 @@ class TestGetDisabledSkillNames:
 
     def test_session_platform_env_var(self, tmp_path, monkeypatch):
         """HERMES_SESSION_PLATFORM should be used when HERMES_PLATFORM is unset."""
+        # Earlier gateway-oriented tests deliberately leave the current
+        # ContextVar scope explicitly cleared (""), which suppresses the
+        # legacy os.environ fallback. This case models a fresh CLI/test scope,
+        # so establish the corresponding _UNSET state explicitly.
+        from gateway.session_context import reset_session_vars
+
+        reset_session_vars()
         config = tmp_path / "config.yaml"
         config.write_text(
             "skills:\n"

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -22,13 +22,20 @@ def hub_env(monkeypatch, tmp_path):
     import tools.skills_hub as hub
 
     hub_dir = tmp_path / "skills" / ".hub"
-    monkeypatch.setattr(hub, "SKILLS_DIR", tmp_path / "skills")
-    monkeypatch.setattr(hub, "HUB_DIR", hub_dir)
-    monkeypatch.setattr(hub, "LOCK_FILE", hub_dir / "lock.json")
-    monkeypatch.setattr(hub, "QUARANTINE_DIR", hub_dir / "quarantine")
-    monkeypatch.setattr(hub, "AUDIT_LOG", hub_dir / "audit.log")
-    monkeypatch.setattr(hub, "TAPS_FILE", hub_dir / "taps.json")
-    monkeypatch.setattr(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache")
+    # These legacy names are supplied by module-level __getattr__. Using
+    # setattr would make monkeypatch "restore" the dynamically resolved value
+    # as a real module attribute, freezing profile paths for all later tests.
+    # Patch the module dictionary so teardown deletes originally-absent keys.
+    for name, value in {
+        "SKILLS_DIR": tmp_path / "skills",
+        "HUB_DIR": hub_dir,
+        "LOCK_FILE": hub_dir / "lock.json",
+        "QUARANTINE_DIR": hub_dir / "quarantine",
+        "AUDIT_LOG": hub_dir / "audit.log",
+        "TAPS_FILE": hub_dir / "taps.json",
+        "INDEX_CACHE_DIR": hub_dir / "index-cache",
+    }.items():
+        monkeypatch.setitem(hub.__dict__, name, value)
 
     return hub_dir
 
@@ -312,4 +319,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -187,11 +187,17 @@ class TestSaveRouting:
     def test_async_mode_enqueues(self, make_manager):
         mgr = make_manager(write_frequency="async")
         sess = self._make_session_with_message(mgr)
-        with patch.object(mgr, "_flush_session") as mock_flush:
+        # Keep the consumer stopped so this test observes the enqueue itself
+        # instead of racing the background writer as it drains the queue.
+        with (
+            patch.object(mgr, "_ensure_async_writer") as mock_start,
+            patch.object(mgr, "_flush_session") as mock_flush,
+        ):
             mgr.save(sess)
             # flush_session should NOT be called synchronously
             mock_flush.assert_not_called()
-        assert not mgr._async_queue.empty()
+            mock_start.assert_called_once_with()
+        assert mgr._async_queue.get_nowait() is sess
 
     def test_int_frequency_flushes_on_nth_turn(self, make_manager):
         mgr = make_manager(write_frequency=3)
@@ -455,4 +461,3 @@ class TestPrefetchCacheAccessors:
 
         assert mgr.pop_context_result("cli:test") == payload
         assert mgr.pop_context_result("cli:test") == {}
-

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -337,6 +337,10 @@ class TestConfig:
 
         monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
         monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+        monkeypatch.setattr(
+            "tools.lazy_deps.ensure",
+            lambda *_args, **_kwargs: None,
+        )
 
         p = HindsightMemoryProvider()
         p._mode = "local_embedded"

--- a/tests/run_agent/test_codex_app_server_compaction.py
+++ b/tests/run_agent/test_codex_app_server_compaction.py
@@ -1,5 +1,6 @@
 import time
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -142,6 +143,132 @@ def test_codex_app_server_compaction_heartbeat_refreshes_activity_while_waiting(
 
 
 
+@pytest.mark.parametrize(
+    ("auto_compaction", "force"),
+    [
+        ("hermes", False),
+        ("native", True),
+        ("off", True),
+    ],
+)
+def test_codex_app_server_without_thread_uses_builtin_compressor(
+    auto_compaction,
+    force,
+):
+    """Preflight/hygiene must not count a missing Codex thread as compaction."""
+    agent = MagicMock()
+    agent.api_mode = "codex_app_server"
+    agent.codex_app_server_auto_compaction = auto_compaction
+    agent._codex_session = None
+    agent.session_id = "hermes-session-1"
+    agent.platform = "cli"
+    agent.model = "test/model"
+    agent.provider = "test"
+    agent.tools = []
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = True
+    agent._memory_manager = None
+    agent._session_db = None
+    agent._memory_store = None
+    agent._memory_enabled = False
+    agent._user_profile_enabled = False
+    agent._todo_store = MagicMock()
+    agent._todo_store.format_for_injection.return_value = ""
+    agent._cached_system_prompt = "cached prompt"
+    agent.context_compressor = MagicMock()
+    compressed = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "assistant", "content": "recent reply"},
+    ]
+    agent.context_compressor.compress.return_value = compressed
+    agent.context_compressor.compression_count = 1
+    agent.context_compressor.last_compression_rough_tokens = 0
+    agent.context_compressor._last_compress_aborted = False
+    agent.context_compressor._last_summary_error = None
+    messages = [{"role": "user", "content": f"message {i}"} for i in range(8)]
+
+    returned, prompt = compress_context(
+        agent,
+        messages,
+        "system",
+        approx_tokens=100000,
+        force=force,
+    )
+
+    assert returned == compressed
+    assert prompt == "cached prompt"
+    agent.context_compressor.compress.assert_called_once()
+
+
+@pytest.mark.parametrize("auto_compaction", ["native", "off"])
+def test_codex_app_server_auto_without_thread_skips_builtin_compressor(
+    auto_compaction,
+):
+    agent = DummyAgent(
+        TurnResult(thread_id="thread-1", turn_id="compact-turn-1"),
+        auto_compaction=auto_compaction,
+    )
+    agent._codex_session = None
+    messages = [{"role": "user", "content": "hi"}]
+
+    returned, prompt = compress_context(
+        agent,
+        messages,
+        "system",
+        approx_tokens=100000,
+    )
+
+    assert returned is messages
+    assert prompt == "cached prompt"
+    assert agent.context_compressor.compression_count == 0
+
+
+def test_codex_app_server_off_mode_force_with_thread_uses_native_compaction():
+    agent = DummyAgent(
+        TurnResult(thread_id="thread-1", turn_id="compact-turn-1"),
+        auto_compaction="off",
+    )
+    messages = [{"role": "user", "content": "hi"}]
+
+    returned, prompt = compress_context(
+        agent,
+        messages,
+        "system",
+        approx_tokens=100000,
+        force=True,
+    )
+
+    assert returned is messages
+    assert prompt == "cached prompt"
+    assert agent._codex_session.calls == 1
+    assert agent.context_compressor.compression_count == 1
+
+
+def test_codex_app_server_compression_failure_preserves_bookkeeping():
+    agent = DummyAgent(TurnResult(error="compact failed"))
+    messages = [{"role": "user", "content": "hi"}]
+
+    returned, prompt = compress_context(
+        agent,
+        messages,
+        "system",
+        approx_tokens=100000,
+        force=True,
+    )
+
+    assert returned is messages
+    assert prompt == "cached prompt"
+    assert agent._codex_session.calls == 1
+    assert agent.context_compressor.compression_count == 0
+    assert agent.context_compressor.last_prompt_tokens == 123
+    assert agent.warnings
+    assert agent.touch_calls[0] == "context compression started"
+    assert agent.touch_calls[-1] == "context compression failed"
+    assert agent.status_events == [
+        ("lifecycle", COMPACTION_STATUS),
+        ("warn", "⚠ Codex app-server compaction failed: compact failed"),
+        ("compacted", COMPACTION_DONE_STATUS),
+    ]
 
 
 

--- a/tests/run_agent/test_codex_app_server_compaction.py
+++ b/tests/run_agent/test_codex_app_server_compaction.py
@@ -114,7 +114,11 @@ def test_codex_app_server_native_auto_mode_leaves_thread_compaction_to_codex():
 
 def test_codex_app_server_compaction_heartbeat_refreshes_activity_while_waiting():
     agent = DummyAgent(
-        TurnResult(thread_id="thread-1", turn_id="compact-turn-1")
+        TurnResult(
+            thread_id="thread-1",
+            turn_id="compact-turn-1",
+            compacted=True,
+        )
     )
     agent._codex_session = SlowCodexSession(
         agent._codex_session.result,
@@ -225,7 +229,11 @@ def test_codex_app_server_auto_without_thread_skips_builtin_compressor(
 
 def test_codex_app_server_off_mode_force_with_thread_uses_native_compaction():
     agent = DummyAgent(
-        TurnResult(thread_id="thread-1", turn_id="compact-turn-1"),
+        TurnResult(
+            thread_id="thread-1",
+            turn_id="compact-turn-1",
+            compacted=True,
+        ),
         auto_compaction="off",
     )
     messages = [{"role": "user", "content": "hi"}]
@@ -269,6 +277,47 @@ def test_codex_app_server_compression_failure_preserves_bookkeeping():
         ("warn", "⚠ Codex app-server compaction failed: compact failed"),
         ("compacted", COMPACTION_DONE_STATUS),
     ]
+
+
+def test_codex_app_server_compaction_requires_context_compaction_event():
+    agent = DummyAgent(
+        TurnResult(
+            thread_id="thread-1",
+            turn_id="compact-turn-1",
+            compacted=False,
+        )
+    )
+    messages = [{"role": "user", "content": "hi"}]
+
+    returned, prompt = compress_context(
+        agent,
+        messages,
+        "system",
+        approx_tokens=100000,
+        force=True,
+    )
+
+    assert returned is messages
+    assert prompt == "cached prompt"
+    assert agent.context_compressor.compression_count == 0
+    assert agent.warnings == [
+        "⚠ Codex app-server compaction failed: Codex completed the compact "
+        "turn without the required contextCompaction event"
+    ]
+    assert agent.touch_calls[-1] == "context compression failed"
+
+
+def test_forced_compaction_record_does_not_manufacture_missing_boundary():
+    agent = DummyAgent(
+        TurnResult(thread_id="thread-1", turn_id="compact-turn-1")
+    )
+
+    assert _record_codex_app_server_compaction(
+        agent,
+        agent._codex_session.result,
+        force=True,
+    ) is False
+    assert agent.context_compressor.compression_count == 0
 
 
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -124,6 +124,24 @@ class TestRunConversationCodexPath:
         assert result["api_calls"] == 1
         assert agent.session_api_calls == 1
 
+    def test_post_send_turn_start_timeout_counts_one_api_call(self, monkeypatch):
+        def timed_out_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                error="turn/start timed out",
+                thread_id="thread-started-1",
+                turn_start_attempted=True,
+                should_retire=True,
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", timed_out_turn)
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("count the attempted request")
+
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert agent.session_api_calls == 1
+
     def test_codex_thread_binding_resumes_after_agent_recreation(
         self, monkeypatch, tmp_path
     ):

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -12,6 +12,8 @@ Verifies that:
 
 from __future__ import annotations
 
+import uuid
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -19,6 +21,7 @@ import pytest
 
 import run_agent
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
+from hermes_state import SessionDB
 
 
 @pytest.fixture
@@ -54,7 +57,11 @@ def _make_codex_agent(**kwargs):
     """Construct an AIAgent in codex_app_server mode without contacting any
     real provider. We pass api_mode explicitly so the constructor takes the
     fast path for direct credentials."""
-    return run_agent.AIAgent(
+    owned_session_db = None
+    if "session_db" not in kwargs:
+        owned_session_db = SessionDB(Path(":memory:"))
+        kwargs["session_db"] = owned_session_db
+    agent = run_agent.AIAgent(
         api_key="stub",
         base_url="https://stub.invalid",
         provider="openai",
@@ -64,6 +71,9 @@ def _make_codex_agent(**kwargs):
         skip_memory=True,
         **kwargs,
     )
+    # Keep the in-memory database alive for the agent's whole test lifetime.
+    agent._test_owned_session_db = owned_session_db
+    return agent
 
 
 class TestApiModeAccepted:
@@ -85,6 +95,241 @@ class TestRunConversationCodexPath:
         assert result["api_calls"] == 1
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
+
+    @pytest.mark.parametrize(
+        ("interrupted", "error"),
+        [
+            (False, "turn failed after start"),
+            (True, None),
+        ],
+    )
+    def test_started_turn_failure_still_counts_one_api_call(
+        self, monkeypatch, interrupted, error
+    ):
+        def failed_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                error=error,
+                interrupted=interrupted,
+                turn_id="turn-started-1",
+                thread_id="thread-started-1",
+                should_retire=True,
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", failed_turn)
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("count this request")
+
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert agent.session_api_calls == 1
+
+    def test_codex_thread_binding_resumes_after_agent_recreation(
+        self, monkeypatch, tmp_path
+    ):
+        instances = []
+
+        class RecordingSession:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.thread_id = (
+                    kwargs.get("resume_thread_id") or "thread-persisted-1"
+                )
+                self.closed = False
+                self.lease_acquired = False
+                instances.append(self)
+
+            def run_turn(self, user_input, **_kwargs):
+                acquire = self.kwargs.get("lease_acquire")
+                if acquire is not None and not self.lease_acquired:
+                    assert acquire()
+                    self.lease_acquired = True
+                callback = self.kwargs.get("on_thread_ready")
+                if callback is not None:
+                    callback(self.thread_id)
+                return TurnResult(
+                    final_text=f"done:{user_input}",
+                    projected_messages=[
+                        {"role": "assistant", "content": f"done:{user_input}"}
+                    ],
+                    turn_id=f"turn-{len(instances)}",
+                    thread_id=self.thread_id,
+                )
+
+            def close(self):
+                self.closed = True
+                if self.lease_acquired:
+                    release = self.kwargs.get("lease_release")
+                    assert release is not None and release()
+                    self.lease_acquired = False
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            RecordingSession,
+        )
+
+        db = SessionDB(tmp_path / "state.db")
+        sid = "hermes-session-1"
+        db.create_session(session_id=sid, source="telegram", model="codex")
+        try:
+            first = _make_codex_agent(session_db=db, session_id=sid)
+            with patch.object(first, "_spawn_background_review", return_value=None):
+                first_result = first.run_conversation("first")
+            first.release_clients()
+
+            assert first_result["completed"] is True
+            assert db.get_codex_thread_id(sid) == "thread-persisted-1"
+            assert instances[0].kwargs["resume_thread_id"] is None
+            assert instances[0].closed is True
+
+            second = _make_codex_agent(session_db=db, session_id=sid)
+            with patch.object(second, "_spawn_background_review", return_value=None):
+                second_result = second.run_conversation("second")
+            second.release_clients()
+
+            assert second_result["completed"] is True
+            assert instances[1].kwargs["resume_thread_id"] == "thread-persisted-1"
+            assert db.get_codex_thread_id(sid) == "thread-persisted-1"
+        finally:
+            db.close()
+
+    @pytest.mark.parametrize("failure_mode", ["binding_read", "missing_row"])
+    def test_codex_thread_start_fails_closed_when_binding_state_is_unavailable(
+        self, monkeypatch, tmp_path, failure_mode
+    ):
+        db = SessionDB(tmp_path / f"{failure_mode}.db")
+        sid = f"hermes-{failure_mode}"
+        if failure_mode == "binding_read":
+            db.create_session(session_id=sid, source="telegram", model="codex")
+            monkeypatch.setattr(
+                db,
+                "get_codex_thread_id",
+                MagicMock(side_effect=RuntimeError("binding read failed")),
+            )
+
+        session_factory = MagicMock(
+            side_effect=AssertionError(
+                "CodexAppServerSession must not be constructed"
+            )
+        )
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            session_factory,
+        )
+
+        agent = _make_codex_agent(session_db=db, session_id=sid)
+        # Exercise the exact cold-rebuild state: the AIAgent believes its
+        # persistence row is already owned by the surrounding session store.
+        # A missing row must be detected explicitly rather than interpreted as
+        # an unbound session that is safe to attach to a fresh Codex thread.
+        agent._session_db_created = True
+        try:
+            with patch.object(agent, "_spawn_background_review", return_value=None):
+                result = agent.run_conversation("must not start")
+
+            session_factory.assert_not_called()
+            assert getattr(agent, "_codex_session", None) is None
+            assert result["completed"] is False
+            assert result["partial"] is True
+            assert result["api_calls"] == 0
+            assert "refused to start a new thread" in result["error"]
+        finally:
+            agent.release_clients()
+            db.close()
+
+    def test_codex_thread_start_fails_closed_when_session_creation_fails(
+        self, monkeypatch, tmp_path
+    ):
+        db = SessionDB(tmp_path / "create_failure.db")
+        sid = "hermes-create-failure"
+        session_factory = MagicMock(
+            side_effect=AssertionError(
+                "CodexAppServerSession must not be constructed"
+            )
+        )
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            session_factory,
+        )
+
+        agent = _make_codex_agent(session_db=db, session_id=sid)
+        monkeypatch.setattr(agent, "_ensure_db_session", MagicMock())
+        try:
+            with patch.object(agent, "_spawn_background_review", return_value=None):
+                result = agent.run_conversation("must not start")
+
+            agent._ensure_db_session.assert_called()
+            session_factory.assert_not_called()
+            assert getattr(agent, "_codex_session", None) is None
+            assert result["completed"] is False
+            assert result["partial"] is True
+            assert result["api_calls"] == 0
+            assert "refused to start a new thread" in result["error"]
+        finally:
+            agent.release_clients()
+            db.close()
+
+    def test_codex_turn_lease_contention_runs_no_app_server_rpc(
+        self, monkeypatch, tmp_path
+    ):
+        db = SessionDB(tmp_path / "lease_contention.db")
+        sid = "hermes-lease-contention"
+        holder = str(uuid.uuid4())
+        db.create_session(session_id=sid, source="telegram", model="codex")
+        assert db.try_acquire_codex_turn_lease(sid, holder)
+
+        client_factory = MagicMock(
+            side_effect=AssertionError("Codex client must not be constructed")
+        )
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerClient",
+            client_factory,
+        )
+
+        agent = _make_codex_agent(session_db=db, session_id=sid)
+        try:
+            with patch.object(agent, "_spawn_background_review", return_value=None):
+                result = agent.run_conversation("must serialize")
+
+            assert result["completed"] is False
+            assert result["partial"] is True
+            assert result["api_calls"] == 0
+            assert "another Hermes/Codex client" in result["error"]
+            client_factory.assert_not_called()
+        finally:
+            agent.release_clients()
+            assert db.release_codex_turn_lease(sid, holder)
+            db.close()
+
+    @pytest.mark.parametrize("missing", ["session_db", "session_id"])
+    def test_codex_thread_start_fails_closed_without_durable_session_identity(
+        self, monkeypatch, missing
+    ):
+        session_factory = MagicMock(
+            side_effect=AssertionError(
+                "CodexAppServerSession must not be constructed"
+            )
+        )
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            session_factory,
+        )
+
+        agent = _make_codex_agent()
+        if missing == "session_db":
+            agent._session_db = None
+        else:
+            agent.session_id = None
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("must not start")
+
+        session_factory.assert_not_called()
+        assert getattr(agent, "_codex_session", None) is None
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert result["api_calls"] == 0
+        assert "refused to start a new thread" in result["error"]
 
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
@@ -747,6 +992,28 @@ class TestSessionRetirementOnRunAgent:
         assert agent._codex_session is None
         assert result["completed"] is False
         assert "codex segfaulted" in result["error"]
+
+    def test_release_clients_closes_codex_session_idempotently(self):
+        agent = _make_codex_agent()
+        codex_session = MagicMock()
+        agent._codex_session = codex_session
+
+        agent.release_clients()
+        agent.release_clients()
+
+        codex_session.close.assert_called_once_with()
+        assert agent._codex_session is None
+
+    def test_close_closes_codex_session_idempotently(self):
+        agent = _make_codex_agent()
+        codex_session = MagicMock()
+        agent._codex_session = codex_session
+
+        agent.close()
+        agent.close()
+
+        codex_session.close.assert_called_once_with()
+        assert agent._codex_session is None
 
 
 class TestCodexToolProgressBridge:

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -186,6 +186,61 @@ class TestRunConversationCodexPath:
             )
         ]
 
+    def test_native_codex_compaction_waits_through_empty_usage_for_real_prompt(
+        self, monkeypatch
+    ):
+        """The app-server usage notification is a sibling of compaction.
+
+        Codex may finish the compaction turn before it has a ``last`` usage
+        bucket.  That empty update is not evidence the compaction worked; the
+        next real low prompt must be the one that clears the verdict.
+        """
+        def fake_run_turn(self, user_input: str, **kwargs):
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-compact-empty-usage",
+                thread_id="thread-compact-empty-usage",
+                compacted=True,
+                # A non-empty partial sibling payload is still not a prompt
+                # measurement, so it must leave the latch armed just like an
+                # entirely absent usage notification.
+                token_usage_last={"totalTokens": 10, "outputTokens": 10},
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession,
+            "ensure_started",
+            lambda self: "thread-compact-empty-usage",
+        )
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert agent.context_compressor.awaiting_real_usage_after_compression is True
+        assert agent.context_compressor._verify_compaction_cleared_threshold is True
+        assert agent.context_compressor.last_prompt_tokens == -1
+
+        from agent.codex_runtime import _record_codex_app_server_usage
+
+        _record_codex_app_server_usage(
+            agent,
+            TurnResult(
+                token_usage_last={
+                    "totalTokens": 5_010,
+                    "inputTokens": 5_000,
+                    "cachedInputTokens": 0,
+                    "outputTokens": 10,
+                }
+            ),
+        )
+
+        assert agent.context_compressor.last_prompt_tokens == 5_000
+        assert agent.context_compressor.awaiting_real_usage_after_compression is False
+        assert agent.context_compressor._verify_compaction_cleared_threshold is False
+
     def test_projected_messages_are_spliced(self, fake_session):
         agent = _make_codex_agent()
         with patch.object(agent, "_spawn_background_review", return_value=None):

--- a/tests/run_agent/test_compression_abort_state_reset.py
+++ b/tests/run_agent/test_compression_abort_state_reset.py
@@ -16,10 +16,14 @@ empty-transcript returns — so every abort path leaves the attempt outcome
 ``None`` and callers retain the previous flush baseline.
 """
 
+import copy
 import os
+import sqlite3
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 
 def _make_agent(session_db):
@@ -73,6 +77,54 @@ class _NoProgressCompressor(_InPlaceSuccessCompressor):
 
     def compress(self, messages, **_kwargs):
         return [dict(m) for m in messages]
+
+
+class _RotationStateMutatingCompressor(_InPlaceSuccessCompressor):
+    """Models the runtime state advanced by the real iterative compressor."""
+
+    compression_count = 3
+    _previous_summary = "summary before failed attempt"
+    _summary_has_user_turn = False
+    _last_compression_made_progress = False
+    last_compression_rough_tokens = 271
+    last_prompt_tokens = 314
+    last_completion_tokens = 15
+    _verify_compaction_cleared_threshold = False
+
+    def __init__(self):
+        self.completed_boundaries = 0
+        self.session_boundary_callbacks = 0
+
+    def compress(self, _messages, **_kwargs):
+        self.compression_count = 4
+        self._previous_summary = "uncommitted summary"
+        self._summary_has_user_turn = True
+        self._last_compression_made_progress = True
+        self.last_compression_rough_tokens = 999
+        return [
+            {"role": "user", "content": "[summary] uncommitted state"},
+            {"role": "assistant", "content": "retained tail"},
+        ]
+
+    def record_completed_compaction(self, **_kwargs):
+        self.completed_boundaries += 1
+        self._verify_compaction_cleared_threshold = True
+
+    def on_session_start(self, *_args, **_kwargs):
+        self.session_boundary_callbacks += 1
+
+    def checkpoint_compression_transaction(self):
+        return copy.deepcopy(self.__dict__)
+
+    def rollback_compression_transaction(self, checkpoint):
+        self.__dict__.clear()
+        self.__dict__.update(copy.deepcopy(checkpoint))
+
+
+class _RollbackFailingCompressor(_RotationStateMutatingCompressor):
+    def rollback_compression_transaction(self, _checkpoint):
+        self.rollback_calls = getattr(self, "rollback_calls", 0) + 1
+        raise RuntimeError("simulated durable rollback failure")
 
 
 class TestAbortPathsResetPerAttemptState:
@@ -133,3 +185,676 @@ class TestAbortPathsResetPerAttemptState:
             db.close()
 
 
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = True
+            original = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(original, [])
+            compacted, history = self._in_place_success(agent, original)
+
+            messages = compacted + [
+                {"role": "user", "content": "new request"},
+                {"role": "assistant", "content": "new answer"},
+            ]
+            agent.context_compressor = _NoProgressCompressor()
+            returned, _ = compress_context(
+                agent, messages, "system", approx_tokens=100_000
+            )
+            assert agent._last_compression_attempt_in_place is None
+            new_history = conversation_history_after_compression(
+                agent, returned, history
+            )
+            assert new_history is history
+            # Run-level gateway signal is untouched by the aborted attempt.
+            assert agent._last_compaction_in_place is True
+            db.close()
+
+    def test_rotation_boundary_still_clears_baseline(self):
+        """A completed rotation attempt must still return None (full rewrite)."""
+        from agent.conversation_compression import (
+            compress_context,
+            conversation_history_after_compression,
+        )
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = False
+            original = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(original, [])
+            agent.context_compressor = _InPlaceSuccessCompressor()
+            compacted, _ = compress_context(
+                agent, original, "system", approx_tokens=100_000
+            )
+            assert agent._last_compression_attempt_in_place is False
+            assert conversation_history_after_compression(
+                agent, compacted, list(original)
+            ) is None
+            db.close()
+
+    def test_rotation_publish_failure_restores_runtime_without_boundary_latch(self):
+        """A failed atomic child publication is a complete runtime no-op."""
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = False
+            original = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(original, [])
+            messages_before_attempt = copy.deepcopy(original)
+
+            compressor = _RotationStateMutatingCompressor()
+            agent.context_compressor = compressor
+            agent._cached_system_prompt = "cached prompt before attempt"
+            agent._cached_system_prompt_static = "cached static prefix"
+            agent._static_rebuild_failed_for = "earlier prompt"
+            agent._last_compaction_in_place = True
+            events = []
+            memory_commits = []
+            agent.commit_memory_session = lambda committed: memory_commits.append(
+                list(committed)
+            )
+            agent.event_callback = lambda event, payload: events.append(
+                (event, payload)
+            )
+
+            with patch.object(
+                db,
+                "publish_compression_child",
+                side_effect=RuntimeError("simulated atomic publication failure"),
+            ):
+                returned, returned_prompt = compress_context(
+                    agent,
+                    original,
+                    "system",
+                    approx_tokens=100_000,
+                )
+
+            assert returned is original
+            assert returned == messages_before_attempt
+            assert returned_prompt == "cached prompt before attempt"
+            assert agent._cached_system_prompt == "cached prompt before attempt"
+            assert agent._cached_system_prompt_static == "cached static prefix"
+            assert agent._static_rebuild_failed_for == "earlier prompt"
+
+            assert agent._last_compression_attempt_recorded is True
+            assert agent._last_compression_attempt_in_place is None
+            assert agent._last_compaction_in_place is True
+            assert compressor.awaiting_real_usage_after_compression is False
+            assert compressor.compression_count == 3
+            assert compressor._previous_summary == "summary before failed attempt"
+            assert compressor._summary_has_user_turn is False
+            assert compressor._last_compression_made_progress is False
+            assert compressor.last_compression_rough_tokens == 271
+            assert compressor.last_prompt_tokens == 314
+            assert compressor.last_completion_tokens == 15
+            assert compressor._verify_compaction_cleared_threshold is False
+            assert compressor.completed_boundaries == 0
+            assert events == []
+            # A failed atomic publish has no durable compaction boundary, so
+            # memory providers must not receive on_session_end either.
+            assert memory_commits == []
+            db.close()
+
+    def test_rotation_commits_memory_after_publish_before_session_id_switch(self):
+        """Rotation ends memory under the old SID only after child publication."""
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = False
+            original_session_id = agent.session_id
+            messages = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(messages, [])
+            agent.context_compressor = _InPlaceSuccessCompressor()
+            order = []
+            publish = db.publish_compression_child
+
+            def publish_then_record(**kwargs):
+                order.append(("publish", agent.session_id))
+                return publish(**kwargs)
+
+            def commit_then_record(_messages):
+                order.append(("memory", agent.session_id))
+
+            agent.commit_memory_session = commit_then_record
+            with patch.object(db, "publish_compression_child", publish_then_record):
+                compress_context(agent, messages, "system", approx_tokens=100_000)
+
+            assert [event for event, _sid in order] == ["publish", "memory"]
+            assert [sid for _event, sid in order] == [
+                original_session_id,
+                original_session_id,
+            ]
+            assert agent.session_id != original_session_id
+            db.close()
+
+    def test_in_place_commits_memory_after_archive(self):
+        """In-place compaction waits for archive_and_compact before memory end."""
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = True
+            original_session_id = agent.session_id
+            messages = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(messages, [])
+            agent.context_compressor = _InPlaceSuccessCompressor()
+            order = []
+            archive = db.archive_and_compact
+
+            def archive_then_record(*args, **kwargs):
+                order.append(("archive", agent.session_id))
+                return archive(*args, **kwargs)
+
+            def commit_then_record(_messages):
+                order.append(("memory", agent.session_id))
+
+            agent.commit_memory_session = commit_then_record
+            with patch.object(db, "archive_and_compact", archive_then_record):
+                compress_context(agent, messages, "system", approx_tokens=100_000)
+
+            assert [event for event, _sid in order] == ["archive", "memory"]
+            assert [sid for _event, sid in order] == [
+                original_session_id,
+                original_session_id,
+            ]
+            db.close()
+
+    def test_in_place_archive_failure_is_complete_no_op(self):
+        """A failed archive never surfaces a compaction boundary."""
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = True
+            messages = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(messages, [])
+            before = copy.deepcopy(messages)
+            compressor = _RotationStateMutatingCompressor()
+            agent.context_compressor = compressor
+            agent._cached_system_prompt = "cached prompt before attempt"
+            agent._cached_system_prompt_static = "cached static prefix"
+            agent._static_rebuild_failed_for = "earlier prompt"
+            events = []
+            dedup_resets = []
+            memory_commits = []
+            agent.event_callback = lambda event, payload: events.append((event, payload))
+            agent.commit_memory_session = lambda _messages: memory_commits.append(True)
+
+            with patch.object(
+                db, "archive_and_compact", side_effect=RuntimeError("archive failed")
+            ), patch("tools.file_tools.reset_file_dedup", dedup_resets.append):
+                returned, returned_prompt = compress_context(
+                    agent, messages, "system", approx_tokens=100_000
+                )
+
+            assert returned is messages
+            assert returned == before
+            assert returned_prompt == "cached prompt before attempt"
+            assert agent._cached_system_prompt == "cached prompt before attempt"
+            assert agent._cached_system_prompt_static == "cached static prefix"
+            assert agent._static_rebuild_failed_for == "earlier prompt"
+            assert compressor.compression_count == 3
+            assert compressor._previous_summary == "summary before failed attempt"
+            assert compressor.awaiting_real_usage_after_compression is False
+            assert compressor._verify_compaction_cleared_threshold is False
+            assert compressor.session_boundary_callbacks == 0
+            assert events == []
+            assert memory_commits == []
+            assert dedup_resets == []
+            db.close()
+
+    def test_in_place_prompt_write_failure_rolls_back_archive_transaction(self):
+        """The prompt write shares the archive transaction, so neither commits."""
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = True
+            session_id = agent.session_id
+            messages = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(messages, [])
+            agent._cached_system_prompt = "old durable prompt"
+            db.update_system_prompt(session_id, "old durable prompt")
+            agent._memory_manager = object()  # force the rebuild path below
+            agent._build_system_prompt = lambda _system: "trigger prompt failure"
+            agent.context_compressor = _InPlaceSuccessCompressor()
+            with db._lock:
+                db._conn.execute(
+                    "CREATE TRIGGER reject_compaction_prompt "
+                    "BEFORE UPDATE OF system_prompt ON sessions "
+                    "WHEN NEW.system_prompt = 'trigger prompt failure' "
+                    "BEGIN SELECT RAISE(ABORT, 'prompt write failed'); END"
+                )
+                db._conn.commit()
+
+            returned, _ = compress_context(
+                agent, messages, "system", approx_tokens=100_000
+            )
+
+            assert returned is messages
+            assert [
+                {key: value for key, value in message.items() if key != "_db_persisted"}
+                for message in returned
+            ] == [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            assert [
+                {"role": message["role"], "content": message["content"]}
+                for message in db.get_messages_as_conversation(session_id)
+            ] == [
+                {"role": message["role"], "content": message["content"]}
+                for message in returned
+            ]
+            assert db.get_session(session_id)["system_prompt"] == "old durable prompt"
+            assert agent._cached_system_prompt == "old durable prompt"
+            db.close()
+
+    def test_rollback_failure_is_raised_not_reported_as_no_op(self):
+        """An unrecoverable compressor rollback is observable and stops the turn."""
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = False
+            messages = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            compressor = _RollbackFailingCompressor()
+            # A semantic no-progress exit still has to roll back the runtime
+            # state advanced by compress().
+            compressor.compress = lambda original, **_kwargs: original
+            agent.context_compressor = compressor
+
+            try:
+                compress_context(agent, messages, "system", approx_tokens=100_000)
+            except RuntimeError as exc:
+                assert "rollback failed" in str(exc)
+            else:  # pragma: no cover - safety contract
+                raise AssertionError("rollback failure was incorrectly reported as no-op")
+            assert compressor.rollback_calls == 1
+            db.close()
+
+    def test_real_compressor_durable_rollback_failure_is_raised_once(self):
+        """A SessionDB restore failure is observable after runtime restoration."""
+        from agent.context_compressor import ContextCompressor
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = False
+            session_id = agent.session_id
+            db.create_session(session_id, "cli")
+            db.record_compression_failure_cooldown(
+                session_id, 4_000_000_000.0, "preexisting timeout"
+            )
+            compressor = ContextCompressor(
+                model="test/model",
+                summary_model_override="aux/test-model",
+                quiet_mode=True,
+                config_context_length=100_000,
+            )
+            compressor.bind_session_state(db, session_id)
+            assert db.get_compression_failure_cooldown(session_id) is not None
+
+            checkpoint = compressor.checkpoint_compression_transaction()
+            compressor._fallback_to_main_for_compression(
+                RuntimeError("auxiliary unavailable"), "failed"
+            )
+            compressor.compression_count += 1
+            restore_calls = []
+
+            def fail_cooldown_restore(*_args, **_kwargs):
+                restore_calls.append(True)
+                raise RuntimeError("simulated SessionDB cooldown restore failure")
+
+            with patch.object(
+                db,
+                "record_compression_failure_cooldown",
+                side_effect=fail_cooldown_restore,
+            ):
+                try:
+                    compressor.rollback_compression_transaction(checkpoint)
+                except RuntimeError as exc:
+                    assert "persistence restore failed" in str(exc)
+                else:  # pragma: no cover - safety contract
+                    raise AssertionError("durable rollback failure was hidden")
+
+            # Runtime rollback happened before the durable failure was exposed,
+            # and the once guard prevents a second partial restore attempt.
+            assert compressor.summary_model == "aux/test-model"
+            assert compressor.compression_count == 0
+            assert restore_calls == [True]
+            db.close()
+
+    def test_summary_abort_rollback_preserves_abort_and_durable_cooldown(self):
+        """A real failed summary is an outcome, not speculative rewrite state."""
+        from agent.context_compressor import ContextCompressor
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            session_id = "summary-abort-outcome"
+            db.create_session(session_id, "cli")
+            compressor = ContextCompressor(
+                model="test/model",
+                quiet_mode=True,
+                config_context_length=100_000,
+            )
+            compressor.bind_session_state(db, session_id)
+            checkpoint = compressor.checkpoint_compression_transaction()
+
+            compressor._previous_summary = "speculative summary"
+            compressor._last_compress_aborted = True
+            compressor._last_summary_error = "summary provider timed out"
+            compressor._last_summary_network_failure = True
+            compressor._last_compression_telemetry = {
+                "event": "compression_attempt",
+                "failure_class": "summary_network_failure",
+            }
+            compressor._record_compression_failure_cooldown(
+                60.0, "summary provider timed out"
+            )
+
+            with (
+                patch.object(
+                    db,
+                    "clear_compression_failure_cooldown",
+                    wraps=db.clear_compression_failure_cooldown,
+                ) as clear_cooldown,
+                patch.object(
+                    db,
+                    "record_compression_failure_cooldown",
+                    wraps=db.record_compression_failure_cooldown,
+                ) as record_cooldown,
+            ):
+                compressor.rollback_compression_transaction(
+                    checkpoint,
+                    preserve_failure_outcome=True,
+                )
+
+            assert clear_cooldown.call_count == 0
+            assert record_cooldown.call_count == 0
+
+            assert compressor._previous_summary is None
+            assert compressor._last_compress_aborted is True
+            assert compressor._last_summary_error == "summary provider timed out"
+            assert compressor._last_summary_network_failure is True
+            assert compressor._last_compression_telemetry["failure_class"] == (
+                "summary_network_failure"
+            )
+            active = compressor.get_active_compression_failure_cooldown(
+                refresh=True
+            )
+            assert active is not None
+            assert active["error"] == "summary provider timed out"
+            assert db.get_compression_failure_cooldown(session_id) is not None
+            db.close()
+
+    @pytest.mark.parametrize("checkpoint_has_cooldown", [True, False])
+    def test_real_sessiondb_cooldown_rollback_write_failure_is_not_swallowed(
+        self, checkpoint_has_cooldown
+    ):
+        """Rollback must use SessionDB's strict path, not its legacy swallow.
+
+        This deliberately patches the real DB write seam rather than replacing
+        either cooldown method: before the strict path, both methods logged and
+        returned, so ContextCompressor incorrectly reported a restored durable
+        checkpoint.
+        """
+        from agent.context_compressor import ContextCompressor
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            session_id = "strict-cooldown-rollback"
+            db.create_session(session_id, "cli")
+            if checkpoint_has_cooldown:
+                db.record_compression_failure_cooldown(
+                    session_id, 4_000_000_000.0, "preexisting timeout"
+                )
+
+            compressor = ContextCompressor(
+                model="test/model", quiet_mode=True, config_context_length=100_000,
+            )
+            compressor.bind_session_state(db, session_id)
+            checkpoint = compressor.checkpoint_compression_transaction()
+
+            # Make the durable row differ from the checkpoint, so rollback
+            # must respectively record or clear it.
+            if checkpoint_has_cooldown:
+                db.clear_compression_failure_cooldown(session_id)
+            else:
+                db.record_compression_failure_cooldown(
+                    session_id, 4_000_000_000.0, "speculative timeout"
+                )
+
+            with patch.object(
+                db,
+                "_execute_write",
+                side_effect=sqlite3.OperationalError("database is locked"),
+            ):
+                with pytest.raises(
+                    RuntimeError, match="compression rollback persistence restore failed"
+                ):
+                    compressor.rollback_compression_transaction(checkpoint)
+
+            # The row remains divergent only because the write really failed;
+            # the important contract is that rollback exposes this and stops
+            # its caller rather than claiming durable recovery.
+            restored = db.get_compression_failure_cooldown(session_id)
+            assert (restored is not None) is not checkpoint_has_cooldown
+            db.close()
+
+    def test_publish_abort_stops_when_real_cooldown_restore_is_not_durable(self):
+        """The compression caller must surface a real strict-restore failure."""
+        from agent.context_compressor import ContextCompressor
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = False
+            session_id = agent.session_id
+            db.create_session(session_id, "cli")
+            db.record_compression_failure_cooldown(
+                session_id, 4_000_000_000.0, "preexisting timeout"
+            )
+            compressor = ContextCompressor(
+                model="test/model",
+                summary_model_override="aux/test-model",
+                quiet_mode=True,
+                config_context_length=100_000,
+            )
+            compressor.bind_session_state(db, session_id)
+
+            def fallback_then_compact(_messages, **_kwargs):
+                compressor._fallback_to_main_for_compression(
+                    RuntimeError("auxiliary unavailable"), "failed"
+                )
+                return [
+                    {"role": "user", "content": "[summary] uncommitted state"},
+                    {"role": "assistant", "content": "retained tail"},
+                ]
+
+            compressor.compress = fallback_then_compact
+            agent.context_compressor = compressor
+            messages = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(messages, [])
+            original_execute_write = db._execute_write
+
+            def fail_publish_then_poison_rollback(*_args, **_kwargs):
+                db._execute_write = lambda _operation: (_ for _ in ()).throw(
+                    sqlite3.OperationalError("database is locked")
+                )
+                raise RuntimeError("publish failed")
+
+            try:
+                with patch.object(
+                    db,
+                    "publish_compression_child",
+                    side_effect=fail_publish_then_poison_rollback,
+                ):
+                    with pytest.raises(RuntimeError, match="compression rollback failed"):
+                        compress_context(
+                            agent, messages, "system", approx_tokens=100_000, force=True
+                        )
+            finally:
+                db._execute_write = original_execute_write
+
+            # The failed rollback propagates from the abort path; it is never
+            # converted into the normal unchanged-message success result.
+            assert compressor.summary_model == "aux/test-model"
+            db.close()
+
+    def test_durable_checkpoint_read_failure_aborts_before_compress_or_publish(self):
+        """An unknown durable baseline fails closed before any mutation."""
+        from agent.context_compressor import ContextCompressor
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = False
+            session_id = agent.session_id
+            db.create_session(session_id, "cli")
+            compressor = ContextCompressor(
+                model="test/model",
+                quiet_mode=True,
+                config_context_length=100_000,
+            )
+            compressor.bind_session_state(db, session_id)
+            compressor.compression_count = 7
+            compressor.compress = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("compress must not run after checkpoint read failure")
+            )
+            agent.context_compressor = compressor
+            messages = [{"role": "user", "content": "unchanged"}]
+
+            with patch.object(
+                db,
+                "get_compression_failure_cooldown",
+                side_effect=RuntimeError("simulated durable read failure"),
+            ), patch.object(db, "publish_compression_child") as publish:
+                try:
+                    compress_context(
+                        agent,
+                        messages,
+                        "system",
+                        approx_tokens=100_000,
+                        force=True,
+                    )
+                except RuntimeError as exc:
+                    assert "checkpoint persistence read failed" in str(exc)
+                else:  # pragma: no cover - safety contract
+                    raise AssertionError("checkpoint read failure was not surfaced")
+
+            assert messages == [{"role": "user", "content": "unchanged"}]
+            assert compressor.compression_count == 7
+            publish.assert_not_called()
+            db.close()
+
+    def test_rotation_rollback_restores_aux_fallback_and_durable_cooldown(self):
+        """Failed publish rolls back every real-compressor fallback side effect."""
+        from agent.context_compressor import ContextCompressor
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = False
+            session_id = agent.session_id
+            db.record_compression_failure_cooldown(
+                session_id, 4_000_000_000.0, "preexisting timeout"
+            )
+            compressor = ContextCompressor(
+                model="test/model",
+                summary_model_override="aux/test-model",
+                quiet_mode=True,
+                config_context_length=100_000,
+            )
+            compressor.bind_session_state(db, session_id)
+            original_summary_model = compressor.summary_model
+            original_cooldown = db.get_compression_failure_cooldown(session_id)
+
+            def fallback_then_compact(_messages, **_kwargs):
+                compressor._fallback_to_main_for_compression(
+                    RuntimeError("auxiliary unavailable"), "failed"
+                )
+                compressor.compression_count += 1
+                compressor._previous_summary = "uncommitted summary"
+                compressor._last_compression_made_progress = True
+                return [
+                    {"role": "user", "content": "[summary] uncommitted state"},
+                    {"role": "assistant", "content": "retained tail"},
+                ]
+
+            compressor.compress = fallback_then_compact
+            agent.context_compressor = compressor
+            messages = [
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            agent._flush_messages_to_session_db(messages, [])
+
+            with patch.object(
+                db,
+                "publish_compression_child",
+                side_effect=RuntimeError("publish failed"),
+            ):
+                returned, _ = compress_context(
+                    agent, messages, "system", approx_tokens=100_000
+                )
+
+            assert returned is messages
+            assert compressor.summary_model == original_summary_model
+            assert compressor._previous_summary is None
+            assert compressor.compression_count == 0
+            assert db.get_compression_failure_cooldown(session_id) == original_cooldown
+            db.close()

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -228,6 +228,12 @@ class TestFlushAfterCompression:
             awaiting_real_usage_after_compression = False
 
             def compress(self, messages, **_kwargs):
+                # Model a plugin compressor that pollutes an already-durable
+                # compacted dict before reporting an abort. Rollback must
+                # restore this same object (not a deep-copy replacement), or
+                # the identity-based flush baseline appends it again.
+                messages[0]["content"] = "CORRUPTED speculative summary"
+                messages[0]["_speculative"] = True
                 self._last_compress_aborted = True
                 return messages
 

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -1,8 +1,9 @@
 """Behavioral regression tests for the post-tool compression attempt cap.
 
 The pre-API pressure gate, the overflow/413 error handlers, and the post-tool
-compaction gate all share ``compression_attempts`` as a per-turn backstop,
-bounded by the resolved ``compression.max_attempts`` cap (default 3).  Before
+compaction gate all share ``compression_attempts`` as a consecutive-failure
+backstop, bounded by the resolved ``compression.max_attempts`` cap (default 3).
+Provider-confirmed recovery starts a fresh interval during a long turn. Before
 the fix the post-tool path neither checked nor incremented the counter, so a
 long tool loop could compact after every tool response for the lifetime of
 the turn.
@@ -21,6 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.context_compressor import ContextCompressor
 from run_agent import AIAgent
 
 
@@ -37,7 +39,7 @@ def _tool_call(i: int):
     )
 
 
-def _tool_response(i: int):
+def _tool_response(i: int, *, prompt_tokens: int | None = None):
     msg = SimpleNamespace(
         content=None,
         reasoning_content=None,
@@ -45,7 +47,14 @@ def _tool_response(i: int):
         tool_calls=[_tool_call(i)],
     )
     choice = SimpleNamespace(message=msg, finish_reason="tool_calls")
-    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+    usage = None
+    if prompt_tokens is not None:
+        usage = SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=10,
+            total_tokens=prompt_tokens + 10,
+        )
+    return SimpleNamespace(choices=[choice], model="test/model", usage=usage)
 
 
 def _stop_response():
@@ -86,9 +95,23 @@ def _pressured_compressor() -> MagicMock:
     compressor.threshold_tokens = 10_000
     compressor.context_length = 200_000
     compressor.last_prompt_tokens = 150_000
-    compressor.should_compress.return_value = True
+    compressor.should_compress.side_effect = (
+        lambda prompt_tokens=None: (
+            prompt_tokens
+            if prompt_tokens is not None
+            else compressor.last_prompt_tokens
+        )
+        >= compressor.threshold_tokens
+    )
     compressor.should_defer_preflight_to_real_usage.return_value = True
     compressor.get_active_compression_failure_cooldown.return_value = None
+
+    def _update_from_response(usage):
+        compressor.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        compressor.awaiting_real_usage_after_compression = False
+
+    compressor.update_from_response.side_effect = _update_from_response
+    compressor.awaiting_real_usage_after_compression = False
     return compressor
 
 
@@ -118,9 +141,23 @@ def agent():
     return a
 
 
-def _run_tool_loop(agent, n_tool_iterations: int):
+def _run_tool_loop(
+    agent,
+    n_tool_iterations: int,
+    *,
+    reported_prompt_tokens: int | list[int] | None = None,
+    compaction_makes_progress: bool | set[int] = False,
+):
     """Drive one turn: ``n_tool_iterations`` tool calls, then a stop."""
-    responses = [_tool_response(i) for i in range(n_tool_iterations)]
+    if isinstance(reported_prompt_tokens, list):
+        assert len(reported_prompt_tokens) == n_tool_iterations
+        prompt_tokens_by_iteration = reported_prompt_tokens
+    else:
+        prompt_tokens_by_iteration = [reported_prompt_tokens] * n_tool_iterations
+    responses = [
+        _tool_response(i, prompt_tokens=prompt_tokens_by_iteration[i])
+        for i in range(n_tool_iterations)
+    ]
     responses.append(_stop_response())
     agent.client.chat.completions.create.side_effect = responses
 
@@ -128,6 +165,12 @@ def _run_tool_loop(agent, n_tool_iterations: int):
 
     def _fake_compress(messages, system_message, **_kwargs):
         compress_calls.append(len(messages))
+        call_number = len(compress_calls)
+        if compaction_makes_progress is True or (
+            isinstance(compaction_makes_progress, set)
+            and call_number in compaction_makes_progress
+        ):
+            agent.context_compressor.awaiting_real_usage_after_compression = True
         return messages, "compressed prompt"
 
     with (
@@ -197,3 +240,129 @@ class TestPostToolCompressionAttemptCap:
 
         assert len(first) == 3
         assert len(second) == 3
+
+    def test_effective_compaction_reopens_budget_during_long_turn(self, agent):
+        """Provider-confirmed recovery makes the cap consecutive, not lifetime.
+
+        The hgfast failure used three effective compactions early in one
+        100-iteration tool turn. Each next provider call reported a prompt well
+        below the threshold, but the cumulative counter stayed at three and
+        disabled later compaction. A real below-threshold reading must reopen
+        the retry budget for later context regrowth.
+        """
+        result, compress_calls = _run_tool_loop(
+            agent,
+            n_tool_iterations=7,
+            reported_prompt_tokens=[
+                150_000,
+                5_000,
+                150_000,
+                5_000,
+                150_000,
+                5_000,
+                150_000,
+            ],
+            compaction_makes_progress=True,
+        )
+
+        assert result["completed"] is True
+        assert len(compress_calls) == 4
+
+    def test_unrelated_low_usage_does_not_reopen_budget_after_noop(self, agent):
+        result, compress_calls = _run_tool_loop(
+            agent,
+            n_tool_iterations=7,
+            reported_prompt_tokens=[
+                150_000,
+                5_000,
+                150_000,
+                5_000,
+                150_000,
+                5_000,
+                150_000,
+            ],
+            compaction_makes_progress=False,
+        )
+
+        assert result["completed"] is True
+        assert len(compress_calls) == 3
+
+    def test_host_consumes_plugin_compaction_verdict_latch_once(self, agent):
+        """Plugins need not know about the host's dynamic one-shot latch."""
+        agent.max_compression_attempts = 1
+        agent.context_compressor.update_from_response.side_effect = (
+            lambda usage: setattr(
+                agent.context_compressor,
+                "last_prompt_tokens",
+                usage.get("prompt_tokens", 0),
+            )
+        )
+        result, compress_calls = _run_tool_loop(
+            agent,
+            n_tool_iterations=5,
+            reported_prompt_tokens=[
+                150_000,
+                5_000,
+                150_000,
+                5_000,
+                150_000,
+            ],
+            # First attempt succeeds and arms the host latch. The second is a
+            # no-op and must not let the following unrelated low reading reset
+            # the cap a second time.
+            compaction_makes_progress={1},
+        )
+
+        assert result["completed"] is True
+        assert len(compress_calls) == 2
+        assert agent.context_compressor.awaiting_real_usage_after_compression is False
+
+    def test_real_compressor_observes_latch_before_host_consumes_it(self, agent):
+        """The host must not erase the built-in compressor's fit baseline."""
+        compressor = ContextCompressor(
+            model="test/model",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        compressor.threshold_tokens = 10_000
+        compressor.last_compression_rough_tokens = 90_000
+        agent.context_compressor = compressor
+
+        result, compress_calls = _run_tool_loop(
+            agent,
+            n_tool_iterations=2,
+            reported_prompt_tokens=[150_000, 5_000],
+            compaction_makes_progress={1},
+        )
+
+        assert result["completed"] is True
+        assert len(compress_calls) == 1
+        assert compressor.last_rough_tokens_when_real_prompt_fit == 90_000
+        assert compressor.awaiting_real_usage_after_compression is False
+
+    def test_zero_prompt_is_not_forwarded_to_plugin_or_used_to_reset_latch(self, agent):
+        agent.max_compression_attempts = 1
+        observed_plugin_prompts = []
+
+        def _plugin_update(usage):
+            prompt = usage["prompt_tokens"]
+            observed_plugin_prompts.append(prompt)
+            # This deliberately bad third-party engine consumes every update.
+            # The host must protect it from zero/missing prompt payloads.
+            agent.context_compressor.last_prompt_tokens = prompt
+            agent.context_compressor.awaiting_real_usage_after_compression = False
+
+        agent.context_compressor.update_from_response.side_effect = _plugin_update
+        result, compress_calls = _run_tool_loop(
+            agent,
+            n_tool_iterations=4,
+            reported_prompt_tokens=[150_000, 0, 5_000, 150_000],
+            compaction_makes_progress={1},
+        )
+
+        assert result["completed"] is True
+        # The zero-prompt response cannot reach the plug-in, clear its latch,
+        # or reset the one-attempt budget.  The later real low prompt can.
+        assert len(compress_calls) == 2
+        assert 0 not in observed_plugin_prompts
+        assert agent.context_compressor.awaiting_real_usage_after_compression is False

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -12,7 +12,7 @@ API call with HTTP 400.
 These tests pin:
 - the cache-hit path returns a fresh list (existing #17098 behavior)
 - the first uncached call also returns a fresh list (the fix)
-- every call returns a list that is not the cached one, even after mutation
+- nested schema mutations never leak into the canonical cache
 """
 from __future__ import annotations
 
@@ -52,7 +52,18 @@ class TestQuietModeCacheIsolation:
         cached = next(iter(model_tools._tool_defs_cache.values()))
         assert second is not cached
 
+    def test_nested_schema_mutation_does_not_poison_cache(self):
+        """Provider sanitizers mutate ``function.parameters`` in place."""
+        first = model_tools.get_tool_definitions(quiet_mode=True)
+        assert first
+        first_schema = first[0]["function"]["parameters"]
+        original = dict(first_schema)
+        first_schema.clear()
+        first_schema["type"] = "string"
 
+        second = model_tools.get_tool_definitions(quiet_mode=True)
+        assert second[0]["function"]["parameters"] == original
+        assert second[0]["function"]["parameters"] is not first_schema
 
     def test_cache_bounded_by_eviction(self):
         """The cache evicts the oldest entry when it reaches the cap,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -356,6 +356,79 @@ class TestSessionLifecycle:
         assert db.get_codex_turn_lease("s1")["holder_uuid"] == owner
         assert db.get_codex_turn_lease("s1")["expires_at"] == 2060.0
 
+    def test_pid_reuse_lease_reclamation_requires_expiry_and_identity_change(
+        self, db, monkeypatch
+    ):
+        """PID reuse is recoverable only after the old lease has expired.
+
+        The stored owner PID is deliberately distinct from this test process.
+        A changed start fingerprint represents PID reuse, while the matching
+        value represents a live owner.  This exercises the three safety cases
+        Sol requested without depending on an actual recycled kernel PID.
+        """
+        owner_pid = 424242
+        old_start = 111111
+        current_start = 222222
+        caller_start = 333333
+        clock = [1000.0]
+        monkeypatch.setattr(hermes_state.time, "time", lambda: clock[0])
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_process_start_time",
+            lambda pid: (
+                caller_start
+                if pid == os.getpid()
+                else current_start
+                if pid == owner_pid
+                else None
+            ),
+        )
+        db.create_session(session_id="s1", source="cli")
+        stale_holder = str(uuid.uuid4())
+        replacement_holder = str(uuid.uuid4())
+
+        def insert_lease(*, expires_at):
+            def _do(conn):
+                conn.execute("DELETE FROM codex_turn_leases WHERE session_id = ?", ("s1",))
+                conn.execute(
+                    "INSERT INTO codex_turn_leases "
+                    "(session_id, codex_thread_id, holder_uuid, owner_pid, "
+                    "owner_started_at, acquired_at, refreshed_at, expires_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        "s1", None, stale_holder, owner_pid, old_start,
+                        900.0, 900.0, expires_at,
+                    ),
+                )
+            db._execute_write(_do)
+
+        # Different start fingerprint is not enough before TTL expiry.
+        insert_lease(expires_at=1100.0)
+        assert not db.try_acquire_codex_turn_lease("s1", replacement_holder)
+        assert db.get_codex_turn_lease("s1")["holder_uuid"] == stale_holder
+
+        # Once expired, that changed fingerprint proves PID reuse and permits
+        # recovery by a new owner.
+        insert_lease(expires_at=999.0)
+        assert db.try_acquire_codex_turn_lease("s1", replacement_holder)
+        assert db.get_codex_turn_lease("s1")["holder_uuid"] == replacement_holder
+
+        # A matching fingerprint remains a live owner even after expiry.
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_process_start_time",
+            lambda pid: (
+                caller_start
+                if pid == os.getpid()
+                else old_start
+                if pid == owner_pid
+                else None
+            ),
+        )
+        insert_lease(expires_at=999.0)
+        assert not db.try_acquire_codex_turn_lease("s1", replacement_holder)
+        assert db.get_codex_turn_lease("s1")["holder_uuid"] == stale_holder
+
     def test_expired_dead_process_lease_is_recovered(self, db, monkeypatch):
         monkeypatch.setattr(
             hermes_state,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,8 +1,11 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import os
 import sqlite3
+import threading
 import time
 import json
+import uuid
 from unittest import mock
 
 import pytest
@@ -82,6 +85,37 @@ def db(tmp_path):
 # =========================================================================
 
 class TestSessionLifecycle:
+    def test_codex_lease_linux_start_time_handles_spaces_and_parentheses(
+        self, monkeypatch
+    ):
+        suffix = ["S", *(["0"] * 18), "987654"]
+        stat_text = f"123 (worker name ) with spaces) {' '.join(suffix)}"
+        monkeypatch.setattr(
+            hermes_state.Path,
+            "read_text",
+            lambda self, encoding=None: stat_text,
+        )
+
+        assert hermes_state._codex_turn_lease_process_start_time(123) == 987654
+
+    def test_codex_lease_linux_never_mixes_proc_and_psutil_fingerprints(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(hermes_state.sys, "platform", "linux")
+        monkeypatch.setattr(
+            hermes_state.Path,
+            "read_text",
+            lambda self, encoding=None: (_ for _ in ()).throw(
+                PermissionError("proc hidden")
+            ),
+        )
+        fake_psutil = mock.MagicMock()
+        fake_psutil.Process.return_value.create_time.return_value = 1234.5
+        monkeypatch.setattr(hermes_state, "psutil", fake_psutil)
+
+        assert hermes_state._codex_turn_lease_process_start_time(123) is None
+        fake_psutil.Process.assert_not_called()
+
     def test_create_and_get_session(self, db):
         sid = db.create_session(
             session_id="s1",
@@ -96,6 +130,366 @@ class TestSessionLifecycle:
         assert session["model"] == "test-model"
         assert session["ended_at"] is None
 
+    def test_codex_thread_binding_is_persistent_idempotent_and_immutable(
+        self, tmp_path
+    ):
+        db_path = tmp_path / "codex_binding.db"
+        first = SessionDB(db_path=db_path)
+        first.create_session(
+            session_id="s1",
+            source="telegram",
+            thread_id="telegram-topic-7",
+        )
+        assert first.get_codex_thread_id("s1") is None
+        assert first.bind_codex_thread_id("s1", "codex-thread-1") is True
+        assert first.bind_codex_thread_id("s1", "codex-thread-1") is True
+        assert first.bind_codex_thread_id("s1", "codex-thread-other") is False
+        assert first.bind_codex_thread_id("missing", "codex-thread-1") is False
+        first.close()
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            session = reopened.get_session("s1")
+            assert session["thread_id"] == "telegram-topic-7"
+            assert reopened.get_codex_thread_id("s1") == "codex-thread-1"
+        finally:
+            reopened.close()
+
+    def test_codex_thread_column_is_reconciled_on_legacy_sessions_table(
+        self, tmp_path
+    ):
+        db_path = tmp_path / "legacy_codex_binding.db"
+        conn = sqlite3.connect(db_path)
+        legacy_schema = SCHEMA_SQL.replace(
+            "    codex_thread_id TEXT,\n",
+            "",
+        )
+        conn.executescript(legacy_schema)
+        conn.execute("INSERT INTO schema_version VALUES (23)")
+        conn.execute(
+            "INSERT INTO sessions (id, source, thread_id, started_at) "
+            "VALUES ('legacy', 'discord', 'discord-thread', 1.0)"
+        )
+        conn.commit()
+        conn.close()
+
+        reconciled = SessionDB(db_path=db_path)
+        try:
+            assert reconciled.get_codex_thread_id("legacy") is None
+            assert reconciled.bind_codex_thread_id(
+                "legacy", "codex-thread-legacy"
+            )
+            session = reconciled.get_session("legacy")
+            assert session["thread_id"] == "discord-thread"
+            assert session["codex_thread_id"] == "codex-thread-legacy"
+        finally:
+            reconciled.close()
+
+    def test_compression_child_does_not_inherit_codex_thread_binding(self, db):
+        db.create_session(session_id="parent", source="cli")
+        assert db.bind_codex_thread_id("parent", "codex-parent")
+
+        db.publish_compression_child(
+            parent_session_id="parent",
+            child_session_id="child",
+            source="cli",
+            messages=[{"role": "user", "content": "bounded handoff"}],
+            require_compression_lease=False,
+        )
+
+        assert db.get_codex_thread_id("parent") == "codex-parent"
+        assert db.get_codex_thread_id("child") is None
+
+
+    def test_cold_start_acquire_then_holder_qualified_thread_attach(
+        self, db, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_process_start_time",
+            lambda pid: 123456 if pid == os.getpid() else None,
+        )
+        holder = str(uuid.uuid4())
+        other_holder = str(uuid.uuid4())
+        db.create_session(session_id="s1", source="cli")
+
+        assert db.try_acquire_codex_turn_lease("s1", holder, ttl_seconds=60)
+        lease = db.get_codex_turn_lease("s1")
+        assert lease["session_id"] == "s1"
+        assert lease["codex_thread_id"] is None
+        assert lease["holder_uuid"] == holder
+        assert lease["owner_pid"] == os.getpid()
+        assert lease["owner_started_at"] == 123456
+
+        assert not db.bind_codex_thread_under_lease(
+            "s1", other_holder, "codex-thread-1"
+        )
+        assert db.get_codex_thread_id("s1") is None
+        assert db.get_codex_turn_lease("s1")["codex_thread_id"] is None
+        assert db.bind_codex_thread_under_lease(
+            "s1",
+            holder,
+            "codex-thread-1",
+        )
+        assert db.get_codex_turn_lease("s1")["codex_thread_id"] == "codex-thread-1"
+        assert db.get_codex_thread_id("s1") == "codex-thread-1"
+        assert db.bind_codex_thread_under_lease(
+            "s1", holder, "codex-thread-1"
+        )
+
+        assert not db.refresh_codex_turn_lease("s1", other_holder)
+        assert not db.release_codex_turn_lease("s1", other_holder)
+        assert db.release_codex_turn_lease("s1", holder)
+        assert db.get_codex_turn_lease("s1") is None
+
+    def test_schema_upgrade_recreates_codex_turn_lease_table(
+        self, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "pre_lease_schema.db"
+        initial = SessionDB(db_path=db_path)
+        initial.create_session(session_id="s1", source="cli")
+        initial.close()
+
+        conn = sqlite3.connect(db_path)
+        conn.execute("DROP TABLE codex_turn_leases")
+        conn.execute("UPDATE schema_version SET version = 24")
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_process_start_time",
+            lambda pid: 198765 if pid == os.getpid() else None,
+        )
+        upgraded = SessionDB(db_path=db_path)
+        holder = str(uuid.uuid4())
+        try:
+            assert upgraded.try_acquire_codex_turn_lease("s1", holder)
+            assert upgraded.get_codex_turn_lease("s1")["holder_uuid"] == holder
+            assert upgraded.release_codex_turn_lease("s1", holder)
+        finally:
+            upgraded.close()
+
+    def test_two_connections_compete_atomically_then_handoff_after_release(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_process_start_time",
+            lambda pid: 234567 if pid == os.getpid() else None,
+        )
+        db_path = tmp_path / "codex_turn_lease_race.db"
+        first = SessionDB(db_path=db_path)
+        second = None
+        try:
+            first.create_session(session_id="s1", source="cli")
+            assert first.bind_codex_thread_id("s1", "codex-thread-1")
+            second = SessionDB(db_path=db_path)
+
+            holders = {"first": str(uuid.uuid4()), "second": str(uuid.uuid4())}
+            handles = {"first": first, "second": second}
+            barrier = threading.Barrier(2)
+            results = {}
+            errors = []
+
+            def compete(name):
+                try:
+                    barrier.wait(timeout=5)
+                    results[name] = handles[name].try_acquire_codex_turn_lease(
+                        "s1",
+                        holders[name],
+                        codex_thread_id="codex-thread-1",
+                        ttl_seconds=60,
+                    )
+                except BaseException as exc:
+                    errors.append(exc)
+
+            workers = [
+                threading.Thread(target=compete, args=(name,))
+                for name in ("first", "second")
+            ]
+            for worker in workers:
+                worker.start()
+            for worker in workers:
+                worker.join(timeout=10)
+
+            assert not any(worker.is_alive() for worker in workers)
+            assert errors == []
+            assert sorted(results.values()) == [False, True]
+
+            winner = next(name for name, acquired in results.items() if acquired)
+            loser = next(name for name, acquired in results.items() if not acquired)
+            assert handles[winner].release_codex_turn_lease(
+                "s1", holders[winner]
+            )
+            assert handles[loser].try_acquire_codex_turn_lease(
+                "s1",
+                holders[loser],
+                codex_thread_id="codex-thread-1",
+                ttl_seconds=60,
+            )
+        finally:
+            if second is not None:
+                second.close()
+            first.close()
+
+    def test_expired_live_same_process_lease_cannot_be_stolen(
+        self, db, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_process_start_time",
+            lambda pid: 345678 if pid == os.getpid() else None,
+        )
+        clock = [1000.0]
+        monkeypatch.setattr(hermes_state.time, "time", lambda: clock[0])
+        owner = str(uuid.uuid4())
+        competitor = str(uuid.uuid4())
+        db.create_session(session_id="s1", source="cli")
+
+        assert db.try_acquire_codex_turn_lease("s1", owner, ttl_seconds=1)
+        clock[0] = 2000.0
+        assert not db.try_acquire_codex_turn_lease(
+            "s1", competitor, ttl_seconds=60
+        )
+        assert db.refresh_codex_turn_lease("s1", owner, ttl_seconds=60)
+        assert db.get_codex_turn_lease("s1")["holder_uuid"] == owner
+        assert db.get_codex_turn_lease("s1")["expires_at"] == 2060.0
+
+    def test_expired_dead_process_lease_is_recovered(self, db, monkeypatch):
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_process_start_time",
+            lambda pid: 456789 if pid == os.getpid() else None,
+        )
+        db.create_session(session_id="s1", source="cli")
+        assert db.bind_codex_thread_id("s1", "codex-thread-1")
+        stale_holder = str(uuid.uuid4())
+
+        def insert_stale(conn):
+            conn.execute(
+                "INSERT INTO codex_turn_leases "
+                "(session_id, codex_thread_id, holder_uuid, owner_pid, "
+                "owner_started_at, acquired_at, refreshed_at, expires_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "s1",
+                    "codex-thread-1",
+                    stale_holder,
+                    999999999,
+                    111111,
+                    10.0,
+                    10.0,
+                    100.0,
+                ),
+            )
+
+        db._execute_write(insert_stale)
+        clock = [50.0]
+        monkeypatch.setattr(hermes_state.time, "time", lambda: clock[0])
+        liveness_calls = []
+
+        def owner_is_alive(pid, started_at):
+            liveness_calls.append((pid, started_at))
+            return False
+
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_owner_is_alive",
+            owner_is_alive,
+        )
+        new_holder = str(uuid.uuid4())
+
+        # Dead alone is insufficient: recovery also requires TTL expiry.
+        assert not db.try_acquire_codex_turn_lease("s1", new_holder)
+        assert liveness_calls == []
+
+        clock[0] = 200.0
+        assert db.try_acquire_codex_turn_lease("s1", new_holder)
+        assert liveness_calls == [(999999999, 111111)]
+        lease = db.get_codex_turn_lease("s1")
+        assert lease["holder_uuid"] == new_holder
+        assert lease["owner_pid"] == os.getpid()
+        assert lease["owner_started_at"] == 456789
+        assert lease["codex_thread_id"] == "codex-thread-1"
+
+    def test_bind_under_lease_enforces_global_thread_uniqueness(
+        self, db, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_process_start_time",
+            lambda pid: 512345 if pid == os.getpid() else None,
+        )
+        first_holder = str(uuid.uuid4())
+        second_holder = str(uuid.uuid4())
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="cli")
+        assert db.try_acquire_codex_turn_lease("s1", first_holder)
+        assert db.try_acquire_codex_turn_lease("s2", second_holder)
+
+        assert db.bind_codex_thread_under_lease(
+            "s1", first_holder, "codex-thread-shared"
+        )
+        assert not db.bind_codex_thread_under_lease(
+            "s2", second_holder, "codex-thread-shared"
+        )
+        assert db.get_codex_thread_id("s1") == "codex-thread-shared"
+        assert db.get_codex_thread_id("s2") is None
+        assert db.get_codex_turn_lease("s2")["codex_thread_id"] is None
+        assert not db.bind_codex_thread_id("s2", "codex-thread-shared")
+
+    def test_bind_under_lease_rolls_back_session_if_attach_fails(
+        self, db, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_process_start_time",
+            lambda pid: 523456 if pid == os.getpid() else None,
+        )
+        holder = str(uuid.uuid4())
+        db.create_session(session_id="s1", source="cli")
+        assert db.try_acquire_codex_turn_lease("s1", holder)
+
+        def install_failure_trigger(conn):
+            conn.execute(
+                "CREATE TRIGGER fail_codex_lease_attach "
+                "BEFORE UPDATE OF codex_thread_id ON codex_turn_leases "
+                "WHEN NEW.codex_thread_id = 'codex-thread-fail' "
+                "BEGIN "
+                "SELECT RAISE(ABORT, 'forced lease attach failure'); "
+                "END"
+            )
+
+        db._execute_write(install_failure_trigger)
+        assert not db.bind_codex_thread_under_lease(
+            "s1", holder, "codex-thread-fail"
+        )
+        assert db.get_codex_thread_id("s1") is None
+        assert db.get_codex_turn_lease("s1")["codex_thread_id"] is None
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            sqlite3.OperationalError("database is locked"),
+            TimeoutError("write patience exhausted"),
+        ],
+    )
+    def test_database_and_timeout_errors_fail_closed(
+        self, db, monkeypatch, error
+    ):
+        monkeypatch.setattr(
+            hermes_state,
+            "_codex_turn_lease_process_start_time",
+            lambda pid: 567890 if pid == os.getpid() else None,
+        )
+        holder = str(uuid.uuid4())
+        db.create_session(session_id="s1", source="cli")
+
+        with mock.patch.object(db, "_execute_write", side_effect=error):
+            assert not db.try_acquire_codex_turn_lease("s1", holder)
+            assert not db.refresh_codex_turn_lease("s1", holder)
+            assert not db.release_codex_turn_lease("s1", holder)
 
 
 

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -69,7 +69,9 @@ class TestPluginSkillRegistry:
     def test_register_and_find(self, pm, tmp_path):
         skill_md = tmp_path / "foo" / "SKILL.md"
         skill_md.parent.mkdir()
-        skill_md.write_text("---\nname: foo\n---\nBody.\n")
+        skill_md.write_text(
+            "---\nname: foo\n---\nBody.\n", encoding="utf-8"
+        )
 
         pm._plugin_skills["myplugin:foo"] = {
             "path": skill_md,
@@ -85,7 +87,9 @@ class TestPluginSkillRegistry:
         for name in ["bar", "foo", "baz"]:
             md = tmp_path / name / "SKILL.md"
             md.parent.mkdir()
-            md.write_text(f"---\nname: {name}\n---\n")
+            md.write_text(
+                f"---\nname: {name}\n---\n", encoding="utf-8"
+            )
             pm._plugin_skills[f"myplugin:{name}"] = {
                 "path": md, "plugin": "myplugin", "bare_name": name, "description": "",
             }
@@ -95,7 +99,7 @@ class TestPluginSkillRegistry:
 
     def test_remove_plugin_skill(self, pm, tmp_path):
         md = tmp_path / "SKILL.md"
-        md.write_text("---\nname: x\n---\n")
+        md.write_text("---\nname: x\n---\n", encoding="utf-8")
         pm._plugin_skills["p:x"] = {"path": md, "plugin": "p", "bare_name": "x", "description": ""}
 
         pm.remove_plugin_skill("p:x")
@@ -124,14 +128,16 @@ class TestPluginContextRegisterSkill:
     def test_happy_path(self, ctx, tmp_path):
         skill_md = tmp_path / "skills" / "my-skill" / "SKILL.md"
         skill_md.parent.mkdir(parents=True)
-        skill_md.write_text("---\nname: my-skill\n---\nContent.\n")
+        skill_md.write_text(
+            "---\nname: my-skill\n---\nContent.\n", encoding="utf-8"
+        )
 
         ctx.register_skill("my-skill", skill_md, "A test skill")
         assert ctx._manager.find_plugin_skill("testplugin:my-skill") == skill_md
 
     def test_rejects_colon_in_name(self, ctx, tmp_path):
         md = tmp_path / "SKILL.md"
-        md.write_text("test")
+        md.write_text("test", encoding="utf-8")
         with pytest.raises(ValueError, match="must not contain ':'"):
             ctx.register_skill("ns:foo", md)
 
@@ -163,7 +169,11 @@ class TestSkillViewQualifiedName:
         skill_dir = tmp_path / "plugins" / plugin / "skills" / name
         skill_dir.mkdir(parents=True, exist_ok=True)
         md = skill_dir / "SKILL.md"
-        md.write_text(content or f"---\nname: {name}\ndescription: {name} desc\n---\n\n{name} body.\n")
+        md.write_text(
+            content
+            or f"---\nname: {name}\ndescription: {name} desc\n---\n\n{name} body.\n",
+            encoding="utf-8",
+        )
         self.pm._plugin_skills[f"{plugin}:{name}"] = {
             "path": md, "plugin": plugin, "bare_name": name, "description": "",
         }
@@ -232,7 +242,7 @@ class TestSkillViewPluginGuards:
         d = tmp_path / "plugins" / plugin / "skills" / name
         d.mkdir(parents=True, exist_ok=True)
         md = d / "SKILL.md"
-        md.write_text(content)
+        md.write_text(content, encoding="utf-8")
         self.pm._plugin_skills[f"{plugin}:{name}"] = {
             "path": md, "plugin": plugin, "bare_name": name, "description": "",
         }
@@ -408,7 +418,10 @@ class TestBundleContextBanner:
             d = tmp_path / "plugins" / "myplugin" / "skills" / name
             d.mkdir(parents=True, exist_ok=True)
             md = d / "SKILL.md"
-            md.write_text(f"---\nname: {name}\ndescription: {name} desc\n---\n\n{name} body.\n")
+            md.write_text(
+                f"---\nname: {name}\ndescription: {name} desc\n---\n\n{name} body.\n",
+                encoding="utf-8",
+            )
             self.pm._plugin_skills[f"myplugin:{name}"] = {
                 "path": md, "plugin": "myplugin", "bare_name": name, "description": "",
             }

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -8,6 +8,7 @@ Covers:
 
 import json
 import logging
+from unittest.mock import patch
 
 import pytest
 
@@ -268,6 +269,125 @@ class TestSkillViewPluginGuards:
         assert result["success"] is True
         assert "Ignore previous instructions" in result["content"]
         assert any("injection" in r.message.lower() for r in caplog.records)
+
+    def test_malformed_fenced_frontmatter_is_refused(self, tmp_path):
+        """Plugin skills cannot use the local parser's lenient YAML fallback."""
+        from tools.skills_tool import skill_view
+
+        self._reg(tmp_path, "---\nname: foo\ndescription: broken\n")
+        result = json.loads(skill_view("myplugin:foo"))
+
+        assert result["success"] is False
+        assert "invalid frontmatter" in result["error"].lower()
+
+    def test_support_file_uses_qualified_bound_reader(self, tmp_path):
+        from tools.skills_tool import skill_view
+
+        self._reg(tmp_path, "---\nname: foo\n---\nBody.\n")
+        package = tmp_path / "plugins" / "myplugin" / "skills" / "foo"
+        references = package / "references"
+        references.mkdir()
+        (references / "guide.md").write_text("BOUND GUIDE", encoding="utf-8")
+
+        result = json.loads(
+            skill_view("myplugin:foo", file_path="references/guide.md")
+        )
+
+        assert result["success"] is True
+        assert result["name"] == "myplugin:foo"
+        assert result["content"] == "BOUND GUIDE"
+
+    def test_support_file_traversal_is_refused(self, tmp_path):
+        from tools.skills_tool import skill_view
+
+        self._reg(tmp_path, "---\nname: foo\n---\nBody.\n")
+        result = json.loads(
+            skill_view("myplugin:foo", file_path="../outside.txt")
+        )
+
+        assert result["success"] is False
+        assert "not safely readable" in result["error"]
+
+    def test_package_replacement_between_snapshot_and_inline_is_refused(
+        self, tmp_path, monkeypatch
+    ):
+        """A registry path cannot redirect preprocessing to a replacement dir."""
+        from tools.skills_tool import skill_view
+
+        self._reg(
+            tmp_path,
+            "---\nname: foo\ndescription: foo\n---\nMarker: !`cat marker.txt`\n",
+        )
+        package = tmp_path / "plugins" / "myplugin" / "skills" / "foo"
+        (package / "marker.txt").write_text("ORIGINAL", encoding="utf-8")
+        replacement = tmp_path / "replacement-plugin-skill"
+        replacement.mkdir()
+        (replacement / "SKILL.md").write_text(
+            "---\nname: foo\ndescription: replacement\n---\nMarker: REPLACEMENT\n",
+            encoding="utf-8",
+        )
+        swapped = False
+
+        def swap_before_inline():
+            nonlocal swapped
+            if not swapped:
+                swapped = True
+                displaced = package.with_name("foo-original")
+                package.rename(displaced)
+                replacement.rename(package)
+            return {
+                "template_vars": True,
+                "inline_shell": True,
+                "inline_shell_timeout": 5,
+            }
+
+        monkeypatch.setattr(
+            "agent.skill_preprocessing.load_skills_config", swap_before_inline
+        )
+        result = json.loads(skill_view("myplugin:foo"))
+
+        assert swapped is True
+        assert result["success"] is False
+        assert "REPLACEMENT" not in json.dumps(result)
+
+    def test_inline_caller_defers_template_vars_to_bound_expander(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.skills_tool import skill_view
+
+        self._reg(
+            tmp_path,
+            (
+                "---\nname: foo\ndescription: foo\n---\n"
+                "Visible: ${HERMES_SKILL_DIR}\n"
+                "Marker: !`cat ${HERMES_SKILL_DIR}/marker.txt`\n"
+                "Session: ${HERMES_SESSION_ID}\n"
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.skill_preprocessing.load_skills_config",
+            lambda: {
+                "template_vars": True,
+                "inline_shell": True,
+                "inline_shell_timeout": 7,
+            },
+        )
+        with patch(
+            "tools.skills_tool._expand_inline_shell_bound",
+            return_value="BOUND",
+        ) as expand:
+            result = json.loads(
+                skill_view("myplugin:foo", task_id="session-123")
+            )
+
+        assert result["success"] is True
+        assert result["content"].endswith("BOUND")
+        raw_content, _package_handle, timeout = expand.call_args.args
+        assert "${HERMES_SKILL_DIR}" in raw_content
+        assert "${HERMES_SESSION_ID}" in raw_content
+        assert timeout == 7
+        assert expand.call_args.kwargs["session_id"] == "session-123"
+        assert expand.call_args.kwargs["template_vars"] is True
 
 
 class TestBundleContextBanner:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -118,6 +118,93 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
         server._sessions.pop(sid, None)
 
 
+def test_context_breakdown_without_live_agent_marks_fallback_as_estimated():
+    sid = "context-breakdown-fallback"
+    server._sessions[sid] = {"agent": None}
+    try:
+        response = server._methods["session.context_breakdown"](
+            "context-1",
+            {"session_id": sid},
+        )
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert response["result"]["context_used_estimated"] is True
+
+
+def test_context_breakdown_without_live_agent_never_uses_cumulative_total():
+    sid = "context-breakdown-cumulative-total"
+    server._sessions[sid] = {
+        "agent": None,
+        "_metadata_mirror": {
+            "usage": {
+                "total": 1_900_000,
+                "context_max": 120_000,
+            }
+        },
+    }
+    try:
+        response = server._methods["session.context_breakdown"](
+            "context-2",
+            {"session_id": sid},
+        )
+    finally:
+        server._sessions.pop(sid, None)
+
+    result = response["result"]
+    assert result["context_used"] == 0
+    assert result["estimated_total"] == 0
+    assert result["context_percent"] == 0
+    assert result["context_used_estimated"] is True
+
+
+def test_context_breakdown_without_live_agent_preserves_measured_window_usage():
+    sid = "context-breakdown-measured-window"
+    server._sessions[sid] = {
+        "agent": None,
+        "_metadata_mirror": {
+            "usage": {
+                "total": 300_600,
+                "context_used": 128_200,
+                "context_max": 272_000,
+                "context_percent": 47,
+            }
+        },
+    }
+    try:
+        response = server._methods["session.context_breakdown"](
+            "context-3",
+            {"session_id": sid},
+        )
+    finally:
+        server._sessions.pop(sid, None)
+
+    result = response["result"]
+    assert result["context_used"] == 128_200
+    assert result["estimated_total"] == 128_200
+    assert result["context_percent"] == 47
+    assert result["context_used_estimated"] is False
+
+
+def test_live_context_output_never_uses_cumulative_total():
+    session = {
+        "history": [],
+        "history_lock": threading.RLock(),
+        "session_key": "",
+        "_metadata_mirror": {
+            "usage": {
+                "total": 1_900_000,
+                "context_max": 120_000,
+            }
+        },
+    }
+
+    output = server._format_live_context_output(session)
+
+    assert "Context usage:" not in output
+    assert "1,900,000" not in output
+
+
 def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
     class DbContext:
         def __init__(self, db):
@@ -662,8 +749,10 @@ def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
     server._sessions[sid] = session
     try:
         server._start_agent_build(sid, session)
-        assert built.wait(timeout=2)
+        assert ready.wait(timeout=2)
+        assert built.is_set()
     finally:
+        server._teardown_session(session)
         server._sessions.pop(sid, None)
 
     assert seen == [str(profile_home)]
@@ -717,11 +806,573 @@ def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path)
     server._sessions[sid] = session
     try:
         server._start_agent_build(sid, session)
-        assert built.wait(timeout=2)
+        assert ready.wait(timeout=2)
+        assert built.is_set()
     finally:
+        server._teardown_session(session)
         server._sessions.pop(sid, None)
 
     assert scopes == [{"PROXMOX_TOKEN": "grace-secret"}]
+
+
+def test_agent_build_reaped_midflight_emits_nothing_and_closes_orphan(
+    monkeypatch,
+):
+    entered = threading.Event()
+    release = threading.Event()
+    ready = threading.Event()
+    emitted = []
+
+    class Agent:
+        model = "test"
+
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    agent = Agent()
+
+    def make_agent(*_args, **_kwargs):
+        entered.set()
+        assert release.wait(timeout=2)
+        return agent
+
+    monkeypatch.setattr(server, "_make_agent", make_agent)
+    monkeypatch.setattr(
+        "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(
+        server,
+        "_start_notification_poller",
+        lambda *_args: pytest.fail("reaped session started a poller"),
+    )
+    monkeypatch.setattr(
+        server,
+        "_notify_session_boundary",
+        lambda *_args: pytest.fail("reaped session emitted a boundary"),
+    )
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda *args: emitted.append(args),
+    )
+
+    sid = "reaped-during-build"
+    session = {
+        "agent_ready": ready,
+        "session_key": "reaped-key",
+    }
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert entered.wait(timeout=2)
+        server._sessions.pop(sid, None)
+        release.set()
+        assert ready.wait(timeout=2)
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)
+
+    assert emitted == []
+    assert agent.closed is True
+
+
+def test_agent_build_worker_rejects_sid_reused_before_thread_runs(monkeypatch):
+    """A queued build belongs to the exact record passed by its caller."""
+    ready = threading.Event()
+    captured = {}
+    built_with = []
+    sid = "reused-before-build-thread"
+    session = {
+        "agent_ready": ready,
+        "session_key": "old-key",
+    }
+    replacement = {"session_key": "replacement-key"}
+
+    class DeferredThread:
+        def __init__(self, *, target, daemon, **_kwargs):
+            captured["target"] = target
+            self.daemon = daemon
+
+        def start(self):
+            captured["started"] = True
+
+    monkeypatch.setattr(server.threading, "Thread", DeferredThread)
+    monkeypatch.setattr(
+        server,
+        "_make_agent",
+        lambda *_args, **_kwargs: built_with.append("old-key"),
+    )
+
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert captured["started"] is True
+        server._sessions[sid] = replacement
+
+        captured["target"]()
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert ready.is_set()
+    assert built_with == []
+    assert "agent" not in replacement
+    assert "_agent_build_publish_lock" not in replacement
+
+
+def test_deferred_credits_notice_rejects_reused_sid_and_new_transport(
+    monkeypatch,
+):
+    """A late notice belongs to the exact session record and agent that seeded it."""
+    from agent import credits_tracker
+    from tools import approval
+
+    notice_waiting = threading.Event()
+    release_notice = threading.Event()
+    notice_done = threading.Event()
+    ready = threading.Event()
+    notice_thread = None
+
+    class RecordingTransport:
+        def __init__(self):
+            self.frames = []
+
+        def write(self, frame):
+            self.frames.append(frame)
+            return True
+
+    class Agent:
+        model = "test"
+
+        def close(self):
+            return None
+
+    def make_agent(
+        build_sid,
+        _key,
+        *,
+        _callback_session=None,
+        **_kwargs,
+    ):
+        identity = server._new_agent_callback_binding(
+            build_sid, _callback_session
+        )
+        callbacks = server._agent_notice_cbs(build_sid, identity)
+        built_agent = Agent()
+        built_agent.notice_callback = callbacks["notice_callback"]
+        built_agent.notice_clear_callback = callbacks["notice_clear_callback"]
+        identity["agent"] = built_agent
+        built_agent._tui_callback_identity = identity
+        return built_agent
+
+    def seed_credits(agent):
+        nonlocal notice_thread
+
+        def late_notice():
+            notice_waiting.set()
+            assert release_notice.wait(timeout=2)
+            agent.notice_callback(
+                types.SimpleNamespace(
+                    text="old session credits",
+                    level="warn",
+                    kind="sticky",
+                    ttl_ms=None,
+                    key="credits.old",
+                    id="credits.old",
+                )
+            )
+            notice_done.set()
+
+        notice_thread = threading.Thread(target=late_notice, daemon=True)
+        notice_thread.start()
+        return True
+
+    monkeypatch.setattr(server, "_make_agent", make_agent)
+    monkeypatch.setattr(
+        "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(server, "_load_memory_notifications", lambda: "off")
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_args: threading.Event()
+    )
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *_args: None)
+    monkeypatch.setattr(server, "_probe_config_health", lambda _cfg: None)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(credits_tracker, "seed_credits_at_session_start", seed_credits)
+    monkeypatch.setattr(approval, "register_gateway_notify", lambda *_args: None)
+    monkeypatch.setattr(approval, "load_permanent_allowlist", lambda: None)
+    monkeypatch.setattr(approval, "unregister_gateway_notify", lambda *_args: None)
+
+    sid = "credits-sid-reuse"
+    old_transport = RecordingTransport()
+    new_transport = RecordingTransport()
+    old_session = {
+        "agent_ready": ready,
+        "session_key": "old-credits-key",
+        "transport": old_transport,
+    }
+    replacement = {
+        "agent": object(),
+        "session_key": "new-credits-key",
+        "transport": new_transport,
+    }
+
+    server._sessions[sid] = old_session
+    try:
+        server._start_agent_build(sid, old_session)
+        assert notice_waiting.wait(timeout=2)
+        assert ready.wait(timeout=2)
+        assert server._pop_session_by_id(sid) is old_session
+        server._sessions[sid] = replacement
+
+        release_notice.set()
+        assert notice_done.wait(timeout=2)
+    finally:
+        release_notice.set()
+        if notice_thread is not None:
+            notice_thread.join(timeout=2)
+        server._sessions.pop(sid, None)
+
+    # The old build may publish its own ready frame before reap, but its late
+    # credits callback must be completely silent on the replacement transport.
+    assert old_transport.frames
+    assert new_transport.frames == []
+
+
+def test_agent_build_reaped_between_boundary_and_info_emits_nothing(
+    monkeypatch,
+):
+    """A reap/reuse after the old gate must suppress the later info frame."""
+    ready = threading.Event()
+    emitted = []
+
+    class Agent:
+        model = "test"
+
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    agent = Agent()
+    sid = "reaped-after-boundary"
+    session = {"agent_ready": ready, "session_key": "reaped-boundary-key"}
+    replacement = {"session_key": "new-owner"}
+
+    monkeypatch.setattr(server, "_make_agent", lambda *_args, **_kwargs: agent)
+    monkeypatch.setattr(
+        "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_args: threading.Event()
+    )
+    monkeypatch.setattr(
+        server,
+        "_notify_session_boundary",
+        # The old still_attached gate has already passed when the boundary
+        # hook runs. Reap and immediately reuse the sid so key-presence checks
+        # would publish this build's info to the wrong live session.
+        lambda *_args: server._sessions.__setitem__(sid, replacement),
+    )
+    monkeypatch.setattr(
+        server,
+        "_schedule_mcp_late_refresh",
+        lambda *_args: pytest.fail("reaped session scheduled a late refresh"),
+    )
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert ready.wait(timeout=2)
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert emitted == []
+    assert agent.closed is True
+
+
+def test_agent_build_exception_after_reap_suppresses_ghost_error(monkeypatch):
+    """An init failure after reap closes its agent but emits no stale error."""
+    ready = threading.Event()
+    emitted = []
+
+    class Agent:
+        model = "test"
+
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    agent = Agent()
+    sid = "reaped-before-build-error"
+    session = {"agent_ready": ready, "session_key": "reaped-error-key"}
+
+    monkeypatch.setattr(server, "_make_agent", lambda *_args, **_kwargs: agent)
+    monkeypatch.setattr(
+        "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_args: threading.Event()
+    )
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+
+    def reap_then_fail(*_args, **_kwargs):
+        server._sessions.pop(sid, None)
+        raise RuntimeError("post-reap init failure")
+
+    monkeypatch.setattr(server, "_session_info", reap_then_fail)
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert ready.wait(timeout=2)
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert emitted == []
+    assert agent.closed is True
+
+
+def test_agent_build_boundary_and_reap_are_linearized(monkeypatch):
+    """A real reap waits for an in-flight boundary, then suppresses later work."""
+    boundary_entered = threading.Event()
+    release_boundary = threading.Event()
+    reap_started = threading.Event()
+    reaped = threading.Event()
+    ready = threading.Event()
+    emitted = []
+
+    class Agent:
+        model = "test"
+
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    agent = Agent()
+    sid = "reap-during-boundary"
+    session = {"agent_ready": ready, "session_key": "boundary-key"}
+
+    monkeypatch.setattr(server, "_make_agent", lambda *_args, **_kwargs: agent)
+    monkeypatch.setattr(
+        "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_args: threading.Event()
+    )
+
+    def hold_boundary(*_args):
+        boundary_entered.set()
+        assert release_boundary.wait(timeout=2)
+
+    monkeypatch.setattr(server, "_notify_session_boundary", hold_boundary)
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    def reap():
+        reap_started.set()
+        server._pop_session_by_id(sid)
+        reaped.set()
+
+    server._sessions[sid] = session
+    reap_thread = None
+    try:
+        server._start_agent_build(sid, session)
+        assert boundary_entered.wait(timeout=2)
+        reap_thread = threading.Thread(target=reap)
+        reap_thread.start()
+        assert reap_started.wait(timeout=2)
+        assert not reaped.wait(timeout=0.05)
+        release_boundary.set()
+        assert reaped.wait(timeout=2)
+        assert ready.wait(timeout=2)
+    finally:
+        release_boundary.set()
+        if reap_thread is not None:
+            reap_thread.join(timeout=2)
+        server._sessions.pop(sid, None)
+
+    assert emitted == []
+    assert agent.closed is True
+
+
+def test_reaper_rechecks_publish_lock_installed_between_registry_reads(
+    monkeypatch,
+):
+    """A late lock installation must close the reaper's no-lock window."""
+    first_registry_read_done = threading.Event()
+    allow_second_registry_read = threading.Event()
+    publish_lock_requested = threading.Event()
+    real_registry_lock = threading.RLock()
+
+    class RegistryLock:
+        def __init__(self):
+            self.entries = 0
+
+        def __enter__(self):
+            real_registry_lock.acquire()
+            self.entries += 1
+            return self
+
+        def __exit__(self, *_exc):
+            first = self.entries == 1
+            real_registry_lock.release()
+            if first:
+                first_registry_read_done.set()
+                assert allow_second_registry_read.wait(timeout=2)
+
+    real_publish_lock = threading.RLock()
+
+    class PublishLock:
+        def __enter__(self):
+            publish_lock_requested.set()
+            real_publish_lock.acquire()
+            return self
+
+        def __exit__(self, *_exc):
+            real_publish_lock.release()
+
+    sid = "publish-lock-installed-late"
+    session = {"session_key": "old-key"}
+    result = {}
+    server._sessions[sid] = session
+    monkeypatch.setattr(server, "_sessions_lock", RegistryLock())
+
+    def reap():
+        result["session"] = server._pop_session_by_id(sid)
+
+    reap_thread = threading.Thread(target=reap)
+    real_publish_lock.acquire()
+    try:
+        reap_thread.start()
+        assert first_registry_read_done.wait(timeout=2)
+        session["_agent_build_publish_lock"] = PublishLock()
+        allow_second_registry_read.set()
+        assert publish_lock_requested.wait(timeout=2)
+        assert server._sessions.get(sid) is session
+        assert reap_thread.is_alive()
+    finally:
+        real_publish_lock.release()
+        allow_second_registry_read.set()
+        reap_thread.join(timeout=2)
+        server._sessions.pop(sid, None)
+
+    assert result["session"] is session
+
+
+def test_late_mcp_refresh_rejects_sid_reused_before_worker_runs(monkeypatch):
+    """A queued refresh cannot rediscover a replacement by the same id."""
+    from tui_gateway import entry
+    from tools import mcp_tool
+
+    captured = {}
+    refreshed = []
+    emitted = []
+    sid = "reused-before-late-refresh"
+    agent = type("Agent", (), {"_user_turn_count": 0, "_api_call_count": 0})()
+    session = {"agent": agent, "session_key": "old-key"}
+    replacement = {"agent": object(), "session_key": "replacement-key"}
+
+    class DeferredThread:
+        def __init__(self, *, target, name, daemon):
+            captured["target"] = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            captured["started"] = True
+
+    monkeypatch.setattr(server.threading, "Thread", DeferredThread)
+    monkeypatch.setattr(entry, "mcp_discovery_in_flight", lambda: True)
+    monkeypatch.setattr(entry, "join_mcp_discovery", lambda timeout=None: True)
+    monkeypatch.setattr(
+        mcp_tool,
+        "refresh_agent_mcp_tools",
+        lambda *_args, **_kwargs: refreshed.append(True),
+    )
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    server._sessions[sid] = session
+    try:
+        server._schedule_mcp_late_refresh(sid, agent, session)
+        assert captured["started"] is True
+        server._sessions[sid] = replacement
+
+        captured["target"]()
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert refreshed == []
+    assert emitted == []
+    assert "tools" not in replacement
+
+
+def test_late_mcp_refresh_rechecks_identity_after_refresh(monkeypatch):
+    """A non-funnel replacement during refresh still suppresses stale info."""
+    from tui_gateway import entry
+    from tools import mcp_tool
+
+    captured = {}
+    emitted = []
+    sid = "reused-during-late-refresh"
+    agent = type("Agent", (), {"_user_turn_count": 0, "_api_call_count": 0})()
+    session = {"agent": agent, "session_key": "old-key"}
+    replacement = {"agent": object(), "session_key": "replacement-key"}
+
+    class DeferredThread:
+        def __init__(self, *, target, name, daemon):
+            captured["target"] = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            pass
+
+    def replace_during_refresh(*_args, **_kwargs):
+        server._sessions[sid] = replacement
+        return ["mcp__late__tool"]
+
+    monkeypatch.setattr(server.threading, "Thread", DeferredThread)
+    monkeypatch.setattr(entry, "mcp_discovery_in_flight", lambda: True)
+    monkeypatch.setattr(entry, "join_mcp_discovery", lambda timeout=None: True)
+    monkeypatch.setattr(
+        mcp_tool, "refresh_agent_mcp_tools", replace_during_refresh
+    )
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda *_args: pytest.fail("stale session info was derived"),
+    )
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    server._sessions[sid] = session
+    try:
+        server._schedule_mcp_late_refresh(sid, agent, session)
+        captured["target"]()
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert emitted == []
+    assert "tools" not in replacement
 
 
 def test_profile_configured_cwd_reads_target_profile(tmp_path):
@@ -4316,10 +4967,10 @@ def test_completion_ownership_lineage_lookup_failure_fails_closed(monkeypatch):
         {"origin_ui_session_id": "missing-owner-sid"},
     ],
 )
-def test_notification_poller_live_loop_drops_addressed_orphan(
+def test_notification_poller_live_loop_requeues_addressed_owner_gap(
     monkeypatch, routing
 ):
-    """A live poll never injects an addressed event whose owner is gone."""
+    """A live poll preserves an addressed event while its owner is absent."""
     import queue as _queue_mod
 
     from tools.process_registry import process_registry
@@ -4355,7 +5006,7 @@ def test_notification_poller_live_loop_drops_addressed_orphan(
 
         assert delivered == []
         assert emitted == []
-        assert isolated_queue.empty()
+        assert isolated_queue.qsize() == 1
     finally:
         server._sessions.pop("sid-live-orphan", None)
         process_registry._completion_consumed.discard(event["session_id"])
@@ -4370,8 +5021,8 @@ def test_notification_poller_live_loop_drops_addressed_orphan(
         {"origin_ui_session_id": "sid_gone"},
     ],
 )
-def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
-    """Addressed completions whose owner is gone are dropped, not hijacked."""
+def test_notification_poller_requeues_orphaned_events(monkeypatch, routing):
+    """Addressed completions whose owner is gone are preserved, not hijacked."""
     import queue as _queue_mod
 
     from tools.process_registry import process_registry
@@ -4410,19 +5061,217 @@ def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
 
         assert [a for a in emitted if a[0] == "status.update"] == []
         assert delivered == []
+        assert isolated_queue.qsize() == 1
     finally:
         server._sessions.pop("sid_a", None)
         while not process_registry.completion_queue.empty():
             process_registry.completion_queue.get_nowait()
 
 
+def test_notification_poller_delivers_requeued_event_after_durable_owner_recovers(monkeypatch):
+    """A temporary owner gap preserves one completion for the resumed owner."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    event = {
+        "type": "completion",
+        "session_id": "recoverable-owner-event",
+        "session_key": "durable-owner-key",
+        "command": "echo recover",
+        "exit_code": 0,
+        "output": "recover",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    delivered = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text: delivered.append(text),
+    )
+    process_registry._completion_consumed.discard(event["session_id"])
+    isolated_queue.put(event)
+
+    unrelated = _session(agent=types.SimpleNamespace(), session_key="unrelated-key")
+    recovered = _session(agent=types.SimpleNamespace(), session_key="durable-owner-key")
+    server._sessions["unrelated-sid"] = unrelated
+    try:
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "unrelated-sid", unrelated
+        )
+        assert isolated_queue.qsize() == 1
+        assert delivered == []
+
+        server._sessions.pop("unrelated-sid", None)
+        server._sessions["recovered-sid"] = recovered
+        stop = threading.Event()
+        stop.set()
+        server._notification_poller_loop(stop, "recovered-sid", recovered)
+        assert len(delivered) == 1
+        assert isolated_queue.empty()
+
+        server._notification_poller_loop(stop, "recovered-sid", recovered)
+        assert len(delivered) == 1
+    finally:
+        server._sessions.pop("unrelated-sid", None)
+        server._sessions.pop("recovered-sid", None)
+        process_registry._completion_consumed.discard(event["session_id"])
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+@pytest.mark.parametrize("shutdown_drain", [False, True])
+def test_notification_requeue_reservation_follows_compression_lineage(
+    monkeypatch, shutdown_drain
+):
+    """An owner-gap reservation for P must permit its compressed child C."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    class _CompressionDB:
+        def resolve_resume_session_id(self, key):
+            return "child-key" if key == "parent-key" else key
+
+    event = {
+        "type": "completion",
+        "session_id": f"compression-reservation-{shutdown_drain}",
+        "session_key": "parent-key",
+        "_tui_requeue_session_key": "parent-key",
+        "command": "echo compressed",
+        "exit_code": 0,
+        "output": "compressed",
+    }
+    delivered = []
+    child = _session(agent=types.SimpleNamespace(), session_key="child-key")
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_get_db", lambda: _CompressionDB())
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *_args, **_kwargs: delivered.append(True),
+    )
+    server._sessions["compressed-owner-sid"] = child
+    process_registry._completion_consumed.discard(event["session_id"])
+    try:
+        stop = threading.Event() if shutdown_drain else _StopAfterOneNotificationPoll()
+        if shutdown_drain:
+            stop.set()
+        server._notification_poller_loop(stop, "compressed-owner-sid", child)
+        assert delivered == [True]
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("compressed-owner-sid", None)
+        process_registry._completion_consumed.discard(event["session_id"])
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_notification_poller_recovers_origin_only_event_without_unrelated_key(monkeypatch):
+    """Origin-only owner gaps wait for that SID, never an observer's key."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    event = {
+        "type": "completion",
+        "session_id": "origin-only-recoverable",
+        "origin_ui_session_id": "original-owner-sid",
+        "command": "echo origin",
+        "exit_code": 0,
+        "output": "origin",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    delivered = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text: delivered.append(text),
+    )
+    process_registry._completion_consumed.discard(event["session_id"])
+    isolated_queue.put(event)
+
+    observer = _session(agent=types.SimpleNamespace(), session_key="unrelated-key")
+    recovered = _session(agent=types.SimpleNamespace(), session_key="different-new-key")
+    server._sessions["observer-sid"] = observer
+    try:
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "observer-sid", observer
+        )
+        queued = isolated_queue.get_nowait()
+        assert queued["_tui_requeue_origin_sid"] == "original-owner-sid"
+        assert "_tui_requeue_session_key" not in queued
+        isolated_queue.put(queued)
+
+        server._sessions.pop("observer-sid", None)
+        server._sessions["original-owner-sid"] = recovered
+        stop = threading.Event()
+        stop.set()
+        server._notification_poller_loop(stop, "original-owner-sid", recovered)
+        assert len(delivered) == 1
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("observer-sid", None)
+        server._sessions.pop("original-owner-sid", None)
+        process_registry._completion_consumed.discard(event["session_id"])
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_notification_poller_same_sid_replacement_cannot_take_requeued_event(monkeypatch):
+    """A replacement short SID cannot adopt an event reserved for old key."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    event = {
+        "type": "completion",
+        "session_id": "replacement-must-not-take",
+        "session_key": "old-durable-key",
+        "_tui_requeue_session_key": "old-durable-key",
+        "command": "echo old",
+        "exit_code": 0,
+        "output": "old",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    delivered = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *_args, **_kwargs: delivered.append(True),
+    )
+    replacement = _session(agent=types.SimpleNamespace(), session_key="replacement-key")
+    isolated_queue.put(event)
+    server._sessions["reused-sid"] = replacement
+    stop = threading.Event()
+    stop.set()
+    try:
+        server._notification_poller_loop(stop, "reused-sid", replacement)
+        assert delivered == []
+        assert isolated_queue.qsize() == 1
+    finally:
+        server._sessions.pop("reused-sid", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 @pytest.mark.parametrize(
-    ("routing", "resolved_key"),
+        ("routing", "resolved_key"),
     [
         ({"session_key": "session-a"}, None),
         (
             {
-                "session_key": "stale-durable-key",
                 "origin_ui_session_id": "sid_a",
             },
             None,
@@ -4485,6 +5334,162 @@ def test_notification_poller_delivers_owned_events(
             process_registry.completion_queue.get_nowait()
 
 
+def test_notification_poller_requeues_when_sid_reused_after_status_emit(monkeypatch):
+    """A paused old poller cannot inject its completion into a SID replacement."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    sid = "poller-sid-reuse"
+    old_session = _session(agent=types.SimpleNamespace(model="old"), session_key="old-key")
+    replacement = _session(
+        agent=types.SimpleNamespace(model="replacement"), session_key="new-key"
+    )
+    emitted = []
+    dispatched = []
+    reaped = threading.Event()
+    reapers = []
+    original_emit_bound = server._emit_bound_agent_event
+
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *_args, **_kwargs: dispatched.append(_args),
+    )
+
+    def pause_after_status(binding, event, payload):
+        result = original_emit_bound(binding, event, payload)
+        if event == "status.update":
+            reaper = threading.Thread(target=reap_and_reuse)
+            reapers.append(reaper)
+            reaper.start()
+            assert reaped.wait(timeout=2)
+        return result
+
+    monkeypatch.setattr(server, "_emit_bound_agent_event", pause_after_status)
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    isolated_queue.put(
+        {
+            "type": "completion",
+            "session_id": "reuse-proc",
+            "command": "echo old",
+            "exit_code": 0,
+            "output": "old",
+        }
+    )
+    server._sessions[sid] = old_session
+    stop = threading.Event()
+    stop.set()  # Exercise the deterministic shutdown-drain delivery path once.
+
+    def reap_and_reuse():
+        assert server._pop_session_by_id(sid) is old_session
+        server._sessions[sid] = replacement
+        reaped.set()
+
+    try:
+        server._notification_poller_loop(stop, sid, old_session)
+    finally:
+        for reaper in reapers:
+            reaper.join(timeout=2)
+        server._sessions.pop(sid, None)
+
+    assert reaped.is_set()
+    assert dispatched == []
+    assert replacement["running"] is False
+    assert not isolated_queue.empty()
+
+
+def test_notification_turn_reuse_drops_late_frames_and_requeues_claim(monkeypatch, tmp_path):
+    """A worker that outlives SID replacement cannot complete or leak its event."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path, immediate_threads=False)
+    entered = threading.Event()
+    release = threading.Event()
+
+    class _RecordingTransport:
+        def __init__(self):
+            self.frames = []
+
+        def write(self, frame):
+            self.frames.append(frame)
+            return True
+
+    class _BlockedAgent(_RecordingAgent):
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+            entered.set()
+            assert release.wait(timeout=5)
+            if stream_callback is not None:
+                stream_callback("late old output")
+            return {"final_response": "late old output", "messages": []}
+
+    old_transport = _RecordingTransport()
+    replacement_transport = _RecordingTransport()
+    turns = []
+    sid = "notification-turn-reuse"
+    old_session = _session(
+        agent=_BlockedAgent(turns),
+        session_key="old-notification-key",
+        transport=old_transport,
+    )
+    replacement = _session(
+        agent=_RecordingAgent([]),
+        session_key="replacement-notification-key",
+        transport=replacement_transport,
+    )
+    event = {
+        "type": "completion",
+        "session_id": "blocked-notification-event",
+        "session_key": "old-notification-key",
+        "command": "echo old",
+        "exit_code": 0,
+        "output": "old",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event_name, event_sid, payload=None: server.write_json(
+            server._event_frame(event_name, event_sid, payload)
+        ),
+    )
+    server._sessions[sid] = old_session
+    process_registry._completion_consumed.discard(event["session_id"])
+    try:
+        stop = threading.Event()
+        stop.set()
+        server._notification_poller_loop(stop, sid, old_session)
+        assert entered.wait(timeout=5)
+
+        server._sessions[sid] = replacement
+        release.set()
+        worker = old_session["_run_thread"]
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+
+        assert replacement_transport.frames == []
+        assert not process_registry.is_completion_consumed(event["session_id"])
+        assert any(
+            queued.get("session_id") == event["session_id"]
+            for queued in list(isolated_queue.queue)
+        )
+    finally:
+        release.set()
+        worker = old_session.get("_run_thread")
+        if worker is not None:
+            worker.join(timeout=5)
+        server._sessions.pop(sid, None)
+        process_registry._completion_consumed.discard(event["session_id"])
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 def _configure_immediate_prompt_run(
     monkeypatch, tmp_path, *, immediate_threads=True
 ):
@@ -4518,6 +5523,525 @@ def _configure_immediate_prompt_run(
     monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_args: False)
     monkeypatch.setattr(server, "_voice_tts_enabled", lambda: False)
     monkeypatch.setattr(server, "_get_db", lambda: None)
+
+
+@pytest.mark.parametrize(
+    ("outcome", "result"),
+    [
+        ("success", {"final_response": "done", "messages": []}),
+        ("returned_error", {"final_response": "", "error": "provider failed", "messages": []}),
+        ("interrupted", {"final_response": "partial", "interrupted": True, "messages": []}),
+        ("blocked", None),
+    ],
+)
+def test_notification_turn_only_completes_successful_results(
+    monkeypatch, tmp_path, outcome, result
+):
+    """Every non-success notification outcome releases and requeues its claim."""
+    import queue as _queue_mod
+
+    from tools import async_delegation
+    from tools.process_registry import process_registry
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    calls = {"complete": [], "release": [], "runs": []}
+
+    class _Agent:
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(self, prompt, **_kwargs):
+            calls["runs"].append(prompt)
+            return result
+
+    sid = f"notification-{outcome}"
+    session = _session(agent=_Agent(), session_key=f"{outcome}-key")
+    event = {"type": "completion", "session_id": f"{outcome}-event"}
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        async_delegation,
+        "complete_event_delivery",
+        lambda *args: calls["complete"].append(args) or True,
+    )
+    monkeypatch.setattr(
+        async_delegation,
+        "release_event_delivery",
+        lambda *args: calls["release"].append(args),
+    )
+    if outcome == "blocked":
+        monkeypatch.setattr(
+            "agent.context_references.preprocess_context_references",
+            lambda *_args, **_kwargs: types.SimpleNamespace(
+                blocked=True, warnings=["blocked for test"]
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.model_metadata.get_model_context_length", lambda *_args, **_kwargs: 1
+        )
+
+    server._sessions[sid] = session
+    try:
+        binding = server._notification_session_binding(sid, session)
+        assert binding is not None
+        server._start_bound_notification_turn(
+            "rid", binding, event, object(), "@blocked" if outcome == "blocked" else "notice"
+        )
+
+        if outcome == "success":
+            assert len(calls["complete"]) == 1
+            assert calls["release"] == []
+            assert isolated_queue.empty()
+        else:
+            assert calls["complete"] == []
+            assert len(calls["release"]) == 1
+            assert isolated_queue.get_nowait() is event
+            assert isolated_queue.empty()
+        assert session["running"] is False
+        assert calls["runs"] == ([] if outcome == "blocked" else ["notice"])
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_complete_event_delivery_requires_durable_ack_but_keeps_empty_claim_compatibility(
+    monkeypatch,
+):
+    """Only durable async-delegation claims need a successful DB acknowledgement."""
+    from tools import async_delegation
+
+    acknowledgements = []
+    monkeypatch.setattr(
+        async_delegation,
+        "complete_completion_delivery",
+        lambda *args: acknowledgements.append(args) or True,
+    )
+    assert async_delegation.complete_event_delivery(
+        {"type": "async_delegation", "delegation_id": "delegation"}, "claim"
+    ) is True
+    assert acknowledgements == [("delegation", "claim")]
+    monkeypatch.setattr(
+        async_delegation, "complete_completion_delivery", lambda *_args: False
+    )
+    assert async_delegation.complete_event_delivery(
+        {"type": "async_delegation", "delegation_id": "delegation"}, "claim"
+    ) is False
+    assert async_delegation.complete_event_delivery(
+        {"type": "completion", "session_id": "process"}, ""
+    ) is True
+
+
+@pytest.mark.parametrize("terminal_state", ["delivered", "dropped"])
+@pytest.mark.parametrize("prune_terminal_row", [False, True])
+def test_notification_claim_rollover_terminal_event_converges_without_duplicate_turn(
+    monkeypatch, tmp_path, terminal_state, prune_terminal_row
+):
+    """A stale claimant must not replay an event consumed by its successor.
+
+    This is the real SQLite sequence from the cross-process rollover race:
+    claimant A pauses past the lease, claimant B takes over and terminally
+    consumes the durable row, then A's late release loses its CAS.  The stale
+    in-memory event must converge instead of being requeued forever or injected
+    into a second agent turn.
+    """
+    import queue as _queue_mod
+    import sqlite3
+
+    from tools import async_delegation
+    from tools.process_registry import process_registry
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    event = {
+        "type": "async_delegation",
+        "delegation_id": f"rollover-{terminal_state}",
+        "session_key": "rollover-owner",
+        "status": "completed",
+        "completed_at": 2.0,
+    }
+    async_delegation._persist_dispatch(
+        {
+            "delegation_id": event["delegation_id"],
+            "session_key": event["session_key"],
+            "origin_ui_session_id": "",
+            "parent_session_id": None,
+            "dispatched_at": 1.0,
+        }
+    )
+    async_delegation._persist_completion(
+        event, {"status": "completed", "summary": "done"}
+    )
+
+    claim_a = async_delegation.claim_event_delivery(event, "claimant-a")
+    assert claim_a
+    busy = async_delegation.claim_event_delivery_state(event, "busy-contender")
+    assert busy.state == "busy_pending"
+    assert busy.claim_id == ""
+    legacy = async_delegation.claim_event_delivery_state(
+        {"type": "completion", "session_id": "legacy-process"}, "legacy"
+    )
+    assert legacy.state == "legacy_non_durable"
+    assert legacy.claim_id == ""
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        conn.execute(
+            """UPDATE async_delegations SET delivery_claimed_at=0
+               WHERE delegation_id=?""",
+            (event["delegation_id"],),
+        )
+
+    claim_b = async_delegation.claim_event_delivery_state(event, "claimant-b")
+    assert claim_b.state == "claimed"
+    assert claim_b.claim_id
+    if terminal_state == "delivered":
+        assert async_delegation.complete_event_delivery(event, claim_b.claim_id)
+    else:
+        assert async_delegation.drop_completion_delivery(
+            event["delegation_id"], claim_b.claim_id
+        )
+    consumed = async_delegation.claim_event_delivery_state(event, "late-contender")
+    assert consumed.state == "terminal_consumed"
+    assert consumed.claim_id == ""
+
+    # A no longer owns the row. A false release is expected and must not make
+    # the already-consumed durable notification live again.
+    assert not async_delegation.release_completion_delivery(
+        event["delegation_id"], claim_a
+    )
+    if prune_terminal_row:
+        with sqlite3.connect(tmp_path / "state.db") as conn:
+            conn.execute(
+                "DELETE FROM async_delegations WHERE delegation_id=?",
+                (event["delegation_id"],),
+            )
+
+    turns = []
+    sid = f"rollover-{terminal_state}-sid"
+    session = _session(
+        agent=_RecordingAgent(turns), session_key=event["session_key"]
+    )
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        server,
+        "_start_bound_notification_turn",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("terminally consumed notification was injected again")
+        ),
+    )
+    emitted = []
+    monkeypatch.setattr(
+        server,
+        "_emit_bound_agent_event",
+        lambda *args: emitted.append(args) or True,
+    )
+    assert not server._release_or_requeue_notification_event(
+        sid, session, event, claim_a
+    )
+    assert isolated_queue.empty()
+    server._sessions[sid] = session
+    try:
+        outcome = server._dispatch_poller_notification(
+            sid, session, event, "completed", set()
+        )
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert outcome == "consumed"
+    assert session["running"] is False
+    assert turns == []
+    assert emitted == []
+    assert isolated_queue.empty()
+
+
+@pytest.mark.parametrize("failure_site", ["complete", "ack_false", "release"])
+def test_notification_settlement_failures_requeue_once_and_leave_old_session_idle(
+    monkeypatch, tmp_path, failure_site
+):
+    """Settlement exceptions cannot consume the event or strand its worker busy."""
+    import queue as _queue_mod
+
+    from tools import async_delegation
+    from tools.process_registry import process_registry
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    calls = {"complete": [], "release": []}
+
+    class _Agent:
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(self, _prompt, **_kwargs):
+            if failure_site == "release":
+                return {"final_response": "", "error": "failed", "messages": []}
+            return {"final_response": "done", "messages": []}
+
+    sid = f"settlement-{failure_site}"
+    session = _session(agent=_Agent(), session_key=f"{failure_site}-key")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": f"{failure_site}-delegation",
+        "session_id": f"{failure_site}-event",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+
+    def _complete(*args):
+        calls["complete"].append(args)
+        if failure_site == "complete":
+            raise RuntimeError("completion store unavailable")
+        return failure_site != "ack_false"
+
+    def _release(*args):
+        calls["release"].append(args)
+        if failure_site == "release":
+            raise RuntimeError("release store unavailable")
+
+    monkeypatch.setattr(async_delegation, "complete_event_delivery", _complete)
+    monkeypatch.setattr(async_delegation, "release_event_delivery", _release)
+    server._sessions[sid] = session
+    try:
+        binding = server._notification_session_binding(sid, session)
+        assert binding is not None
+        server._start_bound_notification_turn("rid", binding, event, "durable-claim", "notice")
+
+        assert len(calls["complete"]) == (0 if failure_site == "release" else 1)
+        assert len(calls["release"]) == 1
+        assert session["running"] is False
+        assert isolated_queue.get_nowait() is event
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_notification_dispatch_identity_loss_after_start_settles_once(monkeypatch):
+    """A post-effect SID replacement delegates exactly one failed settlement."""
+    import queue as _queue_mod
+
+    from tools import async_delegation
+    from tools.process_registry import process_registry
+
+    sid = "notification-dispatch-reused"
+    old = _session(agent=types.SimpleNamespace(), session_key="dispatch-old-key")
+    replacement = _session(
+        agent=types.SimpleNamespace(), session_key="dispatch-new-key", running=True
+    )
+    event = {
+        "type": "completion",
+        "session_id": "notification-dispatch-reused-event",
+        "command": "echo old",
+        "exit_code": 0,
+        "output": "old",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(async_delegation, "claim_event_delivery", lambda *_args: "claim")
+    released = []
+    settles = []
+    monkeypatch.setattr(
+        async_delegation, "release_event_delivery", lambda *args: released.append(args)
+    )
+
+    def _started(_rid, _binding, settled_event, claim, _text, **_kwargs):
+        # The bound effect has executed, but its after-effect identity check
+        # must reject this same-SID replacement and settle only the old claim.
+        server._sessions[sid] = replacement
+
+        def _settle(success):
+            settles.append(success)
+            async_delegation.release_event_delivery(settled_event, claim)
+            server._requeue_notification_event(sid, old, settled_event)
+
+        return _settle
+
+    monkeypatch.setattr(server, "_start_bound_notification_turn", _started)
+    server._sessions[sid] = old
+    try:
+        assert server._dispatch_poller_notification(sid, old, event, "notice", set()) == "requeued"
+        assert settles == [False]
+        assert len(released) == 1
+        assert old["running"] is False
+        assert replacement["running"] is True
+        assert isolated_queue.get_nowait() is event
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop(sid, None)
+
+
+@pytest.mark.parametrize("claim_outcome", [None, RuntimeError("claim unavailable")])
+def test_notification_poller_claim_failure_requeues_and_stays_idle(
+    monkeypatch, claim_outcome
+):
+    """A live poller must not drop or wedge an event when claiming fails."""
+    import queue as _queue_mod
+
+    from tools import async_delegation
+    from tools.process_registry import process_registry
+
+    sid = "claim-failure-poller"
+    session = _session(agent=types.SimpleNamespace(), session_key="claim-failure-key")
+    event = {
+        "type": "completion",
+        "session_id": "claim-failure-event",
+        "command": "echo claim",
+        "exit_code": 0,
+        "output": "claim",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    def _claim(*_args):
+        if isinstance(claim_outcome, Exception):
+            raise claim_outcome
+        return claim_outcome
+
+    monkeypatch.setattr(async_delegation, "claim_event_delivery", _claim)
+    server._sessions[sid] = session
+    stop = threading.Event()
+    stop.set()
+    try:
+        server._notification_poller_loop(stop, sid, session)
+        assert session["running"] is False
+        assert isolated_queue.get_nowait() is event
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop(sid, None)
+        process_registry._completion_consumed.discard(event["session_id"])
+
+
+@pytest.mark.parametrize("claim_outcome", [None, RuntimeError("claim unavailable")])
+def test_post_turn_claim_failure_requeues_and_clears_reservation(
+    monkeypatch, tmp_path, claim_outcome
+):
+    """Post-turn draining has the same fail-closed claim contract as polling."""
+    import queue as _queue_mod
+
+    from tools import async_delegation
+    from tools.process_registry import process_registry
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    turns = []
+    session = _session(
+        agent=_RecordingAgent(turns), session_key="post-turn-claim-key", running=True
+    )
+    event = {
+        "type": "completion",
+        "session_id": "post-turn-claim-event",
+        "session_key": "post-turn-claim-key",
+        "command": "echo claim",
+        "exit_code": 0,
+        "output": "claim",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+
+    def _claim(*_args):
+        if isinstance(claim_outcome, Exception):
+            raise claim_outcome
+        return claim_outcome
+
+    monkeypatch.setattr(async_delegation, "claim_event_delivery", _claim)
+    server._sessions["post-turn-claim-sid"] = session
+    try:
+        server._run_prompt_submit("rid", "post-turn-claim-sid", session, "main turn")
+        assert turns == ["main turn"]
+        assert session["running"] is False
+        assert isolated_queue.get_nowait() is event
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("post-turn-claim-sid", None)
+        process_registry._completion_consumed.discard(event["session_id"])
+
+
+def test_post_turn_claim_identity_loss_releases_and_requeues_once(monkeypatch, tmp_path):
+    """A claim returned just before SID reuse cannot be delivered to its replacement."""
+    import queue as _queue_mod
+
+    from tools import async_delegation
+    from tools.process_registry import process_registry
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    sid = "post-turn-claim-reused-sid"
+    old = _session(
+        agent=_RecordingAgent([]), session_key="post-turn-claim-old", running=True
+    )
+    replacement = _session(
+        agent=_RecordingAgent([]), session_key="post-turn-claim-new", running=True
+    )
+    event = {
+        "type": "completion",
+        "session_id": "post-turn-claim-reused-event",
+        "session_key": "post-turn-claim-old",
+        "command": "echo old",
+        "exit_code": 0,
+        "output": "old",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    released = []
+
+    def _claim(*_args):
+        server._sessions[sid] = replacement
+        return "claim"
+
+    monkeypatch.setattr(async_delegation, "claim_event_delivery", _claim)
+    monkeypatch.setattr(
+        async_delegation, "release_event_delivery", lambda *args: released.append(args)
+    )
+    server._sessions[sid] = old
+    try:
+        server._run_prompt_submit("rid", sid, old, "old main turn")
+        assert len(released) == 1
+        assert old["running"] is False
+        assert replacement["running"] is True
+        assert isolated_queue.get_nowait() is event
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop(sid, None)
+        process_registry._completion_consumed.discard(event["session_id"])
+
+
+def test_post_turn_identity_loss_requeues_without_touching_sid_replacement(
+    monkeypatch, tmp_path
+):
+    """A post-turn owner gap clears only the captured old session record."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    sid = "post-turn-reused-sid"
+    old = _session(
+        agent=_RecordingAgent([]), session_key="post-turn-old-key", running=True
+    )
+    replacement = _session(
+        agent=_RecordingAgent([]), session_key="post-turn-new-key", running=True
+    )
+    event = {
+        "type": "completion",
+        "session_id": "post-turn-identity-loss-event",
+        "session_key": "post-turn-old-key",
+        "command": "echo old",
+        "exit_code": 0,
+        "output": "old",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    # The old worker still holds its exact record, but its short SID now names
+    # a replacement; no action may mutate that replacement's reservation.
+    server._sessions[sid] = replacement
+    try:
+        server._run_prompt_submit("rid", sid, old, "old main turn")
+        assert old["running"] is False
+        assert replacement["running"] is True
+        assert isolated_queue.get_nowait() is event
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop(sid, None)
+        process_registry._completion_consumed.discard(event["session_id"])
 
 
 class _RecordingAgent:
@@ -13976,6 +15500,165 @@ def test_reset_session_agent_clears_session_overrides(monkeypatch):
     assert "create_reasoning_override" not in session
     assert "create_service_tier_override" not in session
     assert session["agent"] is new_agent
+
+
+def test_reset_session_agent_fails_closed_after_sid_reuse(monkeypatch):
+    """A /new build that loses its record cannot publish into the new owner."""
+    sid = "reset-reused"
+    old_agent = types.SimpleNamespace(model="old")
+    session = _session(agent=old_agent)
+    replacement_agent = types.SimpleNamespace(model="replacement")
+    replacement = _session(agent=replacement_agent, session_key="new-key")
+
+    class NewAgent:
+        model = "new"
+
+        def __init__(self):
+            self.closed = False
+            self._tui_callback_identity = server._new_agent_callback_binding(sid, session)
+
+        def close(self):
+            self.closed = True
+
+    new_agent = NewAgent()
+    server._sessions[sid] = session
+    monkeypatch.setattr(server, "_set_session_context", lambda _key: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+
+    def make_agent(*_args, **_kwargs):
+        server._sessions[sid] = replacement
+        return new_agent
+
+    monkeypatch.setattr(server, "_make_agent", make_agent)
+    try:
+        assert server._reset_session_agent(sid, session) == {}
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert new_agent.closed is True
+    assert replacement["agent"] is replacement_agent
+
+
+def test_reset_waits_for_old_bound_callback_before_agent_swap(monkeypatch):
+    """/new cannot swap agents across an already-authorized old callback."""
+    sid = "reset-waits-for-callback"
+    old_agent = types.SimpleNamespace(model="old")
+    session = _session(agent=old_agent)
+    callback_binding = {"sid": sid, "session": session, "agent": old_agent}
+    callback_entered = threading.Event()
+    release_callback = threading.Event()
+    reset_done = threading.Event()
+    emitted = []
+
+    class NewAgent:
+        model = "new"
+
+        def __init__(self):
+            self._tui_callback_identity = server._new_agent_callback_binding(sid, session)
+
+    new_agent = NewAgent()
+
+    def emit(event, *_args):
+        emitted.append(event)
+        if event == "status.update":
+            callback_entered.set()
+            assert release_callback.wait(timeout=2)
+
+    monkeypatch.setattr(server, "_emit", emit)
+    monkeypatch.setattr(server, "_set_session_context", lambda _key: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_make_agent", lambda *_args, **_kwargs: new_agent)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {"model": "new"})
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_args: None)
+
+    server._sessions[sid] = session
+    callback_thread = threading.Thread(
+        target=lambda: server._bound_agent_cbs(sid, callback_binding)["status_callback"](
+            "old callback"
+        )
+    )
+    reset_result = {}
+    reset_thread = threading.Thread(
+        target=lambda: (reset_result.setdefault("info", server._reset_session_agent(sid, session)), reset_done.set())
+    )
+    try:
+        callback_thread.start()
+        assert callback_entered.wait(timeout=2)
+        reset_thread.start()
+        assert not reset_done.wait(timeout=0.05)
+        assert session["agent"] is old_agent
+
+        release_callback.set()
+        callback_thread.join(timeout=2)
+        reset_thread.join(timeout=2)
+    finally:
+        release_callback.set()
+        callback_thread.join(timeout=2)
+        reset_thread.join(timeout=2)
+        server._sessions.pop(sid, None)
+
+    assert reset_done.is_set()
+    assert reset_result["info"] == {"model": "new"}
+    assert session["agent"] is new_agent
+    assert emitted == ["status.update", "session.info"]
+
+
+def test_bound_agent_callback_rejects_reused_sid(monkeypatch):
+    """Ordinary AIAgent callbacks use the exact record, not SID presence."""
+    sid = "callback-reused"
+    old_agent = types.SimpleNamespace()
+    session = _session(agent=old_agent)
+    replacement = _session(agent=types.SimpleNamespace(), session_key="new-key")
+    binding = {"sid": sid, "session": session, "agent": old_agent}
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    server._sessions[sid] = session
+    try:
+        callback = server._bound_agent_cbs(sid, binding)["status_callback"]
+        server._sessions[sid] = replacement
+        callback("old status")
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert emitted == []
+
+
+def test_eager_init_stops_after_sid_reuse_before_wiring(monkeypatch):
+    """An old eager init cannot wire/publish against a replacement record."""
+    sid = "eager-reused"
+    replacement = _session(agent=types.SimpleNamespace(), session_key="new-key")
+    agent = types.SimpleNamespace(model="old", background_review_callback=None)
+    calls = []
+
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+    monkeypatch.setattr(
+        server,
+        "_register_session_cwd",
+        lambda _session: server._sessions.__setitem__(sid, replacement),
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda *_args: calls.append("wire"))
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_args: calls.append("poller")
+    )
+    monkeypatch.setattr(
+        server, "_notify_session_boundary", lambda *_args: calls.append("boundary")
+    )
+    monkeypatch.setattr(
+        server, "_schedule_mcp_late_refresh", lambda *_args: calls.append("refresh")
+    )
+    monkeypatch.setattr(server, "_emit", lambda *_args: calls.append("emit"))
+
+    try:
+        server._init_session(sid, "old-key", agent, [], cols=80)
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert calls == []
+    assert replacement["agent"] is not agent
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1545,10 +1545,25 @@ def test_write_json_serializes_concurrent_writes(monkeypatch):
     for t in threads:
         t.join()
 
-    lines = "".join(out.parts).splitlines()
+    # Snapshot under the same lock so an unrelated long-lived server worker
+    # cannot be halfway through its own frame when we inspect the buffer.
+    with server._stdout_lock:
+        rendered = "".join(out.parts)
 
-    assert len(lines) == 8
-    assert {json.loads(line)["seq"] for line in lines} == set(range(8))
+    payloads = [
+        json.loads(line)
+        for line in rendered.splitlines()
+    ]
+    target_payloads = [
+        payload for payload in payloads
+        if "seq" in payload
+    ]
+
+    # Other server workers may legitimately emit a complete JSON frame while
+    # this test runs; the shared stdout lock must keep every frame parseable,
+    # and these eight target frames must each remain intact.
+    assert len(target_payloads) == 8
+    assert {payload["seq"] for payload in target_payloads} == set(range(8))
 
 
 def test_write_json_returns_false_on_broken_pipe(monkeypatch):
@@ -6863,7 +6878,10 @@ def test_config_set_yolo_global_scope_writes_approvals_mode(tmp_path, monkeypatc
     import yaml
 
     cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text(yaml.safe_dump({"approvals": {"mode": "manual"}}))
+    cfg_path.write_text(
+        yaml.safe_dump({"approvals": {"mode": "manual"}}),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
     resp_on = server.handle_request(
@@ -6998,7 +7016,10 @@ def test_config_set_yolo_global_scope_honors_explicit_value(tmp_path, monkeypatc
     import yaml
 
     cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text(yaml.safe_dump({"approvals": {"mode": "manual"}}))
+    cfg_path.write_text(
+        yaml.safe_dump({"approvals": {"mode": "manual"}}),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
     resp = server.handle_request(
@@ -7242,7 +7263,9 @@ def test_config_set_statusbar_survives_non_dict_display(tmp_path, monkeypatch):
     import yaml
 
     cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text(yaml.safe_dump({"display": "broken"}))
+    cfg_path.write_text(
+        yaml.safe_dump({"display": "broken"}), encoding="utf-8"
+    )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
     resp = server.handle_request(
@@ -7254,7 +7277,7 @@ def test_config_set_statusbar_survives_non_dict_display(tmp_path, monkeypatch):
     )
 
     assert resp["result"]["value"] == "bottom"
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert saved["display"]["tui_statusbar"] == "bottom"
 
 
@@ -7278,7 +7301,7 @@ def test_config_set_details_mode_pins_all_sections(tmp_path, monkeypatch):
     )
 
     assert resp["result"] == {"key": "details_mode", "value": "collapsed"}
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert saved["display"]["details_mode"] == "collapsed"
     assert saved["display"]["sections"] == {
         "thinking": "collapsed",
@@ -7303,7 +7326,7 @@ def test_config_set_section_writes_per_section_override(tmp_path, monkeypatch):
     )
 
     assert resp["result"] == {"key": "details_mode.activity", "value": "hidden"}
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert saved["display"]["sections"] == {"activity": "hidden"}
 
 
@@ -7327,7 +7350,7 @@ def test_config_set_section_clears_override_on_empty_value(tmp_path, monkeypatch
     )
 
     assert resp["result"] == {"key": "details_mode.activity", "value": ""}
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert saved["display"]["sections"] == {"tools": "expanded"}
 
 
@@ -14640,7 +14663,7 @@ def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, t
     assert saved_file.parent == saved_dir
     assert saved_file.exists()
 
-    payload = json.loads(saved_file.read_text())
+    payload = json.loads(saved_file.read_text(encoding="utf-8"))
     assert payload["model"] == "hermes-test"
     assert payload["session_id"] == "20260101_120000_abc123"
     assert payload["session_start"] == "2026-01-01T12:00:00"
@@ -15965,7 +15988,7 @@ def test_persist_model_switch_preserves_sibling_model_keys(tmp_path, monkeypatch
         new_model="new-model", target_provider="anthropic", base_url=None
     )
     server._persist_model_switch(result)
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
 
     # The switched fields updated...
     assert saved["model"]["default"] == "new-model"
@@ -15999,7 +16022,7 @@ def test_persist_model_switch_clears_stale_base_url(tmp_path, monkeypatch):
         new_model="claude-haiku", target_provider="anthropic", base_url=None
     )
     server._persist_model_switch(result)
-    saved = yaml.safe_load(cfg_path.read_text())
+    saved = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
 
     assert saved["model"]["default"] == "claude-haiku"
     assert saved["model"]["provider"] == "anthropic"

--- a/tests/tools/test_nt_secure_fs.py
+++ b/tests/tools/test_nt_secure_fs.py
@@ -1,0 +1,314 @@
+"""Platform-neutral contract tests for the Windows NT skill filesystem.
+
+These tests exercise orchestration with fake handles on POSIX.  They are not a
+claim that the Windows kernel ABI has been executed; real Windows CI remains
+the integration authority for the ctypes calls.
+"""
+
+from __future__ import annotations
+
+import stat
+
+import pytest
+
+from tools import nt_secure_fs as ntfs
+
+
+def test_native_backend_probe_is_false_off_windows():
+    if ntfs.os.name != "nt":
+        assert ntfs.is_available() is False
+
+
+def _metadata(
+    inode: int,
+    *,
+    directory: bool = False,
+    size: int = 0,
+) -> ntfs.NtStat:
+    return ntfs.NtStat(
+        st_dev=7,
+        st_ino=inode,
+        st_mode=(stat.S_IFDIR if directory else stat.S_IFREG) | 0o600,
+        st_size=size,
+        st_mtime_ns=11,
+        st_ctime_ns=13,
+        file_attributes=(
+            ntfs.FILE_ATTRIBUTE_DIRECTORY if directory else 0
+        ),
+    )
+
+
+class _ContextHandle:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.closed = True
+
+
+def test_read_regular_file_is_identity_and_content_stable():
+    class File(_ContextHandle):
+        closed = False
+
+        def stat(self):
+            return _metadata(3, size=4)
+
+        def read_all(self):
+            return b"data"
+
+    file_handle = File()
+
+    class Parent:
+        def open_file(self, name, *, writable):
+            assert (name, writable) == ("SKILL.md", False)
+            return file_handle
+
+    payload, metadata = ntfs.read_regular_file(Parent(), "SKILL.md")
+    assert payload == b"data"
+    assert metadata.identity == (7, 3)
+    assert file_handle.closed is True
+
+
+def test_read_regular_file_rejects_change_during_read():
+    class File(_ContextHandle):
+        closed = False
+        calls = 0
+
+        def stat(self):
+            self.calls += 1
+            return _metadata(self.calls, size=4)
+
+        def read_all(self):
+            return b"data"
+
+    class Parent:
+        def open_file(self, name, *, writable):
+            return File()
+
+    with pytest.raises(RuntimeError, match="changed while being read"):
+        ntfs.read_regular_file(Parent(), "SKILL.md")
+
+
+def test_replace_regular_file_renames_temporary_handle_relative():
+    events = []
+
+    class Existing(_ContextHandle):
+        closed = False
+
+        def stat(self):
+            return _metadata(1)
+
+    class Temporary(_ContextHandle):
+        closed = False
+
+        def write_all(self, payload):
+            events.append(("write", payload))
+
+        def flush(self):
+            events.append(("flush",))
+
+        def rename_to(self, parent, name, *, replace):
+            events.append(("rename", parent, name, replace))
+
+        def mark_delete(self, *, is_directory):
+            events.append(("delete", is_directory))
+
+    temporary = Temporary()
+
+    class Parent:
+        def open_file(self, name, *, create=False, writable=False):
+            if name == "target.md":
+                return Existing()
+            assert (name, create, writable) == (
+                ".tmp",
+                True,
+                True,
+            )
+            return temporary
+
+        def flush(self):
+            events.append(("parent-flush",))
+
+    parent = Parent()
+    ntfs.replace_regular_file(
+        parent,
+        "target.md",
+        b"new",
+        require_existing=True,
+        temp_name=".tmp",
+    )
+    assert events[:3] == [
+        ("write", b"new"),
+        ("flush",),
+        ("rename", parent, "target.md", True),
+    ]
+    assert not any(event[0] == "delete" for event in events)
+
+
+def test_delete_tree_unlinks_reparse_object_without_traversing_it():
+    events = []
+
+    class Reparse(_ContextHandle):
+        closed = False
+
+        def stat(self):
+            return ntfs.NtStat(
+                st_dev=7,
+                st_ino=23,
+                st_mode=stat.S_IFDIR | 0o600,
+                st_size=0,
+                st_mtime_ns=11,
+                st_ctime_ns=13,
+                file_attributes=(
+                    ntfs.FILE_ATTRIBUTE_DIRECTORY
+                    | ntfs.FILE_ATTRIBUTE_REPARSE_POINT
+                ),
+            )
+
+        def mark_delete(self, *, is_directory):
+            events.append(("delete-reparse", is_directory))
+
+    class Directory:
+        def list_entries(self):
+            return [
+                ntfs.NtDirectoryEntry(
+                    "redirect",
+                    ntfs.FILE_ATTRIBUTE_DIRECTORY
+                    | ntfs.FILE_ATTRIBUTE_REPARSE_POINT,
+                    0,
+                    file_id=23,
+                    st_mtime_ns=11,
+                    st_ctime_ns=13,
+                )
+            ]
+
+        def open_reparse_entry(
+            self, name, *, directory, writable
+        ):
+            events.append(("open-reparse", name, directory, writable))
+            return Reparse()
+
+        def open_dir(self, *args, **kwargs):
+            raise AssertionError("a reparse target must never be traversed")
+
+    ntfs.delete_tree(Directory())
+    assert events == [
+        ("open-reparse", "redirect", True, True),
+        ("delete-reparse", True),
+    ]
+
+
+def test_delete_tree_rejects_name_reopen_identity_swap():
+    class File(_ContextHandle):
+        def stat(self):
+            return _metadata(99, size=4)
+
+        def mark_delete(self, *, is_directory):
+            raise AssertionError("identity mismatch must be rejected before delete")
+
+    class Directory:
+        def list_entries(self):
+            return [
+                ntfs.NtDirectoryEntry(
+                    "marker.txt",
+                    0,
+                    4,
+                    file_id=2,
+                    st_mtime_ns=11,
+                    st_ctime_ns=13,
+                )
+            ]
+
+        def open_file(self, name, *, writable):
+            assert (name, writable) == ("marker.txt", True)
+            return File()
+
+    with pytest.raises(RuntimeError, match="changed before recursive delete"):
+        ntfs.delete_tree(Directory())
+
+
+def test_snapshot_rejects_name_reopen_identity_swap(tmp_path):
+    class File(_ContextHandle):
+        def stat(self):
+            return _metadata(99, size=4)
+
+        def read_all(self, *, max_bytes):
+            raise AssertionError("identity mismatch must be rejected before read")
+
+    class Directory:
+        def stat(self):
+            return _metadata(1, directory=True)
+
+        def list_entries(self, *, max_entries):
+            assert max_entries == ntfs._SNAPSHOT_MAX_ENTRIES
+            return [
+                ntfs.NtDirectoryEntry(
+                    "marker.txt",
+                    0,
+                    4,
+                    file_id=2,
+                    st_mtime_ns=11,
+                    st_ctime_ns=13,
+                )
+            ]
+
+        def open_file(self, name, *, writable, stable_read):
+            assert (name, writable, stable_read) == (
+                "marker.txt",
+                False,
+                True,
+            )
+            return File()
+
+    with pytest.raises(RuntimeError, match="changed before snapshot"):
+        ntfs.copy_tree_no_reparse(
+            Directory(), tmp_path / "snapshot"
+        )
+
+
+@pytest.mark.parametrize(
+    "unsafe_name",
+    [
+        "NUL",
+        "child. ",
+        "a?b",
+        "COM¹.txt",
+        "CONIN$",
+        " NUL",
+        " foo",
+    ],
+)
+def test_snapshot_rejects_win32_aliasing_names(tmp_path, unsafe_name):
+    class Directory:
+        def stat(self):
+            return _metadata(1, directory=True)
+
+        def list_entries(self, *, max_entries):
+            return [ntfs.NtDirectoryEntry(unsafe_name, 0, 0)]
+
+    with pytest.raises(ValueError):
+        ntfs.copy_tree_no_reparse(
+            Directory(), tmp_path / "snapshot"
+        )
+
+
+@pytest.mark.parametrize(
+    "component",
+    ["", ".", "..", "a/b", "a\\b", "C:", "nul\x00name"],
+)
+def test_handle_relative_components_are_single_names(component):
+    with pytest.raises(ValueError):
+        ntfs._validate_component(component)
+
+
+def test_native_abi_uses_sdk_boolean_layout_for_legacy_delete_and_rename():
+    assert (
+        ntfs._FILE_DISPOSITION_INFO_BUFFER.DeleteFile.size == 1
+    )
+    assert (
+        ntfs._FILE_RENAME_INFO_LEGACY_BUFFER.ReplaceIfExists.size == 1
+    )
+    assert (
+        ntfs._FILE_RENAME_INFO_LEGACY_BUFFER.RootDirectory.offset
+        > ntfs._FILE_RENAME_INFO_LEGACY_BUFFER.ReplaceIfExists.offset
+    )

--- a/tests/tools/test_nt_secure_fs_optional.py
+++ b/tests/tools/test_nt_secure_fs_optional.py
@@ -1,0 +1,35 @@
+import builtins
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def test_optional_backend_fails_closed_when_native_module_is_absent():
+    module_path = (
+        Path(__file__).resolve().parents[2] / "tools" / "nt_secure_fs_optional.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_test_nt_secure_fs_optional_without_backend",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    original_import = builtins.__import__
+
+    def without_native_backend(name, *args, **kwargs):
+        if name == "tools.nt_secure_fs":
+            exc = ModuleNotFoundError("simulated optional backend absence")
+            exc.name = name
+            raise exc
+        return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=without_native_backend):
+        spec.loader.exec_module(module)
+
+    assert module.is_available() is False
+    with pytest.raises(
+        OSError, match="secure Windows skill filesystem backend is not installed"
+    ):
+        module.open_directory("C:/skills", writable=False)

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1,18 +1,25 @@
 """Tests for tools/skill_manager_tool.py — skill creation, editing, and deletion."""
 
 import json
+import multiprocessing
+import os
+import re
+import stat
+import threading
 from contextlib import contextmanager
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+import tools.skill_manager_tool as skill_manager_module
 from tools.skill_manager_tool import (
     _validate_name,
     _validate_category,
     _validate_frontmatter,
     _validate_file_path,
-    _create_skill,
+    _create_skill as _create_skill_impl,
     _edit_skill,
     _patch_skill,
     _delete_skill,
@@ -58,6 +65,49 @@ description: Updated description.
 Step 1: Do the new thing.
 """
 
+
+def test_windows_security_scan_gives_nt_backend_a_new_snapshot_path():
+    fake_os = MagicMock()
+    fake_os.name = "nt"
+    observed = {}
+
+    def fake_copy(skill_handle, destination):
+        observed["skill_handle"] = skill_handle
+        observed["destination_existed"] = destination.exists()
+        destination.mkdir()
+        (destination / "SKILL.md").write_text(
+            VALID_SKILL_CONTENT,
+            encoding="utf-8",
+        )
+
+    def fake_scan(destination):
+        assert (destination / "SKILL.md").is_file()
+        return None
+
+    held_skill = object()
+    with (
+        patch.object(skill_manager_module, "os", fake_os),
+        patch(
+            "tools.nt_secure_fs_optional.copy_tree_no_reparse",
+            side_effect=fake_copy,
+        ),
+        patch.object(
+            skill_manager_module,
+            "_security_scan_skill",
+            side_effect=fake_scan,
+        ),
+    ):
+        assert (
+            skill_manager_module._security_scan_held_skill_impl(held_skill)
+            is None
+        )
+
+    assert observed == {
+        "skill_handle": held_skill,
+        "destination_existed": False,
+    }
+
+
 LONG_DESC_CONTENT = """\
 ---
 name: long-desc
@@ -68,6 +118,158 @@ description: Use when deploying multi-region Kubernetes clusters with custom CNI
 
 Step 1.
 """
+
+
+def _content_for_name(content: str, name: str) -> str:
+    """Keep generic CRUD fixtures valid under the create identity contract."""
+    return re.sub(
+        r"(?m)^name:\s*.*$",
+        f"name: {name}",
+        content,
+        count=1,
+    )
+
+
+def _create_skill(name: str, content: str, category: str = None):
+    return _create_skill_impl(name, _content_for_name(content, name), category)
+
+
+def _process_create_same_skill(
+    skills_dir: str,
+    category: str,
+    start,
+    results,
+) -> None:
+    root = Path(skills_dir)
+    content = _content_for_name(VALID_SKILL_CONTENT, "shared-process-name")
+    with patch("tools.skill_manager_tool.SKILLS_DIR", root), patch(
+        "agent.skill_utils.get_all_skills_dirs",
+        return_value=[root],
+    ):
+        start.wait()
+        results.put(
+            _create_skill_impl(
+                "shared-process-name",
+                content,
+                category,
+            )["success"]
+        )
+
+
+def _process_edit_with_controlled_scan(
+    skills_dir: str,
+    content: str,
+    should_fail: bool,
+    entered_scan,
+    release_scan,
+    done,
+    results,
+) -> None:
+    """Process worker used to prove rollback/commit transaction ordering."""
+    root = Path(skills_dir)
+
+    def controlled_scan(_skill_fd):
+        entered_scan.set()
+        if should_fail:
+            release_scan.wait(timeout=10)
+            return "blocked by deterministic scan"
+        return None
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", root), patch(
+        "agent.skill_utils.get_all_skills_dirs",
+        return_value=[root],
+    ), patch(
+        "tools.skill_manager_tool._security_scan_held_skill",
+        side_effect=controlled_scan,
+    ):
+        result = _edit_skill("transaction-skill", content)
+        results.put(result)
+        done.set()
+
+
+def _process_write_alias_with_controlled_scan(
+    skills_dir: str,
+    alias: str,
+    content: str,
+    should_fail: bool,
+    entered_scan,
+    release_scan,
+    done,
+    results,
+) -> None:
+    """Mutate one supporting file through either physical-skill alias."""
+    root = Path(skills_dir)
+    scan_snapshot = None
+
+    def controlled_scan(skill_fd):
+        nonlocal scan_snapshot
+        file_fd = os.open(
+            "references/state.txt", os.O_RDONLY, dir_fd=skill_fd
+        )
+        try:
+            scan_snapshot = os.read(file_fd, 100).decode("utf-8")
+        finally:
+            os.close(file_fd)
+        entered_scan.set()
+        if should_fail:
+            release_scan.wait(timeout=10)
+            return "blocked by deterministic cross-process alias scan"
+        return None
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", root), patch(
+        "agent.skill_utils.get_all_skills_dirs",
+        return_value=[root],
+    ), patch(
+        "tools.skill_manager_tool._security_scan_held_skill",
+        side_effect=controlled_scan,
+    ):
+        result = _write_file(alias, "references/state.txt", content)
+        results.put((result, scan_snapshot))
+        done.set()
+
+
+def _process_edit_alias_with_controlled_scan(
+    skills_dir: str,
+    alias: str,
+    content: str,
+    entered_scan,
+    release_scan,
+    done,
+    results,
+) -> None:
+    """Pause a canonical edit while its physical skill lock is held."""
+    root = Path(skills_dir)
+
+    def controlled_scan(_skill_fd):
+        entered_scan.set()
+        release_scan.wait(timeout=10)
+        return None
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", root), patch(
+        "agent.skill_utils.get_all_skills_dirs",
+        return_value=[root],
+    ), patch(
+        "tools.skill_manager_tool._security_scan_held_skill",
+        side_effect=controlled_scan,
+    ):
+        results.put(_edit_skill(alias, content))
+        done.set()
+
+
+def _process_delete_alias(
+    skills_dir: str,
+    alias: str,
+    done,
+    results,
+) -> None:
+    """Delete a skill through one of its aliases."""
+    root = Path(skills_dir)
+    with patch("tools.skill_manager_tool.SKILLS_DIR", root), patch(
+        "agent.skill_utils.get_all_skills_dirs",
+        return_value=[root],
+    ):
+        results.put(_delete_skill(alias))
+        done.set()
 
 
 # ---------------------------------------------------------------------------
@@ -111,9 +313,61 @@ class TestValidateFrontmatter:
         err = _validate_frontmatter("# Just a heading\nSome content.\n")
         assert err == "SKILL.md must start with YAML frontmatter (---). See existing skills for format."
 
+    def test_noncanonical_frontmatter_opener_is_rejected(self):
+        content = (
+            "---oops: ignored\n"
+            "name: demo\n"
+            "description: demo routing.\n"
+            "platforms: [windows]\n"
+            "---\nBody.\n"
+        )
+        err = _validate_frontmatter(
+            content, new_skill=True, expected_name="demo"
+        )
+        assert err == (
+            "SKILL.md must start with YAML frontmatter (---). "
+            "See existing skills for format."
+        )
+
+    def test_unclosed_frontmatter(self):
+        content = "---\nname: test\ndescription: desc\nBody content.\n"
+        assert _validate_frontmatter(content) == "SKILL.md frontmatter is not closed. Ensure you have a closing '---' line."
+
+    def test_missing_name_field(self):
+        content = "---\ndescription: desc\n---\n\nBody.\n"
+        assert _validate_frontmatter(content) == "Frontmatter must include 'name' field."
+
+    def test_missing_description_field(self):
+        content = "---\nname: test\n---\n\nBody.\n"
+        assert _validate_frontmatter(content) == "Frontmatter must include 'description' field."
+
+    def test_no_body_after_frontmatter(self):
+        content = "---\nname: test\ndescription: desc\n---\n"
+        assert _validate_frontmatter(content) == "SKILL.md must have content after the frontmatter (instructions, procedures, etc.)."
+
     def test_invalid_yaml(self):
         content = "---\n: invalid: yaml: {{{\n---\n\nBody.\n"
         assert "YAML frontmatter parse error" in _validate_frontmatter(content)
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("name", ""),
+            ("name", "[]"),
+            ("description", ""),
+            ("description", "[]"),
+        ],
+    )
+    def test_required_metadata_must_be_nonempty_strings(self, field, value):
+        content = (
+            "---\n"
+            f"name: {'valid-name' if field != 'name' else value}\n"
+            f"description: {'Valid description.' if field != 'description' else value}\n"
+            "---\n\nBody.\n"
+        )
+        error = _validate_frontmatter(content)
+        assert error is not None
+        assert field in error
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +386,32 @@ class TestValidateFilePath:
         err = _validate_file_path("references/../../../etc/passwd")
         assert err == "Path traversal ('..') is not allowed."
 
+    def test_disallowed_subdirectory(self):
+        err = _validate_file_path("secret/hidden.txt")
+        assert "File must be under one of:" in err
+        assert "'secret/hidden.txt'" in err
+
+    def test_directory_only_rejected(self):
+        err = _validate_file_path("references")
+        assert "Provide a file path, not just a directory" in err
+        assert "'references/myfile.md'" in err
+
+    def test_root_level_file_rejected(self):
+        err = _validate_file_path("malicious.py")
+        assert "File must be under one of:" in err
+        assert "'malicious.py'" in err
+
+    def test_skill_md_accepted_at_root(self):
+        # SKILL.md is the canonical skill file and must be accepted even
+        # though it does not live under an allowed subdirectory.
+        assert _validate_file_path("SKILL.md") is None
+
+    def test_skill_md_accepted_name_prefixed(self):
+        assert (
+            _validate_file_path("my-skill/SKILL.md", skill_name="my-skill")
+            is None
+        )
+        assert _validate_file_path("other/SKILL.md", skill_name="my-skill")
 
     def test_skill_md_traversal_still_rejected(self):
         # The SKILL.md exception must not weaken the traversal guard.
@@ -156,12 +436,46 @@ class TestCreateSkill:
         assert result["success"] is True
         assert (tmp_path / "my-skill" / "SKILL.md").exists()
 
+    def test_create_with_category(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT, category="devops")
+        assert result["success"] is True
+        assert (tmp_path / "devops" / "my-skill" / "SKILL.md").exists()
+        assert result["category"] == "devops"
+
+    def test_create_normalizes_category_whitespace(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _create_skill(
+                "my-skill", VALID_SKILL_CONTENT, category=" devops "
+            )
+        assert result["success"] is True
+        assert result["category"] == "devops"
+        assert (tmp_path / "devops" / "my-skill" / "SKILL.md").exists()
+        assert not (tmp_path / " devops ").exists()
+
     def test_create_duplicate_blocked(self, tmp_path):
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
             result = _create_skill("my-skill", VALID_SKILL_CONTENT)
         assert result["success"] is False
         assert "already exists" in result["error"]
+
+    def test_create_rejects_frontmatter_name_mismatch(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _create_skill_impl("requested", VALID_SKILL_CONTENT)
+        assert result["success"] is False
+        assert "must match" in result["error"]
+        assert not (tmp_path / "requested").exists()
+
+    def test_create_invalid_name(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _create_skill("Invalid Name!", VALID_SKILL_CONTENT)
+        assert result["success"] is False
+
+    def test_create_invalid_content(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", "no frontmatter here")
+        assert result["success"] is False
 
     def test_create_rejects_category_traversal(self, tmp_path):
         skills_dir = tmp_path / "skills"
@@ -175,29 +489,1003 @@ class TestCreateSkill:
         assert "Invalid category '../escape'" in result["error"]
         assert not (tmp_path / "escape").exists()
 
+    def test_create_rejects_absolute_category(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        outside = tmp_path / "outside"
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT, category=str(outside))
+
+        assert result["success"] is False
+        assert f"Invalid category '{outside}'" in result["error"]
+        assert not (outside / "my-skill" / "SKILL.md").exists()
+
+    def test_create_rejects_redirected_category(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        outside = tmp_path / "outside"
+        skills_dir.mkdir()
+        outside.mkdir()
+        category = skills_dir / "redirect"
+        try:
+            category.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), patch(
+            "agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]
+        ):
+            result = _create_skill(
+                "my-skill", VALID_SKILL_CONTENT, category="redirect"
+            )
+
+        assert result["success"] is False
+        assert "redirected category" in result["error"]
+        assert not (outside / "my-skill").exists()
+
+    def test_create_cannot_be_redirected_by_category_swap(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        outside = tmp_path / "outside"
+        skills_dir.mkdir()
+        outside.mkdir()
+        (outside / "my-skill").mkdir()
+        real_replace = __import__("os").replace
+        swapped = False
+
+        def swap_category_before_replace(src, dst, **kwargs):
+            nonlocal swapped
+            if not swapped:
+                swapped = True
+                (skills_dir / "devops").rename(skills_dir / "moved-devops")
+                (skills_dir / "devops").symlink_to(
+                    outside, target_is_directory=True
+                )
+            return real_replace(src, dst, **kwargs)
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), patch(
+            "agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]
+        ), patch(
+            "tools.skill_manager_tool.os.replace",
+            side_effect=swap_category_before_replace,
+        ):
+            result = _create_skill(
+                "my-skill", VALID_SKILL_CONTENT, category="devops"
+            )
+
+        assert result["success"] is False
+        assert "path changed" in result["error"].lower()
+        assert not (outside / "my-skill" / "SKILL.md").exists()
+
+    def test_create_root_retarget_scans_held_new_skill_and_rolls_back(
+        self, tmp_path
+    ):
+        outside_a = tmp_path / "outside-a"
+        outside_b = tmp_path / "outside-b"
+        root_link = tmp_path / "skills"
+        outside_a.mkdir()
+        victim_dir = outside_b / "devops" / "my-skill"
+        victim_dir.mkdir(parents=True)
+        victim_content = "B-VICTIM-MUST-REMAIN-UNCHANGED"
+        (victim_dir / "SKILL.md").write_text(
+            victim_content,
+            encoding="utf-8",
+        )
+        root_link.symlink_to(outside_a, target_is_directory=True)
+        scanned = False
+
+        def inspect_held_snapshot_then_retarget(snapshot):
+            nonlocal scanned
+            scanned = True
+            snapshot_content = (snapshot / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
+            assert "A test skill for unit testing." in snapshot_content
+            assert "B-VICTIM-MUST-REMAIN-UNCHANGED" not in snapshot_content
+            root_link.unlink()
+            root_link.symlink_to(outside_b, target_is_directory=True)
+            return None
+
+        with _skill_dir(root_link), patch(
+            "tools.skill_manager_tool._agent_created_security_scan_enabled",
+            return_value=True,
+        ), patch(
+            "tools.skill_manager_tool._security_scan_skill",
+            side_effect=inspect_held_snapshot_then_retarget,
+        ):
+            result = _create_skill(
+                "my-skill",
+                VALID_SKILL_CONTENT,
+                category="devops",
+            )
+
+        assert scanned is True
+        assert result["success"] is False
+        assert "path changed" in result["error"].lower()
+        assert not (outside_a / "devops").exists()
+        assert (victim_dir / "SKILL.md").read_text(
+            encoding="utf-8"
+        ) == victim_content
+
+    def test_create_fails_closed_without_a_secure_platform_backend(
+        self, tmp_path
+    ):
+        with _skill_dir(tmp_path), patch(
+            "tools.skill_manager_tool._secure_directory_create_supported",
+            return_value=False,
+        ):
+            result = _create_skill(
+                "my-skill", VALID_SKILL_CONTENT, category="devops"
+            )
+
+        assert result["success"] is False
+        assert "secure skill creation" in result["error"].lower()
+        assert not (tmp_path / "devops").exists()
+
+    def test_windows_backend_dispatches_categorized_creation(self):
+        expected = (
+            Path("C:/skills/devops/my-skill"),
+            None,
+        )
+        with patch(
+            "tools.skill_manager_tool._secure_directory_create_supported",
+            return_value=True,
+        ), patch(
+            "tools.skill_manager_tool.os.name",
+            "nt",
+        ), patch(
+            "tools.skill_manager_tool._secure_create_and_write_skill_windows",
+            return_value=expected,
+        ) as windows_create:
+            result = skill_manager_module._secure_create_and_write_skill(
+                "my-skill",
+                "devops",
+                _content_for_name(VALID_SKILL_CONTENT, "my-skill"),
+            )
+
+        assert result == expected
+        windows_create.assert_called_once_with(
+            "my-skill",
+            "devops",
+            _content_for_name(VALID_SKILL_CONTENT, "my-skill"),
+        )
+
+    def test_windows_backend_probe_failure_fails_closed(self):
+        with patch(
+            "tools.skill_manager_tool._secure_directory_create_supported",
+            return_value=False,
+        ), patch(
+            "tools.skill_manager_tool.os.name",
+            "nt",
+        ):
+            result = skill_manager_module._secure_create_and_write_skill(
+                "my-skill",
+                "devops",
+                _content_for_name(VALID_SKILL_CONTENT, "my-skill"),
+            )
+
+        assert result[0] is None
+        assert "unavailable on Windows" in result[1]
+
+    def test_windows_opened_handle_reparse_tag_is_rejected(self):
+        """A post-attributes junction swap is caught on the opened handle."""
+        import ctypes
+        from types import SimpleNamespace
+
+        create_file = MagicMock(return_value=123)
+        get_attributes = MagicMock(return_value=0)
+        close_handle = MagicMock(return_value=True)
+
+        def report_reparse_tag(_handle, info_class, info_ptr, _size):
+            assert info_class == 9
+            fields = ctypes.cast(
+                info_ptr,
+                ctypes.POINTER(ctypes.c_uint32 * 2),
+            ).contents
+            fields[0] = 0x00000400
+            fields[1] = 0xA0000003
+            return True
+
+        get_information = MagicMock(side_effect=report_reparse_tag)
+        kernel32 = SimpleNamespace(
+            CreateFileW=create_file,
+            GetFileAttributesW=get_attributes,
+            GetFileInformationByHandleEx=get_information,
+            CloseHandle=close_handle,
+        )
+        with patch(
+            "ctypes.windll",
+            SimpleNamespace(kernel32=kernel32),
+            create=True,
+        ):
+            with pytest.raises(OSError, match="redirected directory"):
+                skill_manager_module._open_windows_directory_guard(
+                    Path("C:/skills"),
+                    Path("C:/skills"),
+                )
+
+        get_information.assert_called_once()
+        close_handle.assert_called_once_with(123)
+
+    def test_windows_canonical_mutation_uses_held_backend_handle(
+        self,
+    ):
+        from contextlib import contextmanager
+
+        existing = {
+            "path": Path("C:/skills/example"),
+            "_resolved_path": Path("C:/skills/example"),
+            "_dir_identity": (1, 2),
+        }
+        held = MagicMock()
+        held.identity = (1, 2)
+
+        @contextmanager
+        def open_held(_existing):
+            yield held, existing["_resolved_path"]
+
+        with patch(
+            "tools.skill_manager_tool._secure_directory_create_supported",
+            return_value=True,
+        ), patch(
+            "tools.skill_manager_tool.os.name", "nt"
+        ), patch(
+            "tools.skill_manager_tool._open_existing_skill_directory",
+            side_effect=open_held,
+        ), patch(
+            "tools.skill_manager_tool._replace_canonical_skill_md",
+        ) as replace:
+            error = skill_manager_module._secure_replace_existing_skill_md(
+                existing,
+                _content_for_name(VALID_SKILL_CONTENT_2, "example"),
+            )
+
+        assert error is None
+        replace.assert_called_once_with(
+            held,
+            _content_for_name(VALID_SKILL_CONTENT_2, "example"),
+        )
+
+    def test_windows_supporting_mutation_walks_held_backend_handles(
+        self,
+    ):
+        from contextlib import contextmanager
+        from pathlib import PureWindowsPath
+
+        existing = {
+            "path": Path("C:/skills/example"),
+            "_resolved_path": Path("C:/skills/example"),
+            "_dir_identity": (1, 2),
+        }
+        skill_handle = MagicMock()
+        skill_handle.identity = (1, 2)
+        references_handle = MagicMock()
+        references_handle.identity = (1, 3)
+        skill_handle.open_dir.return_value = references_handle
+        skill_handle.entry_identity.return_value = references_handle.identity
+
+        @contextmanager
+        def open_held(_existing):
+            yield skill_handle, existing["_resolved_path"]
+
+        with patch(
+            "tools.skill_manager_tool._secure_directory_create_supported",
+            return_value=True,
+        ), patch(
+            "tools.skill_manager_tool.os.name", "nt"
+        ), patch(
+            "tools.skill_manager_tool._open_existing_skill_directory",
+            side_effect=open_held,
+        ), patch(
+            "tools.skill_manager_tool.Path",
+            PureWindowsPath,
+        ):
+            with skill_manager_module._open_supporting_file_parent(
+                existing,
+                "references/example.md",
+                create_parents=False,
+            ) as opened:
+                assert opened[:4] == (
+                    skill_handle,
+                    references_handle,
+                    "example.md",
+                    existing["_resolved_path"],
+                )
+                assert opened[4]() is True
+
+        skill_handle.open_dir.assert_called_once_with(
+            "references", writable=True
+        )
+        references_handle.close.assert_called_once()
+
+    def test_windows_native_entrypoint_refuses_non_windows_host_without_writes(
+        self, tmp_path
+    ):
+        content = _content_for_name(VALID_SKILL_CONTENT, "windows-skill")
+        with _skill_dir(tmp_path):
+            result = (
+                skill_manager_module._secure_create_and_write_skill_windows(
+                    "windows-skill",
+                    "devops",
+                    content,
+                )
+            )
+
+        assert result[0] is None
+        assert "unavailable on Windows" in result[1]
+        assert not (tmp_path / "devops" / "windows-skill").exists()
+        assert not (tmp_path / "devops").exists()
+
+    def test_concurrent_same_name_across_categories_has_one_winner(
+        self, tmp_path
+    ):
+        content = _content_for_name(VALID_SKILL_CONTENT, "shared-name")
+
+        def create(category):
+            return _create_skill_impl("shared-name", content, category)
+
+        with _skill_dir(tmp_path), ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(create, ("first", "second")))
+
+        assert sum(result["success"] for result in results) == 1
+        assert len(list(tmp_path.rglob("shared-name/SKILL.md"))) == 1
+
+    def test_cross_process_same_name_has_one_winner(self, tmp_path):
+        try:
+            context = multiprocessing.get_context("fork")
+        except ValueError:
+            pytest.skip("fork multiprocessing context unavailable")
+
+        start = context.Event()
+        results = context.Queue()
+        processes = [
+            context.Process(
+                target=_process_create_same_skill,
+                args=(str(tmp_path), category, start, results),
+            )
+            for category in ("first", "second")
+        ]
+        for process in processes:
+            process.start()
+        start.set()
+        outcomes = [results.get(timeout=10) for _ in processes]
+        for process in processes:
+            process.join(timeout=10)
+            assert process.exitcode == 0
+
+        assert sum(outcomes) == 1
+        assert len(list(tmp_path.rglob("shared-process-name/SKILL.md"))) == 1
+
+    def test_create_does_not_reuse_preexisting_non_skill_directory(self, tmp_path):
+        existing = tmp_path / "my-skill"
+        existing.mkdir()
+        marker = existing / "keep.txt"
+        marker.write_text("keep", encoding="utf-8")
+
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT)
+
+        assert result["success"] is False
+        assert marker.read_text(encoding="utf-8") == "keep"
+        assert not (existing / "SKILL.md").exists()
+
+    def test_scan_rejection_rolls_back_only_this_create(self, tmp_path):
+        with _skill_dir(tmp_path), patch(
+            "tools.skill_manager_tool._agent_created_security_scan_enabled",
+            return_value=True,
+        ), patch(
+            "tools.skill_manager_tool._security_scan_skill",
+            return_value="blocked",
+        ):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT)
+
+        assert result == {"success": False, "error": "blocked"}
+        assert not (tmp_path / "my-skill").exists()
+
+    def test_encoding_failure_rolls_back_temporary_create(self, tmp_path):
+        content = _content_for_name(VALID_SKILL_CONTENT, "surrogate-skill")
+        content += "\n\ud800"
+        with _skill_dir(tmp_path):
+            result = _create_skill_impl("surrogate-skill", content)
+
+        assert result["success"] is False
+        assert not (tmp_path / "surrogate-skill").exists()
+        assert not list(tmp_path.rglob(".tmp_SKILL_*"))
+
+    def test_create_normalizes_single_bom_before_persisting(self, tmp_path):
+        content = "\ufeff" + _content_for_name(VALID_SKILL_CONTENT, "bom-skill")
+        with _skill_dir(tmp_path):
+            result = _create_skill_impl("bom-skill", content)
+
+        assert result["success"] is True
+        saved = (tmp_path / "bom-skill" / "SKILL.md").read_text(encoding="utf-8")
+        assert not saved.startswith("\ufeff")
+        assert parse_frontmatter(saved)[0]["name"] == "bom-skill"
+
+    def test_create_long_desc_rejected(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _create_skill("long-desc", LONG_DESC_CONTENT)
+        assert result["success"] is False
+        assert "system-prompt budget" in result["error"]
+
+    def test_create_short_desc_no_prompt_preview(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT)
+        assert result["success"] is True
+        assert "system_prompt_preview" not in result
+
+    def test_create_boundary_at_limit_accepted_no_preview(self, tmp_path):
+        desc = "U" * SKILL_PROMPT_DESC_LIMIT
+        content = f"---\nname: boundary-at\ndescription: {desc}\n---\n\n# Boundary\n\nStep 1.\n"
+        with _skill_dir(tmp_path):
+            result = _create_skill("boundary-at", content)
+        assert result["success"] is True
+        assert "system_prompt_preview" not in result
+
+    def test_create_boundary_over_limit_rejected(self, tmp_path):
+        desc = "U" * (SKILL_PROMPT_DESC_LIMIT + 1)
+        content = f"---\nname: boundary-over\ndescription: {desc}\n---\n\n# Boundary\n\nStep 1.\n"
+        with _skill_dir(tmp_path):
+            result = _create_skill("boundary-over", content)
+        assert result["success"] is False
+        assert "system-prompt budget" in result["error"]
 
     def test_edit_long_desc_still_allowed_with_preview(self, tmp_path):
         """Edit/patch paths stay permissive so existing over-limit skills
         remain maintainable — they warn via system_prompt_preview instead."""
+        content = _content_for_name(LONG_DESC_CONTENT, "my-skill")
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
-            result = _edit_skill("my-skill", LONG_DESC_CONTENT)
+            result = _edit_skill("my-skill", content)
         assert result["success"] is True
         assert "system_prompt_preview" in result
         assert "System prompt will show" in result["system_prompt_preview"]
-        fm, _ = parse_frontmatter(LONG_DESC_CONTENT)
+        fm, _ = parse_frontmatter(content)
         assert extract_skill_description(fm) in result["system_prompt_preview"]
 
 
 class TestEditSkill:
+    @pytest.mark.parametrize("action", ["edit", "patch", "write_file"])
+    def test_canonical_skill_symlink_never_writes_outside(
+        self, tmp_path, action
+    ):
+        outside = tmp_path / "outside.md"
+        outside.write_text(
+            _content_for_name(VALID_SKILL_CONTENT, "evil"),
+            encoding="utf-8",
+        )
+        skill_dir = tmp_path / "evil"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").symlink_to(outside)
+        replacement = _content_for_name(VALID_SKILL_CONTENT_2, "evil")
+
+        with _skill_dir(tmp_path):
+            if action == "edit":
+                result = _edit_skill("evil", replacement)
+            elif action == "patch":
+                result = _patch_skill(
+                    "evil",
+                    "Do the thing.",
+                    "Do something else.",
+                )
+            else:
+                result = _write_file("evil", "SKILL.md", replacement)
+
+        assert result["success"] is False
+        assert outside.read_text(encoding="utf-8") == _content_for_name(
+            VALID_SKILL_CONTENT, "evil"
+        )
+
+    def test_canonical_symlink_swap_is_replaced_not_followed(self, tmp_path):
+        outside = tmp_path / "outside.md"
+        outside.write_text("outside stays unchanged", encoding="utf-8")
+        replacement = _content_for_name(VALID_SKILL_CONTENT_2, "my-skill")
+
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            skill_md = tmp_path / "my-skill" / "SKILL.md"
+            real_replace = os.replace
+            planted = False
+
+            def plant_symlink_before_replace(src, dst, **kwargs):
+                nonlocal planted
+                if (
+                    not planted
+                    and dst == "SKILL.md"
+                    and kwargs.get("dst_dir_fd") is not None
+                ):
+                    planted = True
+                    skill_md.unlink()
+                    skill_md.symlink_to(outside)
+                return real_replace(src, dst, **kwargs)
+
+            with patch(
+                "tools.skill_manager_tool.os.replace",
+                side_effect=plant_symlink_before_replace,
+            ):
+                result = _edit_skill("my-skill", replacement)
+
+        assert result["success"] is True
+        assert outside.read_text(encoding="utf-8") == "outside stays unchanged"
+        assert not skill_md.is_symlink()
+        assert "Updated description." in skill_md.read_text(encoding="utf-8")
+
+    @pytest.mark.parametrize("action", ["edit", "patch", "write_file"])
+    def test_skill_root_retarget_keeps_canonical_transaction_on_one_directory(
+        self, tmp_path, action
+    ):
+        """Read/write/scan/rollback must not mix A and B through a root link."""
+        outside_a = tmp_path / "outside-a"
+        outside_b = tmp_path / "outside-b"
+        root_link = tmp_path / "skills"
+        for root in (outside_a, outside_b):
+            # Deliberately use a legacy directory name so lookup must inspect
+            # frontmatter through its held candidate directory descriptor.
+            skill_dir = root / "legacy-dir"
+            skill_dir.mkdir(parents=True)
+        (outside_a / "legacy-dir" / "SKILL.md").write_text(
+            _content_for_name(VALID_SKILL_CONTENT, "shared"),
+            encoding="utf-8",
+        )
+        (outside_b / "legacy-dir" / "SKILL.md").write_text(
+            _content_for_name(VALID_SKILL_CONTENT, "shared")
+            + "\nB-VICTIM-MUST-NEVER-BE-COPIED\n",
+            encoding="utf-8",
+        )
+        original_a = (outside_a / "legacy-dir" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        original_b = (outside_b / "legacy-dir" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        root_link.symlink_to(outside_a, target_is_directory=True)
+        replacement = _content_for_name(VALID_SKILL_CONTENT_2, "shared")
+        retargeted = False
+        real_read = skill_manager_module._read_canonical_skill_md
+
+        def retarget_during_candidate_read(skill_fd):
+            nonlocal retargeted
+            if not retargeted:
+                retargeted = True
+                root_link.unlink()
+                root_link.symlink_to(outside_b, target_is_directory=True)
+            return real_read(skill_fd)
+
+        def reject_anchored_snapshot(snapshot):
+            scanned = (snapshot / "SKILL.md").read_text(encoding="utf-8")
+            assert "B-VICTIM-MUST-NEVER-BE-COPIED" not in scanned
+            if action == "patch":
+                assert "Do something else." in scanned
+            else:
+                assert "Updated description." in scanned
+            return "blocked after anchored scan"
+
+        with _skill_dir(root_link), patch(
+            "tools.skill_manager_tool._read_canonical_skill_md",
+            side_effect=retarget_during_candidate_read,
+        ), patch(
+            "tools.skill_manager_tool._agent_created_security_scan_enabled",
+            return_value=True,
+        ), patch(
+            "tools.skill_manager_tool._security_scan_skill",
+            side_effect=reject_anchored_snapshot,
+        ):
+            if action == "edit":
+                result = _edit_skill("shared", replacement)
+            elif action == "patch":
+                result = _patch_skill(
+                    "shared",
+                    "Do the thing.",
+                    "Do something else.",
+                )
+            else:
+                result = _write_file("shared", "SKILL.md", replacement)
+
+        assert retargeted is True
+        assert result["success"] is False
+        assert "blocked after anchored scan" in result["error"]
+        assert (outside_a / "legacy-dir" / "SKILL.md").read_text(
+            encoding="utf-8"
+        ) == original_a
+        assert (outside_b / "legacy-dir" / "SKILL.md").read_text(
+            encoding="utf-8"
+        ) == original_b
+
     def test_edit_existing_skill(self, tmp_path):
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
-            result = _edit_skill("my-skill", VALID_SKILL_CONTENT_2)
+            result = _edit_skill(
+                "my-skill", _content_for_name(VALID_SKILL_CONTENT_2, "my-skill")
+            )
         assert result["success"] is True
         content = (tmp_path / "my-skill" / "SKILL.md").read_text()
         assert "Updated description" in content
 
+    def test_failed_rollback_cannot_overwrite_concurrent_success(
+        self, tmp_path
+    ):
+        failed_content = _content_for_name(
+            VALID_SKILL_CONTENT_2.replace(
+                "# Test Skill v2", "# Failed transaction"
+            ),
+            "transaction-skill",
+        )
+        successful_content = _content_for_name(
+            VALID_SKILL_CONTENT_2.replace(
+                "# Test Skill v2", "# Successful transaction"
+            ),
+            "transaction-skill",
+        )
+        failed_scan_entered = threading.Event()
+        release_failed_scan = threading.Event()
+        successful_done = threading.Event()
+
+        def controlled_scan(skill_fd):
+            current = skill_manager_module._read_canonical_skill_md(skill_fd)
+            if "# Failed transaction" in current:
+                failed_scan_entered.set()
+                assert release_failed_scan.wait(timeout=10)
+                return "blocked by deterministic scan"
+            return None
+
+        with _skill_dir(tmp_path):
+            _create_skill("transaction-skill", VALID_SKILL_CONTENT)
+            with patch(
+                "tools.skill_manager_tool._security_scan_held_skill",
+                side_effect=controlled_scan,
+            ), ThreadPoolExecutor(max_workers=2) as pool:
+                failed_future = pool.submit(
+                    _edit_skill, "transaction-skill", failed_content
+                )
+                assert failed_scan_entered.wait(timeout=10)
+
+                def successful_edit():
+                    result = _edit_skill(
+                        "transaction-skill", successful_content
+                    )
+                    successful_done.set()
+                    return result
+
+                successful_future = pool.submit(successful_edit)
+                assert not successful_done.wait(timeout=0.2)
+                release_failed_scan.set()
+                failed_result = failed_future.result(timeout=10)
+                successful_result = successful_future.result(timeout=10)
+
+        assert failed_result["success"] is False
+        assert successful_result["success"] is True
+        assert (
+            tmp_path / "transaction-skill" / "SKILL.md"
+        ).read_text(encoding="utf-8") == successful_content
+
+    def test_directory_and_frontmatter_aliases_share_physical_transaction_lock(
+        self, tmp_path
+    ):
+        """Rollback through one alias cannot clobber a commit via the other."""
+        skill_dir = tmp_path / "legacy-dir"
+        references = skill_dir / "references"
+        references.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            _content_for_name(VALID_SKILL_CONTENT, "shared"),
+            encoding="utf-8",
+        )
+        target = references / "state.txt"
+        target.write_text("original", encoding="utf-8")
+        failed_scan_entered = threading.Event()
+        release_failed_scan = threading.Event()
+        successful_done = threading.Event()
+
+        def controlled_scan(skill_fd):
+            file_fd = os.open(
+                "references/state.txt",
+                os.O_RDONLY,
+                dir_fd=skill_fd,
+            )
+            try:
+                current = os.read(file_fd, 100).decode("utf-8")
+            finally:
+                os.close(file_fd)
+            if current == "failed":
+                failed_scan_entered.set()
+                assert release_failed_scan.wait(timeout=10)
+                return "blocked by deterministic alias scan"
+            return None
+
+        with _skill_dir(tmp_path), patch(
+            "tools.skill_manager_tool._security_scan_held_skill",
+            side_effect=controlled_scan,
+        ), ThreadPoolExecutor(max_workers=2) as pool:
+            failed_future = pool.submit(
+                _write_file,
+                "legacy-dir",
+                "references/state.txt",
+                "failed",
+            )
+            assert failed_scan_entered.wait(timeout=10)
+
+            def successful_write():
+                result = _write_file(
+                    "shared",
+                    "references/state.txt",
+                    "successful",
+                )
+                successful_done.set()
+                return result
+
+            successful_future = pool.submit(successful_write)
+            assert not successful_done.wait(timeout=0.2)
+            release_failed_scan.set()
+            failed_result = failed_future.result(timeout=10)
+            successful_result = successful_future.result(timeout=10)
+
+        assert failed_result["success"] is False
+        assert successful_result["success"] is True
+        assert target.read_text(encoding="utf-8") == "successful"
+
+    def test_threaded_alias_write_rollback_serializes_remove(self, tmp_path):
+        """A remove through one alias cannot race a rollback through another."""
+        skill_dir = tmp_path / "legacy-directory"
+        target = skill_dir / "references" / "state.txt"
+        target.parent.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            _content_for_name(VALID_SKILL_CONTENT, "frontmatter-alias"),
+            encoding="utf-8",
+        )
+        target.write_text("original", encoding="utf-8")
+        failed_scan_entered = threading.Event()
+        release_failed_scan = threading.Event()
+        remove_done = threading.Event()
+
+        def controlled_scan(skill_fd):
+            file_fd = os.open("references/state.txt", os.O_RDONLY, dir_fd=skill_fd)
+            try:
+                current = os.read(file_fd, 100).decode("utf-8")
+            finally:
+                os.close(file_fd)
+            if current == "failed":
+                failed_scan_entered.set()
+                assert release_failed_scan.wait(timeout=10)
+                return "blocked by deterministic write/remove scan"
+            return None
+
+        with _skill_dir(tmp_path), patch(
+            "tools.skill_manager_tool._security_scan_held_skill",
+            side_effect=controlled_scan,
+        ), ThreadPoolExecutor(max_workers=2) as pool:
+            write_future = pool.submit(
+                _write_file,
+                "legacy-directory",
+                "references/state.txt",
+                "failed",
+            )
+            assert failed_scan_entered.wait(timeout=10)
+
+            def remove_file():
+                result = _remove_file(
+                    "frontmatter-alias", "references/state.txt"
+                )
+                remove_done.set()
+                return result
+
+            remove_future = pool.submit(remove_file)
+            assert not remove_done.wait(timeout=0.2)
+            release_failed_scan.set()
+            write_result = write_future.result(timeout=10)
+            remove_result = remove_future.result(timeout=10)
+
+        assert write_result["success"] is False
+        assert remove_result["success"] is True
+        assert not target.exists()
+
+    def test_failed_rollback_cannot_overwrite_cross_process_success(
+        self, tmp_path
+    ):
+        try:
+            context = multiprocessing.get_context("fork")
+        except ValueError:
+            pytest.skip("fork multiprocessing context unavailable")
+
+        failed_content = _content_for_name(
+            VALID_SKILL_CONTENT_2.replace(
+                "# Test Skill v2", "# Failed process transaction"
+            ),
+            "transaction-skill",
+        )
+        successful_content = _content_for_name(
+            VALID_SKILL_CONTENT_2.replace(
+                "# Test Skill v2", "# Successful process transaction"
+            ),
+            "transaction-skill",
+        )
+        with _skill_dir(tmp_path):
+            _create_skill("transaction-skill", VALID_SKILL_CONTENT)
+
+        failed_entered = context.Event()
+        successful_entered = context.Event()
+        release_failed = context.Event()
+        failed_done = context.Event()
+        successful_done = context.Event()
+        results = context.Queue()
+        failed_process = context.Process(
+            target=_process_edit_with_controlled_scan,
+            args=(
+                str(tmp_path),
+                failed_content,
+                True,
+                failed_entered,
+                release_failed,
+                failed_done,
+                results,
+            ),
+        )
+        successful_process = context.Process(
+            target=_process_edit_with_controlled_scan,
+            args=(
+                str(tmp_path),
+                successful_content,
+                False,
+                successful_entered,
+                release_failed,
+                successful_done,
+                results,
+            ),
+        )
+        failed_process.start()
+        assert failed_entered.wait(timeout=10)
+        successful_process.start()
+        assert not successful_done.wait(timeout=0.2)
+        assert not successful_entered.is_set()
+        release_failed.set()
+
+        outcomes = [results.get(timeout=10) for _ in range(2)]
+        for process in (failed_process, successful_process):
+            process.join(timeout=10)
+            assert process.exitcode == 0
+
+        assert sorted(result["success"] for result in outcomes) == [False, True]
+        assert (
+            tmp_path / "transaction-skill" / "SKILL.md"
+        ).read_text(encoding="utf-8") == successful_content
+
+    def test_cross_process_directory_and_frontmatter_aliases_serialize_transaction(
+        self, tmp_path
+    ):
+        """Alias transactions share one physical lock across processes.
+
+        The first process writes through the legacy directory basename and
+        pauses after its held-directory scan rejects the write.  A second
+        process addresses the same directory via its frontmatter name.  It
+        must neither scan the failed content nor commit before the first
+        process has rolled back.
+        """
+        try:
+            context = multiprocessing.get_context("fork")
+        except ValueError:
+            pytest.skip("fork multiprocessing context unavailable")
+
+        skill_dir = tmp_path / "legacy-directory"
+        target = skill_dir / "references" / "state.txt"
+        target.parent.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            _content_for_name(VALID_SKILL_CONTENT, "frontmatter-alias"),
+            encoding="utf-8",
+        )
+        target.write_text("original", encoding="utf-8")
+
+        failed_entered = context.Event()
+        successful_entered = context.Event()
+        release_failed = context.Event()
+        failed_done = context.Event()
+        successful_done = context.Event()
+        results = context.Queue()
+        failed_process = context.Process(
+            target=_process_write_alias_with_controlled_scan,
+            args=(
+                str(tmp_path),
+                "legacy-directory",
+                "failed",
+                True,
+                failed_entered,
+                release_failed,
+                failed_done,
+                results,
+            ),
+        )
+        successful_process = context.Process(
+            target=_process_write_alias_with_controlled_scan,
+            args=(
+                str(tmp_path),
+                "frontmatter-alias",
+                "successful",
+                False,
+                successful_entered,
+                release_failed,
+                successful_done,
+                results,
+            ),
+        )
+
+        failed_process.start()
+        assert failed_entered.wait(timeout=10)
+        successful_process.start()
+        assert not successful_done.wait(timeout=0.2)
+        assert not successful_entered.is_set()
+        release_failed.set()
+
+        outcomes = [results.get(timeout=10) for _ in range(2)]
+        for process in (failed_process, successful_process):
+            process.join(timeout=10)
+            assert process.exitcode == 0
+
+        result_by_success = {result["success"]: (result, snapshot) for result, snapshot in outcomes}
+        failed_result, failed_snapshot = result_by_success[False]
+        successful_result, successful_snapshot = result_by_success[True]
+        assert "blocked by deterministic cross-process alias scan" in failed_result["error"]
+        assert successful_result["success"] is True
+        assert failed_snapshot == "failed"
+        assert successful_snapshot == "successful"
+        assert target.read_text(encoding="utf-8") == "successful"
+
+    def test_cross_process_alias_edit_serializes_delete(self, tmp_path):
+        """A delete cannot remove a skill during an edit's held-dir scan."""
+        try:
+            context = multiprocessing.get_context("fork")
+        except ValueError:
+            pytest.skip("fork multiprocessing context unavailable")
+
+        skill_dir = tmp_path / "legacy-directory"
+        skill_dir.mkdir()
+        updated = _content_for_name(
+            VALID_SKILL_CONTENT_2, "frontmatter-alias"
+        )
+        (skill_dir / "SKILL.md").write_text(
+            _content_for_name(VALID_SKILL_CONTENT, "frontmatter-alias"),
+            encoding="utf-8",
+        )
+        edit_entered = context.Event()
+        release_edit = context.Event()
+        edit_done = context.Event()
+        delete_done = context.Event()
+        results = context.Queue()
+        edit_process = context.Process(
+            target=_process_edit_alias_with_controlled_scan,
+            args=(
+                str(tmp_path),
+                "frontmatter-alias",
+                updated,
+                edit_entered,
+                release_edit,
+                edit_done,
+                results,
+            ),
+        )
+        delete_process = context.Process(
+            target=_process_delete_alias,
+            args=(str(tmp_path), "legacy-directory", delete_done, results),
+        )
+
+        edit_process.start()
+        assert edit_entered.wait(timeout=10)
+        delete_process.start()
+        assert not delete_done.wait(timeout=0.2)
+        release_edit.set()
+
+        outcomes = [results.get(timeout=10) for _ in range(2)]
+        for process in (edit_process, delete_process):
+            process.join(timeout=10)
+            assert process.exitcode == 0
+
+        assert all(result["success"] for result in outcomes)
+        assert not skill_dir.exists()
+
+    def test_edit_nonexistent_skill(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _edit_skill(
+                "nonexistent",
+                _content_for_name(VALID_SKILL_CONTENT, "nonexistent"),
+            )
+        assert result["success"] is False
+        assert "not found" in result["error"]
 
     def test_edit_invalid_content_rejected(self, tmp_path):
         with _skill_dir(tmp_path):
@@ -208,6 +1496,115 @@ class TestEditSkill:
         content = (tmp_path / "my-skill" / "SKILL.md").read_text()
         assert "A test skill" in content
 
+    def test_edit_rejects_frontmatter_identity_change(self, tmp_path):
+        original = _content_for_name(VALID_SKILL_CONTENT, "my-skill")
+        mismatched = _content_for_name(VALID_SKILL_CONTENT_2, "other-skill")
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", original)
+            result = _edit_skill("my-skill", mismatched)
+        assert result["success"] is False
+        assert "must match" in result["error"]
+        assert (tmp_path / "my-skill" / "SKILL.md").read_text() == original
+
+    def test_edit_rejects_ambiguous_skill_identity(self, tmp_path):
+        original = _content_for_name(VALID_SKILL_CONTENT, "same-skill")
+        for category in ("a", "b"):
+            skill_dir = tmp_path / category / "same-skill"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(original, encoding="utf-8")
+
+        updated = _content_for_name(VALID_SKILL_CONTENT_2, "same-skill")
+        with _skill_dir(tmp_path):
+            result = _edit_skill("same-skill", updated)
+
+        assert result["success"] is False
+        assert "ambiguous" in result["error"]
+        for category in ("a", "b"):
+            assert (
+                tmp_path / category / "same-skill" / "SKILL.md"
+            ).read_text(encoding="utf-8") == original
+
+    def test_unavailable_external_root_fails_closed_before_local_edit(
+        self, tmp_path
+    ):
+        local = tmp_path / "local"
+        missing_external = tmp_path / "configured-but-missing"
+        local.mkdir()
+        with patch(
+            "tools.skill_manager_tool.SKILLS_DIR", local
+        ), patch(
+            "agent.skill_utils.get_all_skills_dirs",
+            return_value=[local, missing_external],
+        ):
+            created = _create_skill(
+                "my-skill",
+                VALID_SKILL_CONTENT,
+            )
+            assert created["success"] is False
+
+            skill_dir = local / "my-skill"
+            skill_dir.mkdir()
+            original = _content_for_name(
+                VALID_SKILL_CONTENT, "my-skill"
+            )
+            (skill_dir / "SKILL.md").write_text(
+                original, encoding="utf-8"
+            )
+            result = _edit_skill(
+                "my-skill",
+                _content_for_name(VALID_SKILL_CONTENT_2, "my-skill"),
+            )
+
+        assert result["success"] is False
+        assert "lookup is incomplete" in result["error"].lower()
+        assert (skill_dir / "SKILL.md").read_text(
+            encoding="utf-8"
+        ) == original
+
+    def test_unreadable_candidate_metadata_fails_closed_before_local_edit(
+        self, tmp_path
+    ):
+        local = tmp_path / "local"
+        external = tmp_path / "external"
+        local_skill = local / "my-skill"
+        hidden_candidate = external / "legacy-directory"
+        local_skill.mkdir(parents=True)
+        hidden_candidate.mkdir(parents=True)
+        original = _content_for_name(VALID_SKILL_CONTENT, "my-skill")
+        (local_skill / "SKILL.md").write_text(original, encoding="utf-8")
+        (hidden_candidate / "SKILL.md").write_text(
+            original, encoding="utf-8"
+        )
+
+        with patch(
+            "tools.skill_manager_tool.SKILLS_DIR", local
+        ), patch(
+            "agent.skill_utils.get_all_skills_dirs",
+            return_value=[local, external],
+        ), patch(
+            "tools.skill_manager_tool._read_canonical_skill_md",
+            side_effect=UnicodeError("cannot decode candidate"),
+        ):
+            result = _edit_skill(
+                "my-skill",
+                _content_for_name(VALID_SKILL_CONTENT_2, "my-skill"),
+            )
+
+        assert result["success"] is False
+        assert "lookup is incomplete" in result["error"].lower()
+        assert (local_skill / "SKILL.md").read_text(
+            encoding="utf-8"
+        ) == original
+
+    def test_edit_long_desc_includes_prompt_preview(self, tmp_path):
+        edit_content = LONG_DESC_CONTENT.replace("name: long-desc", "name: test-skill")
+        with _skill_dir(tmp_path):
+            _create_skill("test-skill", VALID_SKILL_CONTENT)
+            result = _edit_skill("test-skill", edit_content)
+        assert result["success"] is True
+        assert "system_prompt_preview" in result
+
+
 class TestPatchSkill:
     def test_patch_unique_match(self, tmp_path):
         with _skill_dir(tmp_path):
@@ -217,6 +1614,59 @@ class TestPatchSkill:
         content = (tmp_path / "my-skill" / "SKILL.md").read_text()
         assert "Do the new thing." in content
 
+    def test_canonical_patch_closes_directory_context_on_fuzzy_exception(
+        self, tmp_path
+    ):
+        session = MagicMock()
+        session.__enter__.return_value = (
+            123,
+            tmp_path / "my-skill",
+        )
+        session.__exit__.return_value = False
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            with patch(
+                "tools.skill_manager_tool._open_existing_skill_directory",
+                return_value=session,
+            ), patch(
+                "tools.skill_manager_tool._read_canonical_skill_md",
+                return_value=_content_for_name(
+                    VALID_SKILL_CONTENT,
+                    "my-skill",
+                ),
+            ), patch(
+                "tools.fuzzy_match.fuzzy_find_and_replace",
+                side_effect=RuntimeError("unexpected fuzzy failure"),
+            ):
+                result = _patch_skill(
+                    "my-skill",
+                    "Do the thing.",
+                    "Do something else.",
+                )
+
+        assert result["success"] is False
+        assert "unexpected fuzzy failure" in result["error"]
+        assert session.__exit__.call_count == 2
+        assert session.__exit__.call_args_list[0].args == (None, None, None)
+        assert session.__exit__.call_args_list[1].args[0] is RuntimeError
+
+    def test_patch_rejects_frontmatter_identity_change(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            original = (tmp_path / "my-skill" / "SKILL.md").read_text()
+            result = _patch_skill(
+                "my-skill", "name: my-skill", "name: other-skill"
+            )
+        assert result["success"] is False
+        assert "must match" in result["error"]
+        assert (tmp_path / "my-skill" / "SKILL.md").read_text() == original
+
+    def test_patch_nonexistent_string(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill("my-skill", "this text does not exist", "replacement")
+        assert result["success"] is False
+        assert "not found" in result["error"].lower() or "could not find" in result["error"].lower()
 
     def test_patch_ambiguous_match_rejected(self, tmp_path):
         content = """\
@@ -254,6 +1704,59 @@ word word
         assert "escapes" in result["error"].lower()
         assert outside_file.read_text() == "old text here"
 
+    @pytest.mark.parametrize("action", ["patch", "write_file"])
+    def test_supporting_parent_symlink_swap_after_validation_is_rejected(
+        self, tmp_path, action
+    ):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        outside_target = outside / "api.md"
+        outside_target.write_text("outside old text", encoding="utf-8")
+
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            references = tmp_path / "my-skill" / "references"
+            references.mkdir()
+            inside_target = references / "api.md"
+            inside_target.write_text("inside old text", encoding="utf-8")
+            moved_references = tmp_path / "my-skill" / "held-references"
+            real_replace = skill_manager_module._replace_held_regular_text
+            swapped = False
+
+            def replace_then_swap(parent_fd, filename, content, **kwargs):
+                nonlocal swapped
+                real_replace(parent_fd, filename, content, **kwargs)
+                if not swapped:
+                    swapped = True
+                    references.rename(moved_references)
+                    references.symlink_to(outside, target_is_directory=True)
+
+            with patch(
+                "tools.skill_manager_tool._replace_held_regular_text",
+                side_effect=replace_then_swap,
+            ):
+                if action == "patch":
+                    result = _patch_skill(
+                        "my-skill",
+                        "old text",
+                        "new text",
+                        file_path="references/api.md",
+                    )
+                else:
+                    result = _write_file(
+                        "my-skill",
+                        "references/api.md",
+                        "new text",
+                    )
+
+        assert swapped is True
+        assert result["success"] is False
+        assert "path changed" in result["error"].lower()
+        assert outside_target.read_text(encoding="utf-8") == "outside old text"
+        assert (
+            moved_references / "api.md"
+        ).read_text(encoding="utf-8") == "inside old text"
+
 
 class TestDeleteSkill:
     def test_delete_cleans_empty_category_dir(self, tmp_path):
@@ -284,6 +1787,44 @@ class TestWriteFile:
         assert result["success"] is True
         assert (tmp_path / "my-skill" / "references" / "api.md").exists()
 
+    def test_write_to_nonexistent_skill(self, tmp_path):
+        with _skill_dir(tmp_path):
+            result = _write_file("nonexistent", "references/doc.md", "content")
+        assert result["success"] is False
+
+    def test_write_to_disallowed_path(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _write_file("my-skill", "secret/evil.py", "malicious")
+        assert result["success"] is False
+
+    def test_write_skill_md_uses_validated_edit_contract(self, tmp_path):
+        mismatched = _content_for_name(VALID_SKILL_CONTENT_2, "other-skill")
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            original = (tmp_path / "my-skill" / "SKILL.md").read_text()
+            result = _write_file("my-skill", "SKILL.md", mismatched)
+        assert result["success"] is False
+        assert "must match" in result["error"]
+        assert (tmp_path / "my-skill" / "SKILL.md").read_text() == original
+
+    def test_write_support_directory_skill_md_remains_supporting_file(
+        self, tmp_path
+    ):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            original = (tmp_path / "my-skill" / "SKILL.md").read_text()
+            result = _write_file(
+                "my-skill",
+                "references/SKILL.md",
+                "preserved package",
+            )
+        assert result["success"] is True
+        assert (
+            tmp_path / "my-skill" / "references" / "SKILL.md"
+        ).read_text() == "preserved package"
+        assert (tmp_path / "my-skill" / "SKILL.md").read_text() == original
+
     def test_write_symlink_escape_blocked(self, tmp_path):
         outside_dir = tmp_path / "outside"
         outside_dir.mkdir()
@@ -312,6 +1853,44 @@ class TestRemoveFile:
             result = _remove_file("my-skill", "references/api.md")
         assert result["success"] is True
         assert not (tmp_path / "my-skill" / "references" / "api.md").exists()
+
+    def test_remove_reports_success_when_empty_parent_cleanup_fails(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            _write_file("my-skill", "references/api.md", "content")
+            with patch(
+                "tools.skill_manager_tool._secure_cleanup_empty_support_parent",
+                side_effect=OSError("injected cleanup failure"),
+            ):
+                result = _remove_file("my-skill", "references/api.md")
+
+        assert result["success"] is True
+        assert not (tmp_path / "my-skill" / "references" / "api.md").exists()
+
+    def test_remove_nonexistent_file(self, tmp_path):
+        from tools.skills_tool import MAX_LINKED_FILES_PER_CATEGORY
+
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            for index in reversed(range(MAX_LINKED_FILES_PER_CATEGORY + 5)):
+                _write_file(
+                    "my-skill",
+                    f"references/{index:03d}.md",
+                    "content",
+                )
+            result = _remove_file("my-skill", "references/nope.md")
+        assert result["success"] is False
+        assert len(result["available_files"]) == MAX_LINKED_FILES_PER_CATEGORY
+        assert result["available_files"] == sorted(result["available_files"])
+        assert result["linked_files_summary"]["truncated"] is True
+
+    def test_remove_skill_md_requires_delete_action(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _remove_file("my-skill", "SKILL.md")
+        assert result["success"] is False
+        assert "delete" in result["error"]
+        assert (tmp_path / "my-skill" / "SKILL.md").exists()
 
     def test_remove_symlink_escape_blocked(self, tmp_path):
         outside_dir = tmp_path / "outside"
@@ -360,6 +1939,44 @@ class TestSkillManageDispatcher:
         rec = usage.get("test-skill") or {}
         assert rec.get("created_by") in {None, "", False}
 
+    def test_create_from_background_review_marks_agent_created(self, tmp_path):
+        """Background-review fork creates ARE marked as agent-created."""
+        from tools.skill_provenance import set_current_write_origin, BACKGROUND_REVIEW
+        token = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            with _skill_dir(tmp_path):
+                raw = skill_manage(
+                    action="create",
+                    name="review-sediment",
+                    content=_content_for_name(VALID_SKILL_CONTENT, "review-sediment"),
+                )
+                from tools.skill_usage import load_usage
+                usage = load_usage()
+        finally:
+            from tools.skill_provenance import reset_current_write_origin
+            reset_current_write_origin(token)
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert usage["review-sediment"]["created_by"] == "agent"
+
+    def test_delete_via_dispatcher_threads_absorbed_into(self, tmp_path):
+        # Dispatcher must plumb absorbed_into through to _delete_skill so the
+        # validation + message suffix paths are exercised end-to-end.
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="umbrella", content=_content_for_name(VALID_SKILL_CONTENT, "umbrella"))
+            skill_manage(action="create", name="narrow", content=_content_for_name(VALID_SKILL_CONTENT, "narrow"))
+            raw = skill_manage(action="delete", name="narrow", absorbed_into="umbrella")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "absorbed into 'umbrella'" in result["message"]
+
+    def test_delete_via_dispatcher_rejects_missing_absorbed_target(self, tmp_path):
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="narrow", content=_content_for_name(VALID_SKILL_CONTENT, "narrow"))
+            raw = skill_manage(action="delete", name="narrow", absorbed_into="ghost")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "does not exist" in result["error"]
 
     def test_background_review_delete_refuses_bundled_even_with_absorbed_into(self, tmp_path):
         from tools.skill_provenance import (
@@ -375,8 +1992,8 @@ class TestSkillManageDispatcher:
                  patch("tools.skill_usage.is_hub_installed", return_value=False), \
                  patch("tools.skill_usage.is_bundled",
                        side_effect=lambda skill_name: skill_name == "bundled"):
-                skill_manage(action="create", name="umbrella", content=VALID_SKILL_CONTENT)
-                skill_manage(action="create", name="bundled", content=VALID_SKILL_CONTENT)
+                skill_manage(action="create", name="umbrella", content=_content_for_name(VALID_SKILL_CONTENT, "umbrella"))
+                skill_manage(action="create", name="bundled", content=_content_for_name(VALID_SKILL_CONTENT, "bundled"))
                 raw = skill_manage(
                     action="delete",
                     name="bundled",
@@ -393,6 +2010,40 @@ class TestSkillManageDispatcher:
 
 class TestSecurityScanGate:
     """_security_scan_skill is gated by skills.guard_agent_created config flag."""
+
+    @pytest.mark.parametrize("mutation", ["create", "edit", "patch"])
+    def test_disabled_guard_skips_held_snapshot_for_canonical_mutations(
+        self, tmp_path, mutation
+    ):
+        """A disabled guard must not copy even a large skill tree to scan it."""
+        replacement = _content_for_name(VALID_SKILL_CONTENT_2, "my-skill")
+        with _skill_dir(tmp_path), patch(
+            "tools.skill_manager_tool._GUARD_AVAILABLE", True
+        ), patch(
+            "tools.skill_manager_tool._guard_agent_created_enabled",
+            return_value=False,
+        ), patch(
+            "tools.skill_manager_tool.os.fwalk"
+        ) as mock_fwalk, patch(
+            "tools.skill_manager_tool.shutil.copyfileobj"
+        ) as mock_copy:
+            if mutation == "create":
+                result = _create_skill("my-skill", VALID_SKILL_CONTENT)
+            else:
+                assert _create_skill("my-skill", VALID_SKILL_CONTENT)["success"]
+                assets = tmp_path / "my-skill" / "assets"
+                assets.mkdir()
+                (assets / "large.bin").write_bytes(b"x" * (2 * 1024 * 1024))
+                if mutation == "edit":
+                    result = _edit_skill("my-skill", replacement)
+                else:
+                    result = _patch_skill(
+                        "my-skill", "Do the thing.", "Do the new thing."
+                    )
+
+        assert result["success"] is True
+        mock_fwalk.assert_not_called()
+        mock_copy.assert_not_called()
 
     def test_scan_noop_when_flag_off(self, tmp_path):
         """Default config (flag off) short-circuits before running scan_skill."""
@@ -667,7 +2318,10 @@ class TestPinnedGuard:
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
             with self._pin("my-skill"):
-                result = _edit_skill("my-skill", VALID_SKILL_CONTENT_2)
+                result = _edit_skill(
+                    "my-skill",
+                    _content_for_name(VALID_SKILL_CONTENT_2, "my-skill"),
+                )
         assert result["success"] is True, result
         # Content updated
         content = (tmp_path / "my-skill" / "SKILL.md").read_text()
@@ -733,7 +2387,11 @@ class TestDeleteSkillRmtreeGuard:
             with patch("tools.skill_manager_tool.SKILLS_DIR", skills), \
                  patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills]), \
                  patch("tools.skill_manager_tool._find_skill",
-                       return_value={"path": evil}):
+                       return_value={
+                           "path": evil,
+                           "_resolved_path": victim,
+                           "_dir_identity": (victim.stat().st_dev, victim.stat().st_ino),
+                       }):
                 result = _delete_skill("evil-skill", absorbed_into="")
             assert result["success"] is False
             assert "symlink" in result["error"].lower()
@@ -742,6 +2400,21 @@ class TestDeleteSkillRmtreeGuard:
             import shutil as _sh
             _sh.rmtree(victim, ignore_errors=True)
 
+    def test_skills_root_itself_refused(self, tmp_path):
+        """If discovery ever hands back the skills root, refuse — rmtree would
+        wipe every installed skill."""
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+             patch("tools.skill_manager_tool._find_skill",
+                   return_value={
+                       "path": tmp_path,
+                       "_resolved_path": tmp_path,
+                       "_dir_identity": (tmp_path.stat().st_dev, tmp_path.stat().st_ino),
+                   }):
+            result = _delete_skill(tmp_path.name, absorbed_into="")
+        assert result["success"] is False
+        assert "skills root" in result["error"].lower()
+        assert tmp_path.exists()
 
     def test_out_of_tree_path_refused(self, tmp_path):
         """A path that resolves outside every known skills root is refused."""
@@ -753,8 +2426,12 @@ class TestDeleteSkillRmtreeGuard:
         with patch("tools.skill_manager_tool.SKILLS_DIR", skills), \
              patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills]), \
              patch("tools.skill_manager_tool._find_skill",
-                   return_value={"path": outside}):
-            result = _delete_skill("outside", absorbed_into="")
+                   return_value={
+                       "path": outside,
+                       "_resolved_path": outside,
+                       "_dir_identity": (outside.stat().st_dev, outside.stat().st_ino),
+                   }):
+            result = _delete_skill("outside_skill", absorbed_into="")
         assert result["success"] is False
         assert "skills root" in result["error"].lower()
         assert outside.exists()
@@ -810,6 +2487,182 @@ def _skill_content(name: str) -> str:
         f"# {name}\n\n"
         "Step 1: Do the thing.\n"
     )
+
+
+class TestSecureCuratorArchive:
+    def test_curator_archive_accepts_directory_alias_for_frontmatter_skill(
+        self, tmp_path, monkeypatch
+    ):
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch) as skills_root:
+            _create_curator_skill("umbrella", _skill_content("umbrella"))
+            legacy = skills_root / "legacy-directory"
+            legacy.mkdir()
+            (legacy / "SKILL.md").write_text(
+                _skill_content("frontmatter-alias"), encoding="utf-8"
+            )
+            with patch(
+                "tools.skill_manager_tool._background_review_write_guard",
+                return_value=None,
+            ):
+                result = _delete_skill(
+                    "legacy-directory", absorbed_into="umbrella"
+                )
+
+        assert result["success"] is True, result
+        assert not legacy.exists()
+        assert (skills_root / ".archive" / "legacy-directory" / "SKILL.md").exists()
+
+    def test_curator_delete_retry_reconciles_archived_canonical_alias(
+        self, tmp_path, monkeypatch
+    ):
+        """A curator delete retry handles a committed alias archive exactly once."""
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch) as skills_root:
+            _create_curator_skill("umbrella", _skill_content("umbrella"))
+            legacy = skills_root / "legacy-directory"
+            legacy.mkdir()
+            (legacy / "SKILL.md").write_text(
+                _skill_content("frontmatter-alias"), encoding="utf-8"
+            )
+            from tools.skill_usage import mark_agent_created, get_record
+            import tools.skill_usage as usage
+
+            mark_agent_created("frontmatter-alias")
+            real_persist = usage.persist_lifecycle_move_metadata_strict
+            monkeypatch.setattr(
+                usage,
+                "persist_lifecycle_move_metadata_strict",
+                lambda *args, **kwargs: (_ for _ in ()).throw(
+                    OSError("state write failed")
+                ),
+            )
+            with patch(
+                "tools.skill_manager_tool._background_review_write_guard",
+                return_value=None,
+            ):
+                first = _delete_skill(
+                    "frontmatter-alias", absorbed_into="umbrella"
+                )
+            assert first["success"] is False
+            assert (skills_root / ".archive" / "legacy-directory").is_dir()
+
+            monkeypatch.setattr(
+                usage, "persist_lifecycle_move_metadata_strict", real_persist
+            )
+            with patch(
+                "tools.skill_manager_tool._background_review_write_guard",
+                return_value=None,
+            ):
+                retry = _delete_skill(
+                    "legacy-directory", absorbed_into="umbrella"
+                )
+
+        assert retry["success"] is True, retry
+        assert retry["_archived"] is True
+        assert get_record("frontmatter-alias")["state"] == "archived"
+
+    def test_curator_archive_refuses_parent_swap_before_rename(self, tmp_path):
+        skill_dir = tmp_path / "legacy-directory"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            _skill_content("frontmatter-alias"), encoding="utf-8"
+        )
+        with _skill_dir(tmp_path):
+            existing = skill_manager_module._find_skill("frontmatter-alias")
+            assert existing is not None
+            real_matches = skill_manager_module._directory_entry_matches_fd
+            calls = 0
+
+            def swap_before_final_match(*args):
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    skill_dir.rename(tmp_path / "moved-original")
+                    replacement = tmp_path / "legacy-directory"
+                    replacement.mkdir()
+                    (replacement / "SKILL.md").write_text(
+                        _skill_content("replacement"), encoding="utf-8"
+                    )
+                return real_matches(*args)
+
+            with patch(
+                "tools.skill_manager_tool._directory_entry_matches_fd",
+                side_effect=swap_before_final_match,
+            ):
+                ok, message = skill_manager_module._secure_archive_existing_skill(
+                    existing, tmp_path
+                )
+
+        assert ok is False
+        assert "changed before archiving" in message
+        assert (tmp_path / "moved-original" / "SKILL.md").exists()
+        assert (tmp_path / "legacy-directory" / "SKILL.md").exists()
+        assert not list((tmp_path / ".archive").iterdir())
+
+    def test_curator_archive_fails_closed_without_secure_platform(self, tmp_path):
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            _skill_content("my-skill"), encoding="utf-8"
+        )
+        with _skill_dir(tmp_path):
+            existing = skill_manager_module._find_skill("my-skill")
+            assert existing is not None
+            with patch(
+                "tools.skill_manager_tool._secure_directory_create_supported",
+                return_value=False,
+            ), patch("tools.skill_manager_tool.os.name", "nt"):
+                ok, message = skill_manager_module._secure_archive_existing_skill(
+                    existing, tmp_path
+                )
+
+        assert ok is False
+        assert "unavailable" in message
+        assert skill_dir.exists()
+
+
+class TestCommittedFsyncFailures:
+    @staticmethod
+    def _fail_directory_fsync():
+        real_fsync = os.fsync
+
+        def fail_directory(fd):
+            if os.path.exists(f"/dev/fd/{fd}") and stat.S_ISDIR(os.fstat(fd).st_mode):
+                raise OSError("injected post-commit directory fsync failure")
+            return real_fsync(fd)
+
+        return fail_directory
+
+    @pytest.mark.parametrize("action", ["edit", "patch", "write"])
+    def test_replace_post_fsync_failure_is_not_reported_as_noop(self, tmp_path, action):
+        replacement = _content_for_name(VALID_SKILL_CONTENT_2, "my-skill")
+        with _skill_dir(tmp_path), patch(
+            "tools.skill_manager_tool.os.fsync", side_effect=self._fail_directory_fsync()
+        ):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            if action == "edit":
+                result = _edit_skill("my-skill", replacement)
+            elif action == "patch":
+                result = _patch_skill("my-skill", "Do the thing.", "Changed.")
+            else:
+                result = _write_file("my-skill", "references/state.txt", "changed")
+        assert result["success"] is True
+
+    def test_remove_post_unlink_fsync_failure_reports_committed_success(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            _write_file("my-skill", "references/state.txt", "old")
+            with patch("tools.skill_manager_tool.os.fsync", side_effect=self._fail_directory_fsync()):
+                result = _remove_file("my-skill", "references/state.txt")
+        assert result["success"] is True
+        assert not (tmp_path / "my-skill" / "references" / "state.txt").exists()
+
+    def test_hard_delete_post_rmdir_fsync_failure_reports_committed_success(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            with patch("tools.skill_manager_tool.os.fsync", side_effect=self._fail_directory_fsync()):
+                result = _delete_skill("my-skill")
+        assert result["success"] is True
+        assert not (tmp_path / "my-skill").exists()
 
 def _create_curator_skill(name: str, content: str):
     """Create a skill and record the agent ownership a real curator create has."""

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1098,7 +1098,9 @@ class TestEditSkill:
                 "my-skill", _content_for_name(VALID_SKILL_CONTENT_2, "my-skill")
             )
         assert result["success"] is True
-        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
         assert "Updated description" in content
 
     def test_failed_rollback_cannot_overwrite_concurrent_success(
@@ -1493,7 +1495,9 @@ class TestEditSkill:
             result = _edit_skill("my-skill", "no frontmatter")
         assert result["success"] is False
         # Original content should be preserved
-        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
         assert "A test skill" in content
 
     def test_edit_rejects_frontmatter_identity_change(self, tmp_path):
@@ -1611,7 +1615,9 @@ class TestPatchSkill:
             _create_skill("my-skill", VALID_SKILL_CONTENT)
             result = _patch_skill("my-skill", "Do the thing.", "Do the new thing.")
         assert result["success"] is True
-        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
         assert "Do the new thing." in content
 
     def test_canonical_patch_closes_directory_context_on_fuzzy_exception(
@@ -1653,7 +1659,9 @@ class TestPatchSkill:
     def test_patch_rejects_frontmatter_identity_change(self, tmp_path):
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
-            original = (tmp_path / "my-skill" / "SKILL.md").read_text()
+            original = (tmp_path / "my-skill" / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
             result = _patch_skill(
                 "my-skill", "name: my-skill", "name: other-skill"
             )
@@ -1687,7 +1695,7 @@ word word
 
     def test_patch_supporting_file_symlink_escape_blocked(self, tmp_path):
         outside_file = tmp_path / "outside.txt"
-        outside_file.write_text("old text here")
+        outside_file.write_text("old text here", encoding="utf-8")
 
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
@@ -1802,7 +1810,9 @@ class TestWriteFile:
         mismatched = _content_for_name(VALID_SKILL_CONTENT_2, "other-skill")
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
-            original = (tmp_path / "my-skill" / "SKILL.md").read_text()
+            original = (tmp_path / "my-skill" / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
             result = _write_file("my-skill", "SKILL.md", mismatched)
         assert result["success"] is False
         assert "must match" in result["error"]
@@ -1813,7 +1823,9 @@ class TestWriteFile:
     ):
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
-            original = (tmp_path / "my-skill" / "SKILL.md").read_text()
+            original = (tmp_path / "my-skill" / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
             result = _write_file(
                 "my-skill",
                 "references/SKILL.md",
@@ -1896,7 +1908,7 @@ class TestRemoveFile:
         outside_dir = tmp_path / "outside"
         outside_dir.mkdir()
         outside_file = outside_dir / "keep.txt"
-        outside_file.write_text("content")
+        outside_file.write_text("content", encoding="utf-8")
 
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
@@ -2143,7 +2155,9 @@ class TestExternalSkillMutations:
             result = _patch_skill("ext-skill", "OLD_MARKER", "NEW_MARKER")
 
         assert result["success"] is True, result
-        assert "NEW_MARKER" in (skill_dir / "SKILL.md").read_text()
+        assert "NEW_MARKER" in (skill_dir / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
         # No duplicate in local
         assert not (local / "ext-skill").exists()
 
@@ -2324,7 +2338,9 @@ class TestPinnedGuard:
                 )
         assert result["success"] is True, result
         # Content updated
-        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
         assert "A test skill" not in content
 
     def test_delete_refuses_pinned(self, tmp_path):
@@ -2378,7 +2394,9 @@ class TestDeleteSkillRmtreeGuard:
         otherwise follow it and delete the link target's contents."""
         victim = tmp_path.parent / "precious_victim"
         victim.mkdir()
-        (victim / "important.txt").write_text("DO NOT DELETE")
+        (victim / "important.txt").write_text(
+            "DO NOT DELETE", encoding="utf-8"
+        )
         skills = tmp_path / "skills"
         skills.mkdir()
         evil = skills / "evil-skill"
@@ -2422,7 +2440,7 @@ class TestDeleteSkillRmtreeGuard:
         skills.mkdir()
         outside = tmp_path / "outside_skill"
         outside.mkdir()
-        (outside / "SKILL.md").write_text("x")
+        (outside / "SKILL.md").write_text("x", encoding="utf-8")
         with patch("tools.skill_manager_tool.SKILLS_DIR", skills), \
              patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills]), \
              patch("tools.skill_manager_tool._find_skill",

--- a/tests/tools/test_skill_size_limits.py
+++ b/tests/tools/test_skill_size_limits.py
@@ -27,11 +27,11 @@ def isolate_skills(tmp_path, monkeypatch):
     return skills_dir
 
 
-def _make_skill_content(body_chars: int) -> str:
+def _make_skill_content(body_chars: int, name: str = "test-skill") -> str:
     """Generate valid SKILL.md content with a body of the given character count."""
     frontmatter = (
         "---\n"
-        "name: test-skill\n"
+        f"name: {name}\n"
         "description: A test skill\n"
         "---\n"
     )
@@ -55,10 +55,17 @@ class TestCreateSkillSizeLimit:
     """create action rejects oversized content."""
 
     def test_create_within_limit(self, isolate_skills):
-        content = _make_skill_content(5000)
+        content = _make_skill_content(5000, "small-skill")
         result = json.loads(skill_manage(action="create", name="small-skill", content=content))
         assert result["success"] is True
 
+    def test_create_over_limit(self, isolate_skills):
+        content = _make_skill_content(
+            MAX_SKILL_CONTENT_CHARS + 100, "huge-skill"
+        )
+        result = json.loads(skill_manage(action="create", name="huge-skill", content=content))
+        assert result["success"] is False
+        assert "100,000" in result["error"]
 
     def test_create_at_limit(self, isolate_skills):
         # Content at exactly the limit should succeed
@@ -75,13 +82,11 @@ class TestEditSkillSizeLimit:
 
     def test_edit_over_limit(self, isolate_skills):
         # Create a small skill first
-        small = _make_skill_content(1000)
+        small = _make_skill_content(1000, "grow-me")
         json.loads(skill_manage(action="create", name="grow-me", content=small))
 
         # Try to edit it to be oversized
-        big = _make_skill_content(MAX_SKILL_CONTENT_CHARS + 100)
-        # Fix the name in frontmatter
-        big = big.replace("name: test-skill", "name: grow-me")
+        big = _make_skill_content(MAX_SKILL_CONTENT_CHARS + 100, "grow-me")
         result = json.loads(skill_manage(action="edit", name="grow-me", content=big))
         assert result["success"] is False
         assert "100,000" in result["error"]
@@ -92,7 +97,9 @@ class TestPatchSkillSizeLimit:
 
     def test_patch_that_would_exceed_limit(self, isolate_skills):
         # Create a skill near the limit
-        near_limit = _make_skill_content(MAX_SKILL_CONTENT_CHARS - 50)
+        near_limit = _make_skill_content(
+            MAX_SKILL_CONTENT_CHARS - 50, "near-limit"
+        )
         json.loads(skill_manage(action="create", name="near-limit", content=near_limit))
 
         # Patch that adds enough to go over
@@ -105,10 +112,32 @@ class TestPatchSkillSizeLimit:
         assert result["success"] is False
         assert "100,000" in result["error"]
 
+    def test_patch_that_reduces_size_on_oversized_skill(self, isolate_skills, tmp_path):
+        """Patches that shrink an already-oversized skill should succeed."""
+        # Manually create an oversized skill (simulating hand-placed)
+        skill_dir = tmp_path / "skills" / "bloated"
+        skill_dir.mkdir(parents=True)
+        oversized = _make_skill_content(
+            MAX_SKILL_CONTENT_CHARS + 5000, "bloated"
+        )
+        (skill_dir / "SKILL.md").write_text(oversized, encoding="utf-8")
+        assert len(oversized) > MAX_SKILL_CONTENT_CHARS
+
+        # Patch that removes content to bring it under the limit.
+        # Use replace_all to replace the repeated x's with a shorter string.
+        result = json.loads(skill_manage(
+            action="patch",
+            name="bloated",
+            old_string="x" * 100,
+            new_string="y",
+            replace_all=True,
+        ))
+        # Should succeed because the result is well within limits
+        assert result["success"] is True
 
     def test_patch_supporting_file_size_limit(self, isolate_skills):
         """Patch on a supporting file also checks size."""
-        small = _make_skill_content(1000)
+        small = _make_skill_content(1000, "with-ref")
         json.loads(skill_manage(action="create", name="with-ref", content=small))
         # Create a supporting file
         json.loads(skill_manage(
@@ -133,7 +162,7 @@ class TestWriteFileSizeLimit:
     """write_file action enforces both char and byte limits."""
 
     def test_write_file_over_char_limit(self, isolate_skills):
-        small = _make_skill_content(1000)
+        small = _make_skill_content(1000, "file-test")
         json.loads(skill_manage(action="create", name="file-test", content=small))
 
         result = json.loads(skill_manage(
@@ -146,7 +175,7 @@ class TestWriteFileSizeLimit:
         assert "100,000" in result["error"]
 
     def test_write_file_within_limit(self, isolate_skills):
-        small = _make_skill_content(1000)
+        small = _make_skill_content(1000, "file-ok")
         json.loads(skill_manage(action="create", name="file-ok", content=small))
 
         result = json.loads(skill_manage(
@@ -167,8 +196,7 @@ class TestHandPlacedSkillsNoLimit:
 
         skill_dir = tmp_path / "skills" / "manual-giant"
         skill_dir.mkdir(parents=True)
-        huge = _make_skill_content(200_000)
-        huge = huge.replace("name: test-skill", "name: manual-giant")
+        huge = _make_skill_content(200_000, "manual-giant")
         (skill_dir / "SKILL.md").write_text(huge, encoding="utf-8")
 
         result = json.loads(skill_view("manual-giant"))

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -3,6 +3,7 @@
 import json
 import multiprocessing as mp
 import os
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -53,6 +54,19 @@ description: test skill
 
 # body
 """,
+        encoding="utf-8",
+    )
+    return d
+
+
+def _write_skill_with_physical_alias(
+    skills_dir: Path, directory_name: str, canonical_name: str
+):
+    """Create a skill whose filesystem alias differs from its lifecycle name."""
+    d = skills_dir / directory_name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {canonical_name}\ndescription: test skill\n---\n\n# body\n",
         encoding="utf-8",
     )
     return d
@@ -201,6 +215,653 @@ def test_is_agent_created(skills_home):
 # ---------------------------------------------------------------------------
 # Archive / restore
 # ---------------------------------------------------------------------------
+
+def test_archive_skill_moves_directory(skills_home):
+    from tools.skill_usage import archive_skill, get_record
+    import tools.skill_usage as usage
+    skills_dir = skills_home / "skills"
+    skill_dir = _write_skill(skills_dir, "old-skill")
+    assert skill_dir.exists()
+
+    ok, msg = archive_skill("old-skill")
+    assert ok, msg
+    assert not skill_dir.exists()
+    assert (skills_dir / ".archive" / "old-skill" / "SKILL.md").exists()
+    assert get_record("old-skill")["state"] == "archived"
+    assert get_record("old-skill")["archived_at"] is not None
+
+
+def test_archive_refuses_bundled_skill(skills_home):
+    from tools.skill_usage import archive_skill
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "bundled")
+    (skills_dir / ".bundled_manifest").write_text("bundled:abc\n", encoding="utf-8")
+
+    ok, msg = archive_skill("bundled")
+    assert not ok
+    assert "bundled" in msg.lower() or "hub" in msg.lower()
+
+
+def test_archive_refuses_hub_skill(skills_home):
+    from tools.skill_usage import archive_skill
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "hub-skill")
+    hub_dir = skills_dir / ".hub"
+    hub_dir.mkdir()
+    (hub_dir / "lock.json").write_text(
+        json.dumps({"installed": {"hub-skill": {}}}), encoding="utf-8",
+    )
+
+    ok, msg = archive_skill("hub-skill")
+    assert not ok
+
+
+def test_archive_refuses_external_skill(skills_home, monkeypatch):
+    from tools.skill_usage import archive_skill
+
+    skills_dir = skills_home / "skills"
+    external = skills_dir / "shared-vault"
+    skill_dir = _write_skill(external, "external-skill")
+    monkeypatch.setattr(
+        "agent.skill_utils.get_external_skills_dirs",
+        lambda: [external.resolve()],
+    )
+
+    ok, msg = archive_skill("external-skill")
+    assert not ok
+    assert "external" in msg.lower()
+    assert skill_dir.exists()
+
+
+def test_archive_missing_skill_returns_error(skills_home):
+    from tools.skill_usage import archive_skill
+    ok, msg = archive_skill("nonexistent")
+    assert not ok
+    assert "not found" in msg.lower()
+
+
+def test_direct_archive_fails_closed_without_secure_manager_backend(
+    skills_home, monkeypatch
+):
+    from tools.skill_usage import archive_skill
+
+    skills_dir = skills_home / "skills"
+    skill_dir = _write_skill(skills_dir, "unsafe-archive")
+    monkeypatch.setattr(
+        "tools.skill_manager_tool._secure_directory_create_supported",
+        lambda: False,
+    )
+
+    ok, message = archive_skill("unsafe-archive")
+
+    assert ok is False
+    assert "unavailable" in message
+    assert skill_dir.exists()
+
+
+def test_direct_restore_fails_closed_without_secure_manager_backend(
+    skills_home, monkeypatch
+):
+    from tools.skill_usage import archive_skill, restore_skill
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "unsafe-restore")
+    ok, message = archive_skill("unsafe-restore")
+    assert ok, message
+    monkeypatch.setattr(
+        "tools.skill_manager_tool._secure_directory_create_supported",
+        lambda: False,
+    )
+
+    ok, message = restore_skill("unsafe-restore")
+
+    assert ok is False
+    assert "unavailable" in message
+    assert (skills_dir / ".archive" / "unsafe-restore").exists()
+
+
+def test_archive_metadata_failure_is_truthful_and_retry_reconciles(skills_home, monkeypatch):
+    from tools.skill_usage import archive_skill, get_record
+    import tools.skill_usage as usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "reconcile-archive")
+    real_persist = usage.persist_lifecycle_move_metadata_strict
+    monkeypatch.setattr(
+        "tools.skill_usage.persist_lifecycle_move_metadata_strict",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("state write failed")),
+    )
+    ok, message = archive_skill("reconcile-archive")
+    assert ok is False
+    assert "filesystem move committed" in message
+    assert (skills_dir / ".archive" / "reconcile-archive").exists()
+    monkeypatch.setattr(usage, "persist_lifecycle_move_metadata_strict", real_persist)
+    ok, message = archive_skill("reconcile-archive")
+    assert ok, message
+    assert get_record("reconcile-archive")["state"] == "archived"
+
+
+def test_restore_metadata_failure_is_truthful_and_retry_reconciles(skills_home, monkeypatch):
+    from tools.skill_usage import archive_skill, restore_skill, get_record
+    import tools.skill_usage as usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "reconcile-restore")
+    assert archive_skill("reconcile-restore")[0]
+    real_persist = usage.persist_lifecycle_move_metadata_strict
+    monkeypatch.setattr(
+        "tools.skill_usage.persist_lifecycle_move_metadata_strict",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("state write failed")),
+    )
+    ok, message = restore_skill("reconcile-restore")
+    assert ok is False
+    assert "filesystem move committed" in message
+    assert (skills_dir / "reconcile-restore").exists()
+    monkeypatch.setattr(usage, "persist_lifecycle_move_metadata_strict", real_persist)
+    ok, message = restore_skill("reconcile-restore")
+    assert ok, message
+    assert get_record("reconcile-restore")["state"] == "active"
+
+
+def test_alias_archive_metadata_retry_uses_canonical_identity(skills_home, monkeypatch):
+    """A post-move archive retry can use either canonical or physical alias."""
+    from tools.skill_usage import archive_skill, get_record, mark_agent_created
+    import tools.skill_usage as usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill_with_physical_alias(
+        skills_dir, "legacy-directory", "frontmatter-alias"
+    )
+    mark_agent_created("frontmatter-alias")
+    real_persist = usage.persist_lifecycle_move_metadata_strict
+    monkeypatch.setattr(
+        usage,
+        "persist_lifecycle_move_metadata_strict",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("state write failed")),
+    )
+
+    ok, message = archive_skill("frontmatter-alias")
+    assert ok is False
+    assert "filesystem move committed" in message
+    assert (skills_dir / ".archive" / "legacy-directory").is_dir()
+
+    monkeypatch.setattr(usage, "persist_lifecycle_move_metadata_strict", real_persist)
+    ok, message = archive_skill("legacy-directory")
+    assert ok, message
+    assert get_record("frontmatter-alias")["state"] == "archived"
+
+
+def test_alias_restore_metadata_retry_preserves_physical_directory(skills_home, monkeypatch):
+    """Restore keeps the physical alias but reconciles canonical metadata."""
+    from tools.skill_usage import archive_skill, get_record, mark_agent_created, restore_skill
+    import tools.skill_usage as usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill_with_physical_alias(
+        skills_dir, "legacy-directory", "frontmatter-alias"
+    )
+    mark_agent_created("frontmatter-alias")
+    assert archive_skill("legacy-directory")[0]
+    real_persist = usage.persist_lifecycle_move_metadata_strict
+    monkeypatch.setattr(
+        usage,
+        "persist_lifecycle_move_metadata_strict",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("state write failed")),
+    )
+
+    # Use the old physical archive alias. The restore path must normalize it
+    # to the canonical lifecycle lock before it checks the active tree.
+    ok, message = restore_skill("legacy-directory")
+    assert ok is False
+    assert "filesystem move committed" in message
+    assert (skills_dir / "legacy-directory").is_dir()
+    assert not (skills_dir / "frontmatter-alias").exists()
+
+    monkeypatch.setattr(usage, "persist_lifecycle_move_metadata_strict", real_persist)
+    ok, message = restore_skill("legacy-directory")
+    assert ok, message
+    assert get_record("frontmatter-alias")["state"] == "active"
+
+
+def test_restore_refuses_active_canonical_name_at_new_physical_alias(skills_home):
+    """Restore must not overwrite lifecycle identity held by a new alias."""
+    from tools.skill_usage import archive_skill, mark_agent_created, restore_skill
+
+    skills_dir = skills_home / "skills"
+    _write_skill_with_physical_alias(
+        skills_dir, "legacy-directory", "frontmatter-alias"
+    )
+    mark_agent_created("frontmatter-alias")
+    assert archive_skill("frontmatter-alias")[0]
+    # A subsequent create can use the canonical physical basename while the
+    # archived version retains an older physical alias.
+    _write_skill(skills_dir, "frontmatter-alias")
+
+    # Exercise the historical physical alias; this must still reserve the
+    # canonical lifecycle lock before checking the active canonical owner.
+    ok, message = restore_skill("legacy-directory")
+
+    assert ok is False
+    assert "already active" in message
+    assert (skills_dir / "frontmatter-alias" / "SKILL.md").exists()
+    assert (skills_dir / ".archive" / "legacy-directory" / "SKILL.md").exists()
+
+
+def test_physical_alias_restore_locks_canonical_before_archive_identity(
+    skills_home, monkeypatch
+):
+    """Physical archive aliases must not invert canonical-to-physical order."""
+    from tools.skill_usage import archive_skill, mark_agent_created, restore_skill
+    import tools.skill_manager_tool as manager
+
+    skills_dir = skills_home / "skills"
+    _write_skill_with_physical_alias(
+        skills_dir, "legacy-directory", "frontmatter-alias"
+    )
+    mark_agent_created("frontmatter-alias")
+    assert archive_skill("legacy-directory")[0]
+    real_lock = manager._skill_mutation_lock
+    lock_names = []
+
+    @contextmanager
+    def recording_lock(lock_name):
+        lock_names.append(lock_name)
+        with real_lock(lock_name):
+            yield
+
+    monkeypatch.setattr(manager, "_skill_mutation_lock", recording_lock)
+    ok, message = restore_skill("legacy-directory")
+
+    assert ok, message
+    assert lock_names[0] == "frontmatter-alias"
+    assert lock_names[1].startswith("physical\x00")
+
+
+def test_collision_archive_roundtrip_restores_physical_alias(skills_home):
+    """A new collision container retains a non-canonical physical basename."""
+    from tools.skill_usage import archive_skill, mark_agent_created, restore_skill
+
+    skills_dir = skills_home / "skills"
+    # This unrelated archived skill occupies the active skill's physical alias.
+    _write_skill_with_physical_alias(
+        skills_dir / ".archive", "legacy-directory", "unrelated-skill"
+    )
+    _write_skill_with_physical_alias(
+        skills_dir, "legacy-directory", "frontmatter-alias"
+    )
+    mark_agent_created("frontmatter-alias")
+
+    ok, message = archive_skill("frontmatter-alias")
+    assert ok, message
+    collision_root = skills_dir / ".archive" / ".collisions"
+    containers = [p for p in collision_root.iterdir() if p.is_dir()]
+    assert len(containers) == 1
+    assert (containers[0] / "legacy-directory" / "SKILL.md").exists()
+
+    ok, message = restore_skill("frontmatter-alias")
+    assert ok, message
+    assert (skills_dir / "legacy-directory" / "SKILL.md").exists()
+    assert not (skills_dir / "frontmatter-alias").exists()
+    assert not collision_root.exists()
+
+
+def test_collision_restore_refuses_occupied_physical_destination(skills_home):
+    """Restore never overwrites a new entry at the recorded physical alias."""
+    from tools.skill_usage import archive_skill, mark_agent_created, restore_skill
+
+    skills_dir = skills_home / "skills"
+    _write_skill_with_physical_alias(
+        skills_dir / ".archive", "legacy-directory", "unrelated-skill"
+    )
+    _write_skill_with_physical_alias(
+        skills_dir, "legacy-directory", "frontmatter-alias"
+    )
+    mark_agent_created("frontmatter-alias")
+    assert archive_skill("frontmatter-alias")[0]
+    _write_skill_with_physical_alias(
+        skills_dir, "legacy-directory", "replacement-skill"
+    )
+
+    ok, message = restore_skill("frontmatter-alias")
+    assert ok is False
+    assert "destination already exists" in message
+    collision_root = skills_dir / ".archive" / ".collisions"
+    assert any((p / "legacy-directory").is_dir() for p in collision_root.iterdir())
+
+
+def test_collision_layout_preserves_legal_timestamped_physical_alias(skills_home):
+    """A valid physical basename ending in a timestamp is never stripped."""
+    from tools.skill_usage import restore_skill
+
+    skills_dir = skills_home / "skills"
+    archived = (
+        skills_dir
+        / ".archive"
+        / ".collisions"
+        / "reserved-container"
+    )
+    physical_name = "frontmatter-alias-20260101000000"
+    _write_skill_with_physical_alias(
+        archived, physical_name, "frontmatter-alias"
+    )
+
+    ok, message = restore_skill("frontmatter-alias")
+    assert ok, message
+    assert (skills_dir / physical_name / "SKILL.md").exists()
+    assert not (skills_dir / "frontmatter-alias").exists()
+
+
+@pytest.mark.parametrize("container", [None, "legacy-import"])
+def test_restore_rejects_legacy_timestamp_leaf_independent_of_canonical_name(
+    skills_home, container
+):
+    """Old timestamp leaves are unsafe even when canonical and basename differ."""
+    from tools.skill_usage import restore_skill
+
+    archive = skills_home / "skills" / ".archive"
+    if container is not None:
+        archive = archive / container
+    physical_name = "legacy-directory-20260101000000"
+    _write_skill_with_physical_alias(
+        archive, physical_name, "frontmatter-alias"
+    )
+
+    ok, message = restore_skill("frontmatter-alias")
+    assert ok is False
+    assert "trustworthy" in message
+    assert (archive / physical_name).is_dir()
+
+
+def test_new_archive_roundtrip_preserves_timestamped_physical_alias(skills_home):
+    """A current archive marks a timestamp-looking physical basename safely."""
+    from tools.skill_usage import archive_skill, mark_agent_created, restore_skill
+
+    skills_dir = skills_home / "skills"
+    physical_name = "legacy-directory-20260101000000"
+    _write_skill_with_physical_alias(
+        skills_dir, physical_name, "frontmatter-alias"
+    )
+    mark_agent_created("frontmatter-alias")
+
+    ok, message = archive_skill("frontmatter-alias")
+    assert ok, message
+    collision_root = skills_dir / ".archive" / ".collisions"
+    assert any((p / physical_name).is_dir() for p in collision_root.iterdir())
+
+    ok, message = restore_skill("frontmatter-alias")
+    assert ok, message
+    assert (skills_dir / physical_name / "SKILL.md").exists()
+    assert not collision_root.exists()
+
+
+def test_failed_timestamp_archive_removes_empty_collision_container(skills_home, monkeypatch):
+    """A pre-commit rename failure leaves no unique collision container behind."""
+    from tools.skill_usage import archive_skill, mark_agent_created
+
+    skills_dir = skills_home / "skills"
+    physical_name = "legacy-directory-20260101000000"
+    _write_skill_with_physical_alias(
+        skills_dir, physical_name, "frontmatter-alias"
+    )
+    mark_agent_created("frontmatter-alias")
+    real_rename = __import__("os").rename
+
+    def fail_skill_rename(src, dst, **kwargs):
+        if src == physical_name:
+            raise OSError("injected rename failure")
+        return real_rename(src, dst, **kwargs)
+
+    import tools.skill_manager_tool as manager
+    monkeypatch.setattr(manager.os, "rename", fail_skill_rename)
+    monkeypatch.setattr(
+        manager.os,
+        "supports_dir_fd",
+        set(manager.os.supports_dir_fd) | {fail_skill_rename},
+    )
+    ok, message = archive_skill("frontmatter-alias")
+    assert ok is False
+    assert "failed to securely archive" in message
+    collision_root = skills_dir / ".archive" / ".collisions"
+    assert not collision_root.exists() or not any(collision_root.iterdir())
+    assert (skills_dir / physical_name).is_dir()
+
+
+def test_restore_rejects_ambiguous_canonical_archive_candidates(skills_home):
+    """Canonical archive recovery must not choose one of several aliases."""
+    from tools.skill_usage import restore_skill
+
+    archive = skills_home / "skills" / ".archive"
+    for directory_name in ("legacy-one", "legacy-two"):
+        _write_skill_with_physical_alias(
+            archive, directory_name, "frontmatter-alias"
+        )
+
+    ok, message = restore_skill("frontmatter-alias")
+    assert ok is False
+    assert "ambiguous" in message.lower()
+    assert (archive / "legacy-one").is_dir()
+    assert (archive / "legacy-two").is_dir()
+
+
+def test_restore_fails_closed_for_corrupt_archive_metadata(skills_home):
+    """An unreadable canonical candidate is not silently skipped or restored."""
+    from tools.skill_usage import restore_skill
+
+    broken = skills_home / "skills" / ".archive" / "legacy-directory"
+    broken.mkdir(parents=True)
+    (broken / "SKILL.md").write_text(
+        "---\nname: [not-a-string]\ndescription: test\n---\n",
+        encoding="utf-8",
+    )
+
+    ok, message = restore_skill("frontmatter-alias")
+    assert ok is False
+    assert "refusing" in message.lower() or "incomplete" in message.lower()
+    assert broken.is_dir()
+    assert not (skills_home / "skills" / "frontmatter-alias").exists()
+
+
+def test_restore_fails_closed_when_skills_config_is_malformed(skills_home):
+    """A broken config may hide an external canonical-name collision."""
+    from agent import skill_utils
+    from tools.skill_usage import restore_skill
+
+    archive = skills_home / "skills" / ".archive"
+    archived = _write_skill(archive, "config-guarded")
+    config_path = skills_home / "config.yaml"
+    config_path.write_text(
+        "skills:\n  external_dirs: [\n",
+        encoding="utf-8",
+    )
+    skill_utils._external_dirs_cache_clear()
+
+    ok, message = restore_skill("config-guarded")
+
+    assert ok is False
+    assert "config" in message.lower()
+    assert archived.is_dir()
+    assert not (skills_home / "skills" / "config-guarded").exists()
+
+
+def test_restore_fails_closed_when_skills_config_is_unreadable(
+    skills_home, monkeypatch
+):
+    """A read failure must leave both archive and active namespaces untouched."""
+    from agent import skill_utils
+    from tools.skill_usage import restore_skill
+
+    archive = skills_home / "skills" / ".archive"
+    archived = _write_skill(archive, "config-unreadable")
+    config_path = skills_home / "config.yaml"
+    config_path.write_text("skills: {}\n", encoding="utf-8")
+    real_read_text = Path.read_text
+
+    def deny_config_read(path, *args, **kwargs):
+        if path == config_path:
+            raise PermissionError("permission denied")
+        return real_read_text(path, *args, **kwargs)
+
+    skill_utils._external_dirs_cache_clear()
+    monkeypatch.setattr(Path, "read_text", deny_config_read)
+
+    ok, message = restore_skill("config-unreadable")
+
+    assert ok is False
+    assert "permission denied" in message.lower()
+    assert archived.is_dir()
+    assert not (skills_home / "skills" / "config-unreadable").exists()
+
+
+def test_restore_fails_closed_when_skills_config_is_dangling_symlink(skills_home):
+    """A dangling config entry must stop restore before its filesystem rename."""
+    from agent import skill_utils
+    from tools.skill_usage import restore_skill
+
+    archive = skills_home / "skills" / ".archive"
+    archived = _write_skill(archive, "config-dangling")
+    config_path = skills_home / "config.yaml"
+    try:
+        config_path.symlink_to(skills_home / "missing-config.yaml")
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation is unavailable")
+    skill_utils._external_dirs_cache_clear()
+
+    ok, message = restore_skill("config-dangling")
+
+    assert ok is False
+    assert "config" in message.lower()
+    assert archived.is_dir()
+    assert not (skills_home / "skills" / "config-dangling").exists()
+
+
+def test_restore_skill_moves_back(skills_home):
+    from tools.skill_usage import archive_skill, restore_skill, get_record
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "temp-skill")
+    archive_skill("temp-skill")
+    assert not (skills_dir / "temp-skill").exists()
+
+    ok, msg = restore_skill("temp-skill")
+    assert ok, msg
+    assert (skills_dir / "temp-skill" / "SKILL.md").exists()
+    assert get_record("temp-skill")["state"] == "active"
+
+
+def test_restore_skill_finds_nested_archive_subdir(skills_home):
+    """Skills archived under nested category subdirs (e.g.
+    .archive/<category>/<skill>/) — left behind by older archive layouts or
+    external imports — must still be restorable by name."""
+    from tools.skill_usage import restore_skill, get_record
+    skills_dir = skills_home / "skills"
+    nested = skills_dir / ".archive" / "openclaw-imports" / "nested-skill"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: nested-skill\ndescription: x\n---\n", encoding="utf-8",
+    )
+
+    ok, msg = restore_skill("nested-skill")
+    assert ok, msg
+    assert (skills_dir / "nested-skill" / "SKILL.md").exists()
+    assert not nested.exists()
+    assert get_record("nested-skill")["state"] == "active"
+
+
+def test_restore_rejects_legacy_nested_timestamped_archive(skills_home):
+    """Old timestamp suffixes lack a reliable original physical basename."""
+    from tools.skill_usage import restore_skill
+    skills_dir = skills_home / "skills"
+    nested = skills_dir / ".archive" / "imports" / "dup-skill-20260101000000"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: dup-skill\ndescription: x\n---\n", encoding="utf-8",
+    )
+
+    ok, msg = restore_skill("dup-skill")
+    assert not ok
+    assert "trustworthy" in msg
+    assert nested.exists()
+
+
+def test_archive_collision_gets_suffix(skills_home):
+    from tools.skill_usage import archive_skill
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "dup")
+    archive_skill("dup")
+    _write_skill(skills_dir, "dup")  # recreate
+    ok, msg = archive_skill("dup")
+    assert ok
+    # The second copy keeps its physical basename beneath a collision container.
+    archived = sorted(p.name for p in (skills_dir / ".archive").iterdir() if p.is_dir())
+    assert "dup" in archived
+    collision_root = skills_dir / ".archive" / ".collisions"
+    containers = [p for p in collision_root.iterdir() if p.is_dir()]
+    assert len(containers) == 1
+    assert (containers[0] / "dup" / "SKILL.md").exists()
+
+
+def test_restore_does_not_pull_unrelated_sibling_out_of_archive(skills_home):
+    """Restoring a name with no exact archive entry must NOT grab a different
+    archived skill that merely shares a ``<name>-`` prefix.
+
+    The timestamped-duplicate fallback recognises only the suffix
+    ``archive_skill`` writes on a collision (``-YYYYMMDDHHMMSS``). A bare
+    ``startswith(f"{name}-")`` also matches sibling skills, so restoring
+    ``git`` would rip an archived ``git-helpers`` out of the archive, rename
+    it to ``git``, and report success — destroying the sibling's only copy."""
+    from tools.skill_usage import (
+        archive_skill, restore_skill, list_archived_skill_names, mark_agent_created,
+    )
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "git-helpers")
+    mark_agent_created("git-helpers")
+    ok, msg = archive_skill("git-helpers")
+    assert ok, msg
+
+    # "git" was never archived; only its prefix-sharing sibling was.
+    ok, msg = restore_skill("git")
+    assert not ok, f"restore('git') should not match 'git-helpers': {msg}"
+    assert "not found" in msg.lower()
+
+    # The sibling must be untouched: still in the archive, never moved to skills/git.
+    assert (skills_dir / ".archive" / "git-helpers" / "SKILL.md").exists()
+    assert "git-helpers" in list_archived_skill_names()
+    assert not (skills_dir / "git").exists()
+
+
+def test_restore_rejects_legacy_flat_timestamped_duplicate(skills_home):
+    """A legacy suffix could also be a user's original physical basename."""
+    from tools.skill_usage import restore_skill
+    skills_dir = skills_home / "skills"
+    dupe = skills_dir / ".archive" / "report-tool-20260101000000"
+    dupe.mkdir(parents=True)
+    (dupe / "SKILL.md").write_text(
+        "---\nname: report-tool\ndescription: x\n---\n", encoding="utf-8",
+    )
+
+    ok, msg = restore_skill("report-tool")
+    assert not ok
+    assert "trustworthy" in msg
+    assert dupe.exists()
+
+
+def test_restore_rejects_legacy_timestamped_dupe_with_unrelated_sibling(skills_home):
+    """A sibling never makes an ambiguous legacy suffix safe to restore."""
+    from tools.skill_usage import restore_skill
+    archive = skills_home / "skills" / ".archive"
+
+    dupe = archive / "report-20260101000000"          # real collision dupe of "report"
+    sibling = archive / "report-card"                  # unrelated sibling skill
+    for d, frontname in ((dupe, "report"), (sibling, "report-card")):
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            f"---\nname: {frontname}\ndescription: x\n---\n", encoding="utf-8",
+        )
+
+    ok, msg = restore_skill("report")
+    assert not ok
+    assert "trustworthy" in msg
+    assert dupe.exists()
+    assert sibling.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -363,4 +1024,3 @@ def test_adopt_rejects_empty_name(skills_home):
     from tools.skill_usage import adopt_skill
 
     assert adopt_skill("")[0] is False
-

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -2,8 +2,11 @@
 
 import json
 import os
+import tempfile
+import threading
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -18,6 +21,7 @@ from tools.skills_tool import (
     skills_list,
     skill_view,
     MAX_DESCRIPTION_LENGTH,
+    MAX_LINKED_FILES_PER_CATEGORY,
 )
 
 
@@ -184,6 +188,64 @@ class TestFindAllSkills:
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "skill-a")
             _make_skill(tmp_path, "skill-b")
+            skills = _find_all_skills()
+        assert len(skills) == 2
+        names = {s["name"] for s in skills}
+        assert "skill-a" in names
+        assert "skill-b" in names
+
+    def test_empty_directory(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skills = _find_all_skills()
+        assert skills == []
+
+    @pytest.mark.parametrize(
+        "broken",
+        (
+            "---\nname: steals-valid\n# no closing fence\n",
+            "---\n- steals-valid\n---\n",
+        ),
+        ids=("unclosed-fence", "non-mapping-yaml"),
+    )
+    def test_list_refuses_partial_catalog_for_invalid_fenced_skill(self, tmp_path, broken):
+        _make_skill(tmp_path, "valid")
+        corrupt = _make_skill(tmp_path, "corrupt") / "SKILL.md"
+        corrupt.write_text(broken, encoding="utf-8")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            result = json.loads(skills_list())
+
+        assert result["success"] is True
+        assert result["skills"] == []
+
+    def test_list_and_view_reject_canonical_skill_symlink(self, tmp_path):
+        outside = tmp_path / "outside.md"
+        outside.write_text(
+            "---\nname: escaped\ndescription: outside\n---\n", encoding="utf-8"
+        )
+        skill_dir = tmp_path / "escaped"
+        skill_dir.mkdir()
+        try:
+            (skill_dir / "SKILL.md").symlink_to(outside)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            listed = json.loads(skills_list())
+            viewed = json.loads(skill_view("escaped"))
+
+        assert listed["success"] is True
+        assert listed["skills"] == []
+        assert viewed["success"] is False
+        assert viewed.get("error_code") == "skills_discovery_incomplete"
+
+    def test_nonexistent_directory(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path / "nope"):
+            skills = _find_all_skills()
+        assert skills == []
+
+    def test_categorized_skills(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "axolotl", category="mlops")
 
             # .git internals are not skills.
@@ -214,8 +276,8 @@ class TestFindAllSkills:
 
             skills = _find_all_skills()
 
-        assert {s["name"] for s in skills} == {"skill-a", "skill-b", "axolotl"}
-        assert [s["category"] for s in skills if s["name"] == "axolotl"] == ["mlops"]
+        assert {s["name"] for s in skills} == {"axolotl"}
+        assert skills[0]["category"] == "mlops"
 
 
     def test_description_falls_back_to_body_and_is_truncated(self, tmp_path):
@@ -251,6 +313,134 @@ class TestFindAllSkills:
         assert [s["name"] for s in skills] == ["knowledge-brain"]
         assert skills[0]["category"] == "linked"
 
+    def test_cache_invalidates_when_kanban_environment_changes(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "tools.kanban_tools._profile_has_kanban_toolset",
+                return_value=False,
+            ),
+        ):
+            _make_skill(
+                tmp_path,
+                "kanban-only",
+                frontmatter_extra="environments: [kanban]\n",
+            )
+            skills_tool_module._SKILLS_CACHE.clear()
+            assert _find_all_skills() == []
+
+            monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+            assert [s["name"] for s in _find_all_skills()] == ["kanban-only"]
+
+            monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+            assert _find_all_skills() == []
+
+    def test_read_error_returns_same_scope_last_good_not_partial(
+        self, tmp_path, monkeypatch
+    ):
+        """A selected file can fail after walk; retain its same-root catalog."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skills_tool_module._SKILLS_CACHE.clear()
+            _make_skill(tmp_path, "good")
+            assert [s["name"] for s in _find_all_skills()] == ["good"]
+
+            bad_file = _make_skill(tmp_path, "bad") / "SKILL.md"
+            original_reader = skills_tool_module.read_strict_skill_index_file
+
+            def fail_only_bad_file(path, *args, **kwargs):
+                if path == bad_file:
+                    raise OSError("simulated file read denial")
+                return original_reader(path, *args, **kwargs)
+
+            monkeypatch.setattr(
+                skills_tool_module, "read_strict_skill_index_file", fail_only_bad_file
+            )
+            monkeypatch.setattr(skills_tool_module, "_SKILLS_CACHE_TTL_SECONDS", 0)
+            assert [s["name"] for s in _find_all_skills()] == ["good"]
+
+    def test_stat_error_does_not_commit_partial_catalog(self, tmp_path, monkeypatch):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skills_tool_module._SKILLS_CACHE.clear()
+            _make_skill(tmp_path, "good")
+            assert [s["name"] for s in _find_all_skills()] == ["good"]
+
+            bad_file = _make_skill(tmp_path, "bad") / "SKILL.md"
+            original_reader = skills_tool_module.read_strict_skill_index_file
+
+            def fail_only_bad_file(path, *args, **kwargs):
+                if path == bad_file:
+                    raise OSError("simulated file stat denial")
+                return original_reader(path, *args, **kwargs)
+
+            monkeypatch.setattr(
+                skills_tool_module, "read_strict_skill_index_file", fail_only_bad_file
+            )
+            monkeypatch.setattr(skills_tool_module, "_SKILLS_CACHE_TTL_SECONDS", 0)
+            assert [s["name"] for s in _find_all_skills()] == ["good"]
+
+    def test_walk_error_does_not_leak_another_scope_cache(self, tmp_path, monkeypatch):
+        first_root = tmp_path / "first"
+        second_root = tmp_path / "second"
+        first_root.mkdir()
+        second_root.mkdir()
+        with patch("tools.skills_tool.SKILLS_DIR", first_root):
+            skills_tool_module._SKILLS_CACHE.clear()
+            _make_skill(first_root, "first-only")
+            assert [s["name"] for s in _find_all_skills()] == ["first-only"]
+
+        def denied_walk(*_args, **kwargs):
+            kwargs["onerror"](OSError("simulated walk denial"))
+            return []
+
+        with patch("tools.skills_tool.SKILLS_DIR", second_root):
+            monkeypatch.setattr("agent.skill_utils.os.walk", denied_walk)
+            assert _find_all_skills() == []
+
+    def test_active_root_stat_error_does_not_cache_external_only_result(
+        self, tmp_path, monkeypatch
+    ):
+        """An unreadable local root is not equivalent to an empty local root."""
+        active_root = tmp_path / "active"
+        external_root = tmp_path / "external"
+        active_root.mkdir()
+        external_root.mkdir()
+        _make_skill(active_root, "local-skill")
+        _make_skill(external_root, "external-skill")
+        original_stat = Path.stat
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", active_root),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[external_root],
+            ),
+        ):
+            skills_tool_module._SKILLS_CACHE.clear()
+            assert sorted(s["name"] for s in _find_all_skills()) == [
+                "external-skill",
+                "local-skill",
+            ]
+            monkeypatch.setattr(
+                skills_tool_module, "_SKILLS_CACHE_TTL_SECONDS", 0
+            )
+
+            def fail_only_active_root(path, *args, **kwargs):
+                if path == active_root:
+                    raise PermissionError("simulated active-root denial")
+                return original_stat(path, *args, **kwargs)
+
+            monkeypatch.setattr(Path, "stat", fail_only_active_root)
+            # The same full-scope last-good catalog is retained; the scan must
+            # not replace it with the external-only subset.
+            assert sorted(s["name"] for s in _find_all_skills()) == [
+                "external-skill",
+                "local-skill",
+            ]
+
 
 # ---------------------------------------------------------------------------
 # skills_list
@@ -266,6 +456,39 @@ class TestSkillsList:
         assert result["success"] is True
         assert result["skills"] == []
         assert skills_dir.exists()
+
+    @pytest.mark.parametrize("root_kind", ["missing", "file"])
+    def test_invalid_configured_external_root_returns_structured_error(
+        self, tmp_path, root_kind
+    ):
+        skills_dir = tmp_path / "skills"
+        _make_skill(skills_dir, "local-only")
+        external_root = tmp_path / "configured-external"
+        if root_kind == "file":
+            external_root.write_text("not a directory", encoding="utf-8")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[external_root],
+            ),
+        ):
+            skills_tool_module._SKILLS_CACHE.clear()
+            result = json.loads(skills_list())
+
+        assert result["success"] is False
+        assert result["error_code"] == "skills_discovery_incomplete"
+        assert "local-only" not in json.dumps(result)
+        assert skills_tool_module._SKILLS_CACHE == {}
+
+    def test_lists_skills(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha")
+            _make_skill(tmp_path, "beta")
+            raw = skills_list()
+        result = json.loads(raw)
+        assert result["count"] == 2
 
     def test_category_filter(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -304,6 +527,99 @@ class TestSkillsList:
 class TestSkillView:
     def test_view_resolves_by_dir_name_and_frontmatter_name(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "my-skill")
+            raw = skill_view("my-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["name"] == "my-skill"
+        assert "Step 1" in result["content"]
+
+    def test_missing_configured_external_root_blocks_ambiguous_local_lookup(
+        self, tmp_path
+    ):
+        local_root = tmp_path / "skills"
+        missing_external = tmp_path / "configured-external"
+        _make_skill(local_root, "possibly-colliding")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_root),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[missing_external],
+            ),
+        ):
+            result = json.loads(skill_view("possibly-colliding"))
+
+        assert result["success"] is False
+        assert result["error_code"] == "skills_discovery_incomplete"
+        assert "Step 1" not in json.dumps(result)
+
+    def test_view_skill_by_frontmatter_name_when_dir_differs(self, tmp_path):
+        # The on-disk directory ("alias-dir") differs from the skill's
+        # frontmatter name ("real-skill-name"). skills_list() exposes the
+        # frontmatter name, so skill_view(name) must resolve it too.
+        skill_dir = tmp_path / "alias-dir"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: real-skill-name\n"
+            "description: A skill whose directory name differs from its name.\n"
+            "---\n\n"
+            "# real-skill-name\n\n"
+            "Step 1: Do the thing.\n"
+        )
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            raw = skill_view("real-skill-name")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "Step 1" in result["content"]
+
+    def test_frontmatter_like_body_prefix_is_not_treated_as_a_fence(self, tmp_path):
+        skill_dir = tmp_path / "plain-body"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---not-a-fence\n\nKeep this as ordinary body text.\n",
+            encoding="utf-8",
+        )
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            result = json.loads(skill_view("plain-body"))
+
+        assert result["success"] is True
+        assert "---not-a-fence" in result["content"]
+
+    def test_skill_view_applies_template_vars(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_preprocessing.load_skills_config",
+                return_value={"template_vars": True, "inline_shell": False},
+            ),
+        ):
+            skill_dir = _make_skill(
+                tmp_path,
+                "templated",
+                body="Run ${HERMES_SKILL_DIR}/scripts/do.sh in ${HERMES_SESSION_ID}",
+            )
+            raw = skill_view("templated", task_id="session-123")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert f"Run {skill_dir}/scripts/do.sh in session-123" in result["content"]
+        assert "${HERMES_SKILL_DIR}" not in result["content"]
+
+    def test_skill_view_applies_inline_shell_when_enabled(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_preprocessing.load_skills_config",
+                return_value={
+                    "template_vars": True,
+                    "inline_shell": True,
+                    "inline_shell_timeout": 5,
+                },
+            ),
+        ):
             _make_skill(
                 tmp_path,
                 "my-skill",
@@ -333,6 +649,234 @@ class TestSkillView:
 
         assert by_name["success"] is True
         assert "Step 1" in by_name["content"]
+    def test_inline_shell_cwd_remains_bound_across_category_symlink_swap(
+        self, tmp_path, monkeypatch
+    ):
+        skills_root = tmp_path / "skills"
+        packages = tmp_path / "packages"
+        original_category = packages / "original"
+        replacement_category = packages / "replacement"
+        skills_root.mkdir()
+        original_skill = _make_skill(
+            original_category,
+            "dynamic",
+            body="Marker: !`cat marker.txt`",
+        )
+        replacement_skill = replacement_category / "dynamic"
+        replacement_skill.mkdir(parents=True)
+        os.link(
+            original_skill / "SKILL.md",
+            replacement_skill / "SKILL.md",
+        )
+        (original_skill / "marker.txt").write_text("ORIGINAL", encoding="utf-8")
+        (replacement_skill / "marker.txt").write_text(
+            "REPLACEMENT", encoding="utf-8"
+        )
+        category_link = skills_root / "linked"
+        category_link.symlink_to(original_category, target_is_directory=True)
+        swapped = False
+
+        def swap_while_loading_config():
+            nonlocal swapped
+            if not swapped:
+                swapped = True
+                category_link.unlink()
+                category_link.symlink_to(
+                    replacement_category, target_is_directory=True
+                )
+            return {
+                "template_vars": True,
+                "inline_shell": True,
+                "inline_shell_timeout": 5,
+            }
+
+        monkeypatch.setattr(
+            "agent.skill_preprocessing.load_skills_config",
+            swap_while_loading_config,
+        )
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_root),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[],
+            ),
+        ):
+            result = json.loads(skill_view("dynamic"))
+
+        assert swapped is True
+        assert result["success"] is True
+        assert "Marker: ORIGINAL" in result["content"]
+        assert "REPLACEMENT" not in result["content"]
+
+    def test_windows_inline_shell_rewrites_only_commands_to_bound_snapshot(
+        self, tmp_path
+    ):
+        from tools import skills_tool
+        from tools import nt_secure_fs_optional as nt_secure_fs
+
+        original = Path("C:/skills/dynamic")
+        handle = MagicMock()
+        handle.final_path.return_value = original
+        content = (
+            "Visible path: ${HERMES_SKILL_DIR}\n"
+            "Marker: !`cat ${HERMES_SKILL_DIR}/marker.txt`"
+        )
+
+        def materialize(_handle, destination):
+            assert str(destination).replace("\\", "/").endswith(
+                "C:/Temp/inline/skill"
+            )
+
+        def expand(bound_content, cwd, timeout):
+            assert timeout == 5
+            assert str(original) in bound_content.splitlines()[0]
+            command = bound_content.split("!`", 1)[1].split("`", 1)[0]
+            assert str(original) not in command
+            assert "\\" not in command
+            assert "C:/Temp/inline/skill" in command
+            return bound_content.replace(f"!`{command}`", "ORIGINAL")
+
+        with (
+            patch.object(
+                skills_tool, "os", SimpleNamespace(name="nt")
+            ),
+            patch(
+                "tools.skills_tool.tempfile.TemporaryDirectory"
+            ) as temp_dir,
+            patch.object(
+                nt_secure_fs,
+                "copy_tree_no_reparse",
+                side_effect=materialize,
+            ),
+            patch(
+                "agent.skill_preprocessing.expand_inline_shell",
+                side_effect=expand,
+            ),
+        ):
+            temp_dir.return_value.__enter__.return_value = (
+                r"C:\Temp\inline"
+            )
+            temp_dir.return_value.__exit__.return_value = False
+            result = skills_tool._expand_inline_shell_bound(
+                content,
+                handle,
+                5,
+                skill_dir=original,
+            )
+
+        assert f"Visible path: {original}" in result
+        assert "Marker: ORIGINAL" in result
+
+    def test_posix_inline_shell_template_path_stays_on_held_package(
+        self, tmp_path
+    ):
+        from tools import skills_tool
+
+        package_path = tmp_path / "dynamic"
+        package_path.mkdir()
+        (package_path / "marker.txt").write_text(
+            "ORIGINAL", encoding="utf-8"
+        )
+        package_fd = os.open(
+            package_path,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+        )
+        moved_path = tmp_path / "moved"
+        package_path.rename(moved_path)
+        package_path.mkdir()
+        (package_path / "marker.txt").write_text(
+            "REPLACEMENT", encoding="utf-8"
+        )
+        try:
+            result = skills_tool._expand_inline_shell_bound(
+                (
+                    "Visible: ${HERMES_SKILL_DIR}\n"
+                    f"Marker: !`cd {package_path} && "
+                    "cat marker.txt`"
+                ),
+                package_fd,
+                5,
+                skill_dir=package_path,
+            )
+        finally:
+            os.close(package_fd)
+
+        assert f"Visible: {package_path}" in result
+        assert "Marker: ORIGINAL" in result
+        assert "REPLACEMENT" not in result
+
+    def test_inline_shell_template_path_with_spaces_is_shell_safe(
+        self, tmp_path, monkeypatch
+    ):
+        from tools import skills_tool
+
+        package_path = tmp_path / "dynamic"
+        package_path.mkdir()
+        (package_path / "marker.txt").write_text(
+            "ORIGINAL", encoding="utf-8"
+        )
+        temp_base = tmp_path / "snapshot base with spaces"
+        temp_base.mkdir()
+        monkeypatch.setattr(tempfile, "tempdir", str(temp_base))
+        package_fd = os.open(
+            package_path,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+        )
+        try:
+            result = skills_tool._expand_inline_shell_bound(
+                (
+                    "Marker: "
+                    "!`cat ${HERMES_SKILL_DIR}/marker.txt`"
+                ),
+                package_fd,
+                5,
+                skill_dir=package_path,
+            )
+        finally:
+            os.close(package_fd)
+
+        assert result == "Marker: ORIGINAL"
+
+    def test_inline_shell_literal_path_with_spaces_is_shell_safe(
+        self, tmp_path, monkeypatch
+    ):
+        from tools import skills_tool
+
+        package_path = tmp_path / "dynamic"
+        package_path.mkdir()
+        (package_path / "marker.txt").write_text(
+            "ORIGINAL", encoding="utf-8"
+        )
+        temp_base = tmp_path / "snapshot base with spaces"
+        temp_base.mkdir()
+        monkeypatch.setattr(tempfile, "tempdir", str(temp_base))
+        package_fd = os.open(
+            package_path,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+        )
+        try:
+            result = skills_tool._expand_inline_shell_bound(
+                (
+                    f"Marker: !`cd {package_path} && "
+                    "cat marker.txt`"
+                ),
+                package_fd,
+                5,
+                skill_dir=package_path,
+            )
+        finally:
+            os.close(package_fd)
+
+        assert result == "Marker: ORIGINAL"
+
+    def test_view_nonexistent_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "other-skill")
+            raw = skill_view("nonexistent")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+        assert "available_skills" in result
 
 
     def test_view_reference_files(self, tmp_path):
@@ -343,17 +887,239 @@ class TestSkillView:
             (refs_dir / "api.md").write_text("# API Docs\nEndpoint info.")
 
             existing = json.loads(skill_view("my-skill", file_path="references/api.md"))
-            missing = json.loads(skill_view("my-skill", file_path="references/nope.md"))
             skill = json.loads(skill_view("my-skill"))
 
         assert existing["success"] is True
         assert "Endpoint info" in existing["content"]
-        assert missing["success"] is False
         # The skill view advertises what else can be opened.
         assert skill["linked_files"] is not None
         assert "references" in skill["linked_files"]
 
+    def test_view_nonexistent_file(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "my-skill")
+            refs_dir = skill_dir / "references"
+            refs_dir.mkdir()
+            for index in reversed(range(MAX_LINKED_FILES_PER_CATEGORY + 5)):
+                (refs_dir / f"{index:03d}.md").write_text("reference")
+            raw = skill_view("my-skill", file_path="references/nope.md")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert (
+            len(result["available_files"]["references"])
+            == MAX_LINKED_FILES_PER_CATEGORY
+        )
+        assert result["available_files"]["references"] == sorted(
+            result["available_files"]["references"]
+        )
+        assert result["linked_files_summary"]["truncated"] is True
+
     def test_disabled_skill_blocked_enabled_allowed(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("tools.skills_tool._is_skill_disabled", return_value=True),
+        ):
+            _make_skill(tmp_path, "hidden-skill")
+            blocked = json.loads(skill_view("hidden-skill"))
+        assert blocked["success"] is False
+        assert "disabled" in blocked["error"].lower()
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("tools.skills_tool._is_skill_disabled", return_value=False),
+        ):
+            _make_skill(tmp_path, "active-skill")
+            allowed = json.loads(skill_view("active-skill"))
+        assert allowed["success"] is True
+
+    def test_view_bounds_and_sorts_linked_file_preview(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "many-assets")
+            assets_dir = skill_dir / "assets"
+            assets_dir.mkdir()
+            for index in reversed(range(MAX_LINKED_FILES_PER_CATEGORY + 5)):
+                (assets_dir / f"{index:03d}.txt").write_text("asset")
+            raw = skill_view("many-assets")
+
+        result = json.loads(raw)
+        shown = result["linked_files"]["assets"]
+        summary = result["linked_files_summary"]
+        assert len(shown) == MAX_LINKED_FILES_PER_CATEGORY
+        assert shown == sorted(shown)
+        assert summary["truncated"] is True
+        assert summary["truncated_categories"] == ["assets"]
+
+        # A file outside the preview remains explicitly readable.
+        omitted = f"assets/{MAX_LINKED_FILES_PER_CATEGORY + 4:03d}.txt"
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            explicit = json.loads(skill_view("many-assets", file_path=omitted))
+        assert explicit["success"] is True
+        assert explicit["content"] == "asset"
+
+    def test_view_does_not_follow_linked_file_category_symlink(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "private.txt").write_text("outside", encoding="utf-8")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "linked-assets")
+            try:
+                (skill_dir / "assets").symlink_to(
+                    outside, target_is_directory=True
+                )
+            except (OSError, NotImplementedError) as exc:
+                pytest.skip(f"symlinks unavailable: {exc}")
+            raw = skill_view("linked-assets")
+
+        result = json.loads(raw)
+        assert not result["linked_files"]
+        assert result["linked_files_summary"]["shown"] == 0
+
+    def test_support_file_read_remains_bound_across_category_symlink_swap(
+        self, tmp_path, monkeypatch
+    ):
+        skills_root = tmp_path / "skills"
+        packages = tmp_path / "packages"
+        original_category = packages / "original"
+        replacement_category = packages / "replacement"
+        skills_root.mkdir()
+        original_skill = _make_skill(original_category, "bound-support")
+        replacement_skill = replacement_category / "bound-support"
+        replacement_skill.mkdir(parents=True)
+        os.link(
+            original_skill / "SKILL.md",
+            replacement_skill / "SKILL.md",
+        )
+        for skill_dir, value in (
+            (original_skill, "ORIGINAL SUPPORT"),
+            (replacement_skill, "REPLACEMENT SUPPORT"),
+        ):
+            (skill_dir / "assets").mkdir()
+            (skill_dir / "assets" / "value.txt").write_text(
+                value, encoding="utf-8"
+            )
+        category_link = skills_root / "linked"
+        category_link.symlink_to(original_category, target_is_directory=True)
+        real_path_read_text = Path.read_text
+        real_os_open = os.open
+        swapped = False
+
+        def swap_package():
+            nonlocal swapped
+            if not swapped:
+                swapped = True
+                category_link.unlink()
+                category_link.symlink_to(
+                    replacement_category, target_is_directory=True
+                )
+
+        def swap_before_legacy_read(path, *args, **kwargs):
+            if path.name == "value.txt":
+                swap_package()
+            return real_path_read_text(path, *args, **kwargs)
+
+        def swap_during_bound_open(path, *args, **kwargs):
+            if path == "assets" and kwargs.get("dir_fd") is not None:
+                swap_package()
+            return real_os_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", swap_before_legacy_read)
+        monkeypatch.setattr(os, "open", swap_during_bound_open)
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_root),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[],
+            ),
+        ):
+            result = json.loads(
+                skill_view("bound-support", file_path="assets/value.txt")
+            )
+
+        assert swapped is True
+        assert result["success"] is True
+        assert result["content"] == "ORIGINAL SUPPORT"
+
+    def test_linked_manifest_remains_bound_across_category_symlink_swap(
+        self, tmp_path, monkeypatch
+    ):
+        skills_root = tmp_path / "skills"
+        packages = tmp_path / "packages"
+        original_category = packages / "original"
+        replacement_category = packages / "replacement"
+        skills_root.mkdir()
+        original_skill = _make_skill(original_category, "bound-manifest")
+        replacement_skill = replacement_category / "bound-manifest"
+        replacement_skill.mkdir(parents=True)
+        os.link(
+            original_skill / "SKILL.md",
+            replacement_skill / "SKILL.md",
+        )
+        (original_skill / "assets").mkdir()
+        (original_skill / "assets" / "original.txt").write_text("original")
+        (replacement_skill / "assets").mkdir()
+        (replacement_skill / "assets" / "replacement.txt").write_text(
+            "replacement"
+        )
+        category_link = skills_root / "linked"
+        category_link.symlink_to(original_category, target_is_directory=True)
+        real_walk = os.walk
+        real_scandir = os.scandir
+        swapped = False
+
+        def swap_package():
+            nonlocal swapped
+            if not swapped:
+                swapped = True
+                category_link.unlink()
+                category_link.symlink_to(
+                    replacement_category, target_is_directory=True
+                )
+
+        def swap_before_legacy_walk(*args, **kwargs):
+            if str(args[0]).endswith("/assets"):
+                swap_package()
+            return real_walk(*args, **kwargs)
+
+        def swap_during_bound_scan(path):
+            if isinstance(path, int):
+                swap_package()
+            return real_scandir(path)
+
+        monkeypatch.setattr(os, "walk", swap_before_legacy_walk)
+        monkeypatch.setattr(os, "scandir", swap_during_bound_scan)
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", skills_root),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[],
+            ),
+        ):
+            result = json.loads(skill_view("bound-manifest"))
+
+        assert swapped is True
+        assert result["success"] is True
+        assert result["linked_files"]["assets"] == ["assets/original.txt"]
+
+    def test_view_tags_from_metadata(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "tagged",
+                frontmatter_extra="metadata:\n  hermes:\n    tags: [fine-tuning, llm]\n",
+            )
+            raw = skill_view("tagged")
+        result = json.loads(raw)
+        assert "fine-tuning" in result["tags"]
+        assert "llm" in result["tags"]
+
+    def test_view_nonexistent_skills_dir(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path / "nope"):
+            raw = skill_view("anything")
+        result = json.loads(raw)
+        assert result["success"] is False
+
+    def test_view_disabled_skill_blocked(self, tmp_path):
+        """Disabled skills should not be viewable via skill_view."""
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),
             patch("tools.skills_tool._is_skill_disabled", return_value=True),
@@ -388,6 +1154,48 @@ class TestSkillView:
 
 
 class TestSkillViewSecureSetupOnLoad:
+    def test_context_secret_callbacks_do_not_cross_concurrent_turns(self, monkeypatch):
+        """Two gateway turns retain their own secure-prompt destination."""
+        monkeypatch.setattr(skills_tool_module, "_secret_capture_callback", None)
+        a_entered = threading.Event()
+        b_entered = threading.Event()
+        release = threading.Event()
+        calls = []
+
+        def run(label, name, entered, other_entered):
+            def callback(var_name, _prompt, _metadata=None):
+                calls.append((label, var_name))
+                entered.set()
+                assert other_entered.wait(timeout=2)
+                assert release.wait(timeout=2)
+                return {
+                    "success": True,
+                    "stored_as": var_name,
+                    "validated": False,
+                    "skipped": False,
+                }
+
+            token = skills_tool_module.set_secret_capture_callback_context(callback)
+            try:
+                skills_tool_module._capture_required_environment_variables(
+                    label,
+                    [{"name": name, "prompt": f"prompt for {label}"}],
+                )
+            finally:
+                skills_tool_module.reset_secret_capture_callback_context(token)
+
+        thread_a = threading.Thread(target=run, args=("A", "A_SECRET", a_entered, b_entered))
+        thread_b = threading.Thread(target=run, args=("B", "B_SECRET", b_entered, a_entered))
+        thread_a.start()
+        thread_b.start()
+        assert a_entered.wait(timeout=2)
+        assert b_entered.wait(timeout=2)
+        release.set()
+        thread_a.join(timeout=2)
+        thread_b.join(timeout=2)
+
+        assert sorted(calls) == [("A", "A_SECRET"), ("B", "B_SECRET")]
+
     def test_requests_missing_required_env_and_continues(self, tmp_path, monkeypatch):
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
         calls = []
@@ -727,6 +1535,18 @@ class TestSkillViewPrerequisites:
         assert result["missing_required_environment_variables"] == []
         assert "setup_note" not in result
 
+    def test_skill_view_surfaces_skill_read_errors(self, tmp_path, monkeypatch):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "broken-skill")
+            skill_md = tmp_path / "broken-skill" / "SKILL.md"
+            skill_md.write_bytes(b"\xff")
+            raw = skill_view("broken-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert result["error_code"] == "skills_discovery_incomplete"
+        assert "partial" in result["error"].lower()
+        assert "invalid start byte" in result["detail"]
 
     def test_legacy_flat_md_skill_preserves_frontmatter_metadata(self, tmp_path):
         flat_skill = tmp_path / "legacy-skill.md"
@@ -923,3 +1743,220 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is False
         assert "Ambiguous" in result["error"]
         assert len(result["matches"]) == 2
+
+    def test_local_only_skill_loads_normally(self, tmp_path):
+        """Sanity: a single local skill (no external collision) loads
+        without any error."""
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        _make_skill(
+            local_dir,
+            "my-skill",
+            category="foundations/runtime",
+            body="LOCAL BODY",
+        )
+
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("my-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "LOCAL BODY" in result["content"]
+
+
+class TestSkillViewIncompleteExternalDiscovery:
+    """Accessible external roots must still be complete before local loading."""
+
+    def _patch_dirs(self, local_dir, external_dir):
+        return (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[external_dir],
+            ),
+        )
+
+    @staticmethod
+    def _assert_incomplete(raw):
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert result["error_code"] == "skills_discovery_incomplete"
+        assert "partial" in result["error"].lower()
+        return result
+
+    def test_corrupt_external_skill_frontmatter_refuses_local_candidate(self, tmp_path):
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+        _make_skill(local_dir, "local-only", body="LOCAL BODY")
+        corrupt = _make_skill(external_dir, "broken-external") / "SKILL.md"
+        corrupt.write_text("---\nname: [unterminated\n---\n", encoding="utf-8")
+        p1, p2 = self._patch_dirs(local_dir, external_dir)
+        with p1, p2:
+            result = self._assert_incomplete(skill_view("local-only"))
+
+        assert str(corrupt) in result["detail"]
+
+    @pytest.mark.parametrize(
+        "broken_frontmatter",
+        (
+            "---\nname: hidden-collision\n# missing closing fence\n",
+            "---\n- name: hidden-collision\n---\n\nBody.\n",
+        ),
+        ids=("unclosed-fence", "non-mapping-top-level"),
+    )
+    def test_structurally_invalid_external_frontmatter_refuses_local_candidate(
+        self, tmp_path, broken_frontmatter
+    ):
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+        _make_skill(local_dir, "local-only", body="LOCAL BODY")
+        broken = _make_skill(external_dir, "broken-external") / "SKILL.md"
+        broken.write_text(broken_frontmatter, encoding="utf-8")
+
+        p1, p2 = self._patch_dirs(local_dir, external_dir)
+        with p1, p2:
+            result = self._assert_incomplete(skill_view("local-only"))
+
+        assert str(broken) in result["detail"]
+
+    def test_invalid_unrelated_markdown_and_support_package_do_not_block(
+        self, tmp_path
+    ):
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+        _make_skill(local_dir, "local-only", body="LOCAL BODY")
+        unrelated = external_dir / "notes" / "unrelated.md"
+        unrelated.parent.mkdir()
+        unrelated.write_text("---\n- not-a-skill\n---\n", encoding="utf-8")
+        umbrella = _make_skill(external_dir, "umbrella")
+        support_package = umbrella / "references" / "preserved" / "SKILL.md"
+        support_package.parent.mkdir(parents=True)
+        support_package.write_text(
+            "---\nname: never-closed\n", encoding="utf-8"
+        )
+
+        p1, p2 = self._patch_dirs(local_dir, external_dir)
+        with p1, p2:
+            result = json.loads(skill_view("local-only"))
+
+        assert result["success"] is True
+        assert "LOCAL BODY" in result["content"]
+
+    def test_symlinked_skill_root_swap_cannot_change_discovered_canonical_file(
+        self, tmp_path, monkeypatch
+    ):
+        local_dir = tmp_path / "local"
+        linked_parent = tmp_path / "linked-packages"
+        original_category = linked_parent / "original"
+        replacement_category = linked_parent / "replacement"
+        local_dir.mkdir()
+        original_category.mkdir(parents=True)
+        replacement_category.mkdir(parents=True)
+        original_skill = _make_skill(
+            original_category, "linked-skill", body="ORIGINAL BODY"
+        )
+        replacement_skill = replacement_category / "linked-skill"
+        replacement_skill.mkdir()
+        try:
+            os.link(
+                original_skill / "SKILL.md",
+                replacement_skill / "SKILL.md",
+            )
+        except OSError as exc:
+            pytest.skip(f"hard links unavailable in test environment: {exc}")
+        (replacement_skill / "assets").mkdir()
+        (replacement_skill / "assets" / "swapped.txt").write_text(
+            "SWAPPED PACKAGE", encoding="utf-8"
+        )
+        category_link = local_dir / "linked"
+        try:
+            category_link.symlink_to(original_category, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        real_parse = skills_tool_module._parse_frontmatter
+        swapped = False
+
+        def swap_after_discovery(content):
+            nonlocal swapped
+            result = real_parse(content)
+            if not swapped and "ORIGINAL BODY" in content:
+                swapped = True
+                category_link.unlink()
+                category_link.symlink_to(
+                    replacement_category, target_is_directory=True
+                )
+            return result
+
+        monkeypatch.setattr(
+            skills_tool_module, "_parse_frontmatter", swap_after_discovery
+        )
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[],
+            ),
+        ):
+            result = self._assert_incomplete(skill_view("linked-skill"))
+
+        assert swapped is True
+        assert "changed during discovery" in result["detail"]
+
+    def test_unreadable_external_skill_refuses_local_candidate(
+        self, tmp_path, monkeypatch
+    ):
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+        _make_skill(local_dir, "local-only", body="LOCAL BODY")
+        unreadable = _make_skill(external_dir, "unreadable-external") / "SKILL.md"
+        real_open = os.open
+
+        def reject_external_open(path, *args, **kwargs):
+            if Path(path) == unreadable:
+                raise PermissionError("external SKILL.md is unreadable")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(os, "open", reject_external_open)
+        p1, p2 = self._patch_dirs(local_dir, external_dir)
+        with p1, p2:
+            result = self._assert_incomplete(skill_view("local-only"))
+
+        assert "unreadable" in result["detail"]
+
+    def test_external_subtree_traversal_error_refuses_local_candidate(
+        self, tmp_path, monkeypatch
+    ):
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+        _make_skill(local_dir, "local-only", body="LOCAL BODY")
+
+        from agent.skill_utils import iter_skill_index_files as real_iter_skill_index_files
+
+        def traversal_error_iterator(root, filename, *, on_error=None):
+            if root == external_dir and on_error is not None:
+                on_error(PermissionError("cannot traverse external subtree"))
+            yield from real_iter_skill_index_files(root, filename, on_error=on_error)
+
+        monkeypatch.setattr(
+            "agent.skill_utils.iter_skill_index_files", traversal_error_iterator
+        )
+        p1, p2 = self._patch_dirs(local_dir, external_dir)
+        with p1, p2:
+            result = self._assert_incomplete(skill_view("local-only"))
+
+        assert "cannot traverse external subtree" in result["detail"]

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -44,7 +44,7 @@ description: Description for {name}.
 
 {body}
 """
-    (skill_dir / "SKILL.md").write_text(content)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir
 
 
@@ -884,7 +884,9 @@ class TestSkillView:
             skill_dir = _make_skill(tmp_path, "my-skill")
             refs_dir = skill_dir / "references"
             refs_dir.mkdir()
-            (refs_dir / "api.md").write_text("# API Docs\nEndpoint info.")
+            (refs_dir / "api.md").write_text(
+                "# API Docs\nEndpoint info.", encoding="utf-8"
+            )
 
             existing = json.loads(skill_view("my-skill", file_path="references/api.md"))
             skill = json.loads(skill_view("my-skill"))
@@ -901,7 +903,9 @@ class TestSkillView:
             refs_dir = skill_dir / "references"
             refs_dir.mkdir()
             for index in reversed(range(MAX_LINKED_FILES_PER_CATEGORY + 5)):
-                (refs_dir / f"{index:03d}.md").write_text("reference")
+                (refs_dir / f"{index:03d}.md").write_text(
+                    "reference", encoding="utf-8"
+                )
             raw = skill_view("my-skill", file_path="references/nope.md")
         result = json.loads(raw)
         assert result["success"] is False
@@ -938,7 +942,9 @@ class TestSkillView:
             assets_dir = skill_dir / "assets"
             assets_dir.mkdir()
             for index in reversed(range(MAX_LINKED_FILES_PER_CATEGORY + 5)):
-                (assets_dir / f"{index:03d}.txt").write_text("asset")
+                (assets_dir / f"{index:03d}.txt").write_text(
+                    "asset", encoding="utf-8"
+                )
             raw = skill_view("many-assets")
 
         result = json.loads(raw)
@@ -1055,7 +1061,9 @@ class TestSkillView:
             replacement_skill / "SKILL.md",
         )
         (original_skill / "assets").mkdir()
-        (original_skill / "assets" / "original.txt").write_text("original")
+        (original_skill / "assets" / "original.txt").write_text(
+            "original", encoding="utf-8"
+        )
         (replacement_skill / "assets").mkdir()
         (replacement_skill / "assets" / "replacement.txt").write_text(
             "replacement"
@@ -1709,7 +1717,9 @@ class TestSkillViewCollisionDetection:
             / "sketch.md"
         )
         support_file.parent.mkdir(parents=True, exist_ok=True)
-        support_file.write_text("# Sketch style support doc\n")
+        support_file.write_text(
+            "# Sketch style support doc\n", encoding="utf-8"
+        )
         _make_skill(local_dir, "sketch", category="creative", body="REAL SKETCH SKILL")
 
         p1, p2 = self._patch_dirs(local_dir, [external_dir])

--- a/tests/tools/test_skills_tool_discovery_cache.py
+++ b/tests/tools/test_skills_tool_discovery_cache.py
@@ -57,6 +57,112 @@ def test_cache_hit_serves_copies_not_cache_objects(tmp_path):
     assert second is not first
 
 
+@pytest.mark.parametrize("root_kind", ["missing", "file"])
+def test_cold_invalid_external_root_never_caches_local_only(
+    tmp_path, monkeypatch, root_kind
+):
+    _write_skill(tmp_path, "cat-a", "local-only")
+    external_root = tmp_path / "configured-external"
+    if root_kind == "file":
+        external_root.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr(
+        "agent.skill_utils.get_external_skills_dirs",
+        lambda: [external_root],
+    )
+
+    assert st._find_all_skills() == []
+    assert st._SKILLS_CACHE == {}
+
+
+def test_deleted_configured_external_root_refuses_exact_scope_cache(
+    tmp_path, monkeypatch
+):
+    _write_skill(tmp_path, "cat-a", "local")
+    external_root = tmp_path / "configured-external"
+    external_skill = external_root / "external"
+    external_skill.mkdir(parents=True)
+    (external_skill / "SKILL.md").write_text(
+        "---\nname: external\ndescription: External\n---\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "agent.skill_utils.get_external_skills_dirs",
+        lambda: [external_root],
+    )
+
+    assert sorted(s["name"] for s in st._find_all_skills()) == [
+        "external",
+        "local",
+    ]
+    (external_skill / "SKILL.md").unlink()
+    external_skill.rmdir()
+    external_root.rmdir()
+
+    assert st._find_all_skills() == []
+    assert st._SKILLS_CACHE, "last-good cache may remain but must not be served"
+
+
+def test_nested_category_skill_add_invalidates(tmp_path):
+    """THE bug in the original PR: a new skill inside an existing category
+    bumps the category dir's mtime only — the root-mtime key missed it."""
+    _write_skill(tmp_path, "cat-a", "skill-one")
+    first = st._find_all_skills()
+    assert [s["name"] for s in first] == ["skill-one"]
+
+    # Freeze the ROOT dir's mtime so only the category-child signature moves
+    # (guards against filesystems bumping the parent too).
+    root = tmp_path / "skills"
+    root_stat = root.stat()
+    _write_skill(tmp_path, "cat-a", "skill-two")
+    import os
+    os.utime(root, (root_stat.st_atime, root_stat.st_mtime))
+
+    names = sorted(s["name"] for s in st._find_all_skills())
+    assert names == ["skill-one", "skill-two"], (
+        "category-nested skill add must invalidate the cache"
+    )
+
+
+def test_disabled_set_change_invalidates(tmp_path, monkeypatch):
+    """Disabling a skill is a config change with NO filesystem mtime bump —
+    it must still invalidate."""
+    _write_skill(tmp_path, "cat-a", "skill-one")
+    _write_skill(tmp_path, "cat-a", "skill-two")
+    names = sorted(s["name"] for s in st._find_all_skills())
+    assert names == ["skill-one", "skill-two"]
+
+    monkeypatch.setattr(st, "_get_disabled_skill_names", lambda: {"skill-two"})
+    names = sorted(s["name"] for s in st._find_all_skills())
+    assert names == ["skill-one"], "disabled-set change must invalidate the cache"
+
+
+def test_ttl_expiry_forces_rescan(tmp_path, monkeypatch):
+    """In-place SKILL.md edits are invisible to any directory signature;
+    the TTL bounds that staleness."""
+    skill_dir = _write_skill(tmp_path, "cat-a", "skill-one", "old description")
+    first = st._find_all_skills()
+    assert first[0]["description"] == "old description"
+
+    # Edit the file in place; keep every directory mtime identical.
+    import os
+    cat = tmp_path / "skills" / "cat-a"
+    root = tmp_path / "skills"
+    stats = {p: p.stat() for p in (root, cat, skill_dir)}
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: skill-one\ndescription: new description\n---\n# skill-one\n",
+        encoding="utf-8",
+    )
+    for p, s in stats.items():
+        os.utime(p, (s.st_atime, s.st_mtime))
+
+    # Within TTL: stale (documented trade-off).
+    assert st._find_all_skills()[0]["description"] == "old description"
+
+    # Past TTL: fresh.
+    monkeypatch.setattr(st, "_SKILLS_CACHE_TTL_SECONDS", 0.0)
+    assert st._find_all_skills()[0]["description"] == "new description"
+
+
 def test_disabled_and_full_views_cached_separately(tmp_path, monkeypatch):
     _write_skill(tmp_path, "cat-a", "skill-one")
     _write_skill(tmp_path, "cat-a", "skill-two")

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -139,10 +139,68 @@ def test_load_on_disk_store_honors_configured_char_limits(hermes_home, monkeypat
 # Skill gate
 # ---------------------------------------------------------------------------
 
-_SKILL = (
-    "---\nname: test-skill\ndescription: A test skill\nversion: 1.0.0\n---\n"
-    "# Test\nbody\n"
-)
+def _skill(name):
+    return (
+        f"---\nname: {name}\ndescription: A test skill\n"
+        "version: 1.0.0\n---\n# Test\nbody\n"
+    )
+
+
+def test_skill_gate_off_allows_create(hermes_home):
+    # Default (gate off) → skill is created normally, not staged.
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from tools import write_approval as wa
+    r = json.loads(
+        smt.skill_manage("create", "free-skill", content=_skill("free-skill"))
+    )
+    assert r.get("success") is True
+    assert wa.pending_count("skills") == 0
+
+
+def test_skill_gate_on_always_stages(hermes_home):
+    # Skills stage even in the foreground (too big to review inline).
+    from tools.skill_manager_tool import skill_manage
+    from tools import write_approval as wa
+    _set_approval("skills", True)
+    r = json.loads(
+        skill_manage("create", "staged-skill", content=_skill("staged-skill"))
+    )
+    assert r.get("staged") is True
+    assert "staged-skill" in r.get("gist", "")
+    assert wa.pending_count("skills") == 1
+
+
+def test_skill_gate_on_then_apply_writes_file(hermes_home):
+    # SKILLS_DIR is resolved at import time, so reload the skill module under
+    # this test's HERMES_HOME to exercise the real on-disk write path.
+    import importlib
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    from tools import write_approval as wa
+    _set_approval("skills", True)
+    r = json.loads(
+        smt.skill_manage(
+            "create", "applied-skill", content=_skill("applied-skill")
+        )
+    )
+    rec = wa.get_pending("skills", r["pending_id"])
+    res = json.loads(smt.apply_skill_pending(rec["payload"]))
+    assert res["success"] is True
+    assert smt._find_skill("applied-skill") is not None
+
+
+def test_skill_create_diff_is_full_content(hermes_home):
+    from tools.skill_manager_tool import skill_manage
+    from tools import write_approval as wa
+    _set_approval("skills", True)
+    r = json.loads(
+        skill_manage("create", "diff-skill", content=_skill("diff-skill"))
+    )
+    rec = wa.get_pending("skills", r["pending_id"])
+    diff = wa.skill_pending_diff(rec)
+    assert "name: diff-skill" in diff
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tui_gateway/test_compress_lock_skip.py
+++ b/tests/tui_gateway/test_compress_lock_skip.py
@@ -170,3 +170,129 @@ def test_mirror_slash_side_effects_reports_lock_skip():
     assert "live session sync failed" not in output
 
 
+def test_mirror_slash_side_effects_unconfirmed_lock_skip_wording():
+    """signal=True (no confirmed holder) must use the 'could not acquire'
+    wording rather than claiming another compression is running."""
+    from tui_gateway import server
+
+    agent = _make_lock_skip_agent(True)
+    session = _make_session(agent, _make_history())
+    sid = "sid-lock-mirror-unconfirmed"
+    server._sessions[sid] = session
+    try:
+        with (
+            patch.object(server, "_sync_session_key_after_compress"),
+            patch.object(server, "_emit"),
+            patch(
+                "agent.model_metadata.estimate_request_tokens_rough",
+                return_value=100,
+            ),
+        ):
+            output = server._mirror_slash_side_effects(sid, session, "/compress")
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert "Compression skipped" in output
+    assert "could not acquire" in output
+    assert "already in progress" not in output
+
+
+@pytest.mark.parametrize("route", ["rpc", "command_dispatch", "slash_mirror"])
+def test_manual_compress_reserves_history_before_prompt_can_start(route):
+    """Every in-process route queues prompts during manual compaction.
+
+    The blocking compressor is a deterministic stand-in for the durable
+    SessionDB commit window: while it is paused, ``prompt.submit`` must not
+    mutate ``history`` or ``history_version``.  Once released, the compressed
+    in-memory transcript is the sole committed successor.
+    """
+    from tui_gateway import server
+
+    entered = threading.Event()
+    release = threading.Event()
+    history = _make_history()
+    compressed = [{"role": "user", "content": "[summary]"}]
+    agent = _make_lock_skip_agent(None)
+
+    def _compress(msgs, *_args, **_kwargs):
+        entered.set()
+        assert release.wait(5), "test did not release the compressor"
+        return compressed, ""
+
+    agent._compress_context.side_effect = _compress
+    session = _make_session(agent, history)
+    sid = f"sid-compress-reservation-{route}"
+    server._sessions[sid] = session
+    result = {}
+
+    def _run_compress():
+        if route == "rpc":
+            result["response"] = server._methods["session.compress"](
+                "rpc-compress", {"session_id": sid}
+            )
+        elif route == "command_dispatch":
+            result["response"] = server._methods["command.dispatch"](
+                "dispatch-compress",
+                {"name": "compress", "arg": "", "session_id": sid},
+            )
+        else:
+            result["response"] = server._mirror_slash_side_effects(
+                sid, session, "/compress"
+            )
+
+    try:
+        with (
+            patch.object(server, "_session_uses_compute_host", return_value=False),
+            patch.object(server, "_status_update"),
+            patch.object(server, "_sync_session_key_after_compress"),
+            patch.object(server, "_emit"),
+            patch.object(server, "_session_info", return_value={}),
+            patch.object(server, "_get_usage", return_value={}),
+            patch.object(server, "_ensure_active_session_slot", return_value=None),
+            patch.object(server, "_load_dashboard_process_isolation_config", return_value={}),
+            patch.object(server, "_drain_queued_prompt") as drain,
+            patch(
+                "agent.manual_compression_feedback.summarize_manual_compression",
+                return_value={
+                    "aborted": False,
+                    "headline": "Compressed",
+                    "token_line": "",
+                    "note": "",
+                },
+            ),
+            patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+        ):
+            thread = threading.Thread(target=_run_compress)
+            thread.start()
+            assert entered.wait(5), "compressor did not enter its commit window"
+
+            prompt = server._methods["prompt.submit"](
+                "prompt", {"session_id": sid, "text": "must run after compress"}
+            )
+            assert prompt["result"] == {"status": "queued"}
+            assert session["history"] == history
+            assert session["history_version"] == 1
+            assert session["running"] is True
+            assert session["queued_prompt"]["text"] == "must run after compress"
+
+            release.set()
+            thread.join(5)
+            assert not thread.is_alive()
+
+        if route == "slash_mirror":
+            assert "live session sync failed" not in result["response"]
+        else:
+            assert "error" not in result["response"]
+        assert session["history"] == compressed
+        assert session["history_version"] == 2
+        assert session["running"] is False
+        assert "_manual_compression_reservation" not in session
+        expected_rid = (
+            "rpc-compress" if route == "rpc"
+            else "dispatch-compress" if route == "command_dispatch"
+            else "slash-compress"
+        )
+        drain.assert_called_once_with(expected_rid, sid, session)
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -194,6 +194,13 @@ class TestNotificationPollerLoopKanbanWiring:
         import threading
         import tui_gateway.server as server
 
+        # Production pollers are attached only after the exact session record
+        # and its agent are live in the registry. The lifecycle-safe delivery
+        # path deliberately rejects bare/stale records so a reused short SID
+        # cannot receive an old poller's notification.
+        session.setdefault("agent", object())
+        monkeypatch.setitem(server._sessions, "sid-poller-test", session)
+
         emits: list = []
         submits: list = []
         monkeypatch.setattr(server, "_KANBAN_POLL_SECONDS", 0.01)

--- a/tests/tui_gateway/test_review_summary_callback.py
+++ b/tests/tui_gateway/test_review_summary_callback.py
@@ -123,6 +123,58 @@ def test_review_summary_callback_survives_agent_without_attribute(server, monkey
     # If we got here, _init_session swallowed the AttributeError gracefully.
 
 
+def test_eager_review_callback_rejects_reused_sid(server, monkeypatch):
+    """A delayed review from eager init must not target a replacement SID."""
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_args: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda *_args: None)
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *_args: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    class Agent:
+        model = "fake/model"
+        background_review_callback = None
+
+    agent = Agent()
+    server._init_session("reused", "old-key", agent, [], cols=80)
+    review = agent.background_review_callback
+    server._sessions["reused"] = {"agent": object(), "session_key": "new-key"}
+
+    review("old review")
+
+    assert [event for event in emitted if event[0] == "review.summary"] == []
+
+
+def test_init_session_sets_memory_notifications_from_config(server, monkeypatch):
+    """_init_session must apply display.memory_notifications to the agent so
+    the TUI/desktop honors the same off/on/verbose toggle as the messaging
+    gateway and CLI. Without this the review always behaved as 'on'."""
+    monkeypatch.setattr(server, "_SlashWorker", lambda *a, **kw: object())
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_session_info", lambda agent, session=None: {"model": "m"})
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_load_memory_notifications", lambda: "verbose")
+
+    class FakeAgent:
+        model = "fake/model"
+        background_review_callback = None
+        memory_notifications = "on"
+
+    agent = FakeAgent()
+    server._init_session("sid-mn", "key-mn", agent, [], cols=80)
+
+    assert agent.memory_notifications == "verbose"
+
+
 @pytest.mark.parametrize(
     "raw,expected",
     [
@@ -141,4 +193,3 @@ def test_load_memory_notifications_normalization(server, monkeypatch, raw, expec
     display = {} if raw is None else {"memory_notifications": raw}
     monkeypatch.setattr(server, "_load_cfg", lambda: {"display": display})
     assert server._load_memory_notifications() == expected
-

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -44,6 +44,7 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
@@ -84,6 +85,25 @@ _MAX_DURABLE_PENDING = 1000
 # instead of replaying on every restart forever.
 _MAX_DELIVERY_ATTEMPTS = 8
 _DB_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class EventDeliveryClaim:
+    """Outcome of trying to reserve one process-notification delivery.
+
+    ``None`` historically represented both a live competing claim and an
+    already terminal durable row.  Consumers that requeue on ``None`` cannot
+    converge after a lease rollover, so keep those states explicit.
+    """
+
+    state: str
+    claim_id: str = ""
+
+
+DELIVERY_CLAIMED = "claimed"
+DELIVERY_BUSY_PENDING = "busy_pending"
+DELIVERY_TERMINAL_CONSUMED = "terminal_consumed"
+DELIVERY_LEGACY_NON_DURABLE = "legacy_non_durable"
 
 # ---------------------------------------------------------------------------
 # Stale-delegation detection (progress-based, on by default)
@@ -271,6 +291,11 @@ def _prune_durable_records() -> None:
 
 
 def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
+    # Keep enough provenance on the in-memory/restored event to distinguish a
+    # pruned terminal durable row from a truly legacy non-durable event.  A
+    # stale claimant can outlive retention pruning after another claimant has
+    # already consumed the row.
+    event["_durable_delivery"] = True
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
@@ -318,6 +343,7 @@ def recover_abandoned_delegations() -> int:
             task = json.loads(task_json or "{}")
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
+                "_durable_delivery": True,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
                 # Restore the durable wake target so completions recovered
                 # after a restart remain routable to api_server sessions.
@@ -411,6 +437,56 @@ def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
     return claim_id if claim_completion_delivery(delegation_id, claim_id) else None
 
 
+def inspect_event_delivery_state(evt: Dict[str, Any]) -> str:
+    """Classify an event without mutating its durable delivery row."""
+    if evt.get("type") != "async_delegation":
+        return DELIVERY_LEGACY_NON_DURABLE
+    delegation_id = str(evt.get("delegation_id") or "")
+    if not delegation_id:
+        return DELIVERY_LEGACY_NON_DURABLE
+    with _DB_LOCK, _transaction() as conn:
+        row = conn.execute(
+            "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+    if row is None:
+        return (
+            DELIVERY_TERMINAL_CONSUMED
+            if evt.get("_durable_delivery") is True
+            else DELIVERY_LEGACY_NON_DURABLE
+        )
+    if str(row[0]) in {"delivered", "dropped"}:
+        return DELIVERY_TERMINAL_CONSUMED
+    return DELIVERY_BUSY_PENDING
+
+
+def claim_event_delivery_state(
+    evt: Dict[str, Any], consumer: str
+) -> EventDeliveryClaim:
+    """Claim an event while preserving why a claim was unavailable.
+
+    The historical ``claim_event_delivery`` call remains the compatibility
+    seam for CLI consumers and tests.  A follow-up read is sufficient here:
+    a pending row may move to terminal after the read (the next queue pass
+    then consumes it), while a terminal row can never become pending again.
+    """
+    claim_id = claim_event_delivery(evt, consumer)
+    if claim_id is None:
+        if evt.get("type") != "async_delegation":
+            return EventDeliveryClaim(DELIVERY_BUSY_PENDING)
+        return EventDeliveryClaim(inspect_event_delivery_state(evt))
+    if not claim_id:
+        return EventDeliveryClaim(DELIVERY_LEGACY_NON_DURABLE)
+    state = inspect_event_delivery_state(evt)
+    if state == DELIVERY_LEGACY_NON_DURABLE:
+        # Async events predating the durable registry are intentionally
+        # delivered with no database acknowledgement.
+        return EventDeliveryClaim(state)
+    if state == DELIVERY_TERMINAL_CONSUMED:
+        return EventDeliveryClaim(state)
+    return EventDeliveryClaim(DELIVERY_CLAIMED, claim_id)
+
+
 def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
     """Release a failed delivery claim so another consumer may retry.
 
@@ -484,14 +560,27 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
         return cur.rowcount == 1
 
 
-def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
+def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    """Return whether this event's delivery was durably acknowledged.
+
+    Ordinary process notifications have no durable delivery row, so completing
+    them remains a successful no-op (including the historical empty-claim
+    path).  Async-delegation notifications are successful only when the
+    claimed database row was actually transitioned to ``delivered``.
+    """
     if claim_id and evt.get("type") == "async_delegation":
-        complete_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+        return complete_completion_delivery(
+            str(evt.get("delegation_id") or ""), claim_id
+        )
+    return True
 
 
-def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
+def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
     if claim_id and evt.get("type") == "async_delegation":
-        release_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+        return release_completion_delivery(
+            str(evt.get("delegation_id") or ""), claim_id
+        )
+    return True
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:

--- a/tools/nt_secure_fs.py
+++ b/tools/nt_secure_fs.py
@@ -1,0 +1,1176 @@
+"""Windows NT handle-relative filesystem operations for skill packages.
+
+The ordinary Win32 path APIs resolve the complete path again for every
+operation.  That is not strong enough for skill discovery or mutation: a
+junction swapped into any parent between validation and use can redirect a
+read, replacement, rename, or recursive delete.
+
+This module binds an absolute root with ``NtCreateFile`` and
+``OBJ_DONT_REPARSE`` and resolves every descendant one component at a time
+through ``OBJECT_ATTRIBUTES.RootDirectory``.  Every returned object is
+identified from its handle, and namespace mutations use handle-relative
+``SetFileInformationByHandle`` calls.  No security decision is made from a
+subsequent string-path resolution.
+
+The module is importable on non-Windows hosts so its public contract can be
+mock-tested there.  Native calls are initialized lazily and fail explicitly
+when invoked off Windows.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import stat as stat_module
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional, Sequence
+
+
+# OBJECT_ATTRIBUTES flags.
+OBJ_CASE_INSENSITIVE = 0x00000040
+OBJ_DONT_REPARSE = 0x00001000
+
+# Native create dispositions and options.
+FILE_OPEN = 0x00000001
+FILE_CREATE = 0x00000002
+FILE_DIRECTORY_FILE = 0x00000001
+FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020
+FILE_NON_DIRECTORY_FILE = 0x00000040
+FILE_OPEN_REPARSE_POINT = 0x00200000
+
+# File-specific access rights.
+FILE_READ_DATA = 0x00000001
+FILE_LIST_DIRECTORY = 0x00000001
+FILE_WRITE_DATA = 0x00000002
+FILE_ADD_FILE = 0x00000002
+FILE_APPEND_DATA = 0x00000004
+FILE_ADD_SUBDIRECTORY = 0x00000004
+FILE_READ_EA = 0x00000008
+FILE_WRITE_EA = 0x00000010
+FILE_TRAVERSE = 0x00000020
+FILE_DELETE_CHILD = 0x00000040
+FILE_READ_ATTRIBUTES = 0x00000080
+FILE_WRITE_ATTRIBUTES = 0x00000100
+DELETE = 0x00010000
+READ_CONTROL = 0x00020000
+SYNCHRONIZE = 0x00100000
+
+FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+FILE_SHARE_DELETE = 0x00000004
+_ALL_SHARES = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
+
+FILE_ATTRIBUTE_NORMAL = 0x00000080
+FILE_ATTRIBUTE_DIRECTORY = 0x00000010
+FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+
+# SetFileInformationByHandle classes and flags.
+FILE_RENAME_INFO = 3
+FILE_DISPOSITION_INFO = 4
+FILE_DISPOSITION_INFO_EX = 21
+FILE_RENAME_INFO_EX = 22
+FILE_RENAME_FLAG_REPLACE_IF_EXISTS = 0x00000001
+FILE_RENAME_FLAG_POSIX_SEMANTICS = 0x00000002
+FILE_DISPOSITION_FLAG_DELETE = 0x00000001
+FILE_DISPOSITION_FLAG_POSIX_SEMANTICS = 0x00000002
+FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE = 0x00000010
+
+ERROR_NO_MORE_FILES = 18
+ERROR_INVALID_PARAMETER = 87
+INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+
+
+class NtSecureFsUnavailable(OSError):
+    """The native Windows backend is not available in this process."""
+
+
+@dataclass(frozen=True)
+class NtStat:
+    """The stat fields used by the skill subsystems, obtained from a handle."""
+
+    st_dev: int
+    st_ino: int
+    st_mode: int
+    st_size: int
+    st_mtime_ns: int
+    st_ctime_ns: int
+    file_attributes: int
+
+    @property
+    def identity(self) -> tuple[int, int]:
+        return self.st_dev, self.st_ino
+
+    @property
+    def signature(self) -> tuple[int, int, int, int, int]:
+        return (
+            self.st_dev,
+            self.st_ino,
+            self.st_size,
+            self.st_mtime_ns,
+            self.st_ctime_ns,
+        )
+
+    @property
+    def is_dir(self) -> bool:
+        return stat_module.S_ISDIR(self.st_mode)
+
+    @property
+    def is_file(self) -> bool:
+        return stat_module.S_ISREG(self.st_mode)
+
+
+@dataclass(frozen=True)
+class NtDirectoryEntry:
+    name: str
+    file_attributes: int
+    size: int
+    file_id: int = 0
+    st_mtime_ns: int = 0
+    st_ctime_ns: int = 0
+
+    @property
+    def is_dir(self) -> bool:
+        return bool(self.file_attributes & FILE_ATTRIBUTE_DIRECTORY)
+
+    @property
+    def is_reparse(self) -> bool:
+        return bool(self.file_attributes & FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+class _UNICODE_STRING(ctypes.Structure):
+    _fields_ = [
+        ("Length", ctypes.c_ushort),
+        ("MaximumLength", ctypes.c_ushort),
+        ("Buffer", ctypes.c_void_p),
+    ]
+
+
+class _OBJECT_ATTRIBUTES(ctypes.Structure):
+    _fields_ = [
+        ("Length", ctypes.c_ulong),
+        ("RootDirectory", ctypes.c_void_p),
+        ("ObjectName", ctypes.POINTER(_UNICODE_STRING)),
+        ("Attributes", ctypes.c_ulong),
+        ("SecurityDescriptor", ctypes.c_void_p),
+        ("SecurityQualityOfService", ctypes.c_void_p),
+    ]
+
+
+class _IO_STATUS_BLOCK_UNION(ctypes.Union):
+    _fields_ = [("Status", ctypes.c_long), ("Pointer", ctypes.c_void_p)]
+
+
+class _IO_STATUS_BLOCK(ctypes.Structure):
+    _fields_ = [
+        ("u", _IO_STATUS_BLOCK_UNION),
+        ("Information", ctypes.c_size_t),
+    ]
+
+
+class _FILETIME(ctypes.Structure):
+    _fields_ = [("dwLowDateTime", ctypes.c_ulong), ("dwHighDateTime", ctypes.c_ulong)]
+
+
+class _BY_HANDLE_FILE_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("dwFileAttributes", ctypes.c_ulong),
+        ("ftCreationTime", _FILETIME),
+        ("ftLastAccessTime", _FILETIME),
+        ("ftLastWriteTime", _FILETIME),
+        ("dwVolumeSerialNumber", ctypes.c_ulong),
+        ("nFileSizeHigh", ctypes.c_ulong),
+        ("nFileSizeLow", ctypes.c_ulong),
+        ("nNumberOfLinks", ctypes.c_ulong),
+        ("nFileIndexHigh", ctypes.c_ulong),
+        ("nFileIndexLow", ctypes.c_ulong),
+    ]
+
+
+class _FILE_ATTRIBUTE_TAG_INFO(ctypes.Structure):
+    _fields_ = [("FileAttributes", ctypes.c_ulong), ("ReparseTag", ctypes.c_ulong)]
+
+
+class _FILE_BASIC_INFO(ctypes.Structure):
+    _fields_ = [
+        ("CreationTime", ctypes.c_longlong),
+        ("LastAccessTime", ctypes.c_longlong),
+        ("LastWriteTime", ctypes.c_longlong),
+        ("ChangeTime", ctypes.c_longlong),
+        ("FileAttributes", ctypes.c_ulong),
+    ]
+
+
+class _FILE_ID_BOTH_DIR_INFO(ctypes.Structure):
+    _fields_ = [
+        ("NextEntryOffset", ctypes.c_ulong),
+        ("FileIndex", ctypes.c_ulong),
+        ("CreationTime", ctypes.c_longlong),
+        ("LastAccessTime", ctypes.c_longlong),
+        ("LastWriteTime", ctypes.c_longlong),
+        ("ChangeTime", ctypes.c_longlong),
+        ("EndOfFile", ctypes.c_longlong),
+        ("AllocationSize", ctypes.c_longlong),
+        ("FileAttributes", ctypes.c_ulong),
+        ("FileNameLength", ctypes.c_ulong),
+        ("EaSize", ctypes.c_ulong),
+        ("ShortNameLength", ctypes.c_byte),
+        ("ShortName", ctypes.c_wchar * 12),
+        ("FileId", ctypes.c_longlong),
+        ("FileName", ctypes.c_wchar * 1),
+    ]
+
+
+class _FILE_RENAME_INFO_BUFFER(ctypes.Structure):
+    _fields_ = [
+        ("Flags", ctypes.c_ulong),
+        ("RootDirectory", ctypes.c_void_p),
+        ("FileNameLength", ctypes.c_ulong),
+        ("FileName", ctypes.c_wchar * 1),
+    ]
+
+
+class _FILE_RENAME_INFO_LEGACY_BUFFER(ctypes.Structure):
+    _fields_ = [
+        ("ReplaceIfExists", ctypes.c_ubyte),
+        ("RootDirectory", ctypes.c_void_p),
+        ("FileNameLength", ctypes.c_ulong),
+        ("FileName", ctypes.c_wchar * 1),
+    ]
+
+
+class _FILE_DISPOSITION_INFO_EX_BUFFER(ctypes.Structure):
+    _fields_ = [("Flags", ctypes.c_ulong)]
+
+
+class _FILE_DISPOSITION_INFO_BUFFER(ctypes.Structure):
+    _fields_ = [("DeleteFile", ctypes.c_ubyte)]
+
+
+class _NativeApi:
+    def __init__(self) -> None:
+        if os.name != "nt":
+            raise NtSecureFsUnavailable(
+                "NT handle-relative filesystem operations require Windows"
+            )
+
+        from ctypes import wintypes
+
+        self.wintypes = wintypes
+        self.ntdll = ctypes.WinDLL("ntdll", use_last_error=True)
+        self.kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+        self.NtCreateFile = self.ntdll.NtCreateFile
+        self.NtCreateFile.argtypes = [
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.c_ulong,
+            ctypes.POINTER(_OBJECT_ATTRIBUTES),
+            ctypes.POINTER(_IO_STATUS_BLOCK),
+            ctypes.c_void_p,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+            ctypes.c_void_p,
+            ctypes.c_ulong,
+        ]
+        self.NtCreateFile.restype = ctypes.c_long
+
+        self.RtlNtStatusToDosError = self.ntdll.RtlNtStatusToDosError
+        self.RtlNtStatusToDosError.argtypes = [ctypes.c_long]
+        self.RtlNtStatusToDosError.restype = ctypes.c_ulong
+
+        self.CloseHandle = self.kernel32.CloseHandle
+        self.CloseHandle.argtypes = [ctypes.c_void_p]
+        self.CloseHandle.restype = ctypes.c_int
+
+        self.GetFileInformationByHandle = self.kernel32.GetFileInformationByHandle
+        self.GetFileInformationByHandle.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(_BY_HANDLE_FILE_INFORMATION),
+        ]
+        self.GetFileInformationByHandle.restype = ctypes.c_int
+
+        self.GetFileInformationByHandleEx = (
+            self.kernel32.GetFileInformationByHandleEx
+        )
+        self.GetFileInformationByHandleEx.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_ulong,
+        ]
+        self.GetFileInformationByHandleEx.restype = ctypes.c_int
+
+        self.GetFinalPathNameByHandleW = self.kernel32.GetFinalPathNameByHandleW
+        self.GetFinalPathNameByHandleW.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_wchar_p,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+        ]
+        self.GetFinalPathNameByHandleW.restype = ctypes.c_ulong
+
+        self.ReadFile = self.kernel32.ReadFile
+        self.ReadFile.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_ulong,
+            ctypes.POINTER(ctypes.c_ulong),
+            ctypes.c_void_p,
+        ]
+        self.ReadFile.restype = ctypes.c_int
+
+        self.WriteFile = self.kernel32.WriteFile
+        self.WriteFile.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_ulong,
+            ctypes.POINTER(ctypes.c_ulong),
+            ctypes.c_void_p,
+        ]
+        self.WriteFile.restype = ctypes.c_int
+
+        self.FlushFileBuffers = self.kernel32.FlushFileBuffers
+        self.FlushFileBuffers.argtypes = [ctypes.c_void_p]
+        self.FlushFileBuffers.restype = ctypes.c_int
+
+        self.SetFileInformationByHandle = (
+            self.kernel32.SetFileInformationByHandle
+        )
+        self.SetFileInformationByHandle.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_ulong,
+        ]
+        self.SetFileInformationByHandle.restype = ctypes.c_int
+
+    def winerror(self, code: Optional[int] = None) -> OSError:
+        if code is None:
+            code = ctypes.get_last_error()
+        return ctypes.WinError(code)
+
+    def raise_status(self, status: int, operation: str) -> None:
+        unsigned = status & 0xFFFFFFFF
+        dos_error = int(self.RtlNtStatusToDosError(ctypes.c_long(status)))
+        error = ctypes.WinError(dos_error)
+        error.args = (
+            dos_error,
+            f"{operation} failed (NTSTATUS 0x{unsigned:08x}): {error.strerror}",
+        )
+        raise error
+
+
+_native_api: Optional[_NativeApi] = None
+
+
+def is_available() -> bool:
+    if os.name != "nt":
+        return False
+    try:
+        _api()
+    except (AttributeError, OSError):
+        return False
+    return True
+
+
+def _api() -> _NativeApi:
+    global _native_api
+    if _native_api is None:
+        _native_api = _NativeApi()
+    return _native_api
+
+
+def _validate_component(name: str) -> None:
+    if (
+        not isinstance(name, str)
+        or not name
+        or name in (".", "..")
+        or "\\" in name
+        or "/" in name
+        or "\x00" in name
+        or ":" in name
+    ):
+        raise ValueError(f"invalid handle-relative path component: {name!r}")
+
+
+def _filetime_ticks_to_unix_ns(ticks: int) -> int:
+    return max(0, (int(ticks) - 116444736000000000) * 100)
+
+
+def _validate_snapshot_component(name: str) -> None:
+    """Reject NT names that Win32 destination paths cannot preserve exactly."""
+    _validate_component(name)
+    if name[0] == " " or name[-1] in (" ", ".") or any(
+        ord(character) < 32 or character in '<>"|?*'
+        for character in name
+    ):
+        raise ValueError(f"unsafe Win32 snapshot component: {name!r}")
+    device_base = name.split(".", 1)[0].upper()
+    reserved = {"CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"}
+    device_digits = tuple("123456789¹²³")
+    reserved.update(f"COM{digit}" for digit in device_digits)
+    reserved.update(f"LPT{digit}" for digit in device_digits)
+    if device_base in reserved:
+        raise ValueError(f"reserved Win32 snapshot component: {name!r}")
+
+
+def _nt_absolute_name(path: Path) -> str:
+    absolute = os.path.abspath(os.fspath(path))
+    if absolute.startswith("\\\\?\\UNC\\"):
+        return "\\??\\UNC\\" + absolute[8:]
+    if absolute.startswith("\\\\?\\"):
+        return "\\??\\" + absolute[4:]
+    if absolute.startswith("\\\\"):
+        return "\\??\\UNC\\" + absolute[2:]
+    return "\\??\\" + absolute
+
+
+def _unicode_string(value: str) -> tuple[ctypes.Array, _UNICODE_STRING]:
+    buffer = ctypes.create_unicode_buffer(value)
+    length = len(value.encode("utf-16-le"))
+    return buffer, _UNICODE_STRING(
+        Length=length,
+        MaximumLength=length + 2,
+        Buffer=ctypes.cast(buffer, ctypes.c_void_p),
+    )
+
+
+def _open_native(
+    name: str,
+    *,
+    root: Optional["NtHandle"],
+    directory: bool,
+    create: bool,
+    writable: bool,
+    allow_final_reparse: bool = False,
+    share_access: int = _ALL_SHARES,
+) -> "NtHandle":
+    api = _api()
+    if root is not None:
+        _validate_component(name)
+    name_buffer, unicode_name = _unicode_string(name)
+    attributes = _OBJECT_ATTRIBUTES(
+        Length=ctypes.sizeof(_OBJECT_ATTRIBUTES),
+        RootDirectory=ctypes.c_void_p(root.raw if root is not None else 0),
+        ObjectName=ctypes.pointer(unicode_name),
+        Attributes=(
+            OBJ_CASE_INSENSITIVE
+            | (0 if allow_final_reparse else OBJ_DONT_REPARSE)
+        ),
+        SecurityDescriptor=None,
+        SecurityQualityOfService=None,
+    )
+    if directory:
+        access = (
+            FILE_LIST_DIRECTORY
+            | FILE_TRAVERSE
+            | FILE_READ_ATTRIBUTES
+            | SYNCHRONIZE
+        )
+        if writable:
+            access |= (
+                FILE_ADD_FILE
+                | FILE_ADD_SUBDIRECTORY
+                | FILE_DELETE_CHILD
+                | FILE_WRITE_ATTRIBUTES
+                | DELETE
+            )
+        options = (
+            FILE_DIRECTORY_FILE
+            | FILE_SYNCHRONOUS_IO_NONALERT
+            | FILE_OPEN_REPARSE_POINT
+        )
+    else:
+        access = FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE
+        if writable or create:
+            access |= (
+                FILE_WRITE_DATA
+                | FILE_APPEND_DATA
+                | FILE_WRITE_ATTRIBUTES
+                | DELETE
+            )
+        options = (
+            FILE_NON_DIRECTORY_FILE
+            | FILE_SYNCHRONOUS_IO_NONALERT
+            | FILE_OPEN_REPARSE_POINT
+        )
+
+    handle_value = ctypes.c_void_p()
+    io_status = _IO_STATUS_BLOCK()
+    status = api.NtCreateFile(
+        ctypes.byref(handle_value),
+        access,
+        ctypes.byref(attributes),
+        ctypes.byref(io_status),
+        None,
+        FILE_ATTRIBUTE_NORMAL,
+        share_access,
+        FILE_CREATE if create else FILE_OPEN,
+        options,
+        None,
+        0,
+    )
+    # Keep the backing UTF-16 allocation live through NtCreateFile.  The
+    # UNICODE_STRING stores only its address, not a Python reference.
+    del name_buffer
+    if status < 0:
+        api.raise_status(status, f"NtCreateFile({name!r})")
+    handle = NtHandle(int(handle_value.value), writable=writable or create)
+    try:
+        metadata = handle.stat()
+        if (
+            metadata.file_attributes & FILE_ATTRIBUTE_REPARSE_POINT
+            and not allow_final_reparse
+        ):
+            raise OSError(f"refusing reparse point: {name}")
+        if directory != metadata.is_dir:
+            raise NotADirectoryError(name) if directory else IsADirectoryError(name)
+    except BaseException:
+        handle.close()
+        raise
+    return handle
+
+
+class NtHandle:
+    """Owned native handle opened without traversing a reparse point."""
+
+    __slots__ = ("raw", "writable", "_closed")
+
+    def __init__(self, raw: int, *, writable: bool) -> None:
+        if not raw or raw == INVALID_HANDLE_VALUE:
+            raise ValueError("invalid NT handle")
+        self.raw = raw
+        self.writable = writable
+        self._closed = False
+
+    def __enter__(self) -> "NtHandle":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if not self._closed:
+            if not _api().CloseHandle(ctypes.c_void_p(self.raw)):
+                raise _api().winerror()
+            self._closed = True
+
+    def stat(self) -> NtStat:
+        info = _BY_HANDLE_FILE_INFORMATION()
+        if not _api().GetFileInformationByHandle(
+            ctypes.c_void_p(self.raw), ctypes.byref(info)
+        ):
+            raise _api().winerror()
+        attrs = int(info.dwFileAttributes)
+        if attrs & FILE_ATTRIBUTE_REPARSE_POINT:
+            tag_info = _FILE_ATTRIBUTE_TAG_INFO()
+            if not _api().GetFileInformationByHandleEx(
+                ctypes.c_void_p(self.raw),
+                9,  # FileAttributeTagInfo
+                ctypes.byref(tag_info),
+                ctypes.sizeof(tag_info),
+            ):
+                raise _api().winerror()
+            if tag_info.ReparseTag:
+                attrs |= FILE_ATTRIBUTE_REPARSE_POINT
+        basic_info = _FILE_BASIC_INFO()
+        if not _api().GetFileInformationByHandleEx(
+            ctypes.c_void_p(self.raw),
+            0,  # FileBasicInfo
+            ctypes.byref(basic_info),
+            ctypes.sizeof(basic_info),
+        ):
+            raise _api().winerror()
+        file_id = (int(info.nFileIndexHigh) << 32) | int(info.nFileIndexLow)
+        size = (int(info.nFileSizeHigh) << 32) | int(info.nFileSizeLow)
+
+        mode = (
+            stat_module.S_IFDIR | 0o700
+            if attrs & FILE_ATTRIBUTE_DIRECTORY
+            else stat_module.S_IFREG | 0o600
+        )
+        return NtStat(
+            st_dev=int(info.dwVolumeSerialNumber),
+            st_ino=file_id,
+            st_mode=mode,
+            st_size=size,
+            st_mtime_ns=_filetime_ticks_to_unix_ns(
+                basic_info.LastWriteTime
+            ),
+            st_ctime_ns=_filetime_ticks_to_unix_ns(
+                basic_info.ChangeTime
+            ),
+            file_attributes=attrs,
+        )
+
+    @property
+    def identity(self) -> tuple[int, int]:
+        return self.stat().identity
+
+    def final_path(self) -> Path:
+        api = _api()
+        needed = api.GetFinalPathNameByHandleW(
+            ctypes.c_void_p(self.raw), None, 0, 0
+        )
+        if not needed:
+            raise api.winerror()
+        buffer = ctypes.create_unicode_buffer(needed + 1)
+        written = api.GetFinalPathNameByHandleW(
+            ctypes.c_void_p(self.raw), buffer, len(buffer), 0
+        )
+        if not written or written >= len(buffer):
+            raise api.winerror()
+        value = buffer.value
+        if value.startswith("\\\\?\\UNC\\"):
+            value = "\\\\" + value[8:]
+        elif value.startswith("\\\\?\\"):
+            value = value[4:]
+        return Path(value)
+
+    def open_dir(
+        self, name: str, *, create: bool = False, writable: Optional[bool] = None
+    ) -> "NtHandle":
+        return _open_native(
+            name,
+            root=self,
+            directory=True,
+            create=create,
+            writable=self.writable if writable is None else writable,
+            allow_final_reparse=False,
+        )
+
+    def open_file(
+        self,
+        name: str,
+        *,
+        create: bool = False,
+        writable: bool = False,
+        stable_read: bool = False,
+    ) -> "NtHandle":
+        return _open_native(
+            name,
+            root=self,
+            directory=False,
+            create=create,
+            writable=writable,
+            allow_final_reparse=False,
+            share_access=(
+                FILE_SHARE_READ if stable_read else _ALL_SHARES
+            ),
+        )
+
+    def open_reparse_entry(
+        self, name: str, *, directory: bool, writable: bool
+    ) -> "NtHandle":
+        """Open the final reparse object itself below a held real directory."""
+        return _open_native(
+            name,
+            root=self,
+            directory=directory,
+            create=False,
+            writable=writable,
+            allow_final_reparse=True,
+        )
+
+    def entry_identity(self, name: str, *, directory: bool) -> tuple[int, int]:
+        with (
+            self.open_dir(name, writable=False)
+            if directory
+            else self.open_file(name, writable=False)
+        ) as child:
+            return child.identity
+
+    def exists(self, name: str, *, directory: Optional[bool] = None) -> bool:
+        _validate_component(name)
+        if directory is None:
+            folded = name.casefold()
+            return any(
+                entry.name.casefold() == folded
+                for entry in self.list_entries()
+            )
+        try:
+            if directory is True:
+                child = self.open_dir(name, writable=False)
+            else:
+                child = self.open_file(name, writable=False)
+        except (FileNotFoundError, NotADirectoryError):
+            return False
+        else:
+            child.close()
+            return True
+
+    def list_entries(
+        self, *, max_entries: Optional[int] = None
+    ) -> list[NtDirectoryEntry]:
+        api = _api()
+        buffer_size = 64 * 1024
+        buffer = ctypes.create_string_buffer(buffer_size)
+        entries: list[NtDirectoryEntry] = []
+        info_class = 11  # FileIdBothDirectoryRestartInfo
+        while True:
+            if not api.GetFileInformationByHandleEx(
+                ctypes.c_void_p(self.raw),
+                info_class,
+                buffer,
+                buffer_size,
+            ):
+                error = ctypes.get_last_error()
+                if error == ERROR_NO_MORE_FILES:
+                    break
+                raise api.winerror(error)
+            info_class = 10  # FileIdBothDirectoryInfo (continue enumeration)
+            offset = 0
+            while True:
+                record = _FILE_ID_BOTH_DIR_INFO.from_buffer(buffer, offset)
+                name_address = (
+                    ctypes.addressof(buffer)
+                    + offset
+                    + _FILE_ID_BOTH_DIR_INFO.FileName.offset
+                )
+                name = ctypes.wstring_at(
+                    name_address, int(record.FileNameLength) // 2
+                )
+                if name not in (".", ".."):
+                    entries.append(
+                        NtDirectoryEntry(
+                            name=name,
+                            file_attributes=int(record.FileAttributes),
+                            size=int(record.EndOfFile),
+                            file_id=(
+                                int(record.FileId) & 0xFFFFFFFFFFFFFFFF
+                            ),
+                            st_mtime_ns=_filetime_ticks_to_unix_ns(
+                                record.LastWriteTime
+                            ),
+                            st_ctime_ns=_filetime_ticks_to_unix_ns(
+                                record.ChangeTime
+                            ),
+                        )
+                    )
+                    if (
+                        max_entries is not None
+                        and len(entries) > max_entries
+                    ):
+                        raise OSError(
+                            "directory enumeration exceeds the safe "
+                            "entry limit"
+                        )
+                if not record.NextEntryOffset:
+                    break
+                offset += int(record.NextEntryOffset)
+        return entries
+
+    def read_all(self, *, max_bytes: Optional[int] = None) -> bytes:
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            buffer = ctypes.create_string_buffer(64 * 1024)
+            read = ctypes.c_ulong()
+            if not _api().ReadFile(
+                ctypes.c_void_p(self.raw),
+                buffer,
+                len(buffer),
+                ctypes.byref(read),
+                None,
+            ):
+                raise _api().winerror()
+            if not read.value:
+                break
+            total += int(read.value)
+            if max_bytes is not None and total > max_bytes:
+                raise OSError("file exceeds the safe read limit")
+            chunks.append(buffer.raw[: read.value])
+        return b"".join(chunks)
+
+    def write_all(self, payload: bytes) -> None:
+        view = memoryview(payload)
+        offset = 0
+        while offset < len(view):
+            chunk = bytes(view[offset : offset + 64 * 1024])
+            buffer = ctypes.create_string_buffer(chunk)
+            written = ctypes.c_ulong()
+            if not _api().WriteFile(
+                ctypes.c_void_p(self.raw),
+                buffer,
+                len(chunk),
+                ctypes.byref(written),
+                None,
+            ):
+                raise _api().winerror()
+            if not written.value:
+                raise OSError("short write through NT handle")
+            offset += int(written.value)
+
+    def flush(self) -> None:
+        if not _api().FlushFileBuffers(ctypes.c_void_p(self.raw)):
+            raise _api().winerror()
+
+    def rename_to(
+        self,
+        destination_parent: "NtHandle",
+        destination_name: str,
+        *,
+        replace: bool,
+    ) -> None:
+        _validate_component(destination_name)
+        encoded = destination_name.encode("utf-16-le")
+        total = _FILE_RENAME_INFO_BUFFER.FileName.offset + len(encoded)
+        buffer = ctypes.create_string_buffer(total)
+        header = _FILE_RENAME_INFO_BUFFER.from_buffer(buffer)
+        header.Flags = (
+            FILE_RENAME_FLAG_POSIX_SEMANTICS
+            | (FILE_RENAME_FLAG_REPLACE_IF_EXISTS if replace else 0)
+        )
+        header.RootDirectory = destination_parent.raw
+        header.FileNameLength = len(encoded)
+        ctypes.memmove(
+            ctypes.addressof(buffer) + _FILE_RENAME_INFO_BUFFER.FileName.offset,
+            encoded,
+            len(encoded),
+        )
+        if _api().SetFileInformationByHandle(
+            ctypes.c_void_p(self.raw),
+            FILE_RENAME_INFO_EX,
+            buffer,
+            total,
+        ):
+            return
+        error = ctypes.get_last_error()
+        if error != ERROR_INVALID_PARAMETER:
+            raise _api().winerror(error)
+
+        # Pre-FileRenameInfoEx fallback has a one-byte BOOLEAN followed by
+        # architecture-dependent padding before HANDLE. Build that SDK layout
+        # independently instead of reusing the DWORD-flags structure.
+        legacy_total = (
+            _FILE_RENAME_INFO_LEGACY_BUFFER.FileName.offset + len(encoded)
+        )
+        legacy_buffer = ctypes.create_string_buffer(legacy_total)
+        legacy = _FILE_RENAME_INFO_LEGACY_BUFFER.from_buffer(legacy_buffer)
+        legacy.ReplaceIfExists = 1 if replace else 0
+        legacy.RootDirectory = destination_parent.raw
+        legacy.FileNameLength = len(encoded)
+        ctypes.memmove(
+            ctypes.addressof(legacy_buffer)
+            + _FILE_RENAME_INFO_LEGACY_BUFFER.FileName.offset,
+            encoded,
+            len(encoded),
+        )
+        if not _api().SetFileInformationByHandle(
+            ctypes.c_void_p(self.raw),
+            FILE_RENAME_INFO,
+            legacy_buffer,
+            legacy_total,
+        ):
+            raise _api().winerror()
+
+    def mark_delete(self, *, is_directory: bool) -> None:
+        del is_directory  # the kernel validates directory emptiness itself
+        extended = _FILE_DISPOSITION_INFO_EX_BUFFER(
+            Flags=(
+                FILE_DISPOSITION_FLAG_DELETE
+                | FILE_DISPOSITION_FLAG_POSIX_SEMANTICS
+                | FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE
+            )
+        )
+        if _api().SetFileInformationByHandle(
+            ctypes.c_void_p(self.raw),
+            FILE_DISPOSITION_INFO_EX,
+            ctypes.byref(extended),
+            ctypes.sizeof(extended),
+        ):
+            return
+        error = ctypes.get_last_error()
+        if error != ERROR_INVALID_PARAMETER:
+            raise _api().winerror(error)
+        legacy = _FILE_DISPOSITION_INFO_BUFFER(DeleteFile=1)
+        if not _api().SetFileInformationByHandle(
+            ctypes.c_void_p(self.raw),
+            FILE_DISPOSITION_INFO,
+            ctypes.byref(legacy),
+            ctypes.sizeof(legacy),
+        ):
+            raise _api().winerror()
+
+
+def open_directory(path: Path, *, writable: bool = False) -> NtHandle:
+    """Open an absolute directory without traversing any reparse point."""
+    return _open_native(
+        _nt_absolute_name(path),
+        root=None,
+        directory=True,
+        create=False,
+        writable=writable,
+        allow_final_reparse=False,
+    )
+
+
+def open_relative_directory(
+    root: NtHandle,
+    parts: Sequence[str],
+    *,
+    writable: bool = False,
+    create: bool = False,
+) -> NtHandle:
+    """Resolve a directory component-by-component below a held root."""
+    current: Optional[NtHandle] = None
+    parent = root
+    try:
+        for part in parts:
+            try:
+                child = parent.open_dir(
+                    part,
+                    create=False,
+                    writable=writable,
+                )
+            except FileNotFoundError:
+                if not create:
+                    raise
+                child = parent.open_dir(
+                    part,
+                    create=True,
+                    writable=writable,
+                )
+            if current is not None:
+                current.close()
+            current = child
+            parent = child
+        if current is None:
+            raise ValueError("relative directory path must not be empty")
+        return current
+    except BaseException:
+        if current is not None:
+            current.close()
+        raise
+
+
+def read_regular_file(parent: NtHandle, name: str) -> tuple[bytes, NtStat]:
+    with parent.open_file(name, writable=False) as file_handle:
+        before = file_handle.stat()
+        if not before.is_file:
+            raise OSError(f"{name} is not a regular file")
+        payload = file_handle.read_all()
+        after = file_handle.stat()
+        if before.signature != after.signature:
+            raise RuntimeError(f"{name} changed while being read")
+        return payload, after
+
+
+def replace_regular_file(
+    parent: NtHandle,
+    name: str,
+    payload: bytes,
+    *,
+    require_existing: bool,
+    temp_name: str,
+) -> None:
+    """Durably write a temporary file and atomically rename it in one handle."""
+    if require_existing:
+        with parent.open_file(name, writable=False) as target:
+            if not target.stat().is_file:
+                raise OSError(f"{name} is not a regular file")
+    with parent.open_file(temp_name, create=True, writable=True) as temporary:
+        try:
+            temporary.write_all(payload)
+            temporary.flush()
+            temporary.rename_to(parent, name, replace=True)
+        except BaseException:
+            try:
+                temporary.mark_delete(is_directory=False)
+            except OSError:
+                pass
+            raise
+    try:
+        parent.flush()
+    except OSError:
+        # Directory flush support varies by Windows/filesystem.  The namespace
+        # operation has already committed; callers preserve that truthful state.
+        pass
+
+
+def delete_tree(directory: NtHandle) -> None:
+    """Delete descendants without ever following a directory entry."""
+    for entry in directory.list_entries():
+        if entry.is_reparse:
+            # Open the reparse object itself through OBJ_DONT_REPARSE and delete
+            # the entry.  Never interpret its target.
+            is_directory = entry.is_dir
+            child = directory.open_reparse_entry(
+                entry.name,
+                directory=is_directory,
+                writable=True,
+            )
+            with child:
+                if not _entry_matches_metadata(
+                    entry,
+                    child.stat(),
+                    expected_reparse=True,
+                ):
+                    raise RuntimeError(
+                        f"{entry.name} changed before recursive delete"
+                    )
+                child.mark_delete(is_directory=is_directory)
+            continue
+        if entry.is_dir:
+            with directory.open_dir(entry.name, writable=True) as child_dir:
+                if not _entry_matches_metadata(entry, child_dir.stat()):
+                    raise RuntimeError(
+                        f"{entry.name} changed before recursive delete"
+                    )
+                delete_tree(child_dir)
+                child_dir.mark_delete(is_directory=True)
+        else:
+            with directory.open_file(entry.name, writable=True) as child_file:
+                if not _entry_matches_metadata(entry, child_file.stat()):
+                    raise RuntimeError(
+                        f"{entry.name} changed before recursive delete"
+                    )
+                child_file.mark_delete(is_directory=False)
+
+
+_SNAPSHOT_MAX_DEPTH = 32
+_SNAPSHOT_MAX_ENTRIES = 4096
+_SNAPSHOT_MAX_FILE_BYTES = 16 * 1024 * 1024
+_SNAPSHOT_MAX_TOTAL_BYTES = 64 * 1024 * 1024
+
+
+def _entry_matches_metadata(
+    entry: NtDirectoryEntry,
+    metadata: NtStat,
+    *,
+    expected_reparse: bool = False,
+) -> bool:
+    return (
+        metadata.st_ino == entry.file_id
+        and metadata.st_size == entry.size
+        and metadata.st_mtime_ns == entry.st_mtime_ns
+        and metadata.st_ctime_ns == entry.st_ctime_ns
+        and metadata.is_dir == entry.is_dir
+        and bool(metadata.file_attributes & FILE_ATTRIBUTE_REPARSE_POINT)
+        == expected_reparse
+        and entry.is_reparse == expected_reparse
+    )
+
+
+def copy_tree_no_reparse(
+    source: NtHandle,
+    destination: Path,
+    *,
+    _state: Optional[dict[str, int]] = None,
+    _depth: int = 0,
+) -> None:
+    """Copy a held tree only after identity-binding every enumerated child."""
+    if _depth > _SNAPSHOT_MAX_DEPTH:
+        raise OSError("skill snapshot exceeds the safe nesting limit")
+    state = _state or {"entries": 0, "bytes": 0}
+    source_before = source.stat().signature
+    remaining_entries = _SNAPSHOT_MAX_ENTRIES - state["entries"]
+    entries = source.list_entries(max_entries=remaining_entries)
+    destination.mkdir(parents=True, exist_ok=False)
+    seen_names: set[str] = set()
+    for entry in entries:
+        _validate_snapshot_component(entry.name)
+        collision_key = entry.name.casefold()
+        if collision_key in seen_names:
+            raise OSError(
+                f"Win32 snapshot name collision: {entry.name!r}"
+            )
+        seen_names.add(collision_key)
+        state["entries"] += 1
+        if state["entries"] > _SNAPSHOT_MAX_ENTRIES:
+            raise OSError("skill snapshot exceeds the safe entry limit")
+        if entry.is_reparse:
+            raise OSError(
+                f"refusing reparse point in skill snapshot: {entry.name}"
+            )
+
+        target = destination / entry.name
+        if entry.is_dir:
+            with source.open_dir(entry.name, writable=False) as child:
+                child_before = child.stat()
+                if not _entry_matches_metadata(entry, child_before):
+                    raise RuntimeError(
+                        f"{entry.name} changed before snapshot copy"
+                    )
+                copy_tree_no_reparse(
+                    child,
+                    target,
+                    _state=state,
+                    _depth=_depth + 1,
+                )
+                if child.stat().signature != child_before.signature:
+                    raise RuntimeError(
+                        f"{entry.name} changed during snapshot copy"
+                    )
+            continue
+
+        if entry.size > _SNAPSHOT_MAX_FILE_BYTES:
+            raise OSError(
+                f"skill snapshot file is too large: {entry.name}"
+            )
+        with source.open_file(
+            entry.name,
+            writable=False,
+            stable_read=True,
+        ) as child:
+            child_before = child.stat()
+            if (
+                not child_before.is_file
+                or not _entry_matches_metadata(entry, child_before)
+            ):
+                raise RuntimeError(
+                    f"{entry.name} changed before snapshot copy"
+                )
+            remaining_bytes = _SNAPSHOT_MAX_TOTAL_BYTES - state["bytes"]
+            payload = child.read_all(
+                max_bytes=min(
+                    _SNAPSHOT_MAX_FILE_BYTES,
+                    remaining_bytes,
+                )
+            )
+            child_after = child.stat()
+            if child_after.signature != child_before.signature:
+                raise RuntimeError(
+                    f"{entry.name} changed during snapshot copy"
+                )
+        state["bytes"] += len(payload)
+        if (
+            len(payload) > _SNAPSHOT_MAX_FILE_BYTES
+            or state["bytes"] > _SNAPSHOT_MAX_TOTAL_BYTES
+        ):
+            raise OSError("skill snapshot exceeds the safe byte limit")
+        target.write_bytes(payload)
+    if source.stat().signature != source_before:
+        raise RuntimeError("skill directory changed during snapshot copy")
+
+
+def walk_directories(
+    root: NtHandle,
+    *,
+    max_directories: Optional[int] = None,
+    max_depth: Optional[int] = None,
+) -> Iterator[tuple[tuple[str, ...], NtHandle]]:
+    """Yield owned handles for real directories below *root*.
+
+    Callers must close every yielded handle.  Reparse entries are skipped.
+    """
+    seen = 0
+
+    def recurse(parent: NtHandle, relative: tuple[str, ...], depth: int):
+        nonlocal seen
+        for entry in sorted(parent.list_entries(), key=lambda item: item.name.casefold()):
+            if not entry.is_dir or entry.is_reparse:
+                continue
+            if max_depth is not None and depth >= max_depth:
+                raise OSError("directory walk exceeds the safe nesting limit")
+            seen += 1
+            if max_directories is not None and seen > max_directories:
+                raise OSError("directory walk exceeds the safe directory limit")
+            child = parent.open_dir(entry.name, writable=False)
+            child_relative = relative + (entry.name,)
+            yield child_relative, child
+            yield from recurse(child, child_relative, depth + 1)
+
+    yield from recurse(root, (), 0)

--- a/tools/nt_secure_fs_optional.py
+++ b/tools/nt_secure_fs_optional.py
@@ -1,0 +1,49 @@
+"""Optional boundary for the native Windows skill-filesystem backend.
+
+The hardened NT implementation may be absent from source distributions that
+do not ship native Windows support.  Skill discovery and mutation must fail
+closed with an actionable ``OSError`` in that case, not crash module loading
+with ``ModuleNotFoundError``.
+"""
+
+from __future__ import annotations
+
+try:
+    from tools.nt_secure_fs import (
+        copy_tree_no_reparse,
+        delete_tree,
+        is_available,
+        open_directory,
+        read_regular_file,
+        replace_regular_file,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name != "tools.nt_secure_fs":
+        raise
+
+    class NtSecureFsUnavailable(OSError):
+        """The optional native Windows backend is not installed."""
+
+    def is_available() -> bool:
+        return False
+
+    def _unavailable(*_args, **_kwargs):
+        raise NtSecureFsUnavailable(
+            "secure Windows skill filesystem backend is not installed"
+        )
+
+    open_directory = _unavailable
+    read_regular_file = _unavailable
+    replace_regular_file = _unavailable
+    delete_tree = _unavailable
+    copy_tree_no_reparse = _unavailable
+
+
+__all__ = [
+    "copy_tree_no_reparse",
+    "delete_tree",
+    "is_available",
+    "open_directory",
+    "read_regular_file",
+    "replace_regular_file",
+]

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -33,15 +33,27 @@ Directory layout for user skills:
 """
 
 import json
+import hashlib
 import logging
+import os
 import re
+import secrets
 import shutil
+import stat
+import tempfile
+import threading
 import contextvars as _ctxvars
+from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from hermes_constants import get_hermes_home, display_hermes_home
-from utils import atomic_write_text, is_truthy_value
+from hermes_constants import (
+    get_default_hermes_root,
+    get_hermes_home,
+    display_hermes_home,
+)
+from utils import is_truthy_value
 from hermes_cli.config import cfg_get
 from agent.skill_utils import (
     extract_skill_description,
@@ -51,6 +63,21 @@ from agent.skill_utils import (
 )
 
 logger = logging.getLogger(__name__)
+_skill_mutation_thread_locks_guard = threading.Lock()
+_skill_mutation_thread_locks: dict[str, threading.Lock] = {}
+
+
+def _fsync_committed(fd: int, operation: str) -> None:
+    """Best-effort durability barrier after an already-visible mutation.
+
+    The namespace change has committed before this call.  Propagating a later
+    fsync error as an ordinary failure incorrectly tells callers that nothing
+    changed, so retain the truthful committed result and leave diagnostics.
+    """
+    try:
+        os.fsync(fd)
+    except OSError as exc:
+        logger.warning("%s committed but directory fsync failed: %s", operation, exc)
 
 _background_review_read_paths: "_ctxvars.ContextVar[frozenset[str]]" = _ctxvars.ContextVar(
     "background_review_read_paths", default=frozenset()
@@ -122,14 +149,23 @@ def _guard_agent_created_enabled() -> bool:
         return False
 
 
+def _agent_created_security_scan_enabled() -> bool:
+    """Whether agent-created mutations must run the security scanner.
+
+    Keep this predicate as the single fast-path contract for both normal and
+    descriptor-anchored scans.  In particular, the anchored path must not
+    copy an entire skill tree merely to reach the same disabled guard inside
+    :func:`_security_scan_skill`.
+    """
+    return _GUARD_AVAILABLE and _guard_agent_created_enabled()
+
+
 def _security_scan_skill(skill_dir: Path) -> Optional[str]:
     """Scan a skill directory after write. Returns error string if blocked, else None.
 
     No-op when skills.guard_agent_created is disabled (the default).
     """
-    if not _GUARD_AVAILABLE:
-        return None
-    if not _guard_agent_created_enabled():
+    if not _agent_created_security_scan_enabled():
         return None
     try:
         result = scan_skill(skill_dir, source="agent-created")
@@ -455,6 +491,9 @@ def _background_review_preflight(action: str, name: str) -> Optional[Dict[str, A
     if action not in {"edit", "patch", "delete", "write_file", "remove_file"}:
         return None
     existing = _find_skill(name)
+    lookup_error = _skill_lookup_error(existing)
+    if lookup_error:
+        return lookup_error
     if not existing:
         return None
     return _background_review_write_guard(name, existing["path"], action)
@@ -563,7 +602,17 @@ def _validate_category(category: Optional[str]) -> Optional[str]:
     return None
 
 
-def _validate_frontmatter(content: str, *, new_skill: bool = False) -> Optional[str]:
+def _normalize_skill_content(content: str) -> str:
+    """Normalize the one encoding artifact accepted by the runtime parser."""
+    return content.removeprefix("\ufeff")
+
+
+def _validate_frontmatter(
+    content: str,
+    *,
+    new_skill: bool = False,
+    expected_name: Optional[str] = None,
+) -> Optional[str]:
     """
     Validate that SKILL.md content has proper frontmatter with required fields.
     Returns error message or None if valid.
@@ -577,17 +626,21 @@ def _validate_frontmatter(content: str, *, new_skill: bool = False) -> Optional[
     if not content.strip():
         return "Content cannot be empty."
 
-    # Tolerate a leading UTF-8 BOM (Windows editors) before the fence.
-    content = content.lstrip("\ufeff")
+    # Tolerate exactly one leading UTF-8 BOM (Windows editors) before the
+    # fence. The create path persists this normalized form so validation and
+    # runtime parsing cannot disagree.
+    content = _normalize_skill_content(content)
 
-    if not content.startswith("---"):
+    opening_match = re.match(r"---[ \t]*\r?\n", content)
+    if opening_match is None:
         return "SKILL.md must start with YAML frontmatter (---). See existing skills for format."
 
-    end_match = re.search(r'\n---\s*\n', content[3:])
+    remainder = content[opening_match.end():]
+    end_match = re.search(r'\r?\n---[ \t]*(?:\r?\n|$)', remainder)
     if not end_match:
         return "SKILL.md frontmatter is not closed. Ensure you have a closing '---' line."
 
-    yaml_content = content[3:end_match.start() + 3]
+    yaml_content = remainder[:end_match.start()]
 
     try:
         parsed = yaml.safe_load(yaml_content)
@@ -601,7 +654,23 @@ def _validate_frontmatter(content: str, *, new_skill: bool = False) -> Optional[
         return "Frontmatter must include 'name' field."
     if "description" not in parsed:
         return "Frontmatter must include 'description' field."
-    desc = str(parsed["description"])
+    frontmatter_name = parsed["name"]
+    if not isinstance(frontmatter_name, str) or not frontmatter_name.strip():
+        return "Frontmatter 'name' must be a non-empty string."
+    if new_skill:
+        name_error = _validate_name(frontmatter_name)
+        if name_error:
+            return f"Invalid frontmatter 'name': {name_error}"
+    if expected_name is not None and frontmatter_name != expected_name:
+        return (
+            f"Frontmatter name '{frontmatter_name}' must match the requested "
+            f"skill name '{expected_name}'."
+        )
+
+    desc_value = parsed["description"]
+    if not isinstance(desc_value, str) or not desc_value.strip():
+        return "Frontmatter 'description' must be a non-empty string."
+    desc = desc_value
     if len(desc) > MAX_DESCRIPTION_LENGTH:
         return f"Description exceeds {MAX_DESCRIPTION_LENGTH} characters."
     if new_skill and len(desc.strip().strip("'\"")) > SKILL_PROMPT_DESC_LIMIT:
@@ -613,7 +682,7 @@ def _validate_frontmatter(content: str, *, new_skill: bool = False) -> Optional[
             f"destroying the routing signal. Move detail into the skill body."
         )
 
-    body = content[end_match.end() + 3:].strip()
+    body = remainder[end_match.end():].strip()
     if not body:
         return "SKILL.md must have content after the frontmatter (instructions, procedures, etc.)."
 
@@ -642,6 +711,2394 @@ def _resolve_skill_dir(name: str, category: str = None) -> Path:
     return _skills_dir() / name
 
 
+def _cleanup_created_skill_dir(
+    skill_dir: Path,
+    *,
+    skill_md: Optional[Path] = None,
+    created_category: Optional[Path] = None,
+) -> None:
+    """Remove only artifacts owned by the current create attempt."""
+    if skill_md is not None:
+        try:
+            skill_md.unlink(missing_ok=True)
+        except OSError:
+            pass
+    try:
+        skill_dir.rmdir()
+    except OSError:
+        # Preserve any pre-existing or concurrently-added files.
+        pass
+    if created_category is not None:
+        try:
+            created_category.rmdir()
+        except OSError:
+            pass
+
+
+def _directory_entry_matches_fd(parent_fd: Any, name: str, child_fd: Any) -> bool:
+    """Return whether ``parent_fd/name`` is the directory held by ``child_fd``."""
+    if os.name == "nt":
+        try:
+            return (
+                parent_fd.entry_identity(name, directory=True)
+                == child_fd.identity
+            )
+        except OSError:
+            return False
+    try:
+        entry_stat = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+        held_stat = os.fstat(child_fd)
+    except OSError:
+        return False
+    return (
+        stat.S_ISDIR(entry_stat.st_mode)
+        and entry_stat.st_dev == held_stat.st_dev
+        and entry_stat.st_ino == held_stat.st_ino
+    )
+
+
+def _secure_directory_create_supported() -> bool:
+    """Whether this runtime supports no-follow, dir-fd-relative creation."""
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import is_available
+
+        return is_available()
+    return (
+        os.name == "posix"
+        and hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and os.open in os.supports_dir_fd
+        and os.mkdir in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.unlink in os.supports_dir_fd
+        and os.rmdir in os.supports_dir_fd
+    )
+
+
+@contextmanager
+def _skill_mutation_lock(name: str):
+    """Serialize one skill's complete mutation transaction.
+
+    The in-process lock covers threads because ``flock`` is process-scoped on
+    some platforms.  The hashed lock file covers other Hermes processes while
+    avoiding user-controlled skill names in lock paths.  Callers must hold this
+    from lookup/read through write, scan, and any rollback.
+    """
+    lock_key = hashlib.sha256(name.encode("utf-8")).hexdigest()
+    with _skill_mutation_thread_locks_guard:
+        thread_lock = _skill_mutation_thread_locks.setdefault(
+            lock_key, threading.Lock()
+        )
+
+    configured = Path(SKILLS_DIR)
+    lock_root = (
+        configured.parent
+        if configured != _SKILLS_DIR_AT_IMPORT
+        else get_default_hermes_root()
+    )
+    lock_dir = lock_root / ".hermes-skill-mutation-locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / f"{lock_key}.lock"
+    with thread_lock:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        locked = False
+        try:
+            if os.name == "posix":
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            elif os.name == "nt":
+                import msvcrt
+
+                if os.fstat(fd).st_size == 0:
+                    os.write(fd, b"\0")
+                    os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            else:
+                raise OSError(
+                    "cross-process skill mutation locking is unavailable"
+                )
+            locked = True
+            yield
+        finally:
+            try:
+                if locked and os.name == "posix":
+                    import fcntl
+
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                elif locked and os.name == "nt":
+                    import msvcrt
+
+                    os.lseek(fd, 0, os.SEEK_SET)
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            finally:
+                os.close(fd)
+
+
+def _physical_skill_lock_name(existing: Dict[str, Any]) -> str:
+    """Return a process-stable lock key for one already-resolved skill.
+
+    A skill can be addressed by both its directory basename and its
+    frontmatter ``name``.  Request-name locks alone therefore do not protect
+    the physical directory from transactions started through different
+    aliases.  Directory identity gives every alias the same second lock
+    without trusting either user-controlled name. Do not include the path:
+    archive and restore rename the same directory, and a path-derived key
+    would split its lock while lifecycle metadata is being reconciled.
+    """
+    directory_identity = existing.get("_dir_identity")
+    if not isinstance(directory_identity, tuple) or len(directory_identity) != 2:
+        raise OSError("resolved skill identity is unavailable")
+    device, inode = directory_identity
+    return f"physical\0{device}:{inode}"
+
+
+def _revalidate_locked_skill_alias(
+    name: str,
+    existing: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Fail closed if an alias stopped naming the locked physical skill."""
+    try:
+        with _open_existing_skill_directory(existing) as (skill_fd, _resolved):
+            if existing["path"].name == name:
+                return None
+            frontmatter, _ = _parse_frontmatter(
+                _read_canonical_skill_md(skill_fd)
+            )
+            if frontmatter.get("name") == name:
+                return None
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": f"Skill target changed while reserving mutation: {exc}",
+        }
+    return {
+        "success": False,
+        "error": (
+            f"Skill alias '{name}' changed while reserving mutation; "
+            "refusing to mutate a stale target."
+        ),
+    }
+
+
+@contextmanager
+def _existing_skill_mutation_lock(name: str):
+    """Lock an existing skill by request alias, then by physical identity.
+
+    Every caller takes locks in the same alias-then-physical order.  The alias
+    lock preserves create/same-name exclusion, while the physical lock makes
+    directory-name and frontmatter-name aliases share one complete
+    transaction.  Identity is revalidated after waiting for the physical
+    lock, before any caller reads or writes.
+    """
+    with _skill_mutation_lock(name):
+        existing = _find_skill(name)
+        lookup_error = _skill_lookup_error(existing)
+        if lookup_error:
+            yield None, lookup_error
+            return
+        if not existing:
+            yield None, {
+                "success": False,
+                "error": _skill_not_found_error(name),
+            }
+            return
+
+        with _skill_mutation_lock(_physical_skill_lock_name(existing)):
+            revalidation_error = _revalidate_locked_skill_alias(name, existing)
+            if revalidation_error:
+                yield None, revalidation_error
+                return
+            yield existing, None
+
+
+_ARCHIVE_SCAN_MAX_DIRECTORIES = 256
+_ARCHIVE_SCAN_MAX_DEPTH = 4
+
+
+def _archive_directory_alias_matches(directory_name: str, requested_name: str) -> bool:
+    """Match only an exact archive basename or our collision suffix form."""
+    if directory_name == requested_name:
+        return True
+    prefix = f"{requested_name}-"
+    if not directory_name.startswith(prefix):
+        return False
+    suffix = directory_name[len(prefix):]
+    if len(suffix) == 14 and suffix.isdigit():
+        return True
+    stamp, separator, counter = suffix.partition("-")
+    return bool(separator and len(stamp) == 14 and stamp.isdigit() and counter.isdigit())
+
+
+def _has_legacy_archive_timestamp_suffix(directory_name: str) -> bool:
+    """Whether a basename is indistinguishable from the old collision form."""
+    return bool(re.fullmatch(r".+-\d{14}(?:-\d+)?", directory_name))
+
+
+def _find_archived_skill(
+    name: str, skills_root: Optional[Path] = None
+) -> Optional[Dict[str, Any]]:
+    """Find one archived skill by canonical frontmatter name or exact alias.
+
+    Recovery cannot trust a physical basename after an archive move.  Scan a
+    bounded archive tree through no-follow directory descriptors and read the
+    canonical metadata from that held directory.  Ambiguity is always refused.
+    """
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import open_directory
+
+        root_path = Path(skills_root or _skills_dir())
+        try:
+            root_handle = open_directory(
+                root_path.resolve(strict=True), writable=False
+            )
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            return {
+                "error": f"could not securely open skills directory: {exc}",
+                "paths": [],
+            }
+        try:
+            try:
+                archive_handle = root_handle.open_dir(
+                    ".archive", writable=False
+                )
+            except FileNotFoundError:
+                return None
+            matches: list[Dict[str, Any]] = []
+            seen_directories = 0
+
+            def scan(
+                directory,
+                relative: tuple[str, ...],
+                depth: int,
+            ) -> None:
+                nonlocal seen_directories
+                for entry in sorted(
+                    directory.list_entries(),
+                    key=lambda item: item.name.casefold(),
+                ):
+                    if not entry.is_dir or entry.is_reparse:
+                        continue
+                    seen_directories += 1
+                    if seen_directories > _ARCHIVE_SCAN_MAX_DIRECTORIES:
+                        raise OSError(
+                            "archive scan exceeds the safe directory limit"
+                        )
+                    with directory.open_dir(
+                        entry.name, writable=False
+                    ) as child:
+                        child_relative = relative + (entry.name,)
+                        try:
+                            content = _read_canonical_skill_md(child)
+                        except FileNotFoundError:
+                            content = None
+                        if content is not None:
+                            frontmatter, _ = _parse_frontmatter(content)
+                            canonical_name = frontmatter.get("name")
+                            if (
+                                not isinstance(canonical_name, str)
+                                or _validate_name(canonical_name) is not None
+                            ):
+                                raise OSError(
+                                    "archived SKILL.md has no valid "
+                                    "canonical name"
+                                )
+                            if (
+                                canonical_name == name
+                                or _archive_directory_alias_matches(
+                                    entry.name, name
+                                )
+                            ):
+                                matches.append(
+                                    {
+                                        "path": root_path
+                                        / ".archive"
+                                        / Path(*child_relative),
+                                        "_resolved_path": child.final_path(),
+                                        "_dir_identity": child.identity,
+                                        "_archive_relative_parts": child_relative,
+                                        "_canonical_name": canonical_name,
+                                    }
+                                )
+                            continue
+                        if depth >= _ARCHIVE_SCAN_MAX_DEPTH:
+                            raise OSError(
+                                "archive scan exceeds the safe nesting limit"
+                            )
+                        scan(child, child_relative, depth + 1)
+
+            try:
+                with archive_handle:
+                    scan(archive_handle, (), 0)
+            except (OSError, UnicodeError, yaml.YAMLError) as exc:
+                return {
+                    "error": (
+                        "archive lookup is incomplete; refusing recovery: "
+                        f"{exc}"
+                    ),
+                    "paths": [],
+                }
+            if not matches:
+                return None
+            if len(matches) > 1:
+                paths = sorted(str(match["path"]) for match in matches)
+                return {
+                    "error": (
+                        f"Archived skill alias '{name}' is ambiguous; it "
+                        f"matches multiple directories: {', '.join(paths)}"
+                    ),
+                    "paths": paths,
+                }
+            return matches[0]
+        finally:
+            root_handle.close()
+
+    if not _secure_directory_create_supported():
+        return {"error": "secure archived skill lookup is unavailable on this platform", "paths": []}
+    root_path = Path(skills_root or _skills_dir())
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        root_fd = os.open(root_path, flags)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        return {"error": f"could not securely open skills directory: {exc}", "paths": []}
+    try:
+        try:
+            archive_fd = os.open(".archive", flags, dir_fd=root_fd)
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            return {"error": f"could not securely open archive directory: {exc}", "paths": []}
+        try:
+            if not _directory_entry_matches_fd(root_fd, ".archive", archive_fd):
+                return {"error": "archive directory changed during lookup", "paths": []}
+            archive_path = root_path / ".archive"
+            matches: list[Dict[str, Any]] = []
+            seen_directories = 0
+
+            def scan(directory_fd: int, relative: tuple[str, ...], depth: int) -> None:
+                nonlocal seen_directories
+                with os.scandir(directory_fd) as entries:
+                    for entry in entries:
+                        entry_stat = os.stat(entry.name, dir_fd=directory_fd, follow_symlinks=False)
+                        if stat.S_ISLNK(entry_stat.st_mode) or not stat.S_ISDIR(entry_stat.st_mode):
+                            continue
+                        seen_directories += 1
+                        if seen_directories > _ARCHIVE_SCAN_MAX_DIRECTORIES:
+                            raise OSError("archive scan exceeds the safe directory limit")
+                        child_fd = os.open(entry.name, flags, dir_fd=directory_fd)
+                        try:
+                            if not _directory_entry_matches_fd(directory_fd, entry.name, child_fd):
+                                raise OSError("archive directory changed during lookup")
+                            child_relative = relative + (entry.name,)
+                            try:
+                                metadata_stat = os.stat("SKILL.md", dir_fd=child_fd, follow_symlinks=False)
+                            except FileNotFoundError:
+                                metadata_stat = None
+                            if metadata_stat is not None and stat.S_ISREG(metadata_stat.st_mode):
+                                frontmatter, _ = _parse_frontmatter(_read_canonical_skill_md(child_fd))
+                                canonical_name = frontmatter.get("name")
+                                if (
+                                    not isinstance(canonical_name, str)
+                                    or _validate_name(canonical_name) is not None
+                                ):
+                                    raise OSError("archived SKILL.md has no valid canonical name")
+                                if canonical_name == name or _archive_directory_alias_matches(entry.name, name):
+                                    child_stat = os.fstat(child_fd)
+                                    matches.append({
+                                        "path": archive_path.joinpath(*child_relative),
+                                        "_resolved_path": archive_path.joinpath(*child_relative),
+                                        "_dir_identity": (child_stat.st_dev, child_stat.st_ino),
+                                        "_archive_relative_parts": child_relative,
+                                        "_canonical_name": canonical_name,
+                                    })
+                                # Skill folders are leaves: do not treat resources as skills.
+                                continue
+                            if metadata_stat is not None:
+                                raise OSError("archived canonical metadata is not a regular file")
+                            if depth >= _ARCHIVE_SCAN_MAX_DEPTH:
+                                raise OSError("archive scan exceeds the safe nesting limit")
+                            scan(child_fd, child_relative, depth + 1)
+                        finally:
+                            os.close(child_fd)
+
+            try:
+                scan(archive_fd, (), 0)
+            except (OSError, UnicodeError, yaml.YAMLError) as exc:
+                return {"error": f"archive lookup is incomplete; refusing recovery: {exc}", "paths": []}
+            if not matches:
+                return None
+            if len(matches) > 1:
+                paths = sorted(str(match["path"]) for match in matches)
+                return {"error": f"Archived skill alias '{name}' is ambiguous; it matches multiple directories: {', '.join(paths)}", "paths": paths}
+            return matches[0]
+        finally:
+            os.close(archive_fd)
+    finally:
+        os.close(root_fd)
+
+
+@contextmanager
+def _open_archived_skill_directory(existing: Dict[str, Any], skills_root: Path):
+    """Hold one archived skill using no-follow archive-relative descriptors."""
+    relative = existing.get("_archive_relative_parts")
+    identity = existing.get("_dir_identity")
+    if not isinstance(relative, tuple) or not relative or not isinstance(identity, tuple):
+        raise OSError("archived skill identity is unavailable")
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import open_directory
+
+        root_handle = open_directory(
+            Path(skills_root).resolve(strict=True), writable=True
+        )
+        archive_handle = parent_handle = source_handle = None
+        try:
+            archive_handle = root_handle.open_dir(
+                ".archive", writable=True
+            )
+            parent_handle = archive_handle
+            for component in relative[:-1]:
+                child = parent_handle.open_dir(
+                    component, writable=True
+                )
+                if parent_handle is not archive_handle:
+                    parent_handle.close()
+                parent_handle = child
+            source_name = relative[-1]
+            source_handle = parent_handle.open_dir(
+                source_name, writable=True
+            )
+            if source_handle.identity != tuple(identity):
+                raise OSError("archive source changed before mutation")
+            yield (
+                source_handle,
+                parent_handle,
+                root_handle,
+                archive_handle,
+                source_name,
+            )
+        finally:
+            if source_handle is not None:
+                source_handle.close()
+            if (
+                parent_handle is not None
+                and parent_handle is not archive_handle
+            ):
+                parent_handle.close()
+            if archive_handle is not None:
+                archive_handle.close()
+            root_handle.close()
+        return
+
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    root_fd = os.open(Path(skills_root), flags)
+    archive_fd = parent_fd = source_fd = None
+    try:
+        archive_fd = os.open(".archive", flags, dir_fd=root_fd)
+        if not _directory_entry_matches_fd(root_fd, ".archive", archive_fd):
+            raise OSError("archive directory changed before mutation")
+        parent_fd = archive_fd
+        for component in relative[:-1]:
+            child_fd = os.open(component, flags, dir_fd=parent_fd)
+            if not _directory_entry_matches_fd(parent_fd, component, child_fd):
+                os.close(child_fd)
+                raise OSError("archive parent changed before mutation")
+            if parent_fd != archive_fd:
+                os.close(parent_fd)
+            parent_fd = child_fd
+        source_name = relative[-1]
+        source_fd = os.open(source_name, flags, dir_fd=parent_fd)
+        if not _directory_entry_matches_fd(parent_fd, source_name, source_fd):
+            raise OSError("archive source changed before mutation")
+        held_stat = os.fstat(source_fd)
+        if (held_stat.st_dev, held_stat.st_ino) != identity:
+            raise OSError("archive source changed before mutation")
+        yield source_fd, parent_fd, root_fd, archive_fd, source_name
+    finally:
+        if source_fd is not None:
+            os.close(source_fd)
+        if parent_fd is not None and parent_fd != archive_fd:
+            os.close(parent_fd)
+        if archive_fd is not None:
+            os.close(archive_fd)
+        os.close(root_fd)
+
+
+def _revalidate_locked_archived_alias(name: str, existing: Dict[str, Any], skills_root: Path) -> Optional[Dict[str, Any]]:
+    try:
+        with _open_archived_skill_directory(existing, skills_root) as (source_fd, _parent_fd, _root_fd, _archive_fd, source_name):
+            frontmatter, _ = _parse_frontmatter(_read_canonical_skill_md(source_fd))
+            canonical_name = frontmatter.get("name")
+            if canonical_name == existing.get("_canonical_name") and (
+                canonical_name == name or _archive_directory_alias_matches(source_name, name)
+            ):
+                return None
+    except Exception as exc:
+        return {"success": False, "error": f"Archived skill target changed while reserving mutation: {exc}"}
+    return {"success": False, "error": f"Archived skill alias '{name}' changed while reserving mutation; refusing a stale target."}
+
+
+@contextmanager
+def _archived_skill_mutation_lock(name: str, skills_root: Optional[Path] = None):
+    """Lock an archived skill by canonical identity, then physical identity.
+
+    An archived directory can be addressed by a historical physical basename.
+    Resolve that alias before locking, then reserve its canonical frontmatter
+    name so restore serializes with canonical create/restore calls.  Re-resolve
+    after taking the canonical lock: the preliminary lookup is intentionally
+    only a lock-key discovery step and must never authorize a mutation.
+    """
+    root = Path(skills_root or _skills_dir())
+    preliminary = _find_archived_skill(name, root)
+    preliminary_error = _skill_lookup_error(preliminary)
+    if preliminary_error:
+        yield None, preliminary_error
+        return
+    if not preliminary:
+        yield None, {"success": False, "error": f"archived skill '{name}' not found"}
+        return
+    canonical_name = preliminary.get("_canonical_name")
+    if not isinstance(canonical_name, str) or not canonical_name:
+        yield None, {
+            "success": False,
+            "error": "archived skill has no valid canonical identity",
+        }
+        return
+
+    # Every restore caller now takes the same canonical -> physical order.
+    # This avoids the physical-alias -> canonical inversion that could deadlock
+    # a physical-alias restore against a canonical-name restore/create.
+    with _skill_mutation_lock(canonical_name):
+        existing = _find_archived_skill(name, root)
+        lookup_error = _skill_lookup_error(existing)
+        if lookup_error:
+            yield None, lookup_error
+            return
+        if not existing:
+            yield None, {"success": False, "error": f"archived skill '{name}' not found"}
+            return
+        if existing.get("_canonical_name") != canonical_name:
+            yield None, {
+                "success": False,
+                "error": (
+                    "Archived skill canonical identity changed while reserving "
+                    "mutation; refusing a stale target."
+                ),
+            }
+            return
+        with _skill_mutation_lock(_physical_skill_lock_name(existing)):
+            revalidation_error = _revalidate_locked_archived_alias(name, existing, root)
+            if revalidation_error:
+                yield None, revalidation_error
+                return
+            yield existing, None
+
+
+def _windows_final_path(handle: int) -> str:
+    """Return a normalized final path for a Windows directory handle."""
+    import ctypes
+    from ctypes import wintypes
+
+    get_final_path = ctypes.windll.kernel32.GetFinalPathNameByHandleW
+    get_final_path.argtypes = [
+        wintypes.HANDLE,
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+    ]
+    get_final_path.restype = wintypes.DWORD
+    size = get_final_path(handle, None, 0, 0)
+    if not size:
+        raise ctypes.WinError()
+    buffer = ctypes.create_unicode_buffer(size + 1)
+    written = get_final_path(handle, buffer, len(buffer), 0)
+    if not written or written >= len(buffer):
+        raise ctypes.WinError()
+    value = buffer.value
+    if value.startswith("\\\\?\\UNC\\"):
+        value = "\\\\" + value[8:]
+    elif value.startswith("\\\\?\\"):
+        value = value[4:]
+    return os.path.normcase(os.path.abspath(value))
+
+
+def _open_windows_directory_guard(path: Path, expected: Path) -> int:
+    """Open a non-reparse Windows directory while denying rename/delete."""
+    import ctypes
+    from ctypes import wintypes
+
+    create_file = ctypes.windll.kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    get_attributes = ctypes.windll.kernel32.GetFileAttributesW
+    get_attributes.argtypes = [wintypes.LPCWSTR]
+    get_attributes.restype = wintypes.DWORD
+    close_handle = ctypes.windll.kernel32.CloseHandle
+
+    file_share_read = 0x00000001
+    file_share_write = 0x00000002
+    open_existing = 3
+    file_flag_backup_semantics = 0x02000000
+    file_flag_open_reparse_point = 0x00200000
+    file_attribute_reparse_point = 0x00000400
+    invalid_handle = wintypes.HANDLE(-1).value
+
+    attrs = get_attributes(str(path))
+    if attrs == 0xFFFFFFFF or attrs & file_attribute_reparse_point:
+        raise OSError(f"Refusing redirected directory path: {path}")
+    handle = create_file(
+        str(path),
+        0,
+        file_share_read | file_share_write,
+        None,
+        open_existing,
+        file_flag_backup_semantics | file_flag_open_reparse_point,
+        None,
+    )
+    if handle == invalid_handle:
+        raise ctypes.WinError()
+    try:
+        if _windows_handle_is_reparse_point(handle):
+            raise OSError(f"Refusing redirected directory path: {path}")
+        if _windows_final_path(handle) != os.path.normcase(
+            os.path.abspath(str(expected))
+        ):
+            raise OSError(f"Directory path changed during creation: {path}")
+    except Exception:
+        close_handle(handle)
+        raise
+    return handle
+
+
+def _windows_handle_is_reparse_point(handle: int) -> bool:
+    """Validate reparse metadata on the object opened by ``CreateFileW``.
+
+    The pre-open ``GetFileAttributesW`` check is only an early rejection: a
+    junction can be swapped in before ``CreateFileW``.  Querying
+    ``FileAttributeTagInfo`` on the returned handle closes that race.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    class FILE_ATTRIBUTE_TAG_INFO(ctypes.Structure):
+        _fields_ = [
+            ("FileAttributes", wintypes.DWORD),
+            ("ReparseTag", wintypes.DWORD),
+        ]
+
+    get_information = ctypes.windll.kernel32.GetFileInformationByHandleEx
+    get_information.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    get_information.restype = wintypes.BOOL
+    info = FILE_ATTRIBUTE_TAG_INFO()
+    file_attribute_tag_info = 9
+    if not get_information(
+        handle,
+        file_attribute_tag_info,
+        ctypes.byref(info),
+        ctypes.sizeof(info),
+    ):
+        raise ctypes.WinError()
+    return bool(info.FileAttributes & 0x00000400 or info.ReparseTag)
+
+
+@contextmanager
+def _open_existing_skill_directory(
+    existing: Dict[str, Any],
+):
+    """Hold the exact discovered skill directory for a canonical mutation."""
+    if os.name == "nt":
+        if not _secure_directory_create_supported():
+            raise OSError(
+                "Secure canonical SKILL.md mutation is unavailable on Windows: "
+                "the NT handle-relative backend could not be initialized."
+            )
+        from tools.nt_secure_fs_optional import open_directory
+
+        resolved_dir = Path(
+            existing.get("_resolved_path") or Path(existing["path"]).resolve()
+        )
+        expected_identity = existing.get("_dir_identity")
+        skill_handle = open_directory(resolved_dir, writable=True)
+        try:
+            if expected_identity and skill_handle.identity != tuple(
+                expected_identity
+            ):
+                raise OSError("skill directory changed before mutation")
+            yield skill_handle, resolved_dir
+        finally:
+            skill_handle.close()
+        return
+
+    if not _secure_directory_create_supported():
+        raise OSError(
+            "Secure canonical SKILL.md mutation is unavailable on this platform."
+        )
+
+    resolved_dir = Path(
+        existing.get("_resolved_path") or Path(existing["path"]).resolve()
+    )
+    expected_identity = existing.get("_dir_identity")
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    skill_fd = os.open(resolved_dir, directory_flags)
+    try:
+        held_stat = os.fstat(skill_fd)
+        if expected_identity and (
+            held_stat.st_dev,
+            held_stat.st_ino,
+        ) != tuple(expected_identity):
+            raise OSError("skill directory changed before mutation")
+        yield skill_fd, resolved_dir
+    finally:
+        os.close(skill_fd)
+
+
+def _secure_delete_held_directory_contents(directory_fd: int) -> None:
+    """Delete a held directory tree without resolving any child path.
+
+    Symlinks are unlinked as directory entries; they are never traversed.
+    Every real child directory is reopened with ``O_NOFOLLOW`` and checked
+    against the preceding ``lstat`` before recursion.
+    """
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import delete_tree
+
+        delete_tree(directory_fd)
+        return
+
+    for entry in os.scandir(directory_fd):
+        entry_stat = os.stat(
+            entry.name, dir_fd=directory_fd, follow_symlinks=False
+        )
+        if stat.S_ISDIR(entry_stat.st_mode):
+            child_fd = os.open(
+                entry.name,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                dir_fd=directory_fd,
+            )
+            try:
+                held_stat = os.fstat(child_fd)
+                if (held_stat.st_dev, held_stat.st_ino) != (
+                    entry_stat.st_dev,
+                    entry_stat.st_ino,
+                ):
+                    raise OSError("skill child directory changed during deletion")
+                _secure_delete_held_directory_contents(child_fd)
+            finally:
+                os.close(child_fd)
+            os.rmdir(entry.name, dir_fd=directory_fd)
+        else:
+            os.unlink(entry.name, dir_fd=directory_fd)
+    _fsync_committed(directory_fd, "recursive skill deletion")
+
+
+def _secure_delete_existing_skill(
+    existing: Dict[str, Any],
+    skills_root: Path,
+) -> None:
+    """Delete one revalidated skill via held no-follow directory descriptors."""
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import open_directory
+
+        with _open_existing_skill_directory(existing) as (
+            skill_handle,
+            resolved_dir,
+        ):
+            parent_path = resolved_dir.parent
+            with open_directory(parent_path, writable=True) as parent:
+                if not _directory_entry_matches_fd(
+                    parent, resolved_dir.name, skill_handle
+                ):
+                    raise OSError("skill directory changed before deletion")
+                _secure_delete_held_directory_contents(skill_handle)
+                skill_handle.mark_delete(is_directory=True)
+
+                # Preserve empty-category cleanup. Compare the held parent to
+                # the physical skills root, and remove only an empty real
+                # category still named by its held grandparent.
+                with open_directory(
+                    Path(skills_root).resolve(strict=True), writable=True
+                ) as root:
+                    if parent.identity == root.identity:
+                        return
+                if parent.list_entries():
+                    return
+                with open_directory(
+                    parent_path.parent, writable=True
+                ) as grandparent:
+                    if not _directory_entry_matches_fd(
+                        grandparent, parent_path.name, parent
+                    ):
+                        raise OSError(
+                            "skill category changed during cleanup"
+                        )
+                    parent.mark_delete(is_directory=True)
+        return
+
+    if not _secure_directory_create_supported():
+        raise OSError(
+            "Secure skill deletion is unavailable on this platform."
+        )
+
+    with _open_existing_skill_directory(existing) as (skill_fd, resolved_dir):
+        parent_path = resolved_dir.parent
+        parent_fd = os.open(
+            parent_path,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        try:
+            if not _directory_entry_matches_fd(
+                parent_fd, resolved_dir.name, skill_fd
+            ):
+                raise OSError("skill directory changed before deletion")
+            _secure_delete_held_directory_contents(skill_fd)
+            os.rmdir(resolved_dir.name, dir_fd=parent_fd)
+            _fsync_committed(parent_fd, "skill deletion")
+
+            # Preserve the legacy empty-category cleanup without trusting the
+            # mutable display path used for discovery.
+            root_stat = os.stat(skills_root)
+            parent_stat = os.fstat(parent_fd)
+            with os.scandir(parent_fd) as entries:
+                parent_is_empty = not any(entries)
+            if (
+                (parent_stat.st_dev, parent_stat.st_ino)
+                == (root_stat.st_dev, root_stat.st_ino)
+                or not parent_is_empty
+            ):
+                return
+            grandparent_path = parent_path.parent
+            grandparent_fd = os.open(
+                grandparent_path,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
+            try:
+                if not _directory_entry_matches_fd(
+                    grandparent_fd, parent_path.name, parent_fd
+                ):
+                    raise OSError("skill category changed during cleanup")
+                os.rmdir(parent_path.name, dir_fd=grandparent_fd)
+                _fsync_committed(grandparent_fd, "skill category cleanup")
+            finally:
+                os.close(grandparent_fd)
+        finally:
+            os.close(parent_fd)
+
+
+def _secure_archive_existing_skill(
+    existing: Dict[str, Any],
+    skills_root: Path,
+) -> tuple[bool, str]:
+    """Archive a curator skill through its revalidated physical directory.
+
+    This deliberately does not call ``skill_usage.archive_skill``: that helper
+    resolves the name anew and moves a path, which would escape the held-dirfd
+    transaction that protects alias-based mutations here.
+    """
+    if os.name == "nt":
+        if not _secure_directory_create_supported():
+            return (
+                False,
+                "secure curator archiving is unavailable on this platform",
+            )
+        return _secure_archive_existing_skill_windows(existing, skills_root)
+    if not _secure_directory_create_supported() or os.rename not in os.supports_dir_fd:
+        return False, "secure curator archiving is unavailable on this platform"
+
+    with _open_existing_skill_directory(existing) as (skill_fd, resolved_dir):
+        frontmatter, _ = _parse_frontmatter(_read_canonical_skill_md(skill_fd))
+        skill_name = frontmatter.get("name")
+        if not isinstance(skill_name, str) or not skill_name:
+            return False, "canonical SKILL.md has no valid skill name"
+
+        from agent.skill_utils import is_external_skill_path
+        from tools.skill_usage import (
+            is_bundled,
+            is_curation_eligible,
+            is_hub_installed,
+            is_protected_builtin,
+            persist_lifecycle_move_metadata_strict,
+        )
+
+        if is_external_skill_path(resolved_dir):
+            return False, (
+                f"skill '{skill_name}' lives in skills.external_dirs; "
+                "external skills are read-only to the curator"
+            )
+        if not is_curation_eligible(skill_name, resolved_dir):
+            if is_protected_builtin(skill_name):
+                return False, (
+                    f"skill '{skill_name}' is a protected built-in; it backs "
+                    "load-bearing UX and is never archived or consolidated"
+                )
+            if is_hub_installed(skill_name):
+                return False, (
+                    f"skill '{skill_name}' is hub-installed; never archive"
+                )
+            return False, (
+                f"skill '{skill_name}' is a bundled built-in; enable "
+                "curator.prune_builtins to allow pruning it"
+            )
+
+        root_path = skills_root.resolve()
+        root_fd = os.open(
+            root_path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        )
+        source_parent_path = resolved_dir.parent
+        source_parent_fd = os.open(
+            source_parent_path,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        try:
+            if not _directory_entry_matches_fd(
+                source_parent_fd, resolved_dir.name, skill_fd
+            ):
+                return False, "skill directory changed before archiving"
+            try:
+                os.mkdir(".archive", dir_fd=root_fd)
+            except FileExistsError:
+                pass
+            archive_fd = os.open(
+                ".archive",
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                dir_fd=root_fd,
+            )
+            try:
+                if not _directory_entry_matches_fd(root_fd, ".archive", archive_fd):
+                    return False, "archive directory changed before archiving"
+                destination = resolved_dir.name
+                destination_parent_fd = archive_fd
+                collision_fd = container_fd = None
+                destination_parent_path = root_path / ".archive"
+                container = None
+                moved = False
+                try:
+                    os.stat(destination, dir_fd=archive_fd, follow_symlinks=False)
+                except FileNotFoundError:
+                    destination_collision = False
+                else:
+                    destination_collision = True
+                if (
+                    destination_collision
+                    or _has_legacy_archive_timestamp_suffix(destination)
+                ):
+                    # A flat timestamp suffix cannot distinguish an archive
+                    # collision from a user's legitimate timestamped physical
+                    # alias. Keep the leaf basename unchanged under a private
+                    # collision container instead, so restore has an exact,
+                    # unambiguous physical name to put back.
+                    try:
+                        os.mkdir(".collisions", dir_fd=archive_fd)
+                    except FileExistsError:
+                        pass
+                    collision_fd = os.open(
+                        ".collisions",
+                        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                        dir_fd=archive_fd,
+                    )
+                    if not _directory_entry_matches_fd(
+                        archive_fd, ".collisions", collision_fd
+                    ):
+                        return False, "archive collision directory changed before archiving"
+                    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+                    for _ in range(16):
+                        container = (
+                            f"{resolved_dir.name}-{stamp}-"
+                            f"{secrets.token_hex(8)}"
+                        )
+                        try:
+                            os.mkdir(container, dir_fd=collision_fd)
+                            break
+                        except FileNotFoundError:
+                            return False, "archive collision directory disappeared before archiving"
+                        except FileExistsError:
+                            continue
+                    else:
+                        return False, "could not reserve a unique archive collision container"
+                    container_fd = os.open(
+                        container,
+                        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                        dir_fd=collision_fd,
+                    )
+                    if not _directory_entry_matches_fd(
+                        collision_fd, container, container_fd
+                    ):
+                        return False, "archive collision container changed before archiving"
+                    destination_parent_fd = container_fd
+                    destination_parent_path = (
+                        root_path / ".archive" / ".collisions" / container
+                    )
+                if not _directory_entry_matches_fd(
+                    source_parent_fd, resolved_dir.name, skill_fd
+                ):
+                    return False, "skill directory changed before archiving"
+                try:
+                    os.stat(
+                        destination,
+                        dir_fd=destination_parent_fd,
+                        follow_symlinks=False,
+                    )
+                except FileNotFoundError:
+                    pass
+                else:
+                    return False, "archive destination appeared before archiving"
+                os.rename(
+                    resolved_dir.name,
+                    destination,
+                    src_dir_fd=source_parent_fd,
+                    dst_dir_fd=destination_parent_fd,
+                )
+                moved = True
+                _fsync_committed(source_parent_fd, "skill archive")
+                _fsync_committed(destination_parent_fd, "skill archive")
+                if destination_parent_fd != archive_fd:
+                    _fsync_committed(archive_fd, "skill archive collision container")
+            finally:
+                if container_fd is not None:
+                    if not moved and collision_fd is not None and container is not None:
+                        try:
+                            if _directory_entry_matches_fd(
+                                collision_fd, container, container_fd
+                            ):
+                                with os.scandir(container_fd) as entries:
+                                    container_is_empty = not any(entries)
+                                if container_is_empty:
+                                    os.rmdir(container, dir_fd=collision_fd)
+                                    _fsync_committed(
+                                        collision_fd, "archive collision rollback"
+                                    )
+                        except OSError:
+                            logger.debug("could not remove empty archive collision container", exc_info=True)
+                    os.close(container_fd)
+                if collision_fd is not None:
+                    os.close(collision_fd)
+                os.close(archive_fd)
+        finally:
+            os.close(source_parent_fd)
+            os.close(root_fd)
+
+    try:
+        persist_lifecycle_move_metadata_strict(
+            skill_name, "archived", suppressed=is_bundled(skill_name)
+        )
+    except Exception as exc:
+        return False, (
+            "archive filesystem move committed but lifecycle metadata was not "
+            f"durably recorded: {exc}"
+        )
+    return True, f"archived to {destination_parent_path / destination}"
+
+
+def _secure_archive_existing_skill_windows(
+    existing: Dict[str, Any],
+    skills_root: Path,
+) -> tuple[bool, str]:
+    """Windows archive implementation using only held NT handles."""
+    from agent.skill_utils import is_external_skill_path
+    from tools.nt_secure_fs_optional import open_directory
+    from tools.skill_usage import (
+        is_bundled,
+        is_curation_eligible,
+        is_hub_installed,
+        is_protected_builtin,
+        persist_lifecycle_move_metadata_strict,
+    )
+
+    destination_path: Optional[Path] = None
+    skill_name: Optional[str] = None
+    with _open_existing_skill_directory(existing) as (
+        skill_handle,
+        resolved_dir,
+    ):
+        frontmatter, _ = _parse_frontmatter(
+            _read_canonical_skill_md(skill_handle)
+        )
+        skill_name = frontmatter.get("name")
+        if not isinstance(skill_name, str) or not skill_name:
+            return False, "canonical SKILL.md has no valid skill name"
+        if is_external_skill_path(resolved_dir):
+            return False, (
+                f"skill '{skill_name}' lives in skills.external_dirs; "
+                "external skills are read-only to the curator"
+            )
+        if not is_curation_eligible(skill_name, resolved_dir):
+            if is_protected_builtin(skill_name):
+                return False, (
+                    f"skill '{skill_name}' is a protected built-in; it backs "
+                    "load-bearing UX and is never archived or consolidated"
+                )
+            if is_hub_installed(skill_name):
+                return False, (
+                    f"skill '{skill_name}' is hub-installed; never archive"
+                )
+            return False, (
+                f"skill '{skill_name}' is a bundled built-in; enable "
+                "curator.prune_builtins to allow pruning it"
+            )
+
+        root_path = Path(skills_root).resolve(strict=True)
+        with open_directory(root_path, writable=True) as root_handle, (
+            open_directory(resolved_dir.parent, writable=True)
+        ) as source_parent:
+            if not _directory_entry_matches_fd(
+                source_parent, resolved_dir.name, skill_handle
+            ):
+                return False, "skill directory changed before archiving"
+            try:
+                archive = root_handle.open_dir(
+                    ".archive", writable=True
+                )
+            except FileNotFoundError:
+                archive = root_handle.open_dir(
+                    ".archive", create=True, writable=True
+                )
+            with archive:
+                destination = resolved_dir.name
+                destination_parent = archive
+                destination_parent_path = root_path / ".archive"
+                collision = container = None
+                try:
+                    destination_collision = archive.exists(destination)
+                    if (
+                        destination_collision
+                        or _has_legacy_archive_timestamp_suffix(destination)
+                    ):
+                        try:
+                            collision = archive.open_dir(
+                                ".collisions", writable=True
+                            )
+                        except FileNotFoundError:
+                            collision = archive.open_dir(
+                                ".collisions",
+                                create=True,
+                                writable=True,
+                            )
+                        stamp = datetime.now(timezone.utc).strftime(
+                            "%Y%m%d%H%M%S"
+                        )
+                        for _ in range(16):
+                            container_name = (
+                                f"{resolved_dir.name}-{stamp}-"
+                                f"{secrets.token_hex(8)}"
+                            )
+                            try:
+                                container = collision.open_dir(
+                                    container_name,
+                                    create=True,
+                                    writable=True,
+                                )
+                                break
+                            except FileExistsError:
+                                continue
+                        if container is None:
+                            return False, (
+                                "could not reserve a unique archive "
+                                "collision container"
+                            )
+                        destination_parent = container
+                        destination_parent_path = (
+                            root_path
+                            / ".archive"
+                            / ".collisions"
+                            / container_name
+                        )
+                    if destination_parent.exists(destination):
+                        return False, (
+                            "archive destination appeared before archiving"
+                        )
+                    if not _directory_entry_matches_fd(
+                        source_parent, resolved_dir.name, skill_handle
+                    ):
+                        return False, (
+                            "skill directory changed before archiving"
+                        )
+                    skill_handle.rename_to(
+                        destination_parent,
+                        destination,
+                        replace=False,
+                    )
+                    destination_path = (
+                        destination_parent_path / destination
+                    )
+                finally:
+                    if container is not None:
+                        container.close()
+                    if collision is not None:
+                        collision.close()
+
+    assert skill_name is not None and destination_path is not None
+    try:
+        persist_lifecycle_move_metadata_strict(
+            skill_name, "archived", suppressed=is_bundled(skill_name)
+        )
+    except Exception as exc:
+        return False, (
+            "archive filesystem move committed but lifecycle metadata was not "
+            f"durably recorded: {exc}"
+        )
+    return True, f"archived to {destination_path}"
+
+
+def _secure_restore_archived_skill(
+    archived: Dict[str, Any],
+    skill_name: str,
+    skills_root: Path,
+) -> tuple[bool, str]:
+    """Restore one archived directory using no-follow descriptors only.
+
+    Direct curator/CLI restore callers hold the normal request-alias lock;
+    manager delete never calls this helper, so no lock is acquired here.
+    """
+    if os.name == "nt":
+        if not _secure_directory_create_supported():
+            return (
+                False,
+                "secure curator restore is unavailable on this platform",
+            )
+        return _secure_restore_archived_skill_windows(
+            archived, skill_name, skills_root
+        )
+    if not _secure_directory_create_supported() or os.rename not in os.supports_dir_fd:
+        return False, "secure curator restore is unavailable on this platform"
+    root_path = Path(skills_root)
+    try:
+        with _open_archived_skill_directory(archived, root_path) as (
+            source_fd,
+            source_parent_fd,
+            root_fd,
+            archive_fd,
+            source_name,
+        ):
+            frontmatter, _ = _parse_frontmatter(_read_canonical_skill_md(source_fd))
+            if frontmatter.get("name") != skill_name:
+                return False, "archive source canonical name changed before restore"
+            # The caller holds the canonical alias lock before the archived
+            # physical lock.  Check every active configured root while that
+            # alias is reserved: an active directory may use a different
+            # physical basename yet still own this lifecycle identity.  Do not
+            # take its physical lock here (that would invert alias->physical
+            # ordering); discovery plus the held canonical alias is enough to
+            # prevent cooperative create/restore races, and an incomplete scan
+            # fails closed against out-of-band filesystem changes.
+            active = _find_skill(skill_name)
+            active_lookup_error = _skill_lookup_error(active)
+            if active_lookup_error:
+                return False, (
+                    "cannot safely restore while checking active canonical "
+                    f"identity: {active_lookup_error['error']}"
+                )
+            if active:
+                return False, (
+                    f"canonical skill name '{skill_name}' is already active at "
+                    f"{active['path']}; refusing restore"
+                )
+            relative = archived.get("_archive_relative_parts")
+            is_new_collision_layout = (
+                isinstance(relative, tuple)
+                and len(relative) == 3
+                and relative[0] == ".collisions"
+            )
+            if (
+                not is_new_collision_layout
+                and _has_legacy_archive_timestamp_suffix(source_name)
+            ):
+                return False, (
+                    "legacy timestamped archive has no trustworthy record "
+                    "of its original physical basename; refusing restore"
+                )
+            # New collision archives preserve the physical basename as their
+            # leaf under .archive/.collisions/<unique>/, so no suffix parsing
+            # is ever needed. Other physical aliases are restored unchanged.
+            destination_name = source_name
+            destination = root_path / destination_name
+            try:
+                os.stat(destination_name, dir_fd=root_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                return False, f"destination already exists: {destination}"
+            if not _directory_entry_matches_fd(source_parent_fd, source_name, source_fd):
+                return False, "archive source changed before restore"
+            os.rename(
+                source_name,
+                destination_name,
+                src_dir_fd=source_parent_fd,
+                dst_dir_fd=root_fd,
+            )
+            _fsync_committed(source_parent_fd, "skill restore")
+            _fsync_committed(root_fd, "skill restore")
+            _cleanup_empty_archive_collision_container(
+                source_parent_fd, archive_fd, archived
+            )
+    except OSError as exc:
+        return False, f"refusing unsafe archive source: {exc}"
+    try:
+        from tools.skill_usage import persist_lifecycle_move_metadata_strict
+
+        persist_lifecycle_move_metadata_strict(
+            skill_name, "active", suppressed=False
+        )
+    except Exception as exc:
+        return False, (
+            "restore filesystem move committed but lifecycle metadata was not "
+            f"durably recorded: {exc}"
+        )
+    return True, f"restored to {destination}"
+
+
+def _secure_restore_archived_skill_windows(
+    archived: Dict[str, Any],
+    skill_name: str,
+    skills_root: Path,
+) -> tuple[bool, str]:
+    """Restore an archived package with a handle-relative NT rename."""
+    root_path = Path(skills_root)
+    destination: Optional[Path] = None
+    try:
+        with _open_archived_skill_directory(archived, root_path) as (
+            source,
+            source_parent,
+            root,
+            archive,
+            source_name,
+        ):
+            frontmatter, _ = _parse_frontmatter(
+                _read_canonical_skill_md(source)
+            )
+            if frontmatter.get("name") != skill_name:
+                return (
+                    False,
+                    "archive source canonical name changed before restore",
+                )
+            active = _find_skill(skill_name)
+            active_lookup_error = _skill_lookup_error(active)
+            if active_lookup_error:
+                return False, (
+                    "cannot safely restore while checking active canonical "
+                    f"identity: {active_lookup_error['error']}"
+                )
+            if active:
+                return False, (
+                    f"canonical skill name '{skill_name}' is already active "
+                    f"at {active['path']}; refusing restore"
+                )
+            relative = archived.get("_archive_relative_parts")
+            is_new_collision_layout = (
+                isinstance(relative, tuple)
+                and len(relative) == 3
+                and relative[0] == ".collisions"
+            )
+            if (
+                not is_new_collision_layout
+                and _has_legacy_archive_timestamp_suffix(source_name)
+            ):
+                return False, (
+                    "legacy timestamped archive has no trustworthy record "
+                    "of its original physical basename; refusing restore"
+                )
+            destination_name = source_name
+            destination = root_path / destination_name
+            if root.exists(destination_name):
+                return False, f"destination already exists: {destination}"
+            if not _directory_entry_matches_fd(
+                source_parent, source_name, source
+            ):
+                return False, "archive source changed before restore"
+            source.rename_to(root, destination_name, replace=False)
+            _cleanup_empty_archive_collision_container(
+                source_parent, archive, archived
+            )
+    except OSError as exc:
+        return False, f"refusing unsafe archive source: {exc}"
+
+    try:
+        from tools.skill_usage import persist_lifecycle_move_metadata_strict
+
+        persist_lifecycle_move_metadata_strict(
+            skill_name, "active", suppressed=False
+        )
+    except Exception as exc:
+        return False, (
+            "restore filesystem move committed but lifecycle metadata was not "
+            f"durably recorded: {exc}"
+        )
+    return True, f"restored to {destination}"
+
+
+def _cleanup_empty_archive_collision_container(
+    source_parent_fd: Any,
+    archive_fd: Any,
+    archived: Dict[str, Any],
+) -> None:
+    """Best-effort cleanup for the private collision container we created."""
+    relative = archived.get("_archive_relative_parts")
+    if (
+        not isinstance(relative, tuple)
+        or len(relative) != 3
+        or relative[0] != ".collisions"
+    ):
+        return
+    if os.name == "nt":
+        try:
+            collisions = archive_fd.open_dir(
+                ".collisions", writable=True
+            )
+        except OSError:
+            return
+        try:
+            container = relative[1]
+            if not _directory_entry_matches_fd(
+                collisions, container, source_parent_fd
+            ):
+                return
+            if source_parent_fd.list_entries():
+                return
+            source_parent_fd.mark_delete(is_directory=True)
+            if collisions.list_entries():
+                return
+            collisions.mark_delete(is_directory=True)
+        except OSError as exc:
+            logger.debug(
+                "could not clean archive collision container: %s", exc
+            )
+        finally:
+            collisions.close()
+        return
+
+    try:
+        collisions_fd = os.open(
+            ".collisions",
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            dir_fd=archive_fd,
+        )
+    except OSError:
+        return
+    try:
+        container = relative[1]
+        if not _directory_entry_matches_fd(
+            collisions_fd, container, source_parent_fd
+        ):
+            return
+        with os.scandir(source_parent_fd) as entries:
+            if any(entries):
+                return
+        os.rmdir(container, dir_fd=collisions_fd)
+        _fsync_committed(collisions_fd, "archive collision cleanup")
+        with os.scandir(collisions_fd) as entries:
+            if any(entries):
+                return
+        if _directory_entry_matches_fd(archive_fd, ".collisions", collisions_fd):
+            os.rmdir(".collisions", dir_fd=archive_fd)
+            _fsync_committed(archive_fd, "archive collision root cleanup")
+    except OSError as exc:
+        logger.debug("could not clean archive collision container: %s", exc)
+    finally:
+        os.close(collisions_fd)
+
+
+def _secure_cleanup_empty_support_parent(
+    parent_fd: Any,
+    resolved_skill_dir: Path,
+    file_path: str,
+) -> None:
+    """Remove the one empty supporting directory legacy remove_file cleaned."""
+    parts = Path(file_path).parts
+    parent_relative = Path(*parts[:-1])
+    parent_path = resolved_skill_dir / parent_relative
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import open_directory
+
+        if parent_fd.list_entries():
+            return
+        with open_directory(
+            parent_path.parent, writable=True
+        ) as grandparent:
+            if not _directory_entry_matches_fd(
+                grandparent, parent_path.name, parent_fd
+            ):
+                raise OSError(
+                    "supporting directory changed during cleanup"
+                )
+            parent_fd.mark_delete(is_directory=True)
+        return
+
+    with os.scandir(parent_fd) as entries:
+        if any(entries):
+            return
+    grandparent_fd = os.open(
+        parent_path.parent,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    try:
+        if not _directory_entry_matches_fd(
+            grandparent_fd, parent_path.name, parent_fd
+        ):
+            raise OSError("supporting directory changed during cleanup")
+        os.rmdir(parent_path.name, dir_fd=grandparent_fd)
+        _fsync_committed(grandparent_fd, "supporting-directory cleanup")
+    finally:
+        os.close(grandparent_fd)
+
+
+def _remove_held_regular_file(parent_fd: Any, filename: str) -> None:
+    """Remove a regular entry relative to a held parent on either backend."""
+    if os.name == "nt":
+        with parent_fd.open_file(filename, writable=True) as target:
+            if not target.stat().is_file:
+                raise OSError("supporting target must be a regular file")
+            target.mark_delete(is_directory=False)
+        return
+    target_stat = os.stat(
+        filename, dir_fd=parent_fd, follow_symlinks=False
+    )
+    if not stat.S_ISREG(target_stat.st_mode):
+        raise OSError("supporting target must be a regular file")
+    os.unlink(filename, dir_fd=parent_fd)
+    _fsync_committed(parent_fd, "supporting-file removal")
+
+
+def _read_canonical_skill_md(skill_fd: Any) -> str:
+    """Read canonical metadata relative to a held, verified directory."""
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import read_regular_file
+
+        payload, _metadata = read_regular_file(skill_fd, "SKILL.md")
+        return payload.decode("utf-8")
+
+    file_flags = os.O_RDONLY | os.O_NOFOLLOW
+    file_fd = os.open("SKILL.md", file_flags, dir_fd=skill_fd)
+    try:
+        target_stat = os.fstat(file_fd)
+        if not stat.S_ISREG(target_stat.st_mode):
+            raise OSError("canonical SKILL.md must be a regular file")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(file_fd, 64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks).decode("utf-8")
+    finally:
+        os.close(file_fd)
+
+
+def _read_held_regular_text(parent_fd: Any, filename: str) -> str:
+    """Read one regular file without following a mutable path."""
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import read_regular_file
+
+        payload, _metadata = read_regular_file(parent_fd, filename)
+        return payload.decode("utf-8")
+
+    file_fd = os.open(
+        filename,
+        os.O_RDONLY | os.O_NOFOLLOW,
+        dir_fd=parent_fd,
+    )
+    try:
+        target_stat = os.fstat(file_fd)
+        if not stat.S_ISREG(target_stat.st_mode):
+            raise OSError("supporting target must be a regular file")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(file_fd, 64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks).decode("utf-8")
+    finally:
+        os.close(file_fd)
+
+
+def _replace_held_regular_text(
+    parent_fd: Any,
+    filename: str,
+    content: str,
+    *,
+    require_existing: bool,
+) -> None:
+    """Atomically replace a regular file relative to a held parent dirfd."""
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import replace_regular_file
+
+        replace_regular_file(
+            parent_fd,
+            filename,
+            content.encode("utf-8"),
+            require_existing=require_existing,
+            temp_name=f".tmp_support_{secrets.token_hex(8)}",
+        )
+        return
+
+    try:
+        target_stat = os.stat(
+            filename,
+            dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        if require_existing:
+            raise
+    else:
+        if not stat.S_ISREG(target_stat.st_mode):
+            raise OSError("supporting target must be a regular file")
+
+    temp_name = f".tmp_support_{secrets.token_hex(8)}"
+    file_fd = os.open(
+        temp_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+        dir_fd=parent_fd,
+    )
+    try:
+        payload = content.encode("utf-8")
+        offset = 0
+        while offset < len(payload):
+            written = os.write(file_fd, payload[offset:])
+            if written <= 0:
+                raise OSError("short write while replacing supporting file")
+            offset += written
+        os.fsync(file_fd)
+    except BaseException:
+        try:
+            os.unlink(temp_name, dir_fd=parent_fd)
+        except OSError:
+            pass
+        raise
+    finally:
+        os.close(file_fd)
+
+    try:
+        os.replace(
+            temp_name,
+            filename,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+    except BaseException:
+        try:
+            os.unlink(temp_name, dir_fd=parent_fd)
+        except OSError:
+            pass
+        raise
+    _fsync_committed(parent_fd, "supporting-file replacement")
+
+
+@contextmanager
+def _open_supporting_file_parent(
+    existing: Dict[str, Any],
+    file_path: str,
+    *,
+    create_parents: bool,
+):
+    """Hold every directory segment leading to a supporting file.
+
+    POSIX uses ``dir_fd`` plus ``O_NOFOLLOW``. Windows walks each component
+    from the held skill handle through the NT-native backend. Both variants
+    bind the transaction to the discovered skill and verified child edges.
+    """
+    if os.name == "nt":
+        if not _secure_directory_create_supported():
+            raise OSError(
+                "Secure supporting-file mutation is unavailable on Windows: "
+                "the NT handle-relative backend could not be initialized."
+            )
+        parts = Path(file_path).parts
+        if len(parts) < 2:
+            raise OSError(
+                "supporting file path must include a parent directory"
+            )
+        with _open_existing_skill_directory(existing) as (
+            skill_handle,
+            resolved_dir,
+        ):
+            opened = []
+            current = skill_handle
+            try:
+                for component in parts[:-1]:
+                    try:
+                        child = current.open_dir(
+                            component, writable=True
+                        )
+                    except FileNotFoundError:
+                        if not create_parents:
+                            raise
+                        child = current.open_dir(
+                            component, create=True, writable=True
+                        )
+                    opened.append(child)
+                    current = child
+                edges = [
+                    (
+                        skill_handle if index == 0 else opened[index - 1],
+                        parts[index],
+                        opened[index],
+                    )
+                    for index in range(len(opened))
+                ]
+
+                def path_is_current() -> bool:
+                    try:
+                        with _open_existing_skill_directory(existing) as (
+                            current_skill,
+                            _,
+                        ):
+                            if current_skill.identity != skill_handle.identity:
+                                return False
+                    except OSError:
+                        return False
+                    return all(
+                        _directory_entry_matches_fd(parent, name, child)
+                        for parent, name, child in edges
+                    )
+
+                if not path_is_current():
+                    raise OSError(
+                        "supporting path changed while its directories were opened"
+                    )
+                yield (
+                    skill_handle,
+                    current,
+                    parts[-1],
+                    resolved_dir,
+                    path_is_current,
+                )
+            finally:
+                for handle in reversed(opened):
+                    handle.close()
+        return
+
+    if not _secure_directory_create_supported():
+        raise OSError(
+            "Secure supporting-file mutation is unavailable on this platform."
+        )
+
+    parts = Path(file_path).parts
+    if len(parts) < 2:
+        raise OSError("supporting file path must include a parent directory")
+
+    with _open_existing_skill_directory(existing) as (
+        skill_fd,
+        resolved_dir,
+    ):
+        opened_fds: list[int] = []
+        directory_edges: list[tuple[int, str, int]] = []
+        current_fd = os.dup(skill_fd)
+        opened_fds.append(current_fd)
+        try:
+            directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            for component in parts[:-1]:
+                try:
+                    child_fd = os.open(
+                        component,
+                        directory_flags,
+                        dir_fd=current_fd,
+                    )
+                except FileNotFoundError:
+                    if not create_parents:
+                        raise
+                    os.mkdir(component, 0o700, dir_fd=current_fd)
+                    child_fd = os.open(
+                        component,
+                        directory_flags,
+                        dir_fd=current_fd,
+                    )
+                child_stat = os.fstat(child_fd)
+                if not stat.S_ISDIR(child_stat.st_mode):
+                    os.close(child_fd)
+                    raise OSError(
+                        f"supporting path component '{component}' is not a directory"
+                    )
+                directory_edges.append((current_fd, component, child_fd))
+                opened_fds.append(child_fd)
+                current_fd = child_fd
+
+            def path_is_current() -> bool:
+                try:
+                    logical_stat = os.stat(
+                        existing["path"],
+                        follow_symlinks=False,
+                    )
+                    held_skill_stat = os.fstat(skill_fd)
+                except OSError:
+                    return False
+                if (
+                    not stat.S_ISDIR(logical_stat.st_mode)
+                    or logical_stat.st_dev != held_skill_stat.st_dev
+                    or logical_stat.st_ino != held_skill_stat.st_ino
+                ):
+                    return False
+                return all(
+                    _directory_entry_matches_fd(
+                        parent_fd, component, child_fd
+                    )
+                    for parent_fd, component, child_fd in directory_edges
+                )
+
+            if not path_is_current():
+                raise OSError(
+                    "supporting path changed while its directories were opened"
+                )
+            yield (
+                skill_fd,
+                current_fd,
+                parts[-1],
+                resolved_dir,
+                path_is_current,
+            )
+        finally:
+            for opened_fd in reversed(opened_fds):
+                try:
+                    os.close(opened_fd)
+                except OSError:
+                    pass
+
+
+def _replace_canonical_skill_md(skill_fd: Any, content: str) -> None:
+    """Replace canonical metadata relative to a held directory descriptor."""
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import replace_regular_file
+
+        replace_regular_file(
+            skill_fd,
+            "SKILL.md",
+            content.encode("utf-8"),
+            require_existing=True,
+            temp_name=f".tmp_SKILL_{secrets.token_hex(8)}",
+        )
+        return
+
+    payload = content.encode("utf-8")
+    target_stat = os.stat(
+        "SKILL.md",
+        dir_fd=skill_fd,
+        follow_symlinks=False,
+    )
+    if not stat.S_ISREG(target_stat.st_mode):
+        raise OSError("canonical SKILL.md must be a regular file")
+
+    temp_name = f".tmp_SKILL_{secrets.token_hex(8)}"
+    file_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+    file_fd = os.open(temp_name, file_flags, 0o600, dir_fd=skill_fd)
+    try:
+        offset = 0
+        while offset < len(payload):
+            written = os.write(file_fd, payload[offset:])
+            if written <= 0:
+                raise OSError("short write while replacing SKILL.md")
+            offset += written
+        os.fsync(file_fd)
+    except BaseException:
+        try:
+            os.unlink(temp_name, dir_fd=skill_fd)
+        except OSError:
+            pass
+        raise
+    finally:
+        os.close(file_fd)
+
+    try:
+        os.replace(
+            temp_name,
+            "SKILL.md",
+            src_dir_fd=skill_fd,
+            dst_dir_fd=skill_fd,
+        )
+    except BaseException:
+        try:
+            os.unlink(temp_name, dir_fd=skill_fd)
+        except OSError:
+            pass
+        raise
+    _fsync_committed(skill_fd, "canonical SKILL.md replacement")
+
+
+def _security_scan_held_skill_impl(skill_fd: Any) -> Optional[str]:
+    """Scan a no-follow snapshot copied from a held skill directory."""
+    with tempfile.TemporaryDirectory(prefix=".hermes-skill-scan-") as temp_dir:
+        snapshot = Path(temp_dir) / "skill"
+        if os.name == "nt":
+            from tools.nt_secure_fs_optional import copy_tree_no_reparse
+
+            copy_tree_no_reparse(skill_fd, snapshot)
+            return _security_scan_skill(snapshot)
+
+        snapshot.mkdir()
+        for root, dirs, files, root_fd in os.fwalk(
+            ".",
+            topdown=True,
+            follow_symlinks=False,
+            dir_fd=skill_fd,
+        ):
+            relative_root = Path() if root == "." else Path(root)
+            destination_root = snapshot / relative_root
+            destination_root.mkdir(parents=True, exist_ok=True)
+
+            for dirname in list(dirs):
+                entry_stat = os.stat(
+                    dirname,
+                    dir_fd=root_fd,
+                    follow_symlinks=False,
+                )
+                destination = destination_root / dirname
+                if stat.S_ISLNK(entry_stat.st_mode):
+                    dirs.remove(dirname)
+                    destination.symlink_to(
+                        ".hermes-blocked-symlink",
+                        target_is_directory=True,
+                    )
+                elif stat.S_ISDIR(entry_stat.st_mode):
+                    destination.mkdir(exist_ok=True)
+                else:
+                    dirs.remove(dirname)
+
+            for filename in files:
+                entry_stat = os.stat(
+                    filename,
+                    dir_fd=root_fd,
+                    follow_symlinks=False,
+                )
+                destination = destination_root / filename
+                if stat.S_ISLNK(entry_stat.st_mode):
+                    destination.symlink_to(
+                        ".hermes-blocked-symlink"
+                    )
+                    continue
+                if not stat.S_ISREG(entry_stat.st_mode):
+                    continue
+                source_fd = os.open(
+                    filename,
+                    os.O_RDONLY | os.O_NOFOLLOW,
+                    dir_fd=root_fd,
+                )
+                try:
+                    with os.fdopen(os.dup(source_fd), "rb") as source, open(
+                        destination, "wb"
+                    ) as target:
+                        shutil.copyfileobj(source, target)
+                finally:
+                    os.close(source_fd)
+        return _security_scan_skill(snapshot)
+
+
+def _security_scan_held_skill(skill_fd: int) -> Optional[str]:
+    """Fail closed if an enabled anchored scan snapshot cannot be built.
+
+    Disabled scans are intentionally a true no-op: do not ``fwalk`` or copy
+    the held tree before discovering that ``guard_agent_created`` is off.
+    """
+    if not _agent_created_security_scan_enabled():
+        return None
+    try:
+        return _security_scan_held_skill_impl(skill_fd)
+    except Exception as exc:
+        logger.warning(
+            "Could not securely snapshot skill for scanning: %s",
+            exc,
+            exc_info=True,
+        )
+        return f"Could not securely scan updated skill: {exc}"
+
+
+def _secure_replace_existing_skill_md(
+    existing: Dict[str, Any],
+    content: str,
+    *,
+    skill_fd: Optional[int] = None,
+) -> Optional[str]:
+    """Replace canonical SKILL.md without following a mutable target path."""
+    if skill_fd is not None:
+        try:
+            _replace_canonical_skill_md(skill_fd, content)
+            return None
+        except Exception as exc:
+            return f"Could not securely replace SKILL.md: {exc}"
+
+    try:
+        with _open_existing_skill_directory(existing) as (opened_fd, _):
+            _replace_canonical_skill_md(opened_fd, content)
+        return None
+    except Exception as exc:
+        return f"Could not securely replace SKILL.md: {exc}"
+
+
+def _secure_create_and_write_skill_windows(
+    name: str,
+    category: Optional[str],
+    content: str,
+) -> tuple[Optional[Path], Optional[str]]:
+    """Create, scan, and (on failure) roll back through NT directory handles."""
+    if os.name != "nt":
+        return None, (
+            "Secure skill creation is unavailable on Windows because the "
+            "NT handle-relative backend is not running on this host."
+        )
+    from tools.nt_secure_fs_optional import (
+        delete_tree,
+        open_directory,
+        replace_regular_file,
+    )
+
+    root = _skills_dir()
+    skill_dir = root / category / name if category else root / name
+    root_handle = parent_handle = skill_handle = None
+    created_category = False
+    created_skill = False
+
+    def cleanup() -> None:
+        nonlocal skill_handle
+        if skill_handle is not None and created_skill:
+            try:
+                delete_tree(skill_handle)
+                skill_handle.mark_delete(is_directory=True)
+            except OSError:
+                logger.debug(
+                    "could not roll back Windows skill directory",
+                    exc_info=True,
+                )
+        if (
+            parent_handle is not None
+            and created_category
+            and parent_handle is not root_handle
+        ):
+            try:
+                if not parent_handle.list_entries():
+                    parent_handle.mark_delete(is_directory=True)
+            except OSError:
+                logger.debug(
+                    "could not roll back Windows skill category",
+                    exc_info=True,
+                )
+
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        root_path = root.resolve(strict=True)
+        root_handle = open_directory(root_path, writable=True)
+        if category:
+            try:
+                parent_handle = root_handle.open_dir(
+                    category, writable=True
+                )
+            except FileNotFoundError:
+                parent_handle = root_handle.open_dir(
+                    category, create=True, writable=True
+                )
+                created_category = True
+        else:
+            parent_handle = root_handle
+
+        try:
+            skill_handle = parent_handle.open_dir(
+                name, create=True, writable=True
+            )
+            created_skill = True
+        except FileExistsError:
+            return None, f"A file or directory already exists at {skill_dir}."
+
+        replace_regular_file(
+            skill_handle,
+            "SKILL.md",
+            content.encode("utf-8"),
+            require_existing=False,
+            temp_name=f".tmp_SKILL_{secrets.token_hex(8)}",
+        )
+        if (
+            parent_handle.entry_identity(name, directory=True)
+            != skill_handle.identity
+        ):
+            cleanup()
+            return None, (
+                "Skill path changed during creation; the write was rolled back."
+            )
+        scan_error = _security_scan_held_skill(skill_handle)
+        if scan_error:
+            cleanup()
+            return None, scan_error
+        if (
+            parent_handle.entry_identity(name, directory=True)
+            != skill_handle.identity
+        ):
+            cleanup()
+            return None, (
+                "Skill path changed during security scanning; the write was "
+                "rolled back."
+            )
+        return skill_dir, None
+    except FileExistsError:
+        cleanup()
+        return None, f"A file or directory already exists at {skill_dir}."
+    except Exception as exc:
+        cleanup()
+        return None, f"Could not securely create skill: {exc}"
+    finally:
+        if skill_handle is not None:
+            skill_handle.close()
+        if (
+            parent_handle is not None
+            and parent_handle is not root_handle
+        ):
+            parent_handle.close()
+        if root_handle is not None:
+            root_handle.close()
+
+
+def _secure_create_and_write_skill(
+    name: str,
+    category: Optional[str],
+    content: str,
+) -> tuple[Optional[Path], Optional[str]]:
+    """Create and write a skill without resolving mutable parent path strings.
+
+    On POSIX, all child operations are relative to already-open directory
+    descriptors with ``O_NOFOLLOW``. A category can therefore be renamed or
+    replaced by a symlink during creation without redirecting the write.
+    """
+    if os.name == "nt":
+        if not _secure_directory_create_supported():
+            return None, (
+                "Secure skill creation is unavailable on Windows because "
+                "the NT handle-relative backend could not be initialized."
+            )
+        return _secure_create_and_write_skill_windows(
+            name, category, content
+        )
+    if not _secure_directory_create_supported():
+        return None, (
+            "Secure skill creation is unavailable on this platform."
+        )
+
+    root = _skills_dir()
+    root_fd = parent_fd = skill_fd = None
+    created_category = False
+    created_skill = False
+    temp_name: Optional[str] = None
+    skill_dir = root / category / name if category else root / name
+
+    def cleanup_owned_entries() -> None:
+        if skill_fd is not None:
+            for filename in (temp_name, "SKILL.md"):
+                if not filename:
+                    continue
+                try:
+                    os.unlink(filename, dir_fd=skill_fd)
+                except OSError:
+                    pass
+        if (
+            created_skill
+            and parent_fd is not None
+            and skill_fd is not None
+            and _directory_entry_matches_fd(parent_fd, name, skill_fd)
+        ):
+            try:
+                os.rmdir(name, dir_fd=parent_fd)
+            except OSError:
+                pass
+        if (
+            created_category
+            and root_fd is not None
+            and parent_fd is not None
+            and category
+            and _directory_entry_matches_fd(root_fd, category, parent_fd)
+        ):
+            try:
+                os.rmdir(category, dir_fd=root_fd)
+            except OSError:
+                pass
+
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        root_resolved = root.resolve()
+        directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        root_fd = os.open(root_resolved, directory_flags)
+
+        if category:
+            if _is_path_redirect(root / category):
+                return None, (
+                    f"Refusing to create a skill through redirected category "
+                    f"'{category}'."
+                )
+            try:
+                os.mkdir(category, dir_fd=root_fd)
+                created_category = True
+            except FileExistsError:
+                pass
+            parent_fd = os.open(category, directory_flags, dir_fd=root_fd)
+        else:
+            parent_fd = os.dup(root_fd)
+
+        try:
+            os.mkdir(name, dir_fd=parent_fd)
+            created_skill = True
+        except FileExistsError:
+            cleanup_owned_entries()
+            return None, f"A file or directory already exists at {skill_dir}."
+        skill_fd = os.open(name, directory_flags, dir_fd=parent_fd)
+
+        temp_name = f".tmp_SKILL_{secrets.token_hex(8)}"
+        file_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+        file_fd = os.open(temp_name, file_flags, 0o600, dir_fd=skill_fd)
+        try:
+            payload = content.encode("utf-8")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(file_fd, payload[offset:])
+                if written <= 0:
+                    raise OSError("short write while creating SKILL.md")
+                offset += written
+            os.fsync(file_fd)
+        finally:
+            os.close(file_fd)
+
+        os.replace(
+            temp_name,
+            "SKILL.md",
+            src_dir_fd=skill_fd,
+            dst_dir_fd=skill_fd,
+        )
+        temp_name = None
+        _fsync_committed(skill_fd, "skill creation")
+
+        try:
+            logical_stat = os.stat(skill_dir, follow_symlinks=False)
+            held_stat = os.fstat(skill_fd)
+            path_is_current = (
+                stat.S_ISDIR(logical_stat.st_mode)
+                and logical_stat.st_dev == held_stat.st_dev
+                and logical_stat.st_ino == held_stat.st_ino
+                and skill_dir.resolve().is_relative_to(root_resolved)
+            )
+        except OSError:
+            path_is_current = False
+        if not path_is_current:
+            cleanup_owned_entries()
+            return None, (
+                "Skill path changed during creation; the write was rolled back."
+            )
+
+        scan_error = _security_scan_held_skill(skill_fd)
+        if scan_error:
+            cleanup_owned_entries()
+            return None, scan_error
+
+        # The scan is anchored, but the returned logical path must still name
+        # the held object when creation reports success.
+        try:
+            logical_stat = os.stat(skill_dir, follow_symlinks=False)
+            held_stat = os.fstat(skill_fd)
+            path_is_current = (
+                logical_stat.st_dev == held_stat.st_dev
+                and logical_stat.st_ino == held_stat.st_ino
+            )
+        except OSError:
+            path_is_current = False
+        if not path_is_current:
+            cleanup_owned_entries()
+            return None, (
+                "Skill path changed during security scanning; the write was rolled back."
+            )
+        return skill_dir, None
+    except FileExistsError:
+        cleanup_owned_entries()
+        return None, f"A file or directory already exists at {skill_dir}."
+    except Exception as exc:
+        cleanup_owned_entries()
+        return None, f"Could not securely create skill: {exc}"
+    finally:
+        for fd in (skill_fd, parent_fd, root_fd):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+
+def _create_skill_directory(
+    name: str, category: Optional[str]
+) -> tuple[Optional[Path], Optional[Path], Optional[str]]:
+    """Exclusively create a new local skill directory inside the skills root."""
+    root = _skills_dir()
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        root_resolved = root.resolve()
+    except OSError as exc:
+        return None, None, f"Could not prepare skills directory: {exc}"
+
+    parent = root
+    created_category: Optional[Path] = None
+    if category:
+        parent = root / category
+        if parent.exists() or parent.is_symlink():
+            if _is_path_redirect(parent):
+                return (
+                    None,
+                    None,
+                    f"Refusing to create a skill through redirected category '{category}'.",
+                )
+            if not parent.is_dir():
+                return None, None, f"Skill category path is not a directory: {parent}"
+        else:
+            try:
+                parent.mkdir(exist_ok=False)
+                created_category = parent
+            except FileExistsError:
+                return None, None, f"Skill category path changed during creation: {parent}"
+            except OSError as exc:
+                return None, None, f"Could not create skill category '{category}': {exc}"
+
+    try:
+        parent.resolve().relative_to(root_resolved)
+    except (OSError, ValueError):
+        if created_category is not None:
+            try:
+                created_category.rmdir()
+            except OSError:
+                pass
+        return None, None, "Refusing to create a skill outside the active skills directory."
+
+    skill_dir = parent / name
+    try:
+        skill_dir.mkdir(exist_ok=False)
+    except FileExistsError:
+        if created_category is not None:
+            try:
+                created_category.rmdir()
+            except OSError:
+                pass
+        return None, None, f"A file or directory already exists at {skill_dir}."
+    except OSError as exc:
+        if created_category is not None:
+            try:
+                created_category.rmdir()
+            except OSError:
+                pass
+        return None, None, f"Could not create skill directory: {exc}"
+
+    try:
+        skill_dir.resolve().relative_to(root_resolved)
+    except (OSError, ValueError):
+        _cleanup_created_skill_dir(
+            skill_dir, created_category=created_category
+        )
+        return None, None, "Refusing to create a skill outside the active skills directory."
+
+    return skill_dir, created_category, None
+
+
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     """
     Find a skill by name across all skill directories.
@@ -650,15 +3107,169 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
-    for skills_dir in get_all_skills_dirs():
-        if not skills_dir.exists():
+    from agent.skill_utils import (
+        SkillsConfigError,
+        get_all_skills_dirs,
+        iter_skill_index_files,
+    )
+
+    try:
+        skill_roots = get_all_skills_dirs(require_valid_config=True)
+    except SkillsConfigError as exc:
+        return {
+            "error": (
+                "Skill lookup is incomplete because the configured skills "
+                f"scope could not be read safely: {exc}"
+            ),
+            "paths": [],
+        }
+    matches: list[tuple[Path, Path, tuple[int, int]]] = []
+    seen_paths: set[str] = set()
+    external_roots = {
+        os.path.normcase(os.path.abspath(str(root)))
+        for root in skill_roots[1:]
+    }
+    scan_failures: list[str] = []
+    for skills_dir in skill_roots:
+        root_key = os.path.normcase(os.path.abspath(str(skills_dir)))
+        is_external = root_key in external_roots
+        try:
+            root_stat = skills_dir.stat()
+        except FileNotFoundError as exc:
+            if is_external:
+                scan_failures.append(f"{skills_dir}: {exc}")
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
-            if is_excluded_skill_path(skill_md):
+        except OSError as exc:
+            scan_failures.append(f"{skills_dir}: {exc}")
+            continue
+        if not stat.S_ISDIR(root_stat.st_mode):
+            scan_failures.append(f"{skills_dir}: not a directory")
+            continue
+
+        walk_errors: list[OSError] = []
+        for skill_md in iter_skill_index_files(
+            skills_dir,
+            "SKILL.md",
+            on_error=walk_errors.append,
+        ):
+            # Canonical metadata is executable agent guidance. Never treat a
+            # symlink/reparse-point file as a mutable skill definition.
+            if skill_md.is_symlink():
                 continue
-            if skill_md.parent.name == name:
-                return {"path": skill_md.parent}
+            try:
+                resolved_path = skill_md.parent.resolve()
+                if _secure_directory_create_supported():
+                    if os.name == "nt":
+                        from tools.nt_secure_fs_optional import open_directory
+
+                        with open_directory(
+                            resolved_path, writable=False
+                        ) as candidate_fd:
+                            directory_stat = candidate_fd.stat()
+                            with candidate_fd.open_file(
+                                "SKILL.md", writable=False
+                            ) as canonical:
+                                if not canonical.stat().is_file:
+                                    scan_failures.append(
+                                        f"{skill_md}: canonical metadata is "
+                                        "not a regular file"
+                                    )
+                                    continue
+                            matched = skill_md.parent.name == name
+                            if not matched:
+                                frontmatter, _ = _parse_frontmatter(
+                                    _read_canonical_skill_md(candidate_fd)
+                                )
+                                matched = frontmatter.get("name") == name
+                    else:
+                        directory_flags = (
+                            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+                        )
+                        candidate_fd = os.open(
+                            resolved_path, directory_flags
+                        )
+                        try:
+                            directory_stat = os.fstat(candidate_fd)
+                            canonical_stat = os.stat(
+                                "SKILL.md",
+                                dir_fd=candidate_fd,
+                                follow_symlinks=False,
+                            )
+                            if not stat.S_ISREG(canonical_stat.st_mode):
+                                scan_failures.append(
+                                    f"{skill_md}: canonical metadata is not "
+                                    "a regular file"
+                                )
+                                continue
+                            matched = skill_md.parent.name == name
+                            if not matched:
+                                frontmatter, _ = _parse_frontmatter(
+                                    _read_canonical_skill_md(candidate_fd)
+                                )
+                                matched = frontmatter.get("name") == name
+                        finally:
+                            os.close(candidate_fd)
+                else:
+                    directory_stat = resolved_path.stat()
+                    matched = skill_md.parent.name == name
+                    if not matched:
+                        frontmatter, _ = _parse_frontmatter(
+                            skill_md.read_text(encoding="utf-8")
+                        )
+                        matched = frontmatter.get("name") == name
+                if not matched:
+                    continue
+                identity = str(resolved_path)
+            except (OSError, UnicodeError) as exc:
+                scan_failures.append(f"{skill_md}: {exc}")
+                continue
+            if identity not in seen_paths:
+                seen_paths.add(identity)
+                matches.append(
+                    (
+                        skill_md.parent,
+                        resolved_path,
+                        (directory_stat.st_dev, directory_stat.st_ino),
+                    )
+                )
+        if walk_errors:
+            scan_failures.extend(
+                f"{skills_dir}: {error}" for error in walk_errors
+            )
+
+    if scan_failures:
+        return {
+            "error": (
+                "Skill lookup is incomplete because a configured skills root "
+                "could not be scanned; refusing a local-only mutation that "
+                "could collide with a hidden skill: "
+                + "; ".join(scan_failures[:3])
+            ),
+            "paths": [],
+        }
+    if not matches:
+        return None
+    if len(matches) > 1:
+        paths = sorted(str(path) for path, _, _ in matches)
+        return {
+            "error": (
+                f"Skill name '{name}' is ambiguous; it matches multiple "
+                f"directories: {', '.join(paths)}"
+            ),
+            "paths": paths,
+        }
+    path, resolved_path, directory_identity = matches[0]
+    return {
+        "path": path,
+        "_resolved_path": resolved_path,
+        "_dir_identity": directory_identity,
+    }
+
+
+def _skill_lookup_error(existing: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Convert an ambiguous lookup marker into a normal tool error."""
+    if existing and existing.get("error"):
+        return {"success": False, "error": existing["error"]}
     return None
 
 
@@ -841,7 +3452,10 @@ def _skill_not_found_error(name: str, suffix: str = "") -> str:
     return base
 
 
-def _validate_file_path(file_path: str) -> Optional[str]:
+def _validate_file_path(
+    file_path: str,
+    skill_name: Optional[str] = None,
+) -> Optional[str]:
     """
     Validate a file path for write_file/remove_file.
     Must be under an allowed subdirectory and not escape the skill dir.
@@ -858,13 +3472,13 @@ def _validate_file_path(file_path: str) -> Optional[str]:
     if has_traversal_component(file_path):
         return "Path traversal ('..') is not allowed."
 
-    # SKILL.md is the canonical skill file and lives at the skill root, not
-    # under an allowed subdirectory. Accept its two natural spellings —
-    # 'SKILL.md' and '<skill-name>/SKILL.md' — so callers can target the main
-    # file. The traversal guard above still applies, so this can't escape.
-    if normalized.parts and normalized.name == "SKILL.md":
-        if len(normalized.parts) == 1 or len(normalized.parts) == 2:
-            return None
+    # SKILL.md is the canonical skill file and lives at the skill root. The
+    # optional name-prefixed spelling must match the target skill exactly;
+    # accepting any two-part path would bypass the supporting-dir allowlist.
+    if normalized.parts == ("SKILL.md",):
+        return None
+    if skill_name and normalized.parts == (skill_name, "SKILL.md"):
+        return None
 
     # Must be under an allowed subdirectory
     if not normalized.parts or normalized.parts[0] not in ALLOWED_SUBDIRS:
@@ -876,6 +3490,16 @@ def _validate_file_path(file_path: str) -> Optional[str]:
         return f"Provide a file path, not just a directory. Example: '{normalized.parts[0]}/myfile.md'"
 
     return None
+
+
+def _targets_skill_md(file_path: Optional[str], skill_name: str) -> bool:
+    if not file_path:
+        return False
+    normalized = Path(file_path)
+    return normalized.parts == ("SKILL.md",) or normalized.parts == (
+        skill_name,
+        "SKILL.md",
+    )
 
 
 def _resolve_skill_target(skill_dir: Path, file_path: str) -> Tuple[Optional[Path], Optional[str]]:
@@ -915,9 +3539,18 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     err = _validate_category(category)
     if err:
         return {"success": False, "error": err}
+    category = (category.strip() or None) if isinstance(category, str) else None
 
-    # Validate content
-    err = _validate_frontmatter(content, new_skill=True)
+    # Normalize before both validation and persistence so a BOM accepted here
+    # cannot make runtime parsing lose the frontmatter later.
+    content = _normalize_skill_content(content)
+
+    # Validate content and keep the API/directory/frontmatter identity aligned.
+    err = _validate_frontmatter(
+        content,
+        new_skill=True,
+        expected_name=name,
+    )
     if err:
         return {"success": False, "error": err}
 
@@ -925,27 +3558,38 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     if err:
         return {"success": False, "error": err}
 
-    # Check for name collisions across all directories
-    existing = _find_skill(name)
-    if existing:
+    # Reserve the global frontmatter identity across processes. Directory
+    # exclusivity alone is insufficient because the same name can otherwise
+    # be created concurrently under two different categories.
+    try:
+        with _skill_mutation_lock(name):
+            existing = _find_skill(name)
+            lookup_error = _skill_lookup_error(existing)
+            if lookup_error:
+                return lookup_error
+            if existing:
+                return {
+                    "success": False,
+                    "error": (
+                        f"A skill named '{name}' already exists at "
+                        f"{existing['path']}."
+                    ),
+                }
+
+            # Create and write through held directory handles. This cannot be
+            # redirected by swapping a checked parent for a symlink before the
+            # file write, and the final directory reservation remains exclusive.
+            skill_dir, create_error = _secure_create_and_write_skill(
+                name, category, content
+            )
+    except OSError as exc:
         return {
             "success": False,
-            "error": f"A skill named '{name}' already exists at {existing['path']}."
+            "error": f"Could not reserve skill identity: {exc}",
         }
-
-    # Create the skill directory
-    skill_dir = _resolve_skill_dir(name, category)
-    skill_dir.mkdir(parents=True, exist_ok=True)
-
-    # Write SKILL.md atomically
+    if create_error or skill_dir is None:
+        return {"success": False, "error": create_error or "Could not create skill."}
     skill_md = skill_dir / "SKILL.md"
-    atomic_write_text(skill_md, content)
-
-    # Security scan — roll back on block
-    scan_error = _security_scan_skill(skill_dir)
-    if scan_error:
-        shutil.rmtree(skill_dir, ignore_errors=True)
-        return {"success": False, "error": scan_error}
 
     # Extract description from frontmatter for verbose notifications
     _desc = ""
@@ -975,8 +3619,29 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
 
 
 def _edit_skill(name: str, content: str) -> Dict[str, Any]:
+    """Serialize a full canonical rewrite transaction for one skill."""
+    try:
+        with _existing_skill_mutation_lock(name) as (existing, lock_error):
+            if lock_error:
+                return lock_error
+            assert existing is not None
+            return _edit_skill_transaction(name, content, existing=existing)
+    except OSError as exc:
+        return {
+            "success": False,
+            "error": f"Could not reserve skill mutation: {exc}",
+        }
+
+
+def _edit_skill_transaction(
+    name: str,
+    content: str,
+    *,
+    existing: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Replace the SKILL.md of any existing skill (full rewrite)."""
-    err = _validate_frontmatter(content)
+    content = _normalize_skill_content(content)
+    err = _validate_frontmatter(content, expected_name=name)
     if err:
         return {"success": False, "error": err}
 
@@ -984,9 +3649,13 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if err:
         return {"success": False, "error": err}
 
-    existing = _find_skill(name)
-    if not existing:
-        return {"success": False, "error": _skill_not_found_error(name)}
+    if existing is None:
+        existing = _find_skill(name)
+        lookup_error = _skill_lookup_error(existing)
+        if lookup_error:
+            return lookup_error
+        if not existing:
+            return {"success": False, "error": _skill_not_found_error(name)}
     org_guard = _org_mirror_write_guard(name, existing["path"], "edit")
     if org_guard:
         return org_guard
@@ -1001,16 +3670,40 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if read_guard:
         return read_guard
 
-    # Back up original content for rollback
-    original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
-    atomic_write_text(skill_md, content)
+    try:
+        with _open_existing_skill_directory(existing) as (
+            skill_fd,
+            _resolved_dir,
+        ):
+            # Read, write, scan, and rollback all stay attached to this exact
+            # directory object even if an external skill-root symlink moves.
+            original_content = _read_canonical_skill_md(skill_fd)
+            write_error = _secure_replace_existing_skill_md(
+                existing,
+                content,
+                skill_fd=skill_fd,
+            )
+            if write_error:
+                return {"success": False, "error": write_error}
 
-    # Security scan — roll back on block
-    scan_error = _security_scan_skill(existing["path"])
-    if scan_error:
-        if original_content is not None:
-            atomic_write_text(skill_md, original_content)
-        return {"success": False, "error": scan_error}
+            scan_error = _security_scan_held_skill(skill_fd)
+            if scan_error:
+                rollback_error = _secure_replace_existing_skill_md(
+                    existing,
+                    original_content,
+                    skill_fd=skill_fd,
+                )
+                if rollback_error:
+                    return {
+                        "success": False,
+                        "error": f"{scan_error}; rollback failed: {rollback_error}",
+                    }
+                return {"success": False, "error": scan_error}
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": f"Could not securely mutate SKILL.md: {exc}",
+        }
 
     # Extract description from new content for verbose notifications
     _desc = ""
@@ -1025,7 +3718,7 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     result = {
         "success": True,
         "message": f"Skill '{name}' updated (full rewrite).",
-        "path": str(existing["path"]),
+        "path": str(existing.get("_resolved_path") or existing["path"]),
         "_change": {"description": _desc},
     }
     org_note = _maybe_auto_propose_org_edit(name, existing["path"])
@@ -1036,12 +3729,183 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     return result
 
 
+def _apply_skill_patch(
+    *,
+    name: str,
+    existing: Dict[str, Any],
+    skill_dir: Path,
+    target: Path,
+    file_path: Optional[str],
+    patches_main_file: bool,
+    content: str,
+    old_string: str,
+    new_string: str,
+    replace_all: bool,
+    skill_fd: Optional[int] = None,
+    support_parent_fd: Optional[int] = None,
+    support_filename: Optional[str] = None,
+    support_path_is_current: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Apply a validated patch while the caller owns any canonical dirfd."""
+    from tools.fuzzy_match import fuzzy_find_and_replace
+
+    new_content, match_count, _strategy, match_error = fuzzy_find_and_replace(
+        content, old_string, new_string, replace_all
+    )
+    if match_error:
+        preview = content[:500] + ("..." if len(content) > 500 else "")
+        err_msg = match_error
+        try:
+            from tools.fuzzy_match import format_no_match_hint
+
+            err_msg += format_no_match_hint(
+                match_error, match_count, old_string, content
+            )
+        except Exception:
+            pass
+        return {
+            "success": False,
+            "error": err_msg,
+            "file_preview": preview,
+        }
+
+    if patches_main_file:
+        new_content = _normalize_skill_content(new_content)
+
+    target_label = "SKILL.md" if patches_main_file else file_path
+    err = _validate_content_size(new_content, label=target_label)
+    if err:
+        return {"success": False, "error": err}
+
+    if patches_main_file:
+        err = _validate_frontmatter(new_content, expected_name=name)
+        if err:
+            return {
+                "success": False,
+                "error": f"Patch would break SKILL.md structure: {err}",
+            }
+
+    original_content = content
+    if patches_main_file:
+        assert skill_fd is not None
+        write_error = _secure_replace_existing_skill_md(
+            existing,
+            new_content,
+            skill_fd=skill_fd,
+        )
+        if write_error:
+            return {"success": False, "error": write_error}
+    else:
+        assert support_parent_fd is not None
+        assert support_filename is not None
+        _replace_held_regular_text(
+            support_parent_fd,
+            support_filename,
+            new_content,
+            require_existing=True,
+        )
+
+    if (
+        not patches_main_file
+        and support_path_is_current is not None
+        and not support_path_is_current()
+    ):
+        scan_error = (
+            "Supporting path changed during mutation; the write was rolled back."
+        )
+    else:
+        scan_error = _security_scan_held_skill(skill_fd)
+    if (
+        not scan_error
+        and not patches_main_file
+        and support_path_is_current is not None
+        and not support_path_is_current()
+    ):
+        scan_error = (
+            "Supporting path changed during security scanning; "
+            "the write was rolled back."
+        )
+    if scan_error:
+        if patches_main_file:
+            assert skill_fd is not None
+            rollback_error = _secure_replace_existing_skill_md(
+                existing,
+                original_content,
+                skill_fd=skill_fd,
+            )
+            if rollback_error:
+                return {
+                    "success": False,
+                    "error": f"{scan_error}; rollback failed: {rollback_error}",
+                }
+        else:
+            assert support_parent_fd is not None
+            assert support_filename is not None
+            _replace_held_regular_text(
+                support_parent_fd,
+                support_filename,
+                original_content,
+                require_existing=True,
+            )
+        return {"success": False, "error": scan_error}
+
+    result = {
+        "success": True,
+        "message": (
+            f"Patched {'SKILL.md' if patches_main_file else file_path} in "
+            f"skill '{name}' ({match_count} replacement"
+            f"{'s' if match_count > 1 else ''})."
+        ),
+        "_change": {
+            "old": old_string[:200]
+            + ("…" if len(old_string) > 200 else ""),
+            "new": new_string[:200]
+            + ("…" if len(new_string) > 200 else ""),
+        },
+    }
+    org_note = _maybe_auto_propose_org_edit(name, skill_dir)
+    if org_note:
+        result["org_sharing"] = org_note
+        result["message"] = f"{result['message']} {org_note}"
+    return result
+
+
 def _patch_skill(
     name: str,
     old_string: str,
     new_string: str,
     file_path: str = None,
     replace_all: bool = False,
+) -> Dict[str, Any]:
+    """Serialize a full targeted-update transaction for one skill."""
+    try:
+        with _existing_skill_mutation_lock(name) as (existing, lock_error):
+            if lock_error:
+                return lock_error
+            assert existing is not None
+            return _patch_skill_transaction(
+                name,
+                old_string,
+                new_string,
+                file_path,
+                replace_all,
+                existing=existing,
+            )
+    except OSError as exc:
+        return {
+            "success": False,
+            "error": f"Could not reserve skill mutation: {exc}",
+        }
+
+
+def _patch_skill_transaction(
+    name: str,
+    old_string: str,
+    new_string: str,
+    file_path: str = None,
+    replace_all: bool = False,
+    *,
+    existing: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Targeted find-and-replace within a skill file.
 
@@ -1053,9 +3917,13 @@ def _patch_skill(
     if new_string is None:
         return {"success": False, "error": "new_string is required for 'patch'. Use an empty string to delete matched text."}
 
-    existing = _find_skill(name)
-    if not existing:
-        return {"success": False, "error": _skill_not_found_error(name)}
+    if existing is None:
+        existing = _find_skill(name)
+        lookup_error = _skill_lookup_error(existing)
+        if lookup_error:
+            return lookup_error
+        if not existing:
+            return {"success": False, "error": _skill_not_found_error(name)}
 
     skill_dir = existing["path"]
     org_guard = _org_mirror_write_guard(name, skill_dir, "patch")
@@ -1065,7 +3933,8 @@ def _patch_skill(
     if guard:
         return guard
 
-    if file_path:
+    patches_main_file = not file_path or _targets_skill_md(file_path, name)
+    if file_path and not patches_main_file:
         # Patching a supporting file
         err = _validate_file_path(file_path)
         if err:
@@ -1090,70 +3959,70 @@ def _patch_skill(
     if read_guard:
         return read_guard
 
-    content = target.read_text(encoding="utf-8")
-
-    # Use the same fuzzy matching engine as the file patch tool.
-    # This handles whitespace normalization, indentation differences,
-    # escape sequences, and block-anchor matching — saving the agent
-    # from exact-match failures on minor formatting mismatches.
-    from tools.fuzzy_match import fuzzy_find_and_replace
-
-    new_content, match_count, _strategy, match_error = fuzzy_find_and_replace(
-        content, old_string, new_string, replace_all
-    )
-    if match_error:
-        # Show a short preview of the file so the model can self-correct
-        preview = content[:500] + ("..." if len(content) > 500 else "")
-        err_msg = match_error
+    if patches_main_file:
         try:
-            from tools.fuzzy_match import format_no_match_hint
-            err_msg += format_no_match_hint(match_error, match_count, old_string, content)
-        except Exception:
-            pass
-        return {
-            "success": False,
-            "error": err_msg,
-            "file_preview": preview,
-        }
-
-    # Check size limit on the result
-    target_label = "SKILL.md" if not file_path else file_path
-    err = _validate_content_size(new_content, label=target_label)
-    if err:
-        return {"success": False, "error": err}
-
-    # If patching SKILL.md, validate frontmatter is still intact
-    if not file_path:
-        err = _validate_frontmatter(new_content)
-        if err:
+            with _open_existing_skill_directory(existing) as (
+                skill_fd,
+                _resolved_dir,
+            ):
+                content = _read_canonical_skill_md(skill_fd)
+                return _apply_skill_patch(
+                    name=name,
+                    existing=existing,
+                    skill_dir=skill_dir,
+                    target=target,
+                    file_path=file_path,
+                    patches_main_file=True,
+                    content=content,
+                    old_string=old_string,
+                    new_string=new_string,
+                    replace_all=replace_all,
+                    skill_fd=skill_fd,
+                )
+        except Exception as exc:
             return {
                 "success": False,
-                "error": f"Patch would break SKILL.md structure: {err}",
+                "error": f"Could not securely patch SKILL.md: {exc}",
             }
 
-    original_content = content  # for rollback
-    atomic_write_text(target, new_content)
-
-    # Security scan — roll back on block
-    scan_error = _security_scan_skill(skill_dir)
-    if scan_error:
-        atomic_write_text(target, original_content)
-        return {"success": False, "error": scan_error}
-
-    result = {
-        "success": True,
-        "message": f"Patched {'SKILL.md' if not file_path else file_path} in skill '{name}' ({match_count} replacement{'s' if match_count > 1 else ''}).",
-    }
-    # Include change previews for verbose notifications
-    result["_change"] = {
-        "old": old_string[:200] + ("…" if len(old_string) > 200 else ""),
-        "new": new_string[:200] + ("…" if len(new_string) > 200 else ""),
-    }
-    org_note = _maybe_auto_propose_org_edit(name, skill_dir)
-    if org_note:
-        result["org_sharing"] = org_note
-        result["message"] = f"{result['message']} {org_note}"
-    return result
+    try:
+        assert file_path is not None
+        with _open_supporting_file_parent(
+            existing,
+            file_path,
+            create_parents=False,
+        ) as (
+            skill_fd,
+            parent_fd,
+            filename,
+            _resolved_dir,
+            path_is_current,
+        ):
+            content = _read_held_regular_text(parent_fd, filename)
+            return _apply_skill_patch(
+                name=name,
+                existing=existing,
+                skill_dir=skill_dir,
+                target=target,
+                file_path=file_path,
+                patches_main_file=False,
+                content=content,
+                old_string=old_string,
+                new_string=new_string,
+                replace_all=replace_all,
+                skill_fd=skill_fd,
+                support_parent_fd=parent_fd,
+                support_filename=filename,
+                support_path_is_current=path_is_current,
+            )
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": (
+                "Could not securely patch supporting file; a redirected path "
+                f"may escape the skill directory: {exc}"
+            ),
+        }
 
 
 def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, Any]:
@@ -1168,9 +4037,74 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         target must exist on disk. Validated here so the model can't claim an
         umbrella that doesn't exist.
     """
-    existing = _find_skill(name)
-    if not existing:
-        return {"success": False, "error": _skill_not_found_error(name)}
+    try:
+        with _existing_skill_mutation_lock(name) as (existing, lock_error):
+            if not lock_error:
+                assert existing is not None
+                return _delete_skill_transaction(
+                    name, absorbed_into, existing=existing
+                )
+            active_error = lock_error
+    except OSError as exc:
+        return {
+            "success": False,
+            "error": f"Could not reserve skill deletion: {exc}",
+        }
+
+    # A curator delete is an archive.  If the namespace move committed before
+    # strict lifecycle metadata did, retrying the same canonical/physical alias
+    # must reconcile that archived directory rather than report a false miss or
+    # perform another move. Foreground hard deletes deliberately do not adopt
+    # pre-existing archived content.
+    try:
+        from tools.skill_provenance import is_background_review
+        curator_pass = is_background_review()
+    except Exception:
+        curator_pass = False
+    if not curator_pass or "not found" not in active_error["error"].lower():
+        return active_error
+    try:
+        with _archived_skill_mutation_lock(name, _skills_dir()) as (archived, archive_error):
+            if archive_error:
+                return active_error
+            assert archived is not None
+            canonical_name = archived["_canonical_name"]
+            from tools.skill_usage import is_bundled, persist_lifecycle_move_metadata_strict
+
+            try:
+                persist_lifecycle_move_metadata_strict(
+                    canonical_name, "archived", suppressed=is_bundled(canonical_name)
+                )
+            except Exception as exc:
+                return {
+                    "success": False,
+                    "error": (
+                        "archive already moved; lifecycle metadata reconciliation "
+                        f"failed: {exc}"
+                    ),
+                }
+            return {
+                "success": True,
+                "message": (
+                    f"Skill '{canonical_name}' was already archived; lifecycle "
+                    "metadata reconciled."
+                ),
+                "_archived": True,
+            }
+    except OSError as exc:
+        return {
+            "success": False,
+            "error": f"Could not securely reconcile archived skill deletion: {exc}",
+        }
+
+
+def _delete_skill_transaction(
+    name: str,
+    absorbed_into: Optional[str] = None,
+    *,
+    existing: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Delete one skill while its alias and physical locks are held."""
     org_guard = _org_mirror_write_guard(name, existing["path"], "delete")
     if org_guard:
         return org_guard
@@ -1204,6 +4138,9 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
                 "error": f"absorbed_into='{target_name}' cannot equal the skill being deleted.",
             }
         target = _find_skill(target_name)
+        target_lookup_error = _skill_lookup_error(target)
+        if target_lookup_error:
+            return target_lookup_error
         if not target:
             return {
                 "success": False,
@@ -1236,8 +4173,9 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
 
     if curator_pass:
         try:
-            from tools.skill_usage import archive_skill
-            ok, archive_msg = archive_skill(name)
+            ok, archive_msg = _secure_archive_existing_skill(
+                existing, skills_root
+            )
         except Exception as e:
             return {"success": False, "error": f"failed to archive '{name}': {e}"}
         if not ok:
@@ -1247,12 +4185,13 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
             message += f" Content absorbed into '{absorbed_target}'."
         return {"success": True, "message": message, "_archived": True}
 
-    shutil.rmtree(skill_dir)
-
-    # Clean up empty category directories (don't remove the skills root itself)
-    parent = skill_dir.parent
-    if parent != skills_root and parent.exists() and not any(parent.iterdir()):
-        parent.rmdir()
+    try:
+        _secure_delete_existing_skill(existing, skills_root)
+    except OSError as exc:
+        return {
+            "success": False,
+            "error": f"Could not securely delete skill '{name}': {exc}",
+        }
 
     message = f"Skill '{name}' deleted."
     if is_consolidation:
@@ -1265,13 +4204,48 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
 
 
 def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
+    """Serialize supporting or canonical writes for one skill."""
+    try:
+        with _existing_skill_mutation_lock(name) as (existing, lock_error):
+            if lock_error:
+                return lock_error
+            assert existing is not None
+            return _write_file_transaction(
+                name,
+                file_path,
+                file_content,
+                existing=existing,
+            )
+    except OSError as exc:
+        return {
+            "success": False,
+            "error": f"Could not reserve skill mutation: {exc}",
+        }
+
+
+def _write_file_transaction(
+    name: str,
+    file_path: str,
+    file_content: str,
+    *,
+    existing: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Add or overwrite a supporting file within any skill directory."""
-    err = _validate_file_path(file_path)
+    err = _validate_file_path(file_path, skill_name=name)
     if err:
         return {"success": False, "error": err}
 
     if not file_content and file_content != "":
         return {"success": False, "error": "file_content is required."}
+
+    # Keep the canonical file on the same validated full-rewrite path as edit;
+    # write_file is otherwise only a supporting-file convenience.
+    if _targets_skill_md(file_path, name):
+        return _edit_skill_transaction(
+            name,
+            file_content,
+            existing=existing,
+        )
 
     # Check size limits
     content_bytes = len(file_content.encode("utf-8"))
@@ -1288,9 +4262,13 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if err:
         return {"success": False, "error": err}
 
-    existing = _find_skill(name)
-    if not existing:
-        return {"success": False, "error": _skill_not_found_error(name, " Create it first with action='create'.")}
+    if existing is None:
+        existing = _find_skill(name)
+        lookup_error = _skill_lookup_error(existing)
+        if lookup_error:
+            return lookup_error
+        if not existing:
+            return {"success": False, "error": _skill_not_found_error(name, " Create it first with action='create'.")}
     org_guard = _org_mirror_write_guard(name, existing["path"], "write_file")
     if org_guard:
         return org_guard
@@ -1308,19 +4286,73 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
         )
         if read_guard:
             return read_guard
-    target.parent.mkdir(parents=True, exist_ok=True)
-    # Back up for rollback
-    original_content = target.read_text(encoding="utf-8") if target.exists() else None
-    atomic_write_text(target, file_content)
+    try:
+        with _open_supporting_file_parent(
+            existing,
+            file_path,
+            create_parents=True,
+        ) as (
+            skill_fd,
+            parent_fd,
+            filename,
+            _resolved_dir,
+            path_is_current,
+        ):
+            try:
+                original_content = _read_held_regular_text(
+                    parent_fd, filename
+                )
+            except FileNotFoundError:
+                original_content = None
 
-    # Security scan — roll back on block
-    scan_error = _security_scan_skill(existing["path"])
-    if scan_error:
-        if original_content is not None:
-            atomic_write_text(target, original_content)
-        else:
-            target.unlink(missing_ok=True)
-        return {"success": False, "error": scan_error}
+            _replace_held_regular_text(
+                parent_fd,
+                filename,
+                file_content,
+                require_existing=False,
+            )
+
+            # Scan and rollback remain anchored to the held skill and parent
+            # directory descriptors even if a checked path is retargeted.
+            if not path_is_current():
+                scan_error = (
+                    "Supporting path changed during mutation; "
+                    "the write was rolled back."
+                )
+            else:
+                scan_error = _security_scan_held_skill(skill_fd)
+            if not scan_error and not path_is_current():
+                scan_error = (
+                    "Supporting path changed during security scanning; "
+                    "the write was rolled back."
+                )
+            if scan_error:
+                try:
+                    if original_content is not None:
+                        _replace_held_regular_text(
+                            parent_fd,
+                            filename,
+                            original_content,
+                            require_existing=True,
+                        )
+                    else:
+                        _remove_held_regular_file(parent_fd, filename)
+                except Exception as rollback_exc:
+                    return {
+                        "success": False,
+                        "error": (
+                            f"{scan_error}; rollback failed: {rollback_exc}"
+                        ),
+                    }
+                return {"success": False, "error": scan_error}
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": (
+                "Could not securely write supporting file; a redirected path "
+                f"may escape the skill directory: {exc}"
+            ),
+        }
 
     result = {
         "success": True,
@@ -1336,13 +4368,38 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
 
 def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     """Remove a supporting file from any skill directory."""
-    err = _validate_file_path(file_path)
+    err = _validate_file_path(file_path, skill_name=name)
     if err:
         return {"success": False, "error": err}
+    if _targets_skill_md(file_path, name):
+        return {
+            "success": False,
+            "error": (
+                "SKILL.md cannot be removed as a supporting file; use the "
+                "'delete' action to remove the whole skill."
+            ),
+        }
 
-    existing = _find_skill(name)
-    if not existing:
-        return {"success": False, "error": _skill_not_found_error(name)}
+    try:
+        with _existing_skill_mutation_lock(name) as (existing, lock_error):
+            if lock_error:
+                return lock_error
+            assert existing is not None
+            return _remove_file_transaction(name, file_path, existing=existing)
+    except OSError as exc:
+        return {
+            "success": False,
+            "error": f"Could not reserve skill mutation: {exc}",
+        }
+
+
+def _remove_file_transaction(
+    name: str,
+    file_path: str,
+    *,
+    existing: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Remove a supporting file while its alias and physical locks are held."""
 
     skill_dir = existing["path"]
     guard = _background_review_write_guard(name, skill_dir, "remove_file")
@@ -1354,18 +4411,23 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
         return {"success": False, "error": err}
     assert target is not None
     if not target.exists():
-        # List what's actually there for the model to see
-        available = []
-        for subdir in ALLOWED_SUBDIRS:
-            d = skill_dir / subdir
-            if d.exists():
-                for f in d.rglob("*"):
-                    if f.is_file():
-                        available.append(str(f.relative_to(skill_dir)))
+        # Keep error payloads under the same deterministic preview budget as
+        # skill_view and slash invocation messages.
+        from tools.skills_tool import build_linked_files_manifest
+
+        available_by_category, files_summary = build_linked_files_manifest(
+            skill_dir
+        )
+        available = [
+            path
+            for category in sorted(available_by_category)
+            for path in available_by_category[category]
+        ]
         return {
             "success": False,
             "error": f"File '{file_path}' not found in skill '{name}'.",
             "available_files": available if available else None,
+            "linked_files_summary": files_summary,
         }
 
     read_guard = _background_review_read_before_write_guard(
@@ -1374,12 +4436,68 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     if read_guard:
         return read_guard
 
-    target.unlink()
-
-    # Clean up empty subdirectories
-    parent = target.parent
-    if parent != skill_dir and parent.exists() and not any(parent.iterdir()):
-        parent.rmdir()
+    try:
+        with _open_supporting_file_parent(
+            existing,
+            file_path,
+            create_parents=False,
+        ) as (
+            _skill_fd,
+            parent_fd,
+            filename,
+            resolved_dir,
+            path_is_current,
+        ):
+            if os.name == "nt":
+                try:
+                    with parent_fd.open_file(
+                        filename, writable=False
+                    ) as target_handle:
+                        target_is_regular = target_handle.stat().is_file
+                except (FileNotFoundError, IsADirectoryError):
+                    target_is_regular = False
+            else:
+                target_stat = os.stat(
+                    filename, dir_fd=parent_fd, follow_symlinks=False
+                )
+                target_is_regular = stat.S_ISREG(target_stat.st_mode)
+            if not target_is_regular:
+                return {
+                    "success": False,
+                    "error": "Supporting target must be a regular file.",
+                }
+            if not path_is_current():
+                return {
+                    "success": False,
+                    "error": "Supporting path changed before removal.",
+                }
+            _remove_held_regular_file(parent_fd, filename)
+            try:
+                _secure_cleanup_empty_support_parent(
+                    parent_fd, resolved_dir, file_path
+                )
+            except OSError as exc:
+                # The requested deletion has already committed. Empty-folder
+                # cleanup is convenience only; never report that completed
+                # mutation as a failure just because cleanup raced or failed.
+                logger.debug(
+                    "Could not clean empty supporting directory for %s: %s",
+                    file_path,
+                    exc,
+                )
+    except FileNotFoundError:
+        return {
+            "success": False,
+            "error": f"File '{file_path}' not found in skill '{name}'.",
+        }
+    except OSError as exc:
+        return {
+            "success": False,
+            "error": (
+                "Could not securely remove supporting file; a redirected path "
+                f"may escape the skill directory: {exc}"
+            ),
+        }
 
     return {
         "success": True,
@@ -1652,12 +4770,16 @@ SKILL_MANAGE_SCHEMA = {
         "If you used a skill and hit issues not covered by it, patch it immediately.\n\n"
         "After difficult/iterative tasks, offer to save as a skill. "
         "Skip for simple one-offs. Confirm with user before creating/deleting.\n\n"
-        "Good skills: trigger conditions, numbered steps with exact commands, "
-        "pitfalls section, verification steps. Use skill_view() to see format examples.\n\n"
-        "Description: long descriptions are truncated to the first 57 chars "
-        "plus '...' in the system prompt skill index; longer text is visible "
-        "via skills_list/skill_view. Keep the trigger self-contained in that "
-        "first 57-char window: 'Use when <trigger>. <one-line behavior>.'\n\n"
+        "Generate the smallest reusable skill that captures the proven workflow. "
+        "Put routing signal in the description; put procedures in the body; move "
+        "large examples or reference material into supporting files. Good bodies "
+        "use imperative steps, explicit prerequisites, pitfalls, and verification. "
+        "Use skill_view() to inspect nearby examples before generating.\n\n"
+        "For create, SKILL.md frontmatter `name` must exactly match the tool's "
+        "`name`, and `description` must be a non-empty string of at most 60 "
+        "characters. Make the description a concise capability/trigger sentence "
+        "whose routing signal survives in the skill index. Do not duplicate the "
+        "procedure in the description.\n\n"
         "Pinned skills are protected from deletion only — skill_manage(action='delete') "
         "will refuse with a message pointing the user to `hermes curator unpin <name>`. "
         "Patches and edits go through on pinned skills so you can still improve them as "
@@ -1682,8 +4804,11 @@ SKILL_MANAGE_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Full SKILL.md content (YAML frontmatter + markdown body). "
-                    "Required for 'create' and 'edit'. For 'edit', read the skill "
-                    "first with skill_view() and provide the complete updated text."
+                    "Required for 'create' and 'edit'. On create, frontmatter name "
+                    "must exactly equal the `name` argument and description must be "
+                    "a non-empty routing sentence of at most 60 characters. For "
+                    "'edit', read the skill first with skill_view() and provide the "
+                    "complete updated text."
                 )
             },
             "old_string": {

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -315,6 +315,46 @@ def _write_suppressed_names(names: Set[str]) -> None:
         logger.debug("Failed to write curator suppression list: %s", e, exc_info=True)
 
 
+def _write_suppressed_names_strict(names: Set[str]) -> None:
+    path = _suppressed_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = "\n".join(sorted(names)) + ("\n" if names else "")
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent), prefix=".curator_suppressed_", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+        parent_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def set_suppressed_name_strict(skill_name: str, suppressed: bool) -> None:
+    # Share the usage lock with lifecycle state writes: archive/restore update
+    # both metadata files and must not lose a concurrent suppression change.
+    with _usage_file_lock():
+        names = read_suppressed_names()
+        if suppressed:
+            names.add(skill_name)
+        else:
+            names.discard(skill_name)
+        _write_suppressed_names_strict(names)
+        if (skill_name in read_suppressed_names()) != suppressed:
+            raise OSError("curator suppression metadata verification failed")
+
+
 def add_suppressed_name(skill_name: str) -> None:
     """Record that a built-in skill was pruned, so sync won't restore it."""
     if not skill_name:
@@ -701,6 +741,90 @@ def save_usage(data: Dict[str, Dict[str, Any]]) -> None:
         logger.debug("Failed to write %s: %s", path, e, exc_info=True)
 
 
+def _save_usage_strict(data: Dict[str, Dict[str, Any]]) -> None:
+    """Durably write lifecycle metadata or raise; never silently drop it."""
+    path = _usage_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix=".usage_", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+        parent_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def set_state_strict(skill_name: str, state: str) -> None:
+    """Strict lifecycle-state update for archive/restore filesystem moves."""
+    if state not in _VALID_STATES or not is_curation_eligible(skill_name):
+        raise OSError(f"cannot persist lifecycle state {state!r} for {skill_name}")
+    with _usage_file_lock():
+        data = load_usage()
+        rec = data.get(skill_name)
+        if not isinstance(rec, dict):
+            rec = _empty_record()
+        rec["state"] = state
+        rec["archived_at"] = _now_iso() if state == STATE_ARCHIVED else None
+        data[skill_name] = rec
+        _save_usage_strict(data)
+        persisted = load_usage().get(skill_name, {})
+        if persisted.get("state") != state:
+            raise OSError("lifecycle metadata verification failed")
+
+
+def persist_lifecycle_move_metadata_strict(
+    skill_name: str, state: str, *, suppressed: bool
+) -> None:
+    """Atomically serialize archive/restore's paired metadata intent.
+
+    The two files cannot be atomically replaced together, so retain a snapshot
+    and compensate the suppression file if the usage-state write fails.
+    """
+    if state not in _VALID_STATES or not is_curation_eligible(skill_name):
+        raise OSError(f"cannot persist lifecycle state {state!r} for {skill_name}")
+    with _usage_file_lock():
+        original_names = read_suppressed_names()
+        names = set(original_names)
+        if suppressed:
+            names.add(skill_name)
+        else:
+            names.discard(skill_name)
+        try:
+            _write_suppressed_names_strict(names)
+            data = load_usage()
+            rec = data.get(skill_name)
+            if not isinstance(rec, dict):
+                rec = _empty_record()
+            rec["state"] = state
+            rec["archived_at"] = _now_iso() if state == STATE_ARCHIVED else None
+            data[skill_name] = rec
+            _save_usage_strict(data)
+        except BaseException:
+            try:
+                _write_suppressed_names_strict(original_names)
+            except Exception:
+                logger.exception("failed to compensate curator suppression metadata")
+            raise
+        persisted = load_usage().get(skill_name, {})
+        if persisted.get("state") != state or (
+            (skill_name in read_suppressed_names()) != suppressed
+        ):
+            raise OSError("lifecycle move metadata verification failed")
+
+
 def get_record(skill_name: str) -> Dict[str, Any]:
     """Return the record for *skill_name*, creating a fresh one if missing."""
     data = load_usage()
@@ -881,57 +1005,49 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
     when one is archived, its name is added to the suppression list so the
     update-time re-seeder leaves it archived instead of restoring it.
     """
-    local_skill_dir = _find_skill_dir(skill_name)
-    if local_skill_dir is None and _find_external_skill_dir(skill_name) is not None:
-        return False, _external_read_only_message(skill_name)
-
-    if not is_curation_eligible(skill_name, local_skill_dir):
-        if is_protected_builtin(skill_name):
-            return False, (
-                f"skill '{skill_name}' is a protected built-in; it backs "
-                "load-bearing UX and is never archived or consolidated"
-            )
-        if is_hub_installed(skill_name):
-            return False, f"skill '{skill_name}' is hub-installed; never archive"
-        return False, (
-            f"skill '{skill_name}' is a bundled built-in; enable "
-            "curator.prune_builtins to allow pruning it"
-        )
-
-    skill_dir = local_skill_dir
-    if skill_dir is None:
-        return False, f"skill '{skill_name}' not found"
-    if is_external_skill_path(skill_dir):
-        return False, _external_read_only_message(skill_name)
-
-    archive_root = _archive_dir()
-    try:
-        archive_root.mkdir(parents=True, exist_ok=True)
-    except OSError as e:
-        return False, f"failed to create archive dir: {e}"
-
-    # Flatten any category nesting into a single ".archive/<skill>/" so restores
-    # are simple. If a collision exists, append a timestamp.
-    dest = archive_root / skill_dir.name
-    if dest.exists():
-        dest = archive_root / f"{skill_dir.name}-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
+    # Use the same alias -> physical lock and held-dirfd archive primitive as
+    # skill_manage.  This direct API is also called by curator, learning, and
+    # CLI paths, so a path lookup followed by Path.rename is not sufficient.
+    from tools.skill_manager_tool import (
+        _archived_skill_mutation_lock,
+        _containing_skills_root,
+        _existing_skill_mutation_lock,
+        _secure_archive_existing_skill,
+    )
 
     try:
-        skill_dir.rename(dest)
-    except OSError:
-        # Cross-device — fall back to shutil.move
-        import shutil
-        try:
-            shutil.move(str(skill_dir), str(dest))
-        except Exception as e2:
-            return False, f"failed to archive: {e2}"
+        with _existing_skill_mutation_lock(skill_name) as (existing, lock_error):
+            if not lock_error:
+                assert existing is not None
+                return _secure_archive_existing_skill(
+                    existing, _containing_skills_root(existing["path"])
+                )
+            active_error = lock_error["error"]
+    except OSError as exc:
+        return False, f"failed to securely archive: {exc}"
 
-    # Pruning a built-in only sticks if the re-seeder is told to leave it alone.
-    if is_bundled(skill_name):
-        add_suppressed_name(skill_name)
-
-    set_state(skill_name, STATE_ARCHIVED)
-    return True, f"archived to {dest}"
+    # A secure move may commit before strict metadata persistence fails.  The
+    # archive's directory basename can differ from the frontmatter identity,
+    # so reconcile only a unique, no-follow canonical match; never move again.
+    if "not found" not in active_error.lower():
+        return False, active_error
+    try:
+        with _archived_skill_mutation_lock(skill_name, _skills_dir()) as (archived, lock_error):
+            if lock_error:
+                return False, active_error
+            assert archived is not None
+            canonical_name = archived["_canonical_name"]
+            try:
+                persist_lifecycle_move_metadata_strict(
+                    canonical_name,
+                    STATE_ARCHIVED,
+                    suppressed=is_bundled(canonical_name),
+                )
+            except Exception as exc:
+                return False, f"archive already moved; metadata reconciliation failed: {exc}"
+            return True, f"archive already moved; lifecycle metadata reconciled for {archived['path']}"
+    except OSError as exc:
+        return False, f"failed to securely reconcile archive: {exc}"
 
 
 def restore_skill(skill_name: str) -> Tuple[bool, str]:
@@ -945,68 +1061,60 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     way to lift a prune). Restoring clears any suppression entry so future
     updates may re-seed the built-in again.
     """
-    # Hub skills always have an external upstream owner — never shadow them.
-    if is_hub_installed(skill_name):
-        return False, (
-            f"skill '{skill_name}' is now hub-installed; "
-            "restore would shadow the upstream version"
-        )
-    # A bundled built-in is upstream-owned UNLESS prune_builtins is on. With the
-    # flag off, restoring over it would shadow the bundled version.
-    if is_bundled(skill_name) and not _prune_builtins_enabled():
-        return False, (
-            f"skill '{skill_name}' is now bundled; "
-            "restore would shadow the upstream version"
-        )
-    archive_root = _archive_dir()
-    if not archive_root.exists():
-        return False, "no archive directory"
-
-    # Try exact name match first, then the timestamped-duplicate fallback.
-    # Recursive walk handles nested archive layouts (e.g. .archive/<category>/<skill>/)
-    # left behind by older archive paths or external imports.
-    candidates = [p for p in archive_root.rglob("*") if p.is_dir() and p.name == skill_name]
-    if not candidates:
-        # A name collision makes archive_skill() disambiguate by appending its
-        # UTC timestamp ("<skill>-YYYYMMDDHHMMSS", a 14-digit suffix), so only
-        # that exact shape is another copy of THIS skill. A bare
-        # startswith(f"{skill_name}-") also swallows unrelated sibling skills —
-        # restoring "git" would otherwise pull an archived "git-helpers" out of
-        # the archive and rename it to "git", destroying the sibling's only
-        # copy. Require the suffix to be the timestamp archive_skill writes.
-        prefix = f"{skill_name}-"
-        candidates = sorted(
-            [
-                p for p in archive_root.rglob("*")
-                if p.is_dir()
-                and p.name.startswith(prefix)
-                and len(p.name) - len(prefix) == 14
-                and p.name[len(prefix):].isdigit()
-            ],
-            reverse=True,
-        )
-    if not candidates:
-        return False, f"skill '{skill_name}' not found in archive"
-
-    src = candidates[0]
-    dest = _skills_dir() / skill_name
-    if dest.exists():
-        return False, f"destination already exists: {dest}"
+    from tools.skill_manager_tool import (
+        _archived_skill_mutation_lock,
+        _existing_skill_mutation_lock,
+        _open_existing_skill_directory,
+        _parse_frontmatter,
+        _read_canonical_skill_md,
+        _secure_restore_archived_skill,
+    )
 
     try:
-        src.rename(dest)
-    except OSError:
-        import shutil
+        with _archived_skill_mutation_lock(skill_name, _skills_dir()) as (archived, lock_error):
+            if not lock_error:
+                assert archived is not None
+                canonical_name = archived["_canonical_name"]
+                if is_hub_installed(canonical_name):
+                    return False, f"skill '{canonical_name}' is now hub-installed; restore would shadow the upstream version"
+                if is_bundled(canonical_name) and not _prune_builtins_enabled():
+                    return False, f"skill '{canonical_name}' is now bundled; restore would shadow the upstream version"
+                ok, message = _secure_restore_archived_skill(
+                    archived, canonical_name, _skills_dir()
+                )
+                archive_error = message
+            else:
+                archive_error = lock_error["error"]
+                ok = False
+    except OSError as exc:
+        return False, f"failed to securely restore: {exc}"
+    if not ok:
+        # After a committed move with failed metadata, only the active tree
+        # remains. Re-open it under the same alias+physical lock and persist
+        # the canonical frontmatter identity; a missing/ambiguous archive is
+        # never treated as success.
+        if "not found" not in archive_error.lower():
+            return False, archive_error
         try:
-            shutil.move(str(src), str(dest))
-        except Exception as e:
-            return False, f"failed to restore: {e}"
+            with _existing_skill_mutation_lock(skill_name) as (existing, active_error):
+                if active_error:
+                    return False, archive_error
+                assert existing is not None
+                with _open_existing_skill_directory(existing) as (skill_fd, _resolved):
+                    frontmatter, _ = _parse_frontmatter(
+                        _read_canonical_skill_md(skill_fd)
+                    )
+                canonical_name = frontmatter.get("name")
+                if not isinstance(canonical_name, str) or not canonical_name:
+                    return False, "restore target has no valid canonical skill name"
+                persist_lifecycle_move_metadata_strict(canonical_name, STATE_ACTIVE, suppressed=False)
+                return True, f"restore already moved; lifecycle metadata reconciled for {existing['path']}"
+        except Exception as exc:
+            return False, f"restore already moved; metadata reconciliation failed: {exc}"
+    if not ok:
+        return False, message
 
-    # Restoring a pruned built-in lifts its suppression so updates can manage it.
-    remove_suppressed_name(skill_name)
-
-    set_state(skill_name, STATE_ACTIVE)
-    return True, f"restored to {dest}"
+    return True, message
 
 
 def _find_skill_dir(skill_name: str) -> Optional[Path]:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -66,9 +66,14 @@ Usage:
     content = skill_view("axolotl", "references/dataset-formats.md")
 """
 
+import errno
 import json
 import logging
+import shlex
+import stat
+import tempfile
 import time
+from contextvars import ContextVar, Token
 
 from hermes_constants import get_hermes_home, display_hermes_home
 import os
@@ -83,9 +88,20 @@ from utils import env_var_enabled
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS,
     is_skill_support_path as _is_skill_support_path,
+    parse_strict_fenced_frontmatter,
+    read_strict_skill_index_file,
 )
 
 logger = logging.getLogger(__name__)
+_OS_OPEN_SUPPORTS_DIR_FD = os.open in getattr(os, "supports_dir_fd", set())
+_SECURE_PACKAGE_OPEN_SUPPORTED = (
+    os.name == "nt"
+    or (
+        _OS_OPEN_SUPPORTS_DIR_FD
+        and hasattr(os, "O_NOFOLLOW")
+        and hasattr(os, "O_DIRECTORY")
+    )
+)
 
 # Per-session skill discovery cache.  _find_all_skills() re-reads every
 # SKILL.md on every call; with hundreds of skills this is wasteful.
@@ -102,8 +118,16 @@ _SKILLS_CACHE_TTL_SECONDS = 30.0
 _SKILLS_CACHE_KEY_DISABLED = "with_disabled"
 _SKILLS_CACHE_KEY_FILTERED = "filtered"
 
+# Linked-file manifests are discovery hints, not a directory dump. Keep each
+# category bounded so a skill with a large assets tree cannot flood a tool
+# result or slash-invocation message. Explicit ``skill_view(file_path=...)``
+# remains unrestricted by this preview budget.
+MAX_LINKED_FILES_PER_CATEGORY = 50
+MAX_LINKED_FILE_PATH_CHARS = 8_000
+_LINKED_FILE_CATEGORIES = ("references", "templates", "scripts", "assets")
 
-def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
+
+def _skills_scan_signature(dirs_to_scan, disabled, *, on_error=None) -> tuple:
     """Cheap change-signature for the skill scan inputs.
 
     O(#dirs + #categories) stat calls, not a recursive walk. Includes the
@@ -118,7 +142,9 @@ def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
     for d in dirs_to_scan:
         try:
             m = d.stat().st_mtime
-        except OSError:
+        except OSError as exc:
+            if on_error is not None:
+                on_error(exc)
             continue
         try:
             with os.scandir(d) as it:
@@ -128,12 +154,734 @@ def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
                             em = entry.stat(follow_symlinks=False).st_mtime
                             if em > m:
                                 m = em
-                    except OSError:
+                    except OSError as exc:
+                        if on_error is not None:
+                            on_error(exc)
                         continue
-        except OSError:
-            pass
+        except OSError as exc:
+            if on_error is not None:
+                on_error(exc)
         sig.append((str(d), m))
-    return (tuple(sig), frozenset(disabled), platform)
+    return (
+        tuple(sig),
+        frozenset(disabled),
+        platform,
+        _skill_utils.get_skill_environment_fingerprint(),
+    )
+
+
+def _validate_configured_external_roots() -> tuple[List[Path], Optional[Dict[str, Any]]]:
+    """Return scannable configured roots or a structured scope error.
+
+    Configured roots are discovery inputs even when they are unavailable.
+    Callers must not silently omit one and publish a local-only catalog.
+    """
+    from agent.skill_utils import get_external_skills_dirs
+
+    roots = [Path(root) for root in get_external_skills_dirs()]
+    for root in roots:
+        try:
+            root_stat = root.stat()
+        except OSError as exc:
+            return roots, {
+                "success": False,
+                "error_code": "skills_discovery_incomplete",
+                "error": f"Configured external skills root is unavailable: {root}",
+                "detail": str(exc),
+            }
+        if not stat.S_ISDIR(root_stat.st_mode):
+            return roots, {
+                "success": False,
+                "error_code": "skills_discovery_incomplete",
+                "error": f"Configured external skills root is not a directory: {root}",
+            }
+    return roots, None
+
+
+def build_linked_files_manifest(
+    skill_dir: Path,
+) -> tuple[Dict[str, List[str]], Dict[str, Any]]:
+    """Build a deterministic, bounded preview of a skill's support files.
+
+    The manifest is intentionally shallow in output size while still walking
+    nested support directories. Directory symlinks are not followed. The
+    returned summary tells callers when additional files remain discoverable
+    through an explicit ``skill_view(..., file_path=...)`` call.
+    """
+    linked_files: Dict[str, List[str]] = {}
+    truncated_categories: List[str] = []
+    shown = 0
+    path_chars = 0
+
+    for category in _LINKED_FILE_CATEGORIES:
+        category_dir = skill_dir / category
+        if category_dir.is_symlink() or not category_dir.is_dir():
+            continue
+
+        entries: List[str] = []
+        category_truncated = False
+        stop_category = False
+        for root, dirs, files in os.walk(category_dir, followlinks=False):
+            dirs[:] = sorted(
+                d for d in dirs if not (Path(root) / d).is_symlink()
+            )
+            for filename in sorted(files):
+                file_path = Path(root) / filename
+                if file_path.is_symlink() or not file_path.is_file():
+                    continue
+                rel = file_path.relative_to(skill_dir).as_posix()
+                if (
+                    len(entries) >= MAX_LINKED_FILES_PER_CATEGORY
+                    or path_chars + len(rel) > MAX_LINKED_FILE_PATH_CHARS
+                ):
+                    category_truncated = True
+                    stop_category = True
+                    break
+                entries.append(rel)
+                shown += 1
+                path_chars += len(rel)
+            if stop_category:
+                break
+
+        if entries:
+            linked_files[category] = entries
+        if category_truncated:
+            truncated_categories.append(category)
+
+    return linked_files, {
+        "shown": shown,
+        "truncated": bool(truncated_categories),
+        "truncated_categories": truncated_categories,
+        "per_category_limit": MAX_LINKED_FILES_PER_CATEGORY,
+        "path_char_limit": MAX_LINKED_FILE_PATH_CHARS,
+    }
+
+
+def _stat_signature(value) -> Tuple[int, int, int, int, int]:
+    """Stable identity/content metadata used for bound skill-package reads."""
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _package_signature(path: Path) -> Tuple[int, int, int, int, int]:
+    """Return package metadata from the same no-reparse primitive used to open it."""
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import open_directory
+
+        with open_directory(path, writable=False) as package:
+            return package.stat().signature
+    return _stat_signature(path.stat())
+
+
+def _bound_open_flags(*, directory: bool) -> int:
+    """Return fail-closed POSIX flags for a package-relative open."""
+    if not hasattr(os, "O_NOFOLLOW") or (directory and not hasattr(os, "O_DIRECTORY")):
+        raise OSError("secure package-relative opens are unsupported on this platform")
+    flags = os.O_RDONLY | os.O_NOFOLLOW
+    if directory:
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    return flags
+
+
+def _open_bound_package_dir(
+    skill_dir: Path,
+    expected_signature: Tuple[int, int, int, int, int],
+) -> Any:
+    """Open the already-discovered package and verify its directory identity."""
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import open_directory
+
+        package_handle = open_directory(skill_dir, writable=False)
+        try:
+            if package_handle.stat().signature != expected_signature:
+                raise RuntimeError("skill package changed during loading")
+            return package_handle
+        except Exception:
+            package_handle.close()
+            raise
+
+    package_fd = os.open(skill_dir, _bound_open_flags(directory=True))
+    try:
+        if _stat_signature(os.fstat(package_fd)) != expected_signature:
+            raise RuntimeError("skill package changed during loading")
+        if not _OS_OPEN_SUPPORTS_DIR_FD:
+            raise OSError("secure package-relative opens are unsupported")
+        return package_fd
+    except Exception:
+        os.close(package_fd)
+        raise
+
+
+def _close_bound_handle(handle: Any) -> None:
+    if os.name == "nt":
+        handle.close()
+    else:
+        os.close(handle)
+
+
+def _bound_handle_signature(handle: Any) -> Tuple[int, int, int, int, int]:
+    if os.name == "nt":
+        return handle.stat().signature
+    return _stat_signature(os.fstat(handle))
+
+
+def _bound_relative_parts(file_path: str) -> Tuple[str, ...]:
+    """Normalize a support path without consulting the mutable package path."""
+    if not isinstance(file_path, str) or not file_path.strip():
+        raise ValueError("File path must be a non-empty relative path.")
+    windows_path = PureWindowsPath(file_path)
+    normalized = file_path.replace("\\", "/")
+    posix_path = PurePosixPath(normalized)
+    if (
+        windows_path.is_absolute()
+        or windows_path.drive
+        or posix_path.is_absolute()
+    ):
+        raise ValueError("File path must stay within the skill directory.")
+    if ".." in posix_path.parts:
+        raise ValueError("Path traversal ('..') is not allowed.")
+    if any(part in ("", ".") for part in posix_path.parts):
+        raise ValueError("File path must stay within the skill directory.")
+    return tuple(posix_path.parts)
+
+
+def _read_bound_support_file(
+    package_fd: Any,
+    file_path: str,
+    expected_package_signature: Tuple[int, int, int, int, int],
+) -> tuple[bytes, os.stat_result]:
+    """Read a regular support file through openat without following symlinks."""
+    parts = _bound_relative_parts(file_path)
+    if os.name == "nt":
+        from tools.nt_secure_fs_optional import read_regular_file
+
+        current = package_fd
+        opened = []
+        try:
+            for part in parts[:-1]:
+                current = current.open_dir(part, writable=False)
+                opened.append(current)
+            payload, metadata = read_regular_file(current, parts[-1])
+            if package_fd.stat().signature != expected_package_signature:
+                raise RuntimeError("skill package changed during loading")
+            return payload, metadata
+        finally:
+            for handle in reversed(opened):
+                handle.close()
+
+    current_fd = os.dup(package_fd)
+    file_fd = None
+    try:
+        for part in parts[:-1]:
+            next_fd = os.open(
+                part,
+                _bound_open_flags(directory=True),
+                dir_fd=current_fd,
+            )
+            os.close(current_fd)
+            current_fd = next_fd
+
+        file_fd = os.open(
+            parts[-1],
+            _bound_open_flags(directory=False),
+            dir_fd=current_fd,
+        )
+        before = os.fstat(file_fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise ValueError("Requested support path is not a regular file.")
+        chunks = []
+        while True:
+            chunk = os.read(file_fd, 64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after = os.fstat(file_fd)
+        if _stat_signature(before) != _stat_signature(after):
+            raise RuntimeError("support file changed during loading")
+        if _stat_signature(os.fstat(package_fd)) != expected_package_signature:
+            raise RuntimeError("skill package changed during loading")
+        return b"".join(chunks), after
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        os.close(current_fd)
+
+
+def _build_bound_linked_files_manifest(
+    package_fd: Any,
+    expected_package_signature: Tuple[int, int, int, int, int],
+) -> tuple[Dict[str, List[str]], Dict[str, Any]]:
+    """Build the linked-file preview entirely below a bound package dirfd."""
+    linked_files: Dict[str, List[str]] = {}
+    truncated_categories: List[str] = []
+    shown = 0
+    path_chars = 0
+
+    if os.name == "nt":
+        def walk_nt(directory, relative: str, entries: List[str]) -> bool:
+            nonlocal shown, path_chars
+            before = directory.stat().signature
+            for entry in sorted(
+                directory.list_entries(), key=lambda item: item.name.casefold()
+            ):
+                if entry.is_reparse:
+                    continue
+                rel = f"{relative}/{entry.name}"
+                if entry.is_dir:
+                    with directory.open_dir(
+                        entry.name, writable=False
+                    ) as child:
+                        if walk_nt(child, rel, entries):
+                            return True
+                    continue
+                if (
+                    len(entries) >= MAX_LINKED_FILES_PER_CATEGORY
+                    or path_chars + len(rel) > MAX_LINKED_FILE_PATH_CHARS
+                ):
+                    return True
+                entries.append(rel)
+                shown += 1
+                path_chars += len(rel)
+            if before != directory.stat().signature:
+                raise RuntimeError(
+                    "support directory changed while building manifest"
+                )
+            return False
+
+        for category in _LINKED_FILE_CATEGORIES:
+            try:
+                category_handle = package_fd.open_dir(
+                    category, writable=False
+                )
+            except (FileNotFoundError, NotADirectoryError):
+                continue
+            try:
+                entries: List[str] = []
+                category_truncated = walk_nt(
+                    category_handle, category, entries
+                )
+            finally:
+                category_handle.close()
+            if entries:
+                linked_files[category] = entries
+            if category_truncated:
+                truncated_categories.append(category)
+        if package_fd.stat().signature != expected_package_signature:
+            raise RuntimeError("skill package changed while building manifest")
+        return linked_files, {
+            "shown": shown,
+            "truncated": bool(truncated_categories),
+            "truncated_categories": truncated_categories,
+            "per_category_limit": MAX_LINKED_FILES_PER_CATEGORY,
+            "path_char_limit": MAX_LINKED_FILE_PATH_CHARS,
+        }
+
+    def _walk_bound_dir(
+        directory_fd: int,
+        prefix: str,
+        entries: List[str],
+    ) -> bool:
+        nonlocal shown, path_chars
+        before = _stat_signature(os.fstat(directory_fd))
+        truncated = False
+        with os.scandir(directory_fd) as iterator:
+            children = sorted(iterator, key=lambda entry: entry.name)
+        for entry in children:
+            entry_stat = entry.stat(follow_symlinks=False)
+            rel = f"{prefix}/{entry.name}"
+            if stat.S_ISLNK(entry_stat.st_mode):
+                continue
+            if stat.S_ISDIR(entry_stat.st_mode):
+                child_fd = os.open(
+                    entry.name,
+                    _bound_open_flags(directory=True),
+                    dir_fd=directory_fd,
+                )
+                try:
+                    if _walk_bound_dir(child_fd, rel, entries):
+                        truncated = True
+                        break
+                finally:
+                    os.close(child_fd)
+                continue
+            if not stat.S_ISREG(entry_stat.st_mode):
+                continue
+            if (
+                len(entries) >= MAX_LINKED_FILES_PER_CATEGORY
+                or path_chars + len(rel) > MAX_LINKED_FILE_PATH_CHARS
+            ):
+                truncated = True
+                break
+            entries.append(rel)
+            shown += 1
+            path_chars += len(rel)
+        if before != _stat_signature(os.fstat(directory_fd)):
+            raise RuntimeError("skill support directory changed during loading")
+        return truncated
+
+    for category in _LINKED_FILE_CATEGORIES:
+        try:
+            category_fd = os.open(
+                category,
+                _bound_open_flags(directory=True),
+                dir_fd=package_fd,
+            )
+        except OSError:
+            # Missing, inaccessible, and symlinked support categories are not
+            # part of the manifest, matching the historical path-based helper.
+            continue
+        try:
+            entries: List[str] = []
+            category_truncated = _walk_bound_dir(category_fd, category, entries)
+        finally:
+            os.close(category_fd)
+        if entries:
+            linked_files[category] = entries
+        if category_truncated:
+            truncated_categories.append(category)
+
+    if _stat_signature(os.fstat(package_fd)) != expected_package_signature:
+        raise RuntimeError("skill package changed during loading")
+    return linked_files, {
+        "shown": shown,
+        "truncated": bool(truncated_categories),
+        "truncated_categories": truncated_categories,
+        "per_category_limit": MAX_LINKED_FILES_PER_CATEGORY,
+        "path_char_limit": MAX_LINKED_FILE_PATH_CHARS,
+    }
+
+
+def _expand_inline_shell_bound(
+    content: str,
+    package_fd: Any,
+    timeout: int,
+    *,
+    skill_dir: Path,
+    session_id: Optional[str] = None,
+    template_vars: bool = True,
+) -> str:
+    """Expand inline shell without reopening the mutable package path.
+
+    Template variables in prose use the display path, while variables inside
+    commands use a stable handle-relative location. This distinction must be
+    made before command execution: globally substituting the package path and
+    rewriting it afterwards reintroduces a package-swap race.
+    """
+    from agent import skill_preprocessing
+
+    inline_shell_re = re.compile(r"!`([^`\n]+)`")
+
+    def _substitute_prose(value: str) -> str:
+        if not template_vars:
+            return value
+        pieces: List[str] = []
+        cursor = 0
+        for match in inline_shell_re.finditer(value):
+            pieces.append(
+                skill_preprocessing.substitute_template_vars(
+                    value[cursor:match.start()], skill_dir, session_id
+                )
+            )
+            pieces.append(match.group(0))
+            cursor = match.end()
+        pieces.append(
+            skill_preprocessing.substitute_template_vars(
+                value[cursor:], skill_dir, session_id
+            )
+        )
+        return "".join(pieces)
+
+    content = _substitute_prose(content)
+
+    snapshot_limits = {
+        "max_depth": 32,
+        "max_entries": 4096,
+        "max_file_bytes": 16 * 1024 * 1024,
+        "max_total_bytes": 64 * 1024 * 1024,
+    }
+
+    def _copy_posix_directory(
+        source_fd: int,
+        destination: Path,
+        *,
+        state: Optional[Dict[str, int]] = None,
+        depth: int = 0,
+    ) -> None:
+        if depth > snapshot_limits["max_depth"]:
+            raise OSError("skill snapshot exceeds the safe nesting limit")
+        if state is None:
+            state = {"entries": 0, "bytes": 0}
+        before = _stat_signature(os.fstat(source_fd))
+        destination.mkdir(mode=0o700)
+        for entry in os.scandir(source_fd):
+            state["entries"] += 1
+            if state["entries"] > snapshot_limits["max_entries"]:
+                raise OSError("skill snapshot exceeds the safe entry limit")
+            entry_stat = os.stat(
+                entry.name,
+                dir_fd=source_fd,
+                follow_symlinks=False,
+            )
+            target = destination / entry.name
+            if stat.S_ISDIR(entry_stat.st_mode):
+                child_fd = os.open(
+                    entry.name,
+                    _bound_open_flags(directory=True),
+                    dir_fd=source_fd,
+                )
+                try:
+                    if _stat_signature(os.fstat(child_fd)) != (
+                        _stat_signature(entry_stat)
+                    ):
+                        raise RuntimeError(
+                            "skill package changed while snapshotting"
+                        )
+                    _copy_posix_directory(
+                        child_fd,
+                        target,
+                        state=state,
+                        depth=depth + 1,
+                    )
+                finally:
+                    os.close(child_fd)
+                continue
+            if not stat.S_ISREG(entry_stat.st_mode):
+                raise OSError(
+                    f"refusing non-regular inline-shell input: {entry.name}"
+                )
+            file_fd = os.open(
+                entry.name,
+                _bound_open_flags(directory=False)
+                | getattr(os, "O_NONBLOCK", 0),
+                dir_fd=source_fd,
+            )
+            try:
+                file_before = os.fstat(file_fd)
+                if not stat.S_ISREG(file_before.st_mode):
+                    raise OSError(
+                        f"refusing non-regular inline-shell input: "
+                        f"{entry.name}"
+                    )
+                if _stat_signature(file_before) != _stat_signature(entry_stat):
+                    raise RuntimeError(
+                        "skill file changed while snapshotting"
+                    )
+                if file_before.st_size > snapshot_limits["max_file_bytes"]:
+                    raise OSError(
+                        f"skill snapshot file is too large: {entry.name}"
+                    )
+                with target.open("xb") as destination_file:
+                    copied = 0
+                    while True:
+                        chunk = os.read(file_fd, 64 * 1024)
+                        if not chunk:
+                            break
+                        copied += len(chunk)
+                        if (
+                            copied > snapshot_limits["max_file_bytes"]
+                            or state["bytes"] + copied
+                            > snapshot_limits["max_total_bytes"]
+                        ):
+                            raise OSError(
+                                "skill snapshot exceeds the safe byte limit"
+                            )
+                        destination_file.write(chunk)
+                if _stat_signature(os.fstat(file_fd)) != (
+                    _stat_signature(file_before)
+                ):
+                    raise RuntimeError(
+                        "skill file changed while snapshotting"
+                    )
+                state["bytes"] += copied
+                target.chmod(stat.S_IMODE(file_before.st_mode))
+            finally:
+                os.close(file_fd)
+        if _stat_signature(os.fstat(source_fd)) != before:
+            raise RuntimeError("skill package changed while snapshotting")
+
+    # Both platforms execute from a handle-derived snapshot. Besides avoiding
+    # path replacement, this keeps ${HERMES_SKILL_DIR} stable even when a
+    # command changes cwd before using it.
+    with tempfile.TemporaryDirectory(
+        prefix=".skill-inline-"
+    ) as temp_dir:
+        snapshot = Path(temp_dir) / "skill"
+        if os.name == "nt":
+            from tools.nt_secure_fs_optional import copy_tree_no_reparse
+
+            copy_tree_no_reparse(package_fd, snapshot)
+        else:
+            _copy_posix_directory(package_fd, snapshot)
+
+        snapshot_shell_path = (
+            str(snapshot).replace("\\", "/")
+            if os.name == "nt"
+            else str(snapshot)
+        )
+
+        def _escape_shell_value(
+            value: str,
+            *,
+            in_single_quote: bool,
+            in_double_quote: bool,
+        ) -> str:
+            if in_single_quote:
+                return value.replace("'", "'\"'\"'")
+            if in_double_quote:
+                return (
+                    value.replace("\\", "\\\\")
+                    .replace('"', '\\"')
+                    .replace("$", "\\$")
+                    .replace("`", "\\`")
+                )
+            return shlex.quote(value)
+
+        def _substitute_command_template_vars(command: str) -> str:
+            if not template_vars:
+                return command
+            values = {
+                "${HERMES_SKILL_DIR}": snapshot_shell_path,
+                "${HERMES_SESSION_ID}": (
+                    str(session_id) if session_id is not None else None
+                ),
+            }
+            rendered: List[str] = []
+            index = 0
+            in_single_quote = False
+            in_double_quote = False
+            escaped = False
+            while index < len(command):
+                matched_token = next(
+                    (
+                        token
+                        for token in values
+                        if command.startswith(token, index)
+                    ),
+                    None,
+                )
+                if matched_token is not None:
+                    value = values[matched_token]
+                    if value is None:
+                        rendered.append(matched_token)
+                    else:
+                        rendered.append(
+                            _escape_shell_value(
+                                value,
+                                in_single_quote=in_single_quote,
+                                in_double_quote=in_double_quote,
+                            )
+                        )
+                    index += len(matched_token)
+                    continue
+
+                character = command[index]
+                rendered.append(character)
+                if escaped:
+                    escaped = False
+                elif character == "\\" and not in_single_quote:
+                    escaped = True
+                elif character == "'" and not in_double_quote:
+                    in_single_quote = not in_single_quote
+                elif character == '"' and not in_single_quote:
+                    in_double_quote = not in_double_quote
+                index += 1
+            return "".join(rendered)
+
+        def _replace_command_literal_path(
+            command: str,
+            bound_path: str,
+        ) -> str:
+            rendered: List[str] = []
+            index = 0
+            in_single_quote = False
+            in_double_quote = False
+            escaped = False
+            bound_length = len(bound_path)
+            while index < len(command):
+                candidate = command[index:index + bound_length]
+                matches = (
+                    candidate.casefold() == bound_path.casefold()
+                    if os.name == "nt"
+                    else candidate == bound_path
+                )
+                if matches:
+                    rendered.append(
+                        _escape_shell_value(
+                            snapshot_shell_path,
+                            in_single_quote=in_single_quote,
+                            in_double_quote=in_double_quote,
+                        )
+                    )
+                    index += bound_length
+                    continue
+                character = command[index]
+                rendered.append(character)
+                if escaped:
+                    escaped = False
+                elif character == "\\" and not in_single_quote:
+                    escaped = True
+                elif character == "'" and not in_double_quote:
+                    in_single_quote = not in_single_quote
+                elif character == '"' and not in_single_quote:
+                    in_double_quote = not in_double_quote
+                index += 1
+            return "".join(rendered)
+
+        def _bind_command(match: re.Match) -> str:
+            command = match.group(1)
+            command = _substitute_command_template_vars(command)
+            # A skill may predate the template token and embed its own package
+            # path literally. Keep that legacy form bound too; otherwise a
+            # rename/recreate race can make `cd <skill_dir>` enter an attacker
+            # replacement even though cwd initially points at the snapshot.
+            bound_path_spellings = {str(skill_dir)}
+            if os.name == "nt":
+                bound_path_spellings.add(str(package_fd.final_path()))
+                bound_path_spellings.update(
+                    path.replace("\\", "/")
+                    for path in tuple(bound_path_spellings)
+                )
+            for bound_path in sorted(
+                bound_path_spellings, key=len, reverse=True
+            ):
+                command = _replace_command_literal_path(
+                    command, bound_path
+                )
+            return f"!`{command}`"
+
+        bound_content = inline_shell_re.sub(_bind_command, content)
+        expanded_content = skill_preprocessing.expand_inline_shell(
+            bound_content, snapshot, timeout
+        )
+        # Preserve the historical user-facing path in command output (notably
+        # `pwd`) without ever exposing that mutable path to command execution.
+        snapshot_spellings = {
+            str(snapshot),
+            str(snapshot.resolve()),
+            snapshot.as_posix(),
+        }
+        if os.name == "nt":
+            windows_snapshot = PureWindowsPath(snapshot)
+            if windows_snapshot.drive.endswith(":"):
+                drive = windows_snapshot.drive[0].lower()
+                posix_snapshot = windows_snapshot.as_posix()
+                snapshot_spellings.add(
+                    f"/{drive}{posix_snapshot[len(windows_snapshot.drive):]}"
+                )
+        for snapshot_spelling in sorted(
+            snapshot_spellings, key=len, reverse=True
+        ):
+            expanded_content = expanded_content.replace(
+                snapshot_spelling, str(skill_dir)
+            )
+        return expanded_content
 
 
 # All skills live in ~/.hermes/skills/ (seeded from bundled skills/ on install).
@@ -174,6 +922,11 @@ _REMOTE_ENV_BACKENDS = frozenset(
     {"docker", "singularity", "modal", "ssh", "daytona", "vercel_sandbox"}
 )
 _secret_capture_callback = None
+# Keep the historical process default for CLI callers, but isolate gateway
+# turns: multiple desktop sessions can ask for different secrets concurrently.
+_secret_capture_callback_context: ContextVar = ContextVar(
+    "skills_secret_capture_callback", default=None
+)
 
 
 def _skill_lookup_path_error(name: str) -> Optional[str]:
@@ -242,8 +995,23 @@ _INJECTION_PATTERNS: list = [
 
 
 def set_secret_capture_callback(callback) -> None:
+    """Set the legacy process-default callback (CLI compatibility)."""
     global _secret_capture_callback
     _secret_capture_callback = callback
+
+
+def set_secret_capture_callback_context(callback) -> Token:
+    """Install a secret callback for only the current thread/context."""
+    return _secret_capture_callback_context.set(callback)
+
+
+def reset_secret_capture_callback_context(token: Token) -> None:
+    """Restore the prior thread/context-local callback."""
+    _secret_capture_callback_context.reset(token)
+
+
+def _current_secret_capture_callback():
+    return _secret_capture_callback_context.get() or _secret_capture_callback
 
 
 def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
@@ -427,7 +1195,8 @@ def _capture_required_environment_variables(
             "gateway_setup_hint": _gateway_setup_hint(),
         }
 
-    if _secret_capture_callback is None:
+    callback = _current_secret_capture_callback()
+    if callback is None:
         return {
             "missing_names": missing_names,
             "setup_skipped": False,
@@ -445,7 +1214,7 @@ def _capture_required_environment_variables(
             metadata["required_for"] = entry["required_for"]
 
         try:
-            callback_result = _secret_capture_callback(
+            callback_result = callback(
                 entry["name"],
                 entry["prompt"],
                 metadata,
@@ -683,27 +1452,91 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     """
     from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
 
-    cache_key = _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
+    cache_kind = (
+        _SKILLS_CACHE_KEY_DISABLED
+        if skip_disabled
+        else _SKILLS_CACHE_KEY_FILTERED
+    )
 
     # Load disabled set once (not per-skill). Part of the cache signature:
     # disabling a skill is a config change with no filesystem mtime bump.
     disabled = set() if skip_disabled else _get_disabled_skill_names()
 
+    scan_incomplete = False
+    external_root_failed = False
+
+    def _mark_scan_incomplete(error) -> None:
+        nonlocal scan_incomplete
+        scan_incomplete = True
+        logger.debug("Skills discovery scan incomplete: %s", error)
+
     # Collect directories to scan — same resolution as the scan loop below
     # (_skills_dir() resolves the LIVE profile HERMES_HOME; the module-level
-    # SKILLS_DIR can be stale in long-lived runtimes).
+    # SKILLS_DIR can be stale in long-lived runtimes). Keep the active root in
+    # the cache scope even when it cannot be stat'ed: otherwise an I/O error
+    # can silently turn a local+external catalog into an external-only cache.
     dirs_to_scan: list = []
     active_skills_dir = _skills_dir()
-    if active_skills_dir.exists():
-        dirs_to_scan.append(active_skills_dir)
-    dirs_to_scan.extend(get_external_skills_dirs())
+    scope_dirs: list = [active_skills_dir]
+    try:
+        active_stat = active_skills_dir.stat()
+    except FileNotFoundError:
+        # A missing local skills root is an ordinary empty catalog, not a
+        # partial scan. skills_list creates it later when appropriate.
+        pass
+    except OSError as exc:
+        _mark_scan_incomplete(exc)
+    else:
+        if stat.S_ISDIR(active_stat.st_mode):
+            dirs_to_scan.append(active_skills_dir)
+        else:
+            _mark_scan_incomplete(
+                NotADirectoryError(
+                    f"Local skills root is not a directory: {active_skills_dir}"
+                )
+            )
 
-    signature = _skills_scan_signature(dirs_to_scan, disabled)
+    external_dirs = get_external_skills_dirs()
+    scope_dirs.extend(external_dirs)
+    for external_dir in external_dirs:
+        try:
+            external_stat = external_dir.stat()
+        except OSError as exc:
+            external_root_failed = True
+            _mark_scan_incomplete(exc)
+            continue
+        if not stat.S_ISDIR(external_stat.st_mode):
+            external_root_failed = True
+            _mark_scan_incomplete(
+                NotADirectoryError(
+                    f"External skills root is not a directory: {external_dir}"
+                )
+            )
+            continue
+        dirs_to_scan.append(external_dir)
+
+    # Keep last-good results scoped to the exact discovery inputs. In
+    # particular, a failed scan after a profile/root switch must never return
+    # the old profile's skills just because both use the same cache kind.
+    from agent import skill_utils as _skill_utils
+
+    platform = getattr(getattr(_skill_utils, "sys", None), "platform", "")
+    cache_key = (
+        cache_kind,
+        tuple(str(directory) for directory in scope_dirs),
+        frozenset(disabled),
+        platform,
+        _skill_utils.get_skill_environment_fingerprint(),
+    )
+    signature = _skills_scan_signature(
+        dirs_to_scan, disabled, on_error=_mark_scan_incomplete
+    )
     now = time.monotonic()
 
     cached = _SKILLS_CACHE.get(cache_key)
     if (
-        cached is not None
+        not scan_incomplete
+        and cached is not None
         and cached[0] == signature
         and (now - cached[1]) < _SKILLS_CACHE_TTL_SECONDS
     ):
@@ -718,15 +1551,19 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Scan local dir first, then external dirs (local takes precedence) —
     # dirs_to_scan already resolved above for the signature.
     for scan_dir in dirs_to_scan:
-        for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
+        for skill_md in iter_skill_index_files(
+            scan_dir, "SKILL.md", on_error=_mark_scan_incomplete
+        ):
             if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
                 continue
 
             skill_dir = skill_md.parent
 
             try:
-                content = skill_md.read_text(encoding="utf-8")[:4000]
-                frontmatter, body = _parse_frontmatter(content)
+                # Do not follow a canonical SKILL.md symlink.  A package may
+                # be discovered through a configured category symlink, but
+                # its active entry file itself must remain in that package.
+                _, frontmatter, body = read_strict_skill_index_file(skill_md)
 
                 if not skill_matches_platform(frontmatter):
                     continue
@@ -762,12 +1599,27 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
             except (UnicodeDecodeError, PermissionError) as e:
                 logger.debug("Failed to read skill file %s: %s", skill_md, e)
+                _mark_scan_incomplete(e)
                 continue
             except Exception as e:
                 logger.debug(
                     "Skipping skill at %s: failed to parse: %s", skill_md, e, exc_info=True
                 )
+                _mark_scan_incomplete(e)
                 continue
+
+    if scan_incomplete:
+        # Do not cache a catalog that omitted a directory or file. A same-scope
+        # completed catalog is safe to serve until the transient failure clears;
+        # otherwise return no listing rather than a misleading partial one.
+        # A configured external root that is itself unavailable is stricter:
+        # advertising its old entries is not a usable catalog, so fail closed
+        # even when an exact-scope cache exists.
+        if external_root_failed:
+            return []
+        if cached is not None:
+            return [dict(s) for s in cached[2]]
+        return []
 
     # Store in cache keyed by the scan signature computed BEFORE the scan
     # (a write racing the scan changes the signature, so the next call
@@ -798,17 +1650,33 @@ def skills_list(category: str = None, task_id: str = None) -> str:
     """
     try:
         active_skills_dir = _skills_dir()
-        if not active_skills_dir.exists():
+        _external_roots, external_root_error = _validate_configured_external_roots()
+        if external_root_error is not None:
+            return json.dumps(external_root_error, ensure_ascii=False)
+        try:
+            active_stat = active_skills_dir.stat()
+        except FileNotFoundError:
             active_skills_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
             return json.dumps(
                 {
-                    "success": True,
-                    "skills": [],
-                    "categories": [],
-                    "message": f"No skills found. Skills directory created at {display_hermes_home()}/skills/",
+                    "success": False,
+                    "error_code": "skills_discovery_incomplete",
+                    "error": f"Local skills root is unavailable: {active_skills_dir}",
+                    "detail": str(exc),
                 },
                 ensure_ascii=False,
             )
+        else:
+            if not stat.S_ISDIR(active_stat.st_mode):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error_code": "skills_discovery_incomplete",
+                        "error": f"Local skills root is not a directory: {active_skills_dir}",
+                    },
+                    ensure_ascii=False,
+                )
 
         # Find all skills
         all_skills = _find_all_skills()
@@ -859,10 +1727,17 @@ def _serve_plugin_skill(
     namespace: str,
     bare: str,
     *,
+    file_path: str | None = None,
     preprocess: bool = True,
     session_id: str | None = None,
 ) -> str:
-    """Read a plugin-provided skill, apply guards, return JSON."""
+    """Read a plugin skill through a bound package snapshot.
+
+    Plugin registry entries are paths, not capabilities.  Never use the
+    registry path for a later ``read_text``/preprocessor cwd: a directory or
+    symlink replacement between those operations could otherwise serve one
+    package and execute another.
+    """
     from hermes_cli.plugins import _get_disabled_plugins, get_plugin_manager
 
     if namespace in _get_disabled_plugins():
@@ -877,19 +1752,76 @@ def _serve_plugin_skill(
             ensure_ascii=False,
         )
 
-    try:
-        content = skill_md.read_text(encoding="utf-8")
-    except Exception as e:
+    if not _SECURE_PACKAGE_OPEN_SUPPORTED:
         return json.dumps(
-            {"success": False, "error": f"Failed to read skill '{namespace}:{bare}': {e}"},
+            {
+                "success": False,
+                "error": (
+                    "Secure plugin-skill package binding is unsupported on "
+                    "this platform; refusing inline-capable plugin skill."
+                ),
+            },
             ensure_ascii=False,
         )
 
-    parsed_frontmatter: Dict[str, Any] = {}
     try:
-        parsed_frontmatter, _ = _parse_frontmatter(content)
-    except Exception:
-        pass
+        # Resolve once, then bind the resolved directory with O_NOFOLLOW and
+        # compare the descriptor identity to the pre-open snapshot.  This is
+        # the same package-identity contract as local skill_view.
+        package_path = skill_md.parent.resolve(strict=True)
+        package_signature = _package_signature(package_path)
+        package_fd = _open_bound_package_dir(package_path, package_signature)
+        try:
+            skill_bytes, _ = _read_bound_support_file(
+                package_fd, skill_md.name, package_signature
+            )
+            content = skill_bytes.decode("utf-8")
+            linked_files, linked_files_summary = _build_bound_linked_files_manifest(
+                package_fd, package_signature
+            )
+            support_bytes = None
+            support_stat = None
+            support_error = None
+            if file_path:
+                try:
+                    support_bytes, support_stat = _read_bound_support_file(
+                        package_fd,
+                        file_path,
+                        package_signature,
+                    )
+                except Exception as exc:
+                    support_error = exc
+        finally:
+            _close_bound_handle(package_fd)
+    except Exception as e:
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    f"Failed to bind skill '{namespace}:{bare}' to its "
+                    f"package snapshot: {e}"
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    try:
+        parsed_frontmatter, _ = parse_strict_fenced_frontmatter(content)
+        if parsed_frontmatter:
+            # Retain parser compatibility side effects without accepting its
+            # permissive malformed-YAML fallback as the authority.
+            _parse_frontmatter(content)
+    except Exception as e:
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    f"Plugin skill '{namespace}:{bare}' has invalid "
+                    f"frontmatter: {e}"
+                ),
+            },
+            ensure_ascii=False,
+        )
 
     if not skill_matches_platform(parsed_frontmatter):
         return json.dumps(
@@ -897,6 +1829,52 @@ def _serve_plugin_skill(
                 "success": False,
                 "error": f"Skill '{namespace}:{bare}' is not supported on this platform.",
                 "readiness_status": SkillReadinessStatus.UNSUPPORTED.value,
+            },
+            ensure_ascii=False,
+        )
+
+    if file_path:
+        if support_error is not None or support_bytes is None or support_stat is None:
+            available = [
+                entry
+                for entries in linked_files.values()
+                for entry in entries
+            ]
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"File '{file_path}' is not safely readable within "
+                        f"plugin skill '{namespace}:{bare}': {support_error}"
+                    ),
+                    "available_files": available,
+                    "linked_files_summary": linked_files_summary,
+                },
+                ensure_ascii=False,
+            )
+        try:
+            support_content = support_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            return json.dumps(
+                {
+                    "success": True,
+                    "name": f"{namespace}:{bare}",
+                    "file": file_path,
+                    "content": (
+                        f"[Binary file: {PurePosixPath(file_path).name}, "
+                        f"size: {support_stat.st_size} bytes]"
+                    ),
+                    "is_binary": True,
+                },
+                ensure_ascii=False,
+            )
+        return json.dumps(
+            {
+                "success": True,
+                "name": f"{namespace}:{bare}",
+                "file": file_path,
+                "content": support_content,
+                "file_type": PurePosixPath(file_path.replace("\\", "/")).suffix,
             },
             ensure_ascii=False,
         )
@@ -933,16 +1911,43 @@ def _serve_plugin_skill(
     rendered_content = content
     if preprocess:
         try:
-            from agent.skill_preprocessing import preprocess_skill_content
+            from agent import skill_preprocessing
 
-            rendered_content = preprocess_skill_content(
-                content,
-                skill_md.parent,
-                session_id=session_id,
+            preprocessing_config = skill_preprocessing.load_skills_config()
+            (
+                template_vars_enabled,
+                inline_shell_enabled,
+                timeout,
+            ) = skill_preprocessing.normalize_preprocessing_config(
+                preprocessing_config
             )
-        except Exception:
-            logger.debug(
-                "Could not preprocess plugin skill %s:%s", namespace, bare, exc_info=True
+            if inline_shell_enabled:
+                package_fd = _open_bound_package_dir(package_path, package_signature)
+                try:
+                    rendered_content = _expand_inline_shell_bound(
+                        rendered_content,
+                        package_fd,
+                        timeout,
+                        skill_dir=package_path,
+                        session_id=session_id,
+                        template_vars=template_vars_enabled,
+                    )
+                finally:
+                    _close_bound_handle(package_fd)
+            elif template_vars_enabled:
+                rendered_content = skill_preprocessing.substitute_template_vars(
+                    rendered_content, package_path, session_id
+                )
+        except Exception as e:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"Could not preprocess plugin skill {namespace}:{bare} "
+                        f"from its bound package: {e}"
+                    ),
+                },
+                ensure_ascii=False,
             )
 
     return json.dumps(
@@ -951,7 +1956,12 @@ def _serve_plugin_skill(
             "name": f"{namespace}:{bare}",
             "content": f"{banner}{rendered_content}" if banner else rendered_content,
             "description": description,
-            "linked_files": None,
+            "skill_dir": str(package_path),
+            "lookup_name": f"{namespace}:{bare}",
+            "package_bound": True,
+            "preprocessed": bool(preprocess),
+            "linked_files": linked_files or None,
+            "linked_files_summary": linked_files_summary,
             "readiness_status": SkillReadinessStatus.AVAILABLE.value,
         },
         ensure_ascii=False,
@@ -973,8 +1983,7 @@ def skill_view(
         file_path: Optional path to a specific file within the skill (e.g., "references/api.md")
         task_id: Optional task identifier used to probe the active backend
         preprocess: Apply configured SKILL.md template and inline shell rendering
-            to main skill content. Internal slash/preload callers disable this
-            because they render the skill message themselves.
+            to main skill content while its package snapshot remains bound.
 
     Returns:
         JSON string with skill content or error message
@@ -1040,6 +2049,7 @@ def skill_view(
                     plugin_skill_md,
                     namespace,
                     bare,
+                    file_path=file_path,
                     preprocess=preprocess,
                     session_id=task_id,
                 )
@@ -1063,8 +2073,6 @@ def skill_view(
             if bare:
                 local_category_name = f"{namespace}/{bare}"
 
-        from agent.skill_utils import get_external_skills_dirs
-
         # The categorized fall-through form (namespace/bare) joins onto each
         # search dir too; re-validate it since `bare` is not namespace-checked.
         if local_category_name:
@@ -1079,12 +2087,41 @@ def skill_view(
                     ensure_ascii=False,
                 )
 
-        # Build list of all skill directories to search
+        # Build list of all skill directories to search. Validate the complete
+        # configured external scope before looking for a local match; otherwise
+        # a missing external root could hide a collision and load the wrong
+        # skill.
         all_dirs = []
         active_skills_dir = _skills_dir()
-        if active_skills_dir.exists():
+        try:
+            active_stat = active_skills_dir.stat()
+        except FileNotFoundError:
+            active_stat = None
+        except OSError as exc:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error_code": "skills_discovery_incomplete",
+                    "error": f"Local skills root is unavailable: {active_skills_dir}",
+                    "detail": str(exc),
+                },
+                ensure_ascii=False,
+            )
+        if active_stat is not None and not stat.S_ISDIR(active_stat.st_mode):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error_code": "skills_discovery_incomplete",
+                    "error": f"Local skills root is not a directory: {active_skills_dir}",
+                },
+                ensure_ascii=False,
+            )
+        if active_stat is not None:
             all_dirs.append(active_skills_dir)
-        all_dirs.extend(get_external_skills_dirs())
+        external_dirs, external_root_error = _validate_configured_external_roots()
+        if external_root_error is not None:
+            return json.dumps(external_root_error, ensure_ascii=False)
+        all_dirs.extend(external_dirs)
 
         if not all_dirs:
             return json.dumps(
@@ -1106,81 +2143,273 @@ def skill_view(
         # loaded the other) so we surface it loudly instead of guessing.
         from agent.skill_utils import iter_skill_index_files
 
-        candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
-        seen_md: set = set()
+        # Bind candidates to the exact regular-file bytes inspected during
+        # discovery. Configured roots may legitimately be directory symlinks,
+        # but a symlink/package swap must not redirect the later load.
+        candidates: List[Tuple[Optional[Path], Path, Dict[str, Any]]] = []
+        seen_file_identities: Dict[Tuple[int, ...], Dict[str, Any]] = {}
+        seen_path_identities: Dict[str, Tuple[int, ...]] = {}
+        discovery_errors: List[str] = []
 
-        def _record(sd: Optional[Path], smd: Path) -> None:
+        def _record_discovery_error(context: str, exc: BaseException) -> None:
+            """Remember a scan failure instead of accepting a partial index."""
+            detail = f"{context}: {exc}"
+            if detail not in discovery_errors:
+                discovery_errors.append(detail)
+
+        def _is_directory_for_discovery(path: Path, context: str) -> bool:
             try:
-                key = smd.resolve()
-            except Exception:
-                key = smd
-            if key in seen_md:
+                return stat.S_ISDIR(path.stat().st_mode)
+            except FileNotFoundError:
+                return False
+            except OSError as exc:
+                _record_discovery_error(context, exc)
+                return False
+
+        def _is_regular_file_for_discovery(path: Path, context: str) -> bool:
+            try:
+                return stat.S_ISREG(path.stat().st_mode)
+            except FileNotFoundError:
+                return False
+            except OSError as exc:
+                _record_discovery_error(context, exc)
+                return False
+
+        def _read_discovery_snapshot(path: Path) -> Optional[Dict[str, Any]]:
+            """Open, strictly parse, and identity-bind one skill index file."""
+            try:
+                if os.name == "nt":
+                    from tools.nt_secure_fs_optional import (
+                        open_directory,
+                        read_regular_file,
+                    )
+
+                    package_path = path.parent.resolve(strict=True)
+                    with open_directory(
+                        package_path, writable=False
+                    ) as package:
+                        parent_metadata = package.stat()
+                        payload, file_metadata = read_regular_file(
+                            package, path.name
+                        )
+                        fm_content = payload.decode("utf-8")
+                        fm, _ = parse_strict_fenced_frontmatter(fm_content)
+                        if fm:
+                            _parse_frontmatter(fm_content)
+
+                        # The supported configured/category alias must still
+                        # resolve to the held package after parsing, and its
+                        # canonical file must still be the object read above.
+                        current_package_path = path.parent.resolve(strict=True)
+                        with open_directory(
+                            current_package_path, writable=False
+                        ) as current_package:
+                            if (
+                                current_package.identity
+                                != parent_metadata.identity
+                            ):
+                                raise RuntimeError(
+                                    "skill package changed during discovery"
+                                )
+                            with current_package.open_file(
+                                path.name, writable=False
+                            ) as current_file:
+                                if (
+                                    current_file.identity
+                                    != file_metadata.identity
+                                ):
+                                    raise RuntimeError(
+                                        "skill file changed during discovery"
+                                    )
+                        return {
+                            "content": fm_content,
+                            "frontmatter": fm,
+                            "identity": file_metadata.identity,
+                            "package_signature": parent_metadata.signature,
+                            "package_path": str(package_path),
+                            "signature": file_metadata.signature,
+                        }
+
+                parent_before = path.parent.stat()
+                if not stat.S_ISDIR(parent_before.st_mode):
+                    raise ValueError("skill package is not a directory")
+                if not hasattr(os, "O_NOFOLLOW"):
+                    raise OSError("secure SKILL.md opens are unsupported on this platform")
+                flags = os.O_RDONLY | os.O_NOFOLLOW
+                if hasattr(os, "O_CLOEXEC"):
+                    flags |= os.O_CLOEXEC
+                fd = os.open(path, flags)
+                try:
+                    before = os.fstat(fd)
+                    if not stat.S_ISREG(before.st_mode):
+                        raise ValueError("skill index is not a regular file")
+                    with os.fdopen(
+                        fd, "r", encoding="utf-8", closefd=False
+                    ) as skill_file:
+                        fm_content = skill_file.read()
+                    after = os.fstat(fd)
+                finally:
+                    os.close(fd)
+
+                signature = _stat_signature(before)
+                if signature != _stat_signature(after):
+                    raise RuntimeError("skill file changed during discovery")
+
+                # ``parse_frontmatter`` intentionally has a permissive
+                # key/value fallback for non-discovery callers. A malformed
+                # fence cannot claim a directory-derived active-skill name.
+                fm, _ = parse_strict_fenced_frontmatter(fm_content)
+                if fm:
+                    _parse_frontmatter(fm_content)
+
+                # Re-resolve after parsing too: compatibility hooks or a racing
+                # writer may rename a path while its bytes are being inspected.
+                current_parent = path.parent.stat()
+                parent_signature = (
+                    parent_before.st_dev,
+                    parent_before.st_ino,
+                    parent_before.st_size,
+                    parent_before.st_mtime_ns,
+                    parent_before.st_ctime_ns,
+                )
+                if (
+                    signature != _stat_signature(path.stat())
+                    or parent_signature != _stat_signature(current_parent)
+                ):
+                    raise RuntimeError("skill file changed during discovery")
+                package_path = path.parent.resolve(strict=True)
+                if parent_signature != _stat_signature(package_path.stat()):
+                    raise RuntimeError("skill package changed during discovery")
+
+                return {
+                    "content": fm_content,
+                    "frontmatter": fm,
+                    "identity": (before.st_dev, before.st_ino),
+                    "package_signature": parent_signature,
+                    "package_path": str(package_path),
+                    "signature": signature,
+                }
+            except Exception as exc:
+                _record_discovery_error(f"cannot inspect {path}", exc)
+                return None
+
+        def _record_direct_candidate(search_dir: Path, relative_name: str) -> None:
+            direct_path = search_dir / relative_name
+            if not _is_skill_support_path(direct_path) and _is_directory_for_discovery(
+                direct_path, f"cannot stat skill directory {direct_path}"
+            ):
+                direct_skill_md = direct_path / "SKILL.md"
+                if _is_regular_file_for_discovery(
+                    direct_skill_md, f"cannot stat skill file {direct_skill_md}"
+                ):
+                    _record(direct_path, direct_skill_md)
                 return
-            seen_md.add(key)
-            candidates.append((sd, smd))
+            legacy_path = direct_path.with_suffix(".md")
+            if not _is_skill_support_path(legacy_path) and _is_regular_file_for_discovery(
+                legacy_path, f"cannot stat legacy skill file {legacy_path}"
+            ):
+                _record(None, legacy_path)
+
+        def _record(
+            sd: Optional[Path],
+            smd: Path,
+            snapshot: Optional[Dict[str, Any]] = None,
+        ) -> None:
+            if snapshot is None:
+                snapshot = _read_discovery_snapshot(smd)
+            if snapshot is None:
+                return
+
+            identity = snapshot["identity"] + snapshot["package_signature"]
+            lexical_path = os.path.abspath(os.fspath(smd))
+            previous_path_identity = seen_path_identities.get(lexical_path)
+            if (
+                previous_path_identity is not None
+                and previous_path_identity != identity
+            ):
+                _record_discovery_error(
+                    f"cannot inspect {smd}",
+                    RuntimeError("skill file changed during discovery"),
+                )
+                return
+            seen_path_identities[lexical_path] = identity
+
+            previous = seen_file_identities.get(identity)
+            if previous is not None:
+                if (
+                    previous["signature"] != snapshot["signature"]
+                    or previous["content"] != snapshot["content"]
+                ):
+                    _record_discovery_error(
+                        f"cannot inspect {smd}",
+                        RuntimeError("skill file changed during discovery"),
+                    )
+                return
+
+            seen_file_identities[identity] = snapshot
+            candidates.append((sd, smd, snapshot))
 
         for search_dir in all_dirs:
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
             # at the top of the dir).
-            direct_path = search_dir / name
-            if (
-                not _is_skill_support_path(direct_path)
-                and direct_path.is_dir()
-                and (direct_path / "SKILL.md").exists()
-            ):
-                _record(direct_path, direct_path / "SKILL.md")
-            elif direct_path.with_suffix(".md").exists() and not _is_skill_support_path(
-                direct_path.with_suffix(".md")
-            ):
-                _record(None, direct_path.with_suffix(".md"))
+            _record_direct_candidate(search_dir, name)
 
             # Strategy 1b: categorized form for plugin namespace fall-through
             # (e.g., a "myplugin:explore" name with no plugin registered also
             # tries the on-disk path "myplugin/explore").
             if local_category_name:
-                categorized_path = search_dir / local_category_name
-                if (
-                    not _is_skill_support_path(categorized_path)
-                    and categorized_path.is_dir()
-                    and (categorized_path / "SKILL.md").exists()
-                ):
-                    _record(categorized_path, categorized_path / "SKILL.md")
-                elif categorized_path.with_suffix(
-                    ".md"
-                ).exists() and not _is_skill_support_path(
-                    categorized_path.with_suffix(".md")
-                ):
-                    _record(None, categorized_path.with_suffix(".md"))
+                _record_direct_candidate(search_dir, local_category_name)
 
             # Strategy 2: recursive by directory name (catches nested skills
             # like "foundations/runtime/explore-codebase" called by bare name),
             # plus frontmatter `name:` lookup. `skills_list()` exposes the
             # frontmatter name, so `skill_view(name)` must accept it too even
             # when the on-disk directory is a shorter category/alias.
-            for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
-                if found_skill_md.parent.name == name:
-                    _record(found_skill_md.parent, found_skill_md)
+            for found_skill_md in iter_skill_index_files(
+                search_dir,
+                "SKILL.md",
+                on_error=lambda exc, root=search_dir: _record_discovery_error(
+                    f"cannot traverse skills root {root}", exc
+                ),
+            ):
+                snapshot = _read_discovery_snapshot(found_skill_md)
+                if snapshot is None:
                     continue
-                try:
-                    fm_content = found_skill_md.read_text(encoding="utf-8")
-                    fm, _ = _parse_frontmatter(fm_content)
-                except Exception:
-                    fm = {}
-                if fm.get("name") == name:
-                    _record(found_skill_md.parent, found_skill_md)
+                fm = snapshot["frontmatter"]
+                if found_skill_md.parent.name == name or fm.get("name") == name:
+                    _record(found_skill_md.parent, found_skill_md, snapshot)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
             # Exclude skill support docs: references/templates/assets/scripts
             # are loaded through skill_view(skill, file_path=...) and must not
             # shadow or collide with real skills that share the same basename.
-            for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md" and not _is_skill_support_path(
-                    found_md
-                ):
-                    _record(None, found_md)
+            try:
+                for found_md in search_dir.rglob(f"{name}.md"):
+                    if found_md.name != "SKILL.md" and not _is_skill_support_path(
+                        found_md
+                    ):
+                        _record(None, found_md)
+            except OSError as exc:
+                _record_discovery_error(
+                    f"cannot traverse legacy skills under {search_dir}", exc
+                )
+
+        if discovery_errors:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error_code": "skills_discovery_incomplete",
+                    "error": (
+                        "Skill discovery is incomplete; refusing to load a "
+                        "partial match."
+                    ),
+                    "detail": "; ".join(discovery_errors[:3]),
+                },
+                ensure_ascii=False,
+            )
 
         if len(candidates) > 1:
-            paths = [str(smd) for _, smd in candidates]
+            paths = [str(smd) for _, smd, _ in candidates]
             logging.getLogger(__name__).warning(
                 "Skill name collision for '%s': %d candidates — %s",
                 name, len(candidates), "; ".join(paths),
@@ -1204,9 +2433,9 @@ def skill_view(
             )
 
         if candidates:
-            skill_dir, skill_md = candidates[0]
+            skill_dir, skill_md, discovered_snapshot = candidates[0]
 
-        if not skill_md or not skill_md.exists():
+        if not skill_md:
             available = [s["name"] for s in _sort_skills(_find_all_skills())[:20]]
             return json.dumps(
                 {
@@ -1218,14 +2447,60 @@ def skill_view(
                 ensure_ascii=False,
             )
 
-        # Read the file once — reused for platform check and main content below
-        try:
-            content = skill_md.read_text(encoding="utf-8")
-        except Exception as e:
+        # Re-open once after the complete-root collision scan and require the
+        # same identity, metadata, and bytes. The resulting snapshot supplies
+        # both metadata and content below; there is no redirectable final read.
+        final_snapshot = _read_discovery_snapshot(skill_md)
+        if final_snapshot is None:
             return json.dumps(
                 {
                     "success": False,
-                    "error": f"Failed to read skill '{name}': {e}",
+                    "error_code": "skills_discovery_incomplete",
+                    "error": (
+                        "Skill discovery is incomplete; refusing to load a "
+                        "partial match."
+                    ),
+                    "detail": "; ".join(discovery_errors[-3:]),
+                },
+                ensure_ascii=False,
+            )
+        if (
+            final_snapshot["identity"] != discovered_snapshot["identity"]
+            or final_snapshot["package_signature"]
+            != discovered_snapshot["package_signature"]
+            or final_snapshot["package_path"] != discovered_snapshot["package_path"]
+            or final_snapshot["signature"] != discovered_snapshot["signature"]
+            or final_snapshot["content"] != discovered_snapshot["content"]
+        ):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error_code": "skills_discovery_incomplete",
+                    "error": (
+                        "Skill discovery is incomplete; refusing to load a "
+                        "partial match."
+                    ),
+                    "detail": (
+                        f"cannot inspect {skill_md}: "
+                        "skill file changed during discovery"
+                    ),
+                },
+                ensure_ascii=False,
+            )
+
+        content = final_snapshot["content"]
+        bound_skill_dir = Path(final_snapshot["package_path"])
+
+        def _post_discovery_incomplete(detail: str) -> str:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error_code": "skills_discovery_incomplete",
+                    "error": (
+                        "Skill discovery is incomplete; refusing to load a "
+                        "partial match."
+                    ),
+                    "detail": detail,
                 },
                 ensure_ascii=False,
             )
@@ -1259,11 +2534,7 @@ def skill_view(
                 _warnings.append("skill content contains patterns that may indicate prompt injection")
             logging.getLogger(__name__).warning("Skill security warning for '%s': %s", name, "; ".join(_warnings))
 
-        parsed_frontmatter: Dict[str, Any] = {}
-        try:
-            parsed_frontmatter, _ = _parse_frontmatter(content)
-        except Exception:
-            parsed_frontmatter = {}
+        parsed_frontmatter: Dict[str, Any] = final_snapshot["frontmatter"]
 
         if not skill_matches_platform(parsed_frontmatter):
             return json.dumps(
@@ -1291,81 +2562,87 @@ def skill_view(
 
         # If a specific file path is requested, read that instead
         if file_path and skill_dir:
-            from tools.path_security import validate_within_dir, has_traversal_component
-
-            # Security: Prevent path traversal attacks
-            if has_traversal_component(file_path):
-                return json.dumps(
-                    {
-                        "success": False,
-                        "error": "Path traversal ('..') is not allowed.",
-                        "hint": "Use a relative path within the skill directory",
-                    },
-                    ensure_ascii=False,
-                )
-
-            target_file = skill_dir / file_path
-
-            # Security: Verify resolved path is still within skill directory
-            traversal_error = validate_within_dir(target_file, skill_dir)
-            if traversal_error:
-                return json.dumps(
-                    {
-                        "success": False,
-                        "error": traversal_error,
-                        "hint": "Use a relative path within the skill directory",
-                    },
-                    ensure_ascii=False,
-                )
-            if not target_file.exists():
-                # List available files in the skill directory, organized by type
-                available_files = {
-                    "references": [],
-                    "templates": [],
-                    "assets": [],
-                    "scripts": [],
-                    "other": [],
-                }
-
-                # Scan for all readable files
-                for f in skill_dir.rglob("*"):
-                    if f.is_file() and f.name != "SKILL.md":
-                        rel = str(f.relative_to(skill_dir))
-                        if rel.startswith("references/"):
-                            available_files["references"].append(rel)
-                        elif rel.startswith("templates/"):
-                            available_files["templates"].append(rel)
-                        elif rel.startswith("assets/"):
-                            available_files["assets"].append(rel)
-                        elif rel.startswith("scripts/"):
-                            available_files["scripts"].append(rel)
-                        elif f.suffix in {
-                            ".md",
-                            ".py",
-                            ".yaml",
-                            ".yml",
-                            ".json",
-                            ".tex",
-                            ".sh",
-                        }:
-                            available_files["other"].append(rel)
-
-                # Remove empty categories
-                available_files = {k: v for k, v in available_files.items() if v}
-
-                return json.dumps(
-                    {
-                        "success": False,
-                        "error": f"File '{file_path}' not found in skill '{name}'.",
-                        "available_files": available_files,
-                        "hint": "Use one of the available file paths listed above",
-                    },
-                    ensure_ascii=False,
-                )
-
-            # Read the file content
             try:
-                content = target_file.read_text(encoding="utf-8")
+                relative_parts = _bound_relative_parts(file_path)
+            except ValueError as exc:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": str(exc),
+                        "hint": "Use a relative path within the skill directory",
+                    },
+                    ensure_ascii=False,
+                )
+
+            try:
+                package_fd = _open_bound_package_dir(
+                    bound_skill_dir,
+                    final_snapshot["package_signature"],
+                )
+            except Exception as exc:
+                return _post_discovery_incomplete(
+                    f"cannot bind skill package {bound_skill_dir}: {exc}"
+                )
+            try:
+                try:
+                    support_bytes, support_stat = _read_bound_support_file(
+                        package_fd,
+                        file_path,
+                        final_snapshot["package_signature"],
+                    )
+                except FileNotFoundError:
+                    try:
+                        available_files, files_summary = (
+                            _build_bound_linked_files_manifest(
+                                package_fd,
+                                final_snapshot["package_signature"],
+                            )
+                        )
+                    except Exception as exc:
+                        return _post_discovery_incomplete(
+                            f"cannot inspect skill package {bound_skill_dir}: {exc}"
+                        )
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": (
+                                f"File '{file_path}' not found in skill '{name}'."
+                            ),
+                            "available_files": available_files or None,
+                            "linked_files_summary": files_summary,
+                            "hint": "Use one of the available file paths listed above",
+                        },
+                        ensure_ascii=False,
+                    )
+                except OSError as exc:
+                    if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                        return json.dumps(
+                            {
+                                "success": False,
+                                "error": (
+                                    "Path escapes the allowed directory "
+                                    "boundary or traverses a symlink."
+                                ),
+                                "hint": (
+                                    "Use a regular file path within the skill "
+                                    "directory"
+                                ),
+                            },
+                            ensure_ascii=False,
+                        )
+                    return _post_discovery_incomplete(
+                        f"cannot read support file '{file_path}': {exc}"
+                    )
+                except Exception as exc:
+                    return _post_discovery_incomplete(
+                        f"cannot read support file '{file_path}': {exc}"
+                    )
+            finally:
+                _close_bound_handle(package_fd)
+
+            target_file = bound_skill_dir.joinpath(*relative_parts)
+            try:
+                support_content = support_bytes.decode("utf-8")
             except UnicodeDecodeError:
                 # Binary file - return info about it instead
                 return json.dumps(
@@ -1373,7 +2650,10 @@ def skill_view(
                         "success": True,
                         "name": name,
                         "file": file_path,
-                        "content": f"[Binary file: {target_file.name}, size: {target_file.stat().st_size} bytes]",
+                        "content": (
+                            f"[Binary file: {relative_parts[-1]}, "
+                            f"size: {support_stat.st_size} bytes]"
+                        ),
                         "is_binary": True,
                     },
                     ensure_ascii=False,
@@ -1395,8 +2675,8 @@ def skill_view(
                     "success": True,
                     "name": name,
                     "file": file_path,
-                    "content": content,
-                    "file_type": target_file.suffix,
+                    "content": support_content,
+                    "file_type": PurePosixPath(file_path.replace("\\", "/")).suffix,
                 },
                 ensure_ascii=False,
             )
@@ -1404,50 +2684,39 @@ def skill_view(
         # Reuse the parse from the platform check above
         frontmatter = parsed_frontmatter
 
-        # Get reference, template, asset, and script files if this is a directory-based skill
-        reference_files = []
-        template_files = []
-        asset_files = []
-        script_files = []
-
-        if skill_dir:
-            references_dir = skill_dir / "references"
-            if references_dir.exists():
-                reference_files = [
-                    str(f.relative_to(skill_dir)) for f in references_dir.glob("*.md")
-                ]
-
-            templates_dir = skill_dir / "templates"
-            if templates_dir.exists():
-                for ext in [
-                    "*.md",
-                    "*.py",
-                    "*.yaml",
-                    "*.yml",
-                    "*.json",
-                    "*.tex",
-                    "*.sh",
-                ]:
-                    template_files.extend(
-                        [
-                            str(f.relative_to(skill_dir))
-                            for f in templates_dir.rglob(ext)
-                        ]
+        # Supporting files are a bounded discovery preview. Explicit reads by
+        # file_path remain available even when this manifest is truncated.
+        linked_files: Dict[str, List[str]] = {}
+        linked_files_summary: Dict[str, Any] = {
+            "shown": 0,
+            "truncated": False,
+            "truncated_categories": [],
+            "per_category_limit": MAX_LINKED_FILES_PER_CATEGORY,
+            "path_char_limit": MAX_LINKED_FILE_PATH_CHARS,
+        }
+        if skill_dir and _SECURE_PACKAGE_OPEN_SUPPORTED:
+            try:
+                package_fd = _open_bound_package_dir(
+                    bound_skill_dir,
+                    final_snapshot["package_signature"],
+                )
+            except Exception as exc:
+                return _post_discovery_incomplete(
+                    f"cannot bind skill package {bound_skill_dir}: {exc}"
+                )
+            try:
+                linked_files, linked_files_summary = (
+                    _build_bound_linked_files_manifest(
+                        package_fd,
+                        final_snapshot["package_signature"],
                     )
-
-            # assets/ — agentskills.io standard directory for supplementary files
-            assets_dir = skill_dir / "assets"
-            if assets_dir.exists():
-                for f in assets_dir.rglob("*"):
-                    if f.is_file():
-                        asset_files.append(str(f.relative_to(skill_dir)))
-
-            scripts_dir = skill_dir / "scripts"
-            if scripts_dir.exists():
-                for ext in ["*.py", "*.sh", "*.bash", "*.js", "*.ts", "*.rb"]:
-                    script_files.extend(
-                        [str(f.relative_to(skill_dir)) for f in scripts_dir.glob(ext)]
-                    )
+                )
+            except Exception as exc:
+                return _post_discovery_incomplete(
+                    f"cannot inspect skill package {bound_skill_dir}: {exc}"
+                )
+            finally:
+                _close_bound_handle(package_fd)
 
         # Read tags/related_skills with backward compat:
         # Check metadata.hermes.* first (agentskills.io convention), fall back to top-level
@@ -1460,17 +2729,6 @@ def skill_view(
         related_skills = _parse_tags(
             hermes_meta.get("related_skills") or frontmatter.get("related_skills", "")
         )
-
-        # Build linked files structure for clear discovery
-        linked_files = {}
-        if reference_files:
-            linked_files["references"] = reference_files
-        if template_files:
-            linked_files["templates"] = template_files
-        if asset_files:
-            linked_files["assets"] = asset_files
-        if script_files:
-            linked_files["scripts"] = script_files
 
         try:
             rel_path = str(skill_md.relative_to(active_skills_dir))
@@ -1548,18 +2806,98 @@ def skill_view(
 
         rendered_content = content
         if preprocess:
-            try:
-                from agent.skill_preprocessing import preprocess_skill_content
+            if skill_dir and not _SECURE_PACKAGE_OPEN_SUPPORTED:
+                from agent import skill_preprocessing
 
-                rendered_content = preprocess_skill_content(
-                    content,
-                    skill_dir,
-                    session_id=task_id,
+                preprocessing_config = skill_preprocessing.load_skills_config()
+                (
+                    template_vars_enabled,
+                    inline_shell_enabled,
+                    _timeout,
+                ) = skill_preprocessing.normalize_preprocessing_config(
+                    preprocessing_config
                 )
-            except Exception:
-                logger.debug(
-                    "Could not preprocess skill content for %s", skill_name, exc_info=True
-                )
+                if template_vars_enabled:
+                    rendered_content = (
+                        skill_preprocessing.substitute_template_vars(
+                            rendered_content,
+                            bound_skill_dir,
+                            task_id,
+                        )
+                    )
+                if inline_shell_enabled:
+                    return _post_discovery_incomplete(
+                        "secure inline-shell package binding is unsupported "
+                        "on this platform"
+                    )
+            elif skill_dir:
+                try:
+                    package_fd = _open_bound_package_dir(
+                        bound_skill_dir,
+                        final_snapshot["package_signature"],
+                    )
+                except Exception as exc:
+                    return _post_discovery_incomplete(
+                        f"cannot bind skill package {bound_skill_dir}: {exc}"
+                    )
+                try:
+                    from agent import skill_preprocessing
+
+                    preprocessing_config = (
+                        skill_preprocessing.load_skills_config()
+                    )
+                    (
+                        template_vars_enabled,
+                        inline_shell_enabled,
+                        timeout,
+                    ) = skill_preprocessing.normalize_preprocessing_config(
+                        preprocessing_config
+                    )
+                    if inline_shell_enabled:
+                        rendered_content = _expand_inline_shell_bound(
+                            rendered_content,
+                            package_fd,
+                            timeout,
+                            skill_dir=bound_skill_dir,
+                            session_id=task_id,
+                            template_vars=template_vars_enabled,
+                        )
+                    elif template_vars_enabled:
+                        rendered_content = (
+                            skill_preprocessing.substitute_template_vars(
+                                rendered_content,
+                                bound_skill_dir,
+                                task_id,
+                            )
+                        )
+                    if (
+                        _bound_handle_signature(package_fd)
+                        != final_snapshot["package_signature"]
+                    ):
+                        raise RuntimeError(
+                            "skill package changed during preprocessing"
+                        )
+                except Exception as exc:
+                    return _post_discovery_incomplete(
+                        f"cannot preprocess skill package {bound_skill_dir}: {exc}"
+                    )
+                finally:
+                    _close_bound_handle(package_fd)
+            else:
+                try:
+                    from agent.skill_preprocessing import preprocess_skill_content
+
+                    rendered_content = preprocess_skill_content(
+                        content,
+                        None,
+                        session_id=task_id,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Could not preprocess legacy skill %s",
+                        skill_name,
+                        exc_info=True,
+                    )
 
         # ── M2 org provenance header (load-time) ──────────────────────────
         # An org-shared skill announces its provenance IN the returned content
@@ -1638,7 +2976,14 @@ def skill_view(
             "path": rel_path,
             "skill_dir": str(skill_dir) if skill_dir else None,
             "org_provenance": org_provenance,
+            # Internal slash/preload consumers use these markers to avoid
+            # reopening this path for rendering or a support-file scan after
+            # the checked dirfd has been closed.
+            "lookup_name": name,
+            "package_bound": bool(skill_dir),
+            "preprocessed": bool(preprocess),
             "linked_files": linked_files if linked_files else None,
+            "linked_files_summary": linked_files_summary,
             "usage_hint": "To view linked files, call skill_view(name, file_path) where file_path is e.g. 'references/api.md' or 'assets/config.yaml'"
             if linked_files
             else None,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1202,14 +1202,24 @@ def _(rid, params: dict) -> dict:
     agent = session.get("agent")
     if agent is None:
         usage = _session_usage_snapshot(session) or _get_usage(None)
+        # ``usage.total`` is lifetime API traffic, not the tokens occupying the
+        # current context window.  Falling back to it made a resumed desktop
+        # session report impossible values such as 1.9M / 120K and could
+        # overwrite the last provider-measured status-bar value.  Only a
+        # window-scoped ``context_used`` value is meaningful here.
+        context_used = int(usage.get("context_used", 0) or 0)
+        context_used_estimated = bool(
+            usage.get("context_used_estimated", context_used <= 0)
+        )
         return _ok(
             rid,
             {
                 "categories": [],
                 "context_max": usage.get("context_max", 0) or 0,
                 "context_percent": usage.get("context_percent", 0) or 0,
-                "context_used": usage.get("context_used", 0) or 0,
-                "estimated_total": usage.get("context_used", 0) or usage.get("total", 0) or 0,
+                "context_used": context_used,
+                "context_used_estimated": context_used_estimated,
+                "estimated_total": context_used,
                 "model": _metadata_mirror(session).get("model", ""),
             },
         )
@@ -2365,7 +2375,8 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
-    if session.get("running"):
+    compression_reservation = _reserve_manual_compression(session)
+    if compression_reservation is None:
         return _err(
             rid, 4009, "session busy — /interrupt the current turn before /compress"
         )
@@ -2484,6 +2495,9 @@ def _(rid, params: dict) -> dict:
             committed=False,
         )
         return _err(rid, 5005, str(e))
+    finally:
+        _release_manual_compression(session, compression_reservation)
+        _drain_queued_prompt(rid, sid, session)
 
 
 @method("session.save")

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -984,6 +984,11 @@ def _(rid, params: dict) -> dict:
                 rid,
                 {"type": "exec", "output": str(ack.get("output") or "")},
             )
+        compression_reservation = _reserve_manual_compression(session)
+        if compression_reservation is None:
+            return _err(
+                rid, 4009, "session busy — /interrupt the current turn before /compress"
+            )
         try:
             from agent.manual_compression_feedback import summarize_manual_compression
             from agent.model_metadata import estimate_request_tokens_rough
@@ -1066,6 +1071,9 @@ def _(rid, params: dict) -> dict:
                 committed=False,
             )
             return _err(rid, 5009, f"compress failed: {exc}")
+        finally:
+            _release_manual_compression(session, compression_reservation)
+            _drain_queued_prompt(rid, sid, session)
 
     return _err(rid, 4018, f"not a quick/plugin/bundle/skill command: {name}")
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -16,7 +16,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, Callable, NamedTuple, Optional
 
 from agent.secret_scope import (
     build_profile_secret_scope,
@@ -149,6 +149,13 @@ _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
 _prompt_lock = threading.Lock()
+# Notification turns run on daemon threads after their poller releases its
+# short-lived publication lock.  Keep their exact session/agent/transport
+# identity in thread-local context for the whole turn so a reused SID cannot
+# redirect an old turn's late frames to a replacement client.
+_notification_turn_binding: contextvars.ContextVar[dict[str, Any] | None] = (
+    contextvars.ContextVar("tui_notification_turn_binding", default=None)
+)
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None
@@ -846,10 +853,43 @@ def _pop_session_by_id(sid: str) -> dict | None:
     and close agents/workers.  None of that slow external work belongs under
     the global ``_session_resume_lock``.
     """
-    with _sessions_lock:
-        session = _sessions.pop(sid, None)
-    if session is None:
-        return None
+    # Deferred agent construction can publish its final boundary/info frames
+    # while a close races it.  Such a build installs a per-session publish lock:
+    # claim that lock before detaching so the frame is either fully published
+    # while this exact record is live, or not published at all.  Crucially, the
+    # slow transport write holds only this session's lock — never the global
+    # registry lock — so unrelated sessions can still close/resume promptly.
+    while True:
+        with _sessions_lock:
+            session = _sessions.get(sid)
+            if session is None:
+                return None
+            publish_lock = session.get("_agent_build_publish_lock")
+
+        if publish_lock is None:
+            with _sessions_lock:
+                if _sessions.get(sid) is not session:
+                    continue
+                # A publisher can install its per-session lock after our
+                # first lookup but before this detach phase. Re-check under
+                # the same registry lock used by installation; if a lock
+                # appeared, retry and acquire it instead of popping beneath
+                # an in-flight build/refresh transaction.
+                if session.get("_agent_build_publish_lock") is not None:
+                    continue
+                _sessions.pop(sid, None)
+            break
+
+        with publish_lock:
+            with _sessions_lock:
+                # The id may have been reused while we waited for the old
+                # record's publisher. Retry against the new identity instead
+                # of detaching the wrong session.
+                if _sessions.get(sid) is not session:
+                    continue
+                _sessions.pop(sid, None)
+            break
+
     # The session is already out of _sessions here, so downstream teardown
     # (e.g. _finalize_session's per-session async-delegation interrupt) can't
     # recover its live id by scanning the dict — stamp it on the record.
@@ -1350,6 +1390,27 @@ def write_json(obj: dict) -> bool:
     """
     if obj.get("method") == "event":
         sid = ((obj.get("params") or {}).get("session_id")) or ""
+        bound_turn = _notification_turn_binding.get()
+        if bound_turn is not None and sid == str(bound_turn.get("sid") or ""):
+            session = bound_turn.get("session")
+            agent = bound_turn.get("agent")
+            if not isinstance(session, dict) or agent is None:
+                return True
+            # Linearize the identity check and write with session retirement/
+            # replacement.  Deliberately drop after identity loss: falling
+            # through to a fresh SID lookup would leak old output.
+            with _sessions_lock:
+                if _sessions.get(sid) is not session or session.get("agent") is not agent:
+                    return True
+                publish_lock = session.setdefault(
+                    "_agent_build_publish_lock", threading.RLock()
+                )
+            with publish_lock:
+                with _sessions_lock:
+                    if _sessions.get(sid) is not session or session.get("agent") is not agent:
+                        return True
+                transport = bound_turn.get("transport") or _stdio_transport
+                return transport.write(obj)
         if sid and (t := (_sessions.get(sid) or {}).get("transport")) is not None:
             return t.write(obj)
 
@@ -1901,14 +1962,56 @@ def _start_agent_build(sid: str, session: dict) -> None:
     def _build() -> None:
         with _sessions_lock:
             current = _sessions.get(sid)
-        if current is None:
-            ready.set()
-            return
+            # The deferred worker may not run until after the original record
+            # has been reaped and ``sid`` reused.  A non-empty lookup is not
+            # sufficient: building with the old key and publishing into the
+            # replacement record crosses the session isolation boundary.
+            if current is not session:
+                ready.set()
+                return
+            # Install the publication lock while identity is protected by the
+            # registry lock.  A concurrent reaper therefore either detaches
+            # before this build starts or observes this exact lock and waits.
+            publish_lock = session.setdefault(
+                "_agent_build_publish_lock", threading.RLock()
+            )
 
         notify_registered = False
         home_token = None
         secret_token = None
         profile_home = current.get("profile_home")
+        # Coordinates final session-bound frame publication with
+        # _pop_session_by_id.  It is deliberately per-session: a slow client
+        # transport must not block lifecycle operations for other sessions.
+
+        def _still_attached() -> bool:
+            """Whether *this exact* build record still owns ``sid``.
+
+            A close may remove ``sid`` and reuse the id for a different
+            session while a deferred build is in flight.  Never use mere key
+            presence as a publication permission: all session-bound work in
+            this build must be gated by object identity.
+            """
+            with _sessions_lock:
+                return _sessions.get(sid) is current
+
+        def _run_if_attached(effect: Callable[[], None]) -> bool:
+            """Run one session-bound side effect while this build owns ``sid``.
+
+            The per-session lock makes the identity check and effect linear
+            with _pop_session_by_id without holding the global registry lock
+            across lifecycle hooks, thread scheduling, or transport I/O.
+            """
+            with publish_lock:
+                if not _still_attached():
+                    return False
+                effect()
+            return _still_attached()
+
+        def _emit_if_attached(event: str, payload: dict) -> bool:
+            """Publish only while this build still owns the live session."""
+            return _run_if_attached(lambda: _emit(event, sid, payload))
+
         try:
             tokens = _set_session_context(key)
             # Build against the session's profile (global-remote): bind its
@@ -1963,13 +2066,41 @@ def _start_agent_build(sid: str, session: dict) -> None:
                         kw["reasoning_config_override"] = reasoning
                     if (tier := current.get("create_service_tier_override")) is not None:
                         kw["service_tier_override"] = tier
+                kw["_callback_session"] = current
                 agent = _make_agent(sid, key, **kw)
             finally:
                 _clear_session_context(tokens)
 
             # Session DB row deferred to first run_conversation() call.
             # pending_title applied post-first-message (see cli.exec handler).
-            current["agent"] = agent
+            # Publish the agent under the same lock that serializes every
+            # callback/reaper transition.  Otherwise an old callback could
+            # validate itself, then race this replacement while it is still
+            # performing its side effect.
+            with publish_lock:
+                with _sessions_lock:
+                    attached = _sessions.get(sid) is current
+                    if attached:
+                        current["agent"] = agent
+                if not attached:
+                    try:
+                        if hasattr(agent, "close"):
+                            agent.close()
+                    except Exception:
+                        pass
+                    return
+                if isinstance(getattr(agent, "_tui_callback_identity", None), dict) and not _bind_agent_callback_identity(agent, sid, current):
+                    # A production agent without its exact constructor
+                    # binding must never become a live publisher.
+                    with _sessions_lock:
+                        if _sessions.get(sid) is current and current.get("agent") is agent:
+                            current["agent"] = None
+                    try:
+                        if hasattr(agent, "close"):
+                            agent.close()
+                    except Exception:
+                        pass
+                    return
             # Baseline for the per-turn config sync; the profile home
             # override is still active here.
             current["config_model_seen"] = _config_model_target()
@@ -1990,8 +2121,15 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     load_permanent_allowlist,
                 )
 
+                if not _still_attached():
+                    return
+                _approval_binding = {"sid": sid, "session": current, "agent": agent}
                 register_gateway_notify(
-                    key, lambda data: _emit_approval_request(sid, data)
+                    key,
+                    lambda data: _run_bound_agent_effect(
+                        _approval_binding,
+                        lambda: _emit_approval_request(sid, data)
+                    ),
                 )
                 notify_registered = True
                 load_permanent_allowlist()
@@ -2006,8 +2144,11 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # default cold resume) build through here, so without this their
             # review summaries would leak to stdout instead of the chat.
             try:
-                agent.background_review_callback = lambda message, _sid=sid: _emit(
-                    "review.summary", _sid, {"text": str(message)}
+                _review_binding = {"sid": sid, "session": current, "agent": agent}
+                agent.background_review_callback = lambda message: _emit_bound_agent_event(
+                    _review_binding,
+                    "review.summary",
+                    {"text": str(message)},
                 )
                 agent.memory_notifications = _load_memory_notifications()
             except Exception:
@@ -2016,30 +2157,67 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # message), so depletion / usage-band warnings show at "ready". Runs
             # off the build thread, after the notice_callback is wired. Fail-open.
             try:
+                if not _still_attached():
+                    return
                 from agent.credits_tracker import seed_credits_at_session_start
 
                 seed_credits_at_session_start(agent)
             except Exception:
                 pass
+
+            # Starting the poller may wire global callbacks and start a
+            # thread; do it outside the registry lock.  If a reap wins while
+            # it starts, stop the late poller rather than attaching it to an
+            # already-detached record.
+            if not _still_attached():
+                return
+            notif_stop = _start_notification_poller(sid, current)
             with _sessions_lock:
-                if sid in _sessions:
-                    _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-            _notify_session_boundary("on_session_reset", key, _session_source(current))
+                if _sessions.get(sid) is current:
+                    current["_notif_stop"] = notif_stop
+                    poller_attached = True
+                else:
+                    poller_attached = False
+            if not poller_attached:
+                notif_stop.set()
+                return
+
+            # Every following side effect can yield to a close/reaper. Bind
+            # each one atomically to this exact registry record so an old
+            # successful check cannot authorize a ghost lifecycle hook, frame,
+            # or refresh thread after sid reuse.
+            if not _run_if_attached(
+                lambda: _notify_session_boundary(
+                    "on_session_reset", key, _session_source(current)
+                )
+            ):
+                return
 
             info = _session_info(agent, current)
+            if not _still_attached():
+                return
             cfg_warn = _probe_config_health(_load_cfg())
             if cfg_warn:
                 info["config_warning"] = cfg_warn
                 logger.warning(cfg_warn)
-            _emit("session.info", sid, info)
+            if not _emit_if_attached("session.info", info):
+                return
             # If MCP discovery is still in flight (a server slower than the
             # bounded wait_for_mcp_discovery join in _make_agent), the agent
             # was built without those tools. Catch up once they land — see
             # _schedule_mcp_late_refresh. Cache-safe (pre-first-turn only).
-            _schedule_mcp_late_refresh(sid, agent)
+            if not _run_if_attached(
+                lambda: _schedule_mcp_late_refresh(sid, agent, current)
+            ):
+                return
         except Exception as e:
-            current["agent_error"] = str(e)
-            _emit("error", sid, {"message": f"agent init failed: {e}"})
+            # A build exception is useful only to the session that still owns
+            # this exact record.  A reaped session must not receive a ghost
+            # error after it has gone away (or been replaced under the same
+            # sid).
+            if _still_attached():
+                current["agent_error"] = str(e)
+                _emit_if_attached("error", {"message": f"agent init failed: {e}"})
         finally:
             if home_token is not None:
                 reset_hermes_home_override(home_token)
@@ -2060,6 +2238,18 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     from tools.approval import unregister_gateway_notify
 
                     unregister_gateway_notify(key)
+                except Exception:
+                    pass
+            if replaced:
+                # Teardown may have run before the late-built agent was
+                # attached to ``current``. Close it here so a reaped session
+                # cannot leak provider clients or background resources.
+                try:
+                    orphaned_agent = current.get("agent")
+                    if orphaned_agent is not None and hasattr(
+                        orphaned_agent, "close"
+                    ):
+                        orphaned_agent.close()
                 except Exception:
                     pass
             ready.set()
@@ -4302,6 +4492,35 @@ class CompressionLockHeld(Exception):
         super().__init__(f"Compression lock held: {holder or 'unknown'}")
 
 
+def _reserve_manual_compression(session: dict) -> object | None:
+    """Atomically reserve an in-process session for manual compaction.
+
+    ``_compress_context`` can durably rotate/write the SessionDB before the
+    gateway publishes its replacement history.  Holding only the final
+    history-version CAS left a window where a prompt or poller turn could
+    start from the old in-memory transcript and then lose that CAS.  Reuse the
+    normal ``running`` gate (which already excludes notification turns) and
+    retain a private ownership token so only this compression clears it.
+    """
+    token = object()
+    with session["history_lock"]:
+        if session.get("running") or session.get("_manual_compression_reservation"):
+            return None
+        session["_manual_compression_reservation"] = token
+        session["running"] = True
+    return token
+
+
+def _release_manual_compression(session: dict, token: object | None) -> None:
+    """Release exactly the reservation created by this manual compression."""
+    if token is None:
+        return
+    with session["history_lock"]:
+        if session.get("_manual_compression_reservation") is token:
+            session.pop("_manual_compression_reservation", None)
+            session["running"] = False
+
+
 def _compress_session_history(
     session: dict,
     focus_topic: str | None = None,
@@ -5283,6 +5502,232 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
             _child_mirrors.pop(child_key, None)
 
 
+def _new_agent_callback_binding(
+    sid: str, session: dict | None = None
+) -> dict[str, Any]:
+    """Mutable identity captured by callbacks created before an agent exists.
+
+    ``AIAgent`` receives its callbacks as constructor arguments, so the exact
+    agent object cannot be captured until construction returns.  Eager session
+    builds also construct the agent before installing the session record.  This
+    holder lets both identities be filled in at the appropriate lifecycle
+    boundary; callbacks fail closed until both are bound.
+    """
+    return {"sid": sid, "session": session, "agent": None}
+
+
+def _bind_agent_callback_identity(agent: Any, sid: str, session: dict) -> bool:
+    """Bind an agent's callbacks to its exact live registry record.
+
+    This is called by deferred build, eager ``_init_session``, and ``/new``
+    reset after ``session["agent"]`` has been published.  A stale or orphaned
+    build cannot bind merely because another record reused the same SID.
+    """
+    binding = getattr(agent, "_tui_callback_identity", None)
+    if not isinstance(binding, dict) or binding.get("sid") != sid:
+        return False
+    with _sessions_lock:
+        if _sessions.get(sid) is not session or session.get("agent") is not agent:
+            return False
+        # Reuse the lifecycle publication lock.  _pop_session_by_id observes
+        # locks installed under _sessions_lock, so a notice write and a reap
+        # are linearized without holding the global registry lock across I/O.
+        session.setdefault("_agent_build_publish_lock", threading.RLock())
+        binding["session"] = session
+        binding["agent"] = agent
+    return True
+
+
+def _emit_bound_agent_event(
+    binding: dict[str, Any], event: str, payload: dict
+) -> bool:
+    """Emit only for the exact session record and agent captured at bind time.
+
+    Credits hydration can call the notice spine from a daemon thread long
+    after agent construction.  A one-time SID lookup is insufficient because
+    the old session may be reaped and the SID reused before transport I/O.
+    Acquire the exact record's publication lock, then re-check both record and
+    agent identity immediately before writing.  The global registry lock is
+    used only for short in-memory checks and is never held across ``_emit``.
+    """
+    sid = str(binding.get("sid") or "")
+    session = binding.get("session")
+    agent = binding.get("agent")
+    if not sid or not isinstance(session, dict) or agent is None:
+        return False
+
+    with _sessions_lock:
+        if (
+            _sessions.get(sid) is not session
+            or session.get("agent") is not agent
+        ):
+            return False
+        publish_lock = session.setdefault(
+            "_agent_build_publish_lock", threading.RLock()
+        )
+
+    with publish_lock:
+        with _sessions_lock:
+            if (
+                binding.get("session") is not session
+                or binding.get("agent") is not agent
+                or _sessions.get(sid) is not session
+                or session.get("agent") is not agent
+            ):
+                return False
+        _emit(event, sid, payload)
+        with _sessions_lock:
+            return (
+                binding.get("session") is session
+                and binding.get("agent") is agent
+                and _sessions.get(sid) is session
+                and session.get("agent") is agent
+            )
+
+
+def _run_bound_agent_effect(binding: dict[str, Any], effect: Callable[[], Any]) -> bool:
+    """Run one callback side effect only for its exact live agent/session.
+
+    This is the non-emitting counterpart to :func:`_emit_bound_agent_event`.
+    Tool/status callbacks mutate session-local display state before they emit,
+    so checking only at the transport boundary would still let an old callback
+    alter a replacement record after SID reuse.
+    """
+    sid = str(binding.get("sid") or "")
+    session = binding.get("session")
+    agent = binding.get("agent")
+    if not sid or not isinstance(session, dict) or agent is None:
+        return False
+
+    with _sessions_lock:
+        if _sessions.get(sid) is not session or session.get("agent") is not agent:
+            return False
+        publish_lock = session.setdefault(
+            "_agent_build_publish_lock", threading.RLock()
+        )
+
+    with publish_lock:
+        with _sessions_lock:
+            if (
+                binding.get("session") is not session
+                or binding.get("agent") is not agent
+                or _sessions.get(sid) is not session
+                or session.get("agent") is not agent
+            ):
+                return False
+        effect()
+        with _sessions_lock:
+            return (
+                binding.get("session") is session
+                and binding.get("agent") is agent
+                and _sessions.get(sid) is session
+                and session.get("agent") is agent
+            )
+
+
+def _bound_agent_cbs(sid: str, binding: dict[str, Any]) -> dict:
+    """Identity-gated versions of every live AIAgent callback.
+
+    Keep ``_agent_cbs(sid)`` as the direct-call compatibility surface used by
+    lightweight test doubles and integrations.  Real agents receive this
+    overlay from ``_make_agent`` and therefore fail closed until their exact
+    session record and agent object have both been bound.
+    """
+    def _call(effect: Callable[[], Any], default=None):
+        value: list[Any] = []
+        if _run_bound_agent_effect(binding, lambda: value.append(effect())):
+            return value[0] if value else default
+        return default
+
+    return {
+        "tool_start_callback": lambda tc_id, name, args: _call(
+            lambda: _on_tool_start(sid, tc_id, name, args)
+        ),
+        "tool_complete_callback": lambda tc_id, name, args, result: _call(
+            lambda: _on_tool_complete(sid, tc_id, name, args, result)
+        ),
+        "tool_progress_callback": lambda event_type, name=None, preview=None, args=None, **kwargs: _call(
+            lambda: _on_tool_progress(sid, event_type, name, preview, args, **kwargs)
+        ),
+        "tool_gen_callback": lambda name: _call(
+            lambda: _tool_progress_enabled(sid)
+            and _emit("tool.generating", sid, {"name": name})
+        ),
+        "thinking_callback": lambda text: _emit_bound_agent_event(
+            binding, "thinking.delta", {"text": text}
+        ),
+        "reaction_callback": lambda kind: _emit_bound_agent_event(
+            binding, "reaction", {"kind": kind}
+        ),
+        "reasoning_callback": lambda text: _call(
+            lambda: _emit(
+                "reasoning.delta",
+                sid,
+                {"text": text, **({"verbose": True} if _session_verbose(sid) else {})},
+            )
+        ),
+        "status_callback": lambda kind, text=None: _call(
+            lambda: _status_update(sid, str(kind), None if text is None else str(text))
+        ),
+        "clarify_callback": lambda q, c, multi_select=False: _call(
+            lambda: _block(
+                "clarify.request",
+                sid,
+                ({"question": q, "choices": c, "multi_select": True}
+                 if multi_select else {"question": q, "choices": c}),
+                timeout=_clarify_timeout_seconds(),
+            )
+        ),
+        "read_terminal_callback": lambda start=None, count=None: _call(
+            lambda: _block(
+                "terminal.read.request",
+                sid,
+                {k: v for k, v in (("start", start), ("count", count)) if v is not None},
+                timeout=30,
+            )
+        ),
+        "interim_assistant_callback": lambda text, *, already_streamed=False: _emit_bound_agent_event(
+            binding,
+            "message.interim",
+            {"text": str(text), "already_streamed": bool(already_streamed)},
+        ),
+    }
+
+
+def _agent_notice_cbs(
+    sid: str, callback_identity: dict[str, Any] | None = None
+) -> dict[str, Callable[..., None]]:
+    """Credits/notice spine using the gateway's snake_case event payloads."""
+
+    def _notice(n: Any) -> None:
+        payload = {
+            "text": n.text,
+            "level": n.level,
+            "kind": n.kind,
+            "ttl_ms": n.ttl_ms,
+            "key": n.key,
+            "id": n.id,
+        }
+        if callback_identity is None:
+            # Compatibility for direct callback consumers/tests. Production
+            # AIAgents always pass a binding from _make_agent.
+            _emit("notification.show", sid, payload)
+            return
+        _emit_bound_agent_event(callback_identity, "notification.show", payload)
+
+    def _notice_clear(key: str) -> None:
+        payload = {"key": key}
+        if callback_identity is None:
+            _emit("notification.clear", sid, payload)
+            return
+        _emit_bound_agent_event(callback_identity, "notification.clear", payload)
+
+    return {
+        "notice_callback": _notice,
+        "notice_clear_callback": _notice_clear,
+    }
+
+
 def _agent_cbs(sid: str) -> dict:
     callbacks = {
         "tool_start_callback": lambda tc_id, name, args: _on_tool_start(
@@ -5307,24 +5752,6 @@ def _agent_cbs(sid: str) -> dict:
         ),
         "status_callback": lambda kind, text=None: _status_update(
             sid, str(kind), None if text is None else str(text)
-        ),
-        # Credits/notice spine (L1): an AgentNotice fired by the agent becomes a
-        # notification.show WS event; a recovery clear becomes notification.clear.
-        # Snake_case payload to match the existing gateway-event convention.
-        "notice_callback": lambda n: _emit(
-            "notification.show",
-            sid,
-            {
-                "text": n.text,
-                "level": n.level,
-                "kind": n.kind,
-                "ttl_ms": n.ttl_ms,
-                "key": n.key,
-                "id": n.id,
-            },
-        ),
-        "notice_clear_callback": lambda key: _emit(
-            "notification.clear", sid, {"key": key}
         ),
         "clarify_callback": lambda q, c, multi_select=False: _block(
             "clarify.request",
@@ -5365,6 +5792,7 @@ def _agent_cbs(sid: str) -> dict:
             )
         )
 
+    callbacks.update(_agent_notice_cbs(sid))
     return callbacks
 
 
@@ -5429,17 +5857,38 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
 
 def _wire_callbacks(sid: str):
     from tools.terminal_tool import set_sudo_password_callback
-    from tools.skills_tool import set_secret_capture_callback
     from tools.project_tools import set_project_workspace_callback
 
-    set_sudo_password_callback(lambda: _block("sudo.request", sid, {}, timeout=120))
+    # These global tool hooks outlive the call which installed them. Capture
+    # the exact current record/agent so an old eager init cannot route a later
+    # tool prompt into a replacement that reused its short SID.
+    with _sessions_lock:
+        session = _sessions.get(sid)
+        agent = session.get("agent") if isinstance(session, dict) else None
+    binding = (
+        {"sid": sid, "session": session, "agent": agent}
+        if isinstance(session, dict) and agent is not None
+        else None
+    )
+
+    def _call(effect: Callable[[], Any], default=None):
+        if binding is None:
+            return effect()
+        value: list[Any] = []
+        if _run_bound_agent_effect(binding, lambda: value.append(effect())):
+            return value[0] if value else default
+        return default
+
+    set_sudo_password_callback(
+        lambda: _call(lambda: _block("sudo.request", sid, {}, timeout=120))
+    )
     set_project_workspace_callback(_apply_project_workspace)
 
-    def secret_cb(env_var, prompt, metadata=None):
+    def _new_secret_cb(env_var, prompt, metadata=None):
         pl = {"prompt": prompt, "env_var": env_var}
         if metadata:
             pl["metadata"] = metadata
-        val = _block("secret.request", sid, pl)
+        val = _call(lambda: _block("secret.request", sid, pl))
         if not val:
             return {
                 "success": True,
@@ -5456,7 +5905,18 @@ def _wire_callbacks(sid: str):
             "message": "ok",
         }
 
-    set_secret_capture_callback(secret_cb)
+    # Do not register this in tools.skills_tool's process-global fallback:
+    # concurrent gateway turns would overwrite one another's prompt route.
+    # The turn installs this exact callback in its ContextVar and restores its
+    # prior token on exit. Store it on the record so re-wiring in the turn
+    # thread reuses the callback bound during eager/deferred initialization.
+    if isinstance(session, dict):
+        secret_cb = session.get("_secret_capture_callback")
+        if not callable(secret_cb):
+            secret_cb = _new_secret_cb
+            session["_secret_capture_callback"] = secret_cb
+        return secret_cb
+    return _new_secret_cb
 
 
 def _render_personality_prompt(value) -> str:
@@ -5792,28 +6252,118 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
             session["session_key"],
             session_id=session["session_key"],
             platform_override=_session_source(session),
+            _callback_session=session,
         )
     finally:
         _clear_session_context(tokens)
+    binding = {"sid": sid, "session": session, "agent": new_agent}
+
+    def _close_new_agent() -> None:
+        try:
+            if hasattr(new_agent, "close"):
+                new_agent.close()
+        except Exception:
+            pass
+
+    def _reset_effect() -> dict:
+        session["config_model_seen"] = _config_model_target()
+        session["attached_images"] = []
+        session["edit_snapshots"] = {}
+        session["image_counter"] = 0
+        session["running"] = False
+        session["show_reasoning"] = _load_show_reasoning()
+        session["tool_progress_mode"] = _load_tool_progress_mode()
+        session["tool_started_at"] = {}
+        with session["history_lock"]:
+            session["history"] = []
+            session["history_version"] = int(session.get("history_version", 0)) + 1
+        info = _session_info(new_agent, session)
+        _emit("session.info", sid, info)
+        _restart_slash_worker(sid, session)
+        return info
+
+    with _sessions_lock:
+        live = _sessions.get(sid)
+        previous_agent = session.get("agent")
+        # A real AIAgent always carries the constructor-time identity holder.
+        # If its original record disappeared while /new was building, do not
+        # replace a new SID owner or publish any of this reset's state. The
+        # no-holder path preserves direct unit-test/fake-agent compatibility.
+        requires_live_binding = isinstance(
+            getattr(new_agent, "_tui_callback_identity", None), dict
+        )
+        if live is not session and requires_live_binding:
+            publish_lock = None
+        elif live is session:
+            # Fetch only. Never wait for this lock while holding the registry
+            # lock: old-agent callbacks acquire it before their short registry
+            # identity check, and the reaper follows that same ordering.
+            publish_lock = session.setdefault(
+                "_agent_build_publish_lock", threading.RLock()
+            )
+        else:
+            publish_lock = None
+
+    if live is not session and requires_live_binding:
+        _close_new_agent()
+        return {}
+
+    if live is session:
+        # Agent replacement, callback binding, reset state, UI publication,
+        # and worker restart form one publication transaction. An old callback
+        # that has already passed identity validation finishes before the swap;
+        # a callback arriving after the swap sees ``session["agent"] is not
+        # old_agent`` and fails closed.
+        with publish_lock:
+            with _sessions_lock:
+                attached = _sessions.get(sid) is session
+                if attached:
+                    previous_agent = session.get("agent")
+                    session["agent"] = new_agent
+            if not attached:
+                _close_new_agent()
+                return {}
+
+            if requires_live_binding and not _bind_agent_callback_identity(
+                new_agent, sid, session
+            ):
+                # The record/agent pair changed while binding. Roll back only
+                # if this exact record still owns the SID, then close the
+                # orphaned replacement.
+                with _sessions_lock:
+                    if _sessions.get(sid) is session and session.get("agent") is new_agent:
+                        session["agent"] = previous_agent
+                _close_new_agent()
+                return {}
+
+            with _sessions_lock:
+                attached = (
+                    _sessions.get(sid) is session
+                    and session.get("agent") is new_agent
+                )
+            if not attached:
+                _close_new_agent()
+                return {}
+            result = _reset_effect()
+            with _sessions_lock:
+                attached = (
+                    _sessions.get(sid) is session
+                    and session.get("agent") is new_agent
+                )
+            if not attached:
+                _close_new_agent()
+                return {}
+            return result
+
+    # Compatibility for direct fake-agent unit callers that never register a
+    # session. Production ``/new`` always takes the live branch above.
     session["agent"] = new_agent
-    session["config_model_seen"] = _config_model_target()
-    session["attached_images"] = []
-    session["edit_snapshots"] = {}
-    session["image_counter"] = 0
-    session["running"] = False
-    session["show_reasoning"] = _load_show_reasoning()
-    session["tool_progress_mode"] = _load_tool_progress_mode()
-    session["tool_started_at"] = {}
-    with session["history_lock"]:
-        session["history"] = []
-        session["history_version"] = int(session.get("history_version", 0)) + 1
-    info = _session_info(new_agent, session)
-    _emit("session.info", sid, info)
-    _restart_slash_worker(sid, session)
-    return info
+    return _reset_effect()
 
 
-def _schedule_mcp_late_refresh(sid: str, agent) -> None:
+def _schedule_mcp_late_refresh(
+    sid: str, agent, session: dict | None = None
+) -> None:
     """Refresh a session's tool snapshot when MCP discovery lands late.
 
     The agent snapshots ``agent.tools`` once at build time and never re-reads
@@ -5845,16 +6395,40 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
         return
     if not mcp_discovery_in_flight():
         return
+    with _sessions_lock:
+        current = _sessions.get(sid)
+        if session is None:
+            # Backwards-compatible for direct/internal callers: capture the
+            # exact live record at schedule time, never look it up again by id
+            # as publication authority.
+            session = current
+        if current is not session or session.get("agent") is not agent:
+            return
+        # Share the same per-record lock as deferred build publication and
+        # _pop_session_by_id.  Installing it under the registry lock closes
+        # the no-lock observation window for a concurrent reaper.
+        publish_lock = session.setdefault(
+            "_agent_build_publish_lock", threading.RLock()
+        )
+
+    def _still_current() -> bool:
+        with _sessions_lock:
+            return (
+                _sessions.get(sid) is session
+                and session.get("agent") is agent
+            )
 
     def _wait_then_refresh() -> None:
         # Bounded but generous — a server still not connected after this is
         # genuinely slow/dead; the user can /reload-mcp once it recovers.
         if not join_mcp_discovery(timeout=30.0):
             return
-        with _sessions_lock:
-            session = _sessions.get(sid)
-            # Session may have been closed/reset while we waited.
-            if session is None or session.get("agent") is not agent:
+        # Refresh, info derivation, and publication are one session-scoped
+        # transaction. A reap/reuse waits on this lock, but unrelated sessions
+        # remain independent; the global registry lock is used only for short
+        # identity checks and is never held across refresh or transport I/O.
+        with publish_lock:
+            if not _still_current():
                 return
             # Cache safety: never rebuild the tool list once the conversation
             # has started — that would invalidate the cached prompt prefix.
@@ -5877,9 +6451,15 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
             # No new tools landed (discovery added nothing) → don't churn the client.
             if not added:
                 return
+            # A defensive second identity check also covers callers that
+            # replaced the registry entry without going through the normal
+            # _pop_session_by_id lifecycle funnel while refresh was running.
+            if not _still_current():
+                return
             info = _session_info(agent, session)
-        # Emit outside the lock — write_json must not block under _sessions_lock.
-        _emit("session.info", sid, info)
+            if not _still_current():
+                return
+            _emit("session.info", sid, info)
     threading.Thread(
         target=_wait_then_refresh,
         name=f"tui-mcp-late-refresh-{sid}",
@@ -5959,6 +6539,7 @@ def _make_agent(
     reasoning_config_override: dict | None = None,
     service_tier_override: str | None = None,
     platform_override: str | None = None,
+    _callback_session: dict | None = None,
 ):
     # AC-4 test seam: dead unless explicitly armed by the isolated certify
     # harness. Both inline and compute-host paths construct through _make_agent,
@@ -6087,7 +6668,20 @@ def _make_agent(
                 raise RuntimeError("Auth fallback resolved without a model")
             model = resolution.selected_model
     _pr = _load_provider_routing()
-    return AIAgent(
+    callback_identity = _new_agent_callback_binding(sid, _callback_session)
+    agent_callbacks = _agent_cbs(sid)
+    bound_callbacks = _bound_agent_cbs(sid, callback_identity)
+    # The base factory owns feature gating for interim text; retain that
+    # contract while replacing every installed live callback with its
+    # identity-bound equivalent.
+    if "interim_assistant_callback" not in agent_callbacks:
+        bound_callbacks.pop("interim_assistant_callback", None)
+    agent_callbacks.update(bound_callbacks)
+    # Replace the public/direct-call notice callbacks with the identity-bound
+    # variants used by live AIAgents. Keep the base _agent_cbs(sid) call shape
+    # stable for downstream drivers and test seams that wrap that factory.
+    agent_callbacks.update(_agent_notice_cbs(sid, callback_identity))
+    agent = AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
@@ -6132,8 +6726,11 @@ def _make_agent(
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         fallback_model=_load_fallback_model(),
-        **_agent_cbs(sid),
+        **agent_callbacks,
     )
+    callback_identity["agent"] = agent
+    agent._tui_callback_identity = callback_identity
+    return agent
 
 
 def _init_session(
@@ -6149,7 +6746,7 @@ def _init_session(
 ):
     now = time.time()
     with _sessions_lock:
-        _sessions[sid] = {
+        session_record = {
             "agent": agent,
             "session_key": key,
             "history": history,
@@ -6180,7 +6777,21 @@ def _init_session(
             # Pin async event emissions to whichever transport created the
             # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
             "transport": current_transport() or _stdio_transport,
+            # Installed with the record so eager initialization has the same
+            # reap/publication linearization as deferred construction.
+            "_agent_build_publish_lock": threading.RLock(),
         }
+        _sessions[sid] = session_record
+    binding = {"sid": sid, "session": session_record, "agent": agent}
+    requires_live_binding = isinstance(
+        getattr(agent, "_tui_callback_identity", None), dict
+    )
+    if not _bind_agent_callback_identity(agent, sid, session_record) and requires_live_binding:
+        return
+
+    def _run_init_effect(effect: Callable[[], Any]) -> bool:
+        return _run_bound_agent_effect(binding, effect)
+
     _init_owns_db = False
     if session_db is not None:
         db = session_db
@@ -6198,16 +6809,21 @@ def _init_session(
         if db is not None:
             row = db.get_session(key) if hasattr(db, "get_session") else None
             if row and row.get("cwd"):
-                with _sessions_lock:
-                    if sid in _sessions:
-                        _sessions[sid]["cwd"] = row["cwd"]
+                if not _run_init_effect(
+                    lambda: session_record.__setitem__("cwd", row["cwd"])
+                ):
+                    return
             else:
                 try:
-                    _cwd = _sessions[sid]["cwd"]
-                    if hasattr(db, "update_session_cwd"):
-                        db.update_session_cwd(key, _cwd)
-                    # git branch/root probes run off the hot path (see _set_session_cwd).
-                    _persist_session_git_meta(_sessions[sid], _cwd)
+                    def _persist_cwd() -> None:
+                        _cwd = session_record["cwd"]
+                        if hasattr(db, "update_session_cwd"):
+                            db.update_session_cwd(key, _cwd)
+                        # git branch/root probes run off the hot path (see _set_session_cwd).
+                        _persist_session_git_meta(session_record, _cwd)
+
+                    if not _run_init_effect(_persist_cwd):
+                        return
                 except Exception:
                     logger.debug(
                         "failed to persist resumed session cwd", exc_info=True
@@ -6218,7 +6834,8 @@ def _init_session(
                 db.close()
             except Exception:
                 pass
-    _register_session_cwd(_sessions[sid])
+    if not _run_init_effect(lambda: _register_session_cwd(session_record)):
+        return
     # No eager slash-worker pre-warm — the session dict already carries
     # slash_worker=None and slash.exec builds one on demand. See the
     # deferred-build path in _start_agent_build for the full rationale
@@ -6226,8 +6843,18 @@ def _init_session(
     try:
         from tools.approval import register_gateway_notify, load_permanent_allowlist
 
-        register_gateway_notify(key, lambda data: _emit_approval_request(sid, data))
-        load_permanent_allowlist()
+        if not _run_init_effect(
+            lambda: (
+                register_gateway_notify(
+                    key,
+                    lambda data: _run_bound_agent_effect(
+                        binding, lambda: _emit_approval_request(sid, data)
+                    ),
+                ),
+                load_permanent_allowlist(),
+            )
+        ):
+            return
     except Exception:
         pass
     # Surface the self-improvement background review's "💾 …" summary as a
@@ -6236,8 +6863,8 @@ def _init_session(
     # prompt_toolkit; the TUI has no equivalent print surface, so without
     # this callback the review would write the skill/memory change silently.
     try:
-        agent.background_review_callback = lambda message, _sid=sid: _emit(
-            "review.summary", _sid, {"text": str(message)}
+        agent.background_review_callback = lambda message: _emit_bound_agent_event(
+            binding, "review.summary", {"text": str(message)}
         )
         # Honor display.memory_notifications (off | on | verbose) like the
         # messaging gateway and CLI do — otherwise the review always behaved as
@@ -6247,13 +6874,29 @@ def _init_session(
         # Bare AIAgents that don't expose the attribute (unlikely, but keep
         # session startup resilient).
         pass
-    _wire_callbacks(sid)
-    with _sessions_lock:
-        if sid in _sessions:
-            _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-    _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
-    _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
-    _schedule_mcp_late_refresh(sid, agent)
+    if not _run_init_effect(lambda: _wire_callbacks(sid)):
+        return
+
+    def _start_and_attach_poller() -> None:
+        session_record["_notif_stop"] = _start_notification_poller(sid, session_record)
+
+    if not _run_init_effect(_start_and_attach_poller):
+        # The poller is only started while the publication lock is held, so a
+        # reaper cannot win between start and attach.
+        return
+    if not _run_init_effect(
+        lambda: _notify_session_boundary(
+            "on_session_reset", key, _session_source(session_record)
+        )
+    ):
+        return
+
+    def _publish_info() -> None:
+        _emit("session.info", sid, _session_info(agent, session_record))
+
+    if not _run_init_effect(_publish_info):
+        return
+    _run_init_effect(lambda: _schedule_mcp_late_refresh(sid, agent, session_record))
 
 
 def _new_session_key() -> str:
@@ -8371,6 +9014,91 @@ def _notification_event_requires_owner(evt: dict) -> bool:
     )
 
 
+def _notification_event_reserved_elsewhere(sid: str, session: dict, evt: dict) -> bool:
+    """Whether a requeued event is reserved for a different durable session.
+
+    Queue objects are in-process, so tag a requeued event with the durable
+    owner key that was live when it was set aside.  This prevents a short SID
+    reuse from adopting an old ownerless event merely because it reached the
+    replacement poller first; a real resume with the same durable key remains
+    eligible to deliver it.
+    """
+    reserved_key = str(evt.get("_tui_requeue_session_key") or "")
+    if reserved_key:
+        current_keys = {
+            str(session.get("session_key") or ""),
+            _session_lookup_key(session, fallback=sid),
+        }
+        if reserved_key in current_keys:
+            return False
+        # The durable owner may have compressed while it was absent.  A
+        # literal parent-key reservation must therefore follow the same
+        # lineage resolution as normal ownership checks.  If that proof is
+        # unavailable, leave the reservation in place (fail closed).
+        try:
+            db = _get_db()
+            resolved_key = (
+                db.resolve_resume_session_id(reserved_key)
+                if db is not None
+                else None
+            )
+        except Exception:
+            return True
+        return not resolved_key or str(resolved_key) not in current_keys
+
+    # Origin-only legacy events have no durable session key. Preserve their
+    # original UI route without inventing one from the unrelated poller that
+    # happened to observe the owner gap; that invented key would permanently
+    # strand the event when the real SID came back.
+    reserved_origin = str(evt.get("_tui_requeue_origin_sid") or "")
+    return bool(reserved_origin and reserved_origin != str(sid or ""))
+
+
+def _requeue_notification_event(sid: str, session: dict, evt: dict) -> None:
+    """Return a durable notification without allowing SID reuse to adopt it."""
+    key = str(evt.get("session_key") or "")
+    if key:
+        evt.setdefault("_tui_requeue_session_key", key)
+    else:
+        origin_sid = str(evt.get("origin_ui_session_id") or "")
+        if origin_sid:
+            evt.setdefault("_tui_requeue_origin_sid", origin_sid)
+    from tools.process_registry import process_registry
+
+    process_registry.completion_queue.put(evt)
+
+
+def _release_or_requeue_notification_event(
+    sid: str, session: dict, evt: dict, claim: Any
+) -> bool:
+    """Release a failed claim and requeue only while delivery is still live.
+
+    A lease may have rolled from claimant A to B while A's turn was running.
+    If B has already delivered or dropped the durable row, A's release CAS
+    correctly returns false.  Requeueing A's stale in-memory event in that
+    state creates an immortal queue item, so terminal durable state wins.
+    """
+    from tools.async_delegation import (
+        DELIVERY_TERMINAL_CONSUMED,
+        inspect_event_delivery_state,
+        release_event_delivery,
+    )
+
+    try:
+        release_event_delivery(evt, claim)
+    except Exception:
+        logger.warning("notification delivery release failed", exc_info=True)
+    try:
+        if inspect_event_delivery_state(evt) == DELIVERY_TERMINAL_CONSUMED:
+            return False
+    except Exception:
+        # A state-store read failure is not evidence of terminal consumption.
+        # Preserve the in-memory event so a later pass can retry safely.
+        logger.warning("notification delivery state inspection failed", exc_info=True)
+    _requeue_notification_event(sid, session, evt)
+    return True
+
+
 def _notification_event_dedup_key(evt: dict) -> tuple:
     """Return the UI-emission identity for a process notification event.
 
@@ -8406,6 +9134,142 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
         # and the second completion's status update is suppressed forever.
         return (evt.get("delegation_id", ""), evt_type)
     return (evt_sid, evt_type)
+
+
+def _notification_session_binding(sid: str, session: dict) -> dict[str, Any] | None:
+    """Capture the exact live record/agent for one poller operation.
+
+    Poller threads outlive UI records and short SIDs can be reused.  Never use
+    the SID alone as authority for queue claims, ``running`` mutations, frame
+    writes, or injected prompt turns.
+    """
+    with _sessions_lock:
+        if _sessions.get(sid) is not session:
+            return None
+        agent = session.get("agent")
+        if agent is None:
+            return None
+        session.setdefault("_agent_build_publish_lock", threading.RLock())
+        return {
+            "sid": sid,
+            "session": session,
+            "agent": agent,
+            # Capture once.  A future SID lookup is exactly the replacement
+            # race this binding is meant to prevent.
+            "transport": session.get("transport"),
+        }
+
+
+def _poller_set_running(binding: dict[str, Any], running: bool) -> bool:
+    """Set a poller's running flag only while its agent remains current."""
+    return _run_bound_agent_effect(
+        binding,
+        lambda: _set_notification_running(binding["session"], running),
+    )
+
+
+def _clear_notification_reservation(binding: dict[str, Any]) -> None:
+    """Clear a reservation without ever resolving a replacement by SID.
+
+    A binding that lost registry identity cannot use ``_poller_set_running``;
+    it can still safely clear the exact old record it captured.  That record is
+    not looked up again, so a same-SID replacement is never mutated.
+    """
+    if _poller_set_running(binding, False):
+        return
+    session = binding.get("session")
+    if isinstance(session, dict):
+        _set_notification_running(session, False)
+
+
+def _set_notification_running(session: dict, running: bool) -> None:
+    with session["history_lock"]:
+        session["running"] = running
+
+
+def _start_bound_notification_turn(
+    rid: str,
+    binding: dict[str, Any],
+    evt: dict,
+    claim: Any,
+    text: str,
+    *,
+    display_kind: str | None = None,
+    display_metadata: dict | None = None,
+) -> Callable[[bool], None]:
+    """Start a notification turn and settle its registry claim at turn end.
+
+    ``_run_prompt_submit`` is asynchronous.  Treating thread launch as a
+    delivered event loses notifications when the worker fails or its SID is
+    replaced before terminal frames are emitted.  Production turns receive a
+    lifetime identity binding and report their terminal outcome through this
+    callback; lightweight legacy test seams without the callback keyword keep
+    their synchronous completion behaviour.
+    """
+    from tools.async_delegation import complete_event_delivery
+
+    settled = False
+    settle_lock = threading.Lock()
+
+    def _settle(succeeded: bool) -> None:
+        nonlocal settled
+        with settle_lock:
+            if settled:
+                return
+            settled = True
+        completed = False
+        if succeeded:
+            try:
+                completion_acks: list[bool] = []
+                completed = _run_bound_agent_effect(
+                    binding,
+                    lambda: completion_acks.append(
+                        complete_event_delivery(evt, claim)
+                    ),
+                )
+                # The binding check only proves this exact session/agent was
+                # live around the effect.  Durable async-delegation delivery
+                # additionally requires the DB compare-and-set acknowledgement
+                # to succeed; otherwise release and requeue below.
+                completed = completed and bool(completion_acks and completion_acks[0])
+            except Exception:
+                logger.warning("notification delivery completion failed", exc_info=True)
+        if completed:
+            return
+        _release_or_requeue_notification_event(
+            str(binding.get("sid") or ""), binding["session"], evt, claim
+        )
+
+    kwargs: dict[str, Any] = {}
+    if display_kind is not None:
+        kwargs["display_kind"] = display_kind
+    if display_metadata is not None:
+        kwargs["display_metadata"] = display_metadata
+    try:
+        parameters = inspect.signature(_run_prompt_submit).parameters.values()
+        supports_completion = any(
+            parameter.name == "notification_complete"
+            for parameter in parameters
+        )
+    except (TypeError, ValueError):
+        supports_completion = False
+    if supports_completion:
+        _run_prompt_submit(
+            rid,
+            str(binding["sid"]),
+            binding["session"],
+            text,
+            notification_binding=binding,
+            notification_complete=_settle,
+            **kwargs,
+        )
+        return _settle
+
+    # Compatibility only for test doubles that model a fully synchronous
+    # submit.  The real implementation always takes the lifetime-safe branch.
+    _run_prompt_submit(rid, str(binding["sid"]), binding["session"], text, **kwargs)
+    _settle(True)
+    return _settle
 
 
 # Mirror gateway/kanban_watchers.py TERMINAL_KINDS: claim silent kinds too so
@@ -8560,6 +9424,153 @@ def _collect_kanban_notifications(session: dict) -> list:
     return texts
 
 
+def _dispatch_poller_notification(
+    sid: str,
+    session: dict,
+    evt: dict,
+    text: str,
+    emitted: set,
+) -> str:
+    """Deliver one queue event, or requeue it if this poller lost ownership.
+
+    Each externally visible/ durable action is independently gated by the
+    exact session record and agent.  This deliberately lets a reset happen
+    between actions, but never lets an old poller claim, mutate, emit, or
+    inject into a same-SID replacement.
+    """
+    from tools.async_delegation import (
+        DELIVERY_BUSY_PENDING,
+        DELIVERY_TERMINAL_CONSUMED,
+        claim_event_delivery_state,
+        inspect_event_delivery_state,
+    )
+
+    binding = _notification_session_binding(sid, session)
+    if binding is None:
+        _requeue_notification_event(sid, session, evt)
+        return "requeued"
+    if evt.get("type") == "async_delegation":
+        try:
+            if (
+                inspect_event_delivery_state(evt)
+                == DELIVERY_TERMINAL_CONSUMED
+            ):
+                return "consumed"
+        except Exception:
+            logger.warning(
+                "notification delivery preflight inspection failed",
+                exc_info=True,
+            )
+            _requeue_notification_event(sid, session, evt)
+            return "requeued"
+
+    dedup_key = _notification_event_dedup_key(evt)
+    if dedup_key not in emitted:
+        if not _emit_bound_agent_event(
+            binding, "status.update", {"kind": "process", "text": text}
+        ):
+            _requeue_notification_event(sid, session, evt)
+            return "requeued"
+        emitted.add(dedup_key)
+
+    reserved: list[bool] = []
+
+    def _reserve() -> None:
+        with session["history_lock"]:
+            if session.get("running"):
+                reserved.append(False)
+            else:
+                session["running"] = True
+                reserved.append(True)
+
+    if not _run_bound_agent_effect(binding, _reserve):
+        _clear_notification_reservation(binding)
+        _requeue_notification_event(sid, session, evt)
+        return "requeued"
+    if not reserved or not reserved[0]:
+        _requeue_notification_event(sid, session, evt)
+        return "requeued"
+
+    claims: list[Any] = []
+    try:
+        claimed = _run_bound_agent_effect(
+            binding,
+            lambda: claims.append(
+                claim_event_delivery_state(evt, "tui-poller")
+            ),
+        )
+    except Exception:
+        # A claim failure is not proof that another worker owns this event.
+        # Keep the durable event available for a later retry and release this
+        # session's reservation so the poller cannot wedge itself busy.
+        logger.warning("notification delivery claim failed", exc_info=True)
+        _clear_notification_reservation(binding)
+        _requeue_notification_event(sid, session, evt)
+        return "requeued"
+    if not claimed:
+        if claims and claims[0].claim_id:
+            _release_or_requeue_notification_event(
+                sid, session, evt, claims[0].claim_id
+            )
+        else:
+            _requeue_notification_event(sid, session, evt)
+        _clear_notification_reservation(binding)
+        return "requeued"
+    claim_result = claims[0] if claims else None
+    if claim_result is None or claim_result.state == DELIVERY_BUSY_PENDING:
+        _clear_notification_reservation(binding)
+        _requeue_notification_event(sid, session, evt)
+        return "requeued"
+    if claim_result.state == DELIVERY_TERMINAL_CONSUMED:
+        _clear_notification_reservation(binding)
+        return "consumed"
+    claim = claim_result.claim_id
+
+    rid = f"__notif__{int(time.time() * 1000)}"
+
+    settles: list[Callable[[bool], None]] = []
+
+    def _dispatch() -> None:
+        _emit("message.start", sid)
+        if evt.get("type") == "async_delegation":
+            settles.append(_start_bound_notification_turn(
+                rid,
+                binding,
+                evt,
+                claim,
+                text,
+                display_kind="async_delegation_complete",
+                display_metadata=_async_delegation_display_metadata(evt),
+            ))
+        else:
+            settles.append(_start_bound_notification_turn(rid, binding, evt, claim, text))
+
+    try:
+        if not _run_bound_agent_effect(binding, _dispatch):
+            if settles:
+                settles[0](False)
+            else:
+                _release_or_requeue_notification_event(
+                    sid, session, evt, claim
+                )
+                _clear_notification_reservation(binding)
+            _clear_notification_reservation(binding)
+            return "requeued"
+        return "handled"
+    except Exception as exc:
+        if settles:
+            settles[0](False)
+        else:
+            _release_or_requeue_notification_event(sid, session, evt, claim)
+        _clear_notification_reservation(binding)
+        print(
+            f"[tui_gateway] notification poller dispatch failed: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return "requeued"
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -8570,8 +9581,8 @@ def _notification_poller_loop(
     agent turn via _run_prompt_submit if the session is idle.
 
     The completion_queue is process-global. In multi-session Desktop each
-    poller requeues events owned by another live session and drops addressed
-    events whose owner is gone; ownerless legacy notifications remain global.
+    poller requeues events owned by another live session and preserves addressed
+    events while their owner is absent; ownerless legacy notifications remain global.
 
     Also polls ``kanban_notify_subs`` every ``_KANBAN_POLL_SECONDS`` for this
     session's TUI kanban subscriptions and delivers terminal task events the
@@ -8586,8 +9597,16 @@ def _notification_poller_loop(
         _now = time.monotonic()
         if _now - _last_kanban_poll >= _KANBAN_POLL_SECONDS:
             _last_kanban_poll = _now
+            _kanban_binding = _notification_session_binding(sid, session)
+            _kanban_holder: list[list] = []
             try:
-                _kanban_texts = _collect_kanban_notifications(session)
+                if _kanban_binding is None or not _run_bound_agent_effect(
+                    _kanban_binding,
+                    lambda: _kanban_holder.append(_collect_kanban_notifications(session)),
+                ):
+                    _kanban_texts = []
+                else:
+                    _kanban_texts = _kanban_holder[0] if _kanban_holder else []
             except Exception as _kb_exc:
                 print(
                     f"[tui_gateway] kanban notification poll failed: "
@@ -8597,34 +9616,56 @@ def _notification_poller_loop(
                 _kanban_texts = []
             if _kanban_texts:
                 for _kb_text in _kanban_texts:
-                    _emit("status.update", sid, {"kind": "process", "text": _kb_text})
+                    if _kanban_binding is not None:
+                        _emit_bound_agent_event(
+                            _kanban_binding,
+                            "status.update",
+                            {"kind": "process", "text": _kb_text},
+                        )
                 # Events are cursor-claimed (never re-queued), so buffer them
                 # until the session is idle instead of dropping the agent turn.
-                session.setdefault("_kanban_pending", []).extend(_kanban_texts)
-            _pending = session.get("_kanban_pending") or []
+                if _kanban_binding is not None:
+                    _run_bound_agent_effect(
+                        _kanban_binding,
+                        lambda: session.setdefault("_kanban_pending", []).extend(_kanban_texts),
+                    )
+            _pending = (session.get("_kanban_pending") or []) if _kanban_binding else []
             if _pending:
                 _batch: list = []
-                with session["history_lock"]:
-                    if not session.get("running"):
-                        session["running"] = True
-                        _batch = list(_pending)
-                        session["_kanban_pending"] = []
+                if _kanban_binding is not None:
+                    def _reserve_kanban() -> None:
+                        with session["history_lock"]:
+                            if not session.get("running"):
+                                session["running"] = True
+                                _batch.extend(_pending)
+                                session["_kanban_pending"] = []
+
+                    _run_bound_agent_effect(_kanban_binding, _reserve_kanban)
                 if _batch:
                     rid = f"__notif__{int(time.time() * 1000)}"
                     try:
-                        _emit("message.start", sid)
-                        _run_prompt_submit(rid, sid, session, "\n".join(_batch))
+                        _run_bound_agent_effect(
+                            _kanban_binding,
+                            lambda: (
+                                _emit("message.start", sid),
+                                _run_prompt_submit(rid, sid, session, "\n".join(_batch)),
+                            ),
+                        )
                     except Exception as exc:
                         print(
                             f"[tui_gateway] kanban notification dispatch failed: "
                             f"{type(exc).__name__}: {exc}",
                             file=sys.stderr,
                         )
-                        with session["history_lock"]:
-                            session["running"] = False
+                        _poller_set_running(_kanban_binding, False)
         try:
             evt = process_registry.completion_queue.get(timeout=0.5)
         except Exception:
+            continue
+
+        if _notification_event_reserved_elsewhere(sid, session, evt):
+            process_registry.completion_queue.put(evt)
+            time.sleep(0.1)
             continue
 
         # Multiple desktop sessions share this one process-wide queue. Only
@@ -8640,8 +9681,9 @@ def _notification_poller_loop(
         # What reaches here is not owned by another LIVE session. Addressed
         # events still require positive proof before injection: exact UI origin,
         # direct durable key, or compression lineage. If none proves ownership,
-        # the event is orphaned and must not be adopted by this chat. Truly
-        # ownerless ordinary notifications retain legacy global delivery.
+        # the event is awaiting its durable owner and must not be adopted by
+        # this chat. Requeue rather than discard: the owner may be temporarily
+        # absent while a resume/reconnect recreates its session record.
         requires_owner = _notification_event_requires_owner(evt)
         if requires_owner and not _session_owns_notification_event(sid, session, evt):
             log = (
@@ -8650,13 +9692,15 @@ def _notification_poller_loop(
                 else logger.debug
             )
             log(
-                "Dropping unowned %s notification (origin=%r key=%r) instead "
-                "of delivering to session %s",
+                "Requeueing unowned %s notification (origin=%r key=%r) while "
+                "awaiting its owner instead of delivering to session %s",
                 evt.get("type", "completion"),
                 str(evt.get("origin_ui_session_id") or ""),
                 str(evt.get("session_key") or ""),
                 sid,
             )
+            _requeue_notification_event(sid, session, evt)
+            time.sleep(0.1)
             continue
 
         _evt_sid = evt.get("session_id", "")
@@ -8667,88 +9711,41 @@ def _notification_poller_loop(
         if not text:
             continue
 
-        # Only emit the same notification identity to TUI once — re-queued
-        # completions get re-emitted every 0.5s otherwise when session is busy,
-        # while distinct watch_match events from the same process must remain
-        # visible independently.
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
-        _requeued = False
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                _requeued = True
-            else:
-                session["running"] = True
-        if _requeued:
+        if _dispatch_poller_notification(sid, session, evt, text, _emitted) == "requeued":
             # Back off before re-polling: the re-queued event keeps the queue
-            # non-empty, so without a sleep this loop spins at full speed
-            # (100% CPU, GIL churn) for as long as the session stays busy.
+            # non-empty, so without a sleep this loop spins at full speed.
             time.sleep(0.25)
-            continue
-
-        rid = f"__notif__{int(time.time() * 1000)}"
-        from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
-        )
-        _claim = claim_event_delivery(evt, "tui-poller")
-        if _claim is None:
-            continue
-        try:
-            _emit("message.start", sid)
-            if evt.get("type") == "async_delegation":
-                _run_prompt_submit(
-                    rid,
-                    sid,
-                    session,
-                    text,
-                    display_kind="async_delegation_complete",
-                    display_metadata=_async_delegation_display_metadata(evt),
-                )
-            else:
-                _run_prompt_submit(rid, sid, session, text)
-            complete_event_delivery(evt, _claim)
-        except Exception as exc:
-            release_event_delivery(evt, _claim)
-            print(
-                f"[tui_gateway] notification poller dispatch failed: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            with session["history_lock"]:
-                session["running"] = False
 
     # Drain any remaining events after stop signal (process all pending
     # before exiting so nothing is lost on shutdown). Events owned by other
     # live sessions are set aside and re-queued so their poller still sees them.
-    # Orphaned events (owner gone) are dropped — same guard as the main loop.
+    # Addressed events whose owner is absent are preserved for a later resume,
+    # matching the main loop's fail-closed ownership rule.
     deferred: list = []
     while not process_registry.completion_queue.empty():
         try:
             evt = process_registry.completion_queue.get_nowait()
         except Exception:
             break
+        if _notification_event_reserved_elsewhere(sid, session, evt):
+            deferred.append(evt)
+            continue
         if _notification_event_belongs_elsewhere(sid, session, evt):
             deferred.append(evt)
             continue
-        # Same positive-proof rule as the live loop. Preserve the existing
-        # shutdown behavior for orphaned delegation payloads by deferring them
-        # for a later resume; ordinary addressed orphans are dropped.
+        # Same positive-proof rule as the live loop. Every addressed durable
+        # event is deferred for a later resume; a replacement SID must not
+        # silently consume it.
         requires_owner = _notification_event_requires_owner(evt)
         if requires_owner and not _session_owns_notification_event(sid, session, evt):
-            if evt.get("type") == "async_delegation":
-                deferred.append(evt)
+            key = str(evt.get("session_key") or "")
+            if key:
+                evt.setdefault("_tui_requeue_session_key", key)
             else:
-                logger.debug(
-                    "Dropping unowned %s notification during shutdown drain "
-                    "(origin=%r key=%r)",
-                    evt.get("type", "completion"),
-                    str(evt.get("origin_ui_session_id") or ""),
-                    str(evt.get("session_key") or ""),
-                )
+                origin_sid = str(evt.get("origin_ui_session_id") or "")
+                if origin_sid:
+                    evt.setdefault("_tui_requeue_origin_sid", origin_sid)
+            deferred.append(evt)
             continue
         _evt_sid = evt.get("session_id", "")
         if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
@@ -8757,47 +9754,10 @@ def _notification_poller_loop(
         if not text:
             continue
 
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                break
-            session["running"] = True
-
-        rid = f"__notif__{int(time.time() * 1000)}"
-        from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
-        )
-        _claim = claim_event_delivery(evt, "tui-poller")
-        if _claim is None:
-            continue
-        try:
-            _emit("message.start", sid)
-            if evt.get("type") == "async_delegation":
-                _run_prompt_submit(
-                    rid,
-                    sid,
-                    session,
-                    text,
-                    display_kind="async_delegation_complete",
-                    display_metadata=_async_delegation_display_metadata(evt),
-                )
-            else:
-                _run_prompt_submit(rid, sid, session, text)
-            complete_event_delivery(evt, _claim)
-        except Exception as exc:
-            release_event_delivery(evt, _claim)
-            print(
-                f"[tui_gateway] notification poller dispatch failed: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            with session["history_lock"]:
-                session["running"] = False
+        if _dispatch_poller_notification(sid, session, evt, text, _emitted) == "requeued":
+            # Preserve shutdown-drain ordering: leave the shared queue for the
+            # next live owner instead of spinning this stopped poller.
+            break
 
     # Hand any other sessions' events back to the shared queue.
     for evt in deferred:
@@ -8915,6 +9875,8 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
 def _run_prompt_submit(
     rid, sid: str, session: dict, text: Any, *, display_kind: str | None = None,
     display_metadata: dict | None = None,
+    notification_binding: dict[str, Any] | None = None,
+    notification_complete: Callable[[bool], None] | None = None,
 ) -> None:
     with session["history_lock"]:
         history = list(session["history"])
@@ -8935,10 +9897,16 @@ def _run_prompt_submit(
     _emit("message.start", sid)
 
     def run():
+        # This worker outlives the poller's publication lock.  Its output must
+        # remain bound to the exact record and transport that launched it,
+        # rather than resolving ``sid`` again after a reconnect/reset.
+        if notification_binding is not None:
+            _notification_turn_binding.set(notification_binding)
         approval_token = None
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         secret_token = None
+        skill_secret_capture_token = None
         goal_followup = None  # set by the post-turn goal hook below
         result = None  # turn outcome; read after the finally for leftover /steer
         tts_queue = None  # streaming-TTS feed for this turn (voice mode)
@@ -8947,6 +9915,11 @@ def _run_prompt_submit(
         # True once a failed turn's snapshot was retained for resume replay —
         # tells the finally below to skip the normal inflight clear.
         turn_error_retained = False
+        turn_failed = False
+        # Notification claims settle only after a genuinely successful turn.
+        # A returned error/interruption and an early preprocessing refusal are
+        # terminal outcomes for the UI, but not successful delivery.
+        turn_succeeded = False
         # Durable crash marker: written before the turn runs, retired the
         # moment its outcome reaches the client (see _retire_turn_marker).
         # Any concluded turn — success, handled error, interrupt — retires
@@ -8978,9 +9951,16 @@ def _run_prompt_submit(
             # _callback_tls), so wiring it on the build thread doesn't reach this
             # turn thread — terminal sudo prompts would fall through to /dev/tty
             # and hang the headless gateway. Re-wire here so the prompt routes to
-            # the sudo.request overlay. (secret capture is a module global, so
-            # re-running is a harmless no-op.)
-            _wire_callbacks(sid)
+            # the sudo.request overlay. Secret capture is deliberately
+            # ContextVar-scoped: concurrent desktop sessions must never route a
+            # skill setup prompt through another session's callback.
+            _secret_capture_cb = _wire_callbacks(sid)
+            if _secret_capture_cb is not None:
+                from tools.skills_tool import set_secret_capture_callback_context
+
+                skill_secret_capture_token = set_secret_capture_callback_context(
+                    _secret_capture_cb
+                )
             # Skip the config-model sync while a /model --once override is
             # active: the once-model is intentionally not pinned as a session
             # model_override (it must not persist), so without this guard the
@@ -9372,6 +10352,7 @@ def _run_prompt_submit(
                 payload["recoverable"] = True
             _retire_turn_marker(session, marker_key)
             _emit("message.complete", sid, payload)
+            turn_succeeded = status == "complete"
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
             # After every TUI turn, if a /goal is active, ask the judge
@@ -9516,6 +10497,7 @@ def _run_prompt_submit(
                 except Exception as e:
                     logger.warning("voice TTS dispatch failed: %s", e)
         except Exception as e:
+            turn_failed = True
             import traceback
 
             trace = traceback.format_exc()
@@ -9575,6 +10557,13 @@ def _run_prompt_submit(
                 reset_hermes_home_override(home_token)
             if secret_token is not None:
                 reset_secret_scope(secret_token)
+            if skill_secret_capture_token is not None:
+                try:
+                    from tools.skills_tool import reset_secret_capture_callback_context
+
+                    reset_secret_capture_callback_context(skill_secret_capture_token)
+                except Exception:
+                    pass
             _clear_session_context(session_tokens)
             # Clear the per-turn interim callback so a stale closure from
             # this turn can't fire during a later turn on the same agent.
@@ -9588,7 +10577,17 @@ def _run_prompt_submit(
             # frame paths retire the marker as they emit).
             _retire_turn_marker(session, marker_key)
             session.pop("_auto_continue_scheduled", None)
-            _emit_settled_session_info(sid, session, agent)
+            try:
+                _emit_settled_session_info(sid, session, agent)
+            finally:
+                if notification_complete is not None:
+                    try:
+                        notification_complete(turn_succeeded and not turn_failed)
+                    except Exception:
+                        logger.warning(
+                            "notification turn completion callback failed",
+                            exc_info=True,
+                        )
 
         # A user prompt that arrived mid-turn (interrupt + queue) wins over
         # every auto follow-up below — drain it first and skip them this cycle;
@@ -9631,6 +10630,13 @@ def _run_prompt_submit(
                 with session["history_lock"]:
                     session["running"] = False
 
+        # A notification turn that failed has just released and requeued its
+        # own durable event.  Do not let this same worker's safety-net drain
+        # claim it again synchronously: repeated returned errors would recurse
+        # forever instead of yielding the retry to the live poller.
+        if notification_binding is not None:
+            return
+
         # Drain completion notifications that arrived during this turn.
         # The background poller handles between-turn delivery; this is
         # the safety net for events that arrived mid-turn.
@@ -9653,31 +10659,113 @@ def _run_prompt_submit(
                 skip_poll_observed=False,
             )
             for index, (_evt, synth) in enumerate(drained):
-                with session["history_lock"]:
-                    if session.get("running"):
-                        for pending_evt, _pending_synth in drained[index:]:
-                            process_registry.completion_queue.put(pending_evt)
-                        break
-                    session["running"] = True
                 from tools.async_delegation import (
-                    claim_event_delivery, complete_event_delivery, release_event_delivery,
+                    DELIVERY_BUSY_PENDING,
+                    DELIVERY_TERMINAL_CONSUMED,
+                    claim_event_delivery_state,
                 )
-                _claim = claim_event_delivery(_evt, "tui-post-turn")
-                if _claim is None:
+                _binding = _notification_session_binding(sid, session)
+                if _binding is None:
+                    # This ``session`` is the exact record retained by this
+                    # turn; clear it directly rather than looking up a
+                    # replacement sharing the same short SID.
+                    _set_notification_running(session, False)
+                    _requeue_notification_event(sid, session, _evt)
                     continue
+                _reserved: list[bool] = []
+
+                def _reserve_post_turn_notification() -> None:
+                    with session["history_lock"]:
+                        if session.get("running"):
+                            _reserved.append(False)
+                        else:
+                            session["running"] = True
+                            _reserved.append(True)
+
+                if not _run_bound_agent_effect(
+                    _binding, _reserve_post_turn_notification
+                ):
+                    _clear_notification_reservation(_binding)
+                    _requeue_notification_event(sid, session, _evt)
+                    continue
+                if not _reserved or not _reserved[0]:
+                    for pending_evt, _pending_synth in drained[index:]:
+                        process_registry.completion_queue.put(pending_evt)
+                    break
                 try:
-                    _emit("message.start", sid)
-                    _run_prompt_submit(rid, sid, session, synth)
-                    complete_event_delivery(_evt, _claim)
+                    _claim = None
+                    _settles: list[Callable[[bool], None]] = []
+                    _claims: list[Any] = []
+                    claimed = _run_bound_agent_effect(
+                        _binding,
+                        lambda: _claims.append(
+                            claim_event_delivery_state(_evt, "tui-post-turn")
+                        ),
+                    )
+                    _claim_result = _claims[0] if _claims else None
+                    _claim = (
+                        _claim_result.claim_id
+                        if _claim_result is not None
+                        else None
+                    )
+                    if not claimed:
+                        # A failed/absent claim has not delivered the event.
+                        # Return it to the durable queue and undo only this
+                        # captured record's reservation; never fall back to a
+                        # same-SID replacement.
+                        if _claim is not None:
+                            _release_or_requeue_notification_event(
+                                sid, session, _evt, _claim
+                            )
+                        else:
+                            _requeue_notification_event(sid, session, _evt)
+                        _clear_notification_reservation(_binding)
+                        continue
+                    if (
+                        _claim_result is None
+                        or _claim_result.state == DELIVERY_BUSY_PENDING
+                    ):
+                        _clear_notification_reservation(_binding)
+                        _requeue_notification_event(sid, session, _evt)
+                        continue
+                    if _claim_result.state == DELIVERY_TERMINAL_CONSUMED:
+                        _clear_notification_reservation(_binding)
+                        continue
+                    def _dispatch_post_turn_notification() -> None:
+                        _emit("message.start", sid)
+                        _settles.append(
+                            _start_bound_notification_turn(
+                                rid, _binding, _evt, _claim, synth
+                            )
+                        )
+
+                    if not _run_bound_agent_effect(
+                        _binding, _dispatch_post_turn_notification
+                    ):
+                        if _settles:
+                            _settles[0](False)
+                        else:
+                            _release_or_requeue_notification_event(
+                                sid, session, _evt, _claim
+                            )
+                            _clear_notification_reservation(_binding)
+                        _clear_notification_reservation(_binding)
                 except Exception as _n_exc:
-                    release_event_delivery(_evt, _claim)
+                    if _settles:
+                        _settles[0](False)
+                    else:
+                        if _claim is not None:
+                            _release_or_requeue_notification_event(
+                                sid, session, _evt, _claim
+                            )
+                        else:
+                            _requeue_notification_event(sid, session, _evt)
                     print(
                         f"[tui_gateway] completion notification dispatch failed: "
                         f"{type(_n_exc).__name__}: {_n_exc}",
                         file=sys.stderr,
                     )
-                    with session["history_lock"]:
-                        session["running"] = False
+                    _clear_notification_reservation(_binding)
         except Exception as _drain_exc:
             print(
                 f"[tui_gateway] completion queue drain failed: "
@@ -11756,7 +12844,10 @@ def _format_live_context_output(session: dict) -> str:
     if model:
         lines.append(f"Model: {model}")
     lines.append(f"Provider: {provider}")
-    context_used = int(usage.get("context_used") or usage.get("total") or 0)
+    # Session ``total`` is lifetime cumulative usage, not the current prompt
+    # window. Showing it here as context occupancy recreates the same impossible
+    # over-capacity gauge guarded against by _get_usage().
+    context_used = int(usage.get("context_used") or 0)
     context_max = int(usage.get("context_max") or 0)
     if context_used:
         if context_max:
@@ -11915,6 +13006,7 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     if name in _MUTATES_WHILE_RUNNING and session.get("running"):
         return f"session busy — /interrupt the current turn before running /{name}"
 
+    compression_reservation = None
     try:
         if name == "model" and arg and agent:
             result = _apply_model_switch(sid, session, arg)
@@ -11939,6 +13031,10 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
                 finalize_context_engine_compression_notification,
             )
 
+            compression_reservation = _reserve_manual_compression(session)
+            if compression_reservation is None:
+                return "session busy — /interrupt the current turn before /compress"
+
             with session["history_lock"]:
                 _before_messages = list(session.get("history", []))
             _before_count = len(_before_messages)
@@ -11962,7 +13058,12 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
                 from agent.manual_compression_feedback import (
                     describe_compression_lock_skip,
                 )
-                return describe_compression_lock_skip(e.holder)
+                try:
+                    return describe_compression_lock_skip(e.holder)
+                finally:
+                    _release_manual_compression(session, compression_reservation)
+                    compression_reservation = None
+                    _drain_queued_prompt("slash-compress", sid, session)
             _sync_session_key_after_compress(sid, session)
 
             with session["history_lock"]:
@@ -11991,6 +13092,9 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
                 agent,
                 committed=True,
             )
+            _release_manual_compression(session, compression_reservation)
+            compression_reservation = None
+            _drain_queued_prompt("slash-compress", sid, session)
             return "\n".join(_lines)
         elif name == "fast" and agent:
             mode = arg.lower()
@@ -12015,6 +13119,9 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
                 agent,
                 committed=False,
             )
+            _release_manual_compression(session, compression_reservation)
+            compression_reservation = None
+            _drain_queued_prompt("slash-compress", sid, session)
         return f"live session sync failed: {e}"
     return ""
 

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -195,8 +195,10 @@ local transcript mirror leaves the real thread growing unbounded until a hard
 context reset. For this runtime, compaction goes through the app-server's own
 mechanism instead:
 
-- Manual compaction (`/compress`) asks the app-server to compact the thread
-  (`thread/compact/start`) and waits for the compaction turn to complete.
+- Manual compaction (`/compress`) asks an active app-server thread to compact
+  (`thread/compact/start`) and waits for the compaction turn to complete. If no
+  thread exists yet, it falls back to Hermes' built-in compressor so the
+  durable transcript can still be reduced.
 - Automatic compaction is controlled by `compression.codex_app_server_auto`:
   the default `native` lets the app-server decide when to compact and Hermes
   records the resulting compaction events (compression counters, session
@@ -204,9 +206,12 @@ mechanism instead:
   app-server compaction, or `off` to disable Hermes-initiated automatic
   compaction entirely (codex may still compact natively).
 
-Hermes' local transcript is never rewritten on this runtime — state.db records
-the compaction boundary while the visible transcript stays intact. All other
-routes (including Codex OAuth chat sessions) keep Hermes' summary compressor.
+With an active app-server thread, Hermes' local transcript is not rewritten —
+state.db records the native compaction boundary while the visible transcript
+stays intact. In `hermes` mode, preflight or hygiene may run before an
+app-server thread exists; those paths use Hermes' built-in compressor to shrink
+the durable transcript instead of silently doing nothing. All other routes
+(including Codex OAuth chat sessions) keep Hermes' summary compressor.
 
 ### Computed Values (for a 200K context model at defaults)
 

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -98,6 +98,24 @@ Known failure modes and how to handle them.
 How the agent confirms it worked.
 ```
 
+`name` and `description` must both be non-empty strings. When creating a skill
+through `skill_manage`, the frontmatter `name` must exactly match the requested
+skill name, and `description` must be no longer than 60 characters. Put concise
+trigger and routing language in `description`; keep procedures, examples, and
+edge cases in the body or supporting files. On POSIX, creation and canonical
+`SKILL.md` mutation use no-follow, directory-fd-relative operations. A canonical
+mutation keeps candidate lookup, read, replacement, scan snapshot, and rollback
+attached to one verified directory object. Creation scans a no-follow snapshot
+from the held newly-created directory before it can report success. Windows
+directory guards validate
+`FileAttributeTagInfo` after opening a handle (so a junction swap cannot hide
+between attribute lookup and `CreateFileW`), but Python does not currently
+provide the handle-relative create/replace/rollback primitives this contract
+requires. `skill_manage` therefore fails closed for creation and canonical
+`SKILL.md` mutation on Windows; supporting-file behavior is unchanged. Other
+runtimes also fail closed when they cannot provide an equivalent safe backend.
+Canonical `SKILL.md` files must be regular files and cannot be symlinks.
+
 ### Platform-Specific Skills
 
 Skills can restrict themselves to specific operating systems using the `platforms` field:
@@ -272,6 +290,13 @@ Prefer stdlib Python, curl, and existing Hermes tools (`web_extract`, `terminal`
 ### Progressive Disclosure
 
 Put the most common workflow first. Edge cases and advanced usage go at the bottom. This keeps token usage low for common tasks.
+
+Supporting files under `references/`, `templates/`, `scripts/`, and `assets/`
+are discovered automatically when a skill is activated. To keep activation
+bounded, Hermes previews at most 50 paths per category and applies a total path
+length budget. Any omitted file remains available through
+`skill_view(file_path=...)`, so large skills should link to files by purpose
+instead of copying their full contents into `SKILL.md`.
 
 ### Include Helper Scripts
 

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -139,6 +139,20 @@ Level 2: skill_view(name, path)  → Specific reference file       (varies)
 
 The agent only loads the full skill content when it actually needs it.
 
+Large skill libraries can also use a category-compact system-prompt index:
+
+```yaml
+skills:
+  prompt_index_mode: category_compact
+```
+
+`full` (the default) includes every skill description in the stable system
+prompt. `category_compact` keeps every category and skill name visible, retains
+the full `hermes-agent` routing anchor, and loads ordinary descriptions on
+demand through `skills_list(category=...)` followed by `skill_view(name=...)`.
+The mode is resolved when a session prompt is built; it does not mutate an
+in-flight prompt or invalidate the prefix cache mid-turn.
+
 ## SKILL.md Format
 
 ```markdown


### PR DESCRIPTION
## Summary

- persist the Hermes session ↔ Codex thread binding and serialize cross-process turns with schema-25 leases
- align interrupt, compaction, token-usage, and event-scoping behavior with the official Codex app-server protocol
- resume existing Codex threads with the experimental excludeTurns handshake to preserve long-context continuity without replaying full turn history
- harden API-call accounting, lease recovery/PID reuse handling, Skills prompt selection, and generated-skill validation
- expose the local Hermes/Codex coordination path through MCP without merging isolated profile databases

## Validation

- focused regression suite: 288 passed
- independent accounting review: 106 passed
- full suite: 23,068 passed; 64 failures across 28 files, exactly matching the pre-change baseline failure set
- Ruff and git diff --check passed
- real Codex app-server smoke: initial turn, native compaction, process restart, and exact-thread resume all succeeded
- multiprocessing lease smoke: contention, release handoff, and expired dead-owner recovery succeeded
- final independent Sol review: GO; no new Critical/High/Medium findings

## Protocol basis

The implementation follows the official Codex app-server lifecycle: thread/resume returns the durable thread id; thread/compact/start is only an acknowledgement; compaction succeeds only after a matching item/completed contextCompaction plus turn/completed; turn/interrupt is also acknowledgement-only until the matching terminal event.

## Risk and rollout

- introduces SQLite schema migration 25
- lease recovery is conservative and fails closed when process liveness is uncertain
- default and named Hermes profile databases remain isolated and are never merged
- this is intentionally a draft for upstream maintainer review