### PR TITLE
fix(relay): preserve noop fallback without binding

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -428,9 +428,14 @@ class RelayHostRegistry:
             try:
                 host = RelayRuntime(profile_key=key)
             except Exception as exc:
-                logger.warning(
-                    "Hermes Relay runtime initialization failed", exc_info=True
-                )
+                if isinstance(exc, ModuleNotFoundError) and exc.name == "nemo_relay":
+                    logger.debug(
+                        "nemo_relay is not installed; using the no-op Relay runtime"
+                    )
+                else:
+                    logger.warning(
+                        "Hermes Relay runtime initialization failed", exc_info=True
+                    )
                 host = NoopRelayRuntime(profile_key=key, reason=str(exc))
             self._hosts[key] = host
             return host

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -537,13 +537,16 @@ def test_execution_adapters_do_not_create_relay_host_without_a_consumer(
 
 
 
-def test_core_runtime_is_fail_open_without_a_published_binding(monkeypatch, caplog):
+def test_core_runtime_is_quietly_fail_open_without_a_published_binding(
+    monkeypatch,
+    caplog,
+):
     relay_shared_metrics._reset_for_tests()
     relay_runtime._reset_for_tests()
 
     def missing_relay(name: str):
         assert name == "nemo_relay"
-        raise ModuleNotFoundError(name)
+        raise ModuleNotFoundError(f"No module named '{name}'", name=name)
 
     monkeypatch.setattr(relay_runtime.importlib, "import_module", missing_relay)
 
@@ -558,6 +561,35 @@ def test_core_runtime_is_fail_open_without_a_published_binding(monkeypatch, capl
         args={"command": "true"},
     ) == {"command": "true"}
     assert not relay_runtime.emit_mark("hermes.probe", session_id="s1")
+    assert "Hermes Relay runtime initialization failed" not in caplog.text
+    relay_runtime._reset_for_tests()
+
+
+def test_core_runtime_warns_when_relay_has_a_missing_transitive_dependency(
+    monkeypatch,
+    caplog,
+):
+    relay_shared_metrics._reset_for_tests()
+    relay_runtime._reset_for_tests()
+
+    def missing_transitive_dependency(name: str):
+        assert name == "nemo_relay"
+        dependency = "nemo_relay_native"
+        raise ModuleNotFoundError(
+            f"No module named '{dependency}'",
+            name=dependency,
+        )
+
+    monkeypatch.setattr(
+        relay_runtime.importlib,
+        "import_module",
+        missing_transitive_dependency,
+    )
+
+    assert relay_runtime.get_runtime() is None
+    host = relay_runtime.get_host()
+    assert isinstance(host, relay_runtime.NoopRelayRuntime)
+    assert "nemo_relay_native" in host.reason
     assert "Hermes Relay runtime initialization failed" in caplog.text
     relay_runtime._reset_for_tests()
 


### PR DESCRIPTION
## What does this PR do?

Treats absence of the top-level `nemo_relay` binding as the expected reduced-capability case without logging a WARNING traceback, while preserving the existing `NoopRelayRuntime` fallback.

The registry now:

- logs at DEBUG when `ModuleNotFoundError.name == "nemo_relay"`;
- still constructs `NoopRelayRuntime`, so `get_runtime()` returns `None` and all consumers remain fail-open;
- retains the WARNING traceback for every other initialization exception, including missing transitive dependencies inside an installed `nemo_relay` package.

No telemetry setting, package marker, or supported-platform behavior changes.

## Why not return `None` from `_load_nemo_relay()`?

PR #74834 attempts to silence this warning by returning `None` from the importer. `RelayRuntime.__init__` assigns that result directly to `self.relay`, so construction succeeds instead of activating the registry's no-op fallback. The first session operation then fails:

```text
host_type RelayRuntime
relay_binding None
AttributeError: 'NoneType' object has no attribute 'scope'
```

The exception must remain visible to `RelayHostRegistry` so it can construct `NoopRelayRuntime`; only the expected top-level package absence should be demoted.

## Changes

- `agent/relay_runtime.py`
  - classify an exact top-level `nemo_relay` `ModuleNotFoundError` as expected;
  - log that case at DEBUG;
  - retain WARNING + traceback for all real initialization failures.
- `tests/hermes_cli/test_relay_shared_metrics_runtime.py`
  - update the existing missing-binding regression to require a quiet no-op fallback;
  - add coverage proving a missing transitive dependency still emits the warning.

## Tests

```text
uv run --frozen --with pytest --with pytest-asyncio python -m pytest \
  tests/hermes_cli/test_relay_shared_metrics_runtime.py \
  tests/hermes_cli/test_relay_shared_metrics.py \
  tests/agent/test_relay_llm.py \
  tests/agent/test_relay_tools.py \
  tests/plugins/test_nemo_relay_plugin.py -q

25 passed, 5 skipped in 9.53s
```

Also passed:

```text
uv run --frozen --with ruff ruff check \
  agent/relay_runtime.py \
  tests/hermes_cli/test_relay_shared_metrics_runtime.py

git diff --check
```

Related: #74592, #74607, #74608, #74834.
