### PR TITLE
fix(buzz): discover newly joined channels dynamically

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -84,27 +84,29 @@ from gateway.platforms.base import (
 from gateway.config import Platform
 
 
-# Buzz chat messages are Nostr kind 9 events.  ``buzz messages get`` also
-# returns housekeeping kinds (joins, canvas updates, …) — only kind 9 is
-# dispatched to the agent.
+# Buzz stream messages are Nostr kind 9 events. Forum roots/comments use
+# separate thread semantics and are deliberately outside this adapter.
 _CHAT_KIND = 9
+_FORUM_EVENT_KINDS = frozenset({45001, 45003})
 # How many events to request per poll / seed call.
 _FETCH_LIMIT = 50
 # Bound on the per-channel de-dupe set (events, not bytes).
 _SEEN_CAP = 500
-# Re-run DM discovery (``dms list`` plus the channels-list fallback) every
-# N poll sweeps to pick up conversations opened mid-run.
-_DM_DISCOVERY_EVERY = 5
+# Re-run joined-channel and DM discovery every N poll sweeps so the polling
+# fallback adopts conversations opened mid-run.
+_CHANNEL_DISCOVERY_EVERY = 5
 
 _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
 
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
-# kind 44100 is Buzz's channel-membership event — used for live DM discovery.
+# Buzz emits relay-signed membership notifications for joins and removals.
 _WS_AUTH_TIMEOUT = 20.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
+_WS_MEMBERSHIP_REMOVED_KIND = 44101
+_WS_MEMBERSHIP_KINDS = frozenset({_WS_MEMBERSHIP_KIND, _WS_MEMBERSHIP_REMOVED_KIND})
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
 
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
@@ -344,6 +346,17 @@ def _parse_json_list(stdout: str) -> List[dict]:
     return [item for item in data if isinstance(item, dict)]
 
 
+def _parse_json_list_strict(stdout: str) -> Optional[List[dict]]:
+    """Parse a JSON object array, preserving malformed-vs-empty distinction."""
+    try:
+        data = json.loads(stdout)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        return None
+    return data
+
+
 # ---------------------------------------------------------------------------
 # Buzz Adapter
 # ---------------------------------------------------------------------------
@@ -523,7 +536,12 @@ class BuzzAdapter(BasePlatformAdapter):
             logger.error("Buzz: failed to list channels — %s", message)
             self._set_fatal_error("connect_failed", message, retryable=code == 2)
             return False
-        listed = _parse_json_list(out)
+        listed = _parse_json_list_strict(out)
+        if listed is None:
+            message = "buzz channels list returned malformed JSON"
+            logger.error("Buzz: %s", message)
+            self._set_fatal_error("connect_failed", message, retryable=True)
+            return False
         self._channel_names = {
             str(ch.get("channel_id")): str(ch.get("name") or ch.get("channel_id"))
             for ch in listed
@@ -534,9 +552,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 self._channel_meta[str(ch["channel_id"])] = ch
         watch = self.channels or list(self._channel_names)
         if not watch:
-            logger.error("Buzz: no channels to watch (configure BUZZ_CHANNELS or join a channel)")
-            self._set_fatal_error("config_missing", "no Buzz channels to watch", retryable=False)
-            return False
+            logger.info(
+                "Buzz: no joined channels yet; waiting for dynamic discovery"
+            )
 
         # Seed high-water marks from the newest events so a (re)start never
         # replays channel history into the agent.
@@ -797,9 +815,21 @@ class BuzzAdapter(BasePlatformAdapter):
                 detail = response[-1] if len(response) > 1 else "authentication failed"
                 raise ConnectionError(f"Buzz WebSocket AUTH failed: {detail}")
 
-    async def _send_channel_subscription(self, websocket, subscription_id: str, channel_id: str) -> None:
+    async def _send_channel_subscription(
+        self,
+        websocket,
+        subscription_id: str,
+        channel_id: str,
+        *,
+        since: Optional[int] = None,
+    ) -> None:
         state = self._channel_state.get(channel_id) or {}
-        since = max(int(state.get("last_ts") or time.time()) - 1, 0)
+        if since is None:
+            last_ts = int(state.get("last_ts") or time.time())
+            subscription_floor = int(state.get("subscription_floor") or 0)
+            since = max(last_ts - 1, subscription_floor, 0)
+        else:
+            since = max(int(since), 0)
         request = [
             "REQ",
             subscription_id,
@@ -807,20 +837,47 @@ class BuzzAdapter(BasePlatformAdapter):
         ]
         await websocket.send(json.dumps(request, separators=(",", ":")))
 
+    async def _subscribe_missing_channels(
+        self,
+        websocket,
+        subscriptions: Dict[str, Optional[str]],
+    ) -> None:
+        """Subscribe every watched channel not represented on this socket."""
+        subscribed_channels = {
+            channel_id for channel_id in subscriptions.values() if channel_id is not None
+        }
+        for channel_id in list(self._channel_state):
+            if channel_id in subscribed_channels:
+                continue
+            subscription_index = len(subscriptions)
+            subscription_id = f"hermes-buzz-dm-{subscription_index}"
+            while subscription_id in subscriptions:
+                subscription_index += 1
+                subscription_id = f"hermes-buzz-dm-{subscription_index}"
+            await self._send_channel_subscription(
+                websocket,
+                subscription_id,
+                channel_id,
+            )
+            # Record socket state only after the REQ frame is sent successfully.
+            subscriptions[subscription_id] = channel_id
+            subscribed_channels.add(channel_id)
+            logger.info("Buzz: subscribed to new conversation %s", channel_id)
+
     async def _subscribe_websocket(self, websocket) -> Dict[str, Optional[str]]:
-        """Subscribe to every watched conversation plus membership events
-        (kind 44100 p-tagged to us) for live DM discovery."""
+        """Subscribe to every watched conversation plus relay-signed
+        membership changes for live regular-channel and DM discovery."""
         subscriptions: Dict[str, Optional[str]] = {}
         for index, channel_id in enumerate(list(self._channel_state)):
             subscription_id = f"hermes-buzz-{index}"
-            subscriptions[subscription_id] = channel_id
             await self._send_channel_subscription(websocket, subscription_id, channel_id)
+            subscriptions[subscription_id] = channel_id
         if self._self_pubkey:
             request = [
                 "REQ",
                 _WS_MEMBERSHIP_SUB_ID,
                 {
-                    "kinds": [_WS_MEMBERSHIP_KIND],
+                    "kinds": sorted(_WS_MEMBERSHIP_KINDS),
                     "#p": [self._self_pubkey],
                     "since": max(self._membership_since - 1, 0),
                 },
@@ -830,20 +887,64 @@ class BuzzAdapter(BasePlatformAdapter):
         return subscriptions
 
     async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
-        """Rediscover and subscribe after a membership event p-tagged to us."""
+        """Reconcile subscriptions after a relay-signed membership change."""
         event_since = max(int(event.get("created_at") or 0), 0)
-        before = set(self._channel_state)
-        if not await self._discover_joined_channels(since=event_since):
+        kind = int(event.get("kind") or 0)
+        # Old adds must not widen state. Removals still need an authoritative
+        # snapshot because different channels' notifications can arrive out of
+        # timestamp order and the snapshot also handles a concurrent rejoin.
+        if event_since < self._membership_since and kind != _WS_MEMBERSHIP_REMOVED_KIND:
+            return
+        tags = event.get("tags")
+        channel_id = ""
+        if isinstance(tags, list):
+            channel_id = next(
+                (
+                    str(tag[1])
+                    for tag in tags
+                    if isinstance(tag, (list, tuple))
+                    and len(tag) > 1
+                    and tag[0] == "h"
+                ),
+                "",
+            )
+
+        if kind == _WS_MEMBERSHIP_REMOVED_KIND:
+            self._membership_since = max(self._membership_since, event_since)
+            # Explicit channels are an operator-owned static watch set.
+            if self.channels:
+                return
+            if await self._discover_joined_channels(seed=True, reconcile=True) is None:
+                raise ConnectionError("Buzz joined-channel reconciliation failed")
+            for subscription_id, subscribed_channel in list(subscriptions.items()):
+                if subscribed_channel is None or subscribed_channel in self._channel_state:
+                    continue
+                await websocket.send(
+                    json.dumps(["CLOSE", subscription_id], separators=(",", ":"))
+                )
+                # Mutate socket state only after CLOSE is sent successfully.
+                subscriptions.pop(subscription_id, None)
+                logger.info(
+                    "Buzz: unsubscribed from removed conversation %s",
+                    subscribed_channel,
+                )
+            # The same authoritative snapshot can reveal a concurrent join.
+            await self._subscribe_missing_channels(websocket, subscriptions)
+            return
+        if kind != _WS_MEMBERSHIP_KIND:
+            return
+
+        if await self._discover_joined_channels(
+            since=event_since, seed=True, target_channel_id=channel_id
+        ) is None:
             raise ConnectionError("Buzz joined-channel discovery failed")
         self._membership_since = max(self._membership_since, event_since)
+
+        # The membership-target channel is time-sensitive. Subscribe before
+        # unrelated DM discovery can spend up to two CLI timeouts.
+        await self._subscribe_missing_channels(websocket, subscriptions)
         await self._discover_dms(seed=False)
-        for channel_id in self._channel_state:
-            if channel_id in before:
-                continue
-            subscription_id = f"hermes-buzz-dm-{len(subscriptions)}"
-            subscriptions[subscription_id] = channel_id
-            await self._send_channel_subscription(websocket, subscription_id, channel_id)
-            logger.info("Buzz: subscribed to new conversation %s", channel_id)
+        await self._subscribe_missing_channels(websocket, subscriptions)
 
     async def _websocket_loop(self) -> None:
         """Persistent authenticated subscription with bounded reconnect
@@ -866,6 +967,13 @@ class BuzzAdapter(BasePlatformAdapter):
                         max_size=_WS_MAX_MESSAGE_BYTES,
                     ) as websocket:
                         await self._authenticate_websocket(websocket)
+                        if await self._discover_joined_channels(
+                            seed=True, reconcile=True
+                        ) is None:
+                            raise ConnectionError(
+                                "Buzz joined-channel reconciliation failed"
+                            )
+                        await self._discover_dms(seed=False)
                         subscriptions = await self._subscribe_websocket(websocket)
                         self._ws_active = True
                         if self._ws_ready is not None:
@@ -916,7 +1024,10 @@ class BuzzAdapter(BasePlatformAdapter):
                 await asyncio.sleep(self.poll_interval)
                 self._poll_count += 1
                 try:
-                    if self._poll_count % _DM_DISCOVERY_EVERY == 0:
+                    if self._poll_count % _CHANNEL_DISCOVERY_EVERY == 0:
+                        await self._discover_joined_channels(
+                            seed=True, reconcile=True
+                        )
                         await self._discover_dms(seed=False)
                     for channel_id in list(self._channel_state):
                         await self._poll_channel(channel_id)
@@ -927,20 +1038,36 @@ class BuzzAdapter(BasePlatformAdapter):
         except asyncio.CancelledError:
             raise
 
-    async def _seed_channel(self, channel_id: str, chat_type: str) -> None:
-        """Initialize a channel's high-water mark from its newest events."""
+    async def _seed_channel(
+        self,
+        channel_id: str,
+        chat_type: str,
+        *,
+        before: int = 0,
+        safe_floor: bool = False,
+    ) -> None:
+        """Initialize a channel's high-water mark from its newest history."""
         state = {"chat_type": chat_type, "last_ts": 0, "seen": OrderedDict()}
         self._channel_state[channel_id] = state
-        code, out, err = await self._run_cli(
-            ["messages", "get", "--channel", channel_id, "--limit", str(_FETCH_LIMIT)]
-        )
+        safe_boundary = int(time.time()) if safe_floor else 0
+        history_before = before or max(safe_boundary - 1, 0)
+        args = [
+            "messages", "get", "--channel", channel_id,
+            "--limit", str(_FETCH_LIMIT),
+        ]
+        if history_before:
+            args.extend(["--before", str(history_before)])
+        code, out, err = await self._run_cli(args)
         if code != 0:
             logger.warning(
                 "Buzz: could not seed channel %s — %s", channel_id, _cli_error_message(err, code)
             )
-            # Fall back to "now" so a transiently unreadable channel does not
-            # replay its whole history once it becomes readable.
-            state["last_ts"] = int(time.time())
+            # Fall back to a safe current boundary so a transiently unreadable
+            # channel does not replay history once it becomes readable.
+            floor = safe_boundary if safe_floor else int(time.time())
+            state["last_ts"] = floor
+            if safe_floor:
+                state["subscription_floor"] = floor
             return
         for event in _parse_json_list(out):
             event_id = event.get("id")
@@ -953,32 +1080,95 @@ class BuzzAdapter(BasePlatformAdapter):
             # so it bypasses the mention gate from the very first poll.
             self._maybe_latch_dm(channel_id, state, event)
         self._trim_seen(state)
+        if safe_floor:
+            floor = max(safe_boundary, int(state["last_ts"]) + 1)
+            state["last_ts"] = floor
+            state["subscription_floor"] = floor
 
-    async def _discover_joined_channels(self, *, since: int) -> bool:
-        """Watch newly joined channels when no explicit allowlist is set."""
+    async def _discover_joined_channels(
+        self,
+        *,
+        since: int = 0,
+        seed: bool = False,
+        target_channel_id: str = "",
+        reconcile: bool = True,
+    ) -> Optional[bool]:
+        """Reconcile joined streams; return changed state or ``None`` on failure."""
         if self.channels:
-            return True
+            return False
         code, out, err = await self._run_cli(["channels", "list", "--member"])
         if code != 0:
             logger.warning(
                 "Buzz: failed to rediscover joined channels — %s",
                 _cli_error_message(err, code),
             )
-            return False
-        for channel in _parse_json_list(out):
+            return None
+        channels = _parse_json_list_strict(out)
+        if channels is None:
+            logger.warning("Buzz: joined-channel discovery returned malformed JSON")
+            return None
+        joined_ids = {
+            str(channel.get("channel_id") or "") for channel in channels
+        }
+        if target_channel_id and target_channel_id not in joined_ids:
+            logger.warning(
+                "Buzz: membership channel %s missing from joined-channel snapshot",
+                target_channel_id,
+            )
+            return None
+        changed = False
+        if reconcile:
+            for watched_channel_id, state in list(self._channel_state.items()):
+                if (
+                    state.get("chat_type") == "group"
+                    and watched_channel_id not in joined_ids
+                ):
+                    changed = True
+                    self._channel_state.pop(watched_channel_id, None)
+                    self._channel_names.pop(watched_channel_id, None)
+                    self._channel_meta.pop(watched_channel_id, None)
+                    logger.info(
+                        "Buzz: stopped watching channel no longer joined: %s",
+                        watched_channel_id,
+                    )
+        for channel in channels:
             channel_id = str(channel.get("channel_id") or "")
             if not channel_id:
                 continue
+            name = str(channel.get("name") or channel_id)
+            if self._channel_names.get(channel_id) != name:
+                changed = True
             self._channel_meta[channel_id] = channel
-            self._channel_names[channel_id] = str(channel.get("name") or channel_id)
+            self._channel_names[channel_id] = name
             if channel_id in self._channel_state:
                 continue
-            self._channel_state[channel_id] = {
-                "chat_type": "group",
-                "last_ts": max(int(since), 0),
-                "seen": OrderedDict(),
-            }
-        return True
+            changed = True
+            channel_since = (
+                int(since)
+                if not target_channel_id or channel_id == target_channel_id
+                else 0
+            )
+            if seed:
+                # Buzz maps --before to Nostr's inclusive `until`; stop at the
+                # prior second so events sharing the join timestamp stay live.
+                history_before = max(channel_since - 1, 0) if channel_since else 0
+                await self._seed_channel(
+                    channel_id,
+                    chat_type="group",
+                    before=history_before,
+                    safe_floor=not bool(channel_since),
+                )
+                state = self._channel_state[channel_id]
+                state["last_ts"] = max(state["last_ts"], channel_since)
+                if channel_since:
+                    state["subscription_floor"] = channel_since
+            else:
+                self._channel_state[channel_id] = {
+                    "chat_type": "group",
+                    "last_ts": max(channel_since, 0),
+                    "seen": OrderedDict(),
+                }
+        return changed
 
     async def _discover_dms(self, *, seed: bool) -> None:
         """Watch DM conversations.  New ones found mid-run dispatch from their
@@ -1049,7 +1239,10 @@ class BuzzAdapter(BasePlatformAdapter):
         state["seen"][event_id] = None
         state["last_ts"] = max(state["last_ts"], created_at)
 
-        if int(event.get("kind") or 0) != _CHAT_KIND:
+        kind = int(event.get("kind") or 0)
+        if kind in _FORUM_EVENT_KINDS:
+            return
+        if kind != _CHAT_KIND:
             return
         pubkey = str(event.get("pubkey") or "").lower()
         content = event.get("content")

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -510,8 +510,14 @@ class BuzzAdapter(BasePlatformAdapter):
         except ImportError:
             self._lock_key = None  # status module not available (e.g. tests)
 
+        # Start the membership cursor before taking the joined-channel
+        # snapshot. A join racing with startup is then present either in the
+        # snapshot or in the membership subscription's inclusive overlap.
+        if self.transport in ("auto", "websocket"):
+            self._membership_since = int(time.time())
+
         # Map channel ids to names and pick the watch set.
-        code, out, err = await self._run_cli(["channels", "list"])
+        code, out, err = await self._run_cli(["channels", "list", "--member"])
         if code != 0:
             message = _cli_error_message(err, code)
             logger.error("Buzz: failed to list channels — %s", message)
@@ -743,7 +749,8 @@ class BuzzAdapter(BasePlatformAdapter):
             logger.info("Buzz: WebSocket transport unavailable (%s); falling back to polling", e)
             return False
         self._ws_ready = asyncio.Event()
-        self._membership_since = int(time.time())
+        if not self._membership_since:
+            self._membership_since = int(time.time())
         self._ws_task = asyncio.create_task(self._websocket_loop())
         try:
             await asyncio.wait_for(self._ws_ready.wait(), timeout=_WS_AUTH_TIMEOUT + 5)
@@ -823,10 +830,12 @@ class BuzzAdapter(BasePlatformAdapter):
         return subscriptions
 
     async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
-        """A membership event p-tagged to us: rediscover conversations and
-        subscribe to any new ones (fresh DMs dispatch from their beginning)."""
-        self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
+        """Rediscover and subscribe after a membership event p-tagged to us."""
+        event_since = max(int(event.get("created_at") or 0), 0)
         before = set(self._channel_state)
+        if not await self._discover_joined_channels(since=event_since):
+            raise ConnectionError("Buzz joined-channel discovery failed")
+        self._membership_since = max(self._membership_since, event_since)
         await self._discover_dms(seed=False)
         for channel_id in self._channel_state:
             if channel_id in before:
@@ -944,6 +953,32 @@ class BuzzAdapter(BasePlatformAdapter):
             # so it bypasses the mention gate from the very first poll.
             self._maybe_latch_dm(channel_id, state, event)
         self._trim_seen(state)
+
+    async def _discover_joined_channels(self, *, since: int) -> bool:
+        """Watch newly joined channels when no explicit allowlist is set."""
+        if self.channels:
+            return True
+        code, out, err = await self._run_cli(["channels", "list", "--member"])
+        if code != 0:
+            logger.warning(
+                "Buzz: failed to rediscover joined channels — %s",
+                _cli_error_message(err, code),
+            )
+            return False
+        for channel in _parse_json_list(out):
+            channel_id = str(channel.get("channel_id") or "")
+            if not channel_id:
+                continue
+            self._channel_meta[channel_id] = channel
+            self._channel_names[channel_id] = str(channel.get("name") or channel_id)
+            if channel_id in self._channel_state:
+                continue
+            self._channel_state[channel_id] = {
+                "chat_type": "group",
+                "last_ts": max(int(since), 0),
+                "seen": OrderedDict(),
+            }
+        return True
 
     async def _discover_dms(self, *, seed: bool) -> None:
         """Watch DM conversations.  New ones found mid-run dispatch from their

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -486,8 +486,14 @@ class BuzzAdapter(BasePlatformAdapter):
         except ImportError:
             self._lock_key = None  # status module not available (e.g. tests)
 
+        # Start the membership cursor before taking the joined-channel
+        # snapshot. A join racing with startup is then present either in the
+        # snapshot or in the membership subscription's inclusive overlap.
+        if self.transport in ("auto", "websocket"):
+            self._membership_since = int(time.time())
+
         # Map channel ids to names and pick the watch set.
-        code, out, err = await self._run_cli(["channels", "list"])
+        code, out, err = await self._run_cli(["channels", "list", "--member"])
         if code != 0:
             message = _cli_error_message(err, code)
             logger.error("Buzz: failed to list channels — %s", message)
@@ -719,7 +725,8 @@ class BuzzAdapter(BasePlatformAdapter):
             logger.info("Buzz: WebSocket transport unavailable (%s); falling back to polling", e)
             return False
         self._ws_ready = asyncio.Event()
-        self._membership_since = int(time.time())
+        if not self._membership_since:
+            self._membership_since = int(time.time())
         self._ws_task = asyncio.create_task(self._websocket_loop())
         try:
             await asyncio.wait_for(self._ws_ready.wait(), timeout=_WS_AUTH_TIMEOUT + 5)
@@ -799,10 +806,12 @@ class BuzzAdapter(BasePlatformAdapter):
         return subscriptions
 
     async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
-        """A membership event p-tagged to us: rediscover conversations and
-        subscribe to any new ones (fresh DMs dispatch from their beginning)."""
-        self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
+        """Rediscover and subscribe after a membership event p-tagged to us."""
+        event_since = max(int(event.get("created_at") or 0), 0)
         before = set(self._channel_state)
+        if not await self._discover_joined_channels(since=event_since):
+            raise ConnectionError("Buzz joined-channel discovery failed")
+        self._membership_since = max(self._membership_since, event_since)
         await self._discover_dms(seed=False)
         for channel_id in self._channel_state:
             if channel_id in before:
@@ -920,6 +929,32 @@ class BuzzAdapter(BasePlatformAdapter):
             # so it bypasses the mention gate from the very first poll.
             self._maybe_latch_dm(channel_id, state, event)
         self._trim_seen(state)
+
+    async def _discover_joined_channels(self, *, since: int) -> bool:
+        """Watch newly joined channels when no explicit allowlist is set."""
+        if self.channels:
+            return True
+        code, out, err = await self._run_cli(["channels", "list", "--member"])
+        if code != 0:
+            logger.warning(
+                "Buzz: failed to rediscover joined channels — %s",
+                _cli_error_message(err, code),
+            )
+            return False
+        for channel in _parse_json_list(out):
+            channel_id = str(channel.get("channel_id") or "")
+            if not channel_id:
+                continue
+            self._channel_meta[channel_id] = channel
+            self._channel_names[channel_id] = str(channel.get("name") or channel_id)
+            if channel_id in self._channel_state:
+                continue
+            self._channel_state[channel_id] = {
+                "chat_type": "group",
+                "last_ts": max(int(since), 0),
+                "seen": OrderedDict(),
+            }
+        return True
 
     async def _discover_dms(self, *, seed: bool) -> None:
         """Watch DM conversations.  New ones found mid-run dispatch from their

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -385,6 +385,48 @@ class TestDmClassification:
 
 
 class TestChannelDiscovery:
+    @pytest.mark.asyncio
+    async def test_authoritative_reconciliation_reports_name_change(self):
+        adapter = _make_adapter()
+        adapter._channel_state = {
+            CHANNEL: {"chat_type": "group", "last_ts": 1, "seen": {}},
+        }
+        adapter._channel_names = {CHANNEL: "old name"}
+        adapter._run_cli = AsyncMock(return_value=(0, json.dumps([
+            {"channel_id": CHANNEL, "name": "new name"},
+        ]), ""))
+
+        assert await adapter._discover_joined_channels(since=9) is True
+        assert adapter._channel_names[CHANNEL] == "new name"
+
+    @pytest.mark.asyncio
+    async def test_authoritative_reconciliation_removes_departed_group_but_preserves_dm(self):
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        departed = "12c81eb7-3a12-47c1-b8af-c66f1c74ca8b"
+        dm = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        adapter._channel_state = {
+            CHANNEL: {"chat_type": "group", "last_ts": 1, "seen": {}},
+            departed: {"chat_type": "group", "last_ts": 1, "seen": {}},
+            dm: {"chat_type": "dm", "last_ts": 1, "seen": {}},
+        }
+        adapter._channel_names = {CHANNEL: "kept", departed: "gone", dm: "dm"}
+        adapter._run_cli = AsyncMock(return_value=(0, json.dumps([
+            {"channel_id": CHANNEL, "name": "kept"},
+        ]), ""))
+
+        assert await adapter._discover_joined_channels(since=9) is True
+        assert set(adapter._channel_state) == {CHANNEL, dm}
+        assert departed not in adapter._channel_names
+
+    @pytest.mark.asyncio
+    async def test_explicit_channels_are_not_removed_by_authoritative_joined_snapshot(self):
+        adapter = _make_adapter({"channels": [CHANNEL]})
+        adapter._channel_state = {CHANNEL: {"chat_type": "group", "last_ts": 1, "seen": {}}}
+        adapter._run_cli = AsyncMock()
+        assert await adapter._discover_joined_channels(since=2) is False
+        assert CHANNEL in adapter._channel_state
+        adapter._run_cli.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_connect_lists_only_joined_channels(self, monkeypatch):
@@ -412,7 +454,7 @@ class TestChannelDiscovery:
             if args == ["channels", "list", "--member"]:
                 membership_cursors.append(adapter._membership_since)
                 return 0, json.dumps([
-                    {"channel_id": CHANNEL, "name": "general", "description": "General"},
+                    {"channel_id": CHANNEL, "name": "general"},
                 ]), ""
             if args == ["channels", "list"]:
                 return 0, json.dumps([
@@ -432,6 +474,54 @@ class TestChannelDiscovery:
         assert unjoined_channel not in adapter._channel_state
 
     @pytest.mark.asyncio
+    async def test_connect_with_no_joined_channels_waits_for_dynamic_discovery(
+        self, monkeypatch
+    ):
+        import gateway.status as gateway_status
+
+        monkeypatch.setattr(
+            gateway_status, "acquire_scoped_lock", lambda platform, key: True
+        )
+        monkeypatch.setattr(
+            gateway_status, "release_scoped_lock", lambda platform, key: None
+        )
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        monkeypatch.setattr(_buzz_mod.time, "time", lambda: 1000)
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        adapter._start_websocket = AsyncMock(return_value=True)
+        cli = _ScriptedCli()
+        cli.script(
+            "users", "get",
+            [{"pubkey": SELF_PUBKEY, "display_name": "Chip"}],
+        )
+        cli.script("channels", "list", [])
+        cli.script("dms", "list", [])
+        adapter._run_cli = cli
+
+        try:
+            assert await adapter.connect() is True
+            assert adapter._channel_state == {}
+            adapter._start_websocket.assert_awaited_once()
+            assert adapter._membership_since == 1000
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_websocket_membership_subscription_covers_add_and_remove(self):
+        adapter = _make_adapter()
+        adapter._self_pubkey = SELF_PUBKEY
+        adapter._membership_since = 1000
+        websocket = AsyncMock()
+
+        subscriptions = await adapter._subscribe_websocket(websocket)
+
+        assert subscriptions == {_buzz_mod._WS_MEMBERSHIP_SUB_ID: None}
+        request = json.loads(websocket.send.await_args.args[0])
+        assert request[2]["kinds"] == sorted(_buzz_mod._WS_MEMBERSHIP_KINDS)
+        assert request[2]["#p"] == [SELF_PUBKEY]
+
+    @pytest.mark.asyncio
     async def test_membership_event_subscribes_to_new_joined_channel(self):
         adapter = _make_adapter()
         adapter._channel_state[CHANNEL] = {
@@ -446,22 +536,310 @@ class TestChannelDiscovery:
         cli.script("dms", "list", [])
         adapter._run_cli = cli
         websocket = AsyncMock()
-        subscriptions = {"hermes-buzz-0": CHANNEL}
+
+        async def assert_target_already_subscribed(*, seed):
+            assert seed is False
+            assert websocket.send.await_count == 1
+
+        adapter._discover_dms = AsyncMock(side_effect=assert_target_already_subscribed)
+        subscriptions = {
+            "hermes-buzz-0": CHANNEL,
+            _buzz_mod._WS_MEMBERSHIP_SUB_ID: None,
+            "hermes-buzz-dm-3": CHANNEL,
+        }
 
         await adapter._handle_membership_event(
             websocket,
             subscriptions,
-            {"created_at": 1234, "kind": _buzz_mod._WS_MEMBERSHIP_KIND},
+            {
+                "created_at": 1234,
+                "kind": _buzz_mod._WS_MEMBERSHIP_KIND,
+                "tags": [["p", SELF_PUBKEY], ["h", new_channel]],
+            },
         )
 
         assert new_channel in adapter._channel_state
         assert adapter._channel_state[new_channel]["chat_type"] == "group"
         assert adapter._channel_state[new_channel]["last_ts"] == 1234
         assert new_channel in subscriptions.values()
+        assert subscriptions["hermes-buzz-dm-3"] == CHANNEL
         assert (["channels", "list", "--member"], None) in cli.calls
         request = json.loads(websocket.send.await_args.args[0])
         assert request[2]["#h"] == [new_channel]
-        assert request[2]["since"] == 1233
+        assert request[2]["kinds"] == [_buzz_mod._CHAT_KIND]
+        assert not (_buzz_mod._FORUM_EVENT_KINDS & set(request[2]["kinds"]))
+        assert request[2]["since"] == 1234
+
+    @pytest.mark.asyncio
+    async def test_membership_event_seeds_existing_history_without_dispatch(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group", "last_ts": 100, "seen": {},
+        }
+        adapter._dispatched = []
+
+        async def capture(**kwargs):
+            adapter._dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        adapter._message_handler = AsyncMock()
+        new_channel = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        old_event = _event("old", content="@Chip old history", created_at=900)
+        old_event["tags"] = [["h", new_channel]]
+        cli = _ScriptedCli()
+        cli.script("channels", "list", [
+            {"channel_id": CHANNEL, "name": "general"},
+            {"channel_id": new_channel, "name": "project"},
+        ])
+        cli.script("messages", "get", [old_event])
+        cli.script("dms", "list", [])
+        adapter._run_cli = cli
+        websocket = AsyncMock()
+
+        await adapter._handle_membership_event(
+            websocket,
+            {"hermes-buzz-0": CHANNEL},
+            {"created_at": 1234, "kind": _buzz_mod._WS_MEMBERSHIP_KIND},
+        )
+
+        state = adapter._channel_state[new_channel]
+        assert state["last_ts"] == 1234
+        assert set(state["seen"]) == {"old"}
+        assert adapter._dispatched == []
+        message_call = next(args for args, _ in cli.calls if args[:2] == ["messages", "get"])
+        assert message_call[message_call.index("--before") + 1] == "1233"
+
+        live_event = _event("live", content="@Chip after join", created_at=1234)
+        live_event["tags"] = [["h", new_channel]]
+        await adapter._handle_event(new_channel, state, live_event)
+        assert [item["message_id"] for item in adapter._dispatched] == ["live"]
+
+    @pytest.mark.asyncio
+    async def test_membership_removal_unsubscribes_channel(self):
+        adapter = _make_adapter()
+        adapter._membership_since = 100
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group", "last_ts": 100, "seen": {},
+        }
+        adapter._run_cli = AsyncMock(return_value=(0, "[]", ""))
+        websocket = AsyncMock()
+        subscriptions = {"hermes-buzz-0": CHANNEL}
+
+        await adapter._handle_membership_event(
+            websocket,
+            subscriptions,
+            {
+                "created_at": 1234,
+                "kind": _buzz_mod._WS_MEMBERSHIP_REMOVED_KIND,
+                "tags": [["p", SELF_PUBKEY], ["h", CHANNEL]],
+            },
+        )
+
+        assert CHANNEL not in adapter._channel_state
+        assert CHANNEL not in subscriptions.values()
+        assert adapter._membership_since == 1234
+        websocket.send.assert_awaited_once_with(
+            json.dumps(["CLOSE", "hermes-buzz-0"], separators=(",", ":"))
+        )
+
+    @pytest.mark.asyncio
+    async def test_stale_membership_event_does_not_rewind_discovery(self):
+        adapter = _make_adapter()
+        adapter._membership_since = 200
+        adapter._run_cli = AsyncMock()
+        websocket = AsyncMock()
+
+        await adapter._handle_membership_event(
+            websocket,
+            {},
+            {
+                "created_at": 100,
+                "kind": _buzz_mod._WS_MEMBERSHIP_KIND,
+                "tags": [["p", SELF_PUBKEY], ["h", CHANNEL]],
+            },
+        )
+
+        assert adapter._membership_since == 200
+        adapter._run_cli.assert_not_awaited()
+        websocket.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_websocket_reconnect_reconciles_before_resubscribing(self, monkeypatch):
+        import websockets
+
+        adapter = _make_adapter()
+        stale_channel = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        adapter._self_pubkey = SELF_PUBKEY
+        adapter._channel_state[stale_channel] = {
+            "chat_type": "group", "last_ts": 100, "seen": {},
+        }
+        cli = _ScriptedCli()
+        cli.script("channels", "list", [])
+        cli.script("channels", "list", [])
+        cli.script("dms", "list", [])
+        adapter._run_cli = cli
+        adapter._authenticate_websocket = AsyncMock()
+
+        class OneConnection:
+            def __init__(self):
+                self.sent = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            async def send(self, raw):
+                self.sent.append(json.loads(raw))
+
+            async def recv(self):
+                raise asyncio.CancelledError
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise asyncio.CancelledError
+
+        websocket = OneConnection()
+        monkeypatch.setattr(websockets, "connect", lambda *_args, **_kwargs: websocket)
+
+        with pytest.raises(asyncio.CancelledError):
+            await adapter._websocket_loop()
+
+        channel_requests = [
+            request
+            for request in websocket.sent
+            if len(request) > 2
+            and isinstance(request[2], dict)
+            and "#h" in request[2]
+        ]
+        assert stale_channel not in adapter._channel_state
+        assert channel_requests == []
+        assert any(
+            request[1] == _buzz_mod._WS_MEMBERSHIP_SUB_ID
+            for request in websocket.sent
+        )
+
+    @pytest.mark.asyncio
+    async def test_removal_reconciliation_subscribes_concurrent_new_join(
+        self, monkeypatch
+    ):
+        removed_channel = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        new_channel = "85f52f6f-af83-4a91-bb7a-4e3605cf8e6e"
+        monkeypatch.setattr(_buzz_mod.time, "time", lambda: 2000)
+        adapter = _make_adapter()
+        adapter._membership_since = 100
+        adapter._channel_state = {
+            CHANNEL: {"chat_type": "group", "last_ts": 100, "seen": {}},
+            removed_channel: {"chat_type": "group", "last_ts": 100, "seen": {}},
+        }
+        cli = _ScriptedCli()
+        cli.script("channels", "list", [
+            {"channel_id": CHANNEL, "name": "general"},
+            {"channel_id": new_channel, "name": "new"},
+        ])
+        cli.script("messages", "get", [])
+        adapter._run_cli = cli
+        websocket = AsyncMock()
+        subscriptions = {
+            "existing": CHANNEL,
+            "removed": removed_channel,
+            _buzz_mod._WS_MEMBERSHIP_SUB_ID: None,
+        }
+
+        await adapter._handle_membership_event(
+            websocket,
+            subscriptions,
+            {"created_at": 1500, "kind": _buzz_mod._WS_MEMBERSHIP_REMOVED_KIND},
+        )
+
+        assert removed_channel not in adapter._channel_state
+        assert removed_channel not in subscriptions.values()
+        assert new_channel in adapter._channel_state
+        assert new_channel in subscriptions.values()
+        requests = [json.loads(call.args[0]) for call in websocket.send.await_args_list]
+        assert ["CLOSE", "removed"] in requests
+        new_request = next(
+            request
+            for request in requests
+            if len(request) > 2 and request[2].get("#h") == [new_channel]
+        )
+        assert new_request[2]["since"] == 2000
+
+    @pytest.mark.asyncio
+    async def test_out_of_order_removals_each_reconcile_authoritative_snapshot(self):
+        second_channel = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        adapter = _make_adapter()
+        adapter._membership_since = 100
+        adapter._channel_state = {
+            CHANNEL: {"chat_type": "group", "last_ts": 100, "seen": {}},
+            second_channel: {"chat_type": "group", "last_ts": 100, "seen": {}},
+        }
+        cli = _ScriptedCli()
+        cli.script("channels", "list", [
+            {"channel_id": second_channel, "name": "second"},
+        ])
+        cli.script("channels", "list", [])
+        adapter._run_cli = cli
+        websocket = AsyncMock()
+        subscriptions = {"first": CHANNEL, "second": second_channel}
+
+        await adapter._handle_membership_event(
+            websocket,
+            subscriptions,
+            {"created_at": 1001, "kind": _buzz_mod._WS_MEMBERSHIP_REMOVED_KIND},
+        )
+        await adapter._handle_membership_event(
+            websocket,
+            subscriptions,
+            {"created_at": 1000, "kind": _buzz_mod._WS_MEMBERSHIP_REMOVED_KIND},
+        )
+
+        assert adapter._channel_state == {}
+        assert subscriptions == {}
+        assert adapter._membership_since == 1001
+        assert [call[0] for call in cli.calls].count(
+            ["channels", "list", "--member"]
+        ) == 2
+
+    @pytest.mark.asyncio
+    async def test_membership_removal_preserves_explicit_channel_configuration(self):
+        adapter = _make_adapter({"channels": [CHANNEL]})
+        adapter._membership_since = 100
+        state = {"chat_type": "group", "last_ts": 100, "seen": {}}
+        adapter._channel_state[CHANNEL] = state
+        adapter._run_cli = AsyncMock()
+        websocket = AsyncMock()
+        subscriptions = {"hermes-buzz-0": CHANNEL}
+
+        await adapter._handle_membership_event(
+            websocket,
+            subscriptions,
+            {"created_at": 1234, "kind": _buzz_mod._WS_MEMBERSHIP_REMOVED_KIND},
+        )
+
+        assert adapter._channel_state[CHANNEL] is state
+        assert subscriptions == {"hermes-buzz-0": CHANNEL}
+        assert adapter._membership_since == 1234
+        adapter._run_cli.assert_not_awaited()
+        websocket.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_subscription_send_does_not_mutate_subscription_state(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group", "last_ts": 100, "seen": {},
+        }
+        websocket = AsyncMock()
+        websocket.send.side_effect = ConnectionError("closed")
+        subscriptions = {_buzz_mod._WS_MEMBERSHIP_SUB_ID: None}
+
+        with pytest.raises(ConnectionError, match="closed"):
+            await adapter._subscribe_missing_channels(websocket, subscriptions)
+
+        assert subscriptions == {_buzz_mod._WS_MEMBERSHIP_SUB_ID: None}
 
     @pytest.mark.asyncio
     async def test_membership_event_respects_explicit_channel_allowlist(self):
@@ -507,6 +885,158 @@ class TestChannelDiscovery:
 
         assert adapter._membership_since == 100
         websocket.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_joined_channel_discovery_rejects_malformed_success_output(self):
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(return_value=(0, "not-json", ""))
+
+        assert await adapter._discover_joined_channels(seed=True) is None
+        assert adapter._channel_state == {}
+
+    @pytest.mark.asyncio
+    async def test_polling_fallback_rediscovers_joined_channels_on_discovery_cadence(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter({"transport": "poll"})
+        adapter._poll_count = _buzz_mod._CHANNEL_DISCOVERY_EVERY - 1
+        adapter._discover_joined_channels = AsyncMock(return_value=True)
+        adapter._discover_dms = AsyncMock()
+        adapter._poll_channel = AsyncMock()
+        sleep_calls = 0
+
+        async def one_sweep_then_cancel(_delay):
+            nonlocal sleep_calls
+            sleep_calls += 1
+            if sleep_calls > 1:
+                raise asyncio.CancelledError
+
+        monkeypatch.setattr(_buzz_mod.asyncio, "sleep", one_sweep_then_cancel)
+
+        with pytest.raises(asyncio.CancelledError):
+            await adapter._poll_loop()
+
+        adapter._discover_joined_channels.assert_awaited_once_with(
+            seed=True, reconcile=True
+        )
+        adapter._discover_dms.assert_awaited_once_with(seed=False)
+
+    @pytest.mark.asyncio
+    async def test_polling_discovery_seeds_new_channel_without_replaying_history(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(_buzz_mod.time, "time", lambda: 200)
+        adapter = _make_adapter({"transport": "poll"})
+        adapter._dispatched = []
+
+        async def capture(**kwargs):
+            adapter._dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        adapter._message_handler = AsyncMock()
+        new_channel = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        old_event = _event("old", content="@Chip old history", created_at=100)
+        old_event["tags"] = [["h", new_channel]]
+        cli = _ScriptedCli()
+        cli.script("channels", "list", [
+            {"channel_id": new_channel, "name": "project", "description": "Project"},
+        ])
+        cli.script("messages", "get", [old_event])
+        adapter._run_cli = cli
+
+        assert await adapter._discover_joined_channels(seed=True) is True
+
+        state = adapter._channel_state[new_channel]
+        assert state["last_ts"] == 200
+        assert state["subscription_floor"] == 200
+        assert set(state["seen"]) == {"old"}
+        assert adapter._dispatched == []
+        websocket = AsyncMock()
+        await adapter._send_channel_subscription(
+            websocket, "hermes-buzz-dynamic", new_channel
+        )
+        request = json.loads(websocket.send.await_args.args[0])
+        assert request[2]["since"] == 200
+        message_call = next(args for args, _ in cli.calls if args[:2] == ["messages", "get"])
+        assert message_call[message_call.index("--before") + 1] == "199"
+
+    @pytest.mark.asyncio
+    async def test_discovery_reconciliation_prunes_left_stream_but_preserves_dm(self):
+        adapter = _make_adapter()
+        stale_channel = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        adapter._channel_state[stale_channel] = {
+            "chat_type": "group", "last_ts": 100, "seen": {},
+        }
+        adapter._channel_state[DM_CHANNEL] = {
+            "chat_type": "dm", "last_ts": 100, "seen": {},
+        }
+        adapter._channel_names[stale_channel] = "left"
+        adapter._channel_meta[stale_channel] = {"channel_id": stale_channel}
+        cli = _ScriptedCli()
+        cli.script("channels", "list", [])
+        adapter._run_cli = cli
+
+        discovered = await adapter._discover_joined_channels(
+            seed=True, reconcile=True
+        )
+
+        assert discovered is True
+        assert stale_channel not in adapter._channel_state
+        assert stale_channel not in adapter._channel_names
+        assert stale_channel not in adapter._channel_meta
+        assert DM_CHANNEL in adapter._channel_state
+
+    @pytest.mark.asyncio
+    async def test_forum_event_kinds_never_enter_stream_dispatch(self):
+        adapter = _make_adapter()
+        stream_channel = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        stream_state = {
+            "chat_type": "group", "last_ts": 1234, "seen": {},
+        }
+        adapter._dispatched = []
+
+        async def capture(**kwargs):
+            adapter._dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        adapter._message_handler = AsyncMock()
+        assert _buzz_mod._FORUM_EVENT_KINDS == frozenset({45001, 45003})
+        for kind in _buzz_mod._FORUM_EVENT_KINDS:
+            event = _event(f"forum-{kind}", content="@Chip forum traffic", kind=kind)
+            event["tags"] = [["h", stream_channel]]
+            await adapter._handle_event(stream_channel, stream_state, event)
+
+        assert adapter._dispatched == []
+        assert set(stream_state["seen"]) == {"forum-45001", "forum-45003"}
+
+    @pytest.mark.asyncio
+    async def test_dynamic_channel_uses_existing_mention_allowlist_and_dedupe_pipeline(self):
+        adapter = _make_adapter()
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        adapter._dispatched = []
+
+        async def capture(**kwargs):
+            adapter._dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        adapter._message_handler = AsyncMock()
+        new_channel = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        cli = _ScriptedCli()
+        cli.script("channels", "list", [
+            {"channel_id": new_channel, "name": "project", "description": "Project"},
+        ])
+        adapter._run_cli = cli
+        assert await adapter._discover_joined_channels(since=100, seed=False) is True
+        state = adapter._channel_state[new_channel]
+
+        unmentioned = _event("quiet", content="background chatter", created_at=101)
+        mentioned = _event("ping", content="@Chip canary", created_at=102)
+        for event in (unmentioned, mentioned, mentioned):
+            event["tags"] = [["h", new_channel]]
+            await adapter._handle_event(new_channel, state, event)
+
+        assert [item["message_id"] for item in adapter._dispatched] == ["ping"]
+        assert state["chat_type"] == "group"
 
 
 # ── Sending ───────────────────────────────────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -381,6 +381,134 @@ class TestDmClassification:
         assert a._may_reclassify_as_dm(CHANNEL) is False
 
 
+# ── Dynamic joined-channel discovery ─────────────────────────────────────
+
+
+class TestChannelDiscovery:
+
+    @pytest.mark.asyncio
+    async def test_connect_lists_only_joined_channels(self, monkeypatch):
+        import gateway.status as gateway_status
+
+        monkeypatch.setattr(
+            gateway_status, "acquire_scoped_lock", lambda platform, key: True
+        )
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        monkeypatch.setattr(_buzz_mod.time, "time", lambda: 1000)
+        adapter = _make_adapter()
+        adapter.cli_path = "/fake/buzz"
+        adapter._start_websocket = AsyncMock(return_value=False)
+        unjoined_channel = "12c81eb7-3a12-47c1-b8af-c66f1c74ca8b"
+        cli = _ScriptedCli()
+        cli.script(
+            "users", "get",
+            [{"pubkey": SELF_PUBKEY, "display_name": "Chip"}],
+        )
+        cli.script("messages", "get", [])
+        cli.script("dms", "list", [])
+        membership_cursors = []
+
+        async def run_cli(args, *, input_text=None):
+            if args == ["channels", "list", "--member"]:
+                membership_cursors.append(adapter._membership_since)
+                return 0, json.dumps([
+                    {"channel_id": CHANNEL, "name": "general", "description": "General"},
+                ]), ""
+            if args == ["channels", "list"]:
+                return 0, json.dumps([
+                    {"channel_id": CHANNEL, "name": "general", "description": "General"},
+                    {"channel_id": unjoined_channel, "name": "other", "description": "Other"},
+                ]), ""
+            return await cli(args, input_text=input_text)
+
+        adapter._run_cli = run_cli
+
+        try:
+            assert await adapter.connect() is True
+        finally:
+            await adapter.disconnect()
+
+        assert membership_cursors == [1000]
+        assert unjoined_channel not in adapter._channel_state
+
+    @pytest.mark.asyncio
+    async def test_membership_event_subscribes_to_new_joined_channel(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group", "last_ts": 100, "seen": {},
+        }
+        new_channel = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        cli = _ScriptedCli()
+        cli.script("channels", "list", [
+            {"channel_id": CHANNEL, "name": "general", "description": "General"},
+            {"channel_id": new_channel, "name": "project", "description": "Project"},
+        ])
+        cli.script("dms", "list", [])
+        adapter._run_cli = cli
+        websocket = AsyncMock()
+        subscriptions = {"hermes-buzz-0": CHANNEL}
+
+        await adapter._handle_membership_event(
+            websocket,
+            subscriptions,
+            {"created_at": 1234, "kind": _buzz_mod._WS_MEMBERSHIP_KIND},
+        )
+
+        assert new_channel in adapter._channel_state
+        assert adapter._channel_state[new_channel]["chat_type"] == "group"
+        assert adapter._channel_state[new_channel]["last_ts"] == 1234
+        assert new_channel in subscriptions.values()
+        assert (["channels", "list", "--member"], None) in cli.calls
+        request = json.loads(websocket.send.await_args.args[0])
+        assert request[2]["#h"] == [new_channel]
+        assert request[2]["since"] == 1233
+
+    @pytest.mark.asyncio
+    async def test_membership_event_respects_explicit_channel_allowlist(self):
+        adapter = _make_adapter({"channels": [CHANNEL]})
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group", "last_ts": 100, "seen": {},
+        }
+        new_channel = "4764ae67-7cd8-4f3e-967d-7dd93986b11a"
+        cli = _ScriptedCli()
+        cli.script("channels", "list", [
+            {"channel_id": new_channel, "name": "project", "description": "Project"},
+        ])
+        cli.script("dms", "list", [])
+        adapter._run_cli = cli
+        websocket = AsyncMock()
+        subscriptions = {"hermes-buzz-0": CHANNEL}
+
+        await adapter._handle_membership_event(
+            websocket,
+            subscriptions,
+            {"created_at": 1234, "kind": _buzz_mod._WS_MEMBERSHIP_KIND},
+        )
+
+        assert new_channel not in adapter._channel_state
+        assert new_channel not in subscriptions.values()
+        websocket.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_membership_event_retries_after_joined_channel_discovery_failure(self):
+        adapter = _make_adapter()
+        adapter._membership_since = 100
+        cli = _ScriptedCli()
+        cli.script("channels", "list", [], code=2, stderr="temporary failure")
+        adapter._run_cli = cli
+        websocket = AsyncMock()
+
+        with pytest.raises(ConnectionError, match="joined-channel discovery failed"):
+            await adapter._handle_membership_event(
+                websocket,
+                {"hermes-buzz-0": CHANNEL},
+                {"created_at": 1234, "kind": _buzz_mod._WS_MEMBERSHIP_KIND},
+            )
+
+        assert adapter._membership_since == 100
+        websocket.send.assert_not_awaited()
+
+
 # ── Sending ───────────────────────────────────────────────────────────────
 
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -97,6 +97,8 @@ gateway:
 
 ## Mentions, channels, and DMs
 
+- If `channels` / `BUZZ_CHANNELS` is absent or empty, Hermes discovers all channels the Buzz identity has joined. Joins and leaves are reconciled while the gateway is running, so newly joined channels are added and channels that the identity leaves are removed without a restart.
+- If `channels` / `BUZZ_CHANNELS` is explicitly configured, that list remains a restrictive, static watch set. Runtime membership changes do not add or remove configured channels.
 - In shared channels the agent only responds when **addressed** — by `@name`, its npub, or its hex pubkey. Everything else is ignored.
 - Direct messages always reach the agent, no mention needed.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
@@ -117,7 +119,7 @@ Check status with `hermes gateway status` — Buzz connection state is reported 
 
 ## Notes and limitations
 
-- **Inbound is polled, not streamed.** The `buzz` CLI is request/response, so the adapter polls `buzz messages get` per watched channel every `poll_interval` seconds (default 4). Expect up to one interval of latency on inbound messages. A future optimization is a websocket transport (the Buzz repo ships `buzz-ws-client` for true streaming).
-- On (re)connect the adapter seeds its high-water mark from the newest events, so channel history is never replayed into the agent.
-- New DM conversations are discovered automatically (every few poll sweeps).
+- Inbound uses the authenticated WebSocket transport by default, with CLI polling as the fallback. Polling latency is up to one `poll_interval` (default 4 seconds).
+- On (re)connect the adapter rebuilds joined-channel and DM state and seeds high-water marks from the newest events, so channel history is never replayed into the agent.
+- Joined channels and new DM conversations are also rediscovered periodically when polling.
 - The private key is passed to the CLI via the subprocess environment — it never appears in argv or logs.


### PR DESCRIPTION
## What does this PR do?

Hermes currently snapshots Buzz channels at startup. When the Buzz identity joins or leaves an ordinary channel later, the running Gateway can miss the new channel indefinitely or retain a stale subscription until restart.

This refresh keeps automatic channel discovery synchronized for the lifetime of the Gateway while preserving explicitly configured channel restrictions.

When `channels` / `BUZZ_CHANNELS` is absent or empty, the adapter now:

- seeds from an authoritative snapshot of channels the identity has joined;
- subscribes to new joins without restart;
- reconciles leaves against a fresh authoritative snapshot;
- handles joins racing with removal reconciliation;
- rejects stale join events so removed channels cannot be resurrected;
- rebuilds joined-channel and DM state after reconnect;
- preserves replay floors so history is not dispatched as new work;
- allocates collision-safe WebSocket subscription IDs;
- mutates subscription state only after successful `REQ` / `CLOSE` sends;
- keeps bounded deduplication and polling rediscovery fallback.

When channels are explicitly configured, they remain a restrictive static watch set. Runtime membership events cannot broaden or remove them.

The Buzz user guide now documents both modes and the reconnect/replay behavior.

## Related Issue

No linked issue. This replaces the stale/conflicting implementation already proposed in this PR; it is not a duplicate contribution.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/buzz/adapter.py`
  - Add authoritative joined-channel discovery and runtime reconciliation.
  - Rebuild dynamic state on reconnect and preserve replay-safe cursors.
  - Reconcile removals without losing concurrent joins.
  - Preserve strict behavior for explicit static channel configuration.
  - Make WebSocket subscription bookkeeping collision-safe and successful-send-only.
- `tests/gateway/test_buzz_adapter.py`
  - Cover startup discovery, live joins, removals, stale/out-of-order events, concurrent joins, reconnects, replay floors, failed WebSocket sends, static channels, polling fallback, and bounded state.
- `website/docs/user-guide/messaging/buzz.md`
  - Document dynamic joined-channel mode, restrictive static mode, reconnect rebuilding, and polling fallback.

## How to Test

1. Run:
   `uv run pytest -q tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py`
   Expected: **50 passed**.
2. Run:
   `uv run ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py`
   Expected: **All checks passed**.
3. Run:
   `python -m py_compile plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py`
   Expected: exit status 0.
4. Canonical Linux CI installs the pinned test environment with:
   `uv sync --locked --python 3.11 --extra all --extra dev --extra anthropic --extra mistral --extra fal --extra modal --extra daytona --extra hindsight --extra parallel-web`
   and then runs files in isolated subprocesses through `scripts/run_tests.sh`. The two changed Buzz test files pass independently as reported above.
5. Run:
   `git diff --check upstream/main..HEAD`
   Expected: no output and exit status 0.

### Noncanonical monolithic-suite note

A single shared `pytest tests/` process is not the repository's CI contract. It fails on pristine current `upstream/main` and this branch at the same first node after the same 706-test prefix:

`tests/agent/test_auxiliary_main_first.py::TestResolveVisionCustomProvider::test_custom_main_forwards_runtime_endpoint`

The node passes alone on both trees, proving an upstream order-dependent global-state leak. Current CI avoids this class intentionally by running each file in a fresh subprocess (`.github/workflows/tests.yml`, lines 120-132). The lifecycle branch does not modify provider or auxiliary-client code.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run one monolithic `pytest tests/` process and all tests pass — not checked: this is not canonical CI and current main reproduces the same order-dependent failure; changed test files pass in CI-style isolation
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example`: N/A; no config keys were added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no contributor workflow changed
- [x] Cross-platform impact considered; implementation uses existing Python, CLI, and WebSocket abstractions
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

```text
50 passed
All checks passed
py_compile: passed
git diff --check: passed
monolithic shared-process baseline: same first failure on upstream/main and branch after 706 passed; node passes alone on both
```
