### PR TITLE
fix(update): accept legacy Windows updater handoffs

### DIFF
--- a/hermes_cli/update_lock.py
+++ b/hermes_cli/update_lock.py
@@ -127,6 +127,24 @@ def _handoff_pid() -> int | None:
     return pid if pid > 0 else None
 
 
+def _is_legacy_updater_ancestor(pid: int) -> bool:
+    """Return whether an older Windows updater owns our ancestor process.
+
+    Staged ``hermes-setup.exe`` binaries from before the explicit handoff env
+    fix still hold the shared marker and spawn this update as a descendant.
+    Treat only that real ancestor relationship as an implicit handoff; an
+    unrelated live updater remains blocked.
+    """
+    if os.name != "nt" or pid <= 0:
+        return False
+    try:
+        import psutil
+
+        return any(parent.pid == pid for parent in psutil.Process().parents())
+    except Exception:
+        return False
+
+
 @dataclass(frozen=True)
 class UpdateHolder:
     """A confirmed-live update currently holding the lock."""
@@ -202,14 +220,16 @@ class UpdateLock:
     def acquire(self) -> bool:
         """Claim the lock. Returns False (and sets ``holder``) if it's taken.
 
-        A live holder whose pid matches :data:`HANDOFF_PID_ENV` is our own
-        orchestrating parent (the Tauri updater spawning `hermes update` as a
-        stage): we run under ITS claim rather than refusing or re-writing the
-        marker, and ``release`` leaves the parent's marker untouched.
+        A live holder whose pid matches :data:`HANDOFF_PID_ENV` — or, for an
+        older Windows updater, is proven to be our ancestor — is our own
+        orchestrator. We run under ITS claim rather than refusing or re-writing
+        the marker, and ``release`` leaves the parent's marker untouched.
         """
         existing = read_live_update(path=self.path)
         if existing is not None:
-            if existing.pid == _handoff_pid():
+            if existing.pid == _handoff_pid() or _is_legacy_updater_ancestor(
+                existing.pid
+            ):
                 return True
             self.holder = existing
             return False

--- a/tests/hermes_cli/test_update_lock.py
+++ b/tests/hermes_cli/test_update_lock.py
@@ -17,6 +17,8 @@ disk.
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 import time
 
 import pytest
@@ -199,6 +201,32 @@ class TestHandoffFromOrchestratingUpdater:
         lock.release()
         assert marker.exists(), "the parent still needs its marker after our stage ends"
         assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == os.getpid()
+
+    @pytest.mark.skipif(os.name != "nt", reason="legacy staged updater is Windows-only")
+    def test_legacy_child_recognizes_live_parent_without_handoff_env(
+        self, marker, monkeypatch
+    ):
+        """Older staged updaters omit the handoff env but remain our parent."""
+        marker.write_text(f"{os.getpid()}\n{int(time.time())}\n", encoding="utf-8")
+        monkeypatch.delenv(HANDOFF_PID_ENV, raising=False)
+        code = """
+import sys
+from pathlib import Path
+from hermes_cli.update_lock import UpdateLock
+
+lock = UpdateLock(path=Path(sys.argv[1]))
+raise SystemExit(0 if lock.acquire() and not lock.acquired else 1)
+"""
+
+        result = subprocess.run(
+            [sys.executable, "-c", code, str(marker)],
+            cwd=os.getcwd(),
+            env=os.environ.copy(),
+            check=False,
+        )
+
+        assert result.returncode == 0
+        assert marker.exists(), "the legacy parent still owns the marker"
 
     def test_handoff_pid_that_is_not_the_live_holder_grants_nothing(self, marker, monkeypatch):
         """The env var alone must not bypass the lock."""


### PR DESCRIPTION
## Summary
- recognize a live Windows update-marker owner as an implicit handoff only when it is a real ancestor of the current update process
- preserve fail-closed behavior for unrelated updaters, non-Windows platforms, and unavailable process inspection
- add a real subprocess regression test for staged updater binaries that predate `HERMES_UPDATE_HANDOFF_PID`

## Problem
Older staged `hermes-setup.exe` binaries hold the shared update marker but do not export `HERMES_UPDATE_HANDOFF_PID` when launching `hermes update`. The child therefore rejects its own parent's lock and the Desktop updater repeatedly reports that Hermes is still running.

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_update_lock.py` — 24 passed
- `python -m py_compile hermes_cli/update_lock.py tests/hermes_cli/test_update_lock.py`
- `git diff --check`
- independent pre-commit review: PASS