### PR TITLE
fix(relay): catch ModuleNotFoundError in _load_nemo_relay

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -988,7 +988,11 @@ def current_profile_key() -> str:
 
 def _load_nemo_relay() -> Any:
     """Load the binding only when a producer or consumer needs Relay."""
-    return importlib.import_module("nemo_relay")
+    try:
+        return importlib.import_module("nemo_relay")
+    except ModuleNotFoundError:
+        logger.debug("nemo_relay not installed — relay features unavailable")
+        return None
 
 
 def _session_id(event: dict[str, Any]) -> str:


### PR DESCRIPTION
## What does this PR do?

`_load_nemo_relay()` does a bare `importlib.import_module("nemo_relay")` with no
error handling. When the package is absent, this raises `ModuleNotFoundError`
and logs a full WARNING traceback on startup — noise for every platform without
the wheel. The caller chain (`for_profile()` → `RelayRuntime.__init__`) already
catches exceptions and degrades to `NoopRelayRuntime`, so the runtime handles
absence correctly; this PR just silences the noise at the import site.

Wrap the import in try/except and return `None` when the module is not found.

## How this differs from #74607 / #74608

Both #74607 and #74608 fix the **packaging** side — returning `nemo-relay` to
`[project.optional-dependencies]` so it no longer blocks musl/Alpine at install
time. That is the right fix for the install-blocker.

This PR fixes the **import site** — a defense-in-depth change that makes the
runtime import safe regardless of packaging decisions. Even after #74607 lands,
if `nemo-relay` is absent (manual install, platform without wheel, broken venv),
the import should not log a full traceback. The runtime has a documented
`NoopRelayRuntime` degradation path; this PR lets the import reach it cleanly.

The two fixes are complementary, not competing. Both can land.

## Related Issue

Context: #74592 (nemo-relay base dependency blocks musl installs).

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `agent/relay_runtime.py` — catch `ModuleNotFoundError` in `_load_nemo_relay()`,
  log at DEBUG level, return `None`

## How to Test

1. On any platform without `nemo_relay` installed, start Hermes
2. Before: WARNING traceback with full stack at startup
3. After: no warning; Relay degrades silently to `NoopRelayRuntime`

```bash
python3 -c "from agent.relay_runtime import _load_nemo_relay; assert _load_nemo_relay() is None"
```

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — none address the import site
- [x] My PR contains only changes related to this fix
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have tested on my platform: Linux (WSL2, Ubuntu 24.04, Python 3.12.3)

### Documentation & Housekeeping

- [x] Documentation: N/A
- [x] cli-config.yaml.example: N/A
- [x] CONTRIBUTING.md / AGENTS.md: N/A
- [x] Cross-platform: N/A (exception handler is platform-independent)
- [x] Tool descriptions/schemas: N/A