### PR TITLE
fix(desktop): allow microphone from macOS setup launcher

### DIFF
--- a/apps/bootstrap-installer/src-tauri/Info.plist
+++ b/apps/bootstrap-installer/src-tauri/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSAudioCaptureUsageDescription</key>
+  <string>Hermes launches the desktop app, which uses audio capture for voice conversations.</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Hermes launches the desktop app, which uses the microphone for voice input and voice conversations.</string>
+</dict>
+</plist>

--- a/apps/bootstrap-installer/src-tauri/entitlements.plist
+++ b/apps/bootstrap-installer/src-tauri/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/bootstrap-installer/src-tauri/tauri.conf.json
+++ b/apps/bootstrap-installer/src-tauri/tauri.conf.json
@@ -57,7 +57,8 @@
     },
     "macOS": {
       "minimumSystemVersion": "11.0",
-      "hardenedRuntime": true
+      "hardenedRuntime": true,
+      "entitlements": "entitlements.plist"
     }
   },
   "plugins": {

--- a/tests-js/desktop-mac-entitlements.test.ts
+++ b/tests-js/desktop-mac-entitlements.test.ts
@@ -35,6 +35,10 @@ const REPO_ROOT = path.resolve(__dirname, '..')
 const ELECTRON_DIR = path.join(REPO_ROOT, 'apps', 'desktop', 'electron')
 const MAIN_PLIST = path.join(ELECTRON_DIR, 'entitlements.mac.plist')
 const INHERIT_PLIST = path.join(ELECTRON_DIR, 'entitlements.mac.inherit.plist')
+const BOOTSTRAP_TAURI_DIR = path.join(REPO_ROOT, 'apps', 'bootstrap-installer', 'src-tauri')
+const BOOTSTRAP_TAURI_CONFIG = path.join(BOOTSTRAP_TAURI_DIR, 'tauri.conf.json')
+const BOOTSTRAP_ENTITLEMENTS = path.join(BOOTSTRAP_TAURI_DIR, 'entitlements.plist')
+const BOOTSTRAP_INFO_PLIST = path.join(BOOTSTRAP_TAURI_DIR, 'Info.plist')
 
 const DEVICE_PREFIX = 'com.apple.security.device.'
 
@@ -89,3 +93,41 @@ for (const plist of [MAIN_PLIST, INHERIT_PLIST]) {
     )
   })
 }
+
+test('bootstrap installer carries microphone entitlement for launcher attribution', () => {
+  const config = JSON.parse(fs.readFileSync(BOOTSTRAP_TAURI_CONFIG, 'utf-8'))
+  assert.equal(
+    config.bundle?.macOS?.entitlements,
+    'entitlements.plist',
+    'the macOS bootstrap installer must sign with its entitlements.plist. ' +
+      'When /Applications/Hermes.app is the setup launcher, macOS TCC treats ' +
+      'com.nousresearch.hermes.setup as the responsible process for the desktop ' +
+      'app it opens; without audio-input on the setup app, microphone access is ' +
+      'denied before a permission prompt can appear.'
+  )
+
+  const entitlements = loadEntitlements(BOOTSTRAP_ENTITLEMENTS)
+  assert.equal(
+    entitlements['com.apple.security.device.audio-input'],
+    true,
+    'bootstrap installer entitlements must grant audio-input because it is the ' +
+      'TCC responsible process for the desktop app launched from the setup fast path'
+  )
+})
+
+test('bootstrap installer Info.plist explains microphone usage', () => {
+  const info = plist.parse(fs.readFileSync(BOOTSTRAP_INFO_PLIST, 'utf-8')) as Record<
+    string,
+    unknown
+  >
+  assert.equal(
+    typeof info.NSMicrophoneUsageDescription,
+    'string',
+    'macOS requires NSMicrophoneUsageDescription before it can prompt for microphone access'
+  )
+  assert.match(
+    info.NSMicrophoneUsageDescription as string,
+    /microphone/i,
+    'microphone usage description should be user-visible and specific'
+  )
+})


### PR DESCRIPTION
## Summary
- add macOS audio-input entitlement to the Tauri bootstrap installer
- add microphone/audio usage descriptions to the bootstrap installer's Info.plist
- cover the setup-launcher TCC attribution path with regression tests

## Why
When users launch Hermes from /Applications/Hermes.app after installation, that app is the Tauri setup/launcher bundle (com.nousresearch.hermes.setup). It opens the real Electron desktop app from ~/.hermes, but macOS TCC still treats the setup bundle as the responsible process. Because the setup bundle had hardened runtime enabled but no com.apple.security.device.audio-input entitlement, macOS denied kTCCServiceMicrophone before showing a permission prompt.

## Test Plan
- npm exec vitest run tests-js/desktop-mac-entitlements.test.ts
- npm run typecheck (in apps/bootstrap-installer)

Note: cargo is not installed in this local environment, so Rust tests were not runnable here.