### PR TITLE
fix(agent): backfill TERMINAL_CWD from config for cwd resolution (#74116)

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -57,6 +57,42 @@ def _session_cwd_override() -> str:
     return str(value).strip()
 
 
+_config_bridge_attempted = False
+
+
+def _ensure_terminal_cwd_bridged() -> None:
+    """Backfill ``TERMINAL_CWD`` from config.yaml when no launcher bridged it.
+
+    This module's contract assumes ``terminal.cwd`` was bridged to
+    ``TERMINAL_CWD`` once at startup. Every process that skips those launcher
+    bridges therefore reads an unset variable and falls back to
+    ``os.getcwd()`` — the daemon's working directory — so context discovery
+    loads the wrong ``AGENTS.md`` while the user's configured workspace is
+    ignored (#74116).
+
+    ``tools/terminal_tool.py`` already closes exactly this hole for the
+    terminal backend via ``_ensure_terminal_env_bridged()`` (#63141, #54449,
+    #61115, #65696); context-file discovery was left on the original
+    assumption. Reuse the same ``apply_terminal_config_to_env`` helper rather
+    than re-deriving the value, so both consumers resolve identically.
+
+    Explicit env always wins: ``override=False`` keeps an already-set
+    ``TERMINAL_CWD`` (a launcher's bridge, or the user's .env) authoritative,
+    so this only fills the accidental-default case. Attempted once per
+    process; a config problem must never break cwd resolution.
+    """
+    global _config_bridge_attempted
+    if _config_bridge_attempted or os.environ.get("TERMINAL_CWD", "").strip():
+        return
+    _config_bridge_attempted = True
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env
+
+        apply_terminal_config_to_env(env=None, override=False)
+    except Exception:
+        logger.debug("terminal cwd → env fallback bridge failed", exc_info=True)
+
+
 def resolve_agent_cwd() -> Path:
     override = _session_cwd_override()
     if override:
@@ -64,6 +100,7 @@ def resolve_agent_cwd() -> Path:
         if p.is_dir():
             return p
         logger.warning("configured working directory does not exist: %s", override)
+    _ensure_terminal_cwd_bridged()
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
@@ -90,6 +127,7 @@ def resolve_context_cwd() -> Path | None:
         else:
             return p
         return None
+    _ensure_terminal_cwd_bridged()
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -79,3 +79,125 @@ class TestSessionCwdOverride:
         finally:
             rt._SESSION_CWD.reset(token)
 
+
+
+class TestTerminalCwdFallbackBridge:
+    """config.yaml must reach cwd resolution even when no launcher bridged it.
+
+    This module's contract assumes ``terminal.cwd`` was bridged to
+    ``TERMINAL_CWD`` once at gateway/cron startup. A process that skips those
+    launcher bridges read an unset variable and fell back to ``os.getcwd()``
+    — the daemon's working directory — so context-file discovery loaded the
+    wrong ``AGENTS.md`` while the user's configured workspace was ignored
+    (#74116). ``tools/terminal_tool.py`` already closes this hole for the
+    terminal backend (#63141, #54449, #61115, #65696); these cover the same
+    guarantee for cwd resolution.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _unattempted_bridge(self, monkeypatch):
+        monkeypatch.setattr(rt, "_config_bridge_attempted", False)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        yield
+
+    @staticmethod
+    def _write_config(hermes_home: Path, cwd: Path) -> None:
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            f"terminal:\n  backend: local\n  cwd: {cwd}\n"
+        )
+
+    def test_context_cwd_backfills_from_config_when_env_is_unset(
+        self, monkeypatch, tmp_path,
+    ):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        self._write_config(tmp_path / "hermes", workspace)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.chdir(tmp_path)
+
+        assert resolve_context_cwd() == workspace
+
+    def test_agent_cwd_backfills_from_config_when_env_is_unset(
+        self, monkeypatch, tmp_path,
+    ):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        self._write_config(tmp_path / "hermes", workspace)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.chdir(tmp_path)
+
+        assert resolve_agent_cwd() == workspace
+
+    def test_explicit_env_still_wins_over_config(self, monkeypatch, tmp_path):
+        """A launcher's bridge or the user's .env stays authoritative."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        explicit = tmp_path / "explicit"
+        explicit.mkdir()
+        self._write_config(tmp_path / "hermes", workspace)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setenv("TERMINAL_CWD", str(explicit))
+
+        assert resolve_context_cwd() == explicit
+
+    def test_session_override_still_wins_and_skips_the_bridge(
+        self, monkeypatch, tmp_path,
+    ):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        pinned = tmp_path / "pinned"
+        pinned.mkdir()
+        self._write_config(tmp_path / "hermes", workspace)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+        set_session_cwd(str(pinned))
+        try:
+            assert resolve_context_cwd() == pinned
+        finally:
+            clear_session_cwd()
+
+    def test_no_terminal_config_leaves_context_cwd_unset(
+        self, monkeypatch, tmp_path,
+    ):
+        """Without terminal.cwd, None still means 'use the launch dir'."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model:\n  default: x\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.chdir(tmp_path)
+
+        assert resolve_context_cwd() is None
+
+    def test_bridge_is_attempted_only_once(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model:\n  default: x\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.chdir(tmp_path)
+        calls = []
+
+        def _counting(**kwargs):
+            calls.append(kwargs)
+
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env", _counting,
+        )
+        resolve_context_cwd()
+        resolve_context_cwd()
+        resolve_agent_cwd()
+
+        assert len(calls) == 1
+
+    def test_config_failure_never_breaks_resolution(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.chdir(tmp_path)
+
+        def _boom(**kwargs):
+            raise RuntimeError("config exploded")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.apply_terminal_config_to_env", _boom,
+        )
+        assert resolve_context_cwd() is None
+        assert resolve_agent_cwd() == tmp_path


### PR DESCRIPTION
## Problem

`agent/runtime_cwd.py`'s contract assumes `terminal.cwd` was bridged to `TERMINAL_CWD` once at startup — its module docstring says exactly that ("`terminal.cwd` is bridged once to `TERMINAL_CWD` at gateway/cron startup"). Any process that skips those launcher bridges reads an unset variable and falls back to `os.getcwd()`: the daemon's working directory.

Context discovery then loads the wrong `AGENTS.md` while the user's configured workspace is ignored. That is the downstream half of #74116, and the effect #11763 describes.

**Premise verified on current `main`:** `resolve_context_cwd()` reads `os.environ.get("TERMINAL_CWD", "")` directly (`agent/runtime_cwd.py:93` before this change), with no fallback. `resolve_agent_cwd()` has the same pattern.

## Why this is the same bug class the repo already fixed once

`tools/terminal_tool.py` already closes exactly this hole for the terminal backend. `_ensure_terminal_env_bridged()` backfills `TERMINAL_*` from config.yaml when no launcher did, and its docstring records why:

> processes that skip all of those paths (`hermes serve` / the Desktop app backend's in-process agents, the desktop cron ticker, ACP) used to silently fall back to the local backend even when config.yaml selects `terminal.backend: docker`, running commands on the host the user intended to sandbox (#63141, #54449, #61115, #65696)

Context-file discovery was left on the original "a launcher bridged it" assumption, so the same class stayed open for cwd.

## Fix

`resolve_agent_cwd()` and `resolve_context_cwd()` now go through the **same** `apply_terminal_config_to_env` helper before reading the env var, rather than re-deriving the value — so both consumers resolve identically and there is one place that knows how `terminal.cwd` becomes `TERMINAL_CWD`.

Precedence is unchanged:

- A `_SESSION_CWD` pin short-circuits before the bridge is consulted at all.
- The bridge is skipped entirely when `TERMINAL_CWD` is already set (a launcher's bridge, or the user's `.env`), and `override=False` keeps existing values authoritative. It only fills the accidental default, never an explicit selection.
- Attempted once per process; a config failure can never break cwd resolution.

## Scope — what this does *not* claim

This does **not** explain why the gateway's module-level config → env bridge failed to run in the reporter's systemd setup. I could not reproduce that, and I would rather not ship a fix whose premise I can't point at a line for. Two things I did confirm while looking, in case they help whoever picks that half up:

- The bridge's `except` is **not** silent — it prints a warning to stderr (deliberately, per its own comment: "Previously this was silent ... which hid partial bridge failures"). The reporter did not mention seeing it, which argues the block was *skipped*, not that it threw.
- The skip path **is** silent: `if _config_path.exists():` at `gateway/run.py` has no `else`, so a gateway that resolved a Hermes home without a `config.yaml` bridges nothing and says nothing. That is consistent with the report and would be worth a one-line diagnostic; I left it out to keep this PR to one concern.

What this PR does fix is the reported symptom — the configured workspace now reaches context discovery even when no launcher bridged it.

## Tests

`tests/agent/test_runtime_cwd.py` gains `TestTerminalCwdFallbackBridge`, 7 tests using a real config.yaml under a temp `HERMES_HOME`:

- `resolve_context_cwd()` and `resolve_agent_cwd()` both backfill from config when the env var is unset;
- an explicit `TERMINAL_CWD` still wins;
- a `_SESSION_CWD` pin still wins and skips the bridge;
- no `terminal.cwd` in config still yields `None` (meaning "use the launch dir");
- the bridge is attempted only once across three resolver calls;
- a raising config helper never breaks resolution.

Verified they catch the bug: with the two `_ensure_terminal_cwd_bridged()` calls removed, 3 of the 7 fail.

## Regression check

`tests/agent/test_runtime_cwd.py` 13 passed. `-k "cwd or prompt_builder or context_file"` across `tests/agent/` — 76 passed, 5 skipped. `tests/agent/` + `tests/tools/` produce an **identical** failure set to a pristine `origin/main` checkout (662 on both, zero introduced; the pre-existing ones are local environment issues such as missing optional deps).
