### PR TITLE
fix(state): guard byte-identical ACTIVE duplicate message inserts

### DIFF
--- a/contributors/emails/zhangyingliang@outlook.com
+++ b/contributors/emails/zhangyingliang@outlook.com
@@ -1,0 +1,1 @@
+yingliang-zhang

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9353,12 +9353,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 turn_lease_holder=turn_lease_holder,
                 turn_lease_ttl_seconds=turn_lease_ttl_seconds,
             )
+            # Byte-identical ACTIVE duplicate guard (#53461): a re-append
+            # with the same (session_id, role, content, timestamp) as a live
+            # row collapses to a no-op via the idx_messages_active_dedupe
+            # partial UNIQUE index. Targeted ON CONFLICT — NOT INSERT OR
+            # IGNORE — so FK/NOT NULL violations still raise. The WHERE
+            # clause must mirror the index predicate exactly (SQLite partial
+            # -index inference); rows outside active=1 (e.g. the soft-archived
+            # compaction original) never conflict. A skipped insert does not
+            # fire messages_fts_insert, so FTS stays single-indexed.
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(session_id, role, content, timestamp) WHERE active = 1 DO NOTHING""",
                 (
                     session_id,
                     role,
@@ -9383,6 +9393,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     display_metadata_json,
                 ),
             )
+            if cursor.rowcount == 0:
+                # Duplicate of an already-live row: idempotent no-op — resolve
+                # to the existing row's id and leave sessions.* counters alone.
+                existing = conn.execute(
+                    "SELECT id FROM messages WHERE session_id = ? AND role = ? "
+                    "AND content IS ? AND timestamp = ? AND active = 1 "
+                    "ORDER BY id DESC LIMIT 1",
+                    (session_id, role, stored_content, message_timestamp),
+                ).fetchone()
+                if existing is not None:
+                    return existing["id"]
+                # Defensive: a conflict with no visible active row should be
+                # impossible; fall through to the normal accounting below.
             msg_id = cursor.lastrowid
 
             # Update counters
@@ -9784,12 +9807,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             api_content = msg.get("api_content")
 
+            # Same byte-identical ACTIVE duplicate guard as append_message
+            # (#53461): a re-inserted compacted/rewrite row that matches a
+            # live (session_id, role, content, timestamp) row is skipped via
+            # the idx_messages_active_dedupe partial UNIQUE index — and must
+            # not inflate the caller's inserted/tool-call accounting. Rows
+            # archived to active=0 in the same compaction transaction are
+            # outside the index scope and never conflict.
             cur = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(session_id, role, content, timestamp) WHERE active = 1 DO NOTHING""",
                 (
                     session_id,
                     role,
@@ -9814,10 +9845,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._encode_display_metadata(msg.get("display_metadata")),
                 ),
             )
-            if isinstance(msg, dict) and cur.lastrowid is not None:
+            if isinstance(msg, dict) and cur.lastrowid is not None and cur.rowcount:
                 msg["_row_id"] = cur.lastrowid
-            inserted += 1
-            if tool_calls is not None:
+            inserted += cur.rowcount
+            if cur.rowcount and tool_calls is not None:
                 tool_calls_total += (
                     len(tool_calls) if isinstance(tool_calls, list) else 1
                 )

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -466,6 +466,13 @@ CREATE INDEX IF NOT EXISTS idx_sessions_system_prompt_hash
 -- class, where a duplicate can only be a residual double-write. The
 -- columns here are exactly the conflict target of the ON CONFLICT clause
 -- on the messages INSERTs in hermes_state.py.
+-- LIMITATION: SQLite UNIQUE indexes treat NULL as distinct, so rows with
+-- content = NULL are NOT deduplicated by this index.  The v24 migration
+-- DELETE (in hermes_state_schema.py) uses GROUP BY, which collapses NULL
+-- into one group, so existing NULL-content duplicates are cleaned up on
+-- upgrade.  New NULL-content messages (rare: tool-call-only rows with no
+-- text) are outside the runtime guard — see
+-- test_state_db_duplicate_messages.py::TestNullContentBoundary.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_active_dedupe
     ON messages(session_id, role, content, timestamp)
     WHERE active = 1;

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -458,6 +458,17 @@ CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
     ON sessions(handoff_state, started_at);
 CREATE INDEX IF NOT EXISTS idx_sessions_system_prompt_hash
     ON sessions(system_prompt_hash);
+-- Byte-identical ACTIVE duplicate guard (#53461): two live rows may never
+-- share (session_id, role, content, timestamp). Partial so the intentional
+-- in-place-compaction pair — the same content+timestamp kept once as the
+-- soft-archived original (active=0, compacted=1) and once as the fresh
+-- active row — stays legal; the constraint bites only within the ACTIVE
+-- class, where a duplicate can only be a residual double-write. The
+-- columns here are exactly the conflict target of the ON CONFLICT clause
+-- on the messages INSERTs in hermes_state.py.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_active_dedupe
+    ON messages(session_id, role, content, timestamp)
+    WHERE active = 1;
 """
 
 

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -858,6 +858,35 @@ class SessionSchemaMixin:
         except sqlite3.OperationalError as exc:
             logger.debug("idx_messages_platform_msg_id create skipped: %s", exc)
 
+        # Byte-identical ACTIVE duplicate collapse (v24 data repair): the
+        # idx_messages_active_dedupe partial UNIQUE index in DEFERRED_INDEX_SQL
+        # below cannot be created while a pre-upgrade DB still carries two
+        # live rows sharing (session_id, role, content, timestamp). Delete
+        # those residual double-writes (keeping the first row) whenever the
+        # index is still absent — first open after the upgrade, or a DB
+        # whose index creation previously failed. Once the index exists,
+        # every writer version is constrained, so this probe skips forever.
+        # Soft-archived rows (active=0) are untouched: the archive+live pair
+        # produced by in-place compaction is intentional and shares the same
+        # four-tuple legally. Row deletions flow through the messages_fts*
+        # delete triggers, so FTS stays consistent with the canonical table.
+        try:
+            has_dedupe_index = cursor.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' "
+                "AND name = 'idx_messages_active_dedupe'"
+            ).fetchone() is not None
+        except sqlite3.OperationalError:
+            has_dedupe_index = False
+        if not has_dedupe_index:
+            try:
+                cursor.execute(
+                    "DELETE FROM messages WHERE active = 1 AND id NOT IN ("
+                    "SELECT MIN(id) FROM messages WHERE active = 1 "
+                    "GROUP BY session_id, role, content, timestamp)"
+                )
+            except sqlite3.OperationalError as exc:
+                logger.debug("active-duplicate collapse skipped: %s", exc)
+
         # Deferred indexes that reference the reconciler-added ``active``
         # column (idx_messages_session_active) — same ordering constraint.
         cursor.executescript(DEFERRED_INDEX_SQL)

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -858,6 +858,23 @@ class SessionSchemaMixin:
         except sqlite3.OperationalError as exc:
             logger.debug("idx_messages_platform_msg_id create skipped: %s", exc)
 
+        # Heal NULL ``active`` rows BEFORE the v24 duplicate collapse below.
+        # On real-world DBs the reconciler-added ``active`` column can lack
+        # its NOT NULL DEFAULT 1 (older reconciler builds reconstructed the
+        # type without the default — see #51646), so legacy INSERTs that
+        # omitted the column wrote NULL.  If we leave them NULL, the
+        # duplicate-cleanup DELETE (active = 1) skips them, but the later
+        # unique-index creation + this UPDATE would turn them into active = 1
+        # rows that collide with the index.  Normalising NULL → 1 first
+        # ensures the cleanup sees and collapses any duplicates among the
+        # formerly-NULL rows too.
+        try:
+            cursor.execute(
+                "UPDATE messages SET active = 1 WHERE active IS NULL"
+            )
+        except sqlite3.OperationalError:
+            pass
+
         # Byte-identical ACTIVE duplicate collapse (v24 data repair): the
         # idx_messages_active_dedupe partial UNIQUE index in DEFERRED_INDEX_SQL
         # below cannot be created while a pre-upgrade DB still carries two
@@ -870,6 +887,10 @@ class SessionSchemaMixin:
         # produced by in-place compaction is intentional and shares the same
         # four-tuple legally. Row deletions flow through the messages_fts*
         # delete triggers, so FTS stays consistent with the canonical table.
+        # NOTE: this runs AFTER the NULL-active healing above so that legacy
+        # NULL-active rows are normalised to active=1 before the cleanup,
+        # preventing them from surviving the DELETE and colliding with the
+        # index later.
         try:
             has_dedupe_index = cursor.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'index' "
@@ -890,23 +911,6 @@ class SessionSchemaMixin:
         # Deferred indexes that reference the reconciler-added ``active``
         # column (idx_messages_session_active) — same ordering constraint.
         cursor.executescript(DEFERRED_INDEX_SQL)
-
-        # Heal NULL ``active`` rows unconditionally on every startup.
-        # On real-world DBs the reconciler-added ``active`` column can lack
-        # its NOT NULL DEFAULT 1 (older reconciler builds reconstructed the
-        # type without the default — see #51646: PRAGMA shows
-        # (17,'active','INTEGER',0,None,0) in the wild), so INSERTs that
-        # omitted the column wrote NULL and the ``WHERE active = 1``
-        # transcript loaders hid the whole history.  The INSERTs now set
-        # active=1 explicitly; this idempotent repair un-hides rows written
-        # before the fix.  It was previously gated at ``current_version <
-        # 12`` which never re-ran for already-v12+ databases.
-        try:
-            cursor.execute(
-                "UPDATE messages SET active = 1 WHERE active IS NULL"
-            )
-        except sqlite3.OperationalError:
-            pass
 
         fts5_available = self._sqlite_supports_fts5(cursor)
         fts_migrations_complete = True

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -617,26 +617,60 @@ class SessionSchemaMixin:
         except sqlite3.OperationalError as exc:
             logger.debug("idx_messages_platform_msg_id create skipped: %s", exc)
 
-        # Deferred indexes that reference the reconciler-added ``active``
-        # column (idx_messages_session_active) — same ordering constraint.
-        cursor.executescript(DEFERRED_INDEX_SQL)
-
-        # Heal NULL ``active`` rows unconditionally on every startup.
+        # Heal NULL ``active`` rows BEFORE the v24 duplicate collapse below.
         # On real-world DBs the reconciler-added ``active`` column can lack
         # its NOT NULL DEFAULT 1 (older reconciler builds reconstructed the
-        # type without the default — see #51646: PRAGMA shows
-        # (17,'active','INTEGER',0,None,0) in the wild), so INSERTs that
-        # omitted the column wrote NULL and the ``WHERE active = 1``
-        # transcript loaders hid the whole history.  The INSERTs now set
-        # active=1 explicitly; this idempotent repair un-hides rows written
-        # before the fix.  It was previously gated at ``current_version <
-        # 12`` which never re-ran for already-v12+ databases.
+        # type without the default — see #51646), so legacy INSERTs that
+        # omitted the column wrote NULL.  If we leave them NULL, the
+        # duplicate-cleanup DELETE (active = 1) skips them, but the later
+        # unique-index creation + this UPDATE would turn them into active = 1
+        # rows that collide with the index.  Normalising NULL → 1 first
+        # ensures the cleanup sees and collapses any duplicates among the
+        # formerly-NULL rows too.
         try:
             cursor.execute(
                 "UPDATE messages SET active = 1 WHERE active IS NULL"
             )
         except sqlite3.OperationalError:
             pass
+
+        # Byte-identical ACTIVE duplicate collapse (v24 data repair): the
+        # idx_messages_active_dedupe partial UNIQUE index in DEFERRED_INDEX_SQL
+        # below cannot be created while a pre-upgrade DB still carries two
+        # live rows sharing (session_id, role, content, timestamp). Delete
+        # those residual double-writes (keeping the first row) whenever the
+        # index is still absent — first open after the upgrade, or a DB
+        # whose index creation previously failed. Once the index exists,
+        # every writer version is constrained, so this probe skips forever.
+        # Soft-archived rows (active=0) are untouched: the archive+live pair
+        # produced by in-place compaction is intentional and shares the same
+        # four-tuple legally. Row deletions flow through the messages_fts*
+        # delete triggers, so FTS stays consistent with the canonical table.
+        # NOTE: this runs AFTER the NULL-active healing above so that legacy
+        # NULL-active rows are normalised to active=1 before the cleanup,
+        # preventing them from surviving the DELETE and colliding with the
+        # index later.
+        try:
+            has_dedupe_index = cursor.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' "
+                "AND name = 'idx_messages_active_dedupe'"
+            ).fetchone() is not None
+        except sqlite3.OperationalError:
+            has_dedupe_index = False
+        if not has_dedupe_index:
+            try:
+                cursor.execute(
+                    "DELETE FROM messages WHERE active = 1 AND id NOT IN ("
+                    "SELECT MIN(id) FROM messages WHERE active = 1 "
+                    "GROUP BY session_id, role, content, timestamp)"
+                )
+            except sqlite3.OperationalError as exc:
+                logger.debug("active-duplicate collapse skipped: %s", exc)
+
+
+        # Deferred indexes that reference the reconciler-added ``active``
+        # column (idx_messages_session_active) — same ordering constraint.
+        cursor.executescript(DEFERRED_INDEX_SQL)
 
         fts5_available = self._sqlite_supports_fts5(cursor)
         fts_migrations_complete = True

--- a/tests/run_agent/test_state_db_duplicate_messages.py
+++ b/tests/run_agent/test_state_db_duplicate_messages.py
@@ -229,3 +229,181 @@ class TestMigrationCollapsesExistingDuplicates:
                 assert live_after == 1
             finally:
                 db.close()
+
+
+class TestNullActiveMigrationOrdering:
+    """Regression for review thread on hermes_state_schema.py:L355.
+
+    Legacy DBs may carry rows with ``active IS NULL`` (older reconciler
+    builds omitted the NOT NULL DEFAULT 1).  If the v24 duplicate-cleanup
+    DELETE runs BEFORE those NULL rows are normalised to active=1, the
+    DELETE misses them (it only targets active=1).  Later the NULL→1
+    UPDATE would then collide with the already-created unique index.
+
+    The fix normalises NULL active → 1 BEFORE the cleanup DELETE so the
+    DELETE sees and collapses the formerly-NULL duplicates too.
+    """
+
+    def test_null_active_duplicates_collapsed_before_index_creation(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            sid = "20260730_170159_f8432a"
+            db.create_session(sid, "cli", model="test/model")
+            db.close()
+
+            # Recreate pre-upgrade dirty state: two NULL-active rows with
+            # the same (session_id, role, content, timestamp) — the legacy
+            # double-write that the NULL→1 repair would later turn into
+            # colliding active=1 rows.
+            #
+            # Legacy DBs had ``active`` added by the reconciler WITHOUT a
+            # NOT NULL constraint (#51646), so we relax the column before
+            # inserting NULLs.  PRAGMA writable_schema requires a reconnect
+            # for the change to take effect.
+            raw = sqlite3.connect(db_path)
+            try:
+                raw.execute("DROP INDEX IF EXISTS idx_messages_active_dedupe")
+                raw.execute("PRAGMA writable_schema = 1")
+                raw.execute(
+                    "UPDATE sqlite_master SET sql = REPLACE(sql, "
+                    "'active INTEGER NOT NULL DEFAULT 1', 'active INTEGER') "
+                    "WHERE type = 'table' AND name = 'messages'"
+                )
+                raw.execute("PRAGMA writable_schema = 0")
+                raw.commit()
+            finally:
+                raw.close()
+
+            # Reopen — the relaxed schema is now active.
+            raw = sqlite3.connect(db_path)
+            try:
+                for _ in range(2):
+                    raw.execute(
+                        "INSERT INTO messages (session_id, role, content, "
+                        "timestamp, active, compacted) VALUES "
+                        "(?, 'assistant', ?, ?, NULL, 0)",
+                        (sid, CONTENT, TS),
+                    )
+                raw.commit()
+            finally:
+                raw.close()
+
+            # Re-opening runs the migration: NULL→1 first, then DELETE
+            # duplicates, then create index.  If the ordering is wrong,
+            # the unique-index creation will raise IntegrityError.
+            db = SessionDB(db_path=db_path)
+            try:
+                live = db._conn.execute(
+                    "SELECT COUNT(*) FROM messages "
+                    "WHERE content = ? AND active = 1 AND timestamp = ?",
+                    (CONTENT, TS),
+                ).fetchone()[0]
+                assert live == 1, (
+                    f"NULL-active duplicates not collapsed: {live} live rows"
+                )
+                # Index must exist — migration completed without error.
+                assert db._conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'index' "
+                    "AND name = 'idx_messages_active_dedupe'"
+                ).fetchone() is not None
+            finally:
+                db.close()
+
+
+class TestNullContentBoundary:
+    """Documented limitation for review thread on hermes_state_common.py:L317.
+
+    SQLite UNIQUE indexes treat NULL as distinct, so the
+    idx_messages_active_dedupe index does NOT deduplicate rows with
+    content = NULL.  The migration cleanup (GROUP BY, which collapses NULL
+    into one group) handles EXISTING NULL-content duplicates, but NEW
+    NULL-content duplicate inserts bypass the runtime guard.
+
+    This is an explicit, documented boundary — NULL-content messages are
+    rare (tool-call-only rows with no text body) and typically carry
+    distinct tool_call_id values, so true duplicates are unlikely in
+    practice.
+    """
+
+    def test_null_content_duplicate_insert_is_not_guarded(self):
+        """Two append_message calls with content=None and the same timestamp
+        create two rows — the index does not block this.  This test
+        documents the known limitation; if a future fix adds a null-safe
+        key (e.g. COALESCE(content, '') generated column), this test
+        should be updated to assert deduplication."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            try:
+                sid = "20260730_170159_f8432a"
+                db.create_session(sid, "cli", model="test/model")
+
+                db.append_message(
+                    session_id=sid, role="assistant",
+                    content=None, timestamp=TS,
+                )
+                db.append_message(
+                    session_id=sid, role="assistant",
+                    content=None, timestamp=TS,
+                )
+
+                # Known limitation: both rows persist (NULL is distinct in
+                # SQLite UNIQUE indexes).  The guard does NOT fire here.
+                count = db._conn.execute(
+                    "SELECT COUNT(*) FROM messages "
+                    "WHERE content IS NULL AND active = 1 AND timestamp = ?",
+                    (TS,),
+                ).fetchone()[0]
+                assert count == 2, (
+                    f"expected 2 unguarded NULL-content rows, found {count}"
+                )
+            finally:
+                db.close()
+
+    def test_null_content_existing_duplicates_collapsed_on_migration(self):
+        """The migration cleanup DELETE uses GROUP BY, which treats NULL as
+        a single group.  Existing NULL-content duplicate rows ARE cleaned
+        up on upgrade, even though the runtime index does not guard them
+        going forward."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            sid = "20260730_170159_f8432a"
+            db.create_session(sid, "cli", model="test/model")
+            db.close()
+
+            # Pre-upgrade: two NULL-content active duplicates.
+            raw = sqlite3.connect(db_path)
+            try:
+                raw.execute("DROP INDEX IF EXISTS idx_messages_active_dedupe")
+                for _ in range(2):
+                    raw.execute(
+                        "INSERT INTO messages (session_id, role, content, "
+                        "timestamp, active, compacted) VALUES "
+                        "(?, 'assistant', NULL, ?, 1, 0)",
+                        (sid, TS),
+                    )
+                raw.commit()
+            finally:
+                raw.close()
+
+            db = SessionDB(db_path=db_path)
+            try:
+                count = db._conn.execute(
+                    "SELECT COUNT(*) FROM messages "
+                    "WHERE content IS NULL AND active = 1 AND timestamp = ?",
+                    (TS,),
+                ).fetchone()[0]
+                assert count == 1, (
+                    f"migration should collapse NULL-content duplicates to "
+                    f"1 row, found {count}"
+                )
+            finally:
+                db.close()

--- a/tests/run_agent/test_state_db_duplicate_messages.py
+++ b/tests/run_agent/test_state_db_duplicate_messages.py
@@ -1,0 +1,231 @@
+"""Tests for the state.db byte-identical duplicate-message hole (mechanism 1).
+
+A profile state.db was observed carrying two message rows with the same
+(session_id, role, content, timestamp-to-the-millisecond) — e.g. pair
+id 638962 == id 640246, ts REAL 1785411770.4681301 — so the same report
+rendered twice in the Desktop chat view. Any residual writer path (a poll
+loop, a race in a flush, a missed compaction rebaseline) could persist a
+byte-identical row because the ``messages`` table had no uniqueness guard.
+
+The fix boundary: dedupe applies ONLY within the ACTIVE (active=1) row
+class. The in-place compaction flow INTENTIONALLY keeps the same
+content+timestamp once as (active=0, compacted=1) — the archived original —
+and once as (active=1, compacted=0) — the re-inserted live copy. A
+constraint spanning (active, compacted) would forbid that pair and break
+compaction durability.
+"""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+CONTENT = "quarterly report: revenue up 12%"
+TS = 1785411770.4681301  # fractional-millisecond REAL, as in the live DB
+
+
+def _raw_counts(db_path):
+    """Direct sqlite read — independent of the SessionDB Python API."""
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(
+            "SELECT COUNT(*), "
+            "COALESCE(SUM(active = 1 AND compacted = 0), 0), "
+            "COALESCE(SUM(active = 0 AND compacted = 1), 0) "
+            "FROM messages WHERE content = ?",
+            (CONTENT,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+class TestAppendMessageIdempotence:
+    def test_append_message_idempotent_duplicate_insert(self):
+        """Re-appending a byte-identical (session, role, content, timestamp)
+        message must not create a second row, double-count the session, or
+        double-index FTS."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            try:
+                sid = "20260730_170159_f8432a"
+                db.create_session(sid, "cli", model="test/model")
+
+                first_id = db.append_message(
+                    session_id=sid, role="assistant",
+                    content=CONTENT, timestamp=TS,
+                )
+                # The exact same write again — the idempotence-hole path.
+                second_id = db.append_message(
+                    session_id=sid, role="assistant",
+                    content=CONTENT, timestamp=TS,
+                )
+
+                assert second_id == first_id, (
+                    "idempotent re-append must resolve to the existing row"
+                )
+                # Direct DB read: exactly ONE message row for this content.
+                total, active, archived = _raw_counts(db_path)
+                assert total == 1, (
+                    f"duplicate insert persisted: {total} rows share the same "
+                    "content"
+                )
+                assert (active, archived) == (1, 0)
+                # Session counters must track the single persisted row.
+                assert db.get_session(sid)["message_count"] == 1
+                # FTS got exactly one entry — the duplicate insert must not
+                # fire the messages_fts_insert trigger for a skipped row.
+                fts_count = db._conn.execute(
+                    "SELECT COUNT(*) FROM messages_fts"
+                ).fetchone()[0]
+                assert fts_count == 1, (
+                    "skipped duplicate insert still fired the FTS insert "
+                    "trigger"
+                )
+            finally:
+                db.close()
+
+
+class TestInPlaceCompactionDuplicateBoundary:
+    def test_in_place_compaction_keeps_single_live_copy_and_archive(self):
+        """The mechanism-2 pair must survive the dedupe guard while a
+        duplicate replay is still collapsed.
+
+        Flow: an active message is soft-archived by in-place compaction
+        (active=0, compacted=1) and the same content+timestamp is
+        re-inserted as the new active row — the legitimate archive+active
+        pair. A residual replay then re-appends the identical row a second
+        time. The store must end with exactly ONE live copy AND the archive
+        copy intact — not two live rows, and the archive copy NOT swallowed.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            try:
+                sid = "20260730_170159_f8432a"
+                db.create_session(sid, "cli", model="test/model")
+                db.append_message(
+                    session_id=sid, role="assistant",
+                    content=CONTENT, timestamp=TS,
+                )
+
+                # In-place compaction: soft-archive the live row, re-insert
+                # the same content+timestamp as the fresh active copy.
+                db.archive_and_compact(
+                    sid,
+                    [{"role": "assistant", "content": CONTENT,
+                      "timestamp": TS}],
+                )
+
+                # Residual duplicate writer (race / poll-loop / missed
+                # rebaseline) re-appends the identical row.
+                db.append_message(
+                    session_id=sid, role="assistant",
+                    content=CONTENT, timestamp=TS,
+                )
+
+                total, active, archived = _raw_counts(db_path)
+                assert total == 2, (
+                    f"the archive+live pair must total 2 rows, found {total}"
+                )
+                assert active == 1, (
+                    f"duplicate replay persisted: {active} live active=1 "
+                    "copies of the same content+timestamp"
+                )
+                assert archived == 1, (
+                    "the compaction archive copy (active=0, compacted=1) "
+                    "must survive the dedupe constraint — it is intentional"
+                )
+                # Live count tracks just the active row.
+                assert db.get_session(sid)["message_count"] == 1
+            finally:
+                db.close()
+
+
+class TestMigrationCollapsesExistingDuplicates:
+    def test_upgrade_open_collapses_dirty_active_rows_and_guards_future(self):
+        """An existing DB that already carries byte-identical ACTIVE duplicate
+        rows (written before the guard existed) must open cleanly: the
+        migration keeps the first copy, preserves the intentional
+        archive+live pair, installs the guard index, and blocks new dupes.
+        """
+        from hermes_state import SessionDB
+        from hermes_state_common import SCHEMA_VERSION
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            sid = "20260730_170159_f8432a"
+            db.create_session(sid, "cli", model="test/model")
+            db.close()
+
+            # Recreate a pre-upgrade dirty state: guard index absent, two
+            # live byte-identical rows, plus the intentional compaction pair
+            # (same content+timestamp archived AND active). Plain INSERTs
+            # only succeed while the index is dropped — as before the fix.
+            raw = sqlite3.connect(db_path)
+            try:
+                raw.execute("DROP INDEX idx_messages_active_dedupe")
+                ts_pair = TS + 1000.0
+                for i in range(2):  # byte-identical live duplicates
+                    raw.execute(
+                        "INSERT INTO messages (session_id, role, content, "
+                        "timestamp, active, compacted) VALUES (?, 'assistant', "
+                        "?, ?, 1, 0)",
+                        (sid, CONTENT, TS),
+                    )
+                raw.execute(  # archived original of the compaction pair
+                    "INSERT INTO messages (session_id, role, content, "
+                    "timestamp, active, compacted) VALUES (?, 'assistant', "
+                    "?, ?, 0, 1)",
+                    (sid, CONTENT, ts_pair),
+                )
+                raw.execute(  # its live re-insert — the legitimate pair
+                    "INSERT INTO messages (session_id, role, content, "
+                    "timestamp, active, compacted) VALUES (?, 'assistant', "
+                    "?, ?, 1, 0)",
+                    (sid, CONTENT, ts_pair),
+                )
+                raw.commit()
+            finally:
+                raw.close()
+
+            db = SessionDB(db_path=db_path)  # open runs the migration
+            try:
+                rows = db._conn.execute(
+                    "SELECT id, active, compacted FROM messages "
+                    "WHERE content = ? ORDER BY id",
+                    (CONTENT,),
+                ).fetchall()
+                live = [r for r in rows if r["active"] == 1]
+                archived = [r for r in rows if r["active"] == 0]
+                assert len(rows) == 3 and len(live) == 2, (
+                    f"expected merged duplicate + intact pair, found {rows}"
+                )
+                assert len(archived) == 1 and archived[0]["compacted"] == 1
+                # The surviving duplicate copy is the FIRST-inserted row.
+                assert live[0]["id"] == 1
+                # The guard index landed and schema bookkeeping advanced.
+                assert db._conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'index' "
+                    "AND name = 'idx_messages_active_dedupe'"
+                ).fetchone() is not None
+                assert db._conn.execute(
+                    "SELECT version FROM schema_version"
+                ).fetchone()[0] == SCHEMA_VERSION
+                # New duplicate writes are blocked from here on.
+                db.append_message(
+                    session_id=sid, role="assistant",
+                    content=CONTENT, timestamp=TS,
+                )
+                live_after = db._conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE content = ? "
+                    "AND active = 1 AND timestamp = ?",
+                    (CONTENT, TS),
+                ).fetchone()[0]
+                assert live_after == 1
+            finally:
+                db.close()

--- a/tests/run_agent/test_state_db_duplicate_messages.py
+++ b/tests/run_agent/test_state_db_duplicate_messages.py
@@ -1,0 +1,409 @@
+"""Tests for the state.db byte-identical duplicate-message hole (mechanism 1).
+
+A profile state.db was observed carrying two message rows with the same
+(session_id, role, content, timestamp-to-the-millisecond) — e.g. pair
+id 638962 == id 640246, ts REAL 1785411770.4681301 — so the same report
+rendered twice in the Desktop chat view. Any residual writer path (a poll
+loop, a race in a flush, a missed compaction rebaseline) could persist a
+byte-identical row because the ``messages`` table had no uniqueness guard.
+
+The fix boundary: dedupe applies ONLY within the ACTIVE (active=1) row
+class. The in-place compaction flow INTENTIONALLY keeps the same
+content+timestamp once as (active=0, compacted=1) — the archived original —
+and once as (active=1, compacted=0) — the re-inserted live copy. A
+constraint spanning (active, compacted) would forbid that pair and break
+compaction durability.
+"""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+CONTENT = "quarterly report: revenue up 12%"
+TS = 1785411770.4681301  # fractional-millisecond REAL, as in the live DB
+
+
+def _raw_counts(db_path):
+    """Direct sqlite read — independent of the SessionDB Python API."""
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(
+            "SELECT COUNT(*), "
+            "COALESCE(SUM(active = 1 AND compacted = 0), 0), "
+            "COALESCE(SUM(active = 0 AND compacted = 1), 0) "
+            "FROM messages WHERE content = ?",
+            (CONTENT,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+class TestAppendMessageIdempotence:
+    def test_append_message_idempotent_duplicate_insert(self):
+        """Re-appending a byte-identical (session, role, content, timestamp)
+        message must not create a second row, double-count the session, or
+        double-index FTS."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            try:
+                sid = "20260730_170159_f8432a"
+                db.create_session(sid, "cli", model="test/model")
+
+                first_id = db.append_message(
+                    session_id=sid, role="assistant",
+                    content=CONTENT, timestamp=TS,
+                )
+                # The exact same write again — the idempotence-hole path.
+                second_id = db.append_message(
+                    session_id=sid, role="assistant",
+                    content=CONTENT, timestamp=TS,
+                )
+
+                assert second_id == first_id, (
+                    "idempotent re-append must resolve to the existing row"
+                )
+                # Direct DB read: exactly ONE message row for this content.
+                total, active, archived = _raw_counts(db_path)
+                assert total == 1, (
+                    f"duplicate insert persisted: {total} rows share the same "
+                    "content"
+                )
+                assert (active, archived) == (1, 0)
+                # Session counters must track the single persisted row.
+                assert db.get_session(sid)["message_count"] == 1
+                # FTS got exactly one entry — the duplicate insert must not
+                # fire the messages_fts_insert trigger for a skipped row.
+                fts_count = db._conn.execute(
+                    "SELECT COUNT(*) FROM messages_fts"
+                ).fetchone()[0]
+                assert fts_count == 1, (
+                    "skipped duplicate insert still fired the FTS insert "
+                    "trigger"
+                )
+            finally:
+                db.close()
+
+
+class TestInPlaceCompactionDuplicateBoundary:
+    def test_in_place_compaction_keeps_single_live_copy_and_archive(self):
+        """The mechanism-2 pair must survive the dedupe guard while a
+        duplicate replay is still collapsed.
+
+        Flow: an active message is soft-archived by in-place compaction
+        (active=0, compacted=1) and the same content+timestamp is
+        re-inserted as the new active row — the legitimate archive+active
+        pair. A residual replay then re-appends the identical row a second
+        time. The store must end with exactly ONE live copy AND the archive
+        copy intact — not two live rows, and the archive copy NOT swallowed.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            try:
+                sid = "20260730_170159_f8432a"
+                db.create_session(sid, "cli", model="test/model")
+                db.append_message(
+                    session_id=sid, role="assistant",
+                    content=CONTENT, timestamp=TS,
+                )
+
+                # In-place compaction: soft-archive the live row, re-insert
+                # the same content+timestamp as the fresh active copy.
+                db.archive_and_compact(
+                    sid,
+                    [{"role": "assistant", "content": CONTENT,
+                      "timestamp": TS}],
+                )
+
+                # Residual duplicate writer (race / poll-loop / missed
+                # rebaseline) re-appends the identical row.
+                db.append_message(
+                    session_id=sid, role="assistant",
+                    content=CONTENT, timestamp=TS,
+                )
+
+                total, active, archived = _raw_counts(db_path)
+                assert total == 2, (
+                    f"the archive+live pair must total 2 rows, found {total}"
+                )
+                assert active == 1, (
+                    f"duplicate replay persisted: {active} live active=1 "
+                    "copies of the same content+timestamp"
+                )
+                assert archived == 1, (
+                    "the compaction archive copy (active=0, compacted=1) "
+                    "must survive the dedupe constraint — it is intentional"
+                )
+                # Live count tracks just the active row.
+                assert db.get_session(sid)["message_count"] == 1
+            finally:
+                db.close()
+
+
+class TestMigrationCollapsesExistingDuplicates:
+    def test_upgrade_open_collapses_dirty_active_rows_and_guards_future(self):
+        """An existing DB that already carries byte-identical ACTIVE duplicate
+        rows (written before the guard existed) must open cleanly: the
+        migration keeps the first copy, preserves the intentional
+        archive+live pair, installs the guard index, and blocks new dupes.
+        """
+        from hermes_state import SessionDB
+        from hermes_state_common import SCHEMA_VERSION
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            sid = "20260730_170159_f8432a"
+            db.create_session(sid, "cli", model="test/model")
+            db.close()
+
+            # Recreate a pre-upgrade dirty state: guard index absent, two
+            # live byte-identical rows, plus the intentional compaction pair
+            # (same content+timestamp archived AND active). Plain INSERTs
+            # only succeed while the index is dropped — as before the fix.
+            raw = sqlite3.connect(db_path)
+            try:
+                raw.execute("DROP INDEX idx_messages_active_dedupe")
+                ts_pair = TS + 1000.0
+                for i in range(2):  # byte-identical live duplicates
+                    raw.execute(
+                        "INSERT INTO messages (session_id, role, content, "
+                        "timestamp, active, compacted) VALUES (?, 'assistant', "
+                        "?, ?, 1, 0)",
+                        (sid, CONTENT, TS),
+                    )
+                raw.execute(  # archived original of the compaction pair
+                    "INSERT INTO messages (session_id, role, content, "
+                    "timestamp, active, compacted) VALUES (?, 'assistant', "
+                    "?, ?, 0, 1)",
+                    (sid, CONTENT, ts_pair),
+                )
+                raw.execute(  # its live re-insert — the legitimate pair
+                    "INSERT INTO messages (session_id, role, content, "
+                    "timestamp, active, compacted) VALUES (?, 'assistant', "
+                    "?, ?, 1, 0)",
+                    (sid, CONTENT, ts_pair),
+                )
+                raw.commit()
+            finally:
+                raw.close()
+
+            db = SessionDB(db_path=db_path)  # open runs the migration
+            try:
+                rows = db._conn.execute(
+                    "SELECT id, active, compacted FROM messages "
+                    "WHERE content = ? ORDER BY id",
+                    (CONTENT,),
+                ).fetchall()
+                live = [r for r in rows if r["active"] == 1]
+                archived = [r for r in rows if r["active"] == 0]
+                assert len(rows) == 3 and len(live) == 2, (
+                    f"expected merged duplicate + intact pair, found {rows}"
+                )
+                assert len(archived) == 1 and archived[0]["compacted"] == 1
+                # The surviving duplicate copy is the FIRST-inserted row.
+                assert live[0]["id"] == 1
+                # The guard index landed and schema bookkeeping advanced.
+                assert db._conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'index' "
+                    "AND name = 'idx_messages_active_dedupe'"
+                ).fetchone() is not None
+                assert db._conn.execute(
+                    "SELECT version FROM schema_version"
+                ).fetchone()[0] == SCHEMA_VERSION
+                # New duplicate writes are blocked from here on.
+                db.append_message(
+                    session_id=sid, role="assistant",
+                    content=CONTENT, timestamp=TS,
+                )
+                live_after = db._conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE content = ? "
+                    "AND active = 1 AND timestamp = ?",
+                    (CONTENT, TS),
+                ).fetchone()[0]
+                assert live_after == 1
+            finally:
+                db.close()
+
+
+class TestNullActiveMigrationOrdering:
+    """Regression for review thread on hermes_state_schema.py:L355.
+
+    Legacy DBs may carry rows with ``active IS NULL`` (older reconciler
+    builds omitted the NOT NULL DEFAULT 1).  If the v24 duplicate-cleanup
+    DELETE runs BEFORE those NULL rows are normalised to active=1, the
+    DELETE misses them (it only targets active=1).  Later the NULL→1
+    UPDATE would then collide with the already-created unique index.
+
+    The fix normalises NULL active → 1 BEFORE the cleanup DELETE so the
+    DELETE sees and collapses the formerly-NULL duplicates too.
+    """
+
+    def test_null_active_duplicates_collapsed_before_index_creation(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            sid = "20260730_170159_f8432a"
+            db.create_session(sid, "cli", model="test/model")
+            db.close()
+
+            # Recreate pre-upgrade dirty state: two NULL-active rows with
+            # the same (session_id, role, content, timestamp) — the legacy
+            # double-write that the NULL→1 repair would later turn into
+            # colliding active=1 rows.
+            #
+            # Legacy DBs had ``active`` added by the reconciler WITHOUT a
+            # NOT NULL constraint (#51646), so we relax the column before
+            # inserting NULLs.  PRAGMA writable_schema requires a reconnect
+            # for the change to take effect.
+            raw = sqlite3.connect(db_path)
+            try:
+                raw.execute("DROP INDEX IF EXISTS idx_messages_active_dedupe")
+                raw.execute("PRAGMA writable_schema = 1")
+                raw.execute(
+                    "UPDATE sqlite_master SET sql = REPLACE(sql, "
+                    "'active INTEGER NOT NULL DEFAULT 1', 'active INTEGER') "
+                    "WHERE type = 'table' AND name = 'messages'"
+                )
+                raw.execute("PRAGMA writable_schema = 0")
+                raw.commit()
+            finally:
+                raw.close()
+
+            # Reopen — the relaxed schema is now active.
+            raw = sqlite3.connect(db_path)
+            try:
+                for _ in range(2):
+                    raw.execute(
+                        "INSERT INTO messages (session_id, role, content, "
+                        "timestamp, active, compacted) VALUES "
+                        "(?, 'assistant', ?, ?, NULL, 0)",
+                        (sid, CONTENT, TS),
+                    )
+                raw.commit()
+            finally:
+                raw.close()
+
+            # Re-opening runs the migration: NULL→1 first, then DELETE
+            # duplicates, then create index.  If the ordering is wrong,
+            # the unique-index creation will raise IntegrityError.
+            db = SessionDB(db_path=db_path)
+            try:
+                live = db._conn.execute(
+                    "SELECT COUNT(*) FROM messages "
+                    "WHERE content = ? AND active = 1 AND timestamp = ?",
+                    (CONTENT, TS),
+                ).fetchone()[0]
+                assert live == 1, (
+                    f"NULL-active duplicates not collapsed: {live} live rows"
+                )
+                # Index must exist — migration completed without error.
+                assert db._conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'index' "
+                    "AND name = 'idx_messages_active_dedupe'"
+                ).fetchone() is not None
+            finally:
+                db.close()
+
+
+class TestNullContentBoundary:
+    """Documented limitation for review thread on hermes_state_common.py:L317.
+
+    SQLite UNIQUE indexes treat NULL as distinct, so the
+    idx_messages_active_dedupe index does NOT deduplicate rows with
+    content = NULL.  The migration cleanup (GROUP BY, which collapses NULL
+    into one group) handles EXISTING NULL-content duplicates, but NEW
+    NULL-content duplicate inserts bypass the runtime guard.
+
+    This is an explicit, documented boundary — NULL-content messages are
+    rare (tool-call-only rows with no text body) and typically carry
+    distinct tool_call_id values, so true duplicates are unlikely in
+    practice.
+    """
+
+    def test_null_content_duplicate_insert_is_not_guarded(self):
+        """Two append_message calls with content=None and the same timestamp
+        create two rows — the index does not block this.  This test
+        documents the known limitation; if a future fix adds a null-safe
+        key (e.g. COALESCE(content, '') generated column), this test
+        should be updated to assert deduplication."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            try:
+                sid = "20260730_170159_f8432a"
+                db.create_session(sid, "cli", model="test/model")
+
+                db.append_message(
+                    session_id=sid, role="assistant",
+                    content=None, timestamp=TS,
+                )
+                db.append_message(
+                    session_id=sid, role="assistant",
+                    content=None, timestamp=TS,
+                )
+
+                # Known limitation: both rows persist (NULL is distinct in
+                # SQLite UNIQUE indexes).  The guard does NOT fire here.
+                count = db._conn.execute(
+                    "SELECT COUNT(*) FROM messages "
+                    "WHERE content IS NULL AND active = 1 AND timestamp = ?",
+                    (TS,),
+                ).fetchone()[0]
+                assert count == 2, (
+                    f"expected 2 unguarded NULL-content rows, found {count}"
+                )
+            finally:
+                db.close()
+
+    def test_null_content_existing_duplicates_collapsed_on_migration(self):
+        """The migration cleanup DELETE uses GROUP BY, which treats NULL as
+        a single group.  Existing NULL-content duplicate rows ARE cleaned
+        up on upgrade, even though the runtime index does not guard them
+        going forward."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "t.db"
+            db = SessionDB(db_path=db_path)
+            sid = "20260730_170159_f8432a"
+            db.create_session(sid, "cli", model="test/model")
+            db.close()
+
+            # Pre-upgrade: two NULL-content active duplicates.
+            raw = sqlite3.connect(db_path)
+            try:
+                raw.execute("DROP INDEX IF EXISTS idx_messages_active_dedupe")
+                for _ in range(2):
+                    raw.execute(
+                        "INSERT INTO messages (session_id, role, content, "
+                        "timestamp, active, compacted) VALUES "
+                        "(?, 'assistant', NULL, ?, 1, 0)",
+                        (sid, TS),
+                    )
+                raw.commit()
+            finally:
+                raw.close()
+
+            db = SessionDB(db_path=db_path)
+            try:
+                count = db._conn.execute(
+                    "SELECT COUNT(*) FROM messages "
+                    "WHERE content IS NULL AND active = 1 AND timestamp = ?",
+                    (TS,),
+                ).fetchone()[0]
+                assert count == 1, (
+                    f"migration should collapse NULL-content duplicates to "
+                    f"1 row, found {count}"
+                )
+            finally:
+                db.close()


### PR DESCRIPTION
## Summary

`state.db` can accumulate **byte-identical duplicate message rows** — the same `(session_id, role, content, timestamp-to-the-millisecond)` written twice — which is one cause of the same report rendering twice in the Desktop chat view. The `messages` table had **no uniqueness guard**, so any residual writer path could persist a duplicate.

This PR closes the hole at the **SQL layer** with a **partial UNIQUE index** plus targeted `ON CONFLICT … DO NOTHING` on the two message insert paths.

## Evidence from a real profile DB

- Duplicate pair `id 638962 ≡ id 640246` in session `20260730_170159_f8432a`: same content (1011 chars), same `timestamp = 1785411770.4681301` (REAL, millisecond). One row `active=0, compacted=1`, the other `active=1, compacted=0`.
- All 397,160 `timestamp` values are `REAL`; 397,159 are fractional (millisecond) — so `(session_id, role, content, timestamp)` is a sound discriminator; legitimate distinct messages do not collide.
- Several payload columns are very often `NULL` (`tool_calls` NULL in 239,110/397,160 rows) — the key deliberately uses only the discriminating four-tuple, and `ON CONFLICT` treats `NULL`-vs-`NULL` correctly.

## The design boundary (the crux)

In-place compaction **intentionally** keeps the same `content+timestamp` twice:

- once as the **soft-archived original** (`active=0, compacted=1`), and
- once as the **fresh live row** (`active=1, compacted=0`).

A constraint spanning `(active, compacted)` would forbid that pair and break compaction durability. So the dedupe applies **only within the ACTIVE row class**:

```
CREATE UNIQUE INDEX idx_messages_active_dedupe
  ON messages(session_id, role, content, timestamp)
  WHERE active = 1;
```

The two inserts use `ON CONFLICT(session_id, role, content, timestamp) WHERE active=1 DO NOTHING` — **targeted**, not a blanket `OR IGNORE`, so FK / NOT-NULL violations still raise. A skipped insert is detected via `cursor.rowcount == 0`, resolves to the existing live row's id, and does **not** double-count `sessions.message_count`/`tool_call_count` nor fire `messages_fts_insert`.

## Migration on existing DBs

- `SCHEMA_VERSION` 23 → 24.
- In `_init_schema`, **gated on the index being absent**, a one-time repair deletes pre-existing live duplicates (keep first row) so index creation cannot fail on a dirty DB. Deletions flow through the `messages_fts` delete triggers, keeping FTS consistent. Once the index exists, the probe skips forever (no per-open cost).
- Verified the repair DELETE is a **correct no-op on a real DB whose only intra-key duplicates are the intentional archive+live pair** (14,093 pairs kept intact, 0 rows removed).

## Relationship to existing work

| Item | State | Scope |
|---|---|---|
| #9096 | closed (superseded by #53452) | Old non-in-place full-context re-insert |
| **#53452** | **merged** | Mechanism 2 — in-place compaction **Python flush orchestration** rebaseline (`archive_and_compact`) |
| #38319 | open | **Different bug** — desktop-stream hydration race (`use-message-stream.ts`, TypeScript), not the SQLite persistence layer |
| **This PR** | — | **Mechanism 1 — the SQL idempotence hole**, uncovered by the above; also defense-in-depth against any residual duplicate writer |

## Verification

- `tests/run_agent/test_state_db_duplicate_messages.py` — 3 tests (append idempotence, compaction archive+live boundary, open-time repair on a pre-upgrade dirty DB), all RED-then-GREEN.
- Related suite, canonical runner, clean env: **152 passed, 0 failed** across `tests/test_hermes_state.py`, `tests/run_agent/test_in_place_compaction.py`, `tests/run_agent/test_860_dedup.py`, and the new file.
- Empirical SQLite checks (3.50.4): partial-index inference matches; `rowcount` distinguishes a skip; `AFTER INSERT` triggers do not fire on `DO NOTHING`; the soft-archive `UPDATE` leaves index scope cleanly; `NULL` content stays conflict-free.
