### PR TITLE
fix(config): validate fallback_providers entries, not just fallback_model

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2001,6 +2001,58 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                     "Add: model: anthropic/claude-sonnet-4 (or another model)",
                 ))
 
+    # ── fallback_providers: dict OR list of dicts (the modern chain) ──────
+    # ``fallback_model`` above is the legacy key; ``fallback_providers`` is the
+    # primary source of truth (see ``hermes_cli.fallback_config``) and had no
+    # validation at all. Both keys flow through ``_iter_fallback_entries``,
+    # which drops any entry that is not a dict or is missing provider/model —
+    # with no log line. So a chain whose entries are misspelled or half-filled
+    # produced an *empty* chain, failover never engaged, and the only symptom
+    # was a terminal error with no mention of fallback. The legacy key warned
+    # about exactly this; the key everyone actually uses did not.
+    #
+    # A ``str`` value is deliberately not flagged here: JSON-encoded chains
+    # written by older ``hermes config set`` are a separate bug with its own
+    # fix in flight (#51560).
+    fbp = config.get("fallback_providers")
+    if isinstance(fbp, (dict, list)):
+        # A bare dict is a valid single-entry chain (_iter_fallback_entries
+        # wraps it), so normalize before checking entries.
+        fbp_entries = [fbp] if isinstance(fbp, dict) else fbp
+        for i, entry in enumerate(fbp_entries):
+            label = "fallback_providers" if isinstance(fbp, dict) else f"fallback_providers[{i}]"
+            if not isinstance(entry, dict):
+                issues.append(ConfigIssue(
+                    "error",
+                    f"{label} should be a dict, got {type(entry).__name__}",
+                    "Each entry needs provider + model:\n"
+                    "  fallback_providers:\n"
+                    "    - provider: openrouter\n"
+                    "      model: anthropic/claude-sonnet-4",
+                ))
+                continue
+            if not entry.get("provider"):
+                issues.append(ConfigIssue(
+                    "warning",
+                    f"{label} is missing 'provider' field — this entry is dropped from the fallback chain",
+                    "Add: provider: openrouter (or another provider)",
+                ))
+            if not entry.get("model"):
+                issues.append(ConfigIssue(
+                    "warning",
+                    f"{label} is missing 'model' field — this entry is dropped from the fallback chain",
+                    "Add: model: <model-name>",
+                ))
+    elif fbp is not None and not isinstance(fbp, str):
+        issues.append(ConfigIssue(
+            "error",
+            f"fallback_providers should be a list of provider entries, got {type(fbp).__name__}",
+            "Change to:\n"
+            "  fallback_providers:\n"
+            "    - provider: openrouter\n"
+            "      model: anthropic/claude-sonnet-4",
+        ))
+
     # ── Check for fallback_model accidentally nested inside custom_providers ──
     if isinstance(cp, dict) and "fallback_model" not in config and "fallback_model" in (cp or {}):
         issues.append(ConfigIssue(

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -120,3 +120,75 @@ class TestUnknownTopLevelKeys:
         assert any("base_url" in i.message for i in misplaced)
         assert any("api_key" in i.message for i in misplaced)
 
+
+class TestFallbackProvidersValidation:
+    """fallback_providers entries must be checked like fallback_model entries.
+
+    Both keys are read through ``_iter_fallback_entries``, which drops any
+    entry that is not a dict or is missing provider/model without logging.
+    The legacy ``fallback_model`` key warned about that; the primary
+    ``fallback_providers`` key did not, so a half-filled chain silently
+    became an empty chain and failover never ran.
+    """
+
+    def _messages(self, config, severity=None):
+        issues = validate_config_structure(config)
+        return [i.message for i in issues if severity is None or i.severity == severity]
+
+    def test_entry_missing_provider_warns(self):
+        msgs = self._messages({"fallback_providers": [{"model": "some/model"}]}, "warning")
+        assert any("fallback_providers[0]" in m and "provider" in m for m in msgs)
+
+    def test_entry_missing_model_warns(self):
+        msgs = self._messages({"fallback_providers": [{"provider": "openrouter"}]}, "warning")
+        assert any("fallback_providers[0]" in m and "model" in m for m in msgs)
+
+    def test_second_entry_is_indexed(self):
+        """The index must point at the offending entry, not the first one."""
+        msgs = self._messages({
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+                {"provider": "kimi-coding"},
+            ],
+        }, "warning")
+        assert any("fallback_providers[1]" in m and "model" in m for m in msgs)
+        assert not any("fallback_providers[0]" in m for m in msgs)
+
+    def test_non_dict_entry_errors(self):
+        msgs = self._messages({"fallback_providers": ["openrouter/some-model"]}, "error")
+        assert any("fallback_providers[0]" in m and "dict" in m for m in msgs)
+
+    def test_bare_dict_is_a_valid_single_entry_chain(self):
+        """_iter_fallback_entries wraps a dict, so a complete dict must not warn."""
+        assert self._messages(
+            {"fallback_providers": {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}}
+        ) == []
+
+    def test_bare_dict_missing_model_warns_without_an_index(self):
+        msgs = self._messages(
+            {"fallback_providers": {"provider": "openrouter"}}, "warning")
+        assert any("fallback_providers is missing 'model'" in m for m in msgs)
+
+    def test_complete_chain_is_silent(self):
+        assert self._messages({
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+                {"provider": "deepseek", "model": "deepseek-chat"},
+            ],
+        }) == []
+
+    def test_empty_and_absent_chains_are_silent(self):
+        """DEFAULT_CONFIG ships fallback_providers: [] — it must never warn."""
+        assert self._messages({"fallback_providers": []}) == []
+        assert self._messages({}) == []
+
+    def test_string_chain_is_left_to_the_json_string_fix(self):
+        """A JSON-encoded chain is a separate bug (#51560); do not double-report it."""
+        assert self._messages(
+            {"fallback_providers": '[{"provider": "openrouter", "model": "x"}]'}
+        ) == []
+
+    def test_wrong_scalar_type_errors(self):
+        msgs = self._messages({"fallback_providers": 42}, "error")
+        assert any("fallback_providers should be a list" in m for m in msgs)
+


### PR DESCRIPTION
## What does this PR do?

`validate_config_structure()` validates every `fallback_model` entry for a missing `provider`/`model`, but never looks at **`fallback_providers`** — the key `hermes_cli/fallback_config` documents as *"the primary source of truth"*.

Both keys are read through `_iter_fallback_entries()`, which drops any entry that is not a dict or is missing `provider`/`model`:

```python
for entry in candidates:
    if not isinstance(entry, dict):
        continue
    provider = str(entry.get("provider") or "").strip()
    model = str(entry.get("model") or "").strip()
    if not provider or not model:
        continue
```

Those `continue`s carry no log line. So a half-filled or misspelled chain collapses to an **empty** chain, failover never engages, and the only symptom is a terminal provider error that never mentions fallback. The legacy key warns about exactly this misconfiguration; the key users actually write does not.

Concretely, this config produces zero diagnostics today and silently has no failover:

```yaml
fallback_providers:
  - provider: openrouter
    model: anthropic/claude-sonnet-4
  - provider: kimi-coding      # 'model' forgotten → entry dropped, no warning
```

## Related Issue

No existing issue covers this. The two closest are both distinct and left untouched here:

- #51560 — `fallback_providers` as a JSON **string** silently empties the chain (fix in flight, #67376). This PR deliberately does **not** flag `str`, so it neither duplicates nor conflicts with that work.
- #45309 / #45316 — `fallback_providers` nested under `model:` is ignored. That PR adds a "move it to the top level" warning for the *nested* case; this one validates the *entries* of a top-level chain. Adjacent, not overlapping — though both touch this function, so whichever lands second may need a trivial rebase.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — new `fallback_providers` block in `validate_config_structure()`, mirroring the existing `fallback_model` one:
  - per-entry **warning** for a missing `provider` or `model`, worded as what actually happens ("this entry is dropped from the fallback chain")
  - **error** for a non-dict list entry, and for a wrong scalar type (e.g. `42`)
  - a bare dict is accepted as a valid single-entry chain, because `_iter_fallback_entries` wraps it — its message carries no `[i]` index
  - `str` is left alone (see #51560 above)
  - empty and absent chains stay silent, so the `fallback_providers: []` in `DEFAULT_CONFIG` never warns
- `tests/hermes_cli/test_config_validation.py` — new `TestFallbackProvidersValidation` (10 tests)

No new config keys, so `cli-config.yaml.example` needs no change.

## How to Test

1. Reproduce the silence on `main` — a chain entry missing `model` yields no issues:
   ```bash
   python3 -c "
   from hermes_cli.config import validate_config_structure
   print(validate_config_structure({'fallback_providers': [{'provider': 'kimi-coding'}]}))
   "
   # main:      []
   # this PR:   [ConfigIssue(severity='warning', message=\"fallback_providers[0] is missing 'model' field — this entry is dropped from the fallback chain\", ...)]
   ```
2. Run the tests:
   ```bash
   pytest tests/hermes_cli/test_config_validation.py -q     # 18 passed (8 existing + 10 new)
   ```
3. Confirm the new tests actually catch the bug — with `hermes_cli/config.py` reverted, 6 of the 10 fail. The other 4 are "must stay silent" guards (empty chain, absent chain, complete chain, `str` chain) and pass either way by design.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see Related Issue)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.12.3

> **Note on the full suite.** I could not get a clean full-suite baseline in my environment: `pytest tests/hermes_cli -q` aborts with 44 collection errors (`TypeError: Router.__init__()` in the `test_web_server_*` modules), and `tests/cli/test_cli_init.py` has 22 failures. Both reproduce **identically on unmodified `main`**, so they are environmental/pre-existing, not from this change. Baseline vs. this branch on the config/fallback/doctor/cli-init subset: **22 failed, 72 passed → 22 failed, 82 passed** — same failures, +10 new passes.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments in the new block) — or N/A
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] N/A — pure-Python validation, no platform-specific behavior
- [x] N/A — no tool behavior changed

## Screenshots / Logs

```
$ pytest tests/hermes_cli/test_config_validation.py -q
..................                                                       [100%]
18 passed in 1.16s

$ git stash push hermes_cli/config.py && pytest tests/hermes_cli/test_config_validation.py -q
FAILED ...::TestFallbackProvidersValidation::test_entry_missing_provider_warns
FAILED ...::TestFallbackProvidersValidation::test_entry_missing_model_warns
FAILED ...::TestFallbackProvidersValidation::test_second_entry_is_indexed
FAILED ...::TestFallbackProvidersValidation::test_non_dict_entry_errors
FAILED ...::TestFallbackProvidersValidation::test_bare_dict_missing_model_warns_without_an_index
FAILED ...::TestFallbackProvidersValidation::test_wrong_scalar_type_errors
6 failed, 12 passed in 0.93s
```