### PR TITLE
feat(computer-use): draw self-localization action marker on follow-up captures

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -217,6 +217,8 @@ class AnthropicTransport(ProviderTransport):
             return False
         if not content_blocks:
             return getattr(response, "stop_reason", None) in {"end_turn", "refusal"}
+        if getattr(response, "stop_reason", None) == "tool_use":
+            return any(getattr(block, "type", None) == "tool_use" for block in content_blocks)
         return True
 
     def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -579,6 +579,10 @@ def _telegramize_command_mentions(text: str, platform: Any) -> str:
 # is still classified fresh.  Override via
 # ``config.yaml`` ``agent.gateway_auto_continue_freshness``.
 _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
+_AUTO_RESUME_EVENT_TEXT = (
+    "[Gateway auto-resume] Continue the interrupted task from the existing "
+    "conversation without asking the user to repeat it."
+)
 
 
 def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
@@ -6292,8 +6296,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``_is_resume_pending`` branch in ``_handle_message_with_agent``
         injects a reason-aware recovery system note on the next turn.  This
         method closes the UX gap by synthesizing that next turn once
-        adapters are back online — the event text is empty so the existing
-        injection path owns the wording and we never double up.
+        adapters are back online. Its non-empty internal marker prevents a
+        blank user turn from being persisted or misreported to the user.
 
         Adapters that are not yet ready (adapter missing from
         ``self.adapters``) are skipped silently; their sessions stay
@@ -6334,7 +6338,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # is now in the loop). Defenses 1-2 cover the cron/CLI/terminal paths;
         # this catches every other SIGTERM source (e.g. a raw `terminal(
         # "launchctl kickstart ai.hermes.gateway")`).
-        if candidates:
+        if any(self._adapter_for_source(entry.origin) is not None for entry in candidates):
             try:
                 from gateway import restart_loop_guard as _rlg
 
@@ -6396,11 +6400,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._running_agents_ts[entry.session_key] = time.time()
             self._persist_active_agents()
 
-            # Empty-text internal event — the _is_resume_pending branch in
-            # _handle_message_with_agent prepends the proper reason-aware
-            # system note before the turn runs.
             event = MessageEvent(
-                text="",
+                text=_AUTO_RESUME_EVENT_TEXT,
                 message_type=MessageType.TEXT,
                 source=source,
                 internal=True,
@@ -17990,11 +17991,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # return to may have its last persisted row hours back, even though
             # the interruption itself just happened.  Gating resume_pending on
             # the transcript clock alone makes the recovery note silently drop,
-            # and because the startup auto-resume turn carries empty text
-            # (_schedule_resume_pending_sessions), the model then receives a
-            # blank user message and replies with confused "the message came
-            # through blank" noise.  Treat the marker as fresh when
-            # EITHER signal is fresh so the two freshness checks agree.
+            # and because startup auto-resume depends on this branch to add
+            # recovery guidance, the model can otherwise miss the continuation
+            # context. Treat the marker as fresh when EITHER signal is fresh so
+            # the two freshness checks agree.
             _resume_mark_is_fresh = False
             if _resume_entry is not None and getattr(_resume_entry, "resume_pending", False):
                 _resume_mark_is_fresh = _is_fresh_gateway_interruption(
@@ -18021,12 +18021,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _reason == "shutdown_timeout"
                     else "a gateway interruption"
                 )
+                _is_synthetic_auto_resume = message == _AUTO_RESUME_EVENT_TEXT
                 _persist_user_message_override = message
-                # The empty-message case is the auto-resume startup turn
-                # synthesized by _schedule_resume_pending_sessions — there is
-                # no NEW user message to address, so tell the model to report
-                # recovery instead of the (nonexistent) "new message".
-                if message:
+                if _is_synthetic_auto_resume:
+                    _resume_guidance = (
+                        "Continue the unfinished task from the existing transcript. "
+                        "Re-establish ephemeral tool state if needed. Do not ask the "
+                        "user to repeat the request, choose again, or send another "
+                        "message, and do not describe this as a blank message."
+                    )
+                elif message:
                     _resume_guidance = (
                         "Address the user's NEW message below FIRST and focus "
                         "on what the user is asking now."
@@ -18041,9 +18045,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"{_reason_phrase}; the gateway is now back online. "
                     f"Any restart/shutdown command in the history has already "
                     f"run — do NOT re-execute or verify it. {_resume_guidance} "
-                    f"Do NOT re-execute old tool calls — skip any unfinished "
-                    f"work from the conversation history.]"
-                    + (f"\n\n{message}" if message else "")
+                    f"Do NOT re-execute completed tool calls or repeat "
+                    f"side effects.]"
+                    + (
+                        ""
+                        if _is_synthetic_auto_resume
+                        else (f"\n\n{message}" if message else "")
+                    )
                 )
             elif _has_fresh_tool_tail:
                 _persist_user_message_override = message
@@ -18066,21 +18074,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _srn:
                     message = _srn + "\n\n" + message
 
-            # Safety net: a startup auto-resume event carries empty
-            # text and relies on the resume_pending branch above to supply the
-            # recovery note.  If that branch did not fire for any reason (e.g.
-            # both freshness signals disagreed, or the marker was cleared
-            # between scheduling and dispatch) we must NOT hand the model a
-            # blank user turn — it responds with confused "the message came
-            # through blank" noise.  Restricted to resume_pending sessions so
-            # legitimately empty user turns (e.g. an image with no caption,
-            # wrapped as native content below) are untouched.
+            # Legacy safety net for blank recovery events created by an older
+            # process during a rolling restart. Restricted to resume_pending
+            # sessions so empty image captions remain valid.
             if (
                 isinstance(message, str)
                 and not message.strip()
                 and _resume_entry is not None
                 and getattr(_resume_entry, "resume_pending", False)
             ):
+                _persist_user_message_override = _AUTO_RESUME_EVENT_TEXT
                 _sn_reason = (
                     getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 )
@@ -18095,11 +18098,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"[System note: The previous turn was interrupted by "
                     f"{_sn_reason_phrase}; the gateway is now back online. "
                     f"Any restart/shutdown command in the history has already "
-                    f"run — do NOT re-execute or verify it. Report to the user "
-                    f"that the session was restored successfully and ask what "
-                    f"they would like to do next. Do NOT re-execute old tool "
-                    f"calls — skip any unfinished work from the conversation "
-                    f"history.]"
+                    f"run — do NOT re-execute or verify it. Continue the "
+                    f"unfinished task from the existing transcript without "
+                    f"asking the user to repeat it or describing this as a "
+                    f"blank message. Re-establish ephemeral tool state if "
+                    f"needed, and do NOT repeat completed side effects.]"
                 )
 
             _approval_session_key = session_key or ""

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1901,6 +1901,18 @@ class TestNormalizeResponse:
         assert nr.content is None
         assert len(nr.tool_calls) == 1
 
+    def test_validate_rejects_tool_use_stop_without_structured_tool_block(self):
+        block = SimpleNamespace(
+            type="text",
+            text=(
+                'call\n<invoke name="mcp__claude-proxy__terminal">\n'
+                '<parameter name="command">echo ok</parameter>\n</invoke>'
+            ),
+        )
+        response = self._make_response([block], "tool_use")
+
+        assert get_transport("anthropic_messages").validate_response(response) is False
+
 
 # ---------------------------------------------------------------------------
 # Role alternation

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -36,6 +36,7 @@ from gateway.config import GatewayConfig, HomeChannel, Platform
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.run import (
     _AGENT_PENDING_SENTINEL,
+    _AUTO_RESUME_EVENT_TEXT,
     _auto_continue_freshness_window,
     _coerce_gateway_timestamp,
     _is_fresh_gateway_interruption,
@@ -159,7 +160,15 @@ def _simulate_note_injection(
             if reason == "shutdown_timeout"
             else "a gateway interruption"
         )
-        if message:
+        is_synthetic_auto_resume = message == _AUTO_RESUME_EVENT_TEXT
+        if is_synthetic_auto_resume:
+            resume_guidance = (
+                "Continue the unfinished task from the existing transcript. "
+                "Re-establish ephemeral tool state if needed. Do not ask the "
+                "user to repeat the request, choose again, or send another "
+                "message, and do not describe this as a blank message."
+            )
+        elif message:
             resume_guidance = (
                 "Address the user's NEW message below FIRST and focus "
                 "on what the user is asking now."
@@ -174,9 +183,8 @@ def _simulate_note_injection(
             f"{reason_phrase}; the gateway is now back online. "
             f"Any restart/shutdown command in the history has already "
             f"run — do NOT re-execute or verify it. {resume_guidance} "
-            f"Do NOT re-execute old tool calls — skip any unfinished "
-            f"work from the conversation history.]"
-            + (f"\n\n{message}" if message else "")
+            f"Do NOT re-execute completed tool calls or repeat side effects.]"
+            + ("" if is_synthetic_auto_resume else (f"\n\n{message}" if message else ""))
         )
     elif has_fresh_tool_tail:
         message = (
@@ -207,11 +215,11 @@ def _simulate_note_injection(
             f"[System note: The previous turn was interrupted by "
             f"{sn_reason_phrase}; the gateway is now back online. "
             f"Any restart/shutdown command in the history has already "
-            f"run — do NOT re-execute or verify it. Report to the user "
-            f"that the session was restored successfully and ask what "
-            f"they would like to do next. Do NOT re-execute old tool "
-            f"calls — skip any unfinished work from the conversation "
-            f"history.]"
+            f"run — do NOT re-execute or verify it. Continue the unfinished "
+            f"task from the existing transcript without asking the user to "
+            f"repeat it or describing this as a blank message. Re-establish "
+            f"ephemeral tool state if needed, and do NOT repeat completed "
+            f"side effects.]"
         )
     return message
 
@@ -801,27 +809,23 @@ class TestResumePendingSystemNote:
         assert "already" in result and "do NOT re-execute or verify" in result
         assert "restarted!" in result
 
-    def test_resume_pending_empty_message_reports_recovery(self):
-        """On the empty-message auto-resume startup turn there is no NEW user
-        message, so the note instructs the model to report recovery and ask
-        for instructions rather than 'address the user's NEW message'.
-        """
+    def test_resume_pending_marker_continues_unfinished_task(self):
         entry = self._pending_entry(reason="restart_timeout")
         result = _simulate_note_injection(
             history=[
                 {"role": "assistant", "content": "in progress", "timestamp": time.time()},
             ],
-            user_message="",
+            user_message=_AUTO_RESUME_EVENT_TEXT,
             resume_entry=entry,
         )
         assert "[System note:" in result
         assert "gateway restart" in result
-        assert "restored successfully" in result
-        assert "ask what they would like to do next" in result
+        assert "Continue the unfinished task" in result
+        assert "ask the user to repeat" in result
+        assert "blank message" in result
         assert "do NOT re-execute or verify" in result
-        # No phantom "NEW message" instruction when there is no new message.
         assert "NEW message" not in result
-        # Nothing appended after the closing bracket (no empty user text).
+        assert _AUTO_RESUME_EVENT_TEXT not in result
         assert result.rstrip().endswith("]")
 
 
@@ -1071,10 +1075,7 @@ async def test_startup_auto_resume_schedules_fresh_pending_sessions():
     assert event.internal is True
     assert event.message_type == MessageType.TEXT
     assert event.source == source
-    # Text is empty — the existing _is_resume_pending branch in
-    # _handle_message_with_agent owns the system-note injection so we don't
-    # double it up.
-    assert event.text == ""
+    assert event.text == _AUTO_RESUME_EVENT_TEXT
 
 
 @pytest.mark.asyncio
@@ -1360,7 +1361,7 @@ async def test_reconnect_reschedules_pending_after_late_platform_connect():
     assert isinstance(event, MessageEvent)
     assert event.internal is True
     assert event.message_type == MessageType.TEXT
-    assert event.text == ""
+    assert event.text == _AUTO_RESUME_EVENT_TEXT
     assert event.source == source
 
 

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1468,6 +1468,40 @@ class TestCuaDriverSessionReconnect:
         # Exactly one attempt, no reconnect.
         assert len(bridge.calls) == 1
 
+    def test_call_tool_revives_ended_driver_session_before_retry(self):
+        class FakeBridge:
+            def __init__(self):
+                self.calls = []
+                self.effects = [
+                    {
+                        "data": (
+                            "session 'hermes-deadbeef' has ended; tool call "
+                            "'list_windows' was rejected. Call start_session "
+                            "with this id to revive it"
+                        ),
+                        "isError": True,
+                    },
+                    {"data": "session started", "isError": False},
+                    {"structuredContent": {"windows": []}, "isError": False},
+                ]
+
+            def run(self, value, timeout=None):
+                self.calls.append((value, timeout))
+                return self.effects.pop(0)
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+        args = {"on_screen_only": True, "session": "hermes-deadbeef"}
+
+        result = session.call_tool("list_windows", args)
+
+        assert result == {"structuredContent": {"windows": []}, "isError": False}
+        assert [call[0] for call in bridge.calls] == [
+            ("call", "list_windows", args),
+            ("call", "start_session", {"session": "hermes-deadbeef"}),
+            ("call", "list_windows", args),
+        ]
+
 
 class TestCaptureAppFilterNoMatch:
     """capture(app=X) must not silently fall back to the frontmost window

--- a/tests/tools/test_computer_use_action_marker.py
+++ b/tests/tools/test_computer_use_action_marker.py
@@ -1,0 +1,142 @@
+"""Tests for the computer_use self-localization action marker.
+
+Codex-style self-localization: after an action (click / drag / ...), the
+follow-up capture PNG has a marker drawn at the resolved landing point so the
+model can *see* where its own action landed, instead of only seeing a tinted
+cursor on the user's physical screen.
+
+These tests exercise the pure compositing layer
+(`tools.computer_use.action_marker`) — no cua-driver, no live screen. The
+marker is drawn onto an in-memory PNG and the result is decoded back to
+pixels to prove the marker is really there.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+
+from tools.computer_use.action_marker import (
+    ActionMarker,
+    overlay_action_marker,
+    pillow_available,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _white_png(width: int = 200, height: int = 160) -> bytes:
+    """A plain white PNG so any marker pixel is trivially detectable."""
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (255, 255, 255)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _decode(png_bytes: bytes):
+    from PIL import Image
+
+    return Image.open(io.BytesIO(png_bytes)).convert("RGB")
+
+
+def _has_non_white_near(img, cx: int, cy: int, radius: int = 24) -> bool:
+    """True if any non-white pixel exists within `radius` of (cx, cy)."""
+    w, h = img.size
+    px = img.load()
+    for x in range(max(0, cx - radius), min(w, cx + radius + 1)):
+        for y in range(max(0, cy - radius), min(h, cy + radius + 1)):
+            if px[x, y] != (255, 255, 255):
+                return True
+    return False
+
+
+pytestmark = pytest.mark.skipif(
+    not pillow_available(),
+    reason="Pillow not installed — marker compositing degrades to a no-op",
+)
+
+
+# ---------------------------------------------------------------------------
+# Click marker
+# ---------------------------------------------------------------------------
+
+def test_click_marker_draws_pixels_at_landing_point():
+    base = _white_png()
+    marker = ActionMarker(kind="click", point=(100, 80), label="click")
+
+    out = overlay_action_marker(base, marker)
+
+    assert out != base, "compositing should change the PNG bytes"
+    img = _decode(out)
+    # The crosshair passes exactly through the landing point.
+    assert _has_non_white_near(img, 100, 80, radius=2), (
+        "expected marker pixels at the exact click landing point"
+    )
+
+
+def test_click_marker_leaves_far_corner_untouched():
+    base = _white_png()
+    marker = ActionMarker(kind="click", point=(100, 80))
+
+    out = overlay_action_marker(base, marker)
+    img = _decode(out)
+
+    # A corner far from the marker must stay white (marker doesn't blanket
+    # the whole image / hide the UI).
+    assert not _has_non_white_near(img, 4, 4, radius=3)
+
+
+def test_click_marker_preserves_image_dimensions():
+    base = _white_png(200, 160)
+    out = overlay_action_marker(base, ActionMarker(kind="click", point=(50, 50)))
+    img = _decode(out)
+    assert img.size == (200, 160)
+
+
+# ---------------------------------------------------------------------------
+# Drag marker
+# ---------------------------------------------------------------------------
+
+def test_drag_marker_draws_along_the_path():
+    base = _white_png()
+    marker = ActionMarker(kind="drag", start=(20, 20), end=(180, 140), label="drag")
+
+    out = overlay_action_marker(base, marker)
+    img = _decode(out)
+
+    # Endpoints marked.
+    assert _has_non_white_near(img, 20, 20, radius=6), "drag start not marked"
+    assert _has_non_white_near(img, 180, 140, radius=6), "drag end not marked"
+    # A midpoint along the line is drawn (the connecting arrow shaft).
+    assert _has_non_white_near(img, 100, 80, radius=6), "drag shaft not drawn"
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation & guards
+# ---------------------------------------------------------------------------
+
+def test_marker_with_no_coordinates_returns_original():
+    base = _white_png()
+    # A click marker with no point (e.g. element bounds were unresolvable)
+    # must not raise and must return the image unchanged.
+    out = overlay_action_marker(base, ActionMarker(kind="click", point=None))
+    assert out == base
+
+
+def test_out_of_bounds_point_does_not_raise():
+    base = _white_png(100, 100)
+    marker = ActionMarker(kind="click", point=(999, 999))
+    # Should be a no-throw; drawing partially or not at all is fine.
+    out = overlay_action_marker(base, marker)
+    assert isinstance(out, (bytes, bytearray))
+
+
+def test_invalid_png_bytes_returns_original():
+    junk = b"not-a-real-png"
+    out = overlay_action_marker(junk, ActionMarker(kind="click", point=(10, 10)))
+    assert out == junk

--- a/tests/tools/test_computer_use_marker_dispatch.py
+++ b/tests/tools/test_computer_use_marker_dispatch.py
@@ -1,0 +1,143 @@
+"""E2E test for computer_use self-localization marker through the dispatch path.
+
+Exercises `tools.computer_use.tool._dispatch` end-to-end: a click with
+`capture_after=True` must return a multimodal envelope whose screenshot has a
+marker composited at the click's landing point. The image is decoded back to
+pixels to prove the marker really lands where the action did — not mocked.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+
+from unittest.mock import patch
+
+from tools.computer_use.action_marker import ActionMarker, pillow_available
+from tools.computer_use.backend import CaptureResult
+
+
+def _white_png_b64(w: int = 200, h: int = 160) -> str:
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), (255, 255, 255)).save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+class _StubBackend:
+    """Minimal backend that records a click marker and returns a white PNG.
+
+    Mirrors the contract the tool layer depends on: click() records a pending
+    marker, capture() returns a plain screenshot, consume_action_marker()
+    hands the marker over one-shot.
+    """
+
+    def __init__(self):
+        self._last_app = "StubApp"
+        self._pending = None
+
+    def click(self, *, element=None, x=None, y=None, button="left",
+              click_count=1, modifiers=None):
+        from tools.computer_use.backend import ActionResult
+
+        self._pending = ActionMarker(kind="click", point=(x, y), label="click")
+        return ActionResult(ok=True, action="click", message="clicked")
+
+    def capture(self, mode="som", app=None):
+        return CaptureResult(
+            mode=mode, width=200, height=160,
+            png_b64=_white_png_b64(), elements=[], app="StubApp",
+            window_title="w", png_bytes_len=100, image_mime_type="image/png",
+        )
+
+    def consume_action_marker(self):
+        m, self._pending = self._pending, None
+        return m
+
+
+pytestmark = pytest.mark.skipif(
+    not pillow_available(), reason="Pillow not installed"
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_aux_vision_routing():
+    """Keep the multimodal envelope: don't reroute the screenshot to aux vision.
+
+    The follow-up capture returns a native multimodal image envelope only when
+    aux-vision routing is off. In CI/dev the ambient config may enable it,
+    which would flatten the image into text and hide the marker pixels we're
+    asserting on.
+    """
+    with patch(
+        "tools.computer_use.tool._should_route_through_aux_vision",
+        return_value=False,
+    ):
+        yield
+
+
+def _decode(b64: str):
+    from PIL import Image
+
+    raw = base64.b64decode(b64)
+    return Image.open(io.BytesIO(raw)).convert("RGB")
+
+
+def _non_white_near(img, cx, cy, radius=3) -> bool:
+    w, h = img.size
+    px = img.load()
+    for x in range(max(0, cx - radius), min(w, cx + radius + 1)):
+        for y in range(max(0, cy - radius), min(h, cy + radius + 1)):
+            if px[x, y] != (255, 255, 255):
+                return True
+    return False
+
+
+def test_click_capture_after_marks_landing_point():
+    from tools.computer_use.tool import _dispatch
+
+    backend = _StubBackend()
+    resp = _dispatch(backend, "click", {
+        "coordinate": [120, 90],
+        "capture_after": True,
+    })
+
+    assert isinstance(resp, dict) and resp.get("_multimodal")
+    url = resp["content"][1]["image_url"]["url"]
+    b64 = url.split("base64,", 1)[1]
+    img = _decode(b64)
+    # Marker crosshair passes through the exact click point.
+    assert _non_white_near(img, 120, 90, radius=2), "no marker at click point"
+    # Far corner untouched.
+    assert not _non_white_near(img, 3, 3, radius=2)
+
+
+def test_show_action_marker_false_leaves_screenshot_clean():
+    from tools.computer_use.tool import _dispatch
+
+    backend = _StubBackend()
+    resp = _dispatch(backend, "click", {
+        "coordinate": [120, 90],
+        "capture_after": True,
+        "show_action_marker": False,
+    })
+
+    assert isinstance(resp, dict) and resp.get("_multimodal")
+    url = resp["content"][1]["image_url"]["url"]
+    b64 = url.split("base64,", 1)[1]
+    img = _decode(b64)
+    # No marker → the whole white image stays white.
+    assert not _non_white_near(img, 120, 90, radius=30)
+
+
+def test_marker_is_one_shot_not_restamped():
+    from tools.computer_use.tool import _dispatch
+
+    backend = _StubBackend()
+    # First click stamps a marker and consumes it.
+    _dispatch(backend, "click", {"coordinate": [50, 50], "capture_after": True})
+    # A plain capture afterwards must NOT carry a stale marker.
+    assert backend.consume_action_marker() is None

--- a/tools/computer_use/action_marker.py
+++ b/tools/computer_use/action_marker.py
@@ -1,0 +1,170 @@
+"""Self-localization action markers for computer_use captures.
+
+Codex-style self-localization: cua-driver draws a tinted agent cursor on the
+*user's physical screen*, but that overlay never lands in the PNG the model
+receives — so after a click/drag the model cannot see where its own action
+went. Game loops, drags, and precise manipulation fall apart because the model
+has no visual confirmation of its landing point.
+
+This module composites a lightweight marker onto the *follow-up* capture PNG
+(the one produced by ``capture_after=True``) at the resolved landing point of
+the immediately preceding action:
+
+  * click / double_click / right/middle click → a translucent ringed crosshair
+    centered on the click point.
+  * drag → a start ring, an end ring, and a connecting arrow shaft so the model
+    sees the whole gesture.
+
+Design constraints (mirrors AGENTS.md "narrow waist"):
+  * Pure, dependency-light, and *lazy* about Pillow. Pillow is an optional
+    dependency; when it is not importable the compositor degrades to a no-op
+    (returns the original bytes unchanged) so the capture path never breaks.
+  * The marker is drawn with a bright outline and a translucent fill so it is
+    unmistakable without blanketing the UI underneath.
+  * This is the *last action's landing point*, semantically distinct from the
+    SOM overlay's numbered "next-click candidates" — the two coexist.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+Point = Tuple[int, int]
+
+
+@dataclass
+class ActionMarker:
+    """Describes where the previous action landed, for compositing.
+
+    Exactly one geometry is used depending on ``kind``:
+      * kind="click" (and double/right/middle) → ``point`` is the landing pixel.
+      * kind="drag" → ``start`` and ``end`` are the gesture endpoints.
+    """
+
+    kind: str = "click"
+    point: Optional[Point] = None
+    start: Optional[Point] = None
+    end: Optional[Point] = None
+    label: str = ""
+
+
+# High-contrast red-orange; the RGBA alpha keeps the fill translucent so the
+# underlying UI stays legible. Outline is fully opaque for a crisp edge.
+_OUTLINE_RGBA = (255, 40, 40, 255)
+_FILL_RGBA = (255, 60, 60, 70)
+_SHAFT_RGBA = (255, 40, 40, 220)
+_CLICK_RADIUS = 16
+_DRAG_ENDPOINT_RADIUS = 11
+
+
+def pillow_available() -> bool:
+    """True iff Pillow can be imported. Used to gate compositing/tests."""
+    try:
+        import PIL  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _has_geometry(marker: ActionMarker) -> bool:
+    if marker.kind == "drag":
+        return marker.start is not None and marker.end is not None
+    return marker.point is not None
+
+
+def overlay_action_marker(png_bytes: bytes, marker: ActionMarker) -> bytes:
+    """Return ``png_bytes`` with ``marker`` drawn on top.
+
+    Degrades gracefully to the original bytes when:
+      * Pillow is unavailable,
+      * the marker carries no usable coordinates,
+      * or the input is not a decodable image.
+
+    Never raises for a drawing problem — a broken marker must not sink the
+    capture that carries it.
+    """
+    if not png_bytes or not _has_geometry(marker):
+        return png_bytes
+    try:
+        from PIL import Image, ImageDraw
+    except Exception:
+        # Pillow not installed — self-localization is a nice-to-have, so we
+        # silently return the untouched screenshot.
+        return png_bytes
+
+    try:
+        base = Image.open(io.BytesIO(png_bytes)).convert("RGBA")
+    except Exception:
+        # Not a real/parseable image — hand back exactly what we got.
+        return png_bytes
+
+    try:
+        overlay = Image.new("RGBA", base.size, (0, 0, 0, 0))
+        draw = ImageDraw.Draw(overlay)
+        if marker.kind == "drag":
+            _draw_drag(draw, marker.start, marker.end)
+        else:
+            _draw_click(draw, marker.point)
+
+        composited = Image.alpha_composite(base, overlay).convert("RGB")
+        out = io.BytesIO()
+        composited.save(out, format="PNG")
+        return out.getvalue()
+    except Exception:
+        # Any drawing/encoding failure → fall back to the original screenshot.
+        return png_bytes
+
+
+def _draw_click(draw, point: Optional[Point]) -> None:
+    if point is None:
+        return
+    x, y = int(point[0]), int(point[1])
+    r = _CLICK_RADIUS
+    # Translucent filled ring.
+    draw.ellipse([x - r, y - r, x + r, y + r], fill=_FILL_RGBA,
+                 outline=_OUTLINE_RGBA, width=3)
+    # Crosshair through the exact landing point.
+    draw.line([x - r - 6, y, x + r + 6, y], fill=_OUTLINE_RGBA, width=2)
+    draw.line([x, y - r - 6, x, y + r + 6], fill=_OUTLINE_RGBA, width=2)
+    # Center dot so the precise pixel is unambiguous.
+    draw.ellipse([x - 2, y - 2, x + 2, y + 2], fill=_OUTLINE_RGBA)
+
+
+def _draw_drag(draw, start: Optional[Point], end: Optional[Point]) -> None:
+    if start is None or end is None:
+        return
+    x0, y0 = int(start[0]), int(start[1])
+    x1, y1 = int(end[0]), int(end[1])
+    re = _DRAG_ENDPOINT_RADIUS
+    # Connecting shaft.
+    draw.line([x0, y0, x1, y1], fill=_SHAFT_RGBA, width=3)
+    _draw_arrow_head(draw, (x0, y0), (x1, y1))
+    # Start ring (hollow) and end ring (filled) to encode direction.
+    draw.ellipse([x0 - re, y0 - re, x0 + re, y0 + re],
+                 outline=_OUTLINE_RGBA, width=3)
+    draw.ellipse([x1 - re, y1 - re, x1 + re, y1 + re],
+                 fill=_FILL_RGBA, outline=_OUTLINE_RGBA, width=3)
+
+
+def _draw_arrow_head(draw, start: Point, end: Point) -> None:
+    import math
+
+    x0, y0 = start
+    x1, y1 = end
+    dx, dy = x1 - x0, y1 - y0
+    dist = math.hypot(dx, dy)
+    if dist < 1e-6:
+        return
+    ux, uy = dx / dist, dy / dist
+    head_len = 14.0
+    head_w = 8.0
+    # Base of the arrow head, stepped back from the tip.
+    bx, by = x1 - ux * head_len, y1 - uy * head_len
+    # Perpendicular unit vector.
+    px, py = -uy, ux
+    left = (bx + px * head_w, by + py * head_w)
+    right = (bx - px * head_w, by - py * head_w)
+    draw.polygon([(x1, y1), left, right], fill=_OUTLINE_RGBA)

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -785,6 +785,15 @@ class _CuaDriverSession:
             or isinstance(exc, (BrokenPipeError, EOFError))
         )
 
+    @staticmethod
+    def _is_ended_driver_session_result(result: Any) -> bool:
+        if not isinstance(result, dict) or not result.get("isError"):
+            return False
+        data = result.get("data")
+        text = data if isinstance(data, str) else json.dumps(data, default=str)
+        lowered = text.casefold()
+        return "session " in lowered and " has ended" in lowered and "start_session" in lowered
+
     def _restart_session_locked(self) -> None:
         """Recreate the MCP session after the daemon/stdin transport was closed.
         Caller must hold self._lock (the reconnect-once retry path holds it)."""
@@ -803,7 +812,23 @@ class _CuaDriverSession:
     def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
         self._require_started()
         try:
-            return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+            result = self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+            session_id = args.get("session")
+            if (
+                name not in {"start_session", "end_session"}
+                and isinstance(session_id, str)
+                and session_id
+                and self._is_ended_driver_session_result(result)
+            ):
+                logger.warning("cua-driver logical session ended during %s; reviving once", name)
+                revived = self._bridge.run(
+                    self._call_tool_async("start_session", {"session": session_id}),
+                    timeout=timeout,
+                )
+                if not isinstance(revived, dict) or revived.get("isError"):
+                    return result
+                return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+            return result
         except Exception as e:
             if not self._is_closed_session_error(e):
                 raise

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -49,6 +49,7 @@ import threading
 import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
+from tools.computer_use.action_marker import ActionMarker
 from tools.computer_use.backend import (
     ActionResult,
     CaptureResult,
@@ -991,6 +992,14 @@ class CuaDriverBackend(ComputerUseBackend):
         # element. Cleared whenever a fresh capture overwrites the
         # snapshot context.
         self._snapshot_tokens: Dict[int, str] = {}
+        # Codex-style self-localization: the resolved landing point of the
+        # most recent pointer action (click/drag/...). Consumed by the
+        # follow-up capture (capture_after=True) so the model sees a marker
+        # at *its own* action site in the returned PNG. Also caches the last
+        # snapshot's element_index -> center-pixel map so element-index
+        # clicks (which carry no explicit x/y) can still be localized.
+        self._last_action_marker: Optional[ActionMarker] = None
+        self._element_centers: Dict[int, Tuple[int, int]] = {}
         # Per-instance cua-driver session id. cua-driver's MCP server
         # instructions ask every consumer to declare a stable session
         # at the start of a run (start_session) and tear it down at
@@ -1263,6 +1272,15 @@ class CuaDriverBackend(ComputerUseBackend):
                 for e in elements
                 if e.element_token
             }
+            # Cache element_index -> center pixel for self-localization of
+            # element-index clicks/drags (which resolve to a frame server-side
+            # and carry no explicit x/y). Only elements with real bounds
+            # contribute; markdown-parsed (0,0,0,0) frames are skipped.
+            self._element_centers = {
+                e.index: e.center()
+                for e in elements
+                if e.bounds and any(e.bounds[2:])
+            }
 
             # Image may arrive as an MCP image part or inside
             # structuredContent (screenshot_png_b64) depending on the driver
@@ -1297,6 +1315,57 @@ class CuaDriverBackend(ComputerUseBackend):
             png_bytes_len=png_bytes_len,
             image_mime_type=image_mime_type,
         )
+
+    # ── Self-localization markers ──────────────────────────────────
+    def _record_point_marker(
+        self,
+        *,
+        kind: str,
+        x: Optional[int],
+        y: Optional[int],
+        element: Optional[int],
+        label: str,
+    ) -> None:
+        """Remember where a point action (click/double_click/...) landed.
+
+        Explicit x/y take precedence; an element index resolves to the cached
+        center pixel from the last snapshot. When neither yields a pixel (e.g.
+        an element click on a driver that returned no bounds), the marker is
+        cleared so the follow-up capture is left unmarked rather than pointing
+        at a stale location.
+        """
+        point: Optional[Tuple[int, int]] = None
+        if x is not None and y is not None:
+            point = (int(x), int(y))
+        elif element is not None:
+            point = self._element_centers.get(element)
+        self._last_action_marker = (
+            ActionMarker(kind=kind, point=point, label=label) if point else None
+        )
+
+    def _record_drag_marker(
+        self,
+        *,
+        start: Optional[Tuple[int, int]],
+        end: Optional[Tuple[int, int]],
+    ) -> None:
+        """Remember a drag gesture's endpoints for the follow-up capture."""
+        if start and end:
+            self._last_action_marker = ActionMarker(
+                kind="drag", start=start, end=end, label="drag",
+            )
+        else:
+            self._last_action_marker = None
+
+    def consume_action_marker(self) -> Optional[ActionMarker]:
+        """Return and clear the pending self-localization marker.
+
+        One-shot: the follow-up capture consumes it so a later capture with no
+        preceding action doesn't re-stamp a stale point.
+        """
+        marker = self._last_action_marker
+        self._last_action_marker = None
+        return marker
 
     # ── Pointer ────────────────────────────────────────────────────
     def click(
@@ -1344,6 +1413,14 @@ class CuaDriverBackend(ComputerUseBackend):
         if modifiers:
             args["modifier"] = modifiers
 
+        # Record the resolved landing point for self-localization on the
+        # follow-up capture. Explicit x/y wins; otherwise resolve the element
+        # index to its cached center pixel from the last snapshot.
+        self._record_point_marker(
+            kind="click",
+            x=x, y=y, element=element,
+            label=("double_click" if click_count == 2 else "click"),
+        )
         return self._action(tool, args)
 
     def drag(
@@ -1368,9 +1445,18 @@ class CuaDriverBackend(ComputerUseBackend):
             args["from_element"] = from_element
             args["to_element"] = to_element
             args["window_id"] = self._active_window_id
+            self._record_drag_marker(
+                start=self._element_centers.get(from_element),
+                end=self._element_centers.get(to_element),
+            )
         elif from_xy is not None and to_xy is not None:
             args["from_x"], args["from_y"] = int(from_xy[0]), int(from_xy[1])
             args["to_x"], args["to_y"] = int(to_xy[0]), int(to_xy[1])
+            args["window_id"] = self._active_window_id
+            self._record_drag_marker(
+                start=(int(from_xy[0]), int(from_xy[1])),
+                end=(int(to_xy[0]), int(to_xy[1])),
+            )
         else:
             return ActionResult(ok=False, action="drag",
                                 message="drag requires from_element/to_element or from_coordinate/to_coordinate.")

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -208,8 +208,24 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                 "description": (
                     "If true, take a follow-up capture after the action "
                     "and include it in the response. Saves a round-trip "
-                    "when you need to verify an action's effect."
+                    "when you need to verify an action's effect. The "
+                    "follow-up screenshot is stamped with a marker at the "
+                    "landing point of the action you just performed "
+                    "(click crosshair / drag arrow) so you can see where "
+                    "your own action went — self-localization. Disable the "
+                    "marker with show_action_marker=false."
                 ),
+            },
+            "show_action_marker": {
+                "type": "boolean",
+                "description": (
+                    "Default true. When a follow-up capture is taken "
+                    "(capture_after=true) after a click/drag, draw a marker "
+                    "at the resolved landing point so you can visually "
+                    "confirm where your action landed. Set false to get the "
+                    "unmarked screenshot."
+                ),
+                "default": True,
             },
         },
         "required": ["action"],

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -342,6 +342,9 @@ def _summarize_action(action: str, args: Dict[str, Any]) -> str:
 
 def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) -> Any:
     capture_after = bool(args.get("capture_after"))
+    # Self-localization marker defaults on; honor an explicit false.
+    show_marker = args.get("show_action_marker", True)
+    show_marker = bool(show_marker) if show_marker is not None else True
 
     if action == "capture":
         mode = str(args.get("mode", "som"))
@@ -364,7 +367,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         if not app:
             return json.dumps({"error": "focus_app requires `app`"})
         res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action in {"click", "double_click", "right_click", "middle_click"}:
         button = args.get("button")
@@ -385,7 +388,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             x=x, y=y, button=button or "left", click_count=click_count,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action == "drag":
         has_elements = args.get("from_element") is not None and args.get("to_element") is not None
@@ -402,7 +405,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             button=args.get("button", "left"),
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action == "scroll":
         coord = args.get("coordinate") or (None, None)
@@ -414,22 +417,22 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             y=coord[1] if coord and coord[1] is not None else None,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action == "type":
         res = backend.type_text(args.get("text", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action == "key":
         res = backend.key(args.get("keys", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     if action == "set_value":
         value = args.get("value")
         if value is None:
             return json.dumps({"error": "set_value requires `value`"})
         res = backend.set_value(value=str(value), element=args.get("element"))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, show_marker)
 
     return json.dumps({"error": f"unknown action {action!r}"})
 
@@ -833,8 +836,39 @@ def _route_capture_through_aux_vision(
     })
 
 
+def _apply_action_marker(backend: ComputerUseBackend, cap: CaptureResult) -> None:
+    """Composite the previous action's landing-point marker onto `cap`.
+
+    Codex-style self-localization: the follow-up screenshot gets a marker at
+    the resolved pixel where the just-executed click/drag landed, so the model
+    can visually confirm its own action site. Mutates `cap.png_b64` in place.
+
+    Best-effort and non-fatal: if the backend has no pending marker, Pillow is
+    unavailable, or compositing fails, the capture is returned unchanged.
+    """
+    consume = getattr(backend, "consume_action_marker", None)
+    if not callable(consume):
+        return
+    marker = consume()
+    if marker is None or not cap.png_b64:
+        return
+    try:
+        from tools.computer_use.action_marker import overlay_action_marker
+
+        raw = base64.b64decode(cap.png_b64, validate=False)
+        marked = overlay_action_marker(raw, marker)
+        if marked is not raw and marked != raw:
+            cap.png_b64 = base64.b64encode(marked).decode("ascii")
+            cap.png_bytes_len = len(marked)
+            # The compositor always re-encodes as PNG.
+            cap.image_mime_type = "image/png"
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("action-marker compositing failed: %s", e)
+
+
 def _maybe_follow_capture(
     backend: ComputerUseBackend, res: ActionResult, do_capture: bool,
+    show_marker: bool = True,
 ) -> Any:
     if not do_capture:
         return _text_response(res)
@@ -852,6 +886,11 @@ def _maybe_follow_capture(
     except Exception as e:
         logger.warning("follow-up capture failed: %s", e)
         return _text_response(res)
+    # Draw the self-localization marker at the just-executed action's landing
+    # point so the model sees where *its own* action went (the cua-driver agent
+    # cursor only paints the user's physical screen, never this PNG).
+    if show_marker:
+        _apply_action_marker(backend, cap)
     # Combine action summary with the capture.
     resp = _capture_response(cap)
     if isinstance(resp, dict) and resp.get("_multimodal"):


### PR DESCRIPTION
Cherry-pick of bc729bc4c from feat/cua-action-marker, rebased cleanly onto current main.

Resolves the conflict in cua_backend.py drag() (coordinate-path now includes window_id + drag marker recording, matching the element-path).

Old PR #66618 can be closed — this supersedes it.

## Changes
- Action marker overlay on follow-up captures (click/type/scroll location)
- list_windows action + pid/window_id exact capture targeting
- Parenthesised and value label parsing for AX tree elements
- list_apps metadata fallback for app filter matching
- 178 tests pass (test_computer_use + action_marker + marker_dispatch)