### PR TITLE
fix(desktop): brighten dark glass text contrast

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -521,6 +521,22 @@
        touch — still clearly a surface, no longer the brightest thing in the
        transcript. Derived from the card so every skin follows its own seed. */
     --ui-widget-surface-background: color-mix(in srgb, var(--ui-bg-editor) 88%, #000);
+
+    /* Dark glass themes are often run translucent over wallpaper. The default
+       text ladder is calibrated for opaque panels and becomes too dim when the
+       desktop bleeds through, especially in sidebars, file trees, captions, and
+       assistant prose. Keep the skin hue, then blend toward white so ordinary
+       UI text stays readable without brightening the whole background. */
+    --ui-text-primary: color-mix(in srgb, var(--ui-base) 94%, #ffffff 12%);
+    --ui-text-secondary: color-mix(in srgb, var(--ui-base) 82%, #ffffff 18%);
+    --ui-text-tertiary: color-mix(in srgb, var(--ui-base) 68%, #ffffff 16%);
+    --ui-text-quaternary: color-mix(in srgb, var(--ui-base) 52%, #ffffff 12%);
+    --dt-foreground: var(--ui-text-primary);
+    --dt-card-foreground: var(--ui-text-primary);
+    --dt-muted-foreground: var(--ui-text-tertiary);
+    --dt-secondary-foreground: var(--ui-text-secondary);
+    --dt-accent-foreground: var(--ui-text-primary);
+    --sidebar-foreground: var(--ui-text-primary);
   }
 
   * {


### PR DESCRIPTION
## Summary
- Brighten the dark-mode text ladder for glass/translucent desktop themes.
- Re-map foreground, muted, secondary, accent, and sidebar foreground tokens in ":root.dark" so body copy, captions, sidebars, and file-tree rows remain readable over transparent wallpapers.
- Preserve the existing dark background and surface transparency; this only changes text contrast.

## Test Plan
- npm run build
- Static scan of added CSS diff: 0 findings

## Notes
- Existing untracked local files were left untouched and are not included in this PR.