### PR TITLE
fix(desktop): keep rejected submit restore out of newly focused composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -406,6 +406,7 @@ export function useComposerDraft({
   return {
     activeQueueSessionKeyRef,
     clearDraft,
+    draftScopeRef,
     draftRef,
     editorRef,
     focusInput,

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -21,6 +21,7 @@ function renderSubmitHook({
   text = ''
 }: SubmitHarnessOptions = {}) {
   const draftRef = { current: text }
+  const draftScopeRef = { current: 'stored-session' as string | null }
   const editor = document.createElement('div')
   editor.dataset.slot = 'composer-rich-input'
   editor.textContent = text
@@ -29,6 +30,8 @@ function renderSubmitHook({
   const onSteer = vi.fn(async () => true)
   const onSubmit = vi.fn(async () => true)
   const queueCurrentDraft = vi.fn(() => true)
+  const loadIntoComposer = vi.fn()
+  const stashAt = vi.fn()
 
   const clearDraft = vi.fn(() => {
     draftRef.current = ''
@@ -38,19 +41,19 @@ function renderSubmitHook({
   const hook = renderHook(() =>
     useComposerSubmit({
       activeQueueSessionKey: 'stored-session',
-      activeQueueSessionKeyRef: { current: 'stored-session' },
       attachments,
       busy,
       compacting,
       clearDraft,
       disabled: false,
+      draftScopeRef,
       draftRef,
       drainNextQueued: vi.fn(async () => false),
       editorRef,
       exitQueuedEdit: vi.fn(() => false),
       focusInput: vi.fn(),
       inputDisabled: false,
-      loadIntoComposer: vi.fn(),
+      loadIntoComposer,
       onCancel,
       onSteer,
       onSubmit,
@@ -59,11 +62,21 @@ function renderSubmitHook({
       queuedPrompts: [],
       sessionId: 'runtime-session',
       setComposerText: vi.fn(),
-      stashAt: vi.fn()
+      stashAt
     })
   )
 
-  return { clearDraft, hook, onCancel, onSteer, onSubmit, queueCurrentDraft }
+  return {
+    clearDraft,
+    draftScopeRef,
+    hook,
+    loadIntoComposer,
+    onCancel,
+    onSteer,
+    onSubmit,
+    queueCurrentDraft,
+    stashAt
+  }
 }
 
 describe('useComposerSubmit busy-turn routing', () => {
@@ -184,6 +197,46 @@ describe('useComposerSubmit busy-turn routing', () => {
     await waitFor(() =>
       expect(onSubmit).toHaveBeenCalledWith('hello', expect.objectContaining({ composerScope: 'stored-session' }))
     )
+  })
+
+  it('keeps a rejected submit out of the composer after switching sessions', async () => {
+    let resolveSubmit!: (accepted: boolean) => void
+
+    const pendingSubmit = new Promise<boolean>(resolve => {
+      resolveSubmit = resolve
+    })
+
+    const { draftScopeRef, hook, loadIntoComposer, onSubmit, stashAt } = renderSubmitHook()
+    onSubmit.mockImplementationOnce(() => pendingSubmit)
+
+    act(() => {
+      hook.result.current.dispatchSubmit('draft from session A')
+    })
+
+    draftScopeRef.current = 'stored-session-b'
+
+    act(() => {
+      resolveSubmit(false)
+    })
+
+    await waitFor(() =>
+      expect(stashAt).toHaveBeenCalledWith('stored-session', 'draft from session A', [])
+    )
+    expect(loadIntoComposer).not.toHaveBeenCalled()
+  })
+
+  it('repaints a rejected submit while its composer remains loaded', async () => {
+    const { hook, loadIntoComposer, onSubmit, stashAt } = renderSubmitHook()
+    onSubmit.mockResolvedValueOnce(false)
+
+    act(() => {
+      hook.result.current.dispatchSubmit('draft from this session')
+    })
+
+    await waitFor(() =>
+      expect(stashAt).toHaveBeenCalledWith('stored-session', 'draft from this session', [])
+    )
+    expect(loadIntoComposer).toHaveBeenCalledWith('draft from this session', [])
   })
 })
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -16,12 +16,12 @@ import type { ChatBarProps } from '../types'
 
 interface UseComposerSubmitArgs {
   activeQueueSessionKey: string | null
-  activeQueueSessionKeyRef: RefObject<string | null>
   attachments: ComposerAttachment[]
   busy: boolean
   compacting: boolean
   clearDraft: () => void
   disabled: boolean
+  draftScopeRef: RefObject<string | null>
   draftRef: RefObject<string>
   drainNextQueued: () => Promise<boolean>
   editorRef: RefObject<HTMLDivElement | null>
@@ -51,12 +51,12 @@ interface UseComposerSubmitArgs {
  */
 export function useComposerSubmit({
   activeQueueSessionKey,
-  activeQueueSessionKeyRef,
   attachments,
   busy,
   compacting,
   clearDraft,
   disabled,
+  draftScopeRef,
   draftRef,
   drainNextQueued,
   editorRef,
@@ -77,18 +77,19 @@ export function useComposerSubmit({
   const scope = useComposerScope()
 
   // Shared send primitive: fire onSubmit, and if the gateway rejects (accepted
-  // === false) or throws, re-load + re-stash the draft so the words survive.
+  // === false) or throws, re-stash the draft so the words survive. Repaint it
+  // only while the same session still owns the visible composer; a late reject
+  // must not publish an old session's text into the newly focused one.
   const dispatchSubmit = (text: string, attachments?: ComposerAttachment[]) => {
-    const submittedScope = activeQueueSessionKeyRef.current
+    const submittedScope = draftScopeRef.current
     const submittedAttachments = attachments ?? []
 
     const restore = () => {
-      loadIntoComposer(text, submittedAttachments)
-      // Use the scope captured at dispatch, not whatever session is focused
-      // now — the gateway can reject well after the user has switched away,
-      // and re-stashing into the currently-focused session would overwrite
-      // its draft with the rejected text from a different session (#54527).
       stashAt(submittedScope, text, submittedAttachments)
+
+      if (draftScopeRef.current === submittedScope) {
+        loadIntoComposer(text, submittedAttachments)
+      }
     }
 
     void Promise.resolve(

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -202,6 +202,7 @@ export function ChatBar({
   const {
     activeQueueSessionKeyRef,
     clearDraft,
+    draftScopeRef,
     draftRef,
     editorRef,
     focusInput,
@@ -310,12 +311,12 @@ export function ChatBar({
   // the submit decision tree, the send-with-restore primitive, and steer.
   const { queueDraft, steerDraft, submitDraft } = useComposerSubmit({
     activeQueueSessionKey,
-    activeQueueSessionKeyRef,
     attachments,
     busy,
     compacting,
     clearDraft,
     disabled,
+    draftScopeRef,
     draftRef,
     drainNextQueued,
     editorRef,


### PR DESCRIPTION
## What does this PR do?

A rejected Desktop submit can restore its payload into the wrong visible composer.

`dispatchSubmit()` captures the text, attachments and session scope, clears the composer, then awaits `onSubmit`. The existing restore path correctly stashes a rejected payload under the captured scope, but it also called `loadIntoComposer()` unconditionally. If session A starts a submit, the user switches to session B, and A's submit then resolves `false` or rejects, A's text and attachments are loaded into B's composer.

This runs after the routing guards added by #70986. Those guards stop a turn from being sent under a drifted session context. The rejected-submit restore runs later, so it can repaint stale content after the visible composer has moved to another session.

The fix captures `draftScopeRef.current`, which is updated by the layout effect that actually swaps the editor's draft and attachment scope. Restore still stashes the payload under its original session, but it calls `loadIntoComposer()` only if that same scope remains loaded. Session B stays untouched, and returning to A loads A's stashed draft through the normal draft path.

This reuses the composer's existing scope owner rather than adding another session ref. The queue-session ref remains the fallback before a draft scope has been established.

## Related Issue

No new issue filed.

Follow-up to #59305 and its root-cause analysis in #70609, fixed by #70986. This PR covers a later rejected-submit restore path that was not part of that fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts`: expose the scope ref owned by the draft swap effect.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts`: capture that scope at submit time and skip repainting when another scope owns the loaded composer.
- `apps/desktop/src/app/chat/composer/index.tsx`: pass the draft scope ref into the submit hook.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx`: cover a rejection after A → B and preserve same-scope restore behavior.

## How to Test

Reproduction with a controlled or deferred `onSubmit`:

1. Open session A and start a submit with distinct text or attachments, leaving the submit pending.
2. Switch to session B before A's submit resolves.
3. Resolve A's submit with `false` or reject it.
4. On `main`, A's payload is loaded into B's composer. With this change, B is unchanged and A's rejected payload remains stashed under A.

The new cross-scope regression test failed before the production change because `loadIntoComposer()` received A's draft after the scope changed to B. The companion test pins the existing behavior when A remains loaded.

Automated, from the repository root:

- `npm run test:ui --workspace apps/desktop -- src/app/chat/composer/hooks/use-composer-submit.test.tsx` — 13 passed.
- `npm run check:test:ui --workspace apps/desktop` — 3,100 passed.
- `npm run test:desktop:platforms --workspace apps/desktop` — 867 passed, 2 skipped.
- `npm run check:lint --workspace apps/desktop` — typecheck passed, ESLint 0 errors; existing warnings only.
- `npm run build --workspace apps/desktop` — production build passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. This change only touches the Desktop renderer TypeScript; the relevant Vitest, typecheck and build commands are listed above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8.0 arm64, Node 22.23.1, npm 10.9.8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshot is useful for this timing-dependent hook path. The deterministic regression test covers the state transition directly.

```text
Test Files  349 passed (349)
Tests       3100 passed (3100)
```
