### PR TITLE
fix(buzz): allow explicit ACP CLI auth passthrough

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5295,10 +5295,10 @@ def _inject_platform_plugin_env_vars() -> None:
                     # Trusted bundled platform plugins may declare that one of
                     # their env vars is eligible for an *explicit* terminal
                     # passthrough opt-in. Eligibility alone never exposes the
-                    # value: terminal.env_passthrough (or trusted runtime
-                    # registration) must still name it, and all undeclared
-                    # provider/messaging credentials remain non-bypassable.
-                    "terminal_passthrough": bool(meta.get("terminal_passthrough", False)),
+                    # value: terminal.env_passthrough must still name it, and
+                    # all undeclared provider/messaging credentials remain
+                    # non-bypassable.
+                    "terminal_passthrough": meta.get("terminal_passthrough") is True,
                 }
     except Exception:
         pass

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5292,6 +5292,13 @@ def _inject_platform_plugin_env_vars() -> None:
                     "url": meta.get("url") or None,
                     "password": is_secret,
                     "category": meta.get("category") or "messaging",
+                    # Trusted bundled platform plugins may declare that one of
+                    # their env vars is eligible for an *explicit* terminal
+                    # passthrough opt-in. Eligibility alone never exposes the
+                    # value: terminal.env_passthrough (or trusted runtime
+                    # registration) must still name it, and all undeclared
+                    # provider/messaging credentials remain non-bypassable.
+                    "terminal_passthrough": bool(meta.get("terminal_passthrough", False)),
                 }
     except Exception:
         pass

--- a/plugins/platforms/buzz/plugin.yaml
+++ b/plugins/platforms/buzz/plugin.yaml
@@ -16,10 +16,12 @@ requires_env:
     description: "Base URL of the Buzz community relay (e.g. https://mycommunity.communities.buzz.xyz)"
     prompt: "Buzz relay URL"
     password: false
+    terminal_passthrough: true
   - name: BUZZ_PRIVATE_KEY
     description: "Nostr private key for the agent's Buzz identity (nsec or hex) — the only Buzz secret"
     prompt: "Nostr private key (nsec or hex)"
     password: true
+    terminal_passthrough: true
 optional_env:
   - name: BUZZ_TRANSPORT
     description: "Inbound transport: auto (WebSocket w/ poll fallback, default), websocket, or poll"
@@ -29,6 +31,7 @@ optional_env:
     description: "Optional NIP-OA owner-attestation auth tag JSON for NIP-42 WebSocket auth"
     prompt: "NIP-OA auth tag JSON (or empty)"
     password: false
+    terminal_passthrough: true
   - name: BUZZ_CHANNELS
     description: "Comma-separated channel UUIDs to watch (default: all joined channels)"
     prompt: "Channel UUIDs (comma-separated)"

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -138,7 +138,8 @@ class TestTerminalIntegration:
             _HERMES_PROVIDER_ENV_BLOCKLIST,
         )
 
-        blocked_var = next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))
+        blocked_var = "OPENAI_API_KEY"
+        assert blocked_var in _HERMES_PROVIDER_ENV_BLOCKLIST
         # Attempt to register — must be silently refused (logged warning).
         register_env_passthrough([blocked_var])
 
@@ -193,7 +194,8 @@ class TestTerminalIntegration:
             _HERMES_PROVIDER_ENV_BLOCKLIST,
         )
 
-        blocked_var = next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))
+        blocked_var = "OPENAI_API_KEY"
+        assert blocked_var in _HERMES_PROVIDER_ENV_BLOCKLIST
         os.environ[blocked_var] = "secret_value"
         try:
             # Without passthrough — blocked
@@ -218,6 +220,50 @@ class TestTerminalIntegration:
         # Arbitrary skill-specific var
         register_env_passthrough(["MY_SKILL_CUSTOM_CONFIG"])
         assert is_env_passthrough("MY_SKILL_CUSTOM_CONFIG")
+
+    def test_bundled_plugin_var_requires_explicit_passthrough(
+        self, tmp_path, monkeypatch
+    ):
+        """Trusted plugin metadata makes exact vars eligible, not exposed."""
+        from tools.environments.local import (
+            _HERMES_PROVIDER_ENV_BLOCKLIST,
+            _HERMES_TERMINAL_PASSTHROUGH_ELIGIBLE,
+            _sanitize_subprocess_env,
+        )
+
+        buzz_vars = {
+            "BUZZ_RELAY_URL": "https://relay.example",
+            "BUZZ_PRIVATE_KEY": "test-private-key",
+            "BUZZ_AUTH_TAG": "test-auth-tag",
+        }
+        assert buzz_vars.keys() <= _HERMES_PROVIDER_ENV_BLOCKLIST
+        assert buzz_vars.keys() <= _HERMES_TERMINAL_PASSTHROUGH_ELIGIBLE
+
+        # Eligibility is not exposure: without explicit config, all stay
+        # blocked exactly like every other messaging credential.
+        result_before = _sanitize_subprocess_env(buzz_vars)
+        assert not (buzz_vars.keys() & result_before.keys())
+
+        config = {"terminal": {"env_passthrough": list(buzz_vars)}}
+        (tmp_path / "config.yaml").write_text(yaml.dump(config))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _ep_mod._config_passthrough = None
+
+        for name in buzz_vars:
+            assert is_env_passthrough(name)
+        result_after = _sanitize_subprocess_env(buzz_vars)
+        for name, value in buzz_vars.items():
+            assert result_after[name] == value
+
+    def test_manifest_eligibility_does_not_unlock_provider_credentials(
+        self, tmp_path, monkeypatch
+    ):
+        config = {"terminal": {"env_passthrough": ["OPENAI_API_KEY"]}}
+        (tmp_path / "config.yaml").write_text(yaml.dump(config))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _ep_mod._config_passthrough = None
+
+        assert not is_env_passthrough("OPENAI_API_KEY")
 
     def test_provider_blocklist_import_failure_fails_closed(self, monkeypatch):
         """If the dynamic provider blocklist can't be imported, provider

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -9,6 +9,7 @@ from tools.env_passthrough import (
     clear_env_passthrough,
     get_all_passthrough,
     is_env_passthrough,
+    is_terminal_env_passthrough,
     register_env_passthrough,
 )
 
@@ -18,9 +19,11 @@ def _clean_passthrough():
     """Ensure a clean passthrough state for every test."""
     clear_env_passthrough()
     _ep_mod._config_passthrough = None
+    _ep_mod._terminal_config_passthrough = None
     yield
     clear_env_passthrough()
     _ep_mod._config_passthrough = None
+    _ep_mod._terminal_config_passthrough = None
 
 
 class TestSkillScopedPassthrough:
@@ -221,13 +224,35 @@ class TestTerminalIntegration:
         register_env_passthrough(["MY_SKILL_CUSTOM_CONFIG"])
         assert is_env_passthrough("MY_SKILL_CUSTOM_CONFIG")
 
-    def test_bundled_plugin_var_requires_explicit_passthrough(
+    def test_skill_cannot_self_enable_bundled_plugin_credentials(self):
+        from tools.environments.local import _sanitize_subprocess_env
+
+        buzz_vars = {
+            "BUZZ_RELAY_URL": "https://relay.example",
+            "BUZZ_PRIVATE_KEY": "test-private-key",
+            "BUZZ_AUTH_TAG": "test-auth-tag",
+        }
+        register_env_passthrough(buzz_vars)
+
+        for name in buzz_vars:
+            assert not is_env_passthrough(name)
+            assert not is_terminal_env_passthrough(name)
+        assert not (
+            buzz_vars.keys()
+            & _sanitize_subprocess_env(
+                buzz_vars, terminal_passthrough=True
+            ).keys()
+        )
+
+    def test_bundled_plugin_var_requires_explicit_terminal_config(
         self, tmp_path, monkeypatch
     ):
-        """Trusted plugin metadata makes exact vars eligible, not exposed."""
+        """Explicit config reaches terminal only, never generic sandboxes."""
+        from tools.code_execution_tool import _scrub_child_env
         from tools.environments.local import (
             _HERMES_PROVIDER_ENV_BLOCKLIST,
             _HERMES_TERMINAL_PASSTHROUGH_ELIGIBLE,
+            _make_run_env,
             _sanitize_subprocess_env,
         )
 
@@ -248,22 +273,53 @@ class TestTerminalIntegration:
         (tmp_path / "config.yaml").write_text(yaml.dump(config))
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         _ep_mod._config_passthrough = None
+        _ep_mod._terminal_config_passthrough = None
 
         for name in buzz_vars:
-            assert is_env_passthrough(name)
-        result_after = _sanitize_subprocess_env(buzz_vars)
-        for name, value in buzz_vars.items():
-            assert result_after[name] == value
+            assert not is_env_passthrough(name)
+            assert is_terminal_env_passthrough(name)
 
-    def test_manifest_eligibility_does_not_unlock_provider_credentials(
+        # execute_code/generic children remain unable to read the credentials.
+        generic_result = _sanitize_subprocess_env(buzz_vars)
+        assert not (buzz_vars.keys() & generic_result.keys())
+        execute_code_result = _scrub_child_env(
+            buzz_vars,
+            is_passthrough=is_env_passthrough,
+            is_windows=False,
+        )
+        assert not (buzz_vars.keys() & execute_code_result.keys())
+
+        # Foreground terminal and the shared background/PTY sanitizer receive
+        # only the explicitly configured, manifest-approved names.
+        terminal_result = _sanitize_subprocess_env(
+            buzz_vars, terminal_passthrough=True
+        )
+        for name, value in buzz_vars.items():
+            assert terminal_result[name] == value
+
+        for name, value in buzz_vars.items():
+            monkeypatch.setenv(name, value)
+        foreground_result = _make_run_env({})
+        for name, value in buzz_vars.items():
+            assert foreground_result[name] == value
+
+    def test_terminal_eligibility_does_not_unlock_other_credentials(
         self, tmp_path, monkeypatch
     ):
-        config = {"terminal": {"env_passthrough": ["OPENAI_API_KEY"]}}
+        config = {
+            "terminal": {
+                "env_passthrough": ["OPENAI_API_KEY", "BUZZ_CHANNELS"]
+            }
+        }
         (tmp_path / "config.yaml").write_text(yaml.dump(config))
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         _ep_mod._config_passthrough = None
+        _ep_mod._terminal_config_passthrough = None
 
         assert not is_env_passthrough("OPENAI_API_KEY")
+        assert not is_terminal_env_passthrough("OPENAI_API_KEY")
+        assert not is_env_passthrough("BUZZ_CHANNELS")
+        assert not is_terminal_env_passthrough("BUZZ_CHANNELS")
 
     def test_provider_blocklist_import_failure_fails_closed(self, monkeypatch):
         """If the dynamic provider blocklist can't be imported, provider

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -43,6 +43,7 @@ def _get_allowed() -> set[str]:
 
 # Cache for the config-based allowlist (loaded once per process).
 _config_passthrough: frozenset[str] | None = None
+_terminal_config_passthrough: frozenset[str] | None = None
 
 
 def _is_hermes_provider_credential(name: str) -> bool:
@@ -68,7 +69,6 @@ def _is_hermes_provider_credential(name: str) -> bool:
     try:
         from tools.environments.local import (
             _HERMES_PROVIDER_ENV_BLOCKLIST,
-            _HERMES_TERMINAL_PASSTHROUGH_ELIGIBLE,
             _is_hermes_internal_secret,
         )
     except Exception as e:
@@ -86,10 +86,7 @@ def _is_hermes_provider_credential(name: str) -> bool:
     # as passthrough and tunnel them into an execute_code / terminal child.
     if _is_hermes_internal_secret(name):
         return True
-    return (
-        name in _HERMES_PROVIDER_ENV_BLOCKLIST
-        and name not in _HERMES_TERMINAL_PASSTHROUGH_ELIGIBLE
-    )
+    return name in _HERMES_PROVIDER_ENV_BLOCKLIST
 
 
 def register_env_passthrough(var_names: Iterable[str]) -> None:
@@ -174,6 +171,44 @@ def is_env_passthrough(var_name: str) -> bool:
     if var_name in _get_allowed():
         return True
     return var_name in _load_config_passthrough()
+
+
+def _load_terminal_config_passthrough() -> frozenset[str]:
+    """Load protected vars explicitly approved for terminal use only.
+
+    This path is not skill-facing. It accepts only exact names marked by a
+    trusted bundled platform manifest and explicitly listed by the operator
+    under ``terminal.env_passthrough``. Values remain unavailable to
+    execute_code and other generic sandbox subprocesses.
+    """
+    global _terminal_config_passthrough
+    if _terminal_config_passthrough is not None:
+        return _terminal_config_passthrough
+
+    result: set[str] = set()
+    try:
+        from hermes_cli.config import read_raw_config
+        from tools.environments.local import _HERMES_TERMINAL_PASSTHROUGH_ELIGIBLE
+
+        cfg = read_raw_config()
+        passthrough = cfg_get(cfg, "terminal", "env_passthrough")
+        if isinstance(passthrough, list):
+            requested = {
+                item.strip()
+                for item in passthrough
+                if isinstance(item, str) and item.strip()
+            }
+            result = requested & set(_HERMES_TERMINAL_PASSTHROUGH_ELIGIBLE)
+    except Exception as e:
+        logger.debug("Could not read terminal-only env passthrough: %s", e)
+
+    _terminal_config_passthrough = frozenset(result)
+    return _terminal_config_passthrough
+
+
+def is_terminal_env_passthrough(var_name: str) -> bool:
+    """Return whether *var_name* may reach terminal-spawned processes."""
+    return is_env_passthrough(var_name) or var_name in _load_terminal_config_passthrough()
 
 
 def get_all_passthrough() -> frozenset[str]:

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -68,6 +68,7 @@ def _is_hermes_provider_credential(name: str) -> bool:
     try:
         from tools.environments.local import (
             _HERMES_PROVIDER_ENV_BLOCKLIST,
+            _HERMES_TERMINAL_PASSTHROUGH_ELIGIBLE,
             _is_hermes_internal_secret,
         )
     except Exception as e:
@@ -85,7 +86,10 @@ def _is_hermes_provider_credential(name: str) -> bool:
     # as passthrough and tunnel them into an execute_code / terminal child.
     if _is_hermes_internal_secret(name):
         return True
-    return name in _HERMES_PROVIDER_ENV_BLOCKLIST
+    return (
+        name in _HERMES_PROVIDER_ENV_BLOCKLIST
+        and name not in _HERMES_TERMINAL_PASSTHROUGH_ELIGIBLE
+    )
 
 
 def register_env_passthrough(var_names: Iterable[str]) -> None:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -336,6 +336,32 @@ def _build_provider_env_blocklist() -> frozenset:
 
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 
+
+def _build_terminal_passthrough_eligible() -> frozenset[str]:
+    """Return trusted bundled-plugin vars eligible for explicit passthrough.
+
+    These names deliberately remain in ``_HERMES_PROVIDER_ENV_BLOCKLIST`` so
+    they are stripped by default. The metadata only lets
+    :mod:`tools.env_passthrough` honor an explicit user/runtime opt-in for the
+    named variable; it does not expose anything on its own. Platform plugin
+    manifests are bundled executable-code peers, unlike untrusted skill
+    frontmatter, so allowing them to define this narrow eligibility does not
+    create a new trust boundary.
+    """
+    try:
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        return frozenset(
+            name
+            for name, metadata in OPTIONAL_ENV_VARS.items()
+            if metadata.get("terminal_passthrough") is True
+        )
+    except ImportError:
+        return frozenset()
+
+
+_HERMES_TERMINAL_PASSTHROUGH_ELIGIBLE = _build_terminal_passthrough_eligible()
+
 # Active-virtualenv markers that must NOT leak into terminal subprocesses.
 # The gateway runs inside its own venv, so its process environment carries
 # VIRTUAL_ENV (and possibly CONDA_PREFIX). If those leak into commands the

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -479,10 +479,25 @@ def _inject_session_context_env(env: dict) -> None:
             env.pop(var_name, None)
 
 
-def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
-    """Filter Hermes-managed secrets from a subprocess environment."""
+def _sanitize_subprocess_env(
+    base_env: Mapping[str, str] | None,
+    extra_env: Mapping[str, str] | None = None,
+    *,
+    terminal_passthrough: bool = False,
+) -> dict:
+    """Filter Hermes-managed secrets from a subprocess environment.
+
+    ``terminal_passthrough`` is reserved for terminal foreground/background
+    execution. It permits only protected vars explicitly approved by both a
+    trusted bundled plugin manifest and the operator's config.
+    """
     try:
-        from tools.env_passthrough import is_env_passthrough as _is_passthrough
+        if terminal_passthrough:
+            from tools.env_passthrough import (
+                is_terminal_env_passthrough as _is_passthrough,
+            )
+        else:
+            from tools.env_passthrough import is_env_passthrough as _is_passthrough
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
 
@@ -1245,7 +1260,9 @@ def _path_env_key(run_env: dict) -> str | None:
 def _make_run_env(env: dict) -> dict:
     """Build a run environment with a sane PATH and provider-var stripping."""
     try:
-        from tools.env_passthrough import is_env_passthrough as _is_passthrough
+        from tools.env_passthrough import (
+            is_terminal_env_passthrough as _is_passthrough,
+        )
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -731,7 +731,9 @@ class ProcessRegistry:
                 else:
                     from ptyprocess import PtyProcess as _PtyProcessCls
                 user_shell = _find_shell()
-                pty_env = _sanitize_subprocess_env(os.environ, env_vars)
+                pty_env = _sanitize_subprocess_env(
+                    os.environ, env_vars, terminal_passthrough=True
+                )
                 pty_env["PYTHONUNBUFFERED"] = "1"
                 pty_proc = _PtyProcessCls.spawn(
                     [user_shell, "-lic", f"set +m; {safe_command}"],
@@ -773,7 +775,9 @@ class ProcessRegistry:
         # Force unbuffered output for Python scripts so progress is visible
         # during background execution (libraries like tqdm/datasets buffer when
         # stdout is a pipe, hiding output from process(action="poll")).
-        bg_env = _sanitize_subprocess_env(os.environ, env_vars)
+        bg_env = _sanitize_subprocess_env(
+            os.environ, env_vars, terminal_passthrough=True
+        )
         bg_env["PYTHONUNBUFFERED"] = "1"
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 


### PR DESCRIPTION
## Summary
- let trusted bundled platform manifests mark exact env vars as eligible for explicit **terminal-only** passthrough
- mark the Buzz ACP relay URL, signing key, and auth tag as eligible
- keep all three blocked by default and require an explicit `terminal.env_passthrough` entry
- keep skill registration, `execute_code`, and generic subprocesses unable to access the credentials
- preserve the non-bypassable protection for inference-provider and unmarked messaging credentials

## Root cause
Buzz Desktop correctly injected `BUZZ_PRIVATE_KEY` into `hermes-acp`, but the Hermes subprocess credential blocklist also classified all bundled messaging vars as non-bypassable. As a result, the agent terminal stripped the signing key and the `buzz` CLI failed with `BUZZ_PRIVATE_KEY is required`.

## Security boundary
Manifest eligibility alone exposes nothing. Only the intersection of trusted bundled-plugin metadata and the operator’s explicit `terminal.env_passthrough` config reaches terminal foreground/background/PTY processes. Skill frontmatter cannot self-enable these names, and `execute_code` continues to strip them.

## Verification
- `uv run --extra dev pytest -q tests/tools/test_process_registry.py tests/tools/test_env_passthrough.py tests/tools/test_local_env_blocklist.py tests/tools/test_local_env_session_leak.py tests/gateway/test_buzz_adapter.py` (135 passed)
- `uv run --extra dev ruff check hermes_cli/config.py tools/env_passthrough.py tools/environments/local.py tools/process_registry.py tests/tools/test_env_passthrough.py`
- synthetic skill-registration attempt stayed blocked for all three Buzz vars
- live Buzz-managed parent environment: generic sanitizer and `execute_code` stripped all three, while terminal foreground and background/PTY paths received all three without printing values
- live `openai-codex:gpt-5.6-terra` one-shot returned `OK`, confirming the refreshed OAuth path
- live Ar-Ge round trip succeeded: user mention `31a092…` received signed Herms reply `fe6878…`