### PR TITLE
fix(relay): avoid concurrent turn scope corruption

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -482,10 +482,7 @@ class RelayTurnContext:
         default_factory=threading.RLock,
         repr=False,
     )
-    _token: contextvars.Token[RelayTurnContext | None] | None = field(
-        default=None,
-        repr=False,
-    )
+    _previous_turn: RelayTurnContext | None = field(default=None, repr=False)
     _active_registered: bool = field(default=False, repr=False)
     relay_enabled: bool = True
     closed: bool = False
@@ -639,7 +636,8 @@ class RelaySessionCoordinator:
                 )
             except Exception:
                 logger.warning("Hermes Relay turn initialization failed", exc_info=True)
-        turn._token = _CURRENT_TURN.set(turn)
+        turn._previous_turn = _CURRENT_TURN.get()
+        _CURRENT_TURN.set(turn)
         return turn
 
     def end_turn(
@@ -773,16 +771,18 @@ class RelaySessionCoordinator:
 
     @staticmethod
     def _reset_turn_context(turn: RelayTurnContext) -> None:
-        """Reset the originating ContextVar token when called in that context."""
-        if turn._token is None:
+        """Unwind ``turn`` without disturbing a newer context-local turn."""
+        if _CURRENT_TURN.get() is not turn:
             return
-        try:
-            _CURRENT_TURN.reset(turn._token)
-        except ValueError:
-            # A copied async/thread context may own terminal cleanup. Keep the
-            # token so the originating context can clear its stale reference.
-            return
-        turn._token = None
+        previous = turn._previous_turn
+        seen = {id(turn)}
+        while previous is not None and previous.closed:
+            if id(previous) in seen:
+                previous = None
+                break
+            seen.add(id(previous))
+            previous = previous._previous_turn
+        _CURRENT_TURN.set(previous)
 
     @staticmethod
     def release_conversation(lease: ConversationLease) -> None:
@@ -814,7 +814,7 @@ def current_turn() -> RelayTurnContext | None:
 def relay_instrumentation_enabled() -> bool:
     """Return whether this inherited turn may create Relay instrumentation."""
     turn = current_turn()
-    return turn is None or turn.relay_enabled
+    return turn is None or (turn.relay_enabled and not turn.closed)
 
 
 def active_turn(session_id: str | None = None) -> RelayTurnContext | None:
@@ -844,7 +844,9 @@ def resolve_execution_context(
 ) -> tuple[RelayRuntime | None, RelaySession | None, Any]:
     """Resolve one active turn/session parent for managed Relay execution."""
     inherited_turn = current_turn()
-    if inherited_turn is not None and not inherited_turn.relay_enabled:
+    if inherited_turn is not None and (
+        not inherited_turn.relay_enabled or inherited_turn.closed
+    ):
         return None, None, None
     turn = active_turn(session_id)
     if (

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -487,6 +487,7 @@ class RelayTurnContext:
         repr=False,
     )
     _active_registered: bool = field(default=False, repr=False)
+    relay_enabled: bool = True
     closed: bool = False
 
 
@@ -600,7 +601,28 @@ class RelaySessionCoordinator:
         if lease.released:
             raise RuntimeError("Hermes Relay conversation lease is released")
         turn = RelayTurnContext(lease=lease, turn_id=turn_id, task_id=task_id)
-        if isinstance(lease.host, RelayRuntime) and lease.session is not None:
+        key = (lease.profile_key, lease.session_id)
+        with self._active_turns_lock:
+            active = self._active_turns.get(key)
+            if active:
+                # A Relay session owns one physical scope stack. Concurrent
+                # Hermes turns would create sibling scopes on that stack, but
+                # their completion order is not guaranteed to be LIFO.
+                turn.relay_enabled = False
+                logger.warning(
+                    "Skipping Relay instrumentation for concurrent Hermes turn "
+                    "%s in session %s",
+                    turn_id,
+                    lease.session_id,
+                )
+            else:
+                self._active_turns[key] = {id(turn)}
+                turn._active_registered = True
+        if (
+            turn.relay_enabled
+            and isinstance(lease.host, RelayRuntime)
+            and lease.session is not None
+        ):
             try:
                 turn.handle = lease.host.run_in_session(
                     lease.session,
@@ -618,10 +640,6 @@ class RelaySessionCoordinator:
             except Exception:
                 logger.warning("Hermes Relay turn initialization failed", exc_info=True)
         turn._token = _CURRENT_TURN.set(turn)
-        key = (lease.profile_key, lease.session_id)
-        with self._active_turns_lock:
-            self._active_turns.setdefault(key, set()).add(id(turn))
-            turn._active_registered = True
         return turn
 
     def end_turn(
@@ -796,7 +814,12 @@ def current_turn() -> RelayTurnContext | None:
 def active_turn(session_id: str | None = None) -> RelayTurnContext | None:
     """Return a live turn only when it belongs to the active profile/session."""
     turn = current_turn()
-    if turn is None or turn.closed or turn.lease.released:
+    if (
+        turn is None
+        or not turn.relay_enabled
+        or turn.closed
+        or turn.lease.released
+    ):
         return None
     if turn.lease.profile_key != current_profile_key():
         return None
@@ -814,6 +837,9 @@ def resolve_execution_context(
     session_id: str,
 ) -> tuple[RelayRuntime | None, RelaySession | None, Any]:
     """Resolve one active turn/session parent for managed Relay execution."""
+    inherited_turn = current_turn()
+    if inherited_turn is not None and not inherited_turn.relay_enabled:
+        return None, None, None
     turn = active_turn(session_id)
     if (
         turn is not None

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -811,6 +811,12 @@ def current_turn() -> RelayTurnContext | None:
     return _CURRENT_TURN.get()
 
 
+def relay_instrumentation_enabled() -> bool:
+    """Return whether this inherited turn may create Relay instrumentation."""
+    turn = current_turn()
+    return turn is None or turn.relay_enabled
+
+
 def active_turn(session_id: str | None = None) -> RelayTurnContext | None:
     """Return a live turn only when it belongs to the active profile/session."""
     turn = current_turn()

--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -671,6 +671,8 @@ def observe_lifecycle(hook_name: str, **kwargs: Any) -> None:
     """Project one Hermes lifecycle event into the core Relay integration."""
     if not handles_hook(hook_name):
         return
+    if not relay_runtime.relay_instrumentation_enabled():
+        return
     runtime = _get_runtime()
     if runtime is None:
         return

--- a/run_agent.py
+++ b/run_agent.py
@@ -7624,7 +7624,9 @@ class AIAgent:
                 turn_id=relay_turn_id,
                 task_id=effective_task_id,
             )
-            if relay_turn.relay_enabled:
+            # Keep existing tests and external relay-runtime shims that return
+            # a minimal turn object compatible with the new opt-out flag.
+            if getattr(relay_turn, "relay_enabled", True):
                 start_task_run(
                     **task_context,
                     parent_session_id=getattr(self, "_parent_session_id", None) or "",

--- a/run_agent.py
+++ b/run_agent.py
@@ -7624,11 +7624,12 @@ class AIAgent:
                 turn_id=relay_turn_id,
                 task_id=effective_task_id,
             )
-            start_task_run(
-                **task_context,
-                parent_session_id=getattr(self, "_parent_session_id", None) or "",
-            )
-            task_started = True
+            if relay_turn.relay_enabled:
+                start_task_run(
+                    **task_context,
+                    parent_session_id=getattr(self, "_parent_session_id", None) or "",
+                )
+                task_started = True
             # Publish the conversation id for ambient Nous Portal tagging. Every
             # LLM call made inside this turn — main loop, compression, vision,
             # web_extract, session_search, MoA slots, background-review forks

--- a/run_agent.py
+++ b/run_agent.py
@@ -7677,8 +7677,9 @@ class AIAgent:
                 relay_turn,
                 outcome=relay_outcome,
             )
-            task_finished = True
-            finish_task_run(**task_context, result=result)
+            if task_started:
+                task_finished = True
+                finish_task_run(**task_context, result=result)
             return result
         except BaseException as exc:
             if isinstance(exc, (KeyboardInterrupt, InterruptedError)) or (

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -835,6 +835,43 @@ def test_concurrent_turn_skips_relay_before_scope_stack_can_interleave(
     assert len(turn_closes) == 1
 
 
+def test_concurrent_turn_skips_shared_metrics_scope_creation(direct_runtime):
+    coordinator = relay_runtime.SESSION_COORDINATOR
+    profile_key = relay_runtime.current_profile_key()
+    lease = coordinator.acquire_conversation(
+        profile_key=profile_key,
+        session_id="shared-session",
+        platform="cli",
+    )
+    first = coordinator.begin_turn(lease, turn_id="first", task_id="first-task")
+    second = coordinator.begin_turn(lease, turn_id="second", task_id="second-task")
+
+    relay_shared_metrics.observe_lifecycle(
+        "pre_llm_call",
+        session_id="shared-session",
+        task_id="second-task",
+        platform="cli",
+    )
+    relay_shared_metrics.observe_lifecycle(
+        "pre_api_request",
+        session_id="shared-session",
+        task_id="second-task",
+        api_request_id="second-request",
+        platform="cli",
+    )
+
+    assert second.relay_enabled is False
+    assert not [
+        event
+        for event in direct_runtime.events
+        if event[0] == "scope.push" and event[1] == relay_shared_metrics.TASK_SCOPE
+    ]
+
+    coordinator.end_turn(first, outcome="success")
+    coordinator.end_turn(second, outcome="success")
+    coordinator.release_conversation(lease)
+
+
 
 
 
@@ -1010,7 +1047,6 @@ def test_failed_flush_keeps_daily_export_open_for_later_task(
     assert metrics["hermes.task_run.finished"]["value"] == 2
     assert flush_attempts == 2
     assert "Hermes shared-metrics task flush failed" in caplog.text
-
 
 
 

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -647,6 +647,75 @@ def test_core_task_instrumentation_preserves_prompt_history_and_tool_schema(
     assert json.dumps(agent.tools, ensure_ascii=False, sort_keys=True) == tools_before
 
 
+def test_skipped_turn_does_not_finish_another_sessions_matching_task(
+    direct_runtime,
+    monkeypatch,
+):
+    """A skipped turn must not use shared-metrics' task-id fallback on finish."""
+    from run_agent import AIAgent
+
+    owner_session = "instrumented-session"
+    shared_task_id = "caller-supplied-task-id"
+    relay_shared_metrics.start_task_run(
+        session_id=owner_session,
+        task_id=shared_task_id,
+        platform="cli",
+    )
+    runtime = relay_shared_metrics._get_runtime()
+    assert runtime is not None
+    assert (owner_session, shared_task_id) in runtime._task_sessions
+
+    agent = object.__new__(AIAgent)
+    agent.session_id = "skipped-session"
+    agent.platform = "cli"
+    agent._parent_session_id = None
+    agent._session_db = None
+    agent._cached_system_prompt = "stable"
+    agent.tools = []
+
+    skipped_turn = SimpleNamespace(relay_enabled=False)
+    monkeypatch.setattr(
+        relay_runtime.SESSION_COORDINATOR,
+        "begin_turn",
+        lambda *_args, **_kwargs: skipped_turn,
+    )
+    monkeypatch.setattr(
+        relay_runtime.SESSION_COORDINATOR,
+        "finish_logical_calls",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        relay_runtime.SESSION_COORDINATOR,
+        "end_turn",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "agent.conversation_loop.run_conversation",
+        lambda *_args, **_kwargs: {"final_response": "ok", "completed": True},
+    )
+
+    result = AIAgent.run_conversation(
+        agent,
+        "hello",
+        conversation_history=[],
+        task_id=shared_task_id,
+    )
+
+    assert result["completed"] is True
+    assert (owner_session, shared_task_id) in runtime._task_sessions
+    assert not [
+        event
+        for event in direct_runtime.events
+        if event[0] == "scope.pop" and event[1][1] == relay_shared_metrics.TASK_SCOPE
+    ]
+    relay_shared_metrics.finish_task_run(
+        session_id=owner_session,
+        task_id=shared_task_id,
+        platform="cli",
+        result={"completed": True},
+    )
+
+
 
 
 
@@ -1147,5 +1216,4 @@ def test_failed_flush_keeps_daily_export_open_for_later_task(
     assert metrics["hermes.task_run.finished"]["value"] == 2
     assert flush_attempts == 2
     assert "Hermes shared-metrics task flush failed" in caplog.text
-
 

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -792,6 +792,49 @@ def test_sync_session_runner_releases_lock_before_callback(direct_runtime):
     assert contender.is_alive() is False
 
 
+def test_concurrent_turn_skips_relay_before_scope_stack_can_interleave(
+    direct_runtime,
+):
+    coordinator = relay_runtime.SESSION_COORDINATOR
+    profile_key = relay_runtime.current_profile_key()
+    lease = coordinator.acquire_conversation(
+        profile_key=profile_key,
+        session_id="shared-session",
+        platform="cli",
+    )
+    first = coordinator.begin_turn(lease, turn_id="first", task_id="first-task")
+    second = coordinator.begin_turn(
+        lease,
+        turn_id="second",
+        task_id="second-task",
+    )
+
+    assert first.relay_enabled is True
+    assert first.handle is not None
+    assert second.relay_enabled is False
+    assert second.handle is None
+    assert relay_runtime.resolve_execution_context("shared-session") == (
+        None,
+        None,
+        None,
+    )
+
+    coordinator.end_turn(first, outcome="success")
+    coordinator.end_turn(second, outcome="success")
+    coordinator.release_conversation(lease)
+    coordinator.finalize_conversation(
+        profile_key=profile_key,
+        session_id="shared-session",
+    )
+
+    turn_closes = [
+        event
+        for event in direct_runtime.events
+        if event[0] == "scope.pop" and event[1] == first.handle
+    ]
+    assert len(turn_closes) == 1
+
+
 
 
 
@@ -967,7 +1010,6 @@ def test_failed_flush_keeps_daily_export_open_for_later_task(
     assert metrics["hermes.task_run.finished"]["value"] == 2
     assert flush_attempts == 2
     assert "Hermes shared-metrics task flush failed" in caplog.text
-
 
 
 

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -918,6 +918,60 @@ def test_concurrent_turn_skips_shared_metrics_scope_creation(direct_runtime):
     coordinator.release_conversation(lease)
 
 
+def test_skipped_turn_stays_gated_after_instrumented_turn_ends(direct_runtime):
+    coordinator = relay_runtime.SESSION_COORDINATOR
+    profile_key = relay_runtime.current_profile_key()
+    lease = coordinator.acquire_conversation(
+        profile_key=profile_key,
+        session_id="shared-session",
+        platform="cli",
+    )
+    first = coordinator.begin_turn(lease, turn_id="first", task_id="first-task")
+    second = coordinator.begin_turn(lease, turn_id="second", task_id="second-task")
+    inherited = contextvars.copy_context()
+
+    coordinator.end_turn(first, outcome="success")
+
+    assert relay_runtime.current_turn() is second
+    assert inherited.run(relay_runtime.current_turn) is second
+    assert not relay_runtime.relay_instrumentation_enabled()
+    assert not inherited.run(relay_runtime.relay_instrumentation_enabled)
+    assert relay_runtime.resolve_execution_context("shared-session") == (
+        None,
+        None,
+        None,
+    )
+
+    relay_shared_metrics.observe_lifecycle(
+        "pre_llm_call",
+        session_id="shared-session",
+        task_id="second-task",
+        platform="cli",
+    )
+    inherited.run(
+        relay_shared_metrics.observe_lifecycle,
+        "pre_api_request",
+        session_id="shared-session",
+        task_id="second-task",
+        api_request_id="second-request",
+        platform="cli",
+    )
+
+    assert not [
+        event
+        for event in direct_runtime.events
+        if event[0] == "scope.push"
+        and event[1]
+        in {relay_shared_metrics.TASK_SCOPE, relay_shared_metrics.MODEL_CALL_SCOPE}
+    ]
+
+    coordinator.end_turn(second, outcome="success")
+    assert relay_runtime.current_turn() is None
+    assert inherited.run(relay_runtime.current_turn) is second
+    assert not inherited.run(relay_runtime.relay_instrumentation_enabled)
+    coordinator.release_conversation(lease)
+
+
 
 
 
@@ -1093,7 +1147,5 @@ def test_failed_flush_keeps_daily_export_open_for_later_task(
     assert metrics["hermes.task_run.finished"]["value"] == 2
     assert flush_attempts == 2
     assert "Hermes shared-metrics task flush failed" in caplog.text
-
-
 
 

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -32,6 +32,7 @@ class _Relay:
         self._starts: dict[Any, dict[str, Any]] = {}
         self._scope_starts: dict[Any, dict[str, Any]] = {}
         self._scope = contextvars.ContextVar("relay_scope", default=None)
+        self._scope_stack = contextvars.ContextVar("relay_scope_stack", default=None)
         self._scope_serial = 0
         self.ScopeType = SimpleNamespace(Agent="agent", Function="function")
         self.LLMRequest = _Request
@@ -51,6 +52,11 @@ class _Relay:
     def _scope_push(self, name: str, scope_type: Any, **kwargs: Any) -> Any:
         self._scope_serial += 1
         handle = ("scope", name, self._scope_serial)
+        stack = self._scope_stack.get()
+        if stack is None:
+            stack = []
+            self._scope_stack.set(stack)
+        stack.append(handle)
         self._scope.set(handle)
         self.events.append(("scope.push", name, scope_type, kwargs))
         if scope_type == self.ScopeType.Function:
@@ -69,6 +75,13 @@ class _Relay:
         return handle
 
     def _scope_pop(self, handle: Any, **kwargs: Any) -> None:
+        stack = self._scope_stack.get()
+        if not stack or stack[-1] != handle:
+            current = stack[-1] if stack else None
+            self.events.append(("scope.pop.rejected", handle, current))
+            raise RuntimeError("scope handle is not at the top of the stack")
+        stack.pop()
+        self._scope.set(stack[-1] if stack else None)
         self.events.append(("scope.pop", handle, kwargs))
         start = self._scope_starts.pop(handle, None)
         if start is not None:
@@ -91,7 +104,9 @@ class _Relay:
         self.events.append(("scope.event", name, kwargs))
 
     def _get_scope_stack(self) -> Any:
-        current = self._scope.get()
+        stack = self._scope_stack.get()
+        current = stack[-1] if stack else None
+        self._scope.set(current)
         self.events.append(("scope.sync", current))
         return current
 
@@ -792,6 +807,32 @@ def test_sync_session_runner_releases_lock_before_callback(direct_runtime):
     assert contender.is_alive() is False
 
 
+def test_direct_runtime_fake_enforces_lifo_scope_contract(direct_runtime):
+    runtime = relay_runtime.get_runtime()
+    assert runtime is not None
+    session = runtime.ensure_session({"session_id": "lifo-contract"})
+    assert session is not None
+
+    first = runtime.run_in_session(
+        session,
+        direct_runtime.scope.push,
+        "first",
+        direct_runtime.ScopeType.Function,
+    )
+    second = runtime.run_in_session(
+        session,
+        direct_runtime.scope.push,
+        "second",
+        direct_runtime.ScopeType.Function,
+    )
+
+    with pytest.raises(RuntimeError, match="not at the top"):
+        runtime.run_in_session(session, direct_runtime.scope.pop, first)
+
+    runtime.run_in_session(session, direct_runtime.scope.pop, second)
+    runtime.run_in_session(session, direct_runtime.scope.pop, first)
+
+
 def test_concurrent_turn_skips_relay_before_scope_stack_can_interleave(
     direct_runtime,
 ):
@@ -833,6 +874,11 @@ def test_concurrent_turn_skips_relay_before_scope_stack_can_interleave(
         if event[0] == "scope.pop" and event[1] == first.handle
     ]
     assert len(turn_closes) == 1
+    assert not [
+        event
+        for event in direct_runtime.events
+        if event[0] == "scope.pop.rejected"
+    ]
 
 
 def test_concurrent_turn_skips_shared_metrics_scope_creation(direct_runtime):
@@ -1047,8 +1093,6 @@ def test_failed_flush_keeps_daily_export_open_for_later_task(
     assert metrics["hermes.task_run.finished"]["value"] == 2
     assert flush_attempts == 2
     assert "Hermes shared-metrics task flush failed" in caplog.text
-
-
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the NeMo Relay non-LIFO scope failure when two Hermes turns overlap for the same session. Relay 0.6 gives a session one physical LIFO scope stack; opening a scope for both turns lets turn B sit above turn A, so finishing A first attempts to pop a non-top handle.

Hermes now admits only one instrumented turn per shared session. An overlapping turn remains a normal Hermes turn but is marked `relay_enabled=False`, so it cannot create turn, task, model, tool, logical-call, or shared-metrics Relay scopes. The context-local skipped state is preserved until that turn ends—even if the first turn ends while the skipped turn is current—and stale copied contexts remain fail-closed instead of falling back to the session handle.

### Relay version compatibility

This is the conservative path for Hermes's current `nemo-relay>=0.6.0,<0.7` dependency. It is forward-compatible with Relay 0.7.x as written, but still deliberately instruments only one overlapping turn. A follow-up can capability-detect Relay 0.7.x's public `use_scope_stack()` API and give every turn an isolated stack while retaining this admission guard as the Relay 0.6 fallback.

## Related Issue

Fixes #73746

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/relay_runtime.py`
  - reserves one active Relay turn per profile/session;
  - skips every managed Relay path for an overlapping turn;
  - replaces out-of-order `ContextVar` token resets with an explicit predecessor chain, so ending turn A cannot erase current turn B;
  - keeps copied contexts for ended/skipped turns fail-closed.
- `hermes_cli/observability/relay_shared_metrics.py`
  - gates lifecycle hooks before lazy task/model scope creation.
- `run_agent.py`
  - avoids the explicit shared-metrics task scope for a skipped turn while preserving legacy runtime shims.
- `tests/hermes_cli/test_relay_shared_metrics_runtime.py`
  - makes the Relay fake enforce the native LIFO contract;
  - covers A/B overlap, shared-metrics `pre_api_request`, ending A before continuing B, copied contexts, and subagent parent restoration.

## How to Test

```sh
pytest -q \
  tests/agent/test_relay_llm.py \
  tests/agent/test_relay_tools.py \
  tests/agent/test_auxiliary_relay.py \
  tests/hermes_cli/test_relay_shared_metrics.py \
  tests/hermes_cli/test_relay_shared_metrics_runtime.py \
  tests/plugins/test_nemo_relay_plugin.py
```

Current macOS arm64 validation against the pinned Relay 0.6 binding:

- focused Relay suites: `57 passed`;
- Ruff: `All checks passed!`;
- real native overlap E2E: first turn instrumented, second turn intentionally skipped, second-turn tool callback completed after the first ended, and `non_lifo_errors=0`;
- expanded suite run reached `1895 passed` before an unrelated order-dependent `test_file_safety` failure that passes in isolation on both rebased branches. The full-suite checkbox remains unchecked pending CI's isolated slices.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

Not applicable.

## Screenshots / Logs

Real Relay 0.6 overlap result:

```text
{'first_instrumented': True, 'second_instrumented': False, 'skipped_turn_callbacks': 1, 'non_lifo_errors': 0}
```
