### PR TITLE
fix: tolerate turn-context signature skew after update

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -16,6 +16,7 @@ resolved through :func:`_ra` so those patches keep working.
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
@@ -1150,6 +1151,29 @@ def run_conversation(
     # ``build_turn_context``.  It mutates ``agent`` exactly as the inline code
     # did and returns the locals the loop below reads back.  See
     # ``agent/turn_context.py``.
+    # A dashboard can stay alive while an in-place source update lands. If it
+    # imported ``turn_context`` before that update but lazily imports this
+    # module afterwards, the loaded builder still has the previous signature.
+    # Feature-detect newly-added optional fields at this internal API seam so
+    # an ordinary turn does not die before reaching the model. A fresh process
+    # still passes both fields and retains turn-start display typing.
+    try:
+        _builder_params = inspect.signature(build_turn_context).parameters
+    except (TypeError, ValueError):
+        _builder_params = {}
+    _builder_accepts_kwargs = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in _builder_params.values()
+    )
+    _display_kwargs = {
+        name: value
+        for name, value in (
+            ("persist_user_display_kind", persist_user_display_kind),
+            ("persist_user_display_metadata", persist_user_display_metadata),
+        )
+        if _builder_accepts_kwargs or name in _builder_params
+    }
+
     _ctx = build_turn_context(
         agent,
         user_message,
@@ -1159,8 +1183,6 @@ def run_conversation(
         stream_callback,
         persist_user_message,
         persist_user_timestamp,
-        persist_user_display_kind=persist_user_display_kind,
-        persist_user_display_metadata=persist_user_display_metadata,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,
@@ -1171,6 +1193,7 @@ def run_conversation(
         # MoA turns append per-call aggregated context to the API copy of the
         # user message, so no byte-stable api_content sidecar can be stamped.
         moa_active=bool(moa_config),
+        **_display_kwargs,
     )
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message

--- a/tests/agent/test_turn_context_update_skew.py
+++ b/tests/agent/test_turn_context_update_skew.py
@@ -1,0 +1,106 @@
+"""Regression coverage for in-process source-update skew at turn start.
+
+A long-lived dashboard can import ``agent.turn_context`` before an in-place
+source update, then lazily import ``agent.conversation_loop`` afterwards.  The
+new loop must not pass newly-added optional keywords to that already-loaded
+legacy builder, or the next ordinary prompt fails before reaching the model.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent import conversation_loop
+
+
+class _LegacyBuilderReached(RuntimeError):
+    """Sentinel proving argument binding reached the legacy builder body."""
+
+
+class _CurrentBuilderReached(RuntimeError):
+    def __init__(self, display_kind, display_metadata):
+        self.display_kind = display_kind
+        self.display_metadata = display_metadata
+
+
+def _legacy_build_turn_context(
+    agent,
+    user_message,
+    system_message,
+    conversation_history,
+    task_id,
+    stream_callback,
+    persist_user_message,
+    persist_user_timestamp=None,
+    *,
+    restore_or_build_system_prompt,
+    install_safe_stdio,
+    sanitize_surrogates,
+    summarize_user_message_for_log,
+    set_session_context,
+    set_current_write_origin,
+    ra,
+    moa_active=False,
+):
+    """Signature from before ``persist_user_display_*`` was introduced."""
+    raise _LegacyBuilderReached
+
+
+def _current_build_turn_context(
+    *args,
+    persist_user_display_kind=None,
+    persist_user_display_metadata=None,
+    restore_or_build_system_prompt,
+    install_safe_stdio,
+    sanitize_surrogates,
+    summarize_user_message_for_log,
+    set_session_context,
+    set_current_write_origin,
+    ra,
+    moa_active=False,
+):
+    """Current keyword seam without a permissive ``**kwargs`` escape hatch."""
+    raise _CurrentBuilderReached(
+        persist_user_display_kind,
+        persist_user_display_metadata,
+    )
+
+
+def test_normal_turn_after_model_switch_tolerates_loaded_legacy_builder(monkeypatch):
+    monkeypatch.setattr(
+        conversation_loop,
+        "build_turn_context",
+        _legacy_build_turn_context,
+    )
+
+    # ``moa_config`` skips unrelated decoding. The real turn reaches the builder
+    # after initializing only these per-turn attributes on the agent.
+    agent = SimpleNamespace()
+    with pytest.raises(_LegacyBuilderReached):
+        conversation_loop.run_conversation(
+            agent,
+            "ordinary prompt after /model",
+            moa_config={},
+        )
+
+
+def test_current_builder_still_receives_synthetic_turn_display_fields(monkeypatch):
+    monkeypatch.setattr(
+        conversation_loop,
+        "build_turn_context",
+        _current_build_turn_context,
+    )
+
+    with pytest.raises(_CurrentBuilderReached) as reached:
+        conversation_loop.run_conversation(
+            SimpleNamespace(),
+            "model-switch context",
+            persist_user_display_kind="model_switch",
+            persist_user_display_metadata={"model": "test-model"},
+            moa_config={},
+        )
+
+    assert reached.value.display_kind == "model_switch"
+    assert reached.value.display_metadata == {"model": "test-model"}

--- a/tests/agent/test_turn_context_update_skew.py
+++ b/tests/agent/test_turn_context_update_skew.py
@@ -25,6 +25,11 @@ class _CurrentBuilderReached(RuntimeError):
         self.display_metadata = display_metadata
 
 
+class _UninspectableBuilderReached(RuntimeError):
+    def __init__(self, kwargs):
+        self.kwargs = kwargs
+
+
 def _legacy_build_turn_context(
     agent,
     user_message,
@@ -68,6 +73,26 @@ def _current_build_turn_context(
     )
 
 
+def _kwargs_build_turn_context(*args, **kwargs):
+    """A wrapper-style builder advertises support through ``**kwargs``."""
+    raise _CurrentBuilderReached(
+        kwargs.get("persist_user_display_kind"),
+        kwargs.get("persist_user_display_metadata"),
+    )
+
+
+class _UninspectableBuildTurnContext:
+    """Remain callable even when signature introspection is unavailable."""
+
+    __signature__ = object()
+
+    def __call__(self, *args, **kwargs):
+        raise _UninspectableBuilderReached(kwargs)
+
+
+_uninspectable_build_turn_context = _UninspectableBuildTurnContext()
+
+
 def test_normal_turn_after_model_switch_tolerates_loaded_legacy_builder(monkeypatch):
     monkeypatch.setattr(
         conversation_loop,
@@ -104,3 +129,43 @@ def test_current_builder_still_receives_synthetic_turn_display_fields(monkeypatc
 
     assert reached.value.display_kind == "model_switch"
     assert reached.value.display_metadata == {"model": "test-model"}
+
+
+def test_kwargs_builder_receives_synthetic_turn_display_fields(monkeypatch):
+    monkeypatch.setattr(
+        conversation_loop,
+        "build_turn_context",
+        _kwargs_build_turn_context,
+    )
+
+    with pytest.raises(_CurrentBuilderReached) as reached:
+        conversation_loop.run_conversation(
+            SimpleNamespace(),
+            "delegation context",
+            persist_user_display_kind="delegation",
+            persist_user_display_metadata={"task_count": 2},
+            moa_config={},
+        )
+
+    assert reached.value.display_kind == "delegation"
+    assert reached.value.display_metadata == {"task_count": 2}
+
+
+def test_uninspectable_builder_fails_closed_without_display_fields(monkeypatch):
+    monkeypatch.setattr(
+        conversation_loop,
+        "build_turn_context",
+        _uninspectable_build_turn_context,
+    )
+
+    with pytest.raises(_UninspectableBuilderReached) as reached:
+        conversation_loop.run_conversation(
+            SimpleNamespace(),
+            "model-switch context",
+            persist_user_display_kind="model_switch",
+            persist_user_display_metadata={"model": "test-model"},
+            moa_config={},
+        )
+
+    assert "persist_user_display_kind" not in reached.value.kwargs
+    assert "persist_user_display_metadata" not in reached.value.kwargs


### PR DESCRIPTION
## Summary
- tolerate in-process source-update skew when `conversation_loop` sees an older loaded `build_turn_context` signature
- feature-detect the optional `persist_user_display_*` keyword parameters while preserving them for current builders and `**kwargs` wrappers
- fail closed when `inspect.signature` cannot describe the callable
- add regression coverage for legacy, current, wrapper-style, and uninspectable builder paths

## Root cause
A long-lived dashboard/TUI process can keep the pre-update `agent.turn_context` module loaded while lazily importing the updated `agent.conversation_loop`. The new caller then passed `persist_user_display_kind` to the old function object and failed before the model call.

## Review notes
- Public `run_conversation` and `build_turn_context` signatures remain unchanged.
- Optional display fields are filtered independently; positional binding is untouched.
- `inspect.signature` failures (`TypeError`/`ValueError`) omit only the optional display fields, preserving ordinary turns.
- The signature gate measured about 22.5 µs per turn on the review host and retains no cross-turn cache/state.

## Verification
- `scripts/run_tests.sh tests/agent/test_turn_context_update_skew.py tests/agent/test_synthetic_turn_display_kind.py tests/agent/test_gateway_turn_sidecar.py tests/agent/test_turn_context.py tests/agent/test_turn_context_overflow_warning.py tests/gateway/test_turn_context.py -v --tb=short` → 34 passed
- `.venv/bin/ruff check agent/conversation_loop.py tests/agent/test_turn_context_update_skew.py` → passed
- `.venv/bin/ruff format --check tests/agent/test_turn_context_update_skew.py` → passed
- `.venv/bin/ty check tests/agent/test_turn_context_update_skew.py` → passed
- `git diff --check origin/main...HEAD` → passed

## Deployment fallback
The current-main integration is available on `David-Pascas-Labs/hermes-agent:reviewed/turn-context-update-skew` at `bd0bb9adba39c4dc4de609e78ec37cafedd08ad4`. It contains `origin/main` and the reviewed fix/tests, so controlled local deployment does not depend on the upstream merge.

## Scope
This is separate from corrupt-PNG/OpenAI 400 failures. No production install or gateway restart was performed. Upstream merge remains subject to NousResearch branch policy and maintainer permissions.
