### PR TITLE
Fix empty assistant payloads after chat message conversion

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -271,6 +271,53 @@ class ChatCompletionsTransport(ProviderTransport):
                             copied_tool_calls[tc_idx] = copied_tc
                 if copied_tool_calls is not None:
                     mutable_msg()["tool_calls"] = copied_tool_calls
+
+        # Final wire-boundary guard: a turn that still carried payload when the
+        # pre-call sanitizer vetted it can become wire-EMPTY here, because the
+        # stripping above removes fields that only the Responses transport can
+        # replay. The reachable case is a codex commentary turn (content:"" by
+        # design, text living in ``codex_message_items``): ``_msg_has_payload``
+        # counts the carrier as payload, so ``repair_empty_non_final_messages``
+        # leaves it alone — then this method drops the carrier and a bare
+        # ``{"role": "assistant", "content": ""}`` goes out. A session that ran
+        # on Codex/Responses and is then continued on an OpenAI-compatible
+        # provider (model switch to Moonshot/Kimi, DeepSeek, …) replays that
+        # shell mid-transcript and the provider 400s every subsequent request
+        # ("message at position N must not be empty") until it scrolls out.
+        #
+        # Repair by substitution, not deletion — same policy (and placeholder)
+        # as ``repair_empty_non_final_messages``: dropping a mid-transcript
+        # turn breaks role alternation and tool-call pairing. Only non-final
+        # assistant turns are touched; an empty FINAL assistant message is a
+        # legal prefill and is left exactly as-is.
+        if len(sanitized) >= 2:
+            from agent.agent_runtime_helpers import (
+                _INTERRUPTED_PLACEHOLDER,
+                _msg_has_payload,
+            )
+
+            last_idx = len(sanitized) - 1
+            healed_wire_empty = 0
+            for idx, msg in enumerate(sanitized):
+                if (
+                    idx != last_idx
+                    and isinstance(msg, dict)
+                    and msg.get("role") == "assistant"
+                    and not _msg_has_payload(msg)
+                ):
+                    patched = dict(msg)
+                    patched["content"] = _INTERRUPTED_PLACEHOLDER
+                    sanitized[idx] = patched
+                    healed_wire_empty += 1
+            if healed_wire_empty:
+                import logging
+
+                logging.getLogger(__name__).debug(
+                    "chat-completions wire guard: substituted placeholder "
+                    "content on %d assistant turn(s) that became empty after "
+                    "internal-field stripping (would 400 strict providers)",
+                    healed_wire_empty,
+                )
         return sanitized
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -537,3 +537,166 @@ class TestChatCompletionsGeminiNativeExtraBodyStrip:
         eb = kw.get("extra_body")
         assert eb and "tags" in eb
 
+
+# Wire-boundary guard: a turn that carried payload when the pre-call sanitizer
+# vetted it can become wire-EMPTY after convert_messages strips Responses-only
+# fields. Reachable case: a codex commentary turn (content:"" by design, text
+# in ``codex_message_items``) replayed on an OpenAI-compatible provider after a
+# model switch — the provider then 400s every request ("message at position N
+# must not be empty") until it scrolls out — the same failure class
+# ``repair_empty_non_final_messages`` already repairs for every other shape.
+# ---------------------------------------------------------------------------
+
+
+def _wire_empty_assistants(msgs):
+    out = []
+    for i, m in enumerate(msgs):
+        if m.get("role") != "assistant":
+            continue
+        content = m.get("content")
+        has_text = (isinstance(content, str) and content.strip()) or (
+            isinstance(content, list) and len(content) > 0
+        )
+        if not (has_text or m.get("tool_calls") or m.get("reasoning_content")):
+            out.append(i)
+    return out
+
+
+def _codex_carrier_history():
+    return [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "codex_message_items": [{"type": "message"}]},
+        {"role": "user", "content": "go on"},
+    ]
+
+
+def test_codex_carrier_turn_is_not_wire_empty_after_stripping():
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    out = ChatCompletionsTransport().convert_messages(
+        _codex_carrier_history(), model="moonshotai/kimi-k3"
+    )
+    assert _wire_empty_assistants(out) == []
+    assert out[1]["content"].strip()
+    assert "codex_message_items" not in out[1]
+
+
+def test_wire_guard_uses_the_shared_interrupted_placeholder():
+    from agent.agent_runtime_helpers import _INTERRUPTED_PLACEHOLDER
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    out = ChatCompletionsTransport().convert_messages(
+        _codex_carrier_history(), model="moonshotai/kimi-k3"
+    )
+    assert out[1]["content"] == _INTERRUPTED_PLACEHOLDER
+
+
+def test_wire_guard_does_not_mutate_caller_history():
+    import copy
+
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    history = _codex_carrier_history()
+    snapshot = copy.deepcopy(history)
+    ChatCompletionsTransport().convert_messages(history, model="moonshotai/kimi-k3")
+    assert history == snapshot
+
+
+def test_wire_guard_preserves_reasoning_only_and_tool_call_only_turns():
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "reasoning_content": "thinking"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "res"},
+        {"role": "user", "content": "go on"},
+    ]
+    out = ChatCompletionsTransport().convert_messages(history, model="moonshotai/kimi-k3")
+    assert out[1]["reasoning_content"] == "thinking"
+    assert out[1]["content"] == ""  # reasoning is the payload; untouched
+    assert out[2]["tool_calls"][0]["function"]["name"] == "f"
+    assert out[2]["content"] == ""  # tool_calls are the payload; untouched
+
+
+def test_wire_guard_leaves_valid_content_and_ordering_alone():
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "real answer"},
+        {"role": "user", "content": "go on"},
+    ]
+    out = ChatCompletionsTransport().convert_messages(history, model="moonshotai/kimi-k3")
+    assert [m["role"] for m in out] == ["user", "assistant", "user"]
+    assert out[1]["content"] == "real answer"
+
+
+def test_wire_guard_leaves_empty_final_assistant_prefill_untouched():
+    """An empty FINAL assistant turn is a legal prefill — the guard must not
+    touch it (mirrors repair_empty_non_final_messages' final-message rule)."""
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "codex_message_items": [{"type": "message"}]},
+    ]
+    out = ChatCompletionsTransport().convert_messages(history, model="moonshotai/kimi-k3")
+    assert out[-1]["content"] == ""
+
+
+def test_wire_guard_regression_chain_survives_a_repeated_request():
+    """The wedge was persistent: every retry replayed the shell. Converting the
+    same history twice must produce a valid payload both times."""
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    transport = ChatCompletionsTransport()
+    history = _codex_carrier_history()
+    first = transport.convert_messages(history, model="moonshotai/kimi-k3")
+    second = transport.convert_messages(history, model="moonshotai/kimi-k3")
+    assert _wire_empty_assistants(first) == []
+    assert _wire_empty_assistants(second) == []
+    assert first == second
+
+
+def test_converted_payload_satisfies_strict_provider_contract():
+    """End-to-end contract check with an offline provider stub applying the
+    documented rule ("a non-final assistant message must carry content, tool
+    calls, or reasoning"). Without the guard the middle turn is rejected on
+    every attempt — the persistent-wedge condition; with it the same history
+    is accepted repeatedly."""
+    import copy
+
+    from agent.agent_runtime_helpers import sanitize_api_messages
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    def provider_reject_index(messages):
+        last = len(messages) - 1
+        for idx, msg in enumerate(messages):
+            if msg.get("role") != "assistant" or idx == last:
+                continue
+            content = msg.get("content")
+            valid = (
+                (isinstance(content, str) and content.strip())
+                or (isinstance(content, list) and content)
+                or msg.get("tool_calls")
+                or msg.get("reasoning_content")
+            )
+            if not valid:
+                return idx
+        return None
+
+    transport = ChatCompletionsTransport()
+    history = _codex_carrier_history()
+    for _attempt in range(2):
+        sanitized = sanitize_api_messages(copy.deepcopy(history))
+        kwargs = transport.build_kwargs(
+            model="moonshotai/kimi-k3", messages=sanitized, tools=None
+        )
+        assert provider_reject_index(kwargs["messages"]) is None


### PR DESCRIPTION
## Summary

Prevents non-final assistant messages from becoming empty provider payloads after the chat-completions transport strips internal-only fields.

## Problem

`repair_empty_non_final_messages` heals empty non-final turns at the pre-call chokepoint, but it vets each message *before* `convert_messages` removes internal-only fields — so a turn can pass as non-empty there and still reach the provider empty.

The reachable case is a Codex commentary turn. It persists with `content: ""` by design (its text lives in `codex_message_items`), and `_msg_has_payload` counts that carrier as payload — deliberately, since 5e88745f1 exempted `codex_responses` from the pads so commentary replay wouldn't break. `convert_messages` then drops the carrier for chat-completions providers and what goes out mid-transcript is:

```json
{"role": "assistant", "content": ""}
```

A session that ran on the Responses API and is continued on an OpenAI-compatible provider replays that shell, and strict providers reject **every** subsequent request (`message at position N must not be empty`) until it scrolls out of context — the same persistent poisoning `repair_empty_non_final_messages` was added to prevent.

Reproduced on current `main` through the real path (`sanitize_api_messages` → `ChatCompletionsTransport.build_kwargs`): the payload contains the empty shell, and an offline stub applying that provider rule rejects it on attempt 1 **and** attempt 2.

## Fix

After the stripping that creates the emptiness, revalidate non-final assistant messages with the existing `_msg_has_payload` and substitute the existing `_INTERRUPTED_PLACEHOLDER`.

Substitution rather than deletion, for the reason already documented on `repair_empty_non_final_messages`: dropping a mid-transcript turn breaks role alternation and tool-call pairing.

Scope is deliberately narrow:

- chat-completions transport only — the Responses wire has no such validation and Anthropic messages take a different path;
- non-final assistant turns only — an empty final assistant message is a legal prefill and is left untouched;
- reasoning-only, tool-call-only and ordinary content turns are unaffected;
- caller-owned history is never mutated (shallow copy before patching);
- no new helper or classifier is introduced (0 new functions in production code);
- count-only debug diagnostic, no message content logged.

## Tests

8 focused tests in `tests/agent/transports/test_chat_completions.py`:

- carrier turn is no longer wire-empty after stripping;
- the shared `_INTERRUPTED_PLACEHOLDER` is used;
- caller-owned history is not mutated;
- reasoning-only and tool-call-only turns keep their payloads untouched;
- valid content and message ordering preserved;
- empty **final** assistant prefill left exactly as-is;
- repeated conversion is deterministic and valid (the persistent-replay chain);
- offline provider-contract check: rejected before this change, accepted after.

## Verification

Both runs with `scripts/run_tests.sh` on the same pinned base (`b4f8c491d`):

| | passed | failed |
|---|---|---|
| pristine `main` | 22,635 | 59 |
| this branch | 22,643 | 59 |

`+8` is exactly the new tests. The failing-file sets are **identical** between the two runs (pre-existing, unrelated to this change), and no failure touches either changed file.

Focused suites (`tests/agent/transports/`, `tests/providers/`, `tests/run_agent/test_message_sequence_repair.py`, `tests/agent/test_agent_runtime_helpers.py`): 283 passed, 0 failed.
