### PR TITLE
perf(desktop): stop scroll and status loops in busy sessions

### DIFF
--- a/apps/desktop/src/app/chat/session-status-dot.tsx
+++ b/apps/desktop/src/app/chat/session-status-dot.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react'
 
+import { StatusPulse } from '@/components/ui/status-pulse'
 import { type Translations, useI18n } from '@/i18n'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
@@ -17,18 +18,16 @@ import { type SessionDotState, sessionDotState } from './sidebar/session-row-sta
 type DotVariant = {
   ariaLabel?: (r: Translations['sidebar']['row']) => string
   className: string
+  pulse?: {
+    className: string
+    opacity: number
+  }
   role?: 'status'
   title?: (r: Translations['sidebar']['row']) => string
 }
 
 // Shared base for every active dot; idle is smaller and uses its own class.
 const DOT_BASE = 'relative size-1.5 rounded-full'
-
-// Pseudo-element ping ring that scales outward and fades — shared scaffold for
-// the two pulsing dots. The `before:bg-*` color is written inline per variant
-// (NOT interpolated here): Tailwind only generates utilities it can see as
-// complete static strings, so a `before:bg-${color}` template never emits.
-const PING = "before:absolute before:inset-0 before:animate-ping before:rounded-full before:content-['']"
 
 const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
   // Amber steady — a clarify/approval is blocking the turn. Steady (not
@@ -42,14 +41,22 @@ const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
   // Accent pulse — the LLM turn is actively running.
   working: {
     ariaLabel: r => r.sessionRunning,
-    className: `${DOT_BASE} bg-(--ui-accent) shadow-[0_0_0.625rem_color-mix(in_srgb,var(--ui-accent)_55%,transparent)] ${PING} before:bg-(--ui-accent) before:opacity-70`,
+    className: `${DOT_BASE} bg-(--ui-accent) shadow-[0_0_0.625rem_color-mix(in_srgb,var(--ui-accent)_55%,transparent)]`,
+    pulse: {
+      className: 'absolute inset-0 rounded-full bg-(--ui-accent) opacity-0',
+      opacity: 0.7
+    },
     role: 'status'
   },
   // Quiet accent pulse — the turn is still authoritative-running, but no
   // stream activity has arrived for the watchdog window.
   stalled: {
     ariaLabel: r => r.sessionRunning,
-    className: `${DOT_BASE} bg-(--ui-accent) opacity-70 ${PING} before:bg-(--ui-accent) before:opacity-40`,
+    className: `${DOT_BASE} bg-(--ui-accent) opacity-70`,
+    pulse: {
+      className: 'absolute inset-0 rounded-full bg-(--ui-accent) opacity-0',
+      opacity: 0.4
+    },
     role: 'status',
     title: r => r.sessionRunning
   },
@@ -58,7 +65,11 @@ const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
   // than muted-foreground so it's visible against the surface.
   background: {
     ariaLabel: r => r.backgroundRunning,
-    className: `${DOT_BASE} bg-muted-foreground/80 ${PING} before:bg-muted-foreground/80 before:opacity-60`,
+    className: `${DOT_BASE} bg-muted-foreground/80`,
+    pulse: {
+      className: 'absolute inset-0 rounded-full bg-muted-foreground/80 opacity-0',
+      opacity: 0.6
+    },
     role: 'status',
     title: r => r.backgroundRunning
   },
@@ -123,6 +134,7 @@ export function SessionStatusDot({ storedSessionId, session, branchStem, classNa
   const hasBackground = useStoreSelector($backgroundRunningSessionIds, ids => ids.includes(storedSessionId))
 
   const dotState = sessionDotState({ hasBackground, isStalled, isUnread, isWorking, needsInput })
+  const variant = DOT_VARIANTS[dotState]
 
   return (
     <span className={cn('flex items-center gap-0.5', className)}>
@@ -135,11 +147,20 @@ export function SessionStatusDot({ storedSessionId, session, branchStem, classNa
         <span aria-hidden="true" className="size-1 rounded-full" style={{ backgroundColor: color }} />
       ) : (
         <span
-          aria-label={DOT_VARIANTS[dotState].ariaLabel?.(r)}
-          className={DOT_VARIANTS[dotState].className}
-          role={DOT_VARIANTS[dotState].role}
-          title={DOT_VARIANTS[dotState].title?.(r)}
-        />
+          aria-label={variant.ariaLabel?.(r)}
+          className={variant.className}
+          role={variant.role}
+          title={variant.title?.(r)}
+        >
+          {variant.pulse ? (
+            <StatusPulse
+              aria-hidden="true"
+              className={variant.pulse.className}
+              kind="ping"
+              opacity={variant.pulse.opacity}
+            />
+          ) : null}
+        </span>
       )}
     </span>
   )

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -6,7 +6,8 @@ import {
   LIVE_TAIL_MIN_GROUPS,
   LIVE_TAIL_PARTS,
   liveTailStart,
-  type MessageGroup
+  type MessageGroup,
+  resolveThreadScrollTarget
 } from './list'
 
 // Signature rows are `${index}:${id}:${role}:${weight}` (see the useAuiState
@@ -57,6 +58,53 @@ describe('buildGroups', () => {
     const groups = buildGroups('0:a:assistant:0')
 
     expect(groups).toEqual([{ id: 'a', index: 0, kind: 'standalone', weight: 1 }])
+  })
+})
+
+describe('resolveThreadScrollTarget', () => {
+  const context = (scrollElement: Pick<HTMLElement, 'scrollTop'>) => ({
+    contentElement: document.createElement('div'),
+    scrollElement: scrollElement as HTMLElement
+  })
+
+  it('settles when the browser clamps the requested bottom within half a CSS pixel', () => {
+    let actualScrollTop = 0
+    let writes = 0
+
+    const scrollElement = {
+      get scrollTop() {
+        return actualScrollTop
+      },
+      set scrollTop(value: number) {
+        writes += 1
+        actualScrollTop = value - 0.125
+      }
+    }
+
+    const target = 899
+
+    const requested = resolveThreadScrollTarget(target, context(scrollElement))
+    scrollElement.scrollTop = requested
+    const settled = resolveThreadScrollTarget(target, context(scrollElement))
+
+    expect(requested).toBe(target)
+    expect(actualScrollTop).toBe(898.875)
+    expect(settled).toBe(actualScrollTop)
+    expect(actualScrollTop < settled).toBe(false)
+    expect(writes).toBe(1)
+  })
+
+  it('keeps following while more than half a CSS pixel remains', () => {
+    const scrollElement = { scrollTop: 898.25 }
+
+    expect(resolveThreadScrollTarget(899, context(scrollElement))).toBe(899)
+  })
+
+  it('re-arms after streaming content increases the target', () => {
+    const scrollElement = { scrollTop: 898.875 }
+
+    expect(resolveThreadScrollTarget(899, context(scrollElement))).toBe(898.875)
+    expect(resolveThreadScrollTarget(999, context(scrollElement))).toBe(999)
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -13,7 +13,7 @@ import {
   useRef,
   useState
 } from 'react'
-import { useStickToBottom } from 'use-stick-to-bottom'
+import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
@@ -55,6 +55,20 @@ const RENDER_BUDGET = 300
 // interruptibly, so the only thing a smaller budget changes is how much work
 // blocks the click-to-paint path.
 const FIRST_PAINT_BUDGET = 20
+
+// Browsers may quantize a requested scrollTop to a nearby device-pixel
+// boundary. use-stick-to-bottom otherwise compares the lower actual value to
+// the integer target forever, re-requesting the same instant scroll every
+// frame. Treat a subpixel remainder as achieved; larger gaps still follow new
+// streamed content normally.
+const SCROLL_TARGET_EPSILON_PX = 0.5
+
+export const resolveThreadScrollTarget: GetTargetScrollTop = (targetScrollTop, { scrollElement }) => {
+  const currentScrollTop = scrollElement.scrollTop
+  const remaining = targetScrollTop - currentScrollTop
+
+  return remaining >= 0 && remaining <= SCROLL_TARGET_EPSILON_PX ? currentScrollTop : targetScrollTop
+}
 
 interface ThreadMessageListProps {
   clampToComposer: boolean
@@ -224,7 +238,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // settling. Its refs hang off our own DOM so the sticky human bubbles survive.
   const { scrollRef, contentRef, isAtBottom, scrollToBottom, stopScroll } = useStickToBottom({
     initial: 'instant',
-    resize: 'instant'
+    resize: 'instant',
+    targetScrollTop: resolveThreadScrollTarget
   })
 
   const [renderBudget, setRenderBudget] = useState(FIRST_PAINT_BUDGET)

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -9,6 +9,7 @@ import { ActivityTimerText } from '@/components/chat/activity-timer-text'
 import { SCAFFOLD_LABEL_CLASS } from '@/components/chat/scaffold-row'
 import { Codicon } from '@/components/ui/codicon'
 import { Loader } from '@/components/ui/loader'
+import { StatusPulse } from '@/components/ui/status-pulse'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 import { $backgroundResume } from '@/store/background-delegation'
@@ -130,7 +131,11 @@ export const ResponseLoadingIndicator: FC = () => {
 
   return (
     <StatusRow data-slot="aui_response-loading" label={hint || t.assistant.thread.loadingResponse}>
-      <span aria-hidden="true" className="dither inline-block size-3 rounded-[2px] text-midground/80 animate-pulse" />
+      <StatusPulse
+        aria-hidden="true"
+        className="dither inline-block size-3 rounded-[2px] text-midground/80"
+        kind="opacity"
+      />
       {hint && <HintText>{hint}</HintText>}
       <ActivityTimerText seconds={elapsed} />
     </StatusRow>
@@ -236,7 +241,11 @@ export const StreamStallIndicator: FC = () => {
 
   return (
     <StatusRow data-slot="aui_stream-stall" label={hint || 'Hermes is thinking'}>
-      <span aria-hidden="true" className="dither inline-block size-3 rounded-[2px] text-midground/80 animate-pulse" />
+      <StatusPulse
+        aria-hidden="true"
+        className="dither inline-block size-3 rounded-[2px] text-midground/80"
+        kind="opacity"
+      />
       {hint && <HintText>{hint}</HintText>}
       <ActivityTimerText seconds={elapsed} />
     </StatusRow>

--- a/apps/desktop/src/components/ui/status-pulse.test.tsx
+++ b/apps/desktop/src/components/ui/status-pulse.test.tsx
@@ -1,0 +1,131 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { StatusPulse } from './status-pulse'
+
+interface PlayedAnimation {
+  cancel: ReturnType<typeof vi.fn>
+  keyframes: Keyframe[]
+  options: KeyframeAnimationOptions
+}
+
+interface WindowStatePayload {
+  isMinimized?: boolean
+  isVisible?: boolean
+}
+
+let windowStateCallback: ((payload: WindowStatePayload) => void) | undefined
+
+function installMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      addEventListener: vi.fn(),
+      matches,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      removeEventListener: vi.fn()
+    }))
+  )
+}
+
+function installWindowStateBridge() {
+  const off = vi.fn()
+
+  window.hermesDesktop = {
+    onWindowStateChanged: vi.fn(callback => {
+      windowStateCallback = callback
+
+      return off
+    })
+  } as unknown as typeof window.hermesDesktop
+
+  return off
+}
+
+describe('StatusPulse', () => {
+  const played: PlayedAnimation[] = []
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(window.document, 'hasFocus').mockReturnValue(true)
+    installMatchMedia(false)
+    installWindowStateBridge()
+    Object.defineProperty(HTMLElement.prototype, 'animate', {
+      configurable: true,
+      value: (keyframes: Keyframe[], options: KeyframeAnimationOptions) => {
+        const animation = {
+          cancel: vi.fn(),
+          keyframes,
+          options
+        }
+
+        played.push(animation)
+
+        return animation as unknown as Animation
+      },
+      writable: true
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    played.length = 0
+    windowStateCallback = undefined
+    Reflect.deleteProperty(HTMLElement.prototype, 'animate')
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('plays a finite ping and sleeps between pulses', () => {
+    render(<StatusPulse kind="ping" opacity={0.7} />)
+
+    expect(played).toHaveLength(1)
+    expect(played[0]?.keyframes).toEqual([
+      { opacity: 0.7, transform: 'scale(1)' },
+      { opacity: 0, transform: 'scale(2)' }
+    ])
+    expect(played[0]?.options).toMatchObject({ duration: 400, iterations: 1 })
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => vi.advanceTimersByTime(4_999))
+    expect(played).toHaveLength(1)
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(played).toHaveLength(2)
+  })
+
+  it('cancels scheduled work while minimized and restarts once visible', () => {
+    const offWindowState = installWindowStateBridge()
+    const mounted = render(<StatusPulse kind="opacity" />)
+
+    expect(played).toHaveLength(1)
+
+    act(() => windowStateCallback?.({ isMinimized: true, isVisible: false }))
+
+    expect(played[0]?.cancel).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+
+    act(() => vi.advanceTimersByTime(5_000))
+    expect(played).toHaveLength(1)
+
+    act(() => windowStateCallback?.({ isMinimized: false, isVisible: true }))
+    expect(played).toHaveLength(2)
+
+    mounted.unmount()
+    expect(played[1]?.cancel).toHaveBeenCalledTimes(1)
+    expect(offWindowState).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('stays static when reduced motion is requested', () => {
+    installMatchMedia(true)
+
+    render(<StatusPulse kind="opacity" />)
+
+    expect(played).toHaveLength(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/apps/desktop/src/components/ui/status-pulse.tsx
+++ b/apps/desktop/src/components/ui/status-pulse.tsx
@@ -1,0 +1,93 @@
+import { type ComponentProps, useEffect, useRef } from 'react'
+
+import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
+
+const PULSE_DURATION_MS = 400
+const PULSE_PERIOD_MS = 5_000
+
+export interface StatusPulseProps extends Omit<ComponentProps<'span'>, 'children' | 'ref'> {
+  kind: 'opacity' | 'ping'
+  opacity?: number
+}
+
+/**
+ * A finite status pulse with a real sleep between plays.
+ *
+ * Continuous CSS animations keep Chromium producing frames and recalculating
+ * styles for an otherwise motionless Desktop window. Drive the same visual
+ * cue directly so React stays out of the loop and the renderer/compositor can
+ * sleep between pulses.
+ */
+export function StatusPulse({ kind, opacity = 1, ...props }: StatusPulseProps) {
+  const ref = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    const element = ref.current
+
+    if (
+      !element ||
+      typeof element.animate !== 'function' ||
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    ) {
+      return
+    }
+
+    let animation: Animation | null = null
+    let timer = 0
+    let stopped = false
+    let pauseController: ReturnType<typeof createRendererLoopPauseController> | null = null
+
+    const clearScheduled = () => {
+      if (timer !== 0) {
+        window.clearTimeout(timer)
+        timer = 0
+      }
+
+      animation?.cancel()
+      animation = null
+    }
+
+    const play = () => {
+      timer = 0
+
+      if (stopped || pauseController?.isPaused()) {
+        return
+      }
+
+      animation?.cancel()
+      animation = element.animate(
+        kind === 'ping'
+          ? [
+              { opacity, transform: 'scale(1)' },
+              { opacity: 0, transform: 'scale(2)' }
+            ]
+          : [{ opacity: 1 }, { opacity: 0.5 }, { opacity: 1 }],
+        {
+          duration: PULSE_DURATION_MS,
+          easing: kind === 'ping' ? 'cubic-bezier(0, 0, 0.2, 1)' : 'ease-in-out',
+          iterations: 1
+        }
+      )
+      timer = window.setTimeout(play, PULSE_PERIOD_MS)
+    }
+
+    const handlePauseChange = () => {
+      clearScheduled()
+
+      if (!pauseController?.isPaused()) {
+        play()
+      }
+    }
+
+    pauseController = createRendererLoopPauseController(handlePauseChange)
+    play()
+
+    return () => {
+      stopped = true
+      clearScheduled()
+      pauseController?.dispose()
+    }
+  }, [kind, opacity])
+
+  return <span {...props} ref={ref} />
+}


### PR DESCRIPTION
## What does this PR do?

Stops two independent renderer loops that remain active in a visible, busy-but-silent Desktop session:

1. `use-stick-to-bottom` can request an integer `scrollTop` that Chromium quantizes to a nearby device-pixel boundary. Because the achieved value remains fractionally below the target, the library can schedule the same instant scroll again on every animation frame.
2. Busy-session status surfaces use infinite `animate-ping` / `animate-pulse` CSS animations. They do not cause React commits, but they continuously invalidate style/compositor work while the session is otherwise quiet.

This change:

- supplies `use-stick-to-bottom` with a target resolver that treats a non-negative remainder of at most `0.5px` as achieved;
- replaces the infinite status animations with a shared finite Web Animations API pulse: `400ms` of motion on a `5s` cadence;
- suspends that pulse while the window is hidden, minimized, or unfocused, and keeps it static for reduced-motion users;
- preserves the animated status cues, sticky-bottom behavior, long transcript, and open tool-result DOM.

The scroll tolerance is deliberately narrow. A larger gap still uses the library's original target, and later streamed content increases the target enough to re-arm normal follow behavior.

## Root cause and attribution

The controlled reproduction used an isolated Electron home, user-data directory, backend/CDP/dev ports, and a 60-turn busy-but-silent transcript with 180 open tool rows. The five-second measurement window retained 60 user messages, 61 assistant messages, 180 tool rows, and roughly 7,800 content nodes.

The scroll loop was directly observable:

- requested `scrollTop`: `16503`
- Chromium-achieved `scrollTop`: `16502.77734375`
- repeated writes before the fix: `599` in five seconds
- writes with the epsilon resolver: `1`

That loop was real, but it was not the largest remaining CPU owner. Removing it alone changed renderer CPU from `20.79%` to `18.19%` in the matched run, while GPU sampling remained noisy. With scroll already settled, the status-animation kill switch isolated the larger compositor path:

| Diagnostic state | Renderer CPU | GPU process CPU | React commits/s |
|---|---:|---:|---:|
| status ping running | 17.6% | 11.4% | 1.0 |
| status ping running, repeat | 17.8% | 12.0% | 1.0 |
| known CSS status animations paused | 1.8% | 1.6% | 1.0 |

The unchanged React rate is important: this is compositor/style work, not another React-render explanation.

## Measured impact

In the corrected model-bound A/B, using the same machine, source baseline, harness, transcript, and five-second busy-silent window:

| Metric | Current behavior | This branch | Change |
|---|---:|---:|---:|
| Renderer CPU (one core) | 20.79% | 4.8% | -76.9% |
| GPU process CPU (one core) | 16.79% | 4.6% | -72.6% |
| `scrollTop` writes | 599 | 1 | -99.8% |
| animation-frame callbacks | 602 | 9 | -98.5% |
| style recalculations | 611 | 86 | -85.9% |
| task duration | 776.02ms | 176.40ms | -77.3% |

After the synthetic turn completed, the retained transcript settled further:

| State | Renderer CPU | GPU process CPU | scroll reads/writes | timers / RAFs |
|---|---:|---:|---:|---:|
| completed +1s | 0.8% | 1.0% | 0 / 0 | 0 |
| completed +15s | 1.0% | 1.2% | 0 / 0 | 0 |

This is intentionally scoped evidence. It demonstrates the visible busy-session loops above; it does **not** claim to explain every clean-launch or hidden-window report.

## Related Issue

Related to #73082, #51927, and #53902.

Follow-up to the narrower GlyphSpinner investigation in #72844 and #74357. Related background-loop inventory: #69645.

This PR does not use `Fixes`/`Closes` for the broader reports because their reproduction envelopes are wider than the controlled busy-silent transcript measured here.

### Duplicate / coordination check

- #74679 changes Electron background-throttling policy for hidden or occluded windows. This PR instead removes visible-session scroll/style loops and does not alter that policy.
- #70478, #69554, and #70029 touch the same thread-list scroll owner for session restoration or freeze behavior; none implements the subpixel achieved-target rule.
- #74327 animates a different `StatusDot`. It is not a duplicate, but its proposed continuous CSS breath could reuse this bounded pulse primitive if both changes proceed.
- #73033 and #74357 are competing GlyphSpinner fixes. This PR does not touch `GlyphSpinner`.

No open PR found by `use-stick-to-bottom`, `SessionStatusDot`, `scrollTop` + Desktop CPU, or `animate-ping` searches implements this combination.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/list.tsx`
  - add the `0.5px` achieved-target resolver to the existing single scroll owner.
- `apps/desktop/src/components/assistant-ui/thread/list.test.ts`
  - reproduce browser clamping (`899` requested, `898.875` achieved);
  - prove the write settles once, gaps above the tolerance still follow, and later content growth re-arms following.
- `apps/desktop/src/components/ui/status-pulse.tsx`
  - add the finite, sleeping, reduced-motion-aware and window-state-aware status pulse.
- `apps/desktop/src/components/ui/status-pulse.test.tsx`
  - prove finite cadence, inactive-window cancellation/resume, cleanup, and reduced-motion behavior.
- `apps/desktop/src/app/chat/session-status-dot.tsx`
  - retain the working/stalled/background ping visuals through `StatusPulse`.
- `apps/desktop/src/components/assistant-ui/thread/status.tsx`
  - retain the response-loading and stream-stall opacity cues through `StatusPulse`.

## How to Test

1. Run the focused behavior tests:

   ```shell
   npm --workspace apps/desktop run test:ui -- \
     src/components/assistant-ui/thread/list.test.ts \
     src/components/assistant-ui/thread/status.test.tsx \
     src/components/ui/status-pulse.test.tsx
   ```

2. Run the Desktop static and production gates:

   ```shell
   npm --workspace apps/desktop run typecheck
   npm --workspace apps/desktop run lint
   npm --workspace apps/desktop run build
   ```

3. In Desktop, start a long tool-heavy turn and leave it busy without incoming deltas:
   - confirm the thread remains pinned to the live tail;
   - confirm working/stalled/background and thread-loading indicators still pulse;
   - confirm scrolling up still releases sticky follow;
   - confirm new streamed content re-arms follow when already at the bottom.

## Verification

- Focused scroll/status regression: **3 files, 23 tests passed**
- TypeScript checks (renderer, Electron, E2E): **passed**
- Prettier on all six changed files: **passed**
- ESLint: **0 errors**; 74 warnings outside the changed files
- Production Desktop build and dist assertion: **passed**
- `git diff --check origin/main...HEAD`: **passed**
- Full Desktop run: **427 files / 3,991 tests passed; 1 file / 4 tests failed; 1 file / 2 tests skipped**
  - the only failing file was untouched `src/app/skills/index.test.tsx`, whose async renders overlap under the full parallel run;
  - rerunning it alone passed **4/4**;
  - the changed-file regression tests passed in the full run as well as the focused run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - N/A for this renderer-only TypeScript change; the scoped Desktop gates and production build above were run instead.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0 (26A5378n), Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public API or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; this reuses the existing renderer pause controller
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — browser APIs plus the existing cross-platform window-state bridge only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The active-state semantics remain the same, but the decorative motion is intentionally quieter: a short pulse every five seconds instead of a continuous animation. Reduced-motion users see the existing static status shape/color.
