### PR TITLE
fix(cli): keep startup --model/--provider across session boundaries (#74329)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4367,8 +4367,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # wake-word turn (and every ``/new``) with ``model.default`` instead
         # (#74329). Recorded only when the flag was actually passed, so an
         # unflagged launch keeps re-deriving from config exactly as before.
-        self._startup_model = (model or "").strip() or None
-        self._startup_provider = (provider or "").strip() or None
+        self._record_startup_selection(model, provider)
         # A ``moa:<preset>`` model string selects the MoA virtual provider in
         # one shot (parity with interactive ``/moa`` and the model picker). Do
         # this before provider resolution so ``-Q -m moa:<preset>`` routes
@@ -7942,6 +7941,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return None
         return history_snapshot
 
+    def _record_startup_selection(
+        self, model: Optional[str], provider: Optional[str],
+    ) -> None:
+        """Remember the ``--model``/``--provider`` this process was launched with.
+
+        Recorded only when a flag was actually passed, so an unflagged launch
+        keeps re-deriving from config.yaml at every session boundary exactly
+        as before. See ``new_session()`` for why these outrank the config
+        default there (#74329).
+        """
+        self._startup_model = (model or "").strip() or None
+        self._startup_provider = (provider or "").strip() or None
+
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
         old_session_id = self.session_id
@@ -8018,14 +8030,29 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # wake-word session or a plain /new must not silently answer on
         # ``model.default`` when the operator launched with explicit flags
         # (#74329).
-        _startup_model = getattr(self, "_startup_model", None)
-        if _startup_model:
-            _config_model = _startup_model
-            _config_provider_default = (
-                getattr(self, "_startup_provider", None) or _config_provider_default
+        #
+        # Model and provider are resolved independently: ``--provider`` alone
+        # is a complete startup selection (same model, different backend), and
+        # a session-scoped ``/model --provider`` on the same model has to be
+        # undone here too. Coupling them would leave both cases stuck on the
+        # session's provider.
+        _desired_model = getattr(self, "_startup_model", None) or _config_model
+        _desired_provider = (
+            getattr(self, "_startup_provider", None) or _config_provider_default
+        )
+        # Any difference in the resolved route — model or provider — has to go
+        # back through the shared switch pipeline, so the session lands on the
+        # startup/config backend rather than whichever one it was steered to.
+        _route_changed = bool(_desired_model) and (
+            _desired_model != getattr(self, "model", None)
+            or (
+                bool(_desired_provider)
+                and _desired_provider != getattr(self, "provider", None)
             )
-        if _config_model and _config_model != getattr(self, "model", None):
-            _config_provider = _config_provider_default
+        )
+        if _route_changed:
+            _config_model = _desired_model
+            _config_provider = _desired_provider
             try:
                 from hermes_cli.model_switch import switch_model as _switch_model
 

--- a/cli.py
+++ b/cli.py
@@ -4356,6 +4356,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
+        # Startup-level selection, remembered for the life of the process.
+        #
+        # ``--model``/``--provider`` are NOT session-scoped runtime overrides
+        # like ``/model --session``, ``/fast`` or ``/model --once``: they are
+        # how the process was launched. ``new_session()`` deliberately drops
+        # the session-scoped kind at a conversation boundary (#67979), but it
+        # re-derives from config.yaml, which also discarded these — so a
+        # headless appliance started with explicit flags answered every
+        # wake-word turn (and every ``/new``) with ``model.default`` instead
+        # (#74329). Recorded only when the flag was actually passed, so an
+        # unflagged launch keeps re-deriving from config exactly as before.
+        self._startup_model = (model or "").strip() or None
+        self._startup_provider = (provider or "").strip() or None
         # A ``moa:<preset>`` model string selects the MoA virtual provider in
         # one shot (parity with interactive ``/moa`` and the model picker). Do
         # this before provider resolution so ``-Q -m moa:<preset>`` routes
@@ -7994,12 +8007,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if isinstance(_model_config, dict)
             else (_model_config or "")
         )
-        if _config_model and _config_model != getattr(self, "model", None):
-            _config_provider = (
-                _model_config.get("provider", "")
-                if isinstance(_model_config, dict)
-                else ""
+        _config_provider_default = (
+            _model_config.get("provider", "")
+            if isinstance(_model_config, dict)
+            else ""
+        )
+        # ...but the startup ``--model``/``--provider`` are the baseline this
+        # boundary resets *to*, not an override it resets away. They describe
+        # how the process was launched, so they outrank config.yaml here; a
+        # wake-word session or a plain /new must not silently answer on
+        # ``model.default`` when the operator launched with explicit flags
+        # (#74329).
+        _startup_model = getattr(self, "_startup_model", None)
+        if _startup_model:
+            _config_model = _startup_model
+            _config_provider_default = (
+                getattr(self, "_startup_provider", None) or _config_provider_default
             )
+        if _config_model and _config_model != getattr(self, "model", None):
+            _config_provider = _config_provider_default
             try:
                 from hermes_cli.model_switch import switch_model as _switch_model
 

--- a/tests/hermes_cli/test_cli_startup_model_flags.py
+++ b/tests/hermes_cli/test_cli_startup_model_flags.py
@@ -172,6 +172,62 @@ class TestStartupFlagsSurviveNewSession:
         assert switch_calls[-1]["raw_input"] == "startup/model"
         assert cli.model == "startup/model"
 
+    def test_provider_only_startup_survives(self, config_default, switch_calls):
+        """`hermes --provider X` with no --model is a complete selection.
+
+        The startup provider must not be dropped just because no model flag
+        was given — it is the whole point of that launch.
+        """
+        cli = _make_cli(
+            config_default,
+            startup_model=None,
+            startup_provider="startup-provider",
+            current_model="config/default-model",
+        )
+        cli.provider = "session-provider"
+
+        cli.new_session(silent=True)
+
+        assert switch_calls, "a provider-only startup must still re-derive"
+        assert switch_calls[-1]["explicit_provider"] == "startup-provider"
+
+    def test_provider_only_session_override_is_undone(
+        self, config_default, switch_calls,
+    ):
+        """Same model, different provider: the boundary must still reset it.
+
+        Gating the switch on the model alone let a session-scoped provider
+        change ride through /new.
+        """
+        cli = _make_cli(
+            config_default,
+            startup_model="startup/model",
+            startup_provider="startup-provider",
+            current_model="startup/model",
+        )
+        cli.provider = "session-provider"
+
+        cli.new_session(silent=True)
+
+        assert switch_calls, "a provider-only difference must trigger a reset"
+        assert switch_calls[-1]["raw_input"] == "startup/model"
+        assert switch_calls[-1]["explicit_provider"] == "startup-provider"
+
+    def test_matching_model_and_provider_still_skips_the_switch(
+        self, config_default, switch_calls,
+    ):
+        cli = _make_cli(
+            config_default,
+            startup_model="startup/model",
+            startup_provider="startup-provider",
+            current_model="startup/model",
+        )
+        cli.provider = "startup-provider"
+
+        cli.new_session(silent=True)
+
+        assert not switch_calls
+
     def test_one_turn_restore_is_still_cleared(self, config_default, switch_calls):
         cli = _make_cli(
             config_default,
@@ -184,29 +240,34 @@ class TestStartupFlagsSurviveNewSession:
 
         assert cli._pending_one_turn_model_restore is None
 
-    def test_no_switch_when_already_on_the_startup_model(
-        self, config_default, switch_calls,
-    ):
-        """Nothing to re-derive — the guard must stay a no-op."""
-        cli = _make_cli(
-            config_default,
-            startup_model="startup/model",
-            startup_provider=None,
-            current_model="startup/model",
-        )
-
-        cli.new_session(silent=True)
-
-        assert not switch_calls
-
 
 class TestStartupSelectionCapture:
-    def test_flags_are_recorded_only_when_passed(self, monkeypatch):
-        """An unflagged launch must record nothing, so config keeps winning."""
-        import inspect
+    def test_unflagged_launch_records_no_startup_selection(self, monkeypatch, tmp_path):
+        """An unflagged launch must record nothing, so config keeps winning.
 
+        Behavioral: build a real HermesCLI with no flags and check the
+        recorded selection, rather than reading the constructor's source.
+        """
         import cli as cli_mod
 
-        src = inspect.getsource(cli_mod.HermesCLI.__init__)
-        assert "self._startup_model = (model or \"\").strip() or None" in src
-        assert "self._startup_provider = (provider or \"\").strip() or None" in src
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cli = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+        cli_mod.HermesCLI._record_startup_selection(cli, None, None)
+        assert cli._startup_model is None
+        assert cli._startup_provider is None
+
+    def test_flags_are_recorded_when_passed(self, monkeypatch, tmp_path):
+        import cli as cli_mod
+
+        cli = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+        cli_mod.HermesCLI._record_startup_selection(cli, "  some/model ", " some-provider ")
+        assert cli._startup_model == "some/model"
+        assert cli._startup_provider == "some-provider"
+
+    def test_blank_flags_are_treated_as_absent(self, monkeypatch, tmp_path):
+        import cli as cli_mod
+
+        cli = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+        cli_mod.HermesCLI._record_startup_selection(cli, "   ", "")
+        assert cli._startup_model is None
+        assert cli._startup_provider is None

--- a/tests/hermes_cli/test_cli_startup_model_flags.py
+++ b/tests/hermes_cli/test_cli_startup_model_flags.py
@@ -1,0 +1,212 @@
+"""Startup --model/--provider survive session boundaries (#74329).
+
+``/new`` (and every wake-word session, which calls ``new_session(silent=True)``)
+is a full conversation boundary: session-scoped runtime overrides — ``/model
+--session``, ``/fast``, ``/model --once`` — deliberately do not carry forward
+(#67979, #48055, #23131).
+
+The startup flags are a different thing. They describe how the process was
+launched, so they are the baseline the boundary resets *to*, not an override it
+resets away. Before this fix the reset re-derived from ``config.yaml`` only, so
+a headless voice appliance started with explicit flags answered every wake turn
+on ``model.default`` instead.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.model = "startup/model"
+        self.provider = "startup-provider"
+
+    def switch_model(self, **kwargs):
+        self.model = kwargs["new_model"]
+        self.provider = kwargs["new_provider"]
+
+    def __getattr__(self, name):
+        # new_session pokes a number of agent attributes/methods after the
+        # switch; none of them are what this test is about. Return a callable
+        # that also tolerates attribute access.
+        return _Anything()
+
+
+class _Anything:
+    def __call__(self, *a, **k):
+        return None
+
+    def __getattr__(self, name):
+        return _Anything()
+
+    def __bool__(self):
+        return False
+
+
+def _make_cli(cli_mod, *, startup_model, startup_provider, current_model):
+    stub = SimpleNamespace()
+    stub.session_id = "old_session"
+    stub.session_start = None
+    stub.conversation_history = []
+    stub.agent = _FakeAgent()
+    stub._session_db = None
+    stub._pending_title = None
+    stub._resumed = False
+    stub._pending_one_turn_model_restore = "leftover"
+    stub.reasoning_config = None
+    stub.service_tier = None
+    stub.model = current_model
+    stub.provider = "current-provider"
+    stub.requested_provider = "current-provider"
+    stub.api_key = "sk-current"
+    stub.base_url = "https://current/v1"
+    stub._explicit_api_key = "sk-current"
+    stub._explicit_base_url = "https://current/v1"
+    stub.api_mode = "chat_completions"
+    stub._startup_model = startup_model
+    stub._startup_provider = startup_provider
+    stub._launch_session_boundary_memory_flush = lambda *a, **k: None
+    stub._notify_session_boundary = lambda *a, **k: None
+    stub._discard_session_if_empty = lambda *a, **k: None
+    stub.new_session = cli_mod.HermesCLI.new_session.__get__(stub)
+    return stub
+
+
+@pytest.fixture()
+def switch_calls(monkeypatch):
+    """Capture what new_session asks the shared switch_model pipeline for."""
+    calls = []
+
+    def _fake_switch(**kwargs):
+        calls.append(kwargs)
+        return ModelSwitchResult(
+            success=True,
+            new_model=kwargs["raw_input"],
+            target_provider=kwargs.get("explicit_provider") or "resolved-provider",
+            api_key="sk-new",
+            base_url="https://new/v1",
+            api_mode="chat_completions",
+        )
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _fake_switch)
+    return calls
+
+
+@pytest.fixture()
+def config_default(monkeypatch):
+    import cli as cli_mod
+
+    monkeypatch.setitem(
+        cli_mod.CLI_CONFIG, "model",
+        {"default": "config/default-model", "provider": "config-provider"},
+    )
+    return cli_mod
+
+
+class TestStartupFlagsSurviveNewSession:
+    def test_startup_model_wins_over_config_default(self, config_default, switch_calls):
+        cli = _make_cli(
+            config_default,
+            startup_model="startup/model",
+            startup_provider=None,
+            current_model="something/else",
+        )
+
+        cli.new_session(silent=True)
+
+        assert switch_calls, "new_session should have re-derived a model"
+        assert switch_calls[-1]["raw_input"] == "startup/model", (
+            "a session started with --model must not fall back to model.default"
+        )
+
+    def test_startup_provider_is_carried_too(self, config_default, switch_calls):
+        cli = _make_cli(
+            config_default,
+            startup_model="startup/model",
+            startup_provider="startup-provider",
+            current_model="something/else",
+        )
+
+        cli.new_session(silent=True)
+
+        assert switch_calls[-1]["explicit_provider"] == "startup-provider"
+
+    def test_without_startup_flags_config_default_still_wins(
+        self, config_default, switch_calls,
+    ):
+        """The #67979 contract is unchanged for an unflagged launch."""
+        cli = _make_cli(
+            config_default,
+            startup_model=None,
+            startup_provider=None,
+            current_model="something/else",
+        )
+
+        cli.new_session(silent=True)
+
+        assert switch_calls[-1]["raw_input"] == "config/default-model"
+        assert switch_calls[-1]["explicit_provider"] == "config-provider"
+
+    def test_session_scoped_override_still_does_not_carry_forward(
+        self, config_default, switch_calls,
+    ):
+        """/model --session picked 'session/override'; /new must drop it.
+
+        It resets to the startup selection, not to the override and not to
+        config.yaml.
+        """
+        cli = _make_cli(
+            config_default,
+            startup_model="startup/model",
+            startup_provider=None,
+            current_model="session/override",
+        )
+
+        cli.new_session(silent=True)
+
+        assert switch_calls[-1]["raw_input"] == "startup/model"
+        assert cli.model == "startup/model"
+
+    def test_one_turn_restore_is_still_cleared(self, config_default, switch_calls):
+        cli = _make_cli(
+            config_default,
+            startup_model="startup/model",
+            startup_provider=None,
+            current_model="something/else",
+        )
+
+        cli.new_session(silent=True)
+
+        assert cli._pending_one_turn_model_restore is None
+
+    def test_no_switch_when_already_on_the_startup_model(
+        self, config_default, switch_calls,
+    ):
+        """Nothing to re-derive — the guard must stay a no-op."""
+        cli = _make_cli(
+            config_default,
+            startup_model="startup/model",
+            startup_provider=None,
+            current_model="startup/model",
+        )
+
+        cli.new_session(silent=True)
+
+        assert not switch_calls
+
+
+class TestStartupSelectionCapture:
+    def test_flags_are_recorded_only_when_passed(self, monkeypatch):
+        """An unflagged launch must record nothing, so config keeps winning."""
+        import inspect
+
+        import cli as cli_mod
+
+        src = inspect.getsource(cli_mod.HermesCLI.__init__)
+        assert "self._startup_model = (model or \"\").strip() or None" in src
+        assert "self._startup_provider = (provider or \"\").strip() or None" in src


### PR DESCRIPTION
## Problem

`/new` — and every wake-word session, which calls `new_session(silent=True)` when `wake_word.start_new_session` is on (the default) — is a full conversation boundary. Session-scoped runtime overrides (`/model --session`, `/fast`, `/model --once`) deliberately do not carry forward, so the boundary re-derives model/provider from `config.yaml` (#67979, #48055, #23131).

That re-derivation also discards the flags the process was **launched** with.

**Premise verified on current `main`:** `HermesCLI.__init__` does `self.model = model or _config_model or _DEFAULT_CONFIG_MODEL` — the `--model`/`--provider` flags land on `self.model`/`self.provider` and are *never* written back into `CLI_CONFIG`. `new_session()` then reads `CLI_CONFIG["model"]["default"]`, so the startup selection is gone.

A headless voice appliance started as

```
hermes --provider gb10-dsv4-fast --model deepseek-v4-flash-dspark
```

shows the flag-selected model in the status bar while every wake turn — and every plain `/new` — is silently answered by `model.default`, quietly moving inference to a different (often cloud) backend.

## Why this isn't the intentional behaviour

I checked the intent of the reset before changing it (`git log -p -S`). It comes from `47fb20c0bd` (#67979), whose message is explicit about *what* must not carry forward:

> `/new` and `/reset` are full conversation boundaries: session-scoped runtime overrides do not carry into the next session

and it enumerates them: `/model --session`, `/fast`, `/model --once`, `/reasoning`. Startup flags are not in that category — they describe how the process was launched, so they are the baseline the boundary resets **to**, not an override it resets away. Discarding them is a side effect of re-deriving from config, not a decision the commit made.

## Fix

`__init__` records `_startup_model` / `_startup_provider`, **only when the flag was actually passed**, and `new_session()` prefers them over the config default.

- An unflagged launch keeps re-deriving from `config.yaml` exactly as before — the #67979 contract is untouched.
- A session-scoped `/model --session` still does not survive the boundary: it now resets to the startup selection instead of the config default.
- The existing `_pending_one_turn_model_restore` clear and the service-tier re-derive are unchanged.

## Tests

`tests/hermes_cli/test_cli_startup_model_flags.py`, 7 tests driving the real `HermesCLI.new_session` bound to a stub and capturing what it asks the shared `switch_model` pipeline for:

- startup model wins over `model.default`; startup provider is carried too;
- **without startup flags, the config default still wins** (the #67979 contract);
- a session-scoped override still does not carry forward — it resets to the startup selection;
- the one-turn restore is still cleared;
- no switch at all when already on the startup model;
- plus a guard that the capture is conditional on the flag being passed.

Verified they catch the bug rather than merely passing: with the `new_session` half reverted, 4 of the 7 fail.

## Regression check

`tests/hermes_cli/test_cli_model_once.py`, `tests/cli/test_reasoning_command.py` and `tests/gateway/test_model_switch_persistence.py` — 40 passed, plus one failure (`test_once_skips_session_store_write_through`) that I confirmed fails identically on a pristine `main` checkout.

Across `tests/hermes_cli/ tests/cli/ tests/gateway/` the failure set matches the baseline except for three order-dependent flakes (two Discord async-task tests and `test_update_eol_churn`). I isolated those: with my `cli.py` change reverted to `main`, those same files still produce the identical 11 failures, so they are pre-existing and unrelated.
