### PR TITLE
fix(desktop): hide local reveal actions for remote backends

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.test.tsx
@@ -1,10 +1,16 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ProjectMenu } from './project-menu'
 import type { SidebarProjectTree } from './workspace-groups'
 
+const isDesktopFsRemoteMode = vi.hoisted(() => vi.fn(() => false))
+
 afterEach(cleanup)
+
+beforeEach(() => {
+  isDesktopFsRemoteMode.mockReturnValue(false)
+})
 
 // jsdom doesn't implement ResizeObserver; Radix's PopoverContent/Arrow use it
 // (via @radix-ui/react-use-size) to measure the arrow once the popover is
@@ -55,6 +61,10 @@ vi.mock('@/store/layout', () => ({
     }
   },
   dismissAutoProject: vi.fn()
+}))
+
+vi.mock('@/lib/desktop-fs', () => ({
+  isDesktopFsRemoteMode
 }))
 
 vi.mock('@/store/projects', () => ({
@@ -115,4 +125,23 @@ describe('ProjectMenu', () => {
     // chain rather than getting silently dropped on an intermediate wrapper.
     expect(await screen.findByRole('button', { name: 'No color' })).toBeTruthy()
   }, 15000)
+
+  it('keeps reveal and copy path actions in local mode', async () => {
+    render(<ProjectMenu isActive={false} project={project} />)
+
+    openTriggerMenu(screen.getByRole('button', { name: 'Actions' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Reveal in file manager' })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: 'Copy path' })).toBeTruthy()
+  })
+
+  it('hides reveal but keeps copy path in remote mode', async () => {
+    isDesktopFsRemoteMode.mockReturnValue(true)
+    render(<ProjectMenu isActive={false} project={project} />)
+
+    openTriggerMenu(screen.getByRole('button', { name: 'Actions' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Copy path' })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: 'Reveal in file manager' })).toBeNull()
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { useI18n } from '@/i18n'
+import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { cn } from '@/lib/utils'
 import { $panesFlipped, dismissAutoProject } from '@/store/layout'
 import {
@@ -56,6 +57,7 @@ function useProjectActions({
   const p = t.sidebar.projects
   const target = { id: project.id, name: project.label }
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+  const localFs = !isDesktopFsRemoteMode()
 
   const removeAuto = () => {
     dismissAutoProject(project.id)
@@ -96,13 +98,17 @@ function useProjectActions({
       ]
 
   const pathItems: ActionItemSpec[] = [
-    {
-      disabled: !project.path,
-      icon: 'folder-opened',
-      key: 'reveal',
-      label: p.reveal,
-      onSelect: () => void revealPath(project.path)
-    },
+    ...(localFs
+      ? [
+          {
+            disabled: !project.path,
+            icon: 'folder-opened' as const,
+            key: 'reveal',
+            label: p.reveal,
+            onSelect: () => void revealPath(project.path)
+          }
+        ]
+      : []),
     {
       disabled: !project.path,
       icon: 'copy',

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.test.tsx
@@ -1,9 +1,15 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { StartWorkButton, WorkspaceAddButton, WorkspaceMenu, WorkspaceShowMoreButton } from './workspace-header'
 
+const isDesktopFsRemoteMode = vi.hoisted(() => vi.fn(() => false))
+
 afterEach(cleanup)
+
+beforeEach(() => {
+  isDesktopFsRemoteMode.mockReturnValue(false)
+})
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
@@ -27,6 +33,10 @@ vi.mock('@/store/projects', () => ({
   revealPath: vi.fn()
 }))
 
+vi.mock('@/lib/desktop-fs', () => ({
+  isDesktopFsRemoteMode
+}))
+
 // StartWorkButton renders the full WorktreeDialog (branch picker, git combobox,
 // etc.) as soon as it's open — none of that is relevant to the tooltip fix, so
 // stub it to keep this test focused on the trigger button.
@@ -35,6 +45,12 @@ vi.mock('./worktree-dialog', () => ({
 }))
 
 const tipTrigger = (button: HTMLElement) => button.closest('[data-slot="tooltip-trigger"]')
+
+const openTriggerMenu = (trigger: HTMLElement) => {
+  fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.click(trigger)
+}
 
 describe('WorkspaceAddButton', () => {
   it('wraps the "+" button in a Tip', () => {
@@ -68,6 +84,25 @@ describe('WorkspaceMenu', () => {
 
     const button = screen.getByRole('button', { name: 'Actions' })
     expect(tipTrigger(button)).toBeNull()
+  })
+
+  it('keeps reveal and copy path actions in local mode', async () => {
+    render(<WorkspaceMenu onRemove={vi.fn()} path="/repo/lane" />)
+
+    openTriggerMenu(screen.getByRole('button', { name: 'Actions' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Reveal in file manager' })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: 'Copy path' })).toBeTruthy()
+  })
+
+  it('hides reveal but keeps copy path in remote mode', async () => {
+    isDesktopFsRemoteMode.mockReturnValue(true)
+    render(<WorkspaceMenu onRemove={vi.fn()} path="/repo/lane" />)
+
+    openTriggerMenu(screen.getByRole('button', { name: 'Actions' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Copy path' })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: 'Reveal in file manager' })).toBeNull()
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
@@ -6,6 +6,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
+import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { cn } from '@/lib/utils'
 import { copyPath, revealPath } from '@/store/projects'
 
@@ -83,16 +84,18 @@ export function WorkspaceShowMoreButton({
 function useWorkspaceItems({ path, onRemove }: { path: null | string; onRemove: () => void }) {
   const { t } = useI18n()
   const p = t.sidebar.projects
+  const localFs = !isDesktopFsRemoteMode()
 
   return (kit: MenuKit) => (
     <>
-      {renderActionItem(kit, {
-        disabled: !path,
-        icon: 'folder-opened',
-        key: 'reveal',
-        label: p.reveal,
-        onSelect: () => void revealPath(path)
-      })}
+      {localFs &&
+        renderActionItem(kit, {
+          disabled: !path,
+          icon: 'folder-opened',
+          key: 'reveal',
+          label: p.reveal,
+          onSelect: () => void revealPath(path)
+        })}
       {renderActionItem(kit, {
         disabled: !path,
         icon: 'copy',

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $connection, $currentCwd } from '@/store/session'
+
+import { useStatusbarItems } from './use-statusbar-items'
+
+afterEach(() => {
+  cleanup()
+  $connection.set(null)
+  $currentCwd.set('')
+})
+
+const options = {
+  agentsOpen: false,
+  chatOpen: true,
+  commandCenterOpen: false,
+  extraLeftItems: [],
+  extraRightItems: [],
+  freshDraftReady: true,
+  gatewayState: 'open',
+  inferenceStatus: null,
+  openAgents: vi.fn(),
+  openCommandCenterSection: vi.fn(),
+  requestGateway: vi.fn(() => new Promise<never>(() => undefined)),
+  statusSnapshot: null,
+  toggleCommandCenter: vi.fn()
+} as const
+
+function workspaceMenuIds() {
+  const { result } = renderHook(() => useStatusbarItems(options))
+  const workspace = result.current.leftStatusbarItems.find(item => item.id === 'workspace-cwd')
+
+  return workspace?.menuItems?.map(item => item.id)
+}
+
+describe('useStatusbarItems workspace menu', () => {
+  it('keeps OS reveal, copy path, and in-app reveal in local mode', () => {
+    $connection.set({ mode: 'local' } as never)
+    $currentCwd.set('/repo')
+
+    expect(workspaceMenuIds()).toEqual(['copy-workspace-path', 'reveal-workspace-finder', 'reveal-workspace-sidebar'])
+  })
+
+  it('hides OS reveal but keeps copy path and in-app reveal in remote mode', () => {
+    $connection.set({ mode: 'remote' } as never)
+    $currentCwd.set('/remote/repo')
+
+    expect(workspaceMenuIds()).toEqual(['copy-workspace-path', 'reveal-workspace-sidebar'])
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -9,6 +9,7 @@ import { $paneVisible, togglePaneVisible } from '@/components/pane-shell/tree/st
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
+import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { displayPath, pathLeaf } from '@/lib/display-path'
 import { Activity, AlertCircle, Clock, Command, FolderOpen, Globe, Hash, Loader2, Terminal } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
@@ -96,6 +97,7 @@ export function useStatusbarItems({
   // primary (or a draft with no runtime slice yet). A focused TILE keeps its
   // own cwd in `$sessionStates` and must not paint the primary's workspace.
   const primaryCwd = useStore($currentCwd)
+  const localFs = !isDesktopFsRemoteMode()
   const primaryUsage = useStore($currentUsage)
   const gatewayRestarting = useStore($gatewayRestarting)
   const primarySessionStartedAt = useStore($sessionStartedAt)
@@ -429,12 +431,16 @@ export function useStatusbarItems({
                 onSelect: () => void copyFilePath(currentCwd),
                 title: displayPath(currentCwd)
               },
-              {
-                id: 'reveal-workspace-finder',
-                label: fileMenu.revealFileManager,
-                onSelect: () => void revealFile(currentCwd),
-                title: displayPath(currentCwd)
-              },
+              ...(localFs
+                ? [
+                    {
+                      id: 'reveal-workspace-finder',
+                      label: fileMenu.revealFileManager,
+                      onSelect: () => void revealFile(currentCwd),
+                      title: displayPath(currentCwd)
+                    }
+                  ]
+                : []),
               {
                 id: 'reveal-workspace-sidebar',
                 label: fileMenu.revealInSidebar,
@@ -505,6 +511,7 @@ export function useStatusbarItems({
       gatewayRestarting,
       inferenceReady,
       inferenceStatus?.reason,
+      localFs,
       openAgents,
       projectName,
       subagentsFailed,


### PR DESCRIPTION
## Summary

Desktop's project, workspace/worktree, and statusbar menus expose OS
file-manager reveal actions for remote paths. Electron handles those actions
on the client machine, so a path such as `/home/ubuntu/project` cannot be
revealed in the local Finder or Explorer and the action silently does nothing.

Hide those local-only actions in remote mode, matching the existing behavior
in the Files and Review panes. `Copy Path` and in-app `Reveal in filetree`
remain available, and local backend behavior is unchanged.

## Verification

- Focused Vitest: 3 files, 13 tests passed
- Desktop typecheck, targeted ESLint and Prettier, and production build
- Patched build against an isolated remote backend: the workspace menu kept
  `Copy Path` and `Reveal in filetree` and omitted the OS reveal action
