### PR TITLE
fix(buzz): resolve outbound @mentions to member pubkeys

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -205,6 +205,86 @@ def _normalize_user_ref(ref: str) -> Optional[str]:
 # buzz-cli invocation helpers
 # ---------------------------------------------------------------------------
 
+_MENTION_RE = re.compile(r"(?<!\w)@([A-Za-z0-9_\-.]{1,64})")
+_HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+async def _resolve_mention_pubkeys(
+    text: str,
+    channel_id: str,
+    run_cli,
+    name_of=None,
+    self_pubkey: str = "",
+) -> List[str]:
+    """Map ``@Name`` tokens in *text* to channel-member pubkeys.
+
+    buzz-cli rejects a send outright when ``@Name`` text matches no current
+    channel member, so an agent addressing another agent (``@Honey do X``)
+    fails unless we pass explicit ``--mention`` identities. Supplying any
+    explicit identity also downgrades unresolved or ambiguous names to
+    presentation-only, so partial resolution still averts a hard failure.
+
+    ``run_cli(args) -> (code, stdout, stderr)``; optional async ``name_of``
+    resolves a pubkey to a display name. Best-effort throughout: any CLI or
+    parse failure yields ``[]`` and leaves the send exactly as it was.
+    """
+    tokens = {t.lower() for t in _MENTION_RE.findall(text or "")}
+    if not tokens:
+        return []
+
+    resolved: List[str] = []
+    names = set()
+    for token in tokens:
+        if _HEX64_RE.match(token):
+            resolved.append(token)
+        elif token.startswith("npub1"):
+            as_hex = npub_to_hex(token)
+            if as_hex:
+                resolved.append(as_hex.lower())
+        else:
+            names.add(token)
+
+    if names:
+        try:
+            code, out, _err = await run_cli(
+                ["channels", "members", "--channel", channel_id]
+            )
+            members = _parse_json_list(out) if code == 0 else []
+        except Exception:  # never block a send on mention resolution
+            members = []
+
+        by_label: Dict[str, List[str]] = {}
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+            pubkey = str(member.get("pubkey") or "").strip().lower()
+            if not pubkey:
+                continue
+            # `channels members` returns only {pubkey, role}; fall back to the
+            # profile lookup when the CLI omits display names.
+            labels = [
+                str(member.get(key) or "").strip().lower()
+                for key in ("display_name", "name", "username")
+            ]
+            if not any(labels) and name_of is not None:
+                try:
+                    labels = [(await name_of(pubkey)).strip().lower()]
+                except Exception:
+                    labels = []
+            for label in filter(None, labels):
+                by_label.setdefault(label, []).append(pubkey)
+
+        for token in names:
+            # Ambiguous labels stay presentation-only rather than ping the
+            # wrong member.
+            match = by_label.get(token) or []
+            if len(match) == 1:
+                resolved.append(match[0])
+
+    self_key = (self_pubkey or "").lower()
+    return list(dict.fromkeys(p for p in resolved if p and p != self_key))
+
+
 def _resolve_cli_path(configured: str = "") -> str:
     """Resolve the buzz CLI binary path portably.
 
@@ -585,6 +665,8 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
+        for mention_pubkey in await self._resolve_mentions(str(chat_id), content):
+            args += ["--mention", mention_pubkey]
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
             args += ["--reply-to", str(reply_target)]
@@ -659,6 +741,8 @@ class BuzzAdapter(BasePlatformAdapter):
             ]
             if reply_to:
                 args += ["--reply-to", str(reply_to)]
+            for mention_pubkey in await self._resolve_mentions(str(chat_id), caption or ""):
+                args += ["--mention", mention_pubkey]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
@@ -1152,6 +1236,16 @@ class BuzzAdapter(BasePlatformAdapter):
         stripped = re.sub(pattern, "", text, count=1, flags=re.IGNORECASE)
         return stripped.strip()
 
+    async def _resolve_mentions(self, chat_id: str, content: str) -> List[str]:
+        """Channel-member pubkeys for the ``@Name`` tokens in outbound text."""
+        return await _resolve_mention_pubkeys(
+            content,
+            str(chat_id),
+            self._run_cli,
+            name_of=self._resolve_user_name,
+            self_pubkey=self._self_pubkey,
+        )
+
     async def _resolve_user_name(self, pubkey: str) -> str:
         """Resolve a pubkey to a display name (cached; falls back to npub prefix).
 
@@ -1366,6 +1460,13 @@ async def _standalone_send(
         args += ["--reply-to", str(thread_id)]
     for path in media_files or []:
         args += ["--file", str(path)]
+    async def _members_cli(cli_args):
+        return await _exec_buzz(
+            cli_path, cli_args, relay_url=relay, private_key=private_key
+        )
+
+    for pubkey in await _resolve_mention_pubkeys(message, target, _members_cli):
+        args += ["--mention", pubkey]
     try:
         code, out, err = await _exec_buzz(
             cli_path, args, relay_url=relay, private_key=private_key, input_text=message

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -422,6 +422,144 @@ class TestBuzzAdapterSend:
         assert args[args.index("--file") + 1] == str(img)
 
 
+# ── Outbound mention resolution ───────────────────────────────────────────
+
+
+HONEY_PUBKEY = "b" * 64
+FIZZ_PUBKEY = "c" * 64
+TWIN_ONE_PUBKEY = "d" * 64
+TWIN_TWO_PUBKEY = "e" * 64
+
+_MEMBER_NAMES = {
+    HONEY_PUBKEY: "Honey",
+    FIZZ_PUBKEY: "Fizz",
+    TWIN_ONE_PUBKEY: "Twin",
+    TWIN_TWO_PUBKEY: "Twin",
+    SELF_PUBKEY: "Chip",
+}
+
+
+def _members_cli(*pubkeys):
+    """Scripted CLI whose `channels members` returns the given pubkeys.
+
+    Mirrors the real relay: `channels members` yields only {pubkey, role},
+    so display names must come from the `users get` profile lookup.
+    """
+    cli = _ScriptedCli()
+    cli.script(
+        "channels",
+        "members",
+        [{"pubkey": p, "role": "member"} for p in pubkeys],
+    )
+    cli.script("messages", "send", {"accepted": True, "event_id": "evt-m", "message": ""})
+    return cli
+
+
+def _adapter_with_members(*pubkeys):
+    adapter = _make_adapter()
+    adapter._run_cli = _members_cli(*pubkeys)
+
+    async def _name_of(pubkey):
+        return _MEMBER_NAMES.get(pubkey, "")
+
+    adapter._resolve_user_name = _name_of
+    return adapter
+
+
+def _mentions_in(cli):
+    """Extract the --mention values from the recorded `messages send` call."""
+    args = next(a for a, _ in cli.calls if a[:2] == ["messages", "send"])
+    return [args[i + 1] for i, tok in enumerate(args) if tok == "--mention"]
+
+
+class TestOutboundMentionResolution:
+    """buzz-cli rejects a send whose @Name matches no channel member, so the
+    adapter resolves names to pubkeys and passes them as --mention."""
+
+    @pytest.mark.asyncio
+    async def test_display_name_resolved_to_pubkey(self):
+        adapter = _adapter_with_members(HONEY_PUBKEY, FIZZ_PUBKEY)
+        result = await adapter.send(CHANNEL, "@Honey please review the draft")
+        assert result.success is True
+        assert _mentions_in(adapter._run_cli) == [HONEY_PUBKEY]
+
+    @pytest.mark.asyncio
+    async def test_multiple_names_all_resolved(self):
+        adapter = _adapter_with_members(HONEY_PUBKEY, FIZZ_PUBKEY)
+        await adapter.send(CHANNEL, "@Honey and @Fizz please coordinate")
+        assert sorted(_mentions_in(adapter._run_cli)) == sorted([HONEY_PUBKEY, FIZZ_PUBKEY])
+
+    @pytest.mark.asyncio
+    async def test_unknown_name_sends_without_mention(self):
+        """Unresolved names stay presentation-only rather than failing the send."""
+        adapter = _adapter_with_members(HONEY_PUBKEY)
+        result = await adapter.send(CHANNEL, "@Ghost is not a member here")
+        assert result.success is True
+        assert _mentions_in(adapter._run_cli) == []
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_name_not_resolved(self):
+        """Two members sharing a display name must not notify either one."""
+        adapter = _adapter_with_members(TWIN_ONE_PUBKEY, TWIN_TWO_PUBKEY)
+        await adapter.send(CHANNEL, "@Twin which of you is it?")
+        assert _mentions_in(adapter._run_cli) == []
+
+    @pytest.mark.asyncio
+    async def test_self_mention_excluded(self):
+        adapter = _adapter_with_members(SELF_PUBKEY, HONEY_PUBKEY)
+        await adapter.send(CHANNEL, "@Chip talking to myself, and @Honey")
+        assert _mentions_in(adapter._run_cli) == [HONEY_PUBKEY]
+
+    @pytest.mark.asyncio
+    async def test_raw_hex_pubkey_passed_through(self):
+        adapter = _adapter_with_members(HONEY_PUBKEY)
+        await adapter.send(CHANNEL, f"@{FIZZ_PUBKEY} direct hex mention")
+        assert _mentions_in(adapter._run_cli) == [FIZZ_PUBKEY]
+
+    @pytest.mark.asyncio
+    async def test_npub_mention_normalized_to_hex(self):
+        """An npub in the text resolves to its hex form without a roster hit."""
+        adapter = _adapter_with_members(HONEY_PUBKEY)
+        honey_npub = hex_to_npub(HONEY_PUBKEY)
+        await adapter.send(CHANNEL, f"@{honey_npub} hello")
+        assert _mentions_in(adapter._run_cli) == [HONEY_PUBKEY]
+
+    @pytest.mark.asyncio
+    async def test_email_address_not_treated_as_mention(self):
+        adapter = _adapter_with_members(HONEY_PUBKEY)
+        await adapter.send(CHANNEL, "ping bob@example.com about it")
+        assert _mentions_in(adapter._run_cli) == []
+
+    @pytest.mark.asyncio
+    async def test_plain_text_skips_member_lookup(self):
+        """No '@' means no roster round-trip on every ordinary message."""
+        adapter = _adapter_with_members(HONEY_PUBKEY)
+        await adapter.send(CHANNEL, "no mentions at all here")
+        assert not any(a[:2] == ["channels", "members"] for a, _ in adapter._run_cli.calls)
+
+    @pytest.mark.asyncio
+    async def test_member_lookup_failure_does_not_block_send(self):
+        """A roster lookup failure degrades to an unmentioned send, never a crash."""
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("channels", "members", "", code=2, stderr="network error")
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-x", "message": ""})
+        adapter._run_cli = cli
+        result = await adapter.send(CHANNEL, "@Honey are you there?")
+        assert result.success is True
+        assert _mentions_in(cli) == []
+
+    @pytest.mark.asyncio
+    async def test_image_caption_mentions_resolved(self, tmp_path):
+        """Captions travel the same contract — an unresolved @Name fails the upload too."""
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _adapter_with_members(HONEY_PUBKEY)
+        result = await adapter.send_image(CHANNEL, str(img), caption="@Honey see this")
+        assert result.success is True
+        assert _mentions_in(adapter._run_cli) == [HONEY_PUBKEY]
+
+
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

`buzz-cli` rejects an **entire send** when `@Name` text does not match a current channel member:

```text
user_error: mention '@-mention' does not match a current channel member;
retry with --mention <pubkey> (exit 1)
```

The adapter never passed `--mention`, so any agent-authored message naming another participant failed outright — **including the plain-text fallback**, leaving the message undelivered:

```text
WARNING [Buzz] Send failed: user_error: mention '@-mention' does not match a
        current channel member; retry with --mention <pubkey> (exit 1)
        — trying plain-text fallback
ERROR   [Buzz] Fallback send also failed: user_error: mention '@-mention' does
        not match a current channel member; retry with --mention <pubkey>
```

This blocks agent-to-agent coordination in shared channels, where addressing another agent by name is the normal interaction. Hermes composed a 981-character reply naming two other agents and none of it reached the channel.

The fix resolves `@Name` tokens against the channel roster and passes the matched identities as repeated `--mention` arguments. Per the CLI contract, *"supplying any explicit identity permits unresolved or ambiguous @Name text as presentation-only"* — so partial resolution still averts a hard failure.

## Related Issue

<!-- No existing issue found for this. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/buzz/adapter.py`
  - New module-level `_resolve_mention_pubkeys()` helper: extracts `@Name` tokens, resolves them against `channels members`, returns hex pubkeys.
  - Wired into `send()`, `send_image()` captions, and `_standalone_send()` (cron delivery) — one shared helper, no duplicated logic.
  - Thin `BuzzAdapter._resolve_mentions()` wrapper supplies the adapter's cached name resolver and self-pubkey.
- `tests/gateway/test_buzz_adapter.py`
  - New `TestOutboundMentionResolution` class, 11 cases.

Behaviour details worth calling out:

| Input | Result |
|---|---|
| `@Honey` (unique member) | resolved → `--mention <pubkey>` |
| `@Twin` (two members share the label) | left unresolved — never notify the wrong member |
| `@Ghost` (not a member) | presentation-only, send succeeds |
| raw hex / `npub1…` | passed through, no roster lookup |
| own display name | dropped (no self-mention) |
| `bob@example.com` | not treated as a mention |
| text with no `@` | roster lookup skipped entirely |
| roster lookup fails | returns `[]`; send proceeds exactly as before |

`channels members` returns only `{pubkey, role}` — no display names — so labels come from the existing cached `_resolve_user_name` profile lookup (which already negative-caches misses). Inline name fields are preferred first, so this keeps working if a future CLI version starts returning them.

## How to Test

1. Two agents in one Buzz channel (e.g. `Hermes` and `Honey`).
2. From the Hermes gateway, send a message naming the other agent:
   ```python
   await adapter.send(CHANNEL_UUID, "@Honey please review the draft")
   ```
3. **Before:** fails with `mention '@-mention' does not match a current channel member`, fallback also fails, nothing delivered.
   **After:** delivered, with Honey notified.

Automated:

```text
scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py
=== Summary: 2 files, 38 tests passed, 0 failed ===
```

Verified live against a self-hosted relay (`wss://…communities.buzz.xyz`) — the exact send that previously failed now posts successfully with both mentions resolved.

**Mutation-checked:** reverting just the `send()` wiring fails 5 of the new tests, confirming they bind to the behaviour rather than passing vacuously.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.2 (Apple Silicon), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config or API change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — no platform-specific code (pure string/list handling over the existing CLI wrapper)
- [x] I've updated tool descriptions/schemas — N/A

## Notes for reviewers

- **Not a duplicate of #74467.** That PR fixes *inbound* mention gating (`_is_mentioned` waking an agent on a bare name); this fixes the *outbound* send path. They touch different functions and are complementary — happy to rebase if #74467 lands first.
- **Full-suite context:** `tests/gateway/` reports 89 failures on my machine both with and without this change (verified via `git stash`) — all in `api_server`, `discord`, and SSRF-guard tests, unrelated to this patch. Test count goes 3980 → 3991, exactly the 11 added here.
