### PR TITLE
feat(update): CLI release track infrastructure

### DIFF
--- a/contributors/emails/hustshawn@gmail.com
+++ b/contributors/emails/hustshawn@gmail.com
@@ -1,0 +1,2 @@
+hustshawn
+# PR #74837 salvage

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -273,20 +273,36 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     return None
 
 
+def _load_update_check_settings() -> tuple[str, dict]:
+    """Return the configured update-check mode and stable-tag settings."""
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.stable_update import stable_update_config, stable_updates_enabled
+
+        config = load_config()
+        if stable_updates_enabled(config):
+            return "stable-tags", stable_update_config(config)
+    except Exception:
+        pass
+    return "branch", {}
+
+
 def check_for_updates() -> Optional[int]:
     """Check whether a Hermes update is available.
 
-    Two paths: if ``HERMES_REVISION`` is set (nix builds embed it), compare
-    it to upstream main via ``git ls-remote``. Otherwise look for a local
-    git checkout and count commits behind ``origin/main``.
+    By default this compares the current checkout against ``origin/main``.
+    Stable-tag mode instead compares it with the newest configured release tag.
 
     Returns the number of commits behind, ``UPDATE_AVAILABLE_NO_COUNT`` (-1)
     if behind but the count is unknown, ``0`` if up-to-date, or ``None`` if
     the check failed or doesn't apply. Cached for 6 hours.
     """
+    global _update_context
+
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    mode, update_settings = _load_update_check_settings()
 
     # Docker images have no working tree to count commits against — the
     # published image excludes `.git` (see .dockerignore) and sets no
@@ -302,43 +318,77 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         pass
 
-    # Read cache — invalidate if the embedded rev OR installed version has
-    # changed since the last check.
+    # Read cache — invalidate if the embedded rev, installed version, or update
+    # mode changed since the last check.
     now = time.time()
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text(encoding="utf-8"))
+            cache_mode_matches = cached.get("mode") in {None, mode}
+            if mode == "stable-tags":
+                stable_cfg = cached.get("stable", {}) if isinstance(cached, dict) else {}
+                cache_mode_matches = cache_mode_matches and (
+                    stable_cfg.get("pattern") == update_settings.get("pattern")
+                    and stable_cfg.get("remote") == update_settings.get("remote")
+                )
             if (
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
                 and cached.get("ver") == VERSION
+                and cache_mode_matches
             ):
+                _update_context = cached.get("context", {}) or {}
                 return cached.get("behind")
     except Exception:
         pass
 
-    if embedded_rev:
+    context: dict = {"mode": mode}
+    if embedded_rev and mode != "stable-tags":
         behind = _check_via_rev(embedded_rev)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
+        repo_dir = _resolve_repo_dir()
+        if repo_dir is None:
             # No git checkout and no embedded revision — can't determine
             # update status. This is the Docker path (already short-circuited
             # above) or an unsupported install without a source tree.
             behind = None
+        elif mode == "stable-tags":
+            try:
+                from hermes_cli.stable_update import stable_update_status
+
+                status = stable_update_status(
+                    repo_dir,
+                    pattern=update_settings.get("pattern") or "v20*",
+                    remote=update_settings.get("remote") or "origin",
+                    fetch=True,
+                )
+                if update_settings.get("command"):
+                    status["update_command"] = update_settings["command"]
+                context = status
+                behind = None if status.get("error") else (
+                    0 if status.get("up_to_date") else UPDATE_AVAILABLE_NO_COUNT
+                )
+            except Exception:
+                behind = None
         else:
             behind = _check_via_local_git(repo_dir)
 
+    _update_context = context
     try:
-        cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
-            encoding="utf-8",
-        )
+        cache_payload = {
+            "ts": now,
+            "behind": behind,
+            "rev": embedded_rev,
+            "ver": VERSION,
+            "mode": mode,
+            "context": context,
+        }
+        if mode == "stable-tags":
+            cache_payload["stable"] = {
+                "pattern": update_settings.get("pattern"),
+                "remote": update_settings.get("remote"),
+            }
+        cache_file.write_text(json.dumps(cache_payload), encoding="utf-8")
     except Exception:
         pass
 
@@ -404,6 +454,29 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
             pass
         return None
 
+    mode, update_settings = _load_update_check_settings()
+    if mode == "stable-tags":
+        try:
+            from hermes_cli.stable_update import stable_update_status
+
+            status = stable_update_status(
+                repo_dir,
+                pattern=update_settings.get("pattern") or "v20*",
+                remote=update_settings.get("remote") or "origin",
+                fetch=False,
+            )
+            local = _git_short_hash(repo_dir, "HEAD")
+            if not status.get("error") and local:
+                return {
+                    "mode": "stable-tags",
+                    "stable_tag": status.get("latest_tag"),
+                    "current_tag": status.get("current_tag"),
+                    "local": local,
+                    "up_to_date": status.get("up_to_date"),
+                }
+        except Exception:
+            pass
+
     upstream = _git_short_hash(repo_dir, "origin/main")
     local = _git_short_hash(repo_dir, "HEAD")
     if not upstream or not local:
@@ -434,7 +507,7 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
     except Exception:
         ahead = 0
 
-    return {"upstream": upstream, "local": local, "ahead": max(ahead, 0)}
+    return {"mode": "branch", "upstream": upstream, "local": local, "ahead": max(ahead, 0)}
 
 
 _RELEASE_URL_BASE = "https://github.com/NousResearch/hermes-agent/releases/tag"
@@ -492,6 +565,18 @@ def format_banner_version_label() -> str:
     if not state:
         return base
 
+    if state.get("mode") == "stable-tags":
+        stable_tag = state.get("stable_tag")
+        current_tag = state.get("current_tag")
+        local = state.get("local")
+        if stable_tag and current_tag == stable_tag:
+            return f"{base} · stable {stable_tag}"
+        if stable_tag and current_tag:
+            return f"{base} · stable {stable_tag} · local {current_tag}"
+        if stable_tag and local:
+            return f"{base} · stable {stable_tag} · local {local}"
+        return base
+
     upstream = state["upstream"]
     local = state["local"]
     ahead = int(state.get("ahead") or 0)
@@ -508,7 +593,13 @@ def format_banner_version_label() -> str:
 # =========================================================================
 
 _update_result: Optional[int] = None
+_update_context: dict = {}
 _update_check_done = threading.Event()
+
+
+def get_update_context() -> dict:
+    """Return metadata from the most recent update check."""
+    return dict(_update_context or {})
 
 
 def prefetch_update_check():
@@ -852,7 +943,22 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
         behind = get_update_result(timeout=0.5)
         if behind is not None and behind != 0:
             from hermes_cli.config import get_managed_update_command, recommended_update_command
-            if behind > 0:
+            update_context = get_update_context()
+            if update_context.get("mode") == "stable-tags":
+                target_tag = update_context.get("target_tag") or update_context.get("latest_tag")
+                current_tag = update_context.get("current_tag")
+                line = "[bold yellow]⚠ stable release available[/]"
+                if target_tag:
+                    line = f"[bold yellow]⚠ stable release {target_tag} available[/]"
+                if current_tag and target_tag and current_tag != target_tag:
+                    line += f"[dim yellow], current {current_tag}[/]"
+                stable_cmd = update_context.get("update_command")
+                if stable_cmd:
+                    line += f"[dim yellow], run [bold]{stable_cmd}[/bold][/]"
+                else:
+                    line += "[dim yellow], run your stable-tag update workflow[/]"
+                right_lines.append(line)
+            elif behind > 0:
                 commits_word = "commit" if behind == 1 else "commits"
                 right_lines.append(
                     f"[bold yellow]⚠ {behind} {commits_word} behind[/]"

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -277,10 +277,18 @@ def _load_update_check_settings() -> tuple[str, dict]:
     """Return the configured update-check mode and stable-tag settings."""
     try:
         from hermes_cli.config import load_config
-        from hermes_cli.stable_update import stable_update_config, stable_updates_enabled
+        from hermes_cli.stable_update import (
+            STABLE_TAG_STRATEGIES,
+            configured_update_channel,
+            stable_update_config,
+        )
 
         config = load_config()
-        if stable_updates_enabled(config):
+        if configured_update_channel(config) == "release":
+            return "release", {}
+        updates = config.get("updates", {}) if isinstance(config, dict) else {}
+        legacy_strategy = str(updates.get("check_strategy") or "").strip().lower()
+        if bool(updates.get("stable_tags")) or legacy_strategy in STABLE_TAG_STRATEGIES:
             return "stable-tags", stable_update_config(config)
     except Exception:
         pass
@@ -291,7 +299,8 @@ def check_for_updates() -> Optional[int]:
     """Check whether a Hermes update is available.
 
     By default this compares the current checkout against ``origin/main``.
-    Stable-tag mode instead compares it with the newest configured release tag.
+    Release mode compares it with official Nous GitHub release tags. The legacy
+    stable-tag mode retains explicitly configured custom remotes and patterns.
 
     Returns the number of commits behind, ``UPDATE_AVAILABLE_NO_COUNT`` (-1)
     if behind but the count is unknown, ``0`` if up-to-date, or ``None`` if
@@ -324,7 +333,12 @@ def check_for_updates() -> Optional[int]:
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text(encoding="utf-8"))
-            cache_mode_matches = cached.get("mode") in {None, mode}
+            cached_mode = cached.get("mode")
+            # Mode-less caches predate update tracks and contain branch commit
+            # counts. They remain valid for branch users only; reusing one in
+            # Release Track would restore branch terminology and skip the
+            # official release lookup for up to six hours.
+            cache_mode_matches = cached_mode == mode or (cached_mode is None and mode == "branch")
             if mode == "stable-tags":
                 stable_cfg = cached.get("stable", {}) if isinstance(cached, dict) else {}
                 cache_mode_matches = cache_mode_matches and (
@@ -343,7 +357,7 @@ def check_for_updates() -> Optional[int]:
         pass
 
     context: dict = {"mode": mode}
-    if embedded_rev and mode != "stable-tags":
+    if embedded_rev and mode not in {"release", "stable-tags"}:
         behind = _check_via_rev(embedded_rev)
     else:
         repo_dir = _resolve_repo_dir()
@@ -352,6 +366,17 @@ def check_for_updates() -> Optional[int]:
             # update status. This is the Docker path (already short-circuited
             # above) or an unsupported install without a source tree.
             behind = None
+        elif mode == "release":
+            try:
+                from hermes_cli.stable_update import official_release_status
+
+                status = official_release_status(repo_dir)
+                context = status
+                behind = None if status.get("error") else (
+                    0 if status.get("up_to_date") else UPDATE_AVAILABLE_NO_COUNT
+                )
+            except Exception:
+                behind = None
         elif mode == "stable-tags":
             try:
                 from hermes_cli.stable_update import stable_update_status
@@ -455,6 +480,19 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
         return None
 
     mode, update_settings = _load_update_check_settings()
+    if mode == "release":
+        local = _git_short_hash(repo_dir, "HEAD")
+        context = get_update_context()
+        if context.get("mode") != "official-releases":
+            context = {}
+        return {
+            "mode": "release",
+            "latest_tag": context.get("latest_tag"),
+            "current_tag": context.get("current_release_tag"),
+            "local": local,
+            "up_to_date": context.get("up_to_date"),
+            "error": context.get("error"),
+        }
     if mode == "stable-tags":
         try:
             from hermes_cli.stable_update import stable_update_status
@@ -577,6 +615,16 @@ def format_banner_version_label() -> str:
             return f"{base} · stable {stable_tag} · local {local}"
         return base
 
+    if state.get("mode") == "release":
+        latest_tag = state.get("latest_tag")
+        current_tag = state.get("current_tag")
+        local = state.get("local")
+        if latest_tag and current_tag == latest_tag:
+            return f"{base} · Release Track {latest_tag}"
+        if latest_tag and local:
+            return f"{base} · Release Track {latest_tag} · local {local}"
+        return f"{base} · Release Track"
+
     upstream = state["upstream"]
     local = state["local"]
     ahead = int(state.get("ahead") or 0)
@@ -600,6 +648,16 @@ _update_check_done = threading.Event()
 def get_update_context() -> dict:
     """Return metadata from the most recent update check."""
     return dict(_update_context or {})
+
+
+def _format_official_release_notice(update_context: dict, update_command: str) -> str:
+    """Render official-release status without branch or commit terminology."""
+    target_tag = update_context.get("target_tag") or update_context.get("latest_tag")
+    line = "[bold yellow]⚠ Release Track update available[/]"
+    if target_tag:
+        line = f"[bold yellow]⚠ Release Track update {target_tag} available[/]"
+        line += f"[dim yellow] — run [bold]{update_command} --release {target_tag}[/bold] to update[/]"
+    return line
 
 
 def prefetch_update_check():
@@ -944,7 +1002,9 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
         if behind is not None and behind != 0:
             from hermes_cli.config import get_managed_update_command, recommended_update_command
             update_context = get_update_context()
-            if update_context.get("mode") == "stable-tags":
+            if update_context.get("mode") == "official-releases":
+                right_lines.append(_format_official_release_notice(update_context, recommended_update_command()))
+            elif update_context.get("mode") == "stable-tags":
                 target_tag = update_context.get("target_tag") or update_context.get("latest_tag")
                 current_tag = update_context.get("current_tag")
                 line = "[bold yellow]⚠ stable release available[/]"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2632,6 +2632,10 @@ DEFAULT_CONFIG = {
 
     # ``hermes update`` behaviour.
     "updates": {
+        # Update track shared by CLI, dashboard, and desktop. ``main`` preserves
+        # the historical fast-moving behavior for existing installations;
+        # consumer desktop installs seed ``release`` on their first launch.
+        "channel": "main",
         # Pre-update safety backup — ONE consolidated mechanism, three modes:
         #
         #   quick (default) — snapshot critical small state files (pairing

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4992,6 +4992,7 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _add_upstream_remote,
     _atomic_replace_dir,
     _capture_head_sha,
+    _cmd_update_check_release,
     _cmd_update_check,
     _cmd_update_impl,
     _cold_start_windows_gateway_after_update,
@@ -5029,6 +5030,10 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _refresh_active_lazy_features,
     _refresh_active_memory_provider_dependencies,
     _refresh_windows_gateway_launchers,
+    _configured_release_request,
+    _head_is_at_or_after,
+    _latest_release_tag,
+    _resolve_release_request,
     _reload_updated_runtime_modules,
     _resolve_pre_update_backup_mode,
     _resolve_stash_selector,
@@ -5054,10 +5059,12 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _write_marker_file,
     _write_update_incomplete_marker,
     _write_update_planned_stop_marker,
+    _tag_exists,
     _UPDATE_RUNTIME_RELOAD_MODULES,
     _UPDATE_CRITICAL_FILES,
     OFFICIAL_REPO_URLS,
     OFFICIAL_REPO_URL,
+    RELEASE_LATEST,
     SKIP_UPSTREAM_PROMPT_FILE,
     _PRE_UPDATE_SNAPSHOT_KEEP,
     _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
@@ -8973,6 +8980,12 @@ def cmd_update(args):
         managed_error("update Hermes Agent")
         return
 
+    # Release pins and branch tips are contradictory one-shot targets.
+    if getattr(args, "release", None) is not None and getattr(args, "branch", None):
+        print("✗ --release and --branch are mutually exclusive.")
+        print("  Use --release to pin a tagged version, or --branch to track a branch tip.")
+        sys.exit(1)
+
     # Docker users can't ``git pull`` — the image excludes ``.git`` from
     # the build context.  Bail with a friendly explanation pointing at
     # ``docker pull`` BEFORE any of the apply-path / check-path branches
@@ -8989,6 +9002,10 @@ def cmd_update(args):
         sys.exit(1)
 
     if getattr(args, "check", False):
+        release_request = _configured_release_request(args)
+        if release_request is not None:
+            _cmd_update_check_release(release_request)
+            return
         # --check honors --branch so the "any new commits?" answer matches
         # what a subsequent `hermes update --branch=<x>` would actually pull.
         branch = _resolve_update_branch(args)

--- a/hermes_cli/stable_update.py
+++ b/hermes_cli/stable_update.py
@@ -1,0 +1,164 @@
+"""Stable-tag update helpers for Hermes source checkouts.
+
+This module intentionally does *not* mutate the checkout.  It only fetches
+remote tags and resolves refs so the CLI banner/update-check path can report
+stable release availability without comparing against origin/main commit
+counts.  Operational switching/downgrading is handled by the workspace overlay
+script on installations that opt into the stable-tag channel.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any, Optional
+
+DEFAULT_STABLE_TAG_PATTERN = "v20*"
+DEFAULT_STABLE_TAG_REMOTE = "origin"
+STABLE_TAG_STRATEGIES = {"stable-tags", "stable_tags", "stable-tag", "tags"}
+
+
+def stable_updates_enabled(config: dict[str, Any] | None) -> bool:
+    """Return whether config opts update checks into stable git tags."""
+    updates = config.get("updates", {}) if isinstance(config, dict) else {}
+    if not isinstance(updates, dict):
+        return False
+    strategy = str(
+        updates.get("check_strategy")
+        or updates.get("strategy")
+        or updates.get("channel")
+        or ""
+    ).strip().lower()
+    return bool(updates.get("stable_tags")) or strategy in STABLE_TAG_STRATEGIES
+
+
+def stable_update_config(config: dict[str, Any] | None) -> dict[str, str]:
+    """Extract stable-tag update settings with safe defaults."""
+    updates = config.get("updates", {}) if isinstance(config, dict) else {}
+    if not isinstance(updates, dict):
+        updates = {}
+    return {
+        "pattern": str(updates.get("stable_tag_pattern") or DEFAULT_STABLE_TAG_PATTERN),
+        "remote": str(updates.get("stable_tag_remote") or DEFAULT_STABLE_TAG_REMOTE),
+        "command": str(updates.get("stable_update_command") or ""),
+    }
+
+
+def _run_git(repo_dir: Path, args: list[str], *, timeout: float = 10.0) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo_dir),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def fetch_tags(repo_dir: Path, remote: str = DEFAULT_STABLE_TAG_REMOTE) -> tuple[bool, str]:
+    """Fetch tags from *remote*. Returns ``(ok, stderr)`` and never raises."""
+    try:
+        result = _run_git(repo_dir, ["fetch", remote, "--tags", "--quiet"], timeout=15)
+    except Exception as exc:  # network failures/timeouts should not break startup
+        return False, str(exc)
+    return result.returncode == 0, (result.stderr or "").strip()
+
+
+def list_stable_tags(repo_dir: Path, pattern: str = DEFAULT_STABLE_TAG_PATTERN) -> list[str]:
+    """List local stable-looking tags newest-first using git's version sort."""
+    try:
+        result = _run_git(
+            repo_dir,
+            ["tag", "--list", pattern, "--sort=-v:refname"],
+            timeout=5,
+        )
+    except Exception:
+        return []
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+
+
+def resolve_commit(repo_dir: Path, ref: str) -> Optional[str]:
+    """Resolve a git ref/tag to a full commit hash, or None on failure."""
+    try:
+        result = _run_git(repo_dir, ["rev-parse", f"{ref}^{{commit}}"], timeout=5)
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    value = (result.stdout or "").strip()
+    return value or None
+
+
+def exact_head_tag(repo_dir: Path) -> Optional[str]:
+    """Return the exact tag pointing at HEAD, if any."""
+    try:
+        result = _run_git(repo_dir, ["describe", "--tags", "--exact-match", "HEAD"], timeout=5)
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    value = (result.stdout or "").strip()
+    return value or None
+
+
+def stable_update_status(
+    repo_dir: Path,
+    *,
+    pattern: str = DEFAULT_STABLE_TAG_PATTERN,
+    remote: str = DEFAULT_STABLE_TAG_REMOTE,
+    target_tag: str | None = None,
+    fetch: bool = True,
+) -> dict[str, Any]:
+    """Return stable-tag update status for *repo_dir*.
+
+    The returned dict is JSON-serializable and includes enough context for the
+    banner to say which stable tag is available.  It only compares HEAD to a
+    tag's commit; it never compares against ``origin/main``/``origin/master``.
+    """
+    repo_dir = Path(repo_dir)
+    status: dict[str, Any] = {
+        "mode": "stable-tags",
+        "pattern": pattern,
+        "remote": remote,
+        "current_tag": None,
+        "head": None,
+        "latest_tag": None,
+        "target_tag": target_tag,
+        "target_commit": None,
+        "up_to_date": None,
+        "update_available": False,
+        "fetch_ok": None,
+        "fetch_error": None,
+        "error": None,
+    }
+
+    if not (repo_dir / ".git").exists():
+        status["error"] = "not-a-git-checkout"
+        return status
+
+    if fetch:
+        ok, err = fetch_tags(repo_dir, remote=remote)
+        status["fetch_ok"] = ok
+        status["fetch_error"] = err or None
+
+    tags = list_stable_tags(repo_dir, pattern=pattern)
+    if not tags and not target_tag:
+        status["error"] = "no-stable-tags"
+        return status
+
+    latest_tag = tags[0] if tags else target_tag
+    target = target_tag or latest_tag
+    status["latest_tag"] = latest_tag
+    status["target_tag"] = target
+    status["current_tag"] = exact_head_tag(repo_dir)
+    status["head"] = resolve_commit(repo_dir, "HEAD")
+    status["target_commit"] = resolve_commit(repo_dir, target) if target else None
+
+    if not status["head"] or not status["target_commit"]:
+        status["error"] = "could-not-resolve-ref"
+        return status
+
+    status["up_to_date"] = status["head"] == status["target_commit"]
+    status["update_available"] = not status["up_to_date"]
+    return status

--- a/hermes_cli/stable_update.py
+++ b/hermes_cli/stable_update.py
@@ -9,12 +9,20 @@ script on installations that opt into the stable-tag channel.
 
 from __future__ import annotations
 
+import json
+import re
 import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
 from typing import Any, Optional
 
 DEFAULT_STABLE_TAG_PATTERN = "v20*"
-DEFAULT_STABLE_TAG_REMOTE = "origin"
+OFFICIAL_RELEASE_REPOSITORY = "https://github.com/NousResearch/hermes-agent.git"
+OFFICIAL_RELEASES_API = "https://api.github.com/repos/NousResearch/hermes-agent/releases"
+DEFAULT_STABLE_TAG_REMOTE = OFFICIAL_RELEASE_REPOSITORY
+OFFICIAL_RELEASE_TAG_RE = re.compile(r"^v(20\d{2})\.(\d{1,2})\.(\d{1,2})(?:\.(\d+))?$")
 STABLE_TAG_STRATEGIES = {"stable-tags", "stable_tags", "stable-tag", "tags"}
 UPDATE_CHANNELS = {"main", "release"}
 
@@ -105,6 +113,161 @@ def resolve_commit(repo_dir: Path, ref: str) -> Optional[str]:
         return None
     value = (result.stdout or "").strip()
     return value or None
+
+
+def parse_official_release_refs(output: str) -> dict[str, str]:
+    """Return strict official release tags mapped to their peeled commit SHA."""
+    direct: dict[str, str] = {}
+    peeled: dict[str, str] = {}
+
+    for line in output.splitlines():
+        parts = line.strip().split()
+        if len(parts) != 2:
+            continue
+        sha, ref = parts
+        match = re.fullmatch(
+            r"refs/tags/(v20\d{2}\.\d{1,2}\.\d{1,2}(?:\.\d+)?)(\^\{\})?",
+            ref,
+        )
+        if not match or len(sha) != 40 or any(c not in "0123456789abcdefABCDEF" for c in sha):
+            continue
+        tag = match.group(1)
+        (peeled if match.group(2) else direct)[tag] = sha.lower()
+
+    return {tag: peeled.get(tag, sha) for tag, sha in direct.items()}
+
+
+def resolve_published_release_tag(
+    requested_tag: str | None = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve a published GitHub Release to its strict date tag."""
+    if requested_tag is not None and not OFFICIAL_RELEASE_TAG_RE.fullmatch(requested_tag):
+        return None, f"Official release tag '{requested_tag}' not found."
+
+    endpoint = (
+        f"{OFFICIAL_RELEASES_API}/tags/{urllib.parse.quote(requested_tag, safe='')}"
+        if requested_tag
+        else f"{OFFICIAL_RELEASES_API}/latest"
+    )
+    request = urllib.request.Request(
+        endpoint,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "hermes-agent-updater",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404 and requested_tag:
+            return None, f"Official release tag '{requested_tag}' not found."
+        return None, f"Could not read official GitHub releases (HTTP {exc.code})."
+    except Exception as exc:
+        return None, str(exc)
+
+    tag = str(payload.get("tag_name") or "") if isinstance(payload, dict) else ""
+    is_draft = bool(payload.get("draft")) if isinstance(payload, dict) else True
+    if (
+        not OFFICIAL_RELEASE_TAG_RE.fullmatch(tag)
+        or is_draft
+        or (requested_tag is not None and tag != requested_tag)
+    ):
+        label = requested_tag or tag or "latest"
+        return None, f"Official release tag '{label}' not found."
+    return tag, None
+
+
+def _official_tag_commit(repo_dir: Path, tag: str) -> tuple[Optional[str], Optional[str]]:
+    """Resolve one published release tag from the official repository."""
+    try:
+        result = _run_git(
+            repo_dir,
+            [
+                "ls-remote",
+                "--tags",
+                OFFICIAL_RELEASE_REPOSITORY,
+                f"refs/tags/{tag}",
+                f"refs/tags/{tag}^{{}}",
+            ],
+            timeout=30,
+        )
+    except Exception as exc:
+        return None, str(exc)
+    if result.returncode != 0:
+        return None, (result.stderr or "Could not read the official release tag.").strip()
+
+    refs = parse_official_release_refs(result.stdout or "")
+    commit = refs.get(tag)
+    return commit, None if commit else f"Official release tag '{tag}' was not found in the official repository."
+
+
+def official_release_status(repo_dir: Path) -> dict[str, Any]:
+    """Return exact-pin status against the latest published GitHub Release."""
+    latest_tag, error = resolve_published_release_tag()
+    target_commit = None
+    if not error and latest_tag:
+        target_commit, error = _official_tag_commit(Path(repo_dir), latest_tag)
+    status: dict[str, Any] = {
+        "mode": "official-releases",
+        "current_release_tag": None,
+        "head": resolve_commit(Path(repo_dir), "HEAD"),
+        "latest_tag": None,
+        "target_tag": None,
+        "target_commit": None,
+        "up_to_date": None,
+        "update_available": False,
+        "releases_behind": None,
+        "error": error,
+    }
+    if error or not latest_tag or not target_commit or not status["head"]:
+        status["error"] = error or "could-not-resolve-head"
+        return status
+
+    status["latest_tag"] = latest_tag
+    status["target_tag"] = latest_tag
+    status["target_commit"] = target_commit
+    if status["head"] == target_commit:
+        status["current_release_tag"] = latest_tag
+        status["releases_behind"] = 0
+    status["up_to_date"] = status["head"] == target_commit
+    status["update_available"] = not status["up_to_date"]
+    return status
+
+
+def resolve_official_release(repo_dir: Path, requested_tag: str | None = None) -> dict[str, Any]:
+    """Fetch and verify one published GitHub Release from the official repo."""
+    tag, error = resolve_published_release_tag(requested_tag)
+    if error or not tag:
+        return {"tag": requested_tag, "commit": None, "error": error or "No official release found."}
+
+    expected_commit, error = _official_tag_commit(Path(repo_dir), tag)
+    if error or not expected_commit:
+        return {"tag": tag, "commit": None, "error": error}
+    try:
+        fetched = _run_git(
+            Path(repo_dir),
+            ["fetch", "--quiet", "--no-tags", OFFICIAL_RELEASE_REPOSITORY, f"refs/tags/{tag}"],
+            timeout=30,
+        )
+    except Exception as exc:
+        return {"tag": tag, "commit": None, "error": str(exc)}
+    if fetched.returncode != 0:
+        return {
+            "tag": tag,
+            "commit": None,
+            "error": (fetched.stderr or f"Could not fetch official release {tag}.").strip(),
+        }
+
+    fetched_commit = resolve_commit(Path(repo_dir), "FETCH_HEAD")
+    if fetched_commit != expected_commit:
+        return {
+            "tag": tag,
+            "commit": fetched_commit,
+            "error": f"Official release {tag} did not resolve to its advertised commit.",
+        }
+    return {"tag": tag, "commit": expected_commit, "error": None}
 
 
 def exact_head_tag(repo_dir: Path) -> Optional[str]:

--- a/hermes_cli/stable_update.py
+++ b/hermes_cli/stable_update.py
@@ -16,6 +16,29 @@ from typing import Any, Optional
 DEFAULT_STABLE_TAG_PATTERN = "v20*"
 DEFAULT_STABLE_TAG_REMOTE = "origin"
 STABLE_TAG_STRATEGIES = {"stable-tags", "stable_tags", "stable-tag", "tags"}
+UPDATE_CHANNELS = {"main", "release"}
+
+
+def normalize_update_channel(value: Any, *, default: str = "main") -> str:
+    """Normalize a user-facing update channel to ``main`` or ``release``."""
+    normalized_default = default if default in UPDATE_CHANNELS else "main"
+    raw = str(value or "").strip().lower()
+    if raw in {"release", *STABLE_TAG_STRATEGIES}:
+        return "release"
+    if raw in {"main", "branch", "fast", "fast-track", "fast_track"}:
+        return "main"
+    return normalized_default
+
+
+def configured_update_channel(config: dict[str, Any] | None, *, default: str = "main") -> str:
+    """Return the canonical update channel from an effective config mapping."""
+    updates = config.get("updates", {}) if isinstance(config, dict) else {}
+    if not isinstance(updates, dict):
+        return normalize_update_channel(None, default=default)
+    return normalize_update_channel(
+        updates.get("channel") or updates.get("check_strategy") or updates.get("strategy"),
+        default=default,
+    )
 
 
 def stable_updates_enabled(config: dict[str, Any] | None) -> bool:
@@ -23,13 +46,7 @@ def stable_updates_enabled(config: dict[str, Any] | None) -> bool:
     updates = config.get("updates", {}) if isinstance(config, dict) else {}
     if not isinstance(updates, dict):
         return False
-    strategy = str(
-        updates.get("check_strategy")
-        or updates.get("strategy")
-        or updates.get("channel")
-        or ""
-    ).strip().lower()
-    return bool(updates.get("stable_tags")) or strategy in STABLE_TAG_STRATEGIES
+    return bool(updates.get("stable_tags")) or configured_update_channel(config) == "release"
 
 
 def stable_update_config(config: dict[str, Any] | None) -> dict[str, str]:
@@ -102,6 +119,39 @@ def exact_head_tag(repo_dir: Path) -> Optional[str]:
     return value or None
 
 
+def current_branch(repo_dir: Path) -> Optional[str]:
+    """Return the checked-out branch, or ``None`` for detached HEAD."""
+    try:
+        result = _run_git(repo_dir, ["symbolic-ref", "--quiet", "--short", "HEAD"], timeout=5)
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    value = (result.stdout or "").strip()
+    return value or None
+
+
+def is_ancestor(repo_dir: Path, ancestor: str, descendant: str = "HEAD") -> bool:
+    """Return whether *ancestor* is reachable from *descendant*."""
+    try:
+        result = _run_git(
+            repo_dir,
+            ["merge-base", "--is-ancestor", ancestor, descendant],
+            timeout=5,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0
+
+
+def latest_reachable_tag(repo_dir: Path, tags: list[str]) -> Optional[str]:
+    """Return the newest candidate tag reachable from HEAD."""
+    for tag in tags:
+        if is_ancestor(repo_dir, tag):
+            return tag
+    return None
+
+
 def stable_update_status(
     repo_dir: Path,
     *,
@@ -122,12 +172,15 @@ def stable_update_status(
         "pattern": pattern,
         "remote": remote,
         "current_tag": None,
+        "current_release_tag": None,
+        "current_branch": None,
         "head": None,
         "latest_tag": None,
         "target_tag": target_tag,
         "target_commit": None,
         "up_to_date": None,
         "update_available": False,
+        "releases_behind": None,
         "fetch_ok": None,
         "fetch_error": None,
         "error": None,
@@ -152,6 +205,7 @@ def stable_update_status(
     status["latest_tag"] = latest_tag
     status["target_tag"] = target
     status["current_tag"] = exact_head_tag(repo_dir)
+    status["current_branch"] = current_branch(repo_dir)
     status["head"] = resolve_commit(repo_dir, "HEAD")
     status["target_commit"] = resolve_commit(repo_dir, target) if target else None
 
@@ -159,6 +213,17 @@ def stable_update_status(
         status["error"] = "could-not-resolve-ref"
         return status
 
-    status["up_to_date"] = status["head"] == status["target_commit"]
+    current_release_tag = latest_reachable_tag(repo_dir, tags)
+    status["current_release_tag"] = current_release_tag
+    if current_release_tag in tags:
+        status["releases_behind"] = tags.index(current_release_tag)
+
+    exact_target = status["head"] == status["target_commit"]
+    carries_target = is_ancestor(repo_dir, target) if target else False
+    on_moving_main = status["current_branch"] in {"main", "master"}
+    # A custom overlay commit on top of a release remains release-current, but
+    # selecting the release track while sitting on moving main must still offer
+    # to pin the exact tag. This resolves both reviewer-reported edge cases.
+    status["up_to_date"] = exact_target or (carries_target and not on_moving_main)
     status["update_available"] = not status["up_to_date"]
     return status

--- a/hermes_cli/stable_update.py
+++ b/hermes_cli/stable_update.py
@@ -96,7 +96,7 @@ def list_stable_tags(repo_dir: Path, pattern: str = DEFAULT_STABLE_TAG_PATTERN) 
 
 
 def resolve_commit(repo_dir: Path, ref: str) -> Optional[str]:
-    """Resolve a git ref/tag to a full commit hash, or None on failure."""
+    """Resolve a git ref to its peeled commit SHA."""
     try:
         result = _run_git(repo_dir, ["rev-parse", f"{ref}^{{commit}}"], timeout=5)
     except Exception:
@@ -218,12 +218,8 @@ def stable_update_status(
     if current_release_tag in tags:
         status["releases_behind"] = tags.index(current_release_tag)
 
-    exact_target = status["head"] == status["target_commit"]
-    carries_target = is_ancestor(repo_dir, target) if target else False
-    on_moving_main = status["current_branch"] in {"main", "master"}
-    # A custom overlay commit on top of a release remains release-current, but
-    # selecting the release track while sitting on moving main must still offer
-    # to pin the exact tag. This resolves both reviewer-reported edge cases.
-    status["up_to_date"] = exact_target or (carries_target and not on_moving_main)
+    # Release track means an exact, reproducible tag pin. Descendants of the tag
+    # include unreleased main and local overlays; neither is the selected build.
+    status["up_to_date"] = status["head"] == status["target_commit"]
     status["update_available"] = not status["up_to_date"]
     return status

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -62,6 +62,18 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         ),
     )
     update_parser.add_argument(
+        "--release",
+        nargs="?",
+        const="latest",
+        default=None,
+        metavar="TAG",
+        help=(
+            "Pin to an official tagged release instead of tracking a branch. "
+            "Use --release alone for the latest vYYYY.M.D tag, or provide an "
+            "exact tag. The release is checked out as a detached HEAD."
+        ),
+    )
+    update_parser.add_argument(
         "--force",
         action="store_true",
         default=False,

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -74,6 +74,15 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         ),
     )
     update_parser.add_argument(
+        "--release-commit",
+        default=None,
+        metavar="SHA",
+        help=(
+            "Require --release to resolve to this full 40-character Git commit "
+            "SHA. Used to preserve the commit verified by an earlier update check."
+        ),
+    )
+    update_parser.add_argument(
         "--force",
         action="store_true",
         default=False,
@@ -85,4 +94,10 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
     )
-    update_parser.set_defaults(func=cmd_update)
+
+    def _dispatch_update(args):
+        if args.release_commit and args.release is None:
+            update_parser.error("--release-commit requires --release")
+        return cmd_update(args)
+
+    update_parser.set_defaults(func=_dispatch_update)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2058,7 +2058,7 @@ def _mutate_checkout_to_update_target(
 
 
 def _cmd_update_check_release(release_request: str):
-    """Fetch release tags and report whether the selected release is installed."""
+    """Resolve an official published release and report whether it is installed."""
     from hermes_cli.config import (
         detect_install_method,
         format_docker_update_message,
@@ -2079,57 +2079,27 @@ def _cmd_update_check_release(release_request: str):
         print("✗ Not a git repository — cannot check for updates.")
         sys.exit(1)
 
-    git_cmd = ["git"]
-    if sys.platform == "win32":
-        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+    from hermes_cli.stable_update import resolve_commit, resolve_official_release
 
-    print("→ Fetching release tags...")
-    fetch_result = subprocess.run(
-        git_cmd + ["fetch", "origin", "--tags"],
-        cwd=_m().PROJECT_ROOT,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
-    if fetch_result.returncode != 0:
-        stderr = fetch_result.stderr.strip()
-        if "Could not resolve host" in stderr or "unable to access" in stderr:
-            print("✗ Network error — cannot reach the remote repository.")
-        elif "Authentication failed" in stderr or "could not read Username" in stderr:
-            print("✗ Authentication failed — check your git credentials or SSH key.")
-        else:
-            print("✗ Failed to fetch release tags.")
-            if stderr:
-                print(f"  {stderr.splitlines()[0]}")
+    print("→ Checking official GitHub Releases...")
+    requested_tag = None if release_request == RELEASE_LATEST else release_request
+    release = resolve_official_release(_m().PROJECT_ROOT, requested_tag=requested_tag)
+    target_tag = release.get("tag")
+    target_commit = release.get("commit")
+    error = release.get("error")
+    if error or not target_tag or not target_commit:
+        print(f"✗ {error or 'Could not resolve an official published release.'}")
         sys.exit(1)
 
-    target_tag = (
-        _latest_release_tag(git_cmd, _m().PROJECT_ROOT)
-        if release_request == RELEASE_LATEST
-        else release_request
-    )
-    if not target_tag or not _tag_exists(git_cmd, _m().PROJECT_ROOT, target_tag):
-        label = target_tag or release_request
-        print(f"✗ Release tag '{label}' not found.")
+    head = resolve_commit(_m().PROJECT_ROOT, "HEAD")
+    if not head:
+        print("✗ Could not resolve the installed Hermes commit.")
         sys.exit(1)
-
-    from hermes_cli.stable_update import stable_update_status
-
-    status = stable_update_status(
-        _m().PROJECT_ROOT,
-        target_tag=target_tag,
-        fetch=False,
-    )
-    if status.get("up_to_date"):
+    if head == target_commit:
         print(f"✓ Already on release {target_tag}.")
         return
 
     print(f"⚕ Release update available: {target_tag}.")
-    behind = status.get("releases_behind")
-    if isinstance(behind, int) and behind > 0:
-        noun = "release" if behind == 1 else "releases"
-        print(f"  This install is {behind} {noun} behind.")
     print(f"  Run '{recommended_update_command()} --release {target_tag}' to install.")
 
 
@@ -3502,41 +3472,70 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # Fetch and pull
     try:
 
-        # Resolve the target branch up front so the fetch can be scoped to it.
-        # A bare `git fetch origin` pulls every ref, and this repo carries
-        # thousands of auto-generated branches — an unscoped fetch can stall for
-        # minutes on a non-single-branch checkout. Fetch only what we update
-        # against.
+        # Resolve the branch up front for Fast Track. Release Track never trusts
+        # the checkout's origin: it resolves and fetches the exact tag from the
+        # official Nous repository, then verifies the peeled commit.
         branch = _m()._resolve_update_branch(args)
-        fetch_args = (
-            git_cmd + ["fetch", "origin", "--tags"]
-            if release_request is not None
-            else git_cmd + ["fetch", "origin", branch]
-        )
+        target_tag = None
+        target_commit = None
 
-        print("→ Fetching release tags..." if release_request is not None else "→ Fetching updates...")
-        fetch_result = subprocess.run(
-            fetch_args,
-            cwd=_m().PROJECT_ROOT,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
-        )
-        if fetch_result.returncode != 0:
-            stderr = fetch_result.stderr.strip()
-            if "Could not resolve host" in stderr or "unable to access" in stderr:
-                print("✗ Network error — cannot reach the remote repository.")
-                print(f"  {stderr.splitlines()[0]}" if stderr else "")
-            elif (
-                "Authentication failed" in stderr or "could not read Username" in stderr
+        if release_request is not None:
+            from hermes_cli.stable_update import resolve_official_release
+
+            expected_commit = str(getattr(args, "release_commit", "") or "").strip().lower()
+            if expected_commit and (
+                len(expected_commit) != 40
+                or any(char not in "0123456789abcdef" for char in expected_commit)
             ):
-                print(
-                    "✗ Authentication failed — check your git credentials or SSH key."
-                )
-            else:
-                print("✗ Failed to fetch updates from origin.")
-                if stderr:
-                    print(f"  {stderr.splitlines()[0]}")
-            sys.exit(1)
+                print("✗ --release-commit must be a full 40-character Git commit SHA.")
+                sys.exit(1)
+
+            requested_tag = None if release_request == RELEASE_LATEST else release_request
+            print("→ Resolving official release...")
+            resolved_release = resolve_official_release(
+                _m().PROJECT_ROOT,
+                requested_tag=requested_tag,
+            )
+            target_tag = resolved_release.get("tag")
+            target_commit = resolved_release.get("commit")
+            if resolved_release.get("error") or not target_tag or not target_commit:
+                print(f"✗ {resolved_release.get('error') or 'Could not resolve the official release.'}")
+                sys.exit(1)
+
+            if expected_commit:
+                if target_commit.lower() != expected_commit:
+                    print(f"✗ Release {target_tag} no longer resolves to the checked commit.")
+                    print(f"  Expected: {expected_commit}")
+                    print(f"  Current:  {target_commit}")
+                    print("  Check for updates again before applying.")
+                    sys.exit(1)
+        else:
+            # A bare `git fetch origin` pulls every ref, and this repo carries
+            # thousands of auto-generated branches. Scope the fetch to the
+            # selected Fast Track branch.
+            print("→ Fetching updates...")
+            fetch_result = subprocess.run(
+                git_cmd + ["fetch", "origin", branch],
+                cwd=_m().PROJECT_ROOT,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+            )
+            if fetch_result.returncode != 0:
+                stderr = fetch_result.stderr.strip()
+                if "Could not resolve host" in stderr or "unable to access" in stderr:
+                    print("✗ Network error — cannot reach the remote repository.")
+                    print(f"  {stderr.splitlines()[0]}" if stderr else "")
+                elif (
+                    "Authentication failed" in stderr or "could not read Username" in stderr
+                ):
+                    print(
+                        "✗ Authentication failed — check your git credentials or SSH key."
+                    )
+                else:
+                    print("✗ Failed to fetch updates from origin.")
+                    if stderr:
+                        print(f"  {stderr.splitlines()[0]}")
+                sys.exit(1)
 
         # Get current branch (returns literal "HEAD" when detached)
         result = subprocess.run(
@@ -3547,32 +3546,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
             check=True,
         )
         current_branch = result.stdout.strip()
-
-        target_tag = None
-        target_commit = None
-        release_status = None
-        if release_request is not None:
-            target_tag = (
-                _latest_release_tag(git_cmd, _m().PROJECT_ROOT)
-                if release_request == RELEASE_LATEST
-                else release_request
-            )
-            if not target_tag or not _tag_exists(git_cmd, _m().PROJECT_ROOT, target_tag):
-                label = target_tag or release_request
-                print(f"✗ Release tag '{label}' not found.")
-                sys.exit(1)
-
-            from hermes_cli.stable_update import stable_update_status
-
-            release_status = stable_update_status(
-                _m().PROJECT_ROOT,
-                target_tag=target_tag,
-                fetch=False,
-            )
-            target_commit = release_status.get("target_commit")
-            if release_status.get("error") or not target_commit:
-                print(f"✗ Could not resolve release {target_tag} to a commit.")
-                sys.exit(1)
 
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical
@@ -3636,7 +3609,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Release mode compares exact peeled commit identity; branch mode keeps
         # the historical commit-distance check.
         if target_commit is not None:
-            commit_count = 0 if release_status and release_status.get("up_to_date") else 1
+            current_head = subprocess.run(
+                git_cmd + ["rev-parse", "HEAD^{commit}"],
+                cwd=_m().PROJECT_ROOT,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                check=True,
+            ).stdout.strip()
+            commit_count = 0 if current_head == target_commit else 1
         else:
             result = subprocess.run(
                 git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3321,6 +3321,13 @@ def _normalize_managed_eol(git_cmd, repo_root):
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
+    if (
+        getattr(args, "release_commit", None)
+        and getattr(args, "release", None) is None
+    ):
+        print("✗ --release-commit requires --release.")
+        sys.exit(1)
+
     # In gateway mode, use file-based IPC for prompts instead of stdin
     gw_input_fn = (
         (lambda prompt, default="": _gateway_prompt(prompt, default))

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -547,6 +547,13 @@ def _update_via_zip(args):
     # if the user asked for something else — exactly the silent-divergence
     # bug --branch was added to prevent. Refuse to proceed in that case
     # rather than lie.
+    if _configured_release_request(args) is not None:
+        print("✗ Release-track updates are not supported by the Windows ZIP fallback.")
+        print(
+            "  Resolve the git file-I/O problem and rerun `hermes update --release`; "
+            "the fallback only contains the moving main branch."
+        )
+        _m().sys.exit(1)
     branch = _m()._resolve_update_branch(args)
     if branch != "main":
         print(
@@ -1917,6 +1924,215 @@ def _run_logged_subprocess(cmd, *, cwd=None, env=None):
     _log_only_write(result.stdout or "")
     return result
 
+
+# Sentinel ``--release`` was passed with no value. A concrete value pins that
+# exact tag; ``None`` means the flag was not passed.
+RELEASE_LATEST = "latest"
+
+
+def _resolve_release_request(args) -> str | None:
+    """Return the explicit release request, or ``None`` when absent."""
+    raw = getattr(args, "release", None)
+    if raw is None:
+        return None
+    value = str(raw).strip()
+    if not value or value.lower() == RELEASE_LATEST:
+        return RELEASE_LATEST
+    return value
+
+
+def _configured_release_request(args) -> str | None:
+    """Resolve explicit release flags and the persisted release channel."""
+    explicit = _resolve_release_request(args)
+    if explicit is not None:
+        return explicit
+    # An explicit branch is always a one-shot fast-track override.
+    if getattr(args, "branch", None):
+        return None
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.stable_update import configured_update_channel
+
+        if configured_update_channel(load_config()) == "release":
+            return RELEASE_LATEST
+    except Exception as exc:
+        logger.debug("Could not resolve updates.channel: %s", exc)
+    return None
+
+
+def _latest_release_tag(git_cmd: list, cwd) -> str | None:
+    """Return the newest version-sorted Hermes release tag known locally."""
+    result = subprocess.run(
+        git_cmd + ["tag", "--list", "v20*", "--sort=-version:refname"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        return None
+    return next((line.strip() for line in result.stdout.splitlines() if line.strip()), None)
+
+
+def _tag_exists(git_cmd: list, cwd, tag: str) -> bool:
+    """Return whether *tag* resolves to a local tag object."""
+    result = subprocess.run(
+        git_cmd + ["rev-parse", "--verify", "--quiet", f"refs/tags/{tag}"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return result.returncode == 0
+
+
+def _head_is_at_or_after(git_cmd: list, cwd, ref: str) -> bool:
+    """Return whether *ref* is reachable from HEAD."""
+    result = subprocess.run(
+        git_cmd + ["merge-base", "--is-ancestor", ref, "HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return result.returncode == 0
+
+
+def _mutate_checkout_to_update_target(
+    git_cmd: list,
+    cwd: Path,
+    *,
+    branch: str,
+    target_commit: str | None,
+    target_tag: str | None,
+) -> None:
+    """Move the checkout to a branch tip or exact peeled release commit."""
+    if target_commit is not None:
+        checkout_result = subprocess.run(
+            git_cmd + ["checkout", "--detach", target_commit],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if checkout_result.returncode == 0:
+            return
+        label = target_tag or target_commit[:12]
+        print(f"✗ Failed to check out release {label}.")
+        if checkout_result.stderr.strip():
+            print(f"  {checkout_result.stderr.strip().splitlines()[0]}")
+        print(f"  Try manually: git fetch origin --tags && git checkout --detach {target_commit}")
+        sys.exit(1)
+
+    pull_result = subprocess.run(
+        git_cmd + ["merge", "--ff-only", f"origin/{branch}"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if pull_result.returncode == 0:
+        return
+
+    print("  ⚠ Fast-forward not possible (history diverged), resetting to match remote...")
+    reset_result = subprocess.run(
+        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if reset_result.returncode == 0:
+        return
+    print(f"✗ Failed to reset to origin/{branch}.")
+    if reset_result.stderr.strip():
+        print(f"  {reset_result.stderr.strip()}")
+    print(f"  Try manually: git fetch origin && git reset --hard origin/{branch}")
+    sys.exit(1)
+
+
+def _cmd_update_check_release(release_request: str):
+    """Fetch release tags and report whether the selected release is installed."""
+    from hermes_cli.config import (
+        detect_install_method,
+        format_docker_update_message,
+        recommended_update_command,
+        recommended_update_command_for_method,
+    )
+
+    method = detect_install_method(_m().PROJECT_ROOT)
+    if method == "docker":
+        print(format_docker_update_message())
+        sys.exit(1)
+    if method in {"nix", "nixos"}:
+        print(recommended_update_command_for_method(method))
+        sys.exit(1)
+
+    git_dir = _m().PROJECT_ROOT / ".git"
+    if not git_dir.exists():
+        print("✗ Not a git repository — cannot check for updates.")
+        sys.exit(1)
+
+    git_cmd = ["git"]
+    if sys.platform == "win32":
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+
+    print("→ Fetching release tags...")
+    fetch_result = subprocess.run(
+        git_cmd + ["fetch", "origin", "--tags"],
+        cwd=_m().PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if fetch_result.returncode != 0:
+        stderr = fetch_result.stderr.strip()
+        if "Could not resolve host" in stderr or "unable to access" in stderr:
+            print("✗ Network error — cannot reach the remote repository.")
+        elif "Authentication failed" in stderr or "could not read Username" in stderr:
+            print("✗ Authentication failed — check your git credentials or SSH key.")
+        else:
+            print("✗ Failed to fetch release tags.")
+            if stderr:
+                print(f"  {stderr.splitlines()[0]}")
+        sys.exit(1)
+
+    target_tag = (
+        _latest_release_tag(git_cmd, _m().PROJECT_ROOT)
+        if release_request == RELEASE_LATEST
+        else release_request
+    )
+    if not target_tag or not _tag_exists(git_cmd, _m().PROJECT_ROOT, target_tag):
+        label = target_tag or release_request
+        print(f"✗ Release tag '{label}' not found.")
+        sys.exit(1)
+
+    from hermes_cli.stable_update import stable_update_status
+
+    status = stable_update_status(
+        _m().PROJECT_ROOT,
+        target_tag=target_tag,
+        fetch=False,
+    )
+    if status.get("up_to_date"):
+        print(f"✓ Already on release {target_tag}.")
+        return
+
+    print(f"⚕ Release update available: {target_tag}.")
+    behind = status.get("releases_behind")
+    if isinstance(behind, int) and behind > 0:
+        noun = "release" if behind == 1 else "releases"
+        print(f"  This install is {behind} {noun} behind.")
+    print(f"  Run '{recommended_update_command()} --release {target_tag}' to install.")
+
+
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     """Implement ``hermes update --check``: fetch and report without installing.
 
@@ -3273,6 +3489,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print(f"  {origin_url}")
         print()
 
+    release_request = _configured_release_request(args)
+
     if use_zip_update:
         # ZIP-based update for Windows when git is broken
         try:
@@ -3290,10 +3508,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # minutes on a non-single-branch checkout. Fetch only what we update
         # against.
         branch = _m()._resolve_update_branch(args)
+        fetch_args = (
+            git_cmd + ["fetch", "origin", "--tags"]
+            if release_request is not None
+            else git_cmd + ["fetch", "origin", branch]
+        )
 
-        print("→ Fetching updates...")
+        print("→ Fetching release tags..." if release_request is not None else "→ Fetching updates...")
         fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
+            fetch_args,
             cwd=_m().PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
@@ -3325,12 +3548,42 @@ def _cmd_update_impl(args, gateway_mode: bool):
         )
         current_branch = result.stdout.strip()
 
+        target_tag = None
+        target_commit = None
+        release_status = None
+        if release_request is not None:
+            target_tag = (
+                _latest_release_tag(git_cmd, _m().PROJECT_ROOT)
+                if release_request == RELEASE_LATEST
+                else release_request
+            )
+            if not target_tag or not _tag_exists(git_cmd, _m().PROJECT_ROOT, target_tag):
+                label = target_tag or release_request
+                print(f"✗ Release tag '{label}' not found.")
+                sys.exit(1)
+
+            from hermes_cli.stable_update import stable_update_status
+
+            release_status = stable_update_status(
+                _m().PROJECT_ROOT,
+                target_tag=target_tag,
+                fetch=False,
+            )
+            target_commit = release_status.get("target_commit")
+            if release_status.get("error") or not target_commit:
+                print(f"✗ Could not resolve release {target_tag} to a commit.")
+                sys.exit(1)
+
         # If user is on a different branch than the update target, switch
         # to the target. When the target is "main" this is the historical
         # "always update against main" behavior; for any other target it's
         # the same thing — get HEAD onto the requested branch first, then
         # fast-forward.
-        if current_branch != branch:
+        if target_commit is not None:
+            auto_stash_ref = _m()._stash_local_changes_if_needed(
+                git_cmd, _m().PROJECT_ROOT
+            )
+        elif current_branch != branch:
             label = (
                 "detached HEAD"
                 if current_branch == "HEAD"
@@ -3380,21 +3633,25 @@ def _cmd_update_impl(args, gateway_mode: bool):
             and (gateway_mode or (sys.stdin.isatty() and sys.stdout.isatty()))
         )
 
-        # Check if there are updates
-        result = subprocess.run(
-            git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
-            cwd=_m().PROJECT_ROOT,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
-            check=True,
-        )
-        commit_count = int(result.stdout.strip())
+        # Release mode compares exact peeled commit identity; branch mode keeps
+        # the historical commit-distance check.
+        if target_commit is not None:
+            commit_count = 0 if release_status and release_status.get("up_to_date") else 1
+        else:
+            result = subprocess.run(
+                git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
+                cwd=_m().PROJECT_ROOT,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                check=True,
+            )
+            commit_count = int(result.stdout.strip())
 
         if commit_count == 0:
             _invalidate_update_cache()
 
             # Even if origin is up to date, the fork may be behind upstream
-            if is_fork and branch == "main":
+            if target_commit is None and is_fork and branch == "main":
                 _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
 
             # Restore stash and switch back to original branch if we moved
@@ -3406,7 +3663,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     prompt_user=prompt_for_restore,
                     input_fn=gw_input_fn,
                 )
-            if current_branch not in {branch, "HEAD"}:
+            if target_commit is None and current_branch not in {branch, "HEAD"}:
                 subprocess.run(
                     git_cmd + ["checkout", current_branch],
                     cwd=_m().PROJECT_ROOT,
@@ -3478,7 +3735,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
-                print("✓ Already up to date!")
+                if target_tag is not None:
+                    print(f"✓ Already on release {target_tag}.")
+                else:
+                    print("✓ Already up to date!")
             if runtime_repaired is not None and not _m()._is_windows():
                 print()
                 print(
@@ -3492,9 +3752,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
             return
 
-        print(f"→ Found {commit_count} new commit(s)")
-
-        print("→ Pulling updates...")
+        if target_tag is not None:
+            print(f"→ Pinning to release {target_tag}...")
+        else:
+            print(f"→ Found {commit_count} new commit(s)")
+            print("→ Pulling updates...")
         update_succeeded = False
         # Capture the pre-pull SHA so we can auto-roll-back if the new code
         # has a syntax error in a critical-path file (PR #28452 incident:
@@ -3503,39 +3765,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # the bad commit and the fix landing).
         pre_pull_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
         try:
-            # Merge the ref we already fetched above (→ Fetching updates...)
-            # instead of `git pull`, which performs a SECOND network fetch of
-            # the same branch (~0.5-1.5 s of redundant round-trip per update).
-            # `merge --ff-only origin/<branch>` is byte-identical in effect to
-            # `pull --ff-only origin <branch>` given the fresh tracking ref;
-            # the divergence fallback below is unchanged.
-            pull_result = subprocess.run(
-                git_cmd + ["merge", "--ff-only", f"origin/{branch}"],
-                cwd=_m().PROJECT_ROOT,
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
+            _mutate_checkout_to_update_target(
+                git_cmd,
+                _m().PROJECT_ROOT,
+                branch=branch,
+                target_commit=target_commit,
+                target_tag=target_tag,
             )
-            if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
-                )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=_m().PROJECT_ROOT,
-                    capture_output=True,
-                    text=True, encoding="utf-8", errors="replace",
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
-                    print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
-                    )
-                    sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit
@@ -3558,6 +3794,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 if pre_pull_sha:
                     print()
                     print(f"→ Rolling back to {pre_pull_sha[:10]}...")
+                    if target_commit is not None and current_branch != "HEAD":
+                        subprocess.run(
+                            git_cmd + ["checkout", current_branch],
+                            cwd=_m().PROJECT_ROOT,
+                            capture_output=True,
+                            text=True,
+                            encoding="utf-8",
+                            errors="replace",
+                            check=False,
+                        )
                     rollback_result = subprocess.run(
                         git_cmd + ["reset", "--hard", pre_pull_sha],
                         cwd=_m().PROJECT_ROOT,
@@ -3619,7 +3865,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         _m()._record_bytecode_fingerprint()
 
         # Fork upstream sync logic (only for main branch on forks)
-        if is_fork and branch == "main":
+        if target_commit is None and is_fork and branch == "main":
             _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
 
         # Reinstall Python dependencies. Prefer .[all], but if one optional extra

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -62,3 +62,95 @@ def test_format_banner_version_label_stable_tag_mode():
     assert "upstream" not in value
 
 
+def test_get_git_banner_state_release_mode_uses_official_status(tmp_path):
+    from hermes_cli import banner
+    from hermes_cli import stable_update
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+    status = {
+        "error": None,
+        "latest_tag": "v2026.7.20",
+        "current_release_tag": None,
+        "up_to_date": False,
+    }
+
+    official_status = MagicMock(return_value=status)
+    with (
+        patch.object(banner, "_load_update_check_settings", return_value=("release", {})),
+        patch.object(banner, "_update_context", {"mode": "official-releases", **status}),
+        patch.object(stable_update, "official_release_status", official_status),
+        patch.object(banner, "_git_short_hash", return_value="af8aad31"),
+    ):
+        state = banner.get_git_banner_state(repo_dir)
+
+    assert state == {
+        "mode": "release",
+        "latest_tag": "v2026.7.20",
+        "current_tag": None,
+        "local": "af8aad31",
+        "up_to_date": False,
+        "error": None,
+    }
+    official_status.assert_not_called()
+
+
+def test_get_git_banner_state_release_error_never_falls_through_to_branch(tmp_path):
+    from hermes_cli import banner
+    from hermes_cli import stable_update
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    official_status = MagicMock(return_value={"error": "offline"})
+    with (
+        patch.object(banner, "_load_update_check_settings", return_value=("release", {})),
+        patch.object(banner, "_update_context", {"mode": "official-releases", "error": "offline"}),
+        patch.object(stable_update, "official_release_status", official_status),
+        patch.object(banner, "_git_short_hash", return_value="af8aad31") as short_hash,
+    ):
+        state = banner.get_git_banner_state(repo_dir)
+
+    assert state is not None
+    assert state["mode"] == "release"
+    assert state["error"] == "offline"
+    assert "upstream" not in state
+    assert short_hash.call_count == 1
+    official_status.assert_not_called()
+
+
+def test_format_banner_version_label_release_mode_never_says_upstream():
+    from hermes_cli import banner
+
+    with patch.object(
+        banner,
+        "get_git_banner_state",
+        return_value={
+            "mode": "release",
+            "latest_tag": "v2026.7.20",
+            "current_tag": None,
+            "local": "af8aad31",
+            "up_to_date": False,
+        },
+    ):
+        value = banner.format_banner_version_label()
+
+    assert value.endswith("· Release Track v2026.7.20 · local af8aad31")
+    assert "upstream" not in value
+    assert "commit" not in value
+
+
+def test_official_release_notice_uses_release_command_and_units():
+    from hermes_cli import banner
+
+    value = banner._format_official_release_notice(
+        {"mode": "official-releases", "target_tag": "v2026.7.20"},
+        "hermes update",
+    )
+
+    assert "Release Track update v2026.7.20 available" in value
+    assert "hermes update --release v2026.7.20" in value
+    assert "commit" not in value
+    assert "origin/main" not in value
+
+

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -38,6 +38,27 @@ def test_get_git_banner_state_reads_origin_and_head(tmp_path):
     with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
         state = banner.get_git_banner_state(repo_dir)
 
-    assert state == {"upstream": "b2f477a3", "local": "af8aad31", "ahead": 3}
+    assert state == {"mode": "branch", "upstream": "b2f477a3", "local": "af8aad31", "ahead": 3}
+
+
+def test_format_banner_version_label_stable_tag_mode():
+    from hermes_cli import banner
+
+    with patch.object(
+        banner,
+        "get_git_banner_state",
+        return_value={
+            "mode": "stable-tags",
+            "stable_tag": "v2026.5.16",
+            "current_tag": "v2026.5.16",
+            "local": "a91a57fa",
+            "up_to_date": True,
+        },
+    ):
+        value = banner.format_banner_version_label()
+
+    assert value.endswith("· stable v2026.5.16")
+    assert "origin/main" not in value
+    assert "upstream" not in value
 
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -655,6 +655,157 @@ class TestCmdUpdateZipBranchRefusal:
         assert "Downloading latest version" not in out
 
 
+class TestResolveReleaseRequest:
+    """``--release`` parsing: absent vs. bare vs. explicit tag."""
+
+    def test_absent_returns_none(self):
+        from hermes_cli.main import _resolve_release_request
+
+        assert _resolve_release_request(SimpleNamespace(release=None)) is None
+
+    def test_bare_flag_means_latest(self):
+        from hermes_cli.main import _resolve_release_request, RELEASE_LATEST
+
+        assert _resolve_release_request(SimpleNamespace(release="latest")) == RELEASE_LATEST
+
+    def test_blank_collapses_to_latest(self):
+        from hermes_cli.main import _resolve_release_request, RELEASE_LATEST
+
+        assert _resolve_release_request(SimpleNamespace(release="   ")) == RELEASE_LATEST
+
+    def test_explicit_tag_preserved(self):
+        from hermes_cli.main import _resolve_release_request
+
+        assert _resolve_release_request(SimpleNamespace(release="v2026.5.29")) == "v2026.5.29"
+
+
+class TestCmdUpdateRelease:
+    """``hermes update --release [TAG]`` pins to a tagged release.
+
+    Covers the issue #34514 asks: pin to a specific tag, land on a detached
+    HEAD (don't force the pin back to main), and report "already on" when the
+    requested release is already installed.
+    """
+
+    def _release_side_effect(
+        self,
+        *,
+        current_branch="HEAD",
+        latest_tag="v2026.5.29",
+        requested_tag_exists=True,
+        head_equals_target=False,
+    ):
+        target_sha = "b" * 40
+        head_sha = target_sha if head_equals_target else "a" * 40
+
+        def side_effect(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+
+            if "rev-parse" in joined and "--abbrev-ref" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout=f"{current_branch}\n", stderr="")
+
+            # _tag_exists probe
+            if "rev-parse" in joined and "--verify" in joined and "refs/tags/" in joined:
+                rc = 0 if requested_tag_exists else 1
+                return subprocess.CompletedProcess(cmd, rc, stdout="", stderr="")
+
+            # _latest_release_tag
+            if "tag" in joined and "--list" in joined:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout=f"{latest_tag}\nv2026.5.28\n", stderr=""
+                )
+
+            if "describe" in joined and "--exact-match" in joined:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0 if head_equals_target else 1,
+                    stdout=f"{latest_tag}\n" if head_equals_target else "",
+                    stderr="",
+                )
+
+            if "symbolic-ref" in joined:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    1 if current_branch == "HEAD" else 0,
+                    stdout="" if current_branch == "HEAD" else f"{current_branch}\n",
+                    stderr="",
+                )
+
+            if "rev-parse" in joined and "HEAD^{commit}" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout=f"{head_sha}\n", stderr="")
+
+            if "rev-parse" in joined and "^{commit}" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout=f"{target_sha}\n", stderr="")
+
+            if "merge-base" in joined and "--is-ancestor" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        return side_effect
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_release_latest_checks_out_newest_tag_detached(self, mock_run, _which, capsys):
+        mock_run.side_effect = self._release_side_effect(
+            current_branch="HEAD", latest_tag="v2026.5.29", head_equals_target=False
+        )
+
+        cmd_update(SimpleNamespace(release="latest"))
+
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        # Detached checkout of the resolved tag — a real pin, not a branch move.
+        assert any(f"checkout --detach {'b' * 40}" in c for c in commands), commands
+        # Never pulls a branch and never force-switches a detached HEAD to main.
+        assert not any("pull --ff-only" in c for c in commands), commands
+        assert not any("checkout main" in c for c in commands), commands
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_release_specific_tag_is_pinned(self, mock_run, _which, capsys):
+        mock_run.side_effect = self._release_side_effect(
+            current_branch="main", requested_tag_exists=True, head_equals_target=False
+        )
+
+        cmd_update(SimpleNamespace(release="v2026.5.7"))
+
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        assert any(f"checkout --detach {'b' * 40}" in c for c in commands), commands
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_release_already_installed_short_circuits(self, mock_run, _which, capsys):
+        mock_run.side_effect = self._release_side_effect(
+            requested_tag_exists=True, head_equals_target=True
+        )
+
+        cmd_update(SimpleNamespace(release="v2026.5.29"))
+
+        out = capsys.readouterr().out
+        assert "Already on release v2026.5.29" in out
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        assert not any("checkout --detach" in c for c in commands), commands
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_release_unknown_tag_exits_cleanly(self, mock_run, _which, capsys):
+        mock_run.side_effect = self._release_side_effect(requested_tag_exists=False)
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_update(SimpleNamespace(release="v9999.1.1"))
+        assert exc.value.code == 1
+
+        out = capsys.readouterr().out
+        assert "v9999.1.1" in out
+        assert "not found" in out
+
+    def test_release_and_branch_are_mutually_exclusive(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            cmd_update(SimpleNamespace(release="latest", branch="main"))
+        assert exc.value.code == 1
+        assert "mutually exclusive" in capsys.readouterr().out
+
+
 def test_is_termux_env_true_for_termux_prefix():
     from hermes_cli import main as hm
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,5 +1,6 @@
 """Tests for cmd_update — branch fallback when remote branch doesn't exist."""
 
+import argparse
 import hashlib
 import subprocess
 from types import SimpleNamespace
@@ -8,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from hermes_cli.main import cmd_update, PROJECT_ROOT
+from hermes_cli.subcommands.update import build_update_parser
 
 
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
@@ -38,6 +40,37 @@ def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
 @pytest.fixture
 def mock_args():
     return SimpleNamespace()
+
+
+def _build_update_test_parser(cmd_update_handler):
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build_update_parser(subparsers, cmd_update=cmd_update_handler)
+    return parser
+
+
+def test_release_commit_parser_propagates_with_release():
+    parser = _build_update_test_parser(lambda _args: None)
+
+    args = parser.parse_args(
+        ["update", "--release", "v2026.5.29", "--release-commit", "b" * 40]
+    )
+
+    assert args.release == "v2026.5.29"
+    assert args.release_commit == "b" * 40
+
+
+def test_release_commit_parser_rejects_without_release(capsys):
+    dispatched = []
+    parser = _build_update_test_parser(lambda args: dispatched.append(args))
+    args = parser.parse_args(["update", "--release-commit", "b" * 40])
+
+    with pytest.raises(SystemExit) as exc:
+        args.func(args)
+
+    assert exc.value.code == 2
+    assert "--release-commit requires --release" in capsys.readouterr().err
+    assert dispatched == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -687,6 +687,16 @@ class TestCmdUpdateRelease:
     requested release is already installed.
     """
 
+    @pytest.fixture(autouse=True)
+    def _published_github_releases(self, monkeypatch):
+        def resolve(requested_tag=None):
+            tag = requested_tag or "v2026.5.29"
+            if not tag.startswith("v2026."):
+                return None, f"Official release tag '{tag}' not found."
+            return tag, None
+
+        monkeypatch.setattr("hermes_cli.stable_update.resolve_published_release_tag", resolve)
+
     def _release_side_effect(
         self,
         *,
@@ -701,19 +711,20 @@ class TestCmdUpdateRelease:
         def side_effect(cmd, **kwargs):
             joined = " ".join(str(c) for c in cmd)
 
+            if "ls-remote --tags" in joined:
+                refs = [
+                    f"{target_sha}\trefs/tags/{latest_tag}",
+                    f"{'c' * 40}\trefs/tags/v2026.5.28",
+                ]
+                if requested_tag_exists:
+                    refs.append(f"{target_sha}\trefs/tags/v2026.5.7")
+                return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(refs) + "\n", stderr="")
+
+            if "fetch --quiet --no-tags" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
             if "rev-parse" in joined and "--abbrev-ref" in joined:
                 return subprocess.CompletedProcess(cmd, 0, stdout=f"{current_branch}\n", stderr="")
-
-            # _tag_exists probe
-            if "rev-parse" in joined and "--verify" in joined and "refs/tags/" in joined:
-                rc = 0 if requested_tag_exists else 1
-                return subprocess.CompletedProcess(cmd, rc, stdout="", stderr="")
-
-            # _latest_release_tag
-            if "tag" in joined and "--list" in joined:
-                return subprocess.CompletedProcess(
-                    cmd, 0, stdout=f"{latest_tag}\nv2026.5.28\n", stderr=""
-                )
 
             if "describe" in joined and "--exact-match" in joined:
                 return subprocess.CompletedProcess(
@@ -731,11 +742,11 @@ class TestCmdUpdateRelease:
                     stderr="",
                 )
 
-            if "rev-parse" in joined and "HEAD^{commit}" in joined:
-                return subprocess.CompletedProcess(cmd, 0, stdout=f"{head_sha}\n", stderr="")
-
-            if "rev-parse" in joined and "^{commit}" in joined:
+            if "rev-parse" in joined and cmd[-1] == "FETCH_HEAD^{commit}":
                 return subprocess.CompletedProcess(cmd, 0, stdout=f"{target_sha}\n", stderr="")
+
+            if "rev-parse" in joined and cmd[-1] == "HEAD^{commit}":
+                return subprocess.CompletedProcess(cmd, 0, stdout=f"{head_sha}\n", stderr="")
 
             if "merge-base" in joined and "--is-ancestor" in joined:
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
@@ -743,6 +754,43 @@ class TestCmdUpdateRelease:
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
         return side_effect
+
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("hermes_cli.stable_update.resolve_commit", return_value="a" * 40)
+    @patch("hermes_cli.stable_update.resolve_official_release")
+    @patch("subprocess.run")
+    def test_release_check_uses_official_release_not_origin_tags(
+        self, mock_run, mock_resolve_release, _mock_resolve_commit, _mock_method, capsys
+    ):
+        mock_resolve_release.return_value = {
+            "tag": "v2026.5.29",
+            "commit": "b" * 40,
+            "error": None,
+        }
+
+        cmd_update(SimpleNamespace(check=True, release="latest", branch=None, release_commit=None))
+
+        mock_resolve_release.assert_called_once_with(PROJECT_ROOT, requested_tag=None)
+        mock_run.assert_not_called()
+        out = capsys.readouterr().out
+        assert "official GitHub Releases" in out
+        assert "Release update available: v2026.5.29" in out
+
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("hermes_cli.stable_update.resolve_official_release")
+    def test_release_check_fails_closed_for_unpublished_tag(self, mock_resolve_release, _mock_method, capsys):
+        mock_resolve_release.return_value = {
+            "tag": "v2026.5.27",
+            "commit": None,
+            "error": "Official release tag 'v2026.5.27' not found.",
+        }
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(SimpleNamespace(check=True, release="v2026.5.27", branch=None, release_commit=None))
+
+        assert exc_info.value.code == 1
+        mock_resolve_release.assert_called_once_with(PROJECT_ROOT, requested_tag="v2026.5.27")
+        assert "Official release tag 'v2026.5.27' not found" in capsys.readouterr().out
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
@@ -771,6 +819,46 @@ class TestCmdUpdateRelease:
 
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
         assert any(f"checkout --detach {'b' * 40}" in c for c in commands), commands
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_release_commit_guard_accepts_the_checked_target(self, mock_run, _which, capsys):
+        mock_run.side_effect = self._release_side_effect(
+            current_branch="main", requested_tag_exists=True, head_equals_target=False
+        )
+
+        cmd_update(SimpleNamespace(release="v2026.5.7", release_commit="b" * 40))
+
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        assert any(f"checkout --detach {'b' * 40}" in c for c in commands), commands
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_release_commit_guard_rejects_a_moved_tag_before_checkout(self, mock_run, _which, capsys):
+        mock_run.side_effect = self._release_side_effect(
+            current_branch="main", requested_tag_exists=True, head_equals_target=False
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_update(SimpleNamespace(release="v2026.5.7", release_commit="c" * 40))
+
+        assert exc.value.code == 1
+        assert "no longer resolves to the checked commit" in capsys.readouterr().out
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        assert not any("checkout --detach" in c for c in commands), commands
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_release_commit_guard_rejects_invalid_sha(self, mock_run, _which, capsys):
+        mock_run.side_effect = self._release_side_effect()
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_update(SimpleNamespace(release="v2026.5.7", release_commit="not-a-sha"))
+
+        assert exc.value.code == 1
+        assert "full 40-character Git commit SHA" in capsys.readouterr().out
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        assert not any("checkout --detach" in c for c in commands), commands
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
@@ -804,6 +892,12 @@ class TestCmdUpdateRelease:
             cmd_update(SimpleNamespace(release="latest", branch="main"))
         assert exc.value.code == 1
         assert "mutually exclusive" in capsys.readouterr().out
+
+    def test_release_commit_requires_release(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            cmd_update(SimpleNamespace(release=None, release_commit="b" * 40))
+        assert exc.value.code == 1
+        assert "requires --release" in capsys.readouterr().out
 
 
 def test_is_termux_env_true_for_termux_prefix():

--- a/tests/hermes_cli/test_stable_update.py
+++ b/tests/hermes_cli/test_stable_update.py
@@ -1,0 +1,76 @@
+"""Tests for stable-tag update helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, name: str) -> str:
+    (repo / f"{name}.txt").write_text(name)
+    _git(repo, "add", f"{name}.txt")
+    _git(repo, "commit", "-m", name)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def test_stable_update_status_reports_latest_tag(tmp_path):
+    from hermes_cli.stable_update import stable_update_status
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+
+    _commit(repo, "old")
+    _git(repo, "tag", "v2026.5.7")
+    newest = _commit(repo, "new")
+    _git(repo, "tag", "v2026.5.16")
+
+    _git(repo, "checkout", "-q", "v2026.5.7")
+    status = stable_update_status(repo, fetch=False)
+
+    assert status["latest_tag"] == "v2026.5.16"
+    assert status["target_tag"] == "v2026.5.16"
+    assert status["target_commit"] == newest
+    assert status["current_tag"] == "v2026.5.7"
+    assert status["up_to_date"] is False
+    assert status["update_available"] is True
+
+
+def test_stable_update_status_up_to_date_on_latest_tag(tmp_path):
+    from hermes_cli.stable_update import stable_update_status
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+
+    _commit(repo, "release")
+    _git(repo, "tag", "v2026.5.16")
+
+    status = stable_update_status(repo, fetch=False)
+
+    assert status["latest_tag"] == "v2026.5.16"
+    assert status["up_to_date"] is True
+    assert status["update_available"] is False
+
+
+def test_stable_updates_enabled_accepts_strategy_and_legacy_bool():
+    from hermes_cli.stable_update import stable_updates_enabled
+
+    assert stable_updates_enabled({"updates": {"check_strategy": "stable-tags"}})
+    assert stable_updates_enabled({"updates": {"stable_tags": True}})
+    assert not stable_updates_enabled({"updates": {"check_strategy": "branch"}})

--- a/tests/hermes_cli/test_stable_update.py
+++ b/tests/hermes_cli/test_stable_update.py
@@ -45,6 +45,8 @@ def test_stable_update_status_reports_latest_tag(tmp_path):
     assert status["target_tag"] == "v2026.5.16"
     assert status["target_commit"] == newest
     assert status["current_tag"] == "v2026.5.7"
+    assert status["current_release_tag"] == "v2026.5.7"
+    assert status["releases_behind"] == 1
     assert status["up_to_date"] is False
     assert status["update_available"] is True
 
@@ -64,13 +66,62 @@ def test_stable_update_status_up_to_date_on_latest_tag(tmp_path):
     status = stable_update_status(repo, fetch=False)
 
     assert status["latest_tag"] == "v2026.5.16"
+    assert status["releases_behind"] == 0
     assert status["up_to_date"] is True
     assert status["update_available"] is False
 
 
 def test_stable_updates_enabled_accepts_strategy_and_legacy_bool():
-    from hermes_cli.stable_update import stable_updates_enabled
+    from hermes_cli.stable_update import configured_update_channel, stable_updates_enabled
 
+    assert stable_updates_enabled({"updates": {"channel": "release"}})
     assert stable_updates_enabled({"updates": {"check_strategy": "stable-tags"}})
     assert stable_updates_enabled({"updates": {"stable_tags": True}})
     assert not stable_updates_enabled({"updates": {"check_strategy": "branch"}})
+    assert configured_update_channel({"updates": {"channel": "fast-track"}}) == "main"
+
+
+def test_overlay_commit_on_latest_release_is_current(tmp_path):
+    from hermes_cli.stable_update import stable_update_status
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+
+    _commit(repo, "release")
+    _git(repo, "tag", "v2026.5.16")
+    _git(repo, "checkout", "-q", "-b", "local-overlay")
+    _commit(repo, "overlay")
+
+    status = stable_update_status(repo, fetch=False)
+
+    assert status["current_branch"] == "local-overlay"
+    assert status["current_release_tag"] == "v2026.5.16"
+    assert status["releases_behind"] == 0
+    assert status["up_to_date"] is True
+    assert status["update_available"] is False
+
+
+def test_moving_main_after_latest_release_still_offers_release_pin(tmp_path):
+    from hermes_cli.stable_update import stable_update_status
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "checkout", "-q", "-B", "main")
+
+    _commit(repo, "release")
+    _git(repo, "tag", "v2026.5.16")
+    _commit(repo, "unreleased-main")
+
+    status = stable_update_status(repo, fetch=False)
+
+    assert status["current_branch"] == "main"
+    assert status["current_release_tag"] == "v2026.5.16"
+    assert status["releases_behind"] == 0
+    assert status["up_to_date"] is False
+    assert status["update_available"] is True

--- a/tests/hermes_cli/test_stable_update.py
+++ b/tests/hermes_cli/test_stable_update.py
@@ -81,7 +81,7 @@ def test_stable_updates_enabled_accepts_strategy_and_legacy_bool():
     assert configured_update_channel({"updates": {"channel": "fast-track"}}) == "main"
 
 
-def test_overlay_commit_on_latest_release_is_current(tmp_path):
+def test_overlay_commit_on_latest_release_is_not_exact_pin(tmp_path):
     from hermes_cli.stable_update import stable_update_status
 
     repo = tmp_path / "repo"
@@ -100,8 +100,8 @@ def test_overlay_commit_on_latest_release_is_current(tmp_path):
     assert status["current_branch"] == "local-overlay"
     assert status["current_release_tag"] == "v2026.5.16"
     assert status["releases_behind"] == 0
-    assert status["up_to_date"] is True
-    assert status["update_available"] is False
+    assert status["up_to_date"] is False
+    assert status["update_available"] is True
 
 
 def test_moving_main_after_latest_release_still_offers_release_pin(tmp_path):

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -58,5 +58,46 @@ def test_prefetch_non_blocking():
         assert banner._update_result == 5
 
 
+def test_check_for_updates_stable_tags_returns_no_count_and_context(tmp_path, monkeypatch):
+    """Stable-tag mode reports release availability without branch commit counts."""
+    import hermes_cli.banner as banner
+    import hermes_cli.stable_update as stable_update
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        banner,
+        "_load_update_check_settings",
+        lambda: (
+            "stable-tags",
+            {"pattern": "v20*", "remote": "origin", "command": "stable-update switch"},
+        ),
+    )
+    monkeypatch.setattr(banner, "_resolve_repo_dir", lambda: repo_dir)
+    monkeypatch.setattr(
+        stable_update,
+        "stable_update_status",
+        lambda *args, **kwargs: {
+            "mode": "stable-tags",
+            "current_tag": "v2026.5.7",
+            "latest_tag": "v2026.5.16",
+            "target_tag": "v2026.5.16",
+            "up_to_date": False,
+            "update_available": True,
+            "error": None,
+        },
+    )
+
+    banner._update_context = {}
+    result = banner.check_for_updates()
+
+    assert result == banner.UPDATE_AVAILABLE_NO_COUNT
+    assert banner.get_update_context()["target_tag"] == "v2026.5.16"
+    assert banner.get_update_context()["update_command"] == "stable-update switch"
+
+
 
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -33,6 +33,42 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     mock_run.assert_not_called()
 
 
+def test_release_mode_rejects_legacy_modeless_branch_cache(tmp_path, monkeypatch):
+    """Release Track must not reuse pre-feature branch commit counts."""
+    import hermes_cli.banner as banner
+    import hermes_cli.stable_update as stable_update
+    from hermes_cli import __version__
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(banner, "_load_update_check_settings", lambda: ("release", {}))
+    monkeypatch.setattr(banner, "_resolve_repo_dir", lambda: repo_dir)
+    status = {
+        "mode": "official-releases",
+        "latest_tag": "v2026.7.20",
+        "target_tag": "v2026.7.20",
+        "up_to_date": False,
+        "error": None,
+    }
+    official_status = MagicMock(return_value=status)
+    monkeypatch.setattr(stable_update, "official_release_status", official_status)
+
+    banner._update_context = {}
+    result = banner.check_for_updates()
+
+    assert result == banner.UPDATE_AVAILABLE_NO_COUNT
+    official_status.assert_called_once_with(repo_dir)
+    assert banner.get_update_context()["mode"] == "official-releases"
+
+
 
 
 

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -8,13 +8,13 @@ description: "How to update Hermes Agent to the latest version or uninstall it"
 
 ## Updating
 
-Update to the latest version with a single command:
+Update with a single command:
 
 ```bash
 hermes update
 ```
 
-This pulls the latest code from `main`, updates dependencies, and prompts you to configure any new options that were added since your last update.
+By default, this pulls the latest code from `main`, updates dependencies, and prompts you to configure any new options that were added since your last update. You can instead pin updates to official tagged releases with the release track described below.
 
 :::tip
 `hermes update` automatically detects new configuration options and prompts you to add them. If you skipped that prompt, you can manually run `hermes config check` to see missing options, then `hermes config migrate` to interactively add them.
@@ -25,11 +25,46 @@ This pulls the latest code from `main`, updates dependencies, and prompts you to
 When you run `hermes update`, the following steps occur:
 
 1. **Pre-update snapshot** — a lightweight state snapshot is saved by default (covers pairing data, cron jobs, `config.yaml`, `.env`, `auth.json`, and other state files that get modified at runtime; individual files over 1 GiB are skipped so a large sessions DB never slows the update down). Controlled by `updates.pre_update_backup` (`quick` by default, `full` for a zip of all of `HERMES_HOME`, `off` to disable). Recoverable via the snapshot restore flow described under [Snapshots and rollback](../user-guide/checkpoints-and-rollback.md).
-2. **Git pull** — pulls the latest code from the `main` branch and updates submodules
+2. **Target resolution and checkout** — updates the selected branch (the `main` branch by default), or resolves and checks out the exact commit for an official release when using the release track; submodules are updated afterward
 3. **Post-pull syntax validation + auto-rollback** — after the pull, Hermes compiles the nine critical files every `hermes` invocation imports at startup. If any fails to parse (e.g. an orphan merge-conflict marker, an accidentally truncated file), Hermes runs `git reset --hard <pre-pull-sha>` to roll the install back so your shell stays bootable. Re-run `hermes update` once the upstream fix lands.
 4. **Dependency install** — runs `uv pip install -e ".[all]"` to pick up new or changed dependencies
 5. **Config migration** — detects new config options added since your version and prompts you to set them
 6. **Gateway auto-restart** — running gateways are refreshed after the update completes so the new code takes effect immediately. Service-managed gateways (systemd on Linux, launchd on macOS) are restarted through the service manager. Manual gateways are relaunched automatically when Hermes can map the running PID back to a profile.
+
+### Pinning official releases: `--release`
+
+Use the release track to install an official version published on the [GitHub releases page](https://github.com/NousResearch/hermes-agent/releases), rather than following the moving tip of a branch:
+
+```bash
+hermes update --release                 # latest published release
+hermes update --release v2026.7.20      # one exact release
+hermes update --check --release         # check the latest release only
+hermes update --check --release v2026.7.20
+```
+
+Official release tags use the date-based form `vYYYY.M.D`, with an optional fourth numeric component such as `vYYYY.M.D.N`. An explicitly requested tag must also exist as a published GitHub release. Hermes resolves the release through the official `NousResearch/hermes-agent` repository, verifies the tag's peeled commit, fetches that exact commit, and checks it out. `--release` and `--branch` are mutually exclusive.
+
+A release checkout intentionally uses a **detached HEAD**. This means the source tree is pinned to the release commit instead of being attached to a local branch. It is normal for `git status` to report `HEAD detached`; do not create commits there unless you intend to manage a custom checkout. A later release-track update moves the detached HEAD to the exact commit of the selected release. Running a branch-track update instead switches the checkout back to that branch.
+
+`hermes update --check --release` resolves the latest official release and compares its exact commit with the currently installed `HEAD`. It reports an update whenever those commits differ, including when `HEAD` is a descendant of the release tag on `main`. The check fetches release metadata and the selected tag, but it does not check out the release, reinstall dependencies, or restart gateways.
+
+For an exact check-to-install handoff, `--release-commit <full-40-character-SHA>` can accompany `--release [TAG]`. Hermes refuses the update if the official tag no longer resolves to that checked commit. `--release-commit` is invalid without `--release`.
+
+### Choosing a persistent update track: `updates.channel`
+
+The command-line flags above select a target for one invocation. To make release updates the default, set `updates.channel` in `~/.hermes/config.yaml`:
+
+```yaml
+updates:
+  channel: release
+```
+
+The supported values are:
+
+- `main` (default) — bare `hermes update` and `hermes update --check` follow `origin/main`.
+- `release` — bare `hermes update` pins the latest official release, and bare `hermes update --check` checks the latest official release.
+
+An explicit `--release [TAG]` selects a release for that invocation without changing the saved channel. An explicit `--branch <name>` is a one-time branch-track override, including when `updates.channel` is `release`.
 
 ### Updating against a non-default branch: `--branch`
 
@@ -62,7 +97,7 @@ In the desktop app this is **Settings → Advanced → In-App Update Local Chang
 
 ### Preview-only: `hermes update --check`
 
-Want to know if an update is available before pulling? Run `hermes update --check` — it fetches and compares commits against `origin/main`. No files are modified, no gateway is restarted. Useful in scripts and cron jobs that gate on "is there an update".
+Want to know if an update is available before installing it? Run `hermes update --check`. On the default `main` channel it fetches and compares commits against `origin/main`; on the `release` channel it performs the exact official-release comparison described above. Add `--branch <name>` or `--release [TAG]` to check a one-time target. The command does not check out code, reinstall dependencies, or restart gateways. It is useful in scripts and cron jobs that gate on "is there an update".
 
 ### Full pre-update backup: `--backup`
 
@@ -103,6 +138,10 @@ $ hermes update
 Close the listed processes and re-run. If you're sure the concurrent process won't interfere (rare — usually only useful when an antivirus shim is mis-attributed), pass `--force` to skip the check. In that case the updater will still retry the `.exe` rename with exponential backoff and, on stubborn locks, schedule the replacement for next reboot via `MoveFileEx(MOVEFILE_DELAY_UNTIL_REBOOT)` so the update can complete.
 
 A second, separate guard refuses to touch the venv while any process is running from its Python interpreter (the Desktop app's backend, a gateway, a Python REPL). Those processes keep native extension files (`.pyd`) locked, and a dependency sync that dies partway on an access-denied error strands the install between versions. This guard is **not** bypassed by `--force`; if you're certain the detected holders are false positives, use the explicit `hermes update --force-venv`.
+
+:::warning Release track and the Windows ZIP fallback
+When Git file I/O is unavailable or fails on Windows, Hermes can fall back to a ZIP archive of the moving `main` branch. That archive cannot preserve an exact release pin, so release-track updates deliberately stop instead of silently installing `main`. Resolve the Git file-I/O problem, then rerun `hermes update --release`. The same ZIP fallback limitation applies when `updates.channel` is `release`.
+:::
 
 Expected output looks like:
 
@@ -165,7 +204,7 @@ You can also update directly from Telegram, Discord, Slack, WhatsApp, or Teams b
 /update
 ```
 
-This pulls the latest code, updates dependencies, and restarts running gateways. The bot will briefly go offline during the restart (typically 5–15 seconds) and then resume.
+This updates from the target selected by `updates.channel`, updates dependencies, and restarts running gateways. The bot will briefly go offline during the restart (typically 5–15 seconds) and then resume.
 
 ### Manual Update
 


### PR DESCRIPTION
## Summary

Adds the CLI-side infrastructure for Hermes release tracks, allowing users to pin to official published releases instead of tracking `main`.

### Changes

- **`hermes update --release`** — pin to an official release tag (or `latest` for the newest)
- **`hermes update --check --release`** — check whether the installed commit matches the latest official GitHub release
- **`stable_update.py`** — new module with `resolve_official_release()`, `official_release_status()`, and release-tag comparison helpers
- **Banner** — `Release Track` mode in `get_git_banner_state()` and `format_banner_version_label()` showing release tags instead of branch/upstream terminology. Official-release update notices use `hermes update --release <tag>` wording
- **Cache safety** — modeless update caches (pre-feature) are only valid for branch mode, not release mode, preventing stale branch commit counts from hiding release updates
- **`config_defaults.py`** — `update.check` setting to control update check mode
- **`hermes_cli/main.py`** — `--release` flag on the update subcommand
- **`hermes_cli/subcommands/update.py`** — release argument routing

### Tests

- `test_banner_git_state.py` — release mode banner state, error fallback never falls through to branch, version label never says "upstream", official release notice format
- `test_update_check.py` — release mode rejects legacy modeless branch cache
- `test_stable_update.py` — official release status, overlay-safe freshness, tag comparison
- `test_cmd_update.py` — release check uses official GitHub releases not `git fetch --tags`, fails closed for unpublished tags, `--release` checkout, `--release-commit` pinning

### Relationship to PR #74838  (Desktop)

This PR provides the CLI infrastructure. The companion PR (Desktop release/fast track UX) adds the Electron desktop UI that consumes these release-track primitives. The two PRs are independent — the CLI changes work without the desktop changes and vice versa.