### PR TITLE
fix(gateway): block aliased self-restart commands

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -66,11 +66,59 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 )
 
 
+# A delayed restart is often wrapped in a shell variable so the submitted job
+# can use the exact Hermes executable that is running the current checkout:
+#
+#     H=/path/to/hermes; launchctl submit ... -c '$H gateway restart'
+#
+# The literal lifecycle regex above cannot connect the assignment to the later
+# variable expansion. Resolve only simple assignments whose value's basename is
+# exactly `hermes` (or `hermes.exe`); this avoids treating arbitrary
+# `$APP gateway restart` commands as Hermes lifecycle operations.
+_SHELL_ASSIGNMENT_PATTERN = re.compile(
+    r"(?:^|[;\n]\s*)"
+    r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+    r"(?:\"(?P<double>[^\"\n]*)\"|'(?P<single>[^'\n]*)'|(?P<bare>[^\s;\n]+))",
+    re.MULTILINE,
+)
+_HERMES_EXECUTABLE_PATTERN = re.compile(
+    r"(?:^|[/\\])hermes(?:\.exe)?$",
+    re.IGNORECASE,
+)
+
+
+def _contains_aliased_hermes_lifecycle_command(text: str) -> bool:
+    """Detect a simple shell alias that resolves to the Hermes executable."""
+    aliases: set[str] = set()
+    for match in _SHELL_ASSIGNMENT_PATTERN.finditer(text):
+        value = next(
+            group
+            for group in (
+                match.group("double"),
+                match.group("single"),
+                match.group("bare"),
+            )
+            if group is not None
+        )
+        if _HERMES_EXECUTABLE_PATTERN.search(value.strip()):
+            aliases.add(match.group("name"))
+
+    for alias in aliases:
+        alias_ref = rf"\$(?:{re.escape(alias)}\b|\{{{re.escape(alias)}\}})"
+        lifecycle = rf"{alias_ref}\s+(?i:gateway\s+(?:restart|stop))\b"
+        if re.search(lifecycle, text):
+            return True
+    return False
+
+
 def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
-    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(text))
+    return bool(
+        _GATEWAY_LIFECYCLE_PATTERN.search(text)
+        or _contains_aliased_hermes_lifecycle_command(text)
+    )
 
 
 def _resolve_script_path(script_path: str) -> Path:

--- a/skills/autonomous-ai-agents/hermes-agent/references/troubleshooting.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/troubleshooting.md
@@ -21,6 +21,12 @@
 - **Config changes:** In gateway: `/restart`. In CLI: exit and relaunch.
 - **Code changes:** Restart the CLI or gateway process
 
+When operating from a gateway-backed conversation, never bypass the in-process
+restart guard with a delayed shell, cron job, `launchctl submit`, `systemd-run`,
+or another supervisor. That can create a repeated SIGTERM/respawn loop under
+launchd or systemd. Ask the user to send `/restart`, or have them run
+`hermes gateway restart` from an independent shell outside the gateway.
+
 ### Skills not showing
 1. `hermes skills list` — verify installed
 2. `hermes skills config` — check platform enablement

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -31,6 +31,15 @@ class TestGatewayLifecyclePattern:
         "hermes  gateway  restart",         # double spaces
         "Hermez Gateway Restart".lower().replace("z", "s"),  # case handled
         "HERMES GATEWAY RESTART",           # uppercase
+        # Regression: a shell alias for the Hermes executable previously
+        # bypassed the literal `hermes gateway restart` branch. This is the
+        # shape used by a launchctl-submitted delayed restart job.
+        (
+            "H=/Users/test/.hermes/hermes-agent/venv/bin/hermes; "
+            "launchctl submit -l ai.hermes.restart-once -- /bin/zsh -c "
+            "'sleep 30; $H gateway restart'"
+        ),
+        "H='/opt/Hermes Agent/bin/hermes'; ${H} gateway stop",
     ])
     def test_hermes_gateway_commands(self, text):
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
@@ -57,6 +66,10 @@ class TestGatewayLifecyclePattern:
         "launchctl restart ai.hermes.daemon",
         "systemctl restart hermes-meta.service",
         "systemctl restart hermes-cron-helper",
+        # Alias resolution must stay scoped to an executable whose basename is
+        # `hermes`, and only lifecycle verbs are blocked.
+        "APP=/usr/local/bin/acme; $APP gateway restart",
+        "H=/usr/local/bin/hermes; $H gateway status",
         # Regression (#30728 follow-up): legit prompts that merely mention an
         # unrelated gateway + a restart must NOT be blocked. The cron prompt is
         # fed to an LLM, not a shell, so substring detection on English text is
@@ -235,6 +248,11 @@ class TestTerminalToolGatewayLifecycleGuard:
         "hermes gateway restart",
         "launchctl kickstart gui/501/ai.hermes.gateway",
         "pkill -f hermes.*gateway",
+        (
+            "H=/Users/test/.hermes/hermes-agent/venv/bin/hermes; "
+            "launchctl submit -l ai.hermes.restart-once -- /bin/zsh -c "
+            "'sleep 30; $H gateway restart'"
+        ),
     ])
     def test_blocks_lifecycle_commands_inside_gateway(self, monkeypatch, cmd):
         import tools.terminal_tool as tt


### PR DESCRIPTION
## Summary

- Detect simple shell variables assigned to the Hermes executable before scanning gateway lifecycle commands.
- Block aliased forms such as `H=/path/to/hermes; $H gateway restart` through the existing shared cron/terminal lifecycle guard.
- Document the safe restart boundary in the bundled `hermes-agent` troubleshooting reference.

## Problem

The existing guard catches literal `hermes gateway restart`, full executable paths, direct launchctl/systemctl operations, and cron payloads. It does not connect a shell assignment to a later variable expansion:

```bash
H=/path/to/hermes
launchctl submit -l ai.hermes.restart-once -- /bin/zsh -c \
  'sleep 30; $H gateway restart'
```

That exact shape escaped the terminal hard block in a gateway-backed session. The outer command reached smart approval, the submitted launchd job was registered with `OnDemand=false`, and launchd repeatedly relaunched the supposedly one-shot script. Each relaunch restarted the Hermes gateway again, creating hundreds of restart cycles before manual removal.

This is the same cooperative-mode self-termination class as #30719 and #37453, but through a simple executable alias rather than a literal lifecycle command.

## Fix

`cron.lifecycle_guard` now resolves only simple shell assignments whose value basename is exactly `hermes` or `hermes.exe`, including quoted paths. It then checks `$NAME gateway restart|stop` and `${NAME} gateway restart|stop`.

The scope is intentionally narrow:

- `$APP gateway restart` remains allowed when `APP` does not resolve to Hermes.
- `$H gateway status` remains allowed.
- This is defense-in-depth for cooperative mistakes, not a claim that regex scanning is a complete shell security boundary.

The bundled troubleshooting reference now tells gateway-backed agents to ask the user for `/restart` or have the user restart from an independent shell, rather than scheduling a delayed shell/cron/launchd/systemd workaround.

## Tests

Red/green verification on macOS:

- Before fix: `3 failed, 46 passed` in `tests/hermes_cli/test_gateway_restart_loop.py`.
- After fix: `49 passed`.
- `ruff check cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py` passes.
- `git diff --check` passes.

I also ran the adjacent `tests/tools/test_approval.py` suite. It produced `138 passed, 1 failed`; the single `/tmp` versus `/private/tmp` cleanup-path failure reproduces unchanged on pristine `origin/main` and is unrelated to this patch.

## Type of change

- [x] Bug fix
- [x] Tests
- [x] Documentation
