### PR TITLE
Closing a tab leaves you on the one that fills its slot

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/model.ts
@@ -184,9 +184,9 @@ export function normalize(node: LayoutNode): LayoutNode | null {
   return { ...node, children, weights }
 }
 
-/** Remove a pane wherever it lives. Closing the ACTIVE tab activates its
- *  previous neighbor (the next one when it was first) — browser-tab feel,
- *  never a jump to the strip's start. */
+/** Remove a pane wherever it lives. Closing the ACTIVE tab leaves selection on
+ *  the neighbor that fills its slot (right; left when it was last) — same rule
+ *  as terminals and the preview rail. */
 export function removePane(node: LayoutNode, paneId: string): LayoutNode | null {
   const walk = (n: LayoutNode): LayoutNode => {
     if (n.type === 'group') {
@@ -198,7 +198,8 @@ export function removePane(node: LayoutNode, paneId: string): LayoutNode | null 
 
       const panes = n.panes.filter(p => p !== paneId)
 
-      return { ...n, panes, active: n.active === paneId ? panes[Math.max(0, at - 1)] : n.active }
+      // After splice, `at` indexes the old right neighbor (clamp left at end).
+      return { ...n, panes, active: n.active === paneId ? (panes[Math.min(at, panes.length - 1)] ?? '') : n.active }
     }
 
     return { ...n, children: n.children.map(walk) }

--- a/apps/desktop/src/components/pane-shell/tree/remove-pane.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/remove-pane.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { findGroup, group, removePane, split } from './model'
+
+describe('removePane close-neighbor selection', () => {
+  it('closing a middle active tab keeps you on the tab that slides into its slot', () => {
+    // [a, b, c] active=b → close b → [a, c] active=c (was right of b), not a
+    const next = removePane(group(['a', 'b', 'c'], { active: 'b', id: 'g' }), 'b')
+
+    expect(next).toMatchObject({ type: 'group', panes: ['a', 'c'], active: 'c' })
+  })
+
+  it('closing the first active tab still advances to the former next tab', () => {
+    const next = removePane(group(['a', 'b', 'c'], { active: 'a', id: 'g' }), 'a')
+
+    expect(next).toMatchObject({ type: 'group', panes: ['b', 'c'], active: 'b' })
+  })
+
+  it('closing the last active tab falls back to its left neighbor', () => {
+    const next = removePane(group(['a', 'b', 'c'], { active: 'c', id: 'g' }), 'c')
+
+    expect(next).toMatchObject({ type: 'group', panes: ['a', 'b'], active: 'b' })
+  })
+
+  it('closing a non-active tab leaves the selection alone', () => {
+    const next = removePane(group(['a', 'b', 'c'], { active: 'c', id: 'g' }), 'b')
+
+    expect(next).toMatchObject({ type: 'group', panes: ['a', 'c'], active: 'c' })
+  })
+
+  it('walks nested splits so session stacks still get the slot rule', () => {
+    const tree = split('row', [
+      group(['workspace'], { active: 'workspace', id: 'main' }),
+      group(['tile:1', 'tile:2', 'tile:3'], { active: 'tile:2', id: 'stack' })
+    ])
+    const next = removePane(tree, 'tile:2')
+    const stack = next ? findGroup(next, 'stack') : null
+
+    expect(stack).toMatchObject({ panes: ['tile:1', 'tile:3'], active: 'tile:3' })
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Closing an active desktop tab always selected the *previous* neighbor, so focus jumped left every time — even mid-strip. The strip just removed a chip; the tab that slides into that slot should become active instead (right neighbor; left only when you closed the end). Terminals and the preview rail already behave that way; layout session tabs now match.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/model.ts` — `removePane` activates `panes[min(at, end)]` after splice (was `at - 1`)
- `apps/desktop/src/components/pane-shell/tree/remove-pane.test.ts` — middle / first / last / non-active / nested-split cases

## How to Test

1. Open 5 session tiles in one strip; select tab 2 of 5; close it (⌘W or the ×). Selection stays on what was tab 3, now sitting in slot 2 — not tab 1.
2. Close the first tab → lands on the former second.
3. Close the last tab → lands on the new last (left neighbor).
4. `npx vitest run src/components/pane-shell/tree/remove-pane.test.ts` from `apps/desktop`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — selection rule only; covered by unit tests.