### PR TITLE
[verified] fix(kanban): preserve initial blocked state

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2681,6 +2681,22 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                if initial_status == "blocked":
+                    # ``recompute_ready`` distinguishes intentionally parked
+                    # tasks from transient circuit-breaker blocks by looking
+                    # for a sticky ``blocked`` event.  Without this event, the
+                    # next dispatcher tick promotes an initially-blocked task
+                    # straight back to ready.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "created with initial_status=blocked",
+                            "kind": None,
+                            "recurrences": 0,
+                        },
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -5108,47 +5124,61 @@ def promote_task(
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
     promotion would succeed without mutating state.
     """
-    row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (task_id,)
-    ).fetchone()
-    if row is None:
-        return False, f"task {task_id} not found"
+    with write_txn(conn):
+        # Read and validate under the same write transaction as the update.
+        # Otherwise a dispatcher/worker can change todo → blocked between the
+        # read and update, causing manual promotion to miss the sticky-block
+        # release event.
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            return False, f"task {task_id} not found"
 
-    cur_status = row["status"]
-    if cur_status not in ("todo", "blocked"):
-        return False, (
-            f"task {task_id} is {cur_status!r}; promote only applies to "
-            f"'todo' or 'blocked'"
-        )
-
-    if not force:
-        parents = conn.execute(
-            "SELECT t.id, t.status FROM tasks t "
-            "JOIN task_links l ON l.parent_id = t.id "
-            "WHERE l.child_id = ?",
-            (task_id,),
-        ).fetchall()
-        unsatisfied = [
-            p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
-        ]
-        if unsatisfied:
+        cur_status = row["status"]
+        if cur_status not in ("todo", "blocked"):
             return False, (
-                f"unsatisfied parent dependencies: "
-                f"{', '.join(unsatisfied)} (use --force to override)"
+                f"task {task_id} is {cur_status!r}; promote only applies to "
+                f"'todo' or 'blocked'"
             )
 
-    if dry_run:
-        return True, None
+        if not force:
+            parents = conn.execute(
+                "SELECT t.id, t.status FROM tasks t "
+                "JOIN task_links l ON l.parent_id = t.id "
+                "WHERE l.child_id = ?",
+                (task_id,),
+            ).fetchall()
+            unsatisfied = [
+                p["id"] for p in parents
+                if p["status"] not in ("done", "archived")
+            ]
+            if unsatisfied:
+                return False, (
+                    f"unsatisfied parent dependencies: "
+                    f"{', '.join(unsatisfied)} (use --force to override)"
+                )
 
-    with write_txn(conn):
+        if dry_run:
+            return True, None
+
         upd = conn.execute(
             "UPDATE tasks SET status = 'ready' "
-            "WHERE id = ? AND status IN ('todo', 'blocked')",
-            (task_id,),
+            "WHERE id = ? AND status = ?",
+            (task_id, cur_status),
         )
         if upd.rowcount != 1:
             return False, f"task {task_id} status changed during promotion"
+        if cur_status == "blocked":
+            # Manual promotion is an explicit operator release, just like
+            # ``unblock_task``.  Clear any sticky blocked event so a later
+            # transient circuit-breaker block can auto-recover normally.
+            _append_event(
+                conn,
+                task_id,
+                "unblocked",
+                {"actor": actor, "reason": reason, "via": "promote_task"},
+            )
         _append_event(
             conn,
             task_id,

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -29,6 +29,7 @@ landed via #28754 / #28781 ahead of this fix.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import time
 from pathlib import Path
 
@@ -74,6 +75,114 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             promoted = kb.recompute_ready(conn)
             assert promoted == 0, "worker-blocked task must not auto-promote"
             assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_initial_blocked_task_is_not_auto_promoted_by_recompute_ready(
+    kanban_home: Path,
+) -> None:
+    """A task created directly in ``blocked`` state is intentionally parked.
+
+    Bulk backlog staging relies on ``initial_status='blocked'`` being atomic:
+    the next dispatcher tick must not silently promote and claim the task.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="parked backlog item",
+            assignee="coder",
+            initial_status="blocked",
+        )
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        for _ in range(5):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0, "initially blocked task must stay parked"
+            assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_manual_promotion_clears_initial_sticky_block(
+    kanban_home: Path,
+) -> None:
+    """Manual promotion releases a parked task for future auto-recovery."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="parked then released",
+            assignee="coder",
+            initial_status="blocked",
+        )
+        promoted, error = kb.promote_task(conn, tid, actor="operator")
+        assert promoted is True
+        assert error is None
+        assert kb.get_task(conn, tid).status == "ready"
+
+        # Simulate a later recoverable circuit-breaker block.  This path has
+        # no worker-issued ``blocked`` event and remains below the default
+        # failure limit, so the dispatcher should be allowed to retry it.
+        conn.execute(
+            "UPDATE tasks SET status='blocked', consecutive_failures=1, "
+            "last_failure_error='transient error' WHERE id=?",
+            (tid,),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'gave_up', NULL, ?)",
+            (tid, int(time.time())),
+        )
+        conn.commit()
+
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_manual_promotion_atomically_clears_racing_sticky_block(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Promotion must use the status protected by its write transaction."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="racing promotion", assignee="coder")
+        conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (tid,))
+        conn.commit()
+
+        real_write_txn = kb.write_txn
+        injected = False
+
+        @contextmanager
+        def racing_write_txn(connection):
+            nonlocal injected
+            if not injected:
+                injected = True
+                # Reproduce a worker/operator block after promote_task's
+                # initial status read but before it acquires the write lock.
+                connection.execute(
+                    "UPDATE tasks SET status='blocked' WHERE id=?", (tid,),
+                )
+                connection.execute(
+                    "INSERT INTO task_events "
+                    "(task_id, kind, payload, created_at) "
+                    "VALUES (?, 'blocked', NULL, ?)",
+                    (tid, int(time.time())),
+                )
+                connection.commit()
+            with real_write_txn(connection):
+                yield
+
+        monkeypatch.setattr(kb, "write_txn", racing_write_txn)
+        promoted, error = kb.promote_task(conn, tid, actor="operator")
+        assert promoted is True
+        assert error is None
+
+        # A later recoverable circuit-breaker block must not inherit the
+        # sticky event that the manual promotion explicitly released.
+        conn.execute(
+            "UPDATE tasks SET status='blocked', consecutive_failures=1 "
+            "WHERE id=?",
+            (tid,),
+        )
+        conn.commit()
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, tid).status == "ready"
 
 
 def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Path) -> None:


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

