### PR TITLE
Add hermes-ngit skill (optional-skills/devops) — based on Dan Conway's ngit reference

### DIFF
--- a/optional-skills/devops/hermes-ngit/LICENSE
+++ b/optional-skills/devops/hermes-ngit/LICENSE
@@ -1,0 +1,428 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+     including for purposes of Section 3(b); and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/optional-skills/devops/hermes-ngit/NOTICE
+++ b/optional-skills/devops/hermes-ngit/NOTICE
@@ -1,0 +1,9 @@
+hermes-ngit — Attribution Notice
+
+This skill incorporates contributions from Daniel (Dan). It is distributed
+under the Creative Commons Attribution-ShareAlike 4.0 International
+(CC BY-SA 4.0) license in accordance with that contribution's
+licensing terms.
+
+The full license text is in the LICENSE file. This NOTICE file is
+provided for attribution purposes and is not part of the license.

--- a/optional-skills/devops/hermes-ngit/README.md
+++ b/optional-skills/devops/hermes-ngit/README.md
@@ -1,0 +1,39 @@
+# hermes-ngit
+
+Hermes skill for decentralized Git over Nostr via [ngit](https://gitworkshop.dev/ngit).
+
+## What is this?
+
+A skill file for Hermes that provides instructions and workflows for working with
+Nostr-based Git repositories. ngit is a sovereign, decentralized Git hosting protocol
+built on Nostr — no central forge, no daemon required.
+
+## Features
+
+- Announce repos to Nostr (`ngit init`) and keep gitworkshop current via `git push`
+- Native `git clone` / `git push` against `nostr://` remotes (no daemon)
+- Session repo detection for Nostr-enabled projects
+- Full PR and issue lifecycle: open, view, comment, checkout, merge, close, reopen, label
+- Account management (bunker/NIP-46 login, inline `--nsec` for CI) and key-flags reference
+- Dual/triple-push configuration (GitHub + Radicle + Nostr) with fail-closed fallbacks
+
+## Key Lesson
+
+`ngit sync` only pushes git refs — it does **not** update the NIP-34 announcement that
+gitworkshop.dev reads. To keep gitworkshop current, add the `nostr://` URL as an `origin`
+pushurl so `git push` drives `git-remote-nostr` and re-announces HEAD automatically.
+
+## Usage
+
+Install via `hermes skills install official/devops/hermes-ngit`, or copy `SKILL.md`
+(plus `LICENSE` and `NOTICE`) into your Hermes skills directory.
+
+## Credit / License
+
+This skill builds on **Dan Conway's** ngit command reference
+(`DanConwayDev/ngit-cli`, `skills/ngit/SKILL.md`), incorporated under the
+**Creative Commons Attribution-ShareAlike 4.0 International (CC-BY-SA-4.0)** license in
+accordance with the source material's share-alike terms. Original framing and multi-mirror
+packaging by Joey Stanford.
+
+The full license text is in the `LICENSE` file; attribution is also recorded in `NOTICE`.

--- a/optional-skills/devops/hermes-ngit/SKILL.md
+++ b/optional-skills/devops/hermes-ngit/SKILL.md
@@ -2,7 +2,7 @@
 name: hermes-ngit
 description: Work with Nostr Git repos via ngit and gitworkshop.
 version: 1.1.0
-author: Joey Stanford
+author: Joey Stanford (@rinchen)
 license: CC-BY-SA-4.0
 platforms: [linux, macos]
 compatibility: "ngit installed (gitworkshop.dev/ngit) with git-remote-nostr on PATH; an identity configured via `git config --global nostr.nsec` or a bunker reference. No daemon required. Optional: `gh` CLI for GitHub mirroring."
@@ -10,7 +10,6 @@ metadata:
   hermes:
     tags: [Nostr, Git, ngit, Decentralized, gitworkshop]
     category: devops
-    related_skills: [hermes-radicle]
     requires_toolsets: [terminal]
 ---
 

--- a/optional-skills/devops/hermes-ngit/SKILL.md
+++ b/optional-skills/devops/hermes-ngit/SKILL.md
@@ -1,0 +1,354 @@
+---
+name: hermes-ngit
+description: Work with Nostr Git repos via ngit and gitworkshop.
+version: 1.1.0
+author: Joey Stanford
+license: CC-BY-SA-4.0
+platforms: [linux, macos]
+compatibility: "ngit installed (gitworkshop.dev/ngit) with git-remote-nostr on PATH; an identity configured via `git config --global nostr.nsec` or a bunker reference. No daemon required. Optional: `gh` CLI for GitHub mirroring."
+metadata:
+  hermes:
+    tags: [Nostr, Git, ngit, Decentralized, gitworkshop]
+    category: devops
+    related_skills: [hermes-radicle]
+    requires_toolsets: [terminal]
+---
+
+# ngit Skill
+
+Guide Nostr-based Git hosting via ngit / gitworkshop.dev: announce repos, open
+PRs/issues, sync grasp servers, and configure multi-mirror push. Does not replace
+GitHub CI — keep forges where they help; use ngit for permissionless provenance.
+
+**Credit / Attribution.** Built on **Dan Conway's** ngit command reference
+(`DanConwayDev/ngit-cli`, `skills/ngit/SKILL.md`), incorporated under
+**CC-BY-SA-4.0**. Dan supplies the command reference, PR/issues lifecycle, account
+management, and flag tables. Joey Stanford added multi-mirror packaging, the
+`ngit init` remote-rewrite gotcha, and session detection. See `NOTICE`.
+
+## When to Use
+
+- Announce or clone a Nostr Git repo (`nostr://` remotes)
+- Open/update ngit PRs (mandatory `pr/` branch prefix) or issues
+- Keep gitworkshop.dev current via `git push` (not `ngit sync` alone)
+- Configure dual/triple mirrors (GitHub + Radicle + Nostr) safely
+- Recover from grasp-server NIP-34 state-event "purgatory" push rejections
+- Detect whether the current session repo is Nostr-enabled
+
+## Prerequisites
+
+- `ngit` installed ([gitworkshop.dev/ngit](https://gitworkshop.dev/ngit) —
+  `curl -Ls https://ngit.dev/install.sh | bash` installs `ngit` + `git-remote-nostr`)
+- `git-remote-nostr` on PATH
+- Identity configured:
+  - raw nsec: `git config --global nostr.nsec "<nsec1...>"`, or
+  - bunker (preferred): `nostrsec://...` / `--bunker-url bunker://...`
+- Optional: `gh` CLI for GitHub mirroring
+- Supported platforms: Linux and macOS (`platforms: [linux, macos]`)
+
+**No daemon required.** Unlike Radicle, ngit/relays need no local node.
+
+Quick check via `terminal`:
+
+```bash
+ngit --version && ngit account whoami --json --offline
+```
+
+## How to Run
+
+Prefer `terminal` for all `ngit` / `git` invocations. Inspect remote names and
+URLs in the `terminal` tool result directly (for example after `git remote -v`).
+Use `search_files` only when hunting files on disk, not for filtering remote
+listings.
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Announce repo | `ngit init -d --name <repo>` |
+| Repo metadata | `ngit repo --json --offline` |
+| Clone | `git clone nostr://<npub>/<relay-hint>/<id>` |
+| Open PR branch | `git checkout -b pr/<feature>` then `git push -u origin pr/<feature>` |
+| List PRs / issues | `ngit pr list --json` / `ngit issue list --json` |
+| Sync grasp refs | `ngit sync` (does **not** update gitworkshop announcement) |
+| Whoami | `ngit account whoami --json` |
+| Show remotes | `git remote -v` |
+
+## Procedure
+
+### 1. Session repo detection
+
+When the user is inside a Git working tree, run via `terminal`:
+
+```bash
+git remote -v
+```
+
+If any remote URL contains `nostr://`, treat the repo as Nostr-enabled. Optionally
+confirm with `ngit repo --json --offline` (after `git fetch origin` if the cache is
+cold — `is_nostr_repo: false` can be a false negative). Derive a gitworkshop link as
+`https://gitworkshop.dev/<nostr-url-without-scheme>`.
+
+### 2. How ngit works (mental model)
+
+Nostr publishes signed events to relays. Identity is a keypair; data replicates across
+relays. ngit splits Git into:
+
+- **Git state (refs)** — signed events on Nostr (source of truth)
+- **Git data (objects)** — ordinary git servers listed in the announcement
+
+**Grasp servers** (e.g. `relay.ngit.dev`) combine a relay + git server. `ngit init`
+announces the repo (NIP-34) and sets a `nostr://` origin. `ngit sync` only pushes
+**refs** to grasp git servers — it does **not** update the announcement gitworkshop
+reads. Keep gitworkshop current by adding the `nostr://` URL as an `origin` **pushurl**
+so normal `git push` drives `git-remote-nostr`. `ngit send` opens a PR/proposal — do
+not run it on every push.
+
+### 3. Key rules
+
+- **`pr/` prefix is MANDATORY** for PRs (e.g. `pr/my-feature`)
+- Prefer `--json` on `ngit` read commands; use `--offline` after the first network call
+- Never invent NIP-05 addresses; use `npub1...` unless a NIP-05 was given
+- `<ID|nevent>` accepts hex or `nevent1...`; `--json` returns `nevent1…` for ids
+- Reference related items in `--body` with `nostr:nevent1…` / `nostr:naddr1…` URIs
+
+### 4. GOTCHA: `ngit init` rewrites `origin`
+
+`ngit init` sets `remote.origin.url` to `nostr://` and **drops existing pushurls**.
+
+1. Capture GitHub (or other) push URLs **before** `ngit init`
+2. After init, restore pushurls in this order:
+   1. `git remote set-url --push origin <github-url>`
+   2. `git remote set-url --add --push origin <nostr://url>`
+   3. Optional Radicle: `git remote set-url --add --push origin "$(git remote get-url --push rad)"`
+
+Doing `--add --push` before `--push` leaves only Nostr and drops GitHub.
+
+```bash
+# BEFORE ngit init — capture the forge push URL while origin is still GitHub/etc.
+GH_PUSH=$(git remote get-url --push origin)
+
+ngit init -d --name <repo-name>
+
+[ -n "$GH_PUSH" ] && git remote set-url --push origin "$GH_PUSH"
+git remote set-url --add --push origin "$(git remote get-url origin)"
+[ -n "$(git remote get-url --push rad 2>/dev/null)" ] && \
+  git remote set-url --add --push origin "$(git remote get-url --push rad)"
+```
+
+### 5. Dual / multi-mirror push (generic)
+
+Prefer **distinct remotes** so each target can be pushed independently:
+
+```bash
+git remote add github <github-url>   # fetch source for forge PRs
+# after ngit init, origin.url is nostr://; keep stacked pushurls on origin OR push named remotes
+git push github <branch>
+git push origin <branch>             # if origin carries Nostr (+ optional others)
+```
+
+**Hardened split (recommended):** forge PRs merge on GitHub, but `ngit init` makes
+`git pull` fetch Nostr only — so GitHub merges can be invisible until push rejects.
+
+```bash
+git remote add github <github-url>
+git config branch.<main>.remote github
+git config branch.<main>.merge refs/heads/<main>
+git config remote.pushDefault origin
+git config push.default current
+git config remote.github.fetch '+refs/heads/<main>:refs/remotes/github/<main>'
+```
+
+Lifecycle that stays converged:
+
+```bash
+git checkout -b feat/x
+git push -u github feat/x          # PR branch to forge only — never bare `git push`
+# … PR merges on GitHub …
+git checkout <main> && git pull    # from github
+git push                           # origin triple/dual mirror
+git push -d github feat/x && git branch -d feat/x
+```
+
+**Fail-closed stacked pushurls:** `git push` aborts at the first failed URL. A branch
+refspec does **not** skip a subset of push URLs. Correct fallback:
+
+1. `git remote -v` to list push URLs
+2. `git remote set-url --delete --push origin <unavailable-url>`
+3. `git push origin <branch>` (remaining healthy URLs)
+4. Restore with `git remote set-url --add --push origin <unavailable-url>`
+5. Or push a named remote / direct URL: `git push <github-url> HEAD:<branch>`
+
+If Nostr is the flaky URL, drop that pushurl and use `ngit sync` separately until relays
+recover — do not assume `git push origin <branch>` skips Nostr while it remains configured.
+
+### 6. Announce, clone, publish
+
+```bash
+ngit init --name "My Project" --description "What it does" -d
+ngit repo edit --description "New description"
+ngit repo --json --offline
+```
+
+```bash
+git clone nostr://<npub>/<relay-hint>/<identifier>
+git clone nostr://<npub>/<identifier>
+```
+
+Append Nostr as a pushurl only after restoring any forge pushurl (see gotcha):
+
+```bash
+git remote set-url --add --push origin "$(git remote get-url origin)"
+```
+
+### 7. Pull requests
+
+Branch name **MUST** start with `pr/`:
+
+```bash
+git checkout -b pr/my-feature
+# single commit — omit title/description; commit subject/body used automatically
+git push -u origin pr/my-feature
+
+# multiple commits — literal \n\n in push options (not ANSI-C quoting)
+git push -u origin pr/my-feature \
+  -o 'title=My feature title' \
+  -o 'description=First paragraph.\n\nSecond paragraph.'
+```
+
+Advanced `ngit send` (ANSI-C quoting for real newlines in `--description`):
+
+```bash
+ngit send HEAD~2 --subject "My Feature" --description $'First paragraph.\n\nSecond paragraph.'
+ngit send --defaults
+ngit send HEAD~2 --in-reply-to <PR-event-id>
+```
+
+```bash
+ngit pr list --json
+ngit pr view <ID|nevent> --json --comments
+ngit pr comment <ID|nevent> --body "Looks good"
+ngit pr checkout <ID|nevent>
+ngit merge <ID|nevent>                 # local merge; then publish
+git push origin <default-branch>
+ngit pr close <ID|nevent> --reason "..."
+ngit pr reopen <ID|nevent> --reason "..."
+ngit pr ready <ID|nevent> --reason "..."
+ngit pr draft <ID|nevent> --reason "..."
+ngit pr label <ID|nevent> --label bug
+```
+
+### 8. Issues and accounts
+
+```bash
+ngit issue create --subject "Bug title" --body "Details" --label bug
+ngit issue list --json
+ngit issue view <ID|nevent> --json --comments
+ngit issue comment <ID|nevent> --body "Reproduced"
+ngit issue close <ID|nevent> --reason "wontfix"
+ngit issue resolved <ID|nevent> --reason "fixed"
+ngit issue reopen <ID|nevent> --reason "regression"
+```
+
+```bash
+ngit account whoami --json
+ngit account login
+ngit account login --bunker-url bunker://...
+ngit account create --name "Alice"
+ngit account export-keys
+ngit account logout
+ngit --nsec <nsec> <command>           # CI inline; never commit nsec
+```
+
+### 9. Sync and tuning
+
+```bash
+ngit sync
+ngit sync --ref-name main
+ngit --customize
+git config nostr.repo-relay-only true
+git config nostr.http-io-timeout-ms 600000
+```
+
+| Flag | Description |
+|------|-------------|
+| `-d`, `--defaults` | Non-interactive defaults |
+| `--offline` | Local cache only |
+| `--json` | Structured output (ngit only) |
+| `-n`, `--nsec <NSEC>` | Inline key for CI |
+| `-f`, `--force` | Bypass safety guards |
+| `-v`, `--verbose` | Verbose output |
+
+### 10. Sharing locations
+
+Use placeholders for whatever locations the user configured — never hardcode a personal
+npub, RID, or forge path in this skill:
+
+- Git forge: `https://github.com/<owner>/<repo>`
+- Radicle: `rad:<rid>`
+- Nostr / gitworkshop: `https://gitworkshop.dev/<npub>/<relay>/<repo>`
+
+### 11. Recovery: NIP-34 state-event "purgatory"
+
+**Symptom.** After deleting merged PR branches, `git push` to a grasp server fails with
+`ERR authorisation failed: N state events in purgatory` listing branches that no longer
+exist locally.
+
+**Cause.** Each `ngit init` publishes a kind 30617 state event. Some grasp servers do not
+honor NIP-33 replaceable semantics — old events accumulate. The server may check the
+**union** of all purgatory events.
+
+**Probe** on the `nostr://` URL only (so forge/Radicle pushurls are untouched):
+
+```bash
+git branch enrich <declared-commit>
+git branch -f main <another-declared-commit>
+git push --force nostr://<npub>/<grasp-relay>/<repo> main enrich
+```
+
+- Accepted → latest-only check → `ngit init --clean -f -d`
+- Rejected listing other branches → union check → full reconcile:
+
+```bash
+# Phase 1 — recreate every declared branch at its exact commit
+git branch <name> <sha>
+# …
+
+# Phase 2 — satisfy the union on the nostr URL only
+git push --force --all nostr://<npub>/<grasp-relay>/<repo>
+
+# Phase 3 — single combined state event
+ngit init --clean -f -d
+
+# Phase 4 — drop stale branches; prune ONLY the nostr URL (never origin)
+git branch -f main <current-head-sha>
+git branch -D <stale-1> <stale-2>
+git push --force --prune nostr://<npub>/<grasp-relay>/<repo>
+ngit init --clean -f -d
+```
+
+**Hard rule:** never `--prune` via `origin` when `origin` also carries GitHub/Radicle
+pushurls — that deletes real forge branches. Always push purge steps to the `nostr://`
+URL directly. Treat the primary grasp relay as authoritative; secondary grasp hosts can
+lag.
+
+## Pitfalls
+
+- Stacked `origin` pushurls are fail-closed; delete/restore the bad URL or use distinct
+  remotes / direct URLs — a refspec does not skip Nostr/Radicle.
+- `git pull` after `ngit init` may fetch Nostr only while PRs merge on GitHub — split
+  pull (`github`) vs push (`origin`) as above.
+- Diagnosing divergence: fetch each remote into throwaway refs and compare with
+  `git merge-base --is-ancestor` + `git diff` / tree OIDs before any reset. Prefer
+  `git merge --no-ff` of the forge tip; hard-resetting to GitHub can non-fast-forward
+  Nostr/Radicle.
+- Never store a raw nsec in a repo or repo-local git config — global config or bunker only.
+- `ngit sync` alone leaves gitworkshop stale; use Nostr pushurl + `git push`.
+
+## Verification
+
+- `ngit --version` and `ngit account whoami --json` succeed
+- `git remote -v` shows `nostr://` after init/clone
+- PRs use `pr/` branches; `ngit pr list --json` returns expected entries
+- Mirror fallback uses distinct remotes or delete/restore of failed push URLs
+- Purgatory recovery prunes only via a direct `nostr://` URL, never stacked `origin`

--- a/tests/skills/test_hermes_ngit_skill.py
+++ b/tests/skills/test_hermes_ngit_skill.py
@@ -11,7 +11,6 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
 
 SKILL_DIR = (
     Path(__file__).resolve().parents[2]
@@ -32,16 +31,32 @@ REQUIRED_SECTIONS = (
 )
 
 
+def _frontmatter_block(skill_text: str) -> str:
+    m = re.search(r"^---\n(.*?)\n---", skill_text, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return m.group(1)
+
+
+def _fm_scalar(frontmatter: str, key: str) -> str:
+    m = re.search(rf"^{re.escape(key)}:\s*(.+)$", frontmatter, re.MULTILINE)
+    assert m, f"missing frontmatter field: {key}"
+    return m.group(1).strip().strip('"').strip("'")
+
+
+def _fm_list(frontmatter: str, key: str) -> list[str]:
+    m = re.search(rf"^{re.escape(key)}:\s*\[([^\]]*)\]", frontmatter, re.MULTILINE)
+    assert m, f"missing frontmatter list field: {key}"
+    return [item.strip().strip('"').strip("'") for item in m.group(1).split(",") if item.strip()]
+
+
 @pytest.fixture(scope="module")
 def skill_text() -> str:
     return SKILL_MD.read_text(encoding="utf-8")
 
 
 @pytest.fixture(scope="module")
-def frontmatter(skill_text: str) -> dict:
-    m = re.search(r"^---\n(.*?)\n---", skill_text, re.DOTALL)
-    assert m, "SKILL.md missing YAML frontmatter"
-    return yaml.safe_load(m.group(1))
+def frontmatter(skill_text: str) -> str:
+    return _frontmatter_block(skill_text)
 
 
 def test_skill_dir_exists() -> None:
@@ -57,34 +72,37 @@ def test_license_and_notice_present() -> None:
     assert (SKILL_DIR / "NOTICE").is_file()
 
 
-def test_description_under_60_chars(frontmatter: dict) -> None:
-    desc = frontmatter["description"]
-    assert isinstance(desc, str)
+def test_description_under_60_chars(frontmatter: str) -> None:
+    desc = _fm_scalar(frontmatter, "description")
     assert desc.endswith("."), f"description must end with a period: {desc!r}"
     assert len(desc) <= 60, f"description is {len(desc)} chars (limit ≤60): {desc!r}"
 
 
-def test_name_matches_dir(frontmatter: dict) -> None:
-    assert frontmatter["name"] == "hermes-ngit"
+def test_name_matches_dir(frontmatter: str) -> None:
+    assert _fm_scalar(frontmatter, "name") == "hermes-ngit"
 
 
-def test_has_required_frontmatter_fields(frontmatter: dict) -> None:
+def test_has_required_frontmatter_fields(frontmatter: str) -> None:
     for field in ("name", "description", "version", "author", "license", "platforms"):
-        assert field in frontmatter, f"missing required field: {field}"
+        assert re.search(rf"^{re.escape(field)}:", frontmatter, re.MULTILINE), (
+            f"missing required field: {field}"
+        )
 
 
-def test_platforms_are_posix_desktop(frontmatter: dict) -> None:
-    platforms = frontmatter["platforms"]
+def test_platforms_are_posix_desktop(frontmatter: str) -> None:
+    platforms = _fm_list(frontmatter, "platforms")
     assert set(platforms) == {"linux", "macos"}
     assert "windows" not in platforms
 
 
-def test_license_cc_by_sa(frontmatter: dict) -> None:
-    assert frontmatter["license"] == "CC-BY-SA-4.0"
+def test_license_cc_by_sa(frontmatter: str) -> None:
+    assert _fm_scalar(frontmatter, "license") == "CC-BY-SA-4.0"
 
 
-def test_author_credits_contributor(frontmatter: dict) -> None:
-    assert "Joey Stanford" in frontmatter["author"]
+def test_author_credits_contributor(frontmatter: str) -> None:
+    author = _fm_scalar(frontmatter, "author")
+    assert "Joey Stanford" in author
+    assert "@rinchen" in author
 
 
 def test_credits_dan_conway(skill_text: str) -> None:

--- a/tests/skills/test_hermes_ngit_skill.py
+++ b/tests/skills/test_hermes_ngit_skill.py
@@ -1,0 +1,134 @@
+"""
+Smoke tests for the hermes-ngit optional skill.
+
+Validates hardline SKILL.md standards from AGENTS.md: short description,
+required frontmatter, platforms gating, modern section order, generic
+(non-personal) examples, native-tool guidance, and correct pushurl fallback.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "devops"
+    / "hermes-ngit"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+REQUIRED_SECTIONS = (
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+)
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_text: str) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_text, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_skill_md_present() -> None:
+    assert SKILL_MD.is_file()
+
+
+def test_license_and_notice_present() -> None:
+    assert (SKILL_DIR / "LICENSE").is_file()
+    assert (SKILL_DIR / "NOTICE").is_file()
+
+
+def test_description_under_60_chars(frontmatter: dict) -> None:
+    desc = frontmatter["description"]
+    assert isinstance(desc, str)
+    assert desc.endswith("."), f"description must end with a period: {desc!r}"
+    assert len(desc) <= 60, f"description is {len(desc)} chars (limit ≤60): {desc!r}"
+
+
+def test_name_matches_dir(frontmatter: dict) -> None:
+    assert frontmatter["name"] == "hermes-ngit"
+
+
+def test_has_required_frontmatter_fields(frontmatter: dict) -> None:
+    for field in ("name", "description", "version", "author", "license", "platforms"):
+        assert field in frontmatter, f"missing required field: {field}"
+
+
+def test_platforms_are_posix_desktop(frontmatter: dict) -> None:
+    platforms = frontmatter["platforms"]
+    assert set(platforms) == {"linux", "macos"}
+    assert "windows" not in platforms
+
+
+def test_license_cc_by_sa(frontmatter: dict) -> None:
+    assert frontmatter["license"] == "CC-BY-SA-4.0"
+
+
+def test_author_credits_contributor(frontmatter: dict) -> None:
+    assert "Joey Stanford" in frontmatter["author"]
+
+
+def test_credits_dan_conway(skill_text: str) -> None:
+    assert "Dan Conway" in skill_text
+
+
+def test_required_sections_present(skill_text: str) -> None:
+    for heading in REQUIRED_SECTIONS:
+        assert heading in skill_text, f"missing section: {heading}"
+
+
+def test_no_personal_repo_embedding(skill_text: str) -> None:
+    """Official skills must be reusable — no personal forge URL, npub, or local path."""
+    body = skill_text.split("---", 2)[-1]
+    forbidden = (
+        "rinchen/hermes-ngit",
+        "rinchen/<repo>",
+        "npub1wwaq5gyk7yljly3cwl3wleuk79nz63ukpp2a6lq5x4q9s9r4nrgqjk3dlv",
+        "rad:z2fGx8T85zCue2efEmSHL8NxKCvqd",
+        "ngit-enable-repo",
+        "radicle-links",
+        "~/repos/",
+        "cowx",
+        "persecutio",
+    )
+    for needle in forbidden:
+        assert needle not in body, f"personal/example-specific embedding found: {needle!r}"
+
+
+def test_no_grep_in_skill_prose(skill_text: str) -> None:
+    body = skill_text.split("---", 2)[-1]
+    assert not re.search(r"\bgrep\b", body), "SKILL.md must not name grep in prose"
+
+
+def test_documents_pushurl_fallback_correctly(skill_text: str) -> None:
+    assert "set-url --delete --push" in skill_text
+    assert "distinct remotes" in skill_text.lower() or "distinct remote" in skill_text.lower()
+    assert "refspec does **not** skip" in skill_text or "does **not** skip a subset" in skill_text
+
+
+def test_points_at_terminal_tool(skill_text: str) -> None:
+    assert "`terminal`" in skill_text
+
+
+def test_documents_pr_prefix_rule(skill_text: str) -> None:
+    assert "pr/" in skill_text
+    assert "MANDATORY" in skill_text or "mandatory" in skill_text.lower()


### PR DESCRIPTION
## Summary
Adds the `hermes-ngit` skill to `optional-skills/devops/` for Nostr-based Git hosting (ngit / gitworkshop.dev).

Incorporates **Dan Conway's** ngit command reference under **CC-BY-SA-4.0**, plus multi-mirror packaging, the `ngit init` remote-rewrite gotcha, session detection, and NIP-34 purgatory recovery.

This supersedes closed #72842 with the same hardline skill compliance fixes applied on #72841:

- `description` ≤60 chars
- Required skill sections + generic (non-personal) examples
- `platforms: [linux, macos]` + native `terminal` guidance (no shell-filter prose)
- Correct fail-closed pushurl fallback (delete/restore or distinct remotes)
- `tests/skills/test_hermes_ngit_skill.py`

## Files
- `optional-skills/devops/hermes-ngit/SKILL.md`
- `optional-skills/devops/hermes-ngit/{LICENSE,NOTICE,README.md}`
- `tests/skills/test_hermes_ngit_skill.py`

## Test plan
- [x] `scripts/run_tests.sh tests/skills/test_hermes_ngit_skill.py -q` (16 passing)
- [x] Description length / platforms / no personal embeddings / no `grep` in prose