### PR TITLE
fix(weixin): delegate cross-event-loop sends to live adapter via run_coroutine_threadsafe

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -13,6 +13,7 @@ Design notes:
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import base64
 import hashlib
 import json
@@ -2378,15 +2379,48 @@ async def send_weixin_direct(
         logger.info(
             "send_weixin_direct: live adapter on different loop; scheduling via run_coroutine_threadsafe"
         )
-        future = asyncio.run_coroutine_threadsafe(
-            _send_via_live(live_adapter, chat_id, message, media_files),
-            adapter_loop,
-        )
-        try:
-            return future.result(timeout=60)
-        except Exception as e:
-            logger.warning("send_weixin_direct: cross-loop send failed, falling back to one-shot: %s", e)
+        # Guard: adapter loop may have been shut down (review comment #1)
+        if not adapter_loop.is_running():
+            logger.warning(
+                "send_weixin_direct: adapter loop is not running, falling back to one-shot"
+            )
             # Fall through to one-shot below
+        else:
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    _send_via_live(live_adapter, chat_id, message, media_files),
+                    adapter_loop,
+                )
+            except RuntimeError as e:
+                logger.warning(
+                    "send_weixin_direct: failed to schedule coroutine on adapter loop: %s", e
+                )
+                # Fall through to one-shot below
+            else:
+                try:
+                    return future.result(timeout=60)
+                except concurrent.futures.TimeoutError:
+                    # The coroutine may still be executing on the gateway's event loop.
+                    # Returning a timeout error is safer than falling through to the
+                    # one-shot path, which would duplicate the delivery (review comment #2).
+                    logger.error(
+                        "send_weixin_direct: cross-loop send timed out after 60s "
+                        "(coroutine may still be executing on gateway loop; "
+                        "not falling back to avoid duplicate delivery)"
+                    )
+                    return {"error": "Weixin cross-loop send timed out"}
+                except concurrent.futures.CancelledError:
+                    logger.warning(
+                        "send_weixin_direct: cross-loop send was cancelled, "
+                        "falling back to one-shot"
+                    )
+                    # Safe to fallback: the coroutine was cancelled and won't deliver
+                except Exception as e:
+                    logger.warning(
+                        "send_weixin_direct: cross-loop send failed, "
+                        "falling back to one-shot: %s", e
+                    )
+                    # Fall through to one-shot below
     # --- End Plan B ---
 
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2328,25 +2328,40 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if (live_adapter is not None and send_session is not None
-            and not send_session.closed
-            and send_session._loop is asyncio.get_running_loop()):
+    # --- Begin Plan B: cross-loop delivery via live adapter ---
+    # When a cron job runs in its own event loop (asyncio.run()), the
+    # live adapter's _send_session._loop won't match the running loop.
+    # Previously this fell through to a one-shot throwaway adapter that
+    # iLink rate-limits (ret=-2).  Now we use run_coroutine_threadsafe
+    # to schedule the send on the gateway's event loop where the live
+    # adapter's session lives, preserving the context_token and avoiding
+    # the iLink rate limit.
+    adapter_loop = getattr(send_session, '_loop', None) if send_session else None
+    same_loop = (live_adapter is not None and send_session is not None
+                 and not send_session.closed
+                 and adapter_loop is not None
+                 and adapter_loop is asyncio.get_running_loop())
+    cross_loop = (live_adapter is not None and send_session is not None
+                  and not send_session.closed
+                  and adapter_loop is not None
+                  and not same_loop)
+
+    async def _send_via_live(adapter, chat_id, message, media_files):
+        """Send text + media via the live adapter (runs on gateway's loop)."""
         last_result: Optional[SendResult] = None
-        cleaned = live_adapter.format_message(message)
+        cleaned = adapter.format_message(message)
         if cleaned:
-            last_result = await live_adapter.send(chat_id, cleaned)
+            last_result = await adapter.send(chat_id, cleaned)
             if not last_result.success:
                 return {"error": f"Weixin send failed: {last_result.error}"}
-
         for media_path, _is_voice in media_files or []:
             ext = Path(media_path).suffix.lower()
             if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
-                last_result = await live_adapter.send_image_file(chat_id, media_path)
+                last_result = await adapter.send_image_file(chat_id, media_path)
             else:
-                last_result = await live_adapter.send_document(chat_id, media_path)
+                last_result = await adapter.send_document(chat_id, media_path)
             if not last_result.success:
                 return {"error": f"Weixin media send failed: {last_result.error}"}
-
         return {
             "success": True,
             "platform": "weixin",
@@ -2354,6 +2369,25 @@ async def send_weixin_direct(
             "message_id": last_result.message_id if last_result else None,
             "context_token_used": bool(context_token),
         }
+
+    if same_loop:
+        result = await _send_via_live(live_adapter, chat_id, message, media_files)
+        return result
+
+    if cross_loop:
+        logger.info(
+            "send_weixin_direct: live adapter on different loop; scheduling via run_coroutine_threadsafe"
+        )
+        future = asyncio.run_coroutine_threadsafe(
+            _send_via_live(live_adapter, chat_id, message, media_files),
+            adapter_loop,
+        )
+        try:
+            return future.result(timeout=60)
+        except Exception as e:
+            logger.warning("send_weixin_direct: cross-loop send failed, falling back to one-shot: %s", e)
+            # Fall through to one-shot below
+    # --- End Plan B ---
 
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(


### PR DESCRIPTION
### Problem

When cron jobs or standalone callers execute in an isolated event loop (),  failed the  check and fell back to creating a temporary one-shot adapter/session.

Tencent's iLink Bot API identifies one-shot sessions without recent user interaction context as stranger active messages and rate-limits them with  (). This causes recurring cron job deliveries to WeChat (e.g. daily reports, status checks) to fail with delivery errors even when the gateway is running.

### Fix

When a  is registered but running on a different event loop (), this PR delegates the message/media delivery to the live adapter's event loop using .

This ensures:
1. Delivery executes safely on the gateway's event loop.
2. The active long-poll session and cached  are preserved and reused.
3. Cron deliveries to WeChat succeed without triggering iLink's  rate limit.
