### PR TITLE
fix(auth): persist DEAD on manual xAI invalid_grant

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1360,17 +1360,42 @@ class CredentialPool:
                         logger.debug(
                             "Failed to clear terminal xAI OAuth state: %s", clear_exc
                         )
-                    removed_ids = [
-                        item.id for item in self._entries
-                        if item.source == "device_code"
-                    ]
-                    self._entries = [
-                        item for item in self._entries
-                        if item.source != "device_code"
-                    ]
-                    if self._current_id == entry.id:
-                        self._current_id = None
-                    self._persist(removed_ids=removed_ids)
+                    # Singleton-seeded device_code entries are removed so the
+                    # next load does not re-seed the same revoked grant from
+                    # the (now-cleared) provider singleton.
+                    #
+                    # Independent manual:device_code entries (hermes auth add)
+                    # must instead be marked DEAD and persisted. Removing only
+                    # device_code left manual entries with last_status=null so
+                    # every new process re-selected the revoked refresh token
+                    # and hammered invalid_grant again.
+                    if entry.source == "device_code":
+                        removed_ids = [
+                            item.id for item in self._entries
+                            if item.source == "device_code"
+                        ]
+                        self._entries = [
+                            item for item in self._entries
+                            if item.source != "device_code"
+                        ]
+                        if self._current_id == entry.id:
+                            self._current_id = None
+                        self._persist(removed_ids=removed_ids)
+                    else:
+                        code = getattr(exc, "code", None) or "invalid_grant"
+                        updated = replace(
+                            entry,
+                            last_status=STATUS_DEAD,
+                            last_status_at=time.time(),
+                            last_error_code=getattr(exc, "status_code", None) or 400,
+                            last_error_reason=str(code),
+                            last_error_message=str(exc),
+                            last_error_reset_at=None,
+                        )
+                        self._replace_entry(entry, updated)
+                        if self._current_id == entry.id:
+                            self._current_id = None
+                        self._persist()
                     return None
             # For openai-codex: same race as xAI/nous — another Hermes process
             # may have consumed the refresh token between our proactive sync

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5322,12 +5322,23 @@ def _is_terminal_xai_oauth_refresh_error(exc: Exception) -> bool:
     (invalid_grant, token revoked, refresh_token_reused).
     ``xai_auth_missing_refresh_token`` means the pool entry has no refresh
     token at all — retrying will never work.
-    Both carry ``relogin_required=True``; transient failures (429, 5xx) do not.
+    Raw OAuth codes (``invalid_grant`` / ``invalid_token`` /
+    ``refresh_token_reused``) are also terminal when raised with
+    ``relogin_required=True`` — callers and tests may surface the upstream
+    code directly instead of wrapping it as ``xai_refresh_failed``.
+    Transient failures (429, 5xx, tier denial) do not set
+    ``relogin_required`` and are therefore excluded.
     """
     return (
         isinstance(exc, AuthError)
         and exc.provider == "xai-oauth"
-        and exc.code in {"xai_refresh_failed", "xai_auth_missing_refresh_token"}
+        and exc.code in {
+            "xai_refresh_failed",
+            "xai_auth_missing_refresh_token",
+            "invalid_grant",
+            "invalid_token",
+            "refresh_token_reused",
+        }
         and bool(exc.relogin_required)
     )
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1896,3 +1896,99 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+def test_xai_manual_device_code_invalid_grant_persists_dead_across_reload(tmp_path, monkeypatch):
+    """A terminal xAI invalid_grant on manual:device_code must stick on disk.
+
+    hermes auth add xai-oauth creates independent ``manual:device_code`` pool
+    entries. The previous quarantine path only removed singleton-seeded
+    ``device_code`` rows, so a revoked manual refresh token kept
+    ``last_status=null``, was re-selected after every process restart, and
+    re-hit invalid_grant indefinitely.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+
+    expired_access = _jwt_with_claims({"exp": int(time.time()) - 3600})
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "xai-oauth": [
+                    {
+                        "id": "xai-revoked",
+                        "label": "revoked",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": expired_access,
+                        "refresh_token": "refresh-revoked",
+                    },
+                    {
+                        "id": "xai-healthy",
+                        "label": "healthy",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": _jwt_with_claims({"exp": int(time.time()) + 3600}),
+                        "refresh_token": "refresh-healthy",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth import AuthError
+    from agent.credential_pool import STATUS_DEAD, load_pool
+
+    refresh_calls = {"n": 0}
+
+    def fake_refresh(access_token, refresh_token, **kwargs):
+        refresh_calls["n"] += 1
+        refresh_calls.setdefault("tokens", []).append(refresh_token)
+        if refresh_token == "refresh-revoked":
+            # Production refresh_xai_oauth_pure raises code=xai_refresh_failed on
+            # HTTP 400 with the upstream invalid_grant body in the message.
+            raise AuthError(
+                "xAI token refresh failed. Response: "
+                '{"error":"invalid_grant","error_description":"Refresh token has been revoked"}',
+                provider="xai-oauth",
+                code="xai_refresh_failed",
+                relogin_required=True,
+            )
+        # Healthy entry: return rotated tokens without network.
+        return {
+            "access_token": _jwt_with_claims({"exp": int(time.time()) + 7200}),
+            "refresh_token": "refresh-healthy-rotated",
+            "last_refresh": datetime.now(timezone.utc).isoformat(),
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", fake_refresh)
+
+    pool = load_pool("xai-oauth")
+    # Force refresh of the priority-0 revoked entry.
+    revoked = next(e for e in pool._entries if e.id == "xai-revoked")
+    assert pool._refresh_entry(revoked, force=True) is None
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = auth_payload["credential_pool"]["xai-oauth"]
+    dead = next(e for e in entries if e["id"] == "xai-revoked")
+    healthy = next(e for e in entries if e["id"] == "xai-healthy")
+    assert dead["last_status"] == STATUS_DEAD
+    assert dead["last_error_reason"] == "xai_refresh_failed"
+    assert healthy.get("last_status") in (None, "ok")
+    first_calls = refresh_calls["n"]
+    assert first_calls == 1
+
+    # New process: reloaded pool must skip the dead entry and never re-refresh it.
+    pool2 = load_pool("xai-oauth")
+    selected = pool2.select()
+    assert selected is not None
+    assert selected.id == "xai-healthy"
+
+    dead_in_memory = next(e for e in pool2._entries if e.id == "xai-revoked")
+    assert dead_in_memory.last_status == STATUS_DEAD
+    # Selecting/loading must not retry the revoked refresh token.
+    assert refresh_calls["tokens"].count("refresh-revoked") == 1


### PR DESCRIPTION
## Summary

After `hermes auth add xai-oauth`, credentials are stored as independent `manual:device_code` pool entries. When xAI returns a terminal refresh error (`invalid_grant` / refresh token revoked), Hermes only removed singleton-seeded `device_code` entries. Manual entries kept `last_status=null`, so **every new process re-selected the revoked refresh token and retried `invalid_grant`**.

This PR:
1. Marks the failing **manual** pool entry `DEAD` and persists it.
2. Leaves other healthy pool entries selectable.
3. Keeps the existing singleton `device_code` quarantine path.
4. Treats raw OAuth terminal codes on xAI `AuthError` as terminal (aligned with Codex).

## Test plan

- [x] `pytest tests/agent/test_credential_pool.py::test_xai_manual_device_code_invalid_grant_persists_dead_across_reload -q` → 1 passed
- [ ] Manual: pool with revoked + healthy xAI entries; refresh revoked once; restart process; healthy selected; revoked not retried

## Notes

- `hermes auth add` means add another independent credential. Re-auth of the same account should logout/remove first.
