### PR TITLE
fix(skills): keep pre-edit snapshots out of discovery

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -1,15 +1,14 @@
 """Curator snapshot + rollback.
 
-A pre-run snapshot of ``~/.hermes/skills/`` (excluding ``.curator_backups/``
-itself) is taken before any mutating curator pass. Snapshots are tar.gz
-files under ``~/.hermes/skills/.curator_backups/<utc-iso>/`` with a
+A pre-run snapshot of ``~/.hermes/skills/`` is taken before any mutating curator pass. Snapshots are tar.gz
+files under ``~/.hermes/skill-snapshots/<utc-iso>/`` with a
 companion ``manifest.json`` describing the snapshot (reason, time, size,
 counted skill files). Rollback picks a snapshot, moves the current
 ``skills/`` tree aside into another snapshot so even the rollback itself
 is undoable, then extracts the chosen snapshot into place.
 
 The snapshot does NOT include:
-  - ``.curator_backups/`` (would recurse)
+  - legacy ``.curator_backups/`` (would recurse if an old installation still has it)
   - ``.hub/`` (hub-installed skills — managed by the hub, not us)
 
 It DOES include:
@@ -58,7 +57,8 @@ DEFAULT_KEEP = 5
 
 # Entries under skills/ that should NEVER be rolled up into a snapshot.
 # .hub/ is managed by the skills hub; rolling it back would break lockfile
-# invariants. .curator_backups is the backup dir itself — recursion bomb.
+# invariants. The legacy .curator_backups dir is also excluded so upgrades do
+# not recursively embed old snapshots in a new snapshot.
 _EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub"}
 
 # Snapshot id regex: UTC ISO with colons replaced by dashes so the filename
@@ -68,7 +68,8 @@ _ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z(-\d{2})?$")
 
 
 def _backups_dir() -> Path:
-    return get_hermes_home() / "skills" / ".curator_backups"
+    """Return the profile-local snapshot root, outside every skills root."""
+    return get_hermes_home() / "skill-snapshots"
 
 
 def _skills_dir() -> Path:
@@ -547,10 +548,9 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
     Strategy:
       1. Resolve the target snapshot (explicit id or newest regular).
       2. Take a safety snapshot of the CURRENT skills tree under
-         ``.curator_backups/pre-rollback-<ts>/`` so the rollback itself is
+         ``skill-snapshots/<ts>/`` so the rollback itself is
          undoable.
-      3. Move all current top-level entries (except ``.curator_backups``
-         and ``.hub``) into a tempdir.
+      2. Move all current top-level entries (except ``.hub``) into a tempdir.
       4. Extract the chosen snapshot into ``~/.hermes/skills/``.
       5. On failure during 4, move the tempdir contents back (best-effort)
          and return failure.

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -382,7 +382,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+        from agent.skill_utils import (
+            get_external_skills_dirs,
+            is_excluded_skill_path,
+            iter_skill_index_files,
+        )
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
@@ -395,7 +399,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
+                if is_excluded_skill_path(skill_md):
                     continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -49,6 +49,14 @@ EXCLUDED_SKILL_DIRS = frozenset(
 # archive workflow preserves a complete old skill package under references/.
 SKILL_SUPPORT_DIRS = frozenset(("references", "templates", "assets", "scripts"))
 
+# Curator pre-edit snapshots used to be written below a live skills root. A
+# snapshot is not a skill, even when it contains copied SKILL.md frontmatter.
+# Keep this narrow so ordinary directories named ``snapshot`` or ``pre-edit``
+# remain valid skill categories.
+_PRE_EDIT_SNAPSHOT_DIR_RE = re.compile(
+    r"^[A-Za-z0-9_-]+-pre-edit-snapshot-[A-Za-z0-9_-]+$"
+)
+
 # ── Org-shared skills (sync contract) ───────────────────────────
 # Org mirrors live under ~/.hermes/skills/_org/<org_id>/. Resolution is
 # TOKEN-GATED via a marker file the sync client writes after verifying the
@@ -114,8 +122,10 @@ def is_excluded_skill_path(path, *, root: Optional[Path] = None) -> bool:
     except AttributeError:
         from pathlib import PurePath
         parts = PurePath(str(path)).parts
-    return any(part in EXCLUDED_SKILL_DIRS for part in parts) or is_skill_support_path(
-        path, root=root
+    return (
+        any(part in EXCLUDED_SKILL_DIRS for part in parts)
+        or any(_PRE_EDIT_SNAPSHOT_DIR_RE.fullmatch(part) for part in parts)
+        or is_skill_support_path(path, root=root)
     )
 
 
@@ -888,6 +898,7 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
             d
             for d in dirs
             if d not in EXCLUDED_SKILL_DIRS
+            and not _PRE_EDIT_SNAPSHOT_DIR_RE.fullmatch(d)
             and not (has_skill_md and d in SKILL_SUPPORT_DIRS)
         ]
         if filename in files:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1762,7 +1762,7 @@ DEFAULT_CONFIG = {
         "prune_builtins": True,
         # Pre-run backup: before every real curator pass (dry-run is
         # skipped), snapshot ~/.hermes/skills/ into
-        # ~/.hermes/skills/.curator_backups/<utc-iso>/skills.tar.gz so the
+        # ~/.hermes/skill-snapshots/<utc-iso>/skills.tar.gz so the
         # user can roll back with `hermes curator rollback`.
         "backup": {
             "enabled": True,

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -15,6 +15,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from hermes_constants import display_hermes_home
+
 
 def _fmt_ts(ts: Optional[str]) -> str:
     if not ts:
@@ -524,7 +526,7 @@ def _cmd_backup(args) -> int:
     if snap is None:
         print("curator: snapshot failed — check logs (backup disabled or IO error)")
         return 1
-    print(f"curator: snapshot created at ~/.hermes/skills/.curator_backups/{snap.name}")
+    print(f"curator: snapshot created at {display_hermes_home()}/skill-snapshots/{snap.name}")
     return 0
 
 

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -366,7 +366,7 @@ TIPS = [
     # --- Curator ---
     'hermes curator run --dry-run previews what the curator would archive or consolidate without mutating anything.',
     "hermes curator pin <skill> hard-fences a skill against both auto-archival and the agent's skill_manage tool.",
-    'hermes curator rollback restores skills from a pre-run snapshot — backups live under skills/.curator_backups/.',
+    'hermes curator rollback restores skills from a pre-run snapshot — backups live under skill-snapshots/.',
 
     # --- Credential Pools & Routing ---
     'hermes auth reset <provider> clears all cooldowns and exhaustion flags on a credential pool.',

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -77,7 +77,7 @@ def test_snapshot_prunes_to_keep_count(backup_env, monkeypatch):
         monkeypatch.setattr(cb, "_utc_id", lambda now=None, _f=fid: _f)
         cb.snapshot_skills(reason=f"n{i}")
 
-    remaining = sorted(p.name for p in (backup_env["skills"] / ".curator_backups").iterdir())
+    remaining = sorted(p.name for p in (backup_env["home"] / "skill-snapshots").iterdir())
     # Newest 3 kept (lex order == date order for this id format)
     assert remaining == ids[2:], f"expected newest 3, got {remaining}"
 
@@ -128,7 +128,7 @@ def test_rollback_is_itself_undoable(backup_env):
         f"{[(r.get('id'), r.get('reason')) for r in rows]}"
     )
     # And the transient staging dir must be gone (it's implementation detail)
-    backups_dir = skills / ".curator_backups"
+    backups_dir = backup_env["home"] / "skill-snapshots"
     staging_dirs = [p for p in backups_dir.iterdir() if p.name.startswith(".rollback-staging-")]
     assert staging_dirs == [], (
         f"staging dir should be cleaned up on success, got: {staging_dirs}"
@@ -337,7 +337,7 @@ def test_restore_cron_skill_links_standalone(backup_env):
     home = backup_env["home"]
 
     # Prime a snapshot dir manually with cron-jobs.json
-    backups_dir = home / "skills" / ".curator_backups" / "fake-id"
+    backups_dir = home / "skill-snapshots" / "fake-id"
     backups_dir.mkdir(parents=True)
     (backups_dir / cb.CRON_JOBS_FILENAME).write_text(json.dumps([
         {"id": "job-1", "name": "one", "skills": ["narrow-a", "narrow-b"]},

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -138,6 +138,26 @@ def test_skill_support_path_uses_explicit_discovery_root_not_cwd(tmp_path, monke
     assert is_excluded_skill_path(relative, root=discovery_root) is True
 
 
+def test_pre_edit_snapshot_directories_are_excluded_without_overmatching(tmp_path):
+    """Only the explicit pre-edit snapshot artifact convention is excluded."""
+    snapshot = tmp_path / "category" / "kanban-lifecycle-pre-edit-snapshot-t_0bd96003" / "SKILL.md"
+    snapshot.parent.mkdir(parents=True)
+    snapshot.write_text("---\nname: kanban-lifecycle\n---\n", encoding="utf-8")
+
+    top_level_snapshot = tmp_path / "hermes-kanban-pre-edit-snapshot-t_0bd96003" / "SKILL.md"
+    top_level_snapshot.parent.mkdir()
+    top_level_snapshot.write_text("---\nname: kanban-lifecycle\n---\n", encoding="utf-8")
+
+    legitimate = tmp_path / "snapshot" / "pre-edit" / "skill" / "SKILL.md"
+    legitimate.parent.mkdir(parents=True)
+    legitimate.write_text("---\nname: legitimate\n---\n", encoding="utf-8")
+
+    assert is_excluded_skill_path(snapshot) is True
+    assert is_excluded_skill_path(top_level_snapshot) is True
+    assert is_excluded_skill_path(legitimate) is False
+    assert list(iter_skill_index_files(tmp_path, "SKILL.md")) == [legitimate]
+
+
 # ── skill_matches_platform on Termux ──────────────────────────────────────
 
 

--- a/tools/skills_sync_client.py
+++ b/tools/skills_sync_client.py
@@ -65,6 +65,8 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from agent.skill_utils import is_excluded_skill_path
+
 logger = logging.getLogger(__name__)
 
 # Sync protocol constants
@@ -531,7 +533,7 @@ def _all_local_skill_names() -> List[str]:
         if not root.exists():
             return []
         for skill_md in root.rglob("SKILL.md"):
-            if skill_md.is_symlink():
+            if skill_md.is_symlink() or is_excluded_skill_path(skill_md):
                 continue
             name: Optional[str] = None
             try:
@@ -1656,6 +1658,8 @@ def list_org_skill_names() -> List[str]:
         if not root.is_dir():
             return names
         for skill_md in root.rglob("SKILL.md"):
+            if is_excluded_skill_path(skill_md):
+                continue
             rel = skill_md.parent.relative_to(root)
             if rel.parts:
                 names.append(str(rel).replace("\\", "/"))

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -81,7 +81,7 @@ from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled
 from agent.skill_utils import (
-    EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS,
+    is_excluded_skill_path as _is_excluded_skill_path,
     is_skill_support_path as _is_skill_support_path,
 )
 
@@ -719,7 +719,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # dirs_to_scan already resolved above for the signature.
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+            if _is_excluded_skill_path(skill_md):
                 continue
 
             skill_dir = skill_md.parent

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -116,7 +116,7 @@ hermes curator prune [--days N] # bulk-archive agent-created skills idle >= N da
 
 ## Backups and rollback
 
-Before every real curator pass, Hermes takes a tar.gz snapshot of `~/.hermes/skills/` at `~/.hermes/skills/.curator_backups/<utc-iso>/skills.tar.gz`. If a pass archives or consolidates something you didn't want touched, you can undo the whole run with one command:
+Before every real curator pass, Hermes takes a tar.gz snapshot of `~/.hermes/skills/` at `~/.hermes/skill-snapshots/<utc-iso>/skills.tar.gz`. If a pass archives or consolidates something you didn't want touched, you can undo the whole run with one command:
 
 ```bash
 hermes curator rollback        # restore newest snapshot (with confirmation)

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/curator.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/curator.md
@@ -101,7 +101,7 @@ hermes curator restore <skill>  # move an archived skill back to active
 
 ## 备份与回滚
 
-在每次真正的 curator pass 之前，Hermes 会在 `~/.hermes/skills/.curator_backups/<utc-iso>/skills.tar.gz` 处对 `~/.hermes/skills/` 进行 tar.gz 快照。如果某次 pass 归档或合并了你不希望被触碰的内容，可以用一条命令撤销整次运行：
+在每次真正的 curator pass 之前，Hermes 会在 `~/.hermes/skill-snapshots/<utc-iso>/skills.tar.gz` 处对 `~/.hermes/skills/` 进行 tar.gz 快照。如果某次 pass 归档或合并了你不希望被触碰的内容，可以用一条命令撤销整次运行：
 
 ```bash
 hermes curator rollback        # restore newest snapshot (with confirmation)


### PR DESCRIPTION
## Summary
- store curator snapshots under profile-aware `skill-snapshots/`, outside skill discovery roots
- exclude explicit `*-pre-edit-snapshot-*` artifacts across central and direct scanners
- migrate the two orchestrator-profile leftovers with SHA-256 manifests

## Verification
- `scripts/run_tests.sh` focused skill/curator/sync suites: 261 passed
- synthetic fresh-process skill_view acceptance: snapshot ignored, genuine collision fails closed, cleanup restores unique lookup
- `git diff --check` and Ruff passed