### PR TITLE
fix(gateway): route Discord/Yuanbao's early pairing admission gate to the adapter's own multiplex profile

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3070,6 +3070,13 @@ class BasePlatformAdapter(ABC):
         # mitigating indirect prompt injection from third parties in a shared
         # thread/channel.
         self._authorization_check: Optional[Callable[[str, Optional[str], Optional[str]], bool]] = None
+        # Multiplex profile this adapter instance serves, if any. Set by
+        # GatewayRunner alongside set_authorization_check() (None for the
+        # active/default profile's adapters). Adapters that resolve their own
+        # PairingStore for an early admission gate (rather than going through
+        # authz_mixin._is_user_authorized(), which already routes per-profile)
+        # need this to avoid checking the wrong profile's approved-user list.
+        self._own_profile: Optional[str] = None
         # Auto-TTS on voice input: ``_auto_tts_default`` is the global default
         # (``voice.auto_tts`` in config.yaml, pushed by GatewayRunner on connect).
         # Per-chat overrides live in two sets populated from ``_voice_mode``:

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -5027,7 +5027,13 @@ class YuanbaoAdapter(BasePlatformAdapter):
             if policy.dm_policy == "pairing":
                 from gateway.pairing import PairingStore
 
-                return PairingStore().is_approved(Platform.YUANBAO.value, sender)
+                # Multiplex gateways serve secondary profiles via a
+                # dedicated adapter instance per profile (GatewayRunner
+                # stamps self._own_profile on it); route to that profile's
+                # own PairingStore rather than the global default's.
+                profile = getattr(self, "_own_profile", None)
+                store = PairingStore(profile=profile) if profile else PairingStore()
+                return store.is_approved(Platform.YUANBAO.value, sender)
             return False
         if ctx.chat_type == "group":
             group_code = str(ctx.group_code or "").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13821,6 +13821,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter.set_authorization_check(
             self._make_adapter_auth_check(platform, profile_name=profile_name)
         )
+        # Adapters that resolve their own PairingStore for an early
+        # admission gate (e.g. DiscordAdapter._is_pairing_approved_user)
+        # need to know which profile they serve so they check that
+        # profile's approved-user list, not the global default's.
+        adapter._own_profile = profile_name
         text_modes = getattr(self, "_busy_text_modes_by_profile", None)
         adapter._busy_text_mode = (
             text_modes.get(profile_name, self._busy_text_mode)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4587,14 +4587,25 @@ class DiscordAdapter(BasePlatformAdapter):
         return bool(channel_ids & allowed)
 
     def _is_pairing_approved_user(self, user_id: str) -> bool:
-        """True when the Discord user has an explicit Hermes pairing grant."""
+        """True when the Discord user has an explicit Hermes pairing grant.
+
+        Multiplex gateways serve secondary profiles via a dedicated
+        DiscordAdapter instance per profile (GatewayRunner stamps
+        ``self._own_profile`` on it); route to that profile's own
+        PairingStore so a user paired only on a routed profile isn't
+        rejected here before the pairing-aware gateway layer (which does
+        resolve per-profile, see authz_mixin._pairing_store_for) ever sees
+        the message. Falls back to the global store for the default profile.
+        """
         user_id = str(user_id or "").strip()
         if not user_id:
             return False
         try:
             from gateway.pairing import PairingStore
 
-            return bool(PairingStore().is_approved("discord", user_id))
+            profile = getattr(self, "_own_profile", None)
+            store = PairingStore(profile=profile) if profile else PairingStore()
+            return bool(store.is_approved("discord", user_id))
         except Exception:
             return False
 

--- a/tests/gateway/test_discord_pairing_profile_scope.py
+++ b/tests/gateway/test_discord_pairing_profile_scope.py
@@ -1,0 +1,104 @@
+"""Regression: Discord's early pairing-admission gate must route to the
+adapter's own multiplex profile, not the global default PairingStore.
+
+``DiscordAdapter._is_pairing_approved_user`` (called from ``_is_allowed_user``,
+the on_message admission gate) constructed a bare ``PairingStore()`` — always
+the process-global/default-profile store. In a multiplex gateway, a secondary
+profile is served by its own ``DiscordAdapter`` instance
+(``gateway/run.py::_configure_profile_adapter`` stamps ``_own_profile`` on
+it), and its own pairing whitelist lives in a separate, profile-scoped
+``PairingStore(profile=name)``. A user approved only on that routed profile
+was rejected here — before the message ever reached the correctly-scoped
+downstream check in ``authz_mixin._pairing_store_for`` — because this earlier
+gate consulted the wrong (default/global) whitelist.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from gateway.config import Platform
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _make_adapter(own_profile=None):
+    """Build a minimal DiscordAdapter without running __init__."""
+    adapter = object.__new__(DiscordAdapter)
+    adapter._allowed_user_ids = set()
+    adapter._allowed_role_ids = set()
+    if own_profile is not None:
+        adapter._own_profile = own_profile
+    return adapter
+
+
+def test_default_profile_uses_global_pairing_store():
+    """No _own_profile stamped (default profile, or an adapter built without
+    going through _configure_profile_adapter) -> PairingStore() with no
+    profile kwarg, preserving pre-fix behavior exactly."""
+    adapter = _make_adapter()
+    assert getattr(adapter, "_own_profile", None) is None
+
+    with patch("gateway.pairing.PairingStore") as mock_store_cls:
+        mock_store_cls.return_value.is_approved.return_value = True
+        assert adapter._is_pairing_approved_user("42") is True
+        mock_store_cls.assert_called_once_with()
+        mock_store_cls.return_value.is_approved.assert_called_once_with("discord", "42")
+
+
+def test_secondary_profile_routes_to_its_own_pairing_store():
+    """A secondary-profile adapter (own_profile='coder') must construct
+    PairingStore(profile='coder'), not the global default store."""
+    adapter = _make_adapter(own_profile="coder")
+
+    with patch("gateway.pairing.PairingStore") as mock_store_cls:
+        mock_store_cls.return_value.is_approved.return_value = True
+        assert adapter._is_pairing_approved_user("42") is True
+        mock_store_cls.assert_called_once_with(profile="coder")
+
+
+def test_user_approved_only_on_routed_profile_is_not_rejected():
+    """The regression scenario: a user approved on the 'coder' profile's
+    pairing whitelist but NOT on the global default must be admitted when
+    the adapter serving that profile checks."""
+    adapter = _make_adapter(own_profile="coder")
+
+    def _fake_store(profile=None):
+        store = MagicMock()
+        # Only the 'coder' profile's store has this user approved.
+        store.is_approved.return_value = profile == "coder"
+        return store
+
+    with patch("gateway.pairing.PairingStore", side_effect=_fake_store):
+        assert adapter._is_pairing_approved_user("42") is True
+
+
+def test_is_allowed_user_admits_via_profile_scoped_pairing():
+    """End-to-end through _is_allowed_user (the real on_message gate): a
+    secondary-profile adapter with no configured allowlists must still admit
+    a user approved only on its own profile's pairing store."""
+    adapter = _make_adapter(own_profile="coder")
+
+    with patch("gateway.pairing.PairingStore") as mock_store_cls:
+        mock_store_cls.return_value.is_approved.return_value = True
+        assert adapter._is_allowed_user("42", author=None, is_dm=True) is True
+        mock_store_cls.assert_called_once_with(profile="coder")
+
+
+def test_configure_profile_adapter_stamps_own_profile():
+    """The tests above build their adapters by manually assigning
+    ``_own_profile`` — they verify the PairingStore selection logic but not
+    that the real production wiring path actually sets it. This proves
+    ``GatewayRunner._configure_profile_adapter`` (the one call site that
+    wires every adapter, both at startup and on secondary-profile
+    reconnect — gateway/run.py) stamps ``adapter._own_profile`` with the
+    profile name it's configuring, for a real DiscordAdapter instance."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = MagicMock()
+    runner._busy_text_mode = False
+
+    adapter = _make_adapter()
+    assert not hasattr(adapter, "_own_profile")
+
+    runner._configure_profile_adapter(adapter, "coder", Platform.DISCORD)
+
+    assert adapter._own_profile == "coder"

--- a/tests/test_yuanbao_pipeline.py
+++ b/tests/test_yuanbao_pipeline.py
@@ -552,6 +552,61 @@ class TestSenderMayDesignateHome:
             mock_store_cls.return_value.is_approved.return_value = True
             assert adapter._sender_may_designate_home(ctx) is True
 
+    def test_pairing_check_routes_to_own_profile_store(self, monkeypatch):
+        """Multiplex gateways serve a secondary profile via a dedicated
+        YuanbaoAdapter instance with ``_own_profile`` stamped by
+        GatewayRunner (gateway/run.py::_configure_profile_adapter). The
+        pairing check must construct PairingStore(profile=...) for that
+        profile instead of the global default store — otherwise a sender
+        approved only on the routed profile is denied here even though
+        authz_mixin._pairing_store_for would have found them.
+        """
+        monkeypatch.delenv("YUANBAO_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        adapter = make_adapter()
+        adapter._own_profile = "coder"
+        adapter._access_policy = AccessPolicy(
+            dm_policy="pairing",
+            dm_allow_from=[],
+            group_policy="pairing",
+            group_allow_from=[],
+        )
+        ctx = make_ctx(
+            adapter=adapter,
+            chat_type="dm",
+            from_account="approved-on-coder-only",
+        )
+
+        with patch("gateway.pairing.PairingStore") as mock_store_cls:
+            mock_store_cls.return_value.is_approved.return_value = True
+            assert adapter._sender_may_designate_home(ctx) is True
+            mock_store_cls.assert_called_once_with(profile="coder")
+
+    def test_pairing_check_uses_global_store_for_default_profile(self):
+        """When _own_profile is unset (default/active profile, or an
+        adapter built without going through _configure_profile_adapter),
+        the pairing check must construct the global PairingStore() with no
+        profile kwarg — preserving pre-fix behavior exactly."""
+        adapter = make_adapter()
+        assert getattr(adapter, "_own_profile", None) is None
+        adapter._access_policy = AccessPolicy(
+            dm_policy="pairing",
+            dm_allow_from=[],
+            group_policy="pairing",
+            group_allow_from=[],
+        )
+        ctx = make_ctx(
+            adapter=adapter,
+            chat_type="dm",
+            from_account="approved-sender",
+        )
+
+        with patch("gateway.pairing.PairingStore") as mock_store_cls:
+            mock_store_cls.return_value.is_approved.return_value = True
+            assert adapter._sender_may_designate_home(ctx) is True
+            mock_store_cls.assert_called_once_with()
+
 
 
 class TestExtractContentMiddleware:


### PR DESCRIPTION
## What does this PR do?
`DiscordAdapter._is_pairing_approved_user()` (called from `_is_allowed_user`, the `on_message` admission gate) and `YuanbaoAdapter._sender_may_designate_home()`'s `dm_policy == "pairing"` branch both construct a bare `PairingStore()` — always the process-global/default-profile store.

In a multiplex gateway, a secondary profile is served by its own adapter instance (`gateway/run.py::_configure_profile_adapter` wires the message handler, session store, etc. per profile), and its own DM-pairing whitelist lives in a separate, profile-scoped `PairingStore(profile=name)` — `gateway/run.py` already builds one per served profile into `self.pairing_stores`, and `authz_mixin._pairing_store_for(source)` already resolves it correctly for the *downstream* authorization check.

The problem is these two adapter-level checks run **before** that downstream, correctly-scoped check ever sees the message:
- Discord's fires inside the `on_message` admission gate (`_is_allowed_user`), which drops the message entirely (`return False, False`) on a `False` result — the comment right above this check even says it exists specifically *"so normal guild/DM text messages do not get dropped at the adapter before the pairing-aware gateway layer can see them"*, but the store it consults isn't the pairing-aware layer's store.
- Yuanbao's gates whether an intake-only DM sender may even designate a home channel (`_sender_may_designate_home`).

Net effect: a user approved only on a routed secondary profile's pairing store (`hermes -p coder pairing approve discord <id>`) is silently rejected by these checks before the message ever reaches the profile-aware gateway layer — even though the downstream check would have admitted them.

## Related Issue
No existing issue — found while re-auditing the multiplex `PairingStore(profile=name)` machinery (`gateway/run.py:12502`) for consumers still constructing the bare/global store, after confirming `authz_mixin._pairing_store_for` already resolves per-profile correctly for the primary authorization path.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `gateway/platforms/base.py`: add `self._own_profile: Optional[str] = None` to `BasePlatformAdapter.__init__`, documented as the multiplex profile the adapter instance serves.
- `gateway/run.py::_configure_profile_adapter`: stamp `adapter._own_profile = profile_name` alongside the existing `set_authorization_check(...)` wiring (mirrors that call's own `profile_name` parameter — `None` for the active/default profile's adapters, the actual name for secondary-profile adapters).
- `plugins/platforms/discord/adapter.py::_is_pairing_approved_user`: construct `PairingStore(profile=self._own_profile)` when set, else the global `PairingStore()` (unchanged default-profile behavior).
- `gateway/platforms/yuanbao.py::_sender_may_designate_home`: same fix for its `dm_policy == "pairing"` branch.
- Tests: new `tests/gateway/test_discord_pairing_profile_scope.py` (4 tests: default-profile behavior preserved, secondary-profile routes to its own store, the actual regression scenario, and an end-to-end `_is_allowed_user` check) + 2 new tests in `tests/test_yuanbao_pipeline.py::TestSenderMayDesignateHome`.

**Out of scope:** Discord's component/button-click authorization (`_component_check_auth`) has the identical bare-`PairingStore()` pattern, but it's a module-level function with 6 call sites across several `discord.ui.View` subclasses that don't currently carry adapter/profile context — threading that through cleanly is a larger, separate refactor and is left for a follow-up.

## How to Test
```
pytest tests/gateway/test_discord_pairing_profile_scope.py tests/test_yuanbao_pipeline.py -v
```
Mutation-verified: stashed the four production-file changes (keeping the new tests) and confirmed the 4 profile-routing-specific tests fail against pre-fix code (`PairingStore()` called with no args instead of `profile="coder"`), while the pre-existing default-profile tests still pass unchanged. Restored the fix and re-ran — all green. Also ran the broader neighboring suites: `test_discord_connect.py`, `test_discord_component_auth.py`, `test_discord_roles_dm_scope.py`, `test_discord_missed_message_backfill.py`, `test_discord_slash_auth.py`, `test_multiplex_pairing_stores.py`, `test_pairing.py` (gateway + hermes_cli), `test_platform_base.py`, full `test_yuanbao_pipeline.py` — 170+ tests, all pass. Ruff clean on all six changed files.

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR found — fresh search across "discord pairing profile scope", "_is_pairing_approved_user", "yuanbao pairing profile multiplex", "discord multiplex secondary profile pairing"; the closest hits (#61985, closed, scopes *env-var allowlist* reads to the routed profile via a different mechanism and never touches `_is_pairing_approved_user`; #56273, merged, touches other Discord authz code but not this function) don't overlap
- [x] Single logical fix (route two adapter-level pairing admission checks to their own multiplex profile) | Tests added (mutation-verified) | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A (pure Python logic, no OS dependency)