### PR TITLE
fix(desktop): let the venv blocker scan settle before aborting

### DIFF
--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -197,6 +197,118 @@ describe('scanVenvBlockers', () => {
     assert.equal(o.kind, 'probe-failure')
   })
 
+  // -------------------------------------------------------------------------
+  // #74805: the scan runs immediately after releaseBackendLock tree-kills the
+  // desktop's backends. On Windows those PIDs linger in the process table for
+  // a few scheduler ticks, so a single probe reports a blocker that is really
+  // just a dying remnant and the update aborts on every first attempt.
+  // -------------------------------------------------------------------------
+  describe('blocked-verdict settling (#74805)', () => {
+    const noSleep = async () => {}
+
+    /** Returns each queued payload in order, repeating the last one. */
+    function execSequence(payloads: string[], calls: { n: number }): any {
+      return (async () => {
+        const json = payloads[Math.min(calls.n, payloads.length - 1)]
+        calls.n += 1
+
+        return { stdout: json, stderr: '' }
+      }) as any
+    }
+
+    it('treats a blocked-then-clear scan as clear', async () => {
+      const calls = { n: 0 }
+
+      const outcome = await scanVenvBlockers(
+        '/r',
+        execSequence([blockedJson, okJson], calls),
+        stubVenv,
+        { sleep: noSleep }
+      )
+
+      assert.equal(outcome.kind, 'clear')
+      assert.equal(calls.n, 2)
+    })
+
+    it('still reports blocked when every attempt sees a holder', async () => {
+      const calls = { n: 0 }
+
+      const outcome = await scanVenvBlockers(
+        '/r',
+        execSequence([blockedJson], calls),
+        stubVenv,
+        { sleep: noSleep }
+      )
+
+      assert.equal(outcome.kind, 'blocked')
+      assert.equal(calls.n, 3, 'should exhaust the default attempt budget')
+    })
+
+    it('does not re-probe when the first scan is already clear', async () => {
+      const calls = { n: 0 }
+
+      const outcome = await scanVenvBlockers('/r', execSequence([okJson], calls), stubVenv, {
+        sleep: noSleep
+      })
+
+      assert.equal(outcome.kind, 'clear')
+      assert.equal(calls.n, 1)
+    })
+
+    it('does not re-probe a probe-failure', async () => {
+      const calls = { n: 0 }
+
+      const failing = (async () => {
+        calls.n += 1
+        const e: any = new Error()
+        e.status = 2
+        e.stderr = Buffer.from('ModuleNotFoundError')
+        throw e
+      }) as any
+
+      const outcome = await scanVenvBlockers('/r', failing, stubVenv, { sleep: noSleep })
+
+      assert.equal(outcome.kind, 'probe-failure')
+      assert.equal(calls.n, 1, 'a broken probe cannot become informative by repeating')
+    })
+
+    it('honours an explicit attempt budget and waits between probes', async () => {
+      const calls = { n: 0 }
+      const waits: number[] = []
+
+      const outcome = await scanVenvBlockers(
+        '/r',
+        execSequence([blockedJson], calls),
+        stubVenv,
+        {
+          attempts: 2,
+          delayMs: 250,
+          sleep: async ms => {
+            waits.push(ms)
+          }
+        }
+      )
+
+      assert.equal(outcome.kind, 'blocked')
+      assert.equal(calls.n, 2)
+      assert.deepEqual(waits, [250])
+    })
+
+    it('attempts is clamped to at least one probe', async () => {
+      const calls = { n: 0 }
+
+      const outcome = await scanVenvBlockers(
+        '/r',
+        execSequence([blockedJson], calls),
+        stubVenv,
+        { attempts: 0, sleep: noSleep }
+      )
+
+      assert.equal(outcome.kind, 'blocked')
+      assert.equal(calls.n, 1)
+    })
+  })
+
   it('calls subprocess with correct args, cwd and timeout', async () => {
     const calls: any[] = []
 

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -34,6 +34,13 @@ export type ScanOutcome =
   | { kind: 'blocked'; result: VenvBlockerScanResult }
   | { kind: 'probe-failure'; error: string }
 
+/** Settling knobs for the blocked-verdict retry. Injectable for testing. */
+export interface ScanSettleOptions {
+  attempts?: number
+  delayMs?: number
+  sleep?: (ms: number) => Promise<void>
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -41,9 +48,23 @@ export type ScanOutcome =
 const SCAN_TIMEOUT_MS = 15000
 const SCAN_MODULE = 'hermes_cli._scan_venv_blockers'
 
+// The scan runs immediately after releaseBackendLock tree-kills the desktop's
+// own backends. On Windows the OS does not retire those PIDs instantly —
+// tree-killed grandchildren cascade-settle over several scheduler ticks, so
+// psutil.process_iter() keeps reporting dying entries for a short window and
+// the preflight aborts an update that was actually fine (#74805). Re-probe a
+// couple of times before believing "blocked", mirroring the poll-until-clear
+// pattern releaseBackendLock already uses for the venv shim.
+const SCAN_BLOCKED_ATTEMPTS = 3
+const SCAN_SETTLE_DELAY_MS = 500
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
 
 /**
  * Strictly validate and parse the JSON output from the venv-blocker scan.
@@ -109,12 +130,42 @@ export function parseVenvBlockerScanOutput(raw: string): ScanOutcome {
 }
 
 /**
- * Run the venv-blocker scan subprocess.  Async so the Electron main-process
- * event loop is never blocked by the psutil process scan (up to 15s on a
- * loaded Windows box).  Accepts optional overrides for testing (dependency
- * injection).
+ * Run the venv-blocker scan, re-probing a blocked verdict a few times so a
+ * process table that has not finished retiring the backends we just killed
+ * does not abort an otherwise-fine update (#74805).  Async so the Electron
+ * main-process event loop is never blocked by the psutil process scan (up to
+ * 15s per probe on a loaded Windows box).  Accepts optional overrides for
+ * testing (dependency injection).
  */
 export async function scanVenvBlockers(
+  updateRoot: string,
+  execOverride?: typeof execFileAsync,
+  resolveOverride?: typeof resolveVenvPython,
+  settleOverride?: ScanSettleOptions
+): Promise<ScanOutcome> {
+  const attempts = Math.max(1, settleOverride?.attempts ?? SCAN_BLOCKED_ATTEMPTS)
+  const delayMs = Math.max(0, settleOverride?.delayMs ?? SCAN_SETTLE_DELAY_MS)
+  const sleep = settleOverride?.sleep || defaultSleep
+
+  let outcome = await runVenvBlockerProbe(updateRoot, execOverride, resolveOverride)
+
+  // Only a 'blocked' verdict is retried. 'clear' is already the answer we
+  // want, and 'probe-failure' means the venv state is unknown — re-running a
+  // broken probe cannot turn that into knowledge, and the caller must abort
+  // either way.
+  for (let attempt = 1; attempt < attempts && outcome.kind === 'blocked'; attempt += 1) {
+    await sleep(delayMs)
+    outcome = await runVenvBlockerProbe(updateRoot, execOverride, resolveOverride)
+  }
+
+  return outcome
+}
+
+/**
+ * One probe of the venv-blocker scan subprocess.  No retry, no settling delay
+ * — callers wanting the race-tolerant behaviour should use scanVenvBlockers.
+ */
+export async function runVenvBlockerProbe(
   updateRoot: string,
   execOverride?: typeof execFileAsync,
   resolveOverride?: typeof resolveVenvPython


### PR DESCRIPTION
## What changed and why

`applyUpdates` calls `releaseBackendLockForUpdate`, which tree-kills the desktop's own backend PIDs and then polls `isShimLocked` for up to 15s. Immediately after that, on Windows, it runs `scanVenvBlockers` — **once**, with no settling window:

```ts
const lock = await releaseBackendLockForUpdate(updateRoot)   // polls 15s
...
const scanOutcome = await scanVenvBlockers(updateRoot)       // single probe
```

Windows does not retire tree-killed PIDs instantly; grandchildren cascade-settle over several scheduler ticks, so `psutil.process_iter()` still reports the dying backends the updater just killed. The single probe catches those remnants, returns `blocked`, and the update aborts with "another Hermes process is using this installation" — on the first attempt from a healthy install. A manual retry succeeds because the table has settled by then.

This makes `scanVenvBlockers` re-probe a `blocked` verdict (3 attempts, 500ms apart) before believing it, mirroring the poll-until-clear pattern `releaseBackendLock` already uses one call earlier.

`clear` is never re-probed, and `probe-failure` is never re-probed either — a broken probe cannot become informative by repeating, and the caller aborts on that outcome regardless.

`main.ts` is unchanged: it calls `scanVenvBlockers(updateRoot)` and picks up the retry through the defaults.

Refs #74805

## Scope — this fixes root cause 1 only

The issue reports two root causes. I fixed the first and deliberately left the second alone:

**Root cause 1 (fixed)** — the scan/process-table race. This is a verifiable property of the code: one probe, no settle, directly adjacent to a function that polls for 15s.

**Root cause 2 (not fixed)** — no auto-relaunch after a retried update. The issue offers three competing hypotheses for this ("this can happen if…: renderer takes a different code path / stale marker not overwritten / updater state machine sees a pre-existing marker"). It lives in the Tauri updater's Windows relaunch path, which I cannot observe, instrument, or test from Linux. Picking one of three guesses and shipping it as a fix would be worse than leaving it clearly open. It needs someone who can run the Windows updater with logging.

Because of that, this is `Refs #74805` rather than `Fixes` — the issue should stay open for the relaunch half.

## How it was tested

Six unit tests added to `apps/desktop/electron/venv-blocker-scan.test.ts`, using the dependency-injection hooks the module already exposes:

| Test | Asserts |
|---|---|
| blocked → clear | returns `clear`, 2 probes — the actual race |
| blocked every time | returns `blocked`, exhausts the 3-attempt budget |
| clear first | 1 probe, no retry |
| probe-failure | 1 probe, not retried |
| explicit budget | honours `attempts: 2`, waits `[250]` |
| `attempts: 0` | clamped to 1 probe |

A `sleep` injection point keeps the tests instant rather than sleeping 1s.

Result — whole file, 20 pre-existing tests plus the 6 new ones:

```
26/26 tests passed, 0 failed
```

With `venv-blocker-scan.ts` reverted, 3 of the 6 new tests fail (the three that assert re-probing); the other 3 assert a *single* probe and correctly hold either way, since the old code also probed once:

```
FAIL - treats a blocked-then-clear scan as clear
FAIL - still reports blocked when every attempt sees a holder
FAIL - honours an explicit attempt budget and waits between probes
23/26 tests passed, 3 failed
```

I also checked the un-injected default path end to end: three probes with the real `setTimeout` sleep took 1009ms, confirming the 3×500ms defaults behave as intended.

Both under the project's own runner, `vitest run --project electron`:

```
electron/venv-blocker-scan.test.ts   Tests  26 passed (26)

full electron project              Test Files  74 passed | 1 skipped (75)
                                        Tests  873 passed | 2 skipped (875)
```

No regressions anywhere in the electron project.

**What I could not test at all:** I have no Windows machine, so I did **not** reproduce the underlying OS race, and I did not exercise the real `_scan_venv_blockers.py` against a settling process table. The retry logic is verified by injection; the premise that Windows lags in retiring tree-killed PIDs is taken from the issue report and from the fact that `releaseBackendLock` already compensates for the same effect on the shim lock. If a maintainer on Windows can confirm the first-attempt failure disappears, that would close the loop.

## Timing impact

On the **genuinely** blocked path the preflight now takes longer before showing the error: worst case 3 probes plus 1s of sleeps. `SCAN_TIMEOUT_MS` is a 15s ceiling rather than a typical duration — a normal `psutil` sweep returns well under a second, so the realistic blocked path goes from roughly 0.5s to roughly 2.5s. Worst case is bounded at ~46s, comfortably inside `UPDATE_WAIT_TIMEOUT_MS` (20 min). The `clear` path is unchanged at one probe.

If you'd rather trade less latency for less race tolerance, `SCAN_BLOCKED_ATTEMPTS` / `SCAN_SETTLE_DELAY_MS` are the two knobs.

## Open questions

1. **Is 3×500ms the right window?** I picked it to be small and obviously safe. The issue suggests "2-3 attempts, ~500ms apart". If Windows handle release routinely takes longer, this should grow — a deadline-based loop like `releaseBackendLock`'s 15s budget may fit better than a fixed attempt count.
2. **Should the blocked path skip `startHermes()`?** The issue's suggestion 2 proposes not restarting the backend when the blockers are the same PIDs we just killed, so a retry starts clean. That is a behaviour change to the error path and I left it out of this PR, but it would compose well with this change — happy to add it if you want it here rather than separately.
3. Suggestions 3 and 4 from the issue (stale marker clearing, `spawnUpdaterProcess` orphaning) both belong to root cause 2 and are untouched.

## Related

Adjacent but distinct: #74267 (persistent false positive, survives reboot — this is the transient variant), #63717, #44143, #62311. Open PR #74419 touches Windows update gateway coordination for #74386; no overlap with this file.
