### PR TITLE
fix(desktop): fuse the status stack to the composer again

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -226,7 +226,7 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
       // In flow in the dock column, directly above the composer. The dock is
       // bottom-anchored, so this grows upward over the thread without needing
       // to be positioned — and it shares the dock's left edge for free.
-      className="flex max-h-[40vh] min-h-0 flex-col overflow-y-auto pb-2"
+      className="flex max-h-[40vh] min-h-0 flex-col overflow-y-auto"
       onPointerDownCapture={() => blurComposerInput()}
     >
       {/* The card paints the shared --composer-fill (rest / scrolled / focused


### PR DESCRIPTION
## Summary
- Drop leftover `pb-2` on the composer status-stack wrapper so the card sits flush on the composer seam again.
- That padding was opening an empty gap (most obvious with background tasks) and fighting the fused-capsule layout (`rounded-b-none` + transparent bottom border).

## Test plan
- [ ] Open a session with a running background process above the composer — no 8px gap between the status card and the input surface
- [ ] Queue-only and todo/subagent stacks still sit flush and look fused
- [ ] Tall status content still scrolls inside `max-h-[40vh]` without clipping into the composer