### PR TITLE
fix(qwen): make thinking mode explicit

### DIFF
--- a/plugins/model-providers/qwen-oauth/__init__.py
+++ b/plugins/model-providers/qwen-oauth/__init__.py
@@ -89,11 +89,28 @@ class QwenProfile(ProviderProfile):
         qwen_session_metadata: dict | None = None,
         **context,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Qwen metadata goes to top-level api_kwargs, not extra_body."""
-        top_level = {}
+        """Build Qwen's explicit thinking contract.
+
+        Qwen-compatible endpoints default to server-side ``auto`` when this
+        field is omitted.  Hermes must not rely on that implicit mode: unset
+        reasoning is the safe utility/coding mode, while an explicit enabled
+        config opts into thinking.  The 32K budget is deliberately below the
+        64K completion cap so an enabled request retains room for visible
+        answer tokens.
+        """
+        top_level: dict[str, Any] = {}
         if qwen_session_metadata:
             top_level["metadata"] = qwen_session_metadata
-        return {}, top_level
+
+        enabled = bool(
+            isinstance(reasoning_config, dict)
+            and type(reasoning_config.get("enabled")) is bool
+            and reasoning_config["enabled"] is True
+        )
+        extra_body: dict[str, Any] = {"enable_thinking": enabled}
+        if enabled:
+            extra_body["thinking_budget"] = 32768
+        return extra_body, top_level
 
 
 qwen = QwenProfile(

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -186,6 +186,56 @@ class TestQwenProfile:
         assert tl["metadata"] == meta
         assert "metadata" not in eb
 
+    def test_reasoning_disabled_unless_enabled_is_true(self):
+        p = get_provider_profile("qwen-oauth")
+        assert p is not None
+        disabled_configs: tuple[object, ...] = (
+            None,
+            {},
+            {"effort": "high"},
+            {"enabled": False},
+            {"enabled": "false"},
+            {"enabled": 1},
+            {"enabled": None},
+            [],
+            "malformed",
+        )
+        for config in disabled_configs:
+            eb, _ = p.build_api_kwargs_extras(reasoning_config=config)
+            assert eb == {"enable_thinking": False}, config
+        enabled_with_effort = (
+            {"enabled": True},
+            {"enabled": True, "effort": "none"},
+            {"enabled": True, "effort": " NONE "},
+            {"enabled": True, "effort": "NoNe"},
+            {"enabled": True, "effort": "high"},
+            {"enabled": True, "effort": object()},
+        )
+        for config in enabled_with_effort:
+            eb, _ = p.build_api_kwargs_extras(reasoning_config=config)
+            assert eb == {"enable_thinking": True, "thinking_budget": 32768}, config
+        eb, _ = p.build_api_kwargs_extras(reasoning_config={"enabled": "malformed"})
+        assert eb == {"enable_thinking": False}
+
+    def test_reasoning_is_enabled_with_bounded_budget_and_headroom(self):
+        p = get_provider_profile("qwen-oauth")
+        assert p is not None
+        eb, _ = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}
+        )
+        assert eb == {"enable_thinking": True, "thinking_budget": 32768}
+        assert p.default_max_tokens > eb["thinking_budget"]
+
+    def test_metadata_is_preserved_with_reasoning_contract(self):
+        p = get_provider_profile("qwen-oauth")
+        assert p is not None
+        meta = {"sessionId": "s123", "promptId": "p456"}
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True}, qwen_session_metadata=meta
+        )
+        assert eb == {"enable_thinking": True, "thinking_budget": 32768}
+        assert tl == {"metadata": meta}
+
 
 
 


### PR DESCRIPTION
## Summary

Qwen-compatible endpoints can default to server-side `auto` reasoning. For short utility or coding requests, hidden reasoning can consume the entire completion budget and leave empty visible output.

This PR makes Qwen thinking explicit at the provider boundary:

- absent, malformed, false, or non-boolean reasoning config → `enable_thinking: false`
- explicit `{"enabled": true}` → `enable_thinking: true` plus a bounded `thinking_budget: 32768`
- existing Qwen session metadata remains top-level metadata

## Why this is provider-specific

Qwen uses `enable_thinking` in the request body. This is separate from the custom-provider / llama.cpp/vLLM work in #12427 and #64153, which uses `chat_template_kwargs.enable_thinking` for a different provider path. This PR does not attempt to redesign generic `extra_body` configuration or model-specific field mapping.

## Reasoning contract

Hermes' reasoning parser produces `{"enabled": true, "effort": ...}` for explicit reasoning levels and `{"enabled": false}` for `none`. Only the genuine boolean `enabled=True` is authoritative here; `effort` is intentionally non-authoritative so explicit enablement is not accidentally suppressed by `effort="none"` or malformed effort values.

Unset reasoning is deliberately sent as `enable_thinking=false` rather than relying on a server-side `auto` default. This prevents hidden reasoning from silently consuming utility-request output budgets. The enabled 32K thinking budget is below the profile's 64K completion default, preserving visible-output headroom.

## Validation

- `python3 -m pytest tests/providers/test_provider_profiles.py -q` — 16 passed
- `python3 -m pytest tests/providers/test_profile_wiring.py tests/providers/test_transport_parity.py -q` — 22 passed
- Independent adversarial review — **APPROVE**
- Review covered malformed/absent/false/true/effort edge cases, actual `ChatCompletionsTransport` forwarding, metadata preservation, diff scope, and secret safety

Validation exercised the Qwen-compatible llama.cpp/Lemonade transport path. No live Qwen Portal credential or production service is required or included.

## Related upstream work

- #12427 / #64153 — custom-provider llama.cpp/vLLM thinking opt-out
- #63195 — configurable model-specific thinking field names
- #7209 — general model `extra_body` passthrough
- #8160 — DashScope thinking budget issue

## Scope

Only the Qwen provider profile and its focused tests are changed. No routing, Hindsight, LiteLLM, Lemonade, credentials, or deployment changes are included.