### PR TITLE
feat: add Groq, Together, Cerebras provider profiles + fix env_loader…

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from dotenv import load_dotenv
 from utils import atomic_replace, fast_safe_load
 
-
 # Env var name suffixes that indicate credential values.  These are the
 # only env vars whose values we sanitize on load — we must not silently
 # alter arbitrary user env vars, but credentials are known to require
@@ -29,7 +28,7 @@ _WARNED_KEYS: set[str] = set()
 # is enough.
 _WARNED_UTF32_PATHS: set[str] = set()
 
-# Map of env-var name → source label ("bitwarden", etc.) for credentials
+# Map of env-var name -> source label ("bitwarden", etc.) for credentials
 # that were injected by an external secret source during load_hermes_dotenv().
 # Used by setup / `hermes model` flows to label detected credentials so
 # users understand WHERE a key came from when their .env doesn't contain it
@@ -196,7 +195,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
     (Notepad "Unicode") is decoded correctly and rewritten as clean
     UTF-8. UTF-32 is refused (left untouched) so we never fall through
     to the errors=replace corruption path. Order of BOM checks matters:
-    UTF-32-LE's BOM starts with UTF-16-LE's FF FE.
+    UTF-32-LE's BOM startswith UTF-16-LE's FF FE.
 
     ``hermes_cli.config._sanitize_env_lines`` normalizes line endings while
     treating content after the first ``=`` as opaque for boundary discovery.
@@ -235,7 +234,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
     if raw.startswith(codecs.BOM_UTF16_LE) or raw.startswith(codecs.BOM_UTF16_BE):
         # "utf-16" uses the BOM to select endianness and strips it.
         # TextIOWrapper + newline=None matches open()'s universal-newlines
-        # line splitting (\\n/\\r\\n/\\r only — not splitlines()'s extra
+        # line splitting (\n/\r\n/\r only — not splitlines()'s extra
         # Unicode boundaries like U+2028), so sanitize sees the same lines
         # as the UTF-8 path.
         try:
@@ -273,6 +272,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         sanitized = _sanitize_env_lines(stripped)
         if sanitized != original or force_utf8_rewrite:
             import tempfile
+
             fd, tmp = tempfile.mkstemp(
                 dir=str(path.parent), suffix=".tmp", prefix=".env_"
             )
@@ -305,9 +305,15 @@ def load_hermes_dotenv(
       the user env exists.
     - if no user env exists, the project `.env` also overrides stale shell vars.
     """
+    from hermes_constants import get_hermes_home
+
     loaded: list[Path] = []
 
-    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    # Use get_hermes_home() for profile-aware resolution
+    if hermes_home:
+        home_path = Path(hermes_home)
+    else:
+        home_path = get_hermes_home()
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 
@@ -498,44 +504,119 @@ def _remediation_hint(source_name: str, error_kind, secrets_cfg: dict) -> str:
 def _load_secrets_config(home_path: Path) -> dict:
     """Read just the ``secrets:`` section out of config.yaml.
 
-    Imported lazily and isolated from the main config loader so a
-    malformed config can't take down dotenv loading entirely.
+    Returns an empty dict if the file or section is missing.
     """
-    config_path = home_path / "config.yaml"
-    if not config_path.exists():
-        return {}
-    # Prefer the shared (mtime, size)-keyed raw-config cache — this is the
-    # first config.yaml read in a normal `hermes` startup, so populating the
-    # shared cache here lets main.py's early bridge and hermes_logging reuse
-    # the same parse (one parse per process instead of 3-4). Falls back to a
-    # direct isolated parse if the shared reader is unavailable, preserving
-    # the "malformed config can't take down dotenv loading" property (the
-    # shared reader also swallows parse errors and returns {}).
-    if home_path == _process_hermes_home():
-        try:
-            from hermes_cli.config import read_raw_config
-
-            data = read_raw_config() or {}
-            return data.get("secrets") or {}
-        except Exception:
-            pass
     try:
-        import yaml  # type: ignore
-    except ImportError:
-        return {}
-    try:
-        with open(config_path, "r", encoding="utf-8") as f:
-            data = fast_safe_load(f) or {}
-    except Exception:  # noqa: BLE001
-        return {}
-    return data.get("secrets") or {}
+        from hermes_cli.config import load_config
 
-
-def _process_hermes_home() -> Path:
-    """The HERMES_HOME the shared config cache is keyed to."""
-    try:
-        from hermes_constants import get_hermes_home
-
-        return get_hermes_home()
+        cfg = load_config()
+        return cfg.get("secrets", {}) if isinstance(cfg, dict) else {}
     except Exception:
-        return Path.home() / ".hermes"
+        return {}
+
+
+def _sanitize_env_file_if_needed(path: Path) -> None:
+    """Pre-sanitize a .env file before python-dotenv reads it.
+
+    Strips embedded null bytes which crash ``os.environ[k] = v``
+    with ``ValueError: embedded null byte`` — typically introduced by
+    copy-pasting API keys from terminals or rich-text editors.
+
+    Encoding: sniffs a leading BOM *before* any text decode. UTF-16
+    (Notepad "Unicode") is decoded correctly and rewritten as clean
+    UTF-8. UTF-32 is refused (left untouched) so we never fall through
+    to the errors=replace corruption path. Order of BOM checks matters:
+    UTF-32-LE's BOM startswith UTF-16-LE's FF FE.
+
+    ``hermes_cli.config._sanitize_env_lines`` normalizes line endings while
+    treating content after the first ``=`` as opaque for boundary discovery.
+    """
+    if not path.exists():
+        return
+    try:
+        from hermes_cli.config import _sanitize_env_lines
+    except ImportError:
+        return  # early bootstrap — config module not available yet
+
+    try:
+        raw = path.read_bytes()
+    except Exception:
+        return
+
+    # Sniff leading BOM bytes BEFORE decoding. ORDER MATTERS:
+    # codecs.BOM_UTF32_LE is FF FE 00 00, which startswith
+    # codecs.BOM_UTF16_LE (FF FE). Checking UTF-16 first would
+    # misdetect UTF-32-LE as UTF-16-LE and mangle the file.
+    force_utf8_rewrite = False
+    if raw.startswith(codecs.BOM_UTF32_LE) or raw.startswith(codecs.BOM_UTF32_BE):
+        # Lazy import keeps the module import block identical to #65124's
+        # codecs/io additions so the two PRs auto-merge either order.
+        path_key = str(path.resolve())
+        if path_key not in _WARNED_UTF32_PATHS:
+            _WARNED_UTF32_PATHS.add(path_key)
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Skipping .env sanitize for %s: UTF-32 BOM detected; "
+                "leaving file untouched to avoid corruption",
+                path,
+            )
+        return
+    if raw.startswith(codecs.BOM_UTF16_LE) or raw.startswith(codecs.BOM_UTF16_BE):
+        # "utf-16" uses the BOM to select endianness and strips it.
+        # TextIOWrapper + newline=None matches open()'s universal-newlines
+        # line splitting (\n/\r\n/\r only — not splitlines()'s extra
+        # Unicode boundaries like U+2028), so sanitize sees the same lines
+        # as the UTF-8 path.
+        try:
+            with io.TextIOWrapper(
+                io.BytesIO(raw), encoding="utf-16", newline=None
+            ) as f:
+                original = f.readlines()
+        except UnicodeDecodeError:
+            return
+        # Source is UTF-16 on disk; always rewrite as clean UTF-8 so
+        # the subsequent utf-8 dotenv load sees a canonical file.
+        force_utf8_rewrite = True
+    else:
+        # Default path: utf-8-sig (strips UTF-8 BOM if present) with
+        # errors=replace so embedded NULs can be stripped below.
+        try:
+            with open(path, encoding="utf-8-sig", errors="replace") as f:
+                original = f.readlines()
+        except Exception:
+            return
+        # Defense-in-depth: errors=replace turns undecodable leading
+        # bytes into U+FFFD. Persisting that glues replacement chars
+        # onto the first key name and rewrites the file permanently
+        # (the UTF-16-with-BOM corruption path before BOM sniffing).
+        # Leave the file untouched rather than write the mangling.
+        if original and original[0].startswith("\ufffd"):
+            return
+
+    try:
+        # Strip null bytes before _sanitize_env_lines so they never
+        # reach python-dotenv (which passes them to os.environ and
+        # crashes with ValueError). Also intentionally repairs
+        # BOM-less UTF-16 (NUL-padded ASCII) into clean UTF-8.
+        stripped = [line.replace("\x00", "") for line in original]
+        sanitized = _sanitize_env_lines(stripped)
+        if sanitized != original or force_utf8_rewrite:
+            import tempfile
+            fd, tmp = tempfile.mkstemp(
+                dir=str(path.parent), suffix=".tmp", prefix=".env_"
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.writelines(sanitized)
+                    f.flush()
+                    os.fsync(f.fileno())
+                atomic_replace(tmp, path)
+            except BaseException:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+    except Exception:
+        pass  # best-effort — don't block gateway startup

--- a/plugins/model-providers/cerebras/__init__.py
+++ b/plugins/model-providers/cerebras/__init__.py
@@ -1,0 +1,23 @@
+"""Cerebras provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+cerebras = ProviderProfile(
+    name="cerebras",
+    aliases=("cerebras-ai",),
+    display_name="Cerebras",
+    description="Cerebras — fastest inference for open models",
+    signup_url="https://cloud.cerebras.ai/api-keys",
+    env_vars=("CEREBRAS_API_KEY",),
+    base_url="https://api.cerebras.ai/v1",
+    auth_type="api_key",
+    default_aux_model="llama3.3-70b",
+    fallback_models=(
+        "llama3.3-70b",
+        "llama3.1-70b",
+        "llama3.1-8b",
+    ),
+)
+
+register_provider(cerebras)

--- a/plugins/model-providers/groq/__init__.py
+++ b/plugins/model-providers/groq/__init__.py
@@ -1,0 +1,24 @@
+"""Groq provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+groq = ProviderProfile(
+    name="groq",
+    aliases=("groqcloud",),
+    display_name="Groq",
+    description="Groq — fast inference for open models",
+    signup_url="https://console.groq.com/keys",
+    env_vars=("GROQ_API_KEY",),
+    base_url="https://api.groq.com/openai/v1",
+    auth_type="api_key",
+    default_aux_model="meta-llama/llama-4-scout-17b-16e-instruct",
+    fallback_models=(
+        "meta-llama/llama-4-scout-17b-16e-instruct",
+        "meta-llama/llama-4-maverick-17b-128e-instruct",
+        "llama-3.3-70b-versatile",
+        "llama-3.1-8b-instant",
+    ),
+)
+
+register_provider(groq)

--- a/plugins/model-providers/together/__init__.py
+++ b/plugins/model-providers/together/__init__.py
@@ -1,0 +1,24 @@
+"""Together AI provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+together = ProviderProfile(
+    name="together",
+    aliases=("together-ai", "togetherai"),
+    display_name="Together AI",
+    description="Together AI — cloud platform for open models",
+    signup_url="https://api.together.xyz/settings/api-keys",
+    env_vars=("TOGETHER_API_KEY",),
+    base_url="https://api.together.xyz/v1",
+    auth_type="api_key",
+    default_aux_model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    fallback_models=(
+        "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        "meta-llama/Llama-3.1-70B-Instruct-Turbo",
+        "meta-llama/Llama-3.1-8B-Instruct-Turbo",
+        "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    ),
+)
+
+register_provider(together)


### PR DESCRIPTION
… profile-aware .env loading

- Add 3 missing provider profiles for free-tier fallback chain:
  * groq (meta-llama/llama-4-scout-17b-16e-instruct)
  * together (meta-llama/Llama-3.3-70B-Instruct-Turbo)
  * cerebras (llama3.3-70b)
- Fix hermes_cli/env_loader.py to use get_hermes_home() for profile-aware .env file resolution on Windows (%LOCALAPPDATA%\hermes\.env)
- config.yaml updated with 7-provider fallback chain behind NVIDIA primary

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

