### PR TITLE
fix(desktop): stop Settings Workspace from sticking on skeleton under Strict Mode

### DIFF
--- a/apps/desktop/src/app/hooks/use-config-record.ts
+++ b/apps/desktop/src/app/hooks/use-config-record.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { getHermesConfigRecord } from '@/hermes'
-import { queryClient, writeCache } from '@/lib/query-client'
+import { HERMES_CONFIG_QUERY_KEY, queryClient, writeCache } from '@/lib/query-client'
 import { normalizeProfileKey } from '@/store/profile'
 import type { HermesConfigRecord } from '@/types/hermes'
 
@@ -10,9 +10,13 @@ import type { HermesConfigRecord } from '@/types/hermes'
 // so a save in one shows in the others, and revisiting a tab paints the cache
 // instead of blanking on a fresh fetch.
 //
+// The key itself lives in lib/query-client.ts: on a profile/gateway switch the
+// store-level boundary (invalidateProfileScopedQueries) hard-resets this record
+// so no consumer can seed a draft from the previous profile's data.
+//
 // Distinct from session/hooks/use-hermes-config.ts, which is side-effecting —
 // it pushes personality/cwd/voice/… into the session stores for live chat.
-export const HERMES_CONFIG_KEY = ['hermes-config-record'] as const
+export const HERMES_CONFIG_KEY = HERMES_CONFIG_QUERY_KEY
 
 // Per-profile cache key. The base key (no profile suffix) is the app-wide
 // active profile, unchanged for every caller that passes nothing. An explicit

--- a/apps/desktop/src/app/hooks/use-on-profile-switch.test.tsx
+++ b/apps/desktop/src/app/hooks/use-on-profile-switch.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
+
+import { useOnProfileSwitch } from './use-on-profile-switch'
+
+afterEach(() => {
+  $activeGatewayProfile.set('default')
+})
+
+describe('useOnProfileSwitch', () => {
+  it('does not fire on mount, including under StrictMode double-invoke', () => {
+    const onSwitch = vi.fn()
+
+    renderHook(() => useOnProfileSwitch(onSwitch), {
+      wrapper: StrictMode
+    })
+
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('fires when the active gateway profile actually changes', () => {
+    const onSwitch = vi.fn()
+
+    renderHook(() => useOnProfileSwitch(onSwitch), {
+      wrapper: StrictMode
+    })
+
+    act(() => {
+      $activeGatewayProfile.set('coder')
+    })
+
+    expect(onSwitch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire when the profile atom is set to the same value', () => {
+    const onSwitch = vi.fn()
+
+    renderHook(() => useOnProfileSwitch(onSwitch), {
+      wrapper: StrictMode
+    })
+
+    act(() => {
+      $activeGatewayProfile.set('default')
+    })
+
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when the raw value changes but the normalized key does not', () => {
+    const onSwitch = vi.fn()
+
+    renderHook(() => useOnProfileSwitch(onSwitch), {
+      wrapper: StrictMode
+    })
+
+    // '' and ' default ' both normalize to 'default' — not a real switch.
+    act(() => {
+      $activeGatewayProfile.set('')
+    })
+    act(() => {
+      $activeGatewayProfile.set(' default ')
+    })
+
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/hooks/use-on-profile-switch.ts
+++ b/apps/desktop/src/app/hooks/use-on-profile-switch.ts
@@ -1,25 +1,31 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useRef } from 'react'
 
-import { $activeGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 
 /** Run `onSwitch` when the active gateway profile changes — never on first
  *  mount. For dropping per-profile view state (probes, cached usage, drafts)
- *  when the backend the app talks to swaps underneath a still-mounted view. */
+ *  when the backend the app talks to swaps underneath a still-mounted view.
+ *
+ *  Guarded by comparing the last seen profile key, not by a one-shot "skip
+ *  first run" flag: React Strict Mode re-invokes effects once after mount, and
+ *  a first-flag treats that second pass as a real switch (it wiped the
+ *  settings draft and left the page on its skeleton forever). Keys are
+ *  normalized with the same rule as the store-level cache invalidation in
+ *  store/profile.ts, so both fire under identical conditions. */
 export function useOnProfileSwitch(onSwitch: () => void): void {
-  const profile = useStore($activeGatewayProfile)
-  const first = useRef(true)
+  const profileKey = normalizeProfileKey(useStore($activeGatewayProfile))
+  const prevProfileKey = useRef(profileKey)
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (first.current) {
-      first.current = false
-
+    if (prevProfileKey.current === profileKey) {
       return
     }
 
+    prevProfileKey.current = profileKey
     onSwitch()
     // Fire on profile change only; onSwitch identity is intentionally ignored.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profile])
+  }, [profileKey])
 }

--- a/apps/desktop/src/app/settings/config-settings.test.tsx
+++ b/apps/desktop/src/app/settings/config-settings.test.tsx
@@ -1,0 +1,142 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { queryClient } from '@/lib/query-client'
+import { $activeGatewayProfile } from '@/store/profile'
+import type { HermesConfigRecord } from '@/types/hermes'
+
+import { HERMES_CONFIG_KEY } from '../hooks/use-config-record'
+
+const getHermesConfigRecord = vi.fn()
+const getHermesConfigSchema = vi.fn()
+const saveHermesConfig = vi.fn()
+const getElevenLabsVoices = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getHermesConfigRecord: () => getHermesConfigRecord(),
+  getHermesConfigSchema: () => getHermesConfigSchema(),
+  saveHermesConfig: (config: unknown) => saveHermesConfig(config),
+  getElevenLabsVoices: () => getElevenLabsVoices(),
+  getProfiles: async () => ({ profiles: [] }),
+  setApiRequestProfile: () => {},
+  STARTUP_REQUEST_TIMEOUT_MS: 1000
+}))
+
+vi.mock('@/store/projects', () => ({
+  repoDiscoveryPolicyFromConfig: (config: HermesConfigRecord) => config?.desktop ?? {},
+  repoDiscoveryPolicySignature: (policy: unknown) => JSON.stringify(policy ?? null),
+  scanAndRecordRepos: vi.fn()
+}))
+
+// Heavy neighbours that aren't under test.
+vi.mock('./model-settings', () => ({
+  ModelSettings: () => null,
+  ModelSettingsSkeleton: () => null
+}))
+vi.mock('./memory/connect', () => ({ MemoryConnect: () => null }))
+vi.mock('./memory/provider-config-panel', () => ({ ProviderConfigPanel: () => null }))
+vi.mock('./quick-entry-settings', () => ({ QuickEntrySettings: () => null }))
+
+const workspaceConfig = (cwd: string): HermesConfigRecord => ({ terminal: { cwd } })
+
+const SCHEMA = {
+  fields: {
+    'terminal.cwd': { type: 'string', description: 'Default project folder.' }
+  }
+}
+
+beforeEach(() => {
+  getHermesConfigRecord.mockImplementation(async () => workspaceConfig('.'))
+  getHermesConfigSchema.mockResolvedValue(structuredClone(SCHEMA))
+  saveHermesConfig.mockResolvedValue({ ok: true })
+  getElevenLabsVoices.mockResolvedValue({ available: false, voices: [] })
+})
+
+afterEach(() => {
+  cleanup()
+  queryClient.clear()
+  $activeGatewayProfile.set('default')
+  vi.clearAllMocks()
+})
+
+async function renderWorkspaceSettings() {
+  const { ConfigSettings } = await import('./config-settings')
+
+  return render(
+    // StrictMode is load-bearing: the app runs under it, and the regression
+    // this file guards (profile-switch hook double-fire wiping the draft)
+    // only reproduces with Strict Mode's second effect pass.
+    <StrictMode>
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <ConfigSettings activeSectionId="workspace" importInputRef={{ current: null }} />
+        </QueryClientProvider>
+      </MemoryRouter>
+    </StrictMode>
+  )
+}
+
+describe('ConfigSettings draft seeding', () => {
+  it('keeps the seeded draft under StrictMode when the record is already cached', async () => {
+    // Warm cache = the live repro: another surface fetched the config before
+    // Settings opened, so the seed happens on mount and the (old) first-flag
+    // profile-switch hook wiped it on Strict Mode's second effect pass —
+    // permanent skeleton, because the refetch structural-shares the same
+    // reference and the seed effect never re-ran.
+    queryClient.setQueryData(HERMES_CONFIG_KEY, workspaceConfig('.'))
+
+    await renderWorkspaceSettings()
+
+    await screen.findByText('Working Directory')
+
+    // Let the staleTime-0 background refetch (deep-equal payload) settle.
+    await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 25))
+    })
+
+    expect(screen.queryByText('Working Directory')).not.toBeNull()
+    expect(screen.getByDisplayValue('.')).toBeTruthy()
+  })
+
+  it('re-seeds the other profile record after a profile switch, without autosaving', async () => {
+    await renderWorkspaceSettings()
+    await screen.findByText('Working Directory')
+    expect(screen.getByDisplayValue('.')).toBeTruthy()
+
+    getHermesConfigRecord.mockImplementation(async () => workspaceConfig('/profile-b'))
+
+    act(() => {
+      $activeGatewayProfile.set('coder')
+    })
+
+    // Draft cleared + record hard-reset → refetch lands profile B's config and
+    // the empty draft re-seeds from it.
+    await screen.findByDisplayValue('/profile-b')
+
+    // The switch itself must never write config (that would cross-contaminate).
+    expect(saveHermesConfig).not.toHaveBeenCalled()
+  })
+
+  it('re-seeds after a profile switch even when both profiles have deep-equal configs', async () => {
+    await renderWorkspaceSettings()
+    await screen.findByText('Working Directory')
+
+    const callsBeforeSwitch = getHermesConfigRecord.mock.calls.length
+
+    // Profile B's record has identical content. Without a hard cache reset,
+    // React Query structural sharing keeps the SAME object reference across
+    // the refetch, a reference-keyed seed effect never re-runs, and the page
+    // is a skeleton forever. The state-derived seed + resetQueries must
+    // recover regardless of reference identity.
+    act(() => {
+      $activeGatewayProfile.set('coder')
+    })
+
+    await waitFor(() => expect(getHermesConfigRecord.mock.calls.length).toBeGreaterThan(callsBeforeSwitch))
+    await waitFor(() => expect(screen.getByDisplayValue('.')).toBeTruthy())
+  })
+})

--- a/apps/desktop/src/app/settings/config-settings.test.tsx
+++ b/apps/desktop/src/app/settings/config-settings.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { StrictMode } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { queryClient } from '@/lib/query-client'

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -101,25 +101,27 @@ export function ConfigSettings({
   const savedDiscoverySignatureRef = useRef<string | undefined>(undefined)
   const [saveVersion, setSaveVersion] = useState(0)
 
-  // Seed the local draft once, the first time the shared record lands.
-  // Background refetches thereafter must not clobber in-progress edits.
-  const configSeeded = useRef(false)
-
+  // Seed the local draft whenever it is empty and the shared record is
+  // available. The guard is the draft state itself (not a one-shot ref), so any
+  // path that clears the draft re-seeds automatically once data lands — there
+  // is no "cleared but never re-seeded" state to get stuck in. Background
+  // refetches while an edit is in progress still can't clobber the draft,
+  // because a non-null draft blocks the seed.
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (loadedConfig && !configSeeded.current) {
-      configSeeded.current = true
+    if (loadedConfig && config === null) {
       savedDiscoverySignatureRef.current = repoDiscoveryPolicySignature(repoDiscoveryPolicyFromConfig(loadedConfig))
       setConfig(loadedConfig)
     }
-  }, [loadedConfig])
+  }, [loadedConfig, config])
 
-  // A profile switch invalidates (but doesn't clear) the shared config query, so
-  // the local draft would otherwise keep profile A's data and autosave it into
-  // B. Drop the seed + draft (re-seeds from B's refetch) and zero saveVersion so
-  // the pending debounced autosave is cancelled by its effect cleanup.
+  // A profile switch swaps the backend under the mounted panel. Drop the draft
+  // and zero saveVersion so the pending debounced autosave is cancelled by its
+  // effect cleanup — profile A's draft must never be saved into profile B. The
+  // shared record itself is hard-reset centrally at the switch boundary
+  // (invalidateProfileScopedQueries), so the seed effect re-seeds from B's
+  // fresh fetch rather than A's cached record.
   useOnProfileSwitch(() => {
-    configSeeded.current = false
     savedDiscoverySignatureRef.current = undefined
     setConfig(null)
     saveVersionRef.current = 0
@@ -165,11 +167,14 @@ export function ConfigSettings({
             throw new Error(c.autosaveFailed)
           }
 
-          // Mirror the saved record into the shared cache so MCP/model surfaces
-          // reflect the edit without their own refetch.
-          setHermesConfigCache(config)
-
           if (saveVersionRef.current === v) {
+            // Mirror the saved record into the shared cache so MCP/model
+            // surfaces reflect the edit without their own refetch. Inside the
+            // version guard: a profile switch zeroes saveVersion while this
+            // save is in flight, and mirroring then would write profile A's
+            // record over profile B's freshly-reset cache.
+            setHermesConfigCache(config)
+
             const discoverySignature = repoDiscoveryPolicySignature(repoDiscoveryPolicyFromConfig(config))
 
             if (savedDiscoverySignatureRef.current !== discoverySignature) {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -522,6 +522,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         return
       }
 
+      const epoch = profileEpoch.current
       const prev = config
       const next = setNested(config, key, value)
       setConfig(next)
@@ -529,7 +530,13 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       try {
         await saveHermesConfig(next)
       } catch (err) {
-        setConfig(prev)
+        // Roll back only within the same profile epoch: after a switch the
+        // shared cache holds (or is fetching) profile B's record, and writing
+        // A's `prev` back would stomp it.
+        if (profileEpoch.current === epoch) {
+          setConfig(prev)
+        }
+
         notifyError(err, m.defaultsFailed)
       }
     },

--- a/apps/desktop/src/app/settings/sessions-settings.test.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.test.tsx
@@ -1,0 +1,97 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { queryClient } from '@/lib/query-client'
+import { $activeGatewayProfile } from '@/store/profile'
+import type { HermesConfigRecord } from '@/types/hermes'
+
+const getHermesConfigRecord = vi.fn()
+const saveHermesConfig = vi.fn()
+const listAllProfileSessions = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getHermesConfigRecord: () => getHermesConfigRecord(),
+  saveHermesConfig: (config: unknown) => saveHermesConfig(config),
+  listAllProfileSessions: (limit: number, offset: number, archived: string) =>
+    listAllProfileSessions(limit, offset, archived),
+  deleteSession: vi.fn(),
+  setSessionArchived: vi.fn(),
+  // Pulled in via useOnProfileSwitch → @/store/profile.
+  getProfiles: async () => ({ profiles: [] }),
+  setApiRequestProfile: () => {},
+  STARTUP_REQUEST_TIMEOUT_MS: 1000
+}))
+
+const profileRecord = (cwd: string, sessions: Record<string, unknown>): HermesConfigRecord => ({
+  terminal: { cwd },
+  sessions
+})
+
+beforeEach(() => {
+  // AutoArchiveSetting only fetches config when the Electron bridge exists.
+  ;(window as { hermesDesktop?: unknown }).hermesDesktop = {}
+
+  getHermesConfigRecord.mockImplementation(async () => profileRecord('/profile-a', { auto_archive: false }))
+  saveHermesConfig.mockResolvedValue({ ok: true })
+  listAllProfileSessions.mockResolvedValue({ sessions: [] })
+})
+
+afterEach(() => {
+  cleanup()
+  queryClient.clear()
+  $activeGatewayProfile.set('default')
+  vi.clearAllMocks()
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+async function renderSessionsSettings() {
+  const { SessionsSettings } = await import('./sessions-settings')
+
+  return render(
+    <StrictMode>
+      <MemoryRouter>
+        <SessionsSettings />
+      </MemoryRouter>
+    </StrictMode>
+  )
+}
+
+describe('AutoArchiveSetting profile switches', () => {
+  it('reseeds profile B’s record after a switch and never persists profile A’s copy', async () => {
+    await renderSessionsSettings()
+
+    const toggle = await screen.findByRole('switch', { name: 'Auto-archive stale chats' })
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+
+    const callsBeforeSwitch = getHermesConfigRecord.mock.calls.length
+
+    // Switch to profile B, whose record differs in both the toggle state and
+    // an unrelated key (terminal.cwd) that the whole-record PUT would carry.
+    getHermesConfigRecord.mockImplementation(async () =>
+      profileRecord('/profile-b', { auto_archive: true, auto_archive_days: 9 })
+    )
+
+    act(() => {
+      $activeGatewayProfile.set('coder')
+    })
+
+    // The control drops profile A's copy and refetches for B…
+    await waitFor(() => expect(getHermesConfigRecord.mock.calls.length).toBeGreaterThan(callsBeforeSwitch))
+
+    // …and reseeds every piece of its state from B's record.
+    const reseeded = await screen.findByRole('switch', { name: 'Auto-archive stale chats' })
+    await waitFor(() => expect(reseeded.getAttribute('aria-checked')).toBe('true'))
+    expect(screen.getByDisplayValue('9')).toBeTruthy()
+
+    // Toggling now must PUT a record based on profile B's copy — before the
+    // fix, the stale profile-A record (cwd /profile-a) was written into B.
+    fireEvent.click(reseeded)
+
+    await waitFor(() => expect(saveHermesConfig).toHaveBeenCalledTimes(1))
+    expect(saveHermesConfig.mock.calls[0][0]).toEqual(
+      profileRecord('/profile-b', { auto_archive: false, auto_archive_days: 9 })
+    )
+  })
+})

--- a/apps/desktop/src/app/settings/sessions-settings.test.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.test.tsx
@@ -1,6 +1,6 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { StrictMode } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { queryClient } from '@/lib/query-client'

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -21,6 +21,8 @@ import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSession
 import { forgetSessionUnread } from '@/store/session-unread'
 import type { HermesConfigRecord, SessionInfo } from '@/types/hermes'
 
+import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
+
 import { EmptyState, ListRow, SectionHeading, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
 import { useDeepLinkHighlight } from './use-deep-link-highlight'
 
@@ -185,6 +187,19 @@ function AutoArchiveSetting() {
   const [config, setConfig] = useState<HermesConfigRecord | null>(null)
   const [enabled, setEnabled] = useState(false)
   const [days, setDays] = useState(DEFAULT_AUTO_ARCHIVE_DAYS)
+  // Bumped on profile switch to re-run the fetch effect against the new
+  // profile's backend.
+  const [profileEpoch, setProfileEpoch] = useState(0)
+
+  // This control holds a full config-record copy and PUTs it back on toggle.
+  // On a profile switch, drop profile A's record so persist() can't write it
+  // into profile B, and refetch: re-running the fetch effect flips the previous
+  // run's `alive` flag, so a slow in-flight profile-A response is discarded
+  // instead of seeding B's view.
+  useOnProfileSwitch(() => {
+    setConfig(null)
+    setProfileEpoch(epoch => epoch + 1)
+  })
 
   useEffect(() => {
     // Config REST is only reachable through the Electron bridge; skip in
@@ -214,7 +229,7 @@ function AutoArchiveSetting() {
     return () => {
       alive = false
     }
-  }, [])
+  }, [profileEpoch])
 
   const persist = useCallback(
     async (autoArchive: boolean, archiveDays: number) => {

--- a/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
@@ -63,11 +63,13 @@ vi.mock('@/hermes', () => ({
   getHermesConfigSchema: () => getHermesConfigSchema(),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config),
   getElevenLabsVoices: () => getElevenLabsVoices(),
-  // @/store/profile (pulled in transitively via use-config-record's
-  // normalizeProfileKey import) calls this at module-init; the full-replacement
-  // mock must provide it or the module graph throws on load.
+  // @/store/profile (pulled in transitively via use-config-record /
+  // useOnProfileSwitch) calls these at module-init; the full-replacement
+  // mock must provide them or the module graph throws on load.
   setApiRequestProfile: () => undefined,
-  getApiRequestProfile: () => null
+  getApiRequestProfile: () => null,
+  getProfiles: async () => ({ profiles: [] }),
+  STARTUP_REQUEST_TIMEOUT_MS: 1000
 }))
 
 vi.mock('@/store/notifications', () => ({

--- a/apps/desktop/src/app/settings/voice-provider-fields.test.tsx
+++ b/apps/desktop/src/app/settings/voice-provider-fields.test.tsx
@@ -1,0 +1,120 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { queryClient } from '@/lib/query-client'
+import { $activeGatewayProfile } from '@/store/profile'
+import type { HermesConfigRecord } from '@/types/hermes'
+
+const getHermesConfigRecord = vi.fn()
+const getHermesConfigSchema = vi.fn()
+const saveHermesConfig = vi.fn()
+const getElevenLabsVoices = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getHermesConfigRecord: () => getHermesConfigRecord(),
+  getHermesConfigSchema: () => getHermesConfigSchema(),
+  saveHermesConfig: (config: unknown) => saveHermesConfig(config),
+  getElevenLabsVoices: () => getElevenLabsVoices(),
+  // Pulled in via useOnProfileSwitch → @/store/profile.
+  getProfiles: async () => ({ profiles: [] }),
+  setApiRequestProfile: () => {},
+  STARTUP_REQUEST_TIMEOUT_MS: 1000
+}))
+
+const voiceConfig = (voice: string): HermesConfigRecord => ({
+  tts: { openai: { model: 'gpt-4o-mini-tts', voice } }
+})
+
+// The debounce is 550ms; anything comfortably past it proves the timer either
+// fired (autosave path) or was cancelled (profile-switch path).
+const AUTOSAVE_WINDOW_MS = 700
+
+const settle = (ms: number) =>
+  act(async () => {
+    await new Promise(resolve => setTimeout(resolve, ms))
+  })
+
+beforeEach(() => {
+  // Radix popover / cmdk (the free-input combobox) need these on open; jsdom
+  // ships neither (mirrors toolset-config-panel.test.tsx).
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+
+  getHermesConfigRecord.mockImplementation(async () => voiceConfig('alloy'))
+  getHermesConfigSchema.mockResolvedValue({ fields: {} })
+  saveHermesConfig.mockResolvedValue({ ok: true })
+  getElevenLabsVoices.mockResolvedValue({ available: false, voices: [] })
+})
+
+afterEach(() => {
+  cleanup()
+  queryClient.clear()
+  $activeGatewayProfile.set('default')
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+async function renderVoicePanel() {
+  const { VoiceProviderFields } = await import('./voice-provider-fields')
+
+  return render(
+    // StrictMode is load-bearing: the app runs under it, and the profile-switch
+    // hook regression this file guards only reproduces with Strict Mode's
+    // second effect pass.
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <VoiceProviderFields providerKey="openai" section="tts" />
+      </QueryClientProvider>
+    </StrictMode>
+  )
+}
+
+describe('VoiceProviderFields profile switches', () => {
+  it('never saves profile A’s draft after a switch, and reseeds profile B’s record', async () => {
+    await renderVoicePanel()
+    const voiceInput = await screen.findByDisplayValue('alloy')
+
+    // Edit while on profile A — this schedules the 550ms debounced autosave.
+    fireEvent.change(voiceInput, { target: { value: 'echo' } })
+    expect(await screen.findByDisplayValue('echo')).toBeTruthy()
+
+    // Switch to profile B before the debounce fires. The store-level boundary
+    // hard-resets the shared record; the panel must drop the dirty draft and
+    // cancel the pending save.
+    getHermesConfigRecord.mockImplementation(async () => voiceConfig('nova'))
+
+    act(() => {
+      $activeGatewayProfile.set('coder')
+    })
+
+    // The empty draft reseeds from profile B's fresh fetch.
+    expect(await screen.findByDisplayValue('nova')).toBeTruthy()
+
+    // Let the (cancelled) debounce window elapse: profile A's edited record
+    // must never have been PUT — that would write A's config into B.
+    await settle(AUTOSAVE_WINDOW_MS)
+    expect(saveHermesConfig).not.toHaveBeenCalled()
+  })
+
+  it('still autosaves an edit when no switch happens (cancel is not a kill-switch)', async () => {
+    await renderVoicePanel()
+    const voiceInput = await screen.findByDisplayValue('alloy')
+
+    fireEvent.change(voiceInput, { target: { value: 'echo' } })
+    await settle(AUTOSAVE_WINDOW_MS)
+
+    expect(saveHermesConfig).toHaveBeenCalledTimes(1)
+    expect(saveHermesConfig.mock.calls[0][0]).toEqual(voiceConfig('echo'))
+  })
+})

--- a/apps/desktop/src/app/settings/voice-provider-fields.tsx
+++ b/apps/desktop/src/app/settings/voice-provider-fields.tsx
@@ -7,6 +7,7 @@ import { notifyError } from '@/store/notifications'
 import type { HermesConfigRecord } from '@/types/hermes'
 
 import { setHermesConfigCache, useHermesConfigRecord } from '../hooks/use-config-record'
+import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 
 import { ConfigField } from './config-field'
 import { SECTIONS } from './constants'
@@ -41,31 +42,53 @@ export function VoiceProviderFields({ section, providerKey }: { section: 'tts' |
     staleTime: 5 * 60 * 1000
   })
 
-  // Local editable draft, seeded once from the shared cache (background
-  // refetches must not clobber in-progress edits) — the same shape as
-  // config-settings.tsx's autosave loop.
+  // Local editable draft — the same shape as config-settings.tsx's autosave
+  // loop. Seeded whenever it is empty and the shared record is available: the
+  // guard is the draft state itself (not a one-shot ref), so any path that
+  // clears the draft re-seeds automatically once data lands, while background
+  // refetches still can't clobber in-progress edits (a non-null draft blocks
+  // the seed).
   const [config, setConfig] = useState<HermesConfigRecord | null>(null)
-  const seeded = useRef(false)
 
-  // eslint-disable-next-line no-restricted-syntax -- one-shot config seed flag, not an atom mirror
   useEffect(() => {
-    if (loadedConfig && !seeded.current) {
-      seeded.current = true
+    if (loadedConfig && config === null) {
       setConfig(loadedConfig)
     }
-  }, [loadedConfig])
+  }, [loadedConfig, config])
 
   const saveVersionRef = useRef(0)
   const [saveVersion, setSaveVersion] = useState(0)
+
+  // A profile switch swaps the backend under this panel while it stays mounted
+  // (the Capabilities detail is keyed by toolset name, not by profile). Drop
+  // the draft and zero saveVersion so the pending debounced autosave is
+  // cancelled by its effect cleanup — profile A's draft must never be saved
+  // into profile B. The shared record itself is hard-reset centrally at the
+  // switch boundary (invalidateProfileScopedQueries), so the seed effect
+  // re-seeds from B's fresh fetch rather than A's cached record.
+  useOnProfileSwitch(() => {
+    setConfig(null)
+    saveVersionRef.current = 0
+    setSaveVersion(0)
+  })
 
   useEffect(() => {
     if (!config || saveVersion === 0) {
       return
     }
 
+    const v = saveVersion
+
     const timeout = window.setTimeout(() => {
       void saveHermesConfig(config)
-        .then(() => setHermesConfigCache(config))
+        .then(() => {
+          // Version guard, as in config-settings.tsx: a profile switch zeroes
+          // saveVersion while this save is in flight, and mirroring then would
+          // write profile A's record over profile B's freshly-reset cache.
+          if (saveVersionRef.current === v) {
+            setHermesConfigCache(config)
+          }
+        })
         .catch(err => notifyError(err, t.settings.config.autosaveFailed))
     }, 550)
 

--- a/apps/desktop/src/lib/query-client.test.ts
+++ b/apps/desktop/src/lib/query-client.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { invalidateProfileScopedQueries, queryClient } from './query-client'
+import { HERMES_CONFIG_QUERY_KEY, invalidateProfileScopedQueries, queryClient } from './query-client'
 
 function invalidated(key: unknown[]): boolean {
   return queryClient.getQueryState(key)?.isInvalidated ?? false
@@ -13,7 +13,6 @@ describe('invalidateProfileScopedQueries', () => {
 
   it('invalidates profile-scoped caches and leaves account/global caches intact', () => {
     const profileScoped = [
-      ['hermes-config-record'],
       ['hermes-config-schema'],
       ['skills-list'],
       ['toolsets-list'],
@@ -54,5 +53,22 @@ describe('invalidateProfileScopedQueries', () => {
 
     expect(invalidated(['some-future-profile-query'])).toBe(true)
     expect(invalidated([{ scope: 'weird' }])).toBe(true)
+  })
+
+  it('hard-resets the config record: profile A’s data is gone, not visible-but-stale', () => {
+    queryClient.setQueryData(HERMES_CONFIG_QUERY_KEY, { terminal: { cwd: '/profile-a' } })
+    queryClient.setQueryData(['skills-list'], { from: 'profile-a' })
+
+    invalidateProfileScopedQueries()
+
+    // Settings surfaces seed editable drafts (and autosave whole records) from
+    // this cache. After a switch, invalidate() would leave profile A's record
+    // readable until B's refetch lands — reset must drop it immediately so no
+    // consumer can seed from it.
+    expect(queryClient.getQueryData(HERMES_CONFIG_QUERY_KEY)).toBeUndefined()
+
+    // Ordinary profile-scoped caches keep stale-while-revalidate semantics.
+    expect(queryClient.getQueryData(['skills-list'])).toEqual({ from: 'profile-a' })
+    expect(invalidated(['skills-list'])).toBe(true)
   })
 })

--- a/apps/desktop/src/lib/query-client.ts
+++ b/apps/desktop/src/lib/query-client.ts
@@ -14,10 +14,18 @@ export const queryClient = new QueryClient({
 
 // Curried, setState-shaped cache writer for optimistic write-through: keeps
 // mutation sites terse (`setX(next)` or `setX(prev => …)`) over one query key.
+// Writing `undefined` does NOT clear the entry — React Query's setQueryData
+// treats undefined as a bail-out. To drop cached data use
+// queryClient.resetQueries / removeQueries.
 export const writeCache =
   <T>(key: QueryKey) =>
   (next: T | undefined | ((prev: T | undefined) => T | undefined)): void =>
     void queryClient.setQueryData<T>(key, next)
+
+// Key of the shared profile config record (`GET /api/config`). Owned here —
+// not in app/hooks/use-config-record.ts, which re-exports it — because the
+// profile-switch boundary below needs it and lib must not import from app.
+export const HERMES_CONFIG_QUERY_KEY = ['hermes-config-record'] as const
 
 // Query-key roots that are NOT profile-scoped: account/billing, the theme
 // marketplace, onboarding, and contrib log tails all read global or
@@ -37,12 +45,29 @@ const PROFILE_INDEPENDENT_QUERY_ROOTS = new Set<string>([
 // Invalidate profile-scoped query caches on a profile / gateway switch, leaving
 // account/global caches intact. Replaces a keyless invalidateQueries() that
 // refetched everything (billing, marketplace, onboarding) on every switch.
+//
+// The config record gets a hard RESET instead of an invalidation. Settings
+// surfaces seed editable drafts (and autosave whole records) from that cache,
+// and invalidate() keeps the previous profile's record visible — and seedable —
+// while the new profile's fetch is in flight, so a mounted panel could still
+// read profile A's record after a switch to B. resetQueries drops the data to
+// undefined immediately and refetches for active observers, closing that window
+// for every consumer at once, regardless of which panels happen to be mounted.
+// (`setQueryData(key, undefined)` cannot do this: React Query treats an
+// undefined value as a bail-out, not a delete.)
 export function invalidateProfileScopedQueries(): void {
+  void queryClient.resetQueries({ queryKey: HERMES_CONFIG_QUERY_KEY })
   void queryClient.invalidateQueries({
     predicate: query => {
       const root = query.queryKey[0]
 
-      return typeof root !== 'string' || !PROFILE_INDEPENDENT_QUERY_ROOTS.has(root)
+      if (typeof root !== 'string') {
+        return true
+      }
+
+      // The config record was hard-reset above; re-invalidating it here would
+      // cancel and restart its in-flight refetch for nothing.
+      return !PROFILE_INDEPENDENT_QUERY_ROOTS.has(root) && root !== HERMES_CONFIG_QUERY_KEY[0]
     }
   })
 }


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop Settings → Workspace (and other `ConfigSettings` tabs) getting stuck on the skeleton forever under React Strict Mode, and closes the related class of bugs where a mounted settings draft from profile A can be saved through profile B's route after a live gateway/profile switch.

**Reported failure chain (`ConfigSettings` skeleton):**
1. `useOnProfileSwitch` used a one-shot `first` flag; Strict Mode's second effect pass looked like a profile switch and cleared the local config draft.
2. The seed effect only depended on `loadedConfig`, so React Query structural sharing prevented re-seeding when the draft was empty but the cached reference was unchanged.

**Sibling failure class (review feedback):**
`reset` lived inside `ConfigSettings`, so it only ran when that panel was mounted. Surfaces that stay mounted across a profile swap (notably `VoiceProviderFields` in Capabilities) kept a one-shot draft + debounced `saveHermesConfig` with no switch handler — profile A's draft could be PUT into profile B.

**Approach:**
1. Compare normalized profile keys in `useOnProfileSwitch` (not a first-mount flag).
2. Seed drafts whenever `config === null` and data is available (state-derived, self-healing).
3. Centralize a hard reset of `hermes-config-record` inside `invalidateProfileScopedQueries()` (`resetQueries` — `setQueryData(undefined)` is a bail-out in RQ v5), so every consumer drops profile A's record on switch regardless of which panels are mounted.
4. Cover remaining config-draft holders: cancel pending autosaves / drop copies on switch, and version-/epoch-guard in-flight cache writes.

## Related Issue

Fixes #74824

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/hooks/use-on-profile-switch.ts` (+ test) — normalized key comparison; Strict Mode safe
- `apps/desktop/src/lib/query-client.ts` (+ test) — central `hermes-config-record` hard reset on profile/gateway switch; `HERMES_CONFIG_QUERY_KEY` owned here
- `apps/desktop/src/app/hooks/use-config-record.ts` — re-exports the shared key (no per-panel `resetHermesConfig`)
- `apps/desktop/src/app/settings/config-settings.tsx` (+ test) — state-derived seeding; drop draft on switch; version-guard post-save cache mirror
- `apps/desktop/src/app/settings/voice-provider-fields.tsx` (+ test) — same draft/autosave/switch pattern (Capabilities TTS panel stays mounted)
- `apps/desktop/src/app/settings/sessions-settings.tsx` (+ test) — `AutoArchiveSetting` drops whole-record copy and refetches on switch
- `apps/desktop/src/app/settings/model-settings.tsx` — optimistic rollback only within the same profile epoch
- `apps/desktop/src/app/settings/toolset-config-panel.test.tsx` — hermes mock stubs for profile-switch imports

## How to Test

1. Automated:
   ```bash
   cd apps/desktop
   npx vitest run \
     src/app/hooks/use-on-profile-switch.test.tsx \
     src/app/settings/config-settings.test.tsx \
     src/app/settings/voice-provider-fields.test.tsx \
     src/app/settings/sessions-settings.test.tsx \
     src/lib/query-client.test.ts
   ```
2. Manual — skeleton: `npm run dev` → Settings → Workspace; fields render (not a permanent skeleton) under Strict Mode.
3. Manual — profile switch: with Settings (or Capabilities → TTS provider fields) open, switch gateway profile; draft clears and re-seeds from the new profile; a dirty edit mid-debounce must not autosave into the new profile.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(desktop): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (dev / Strict Mode); desktop suite via `npx vitest run` in `apps/desktop`

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (renderer Strict Mode / React Query only)
- [x] I've updated tool descriptions/schemas — N/A