### PR TITLE
fix(weixin): 空闲连接超时后重建发送会话防止消息静默丢失

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -95,6 +95,7 @@ BACKOFF_DELAY_SECONDS = 30
 SESSION_EXPIRED_ERRCODE = -14
 RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
+SEND_SESSION_MAX_IDLE_SECONDS = 120  # Recreate send_session after this idle period to avoid stale TCP connections
 
 
 def _is_stale_session_ret(
@@ -1170,6 +1171,7 @@ class WeixinAdapter(BasePlatformAdapter):
         self._send_session: Optional[aiohttp.ClientSession] = None
         self._poll_task: Optional[asyncio.Task] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
+        self._last_send_time = 0.0  # Monotonic timestamp of last successful outbound send
 
         self._account_id = str(extra.get("account_id") or get_secret("WEIXIN_ACCOUNT_ID", "")).strip()
         self._token = str(config.token or extra.get("token") or get_secret("WEIXIN_TOKEN", "")).strip()
@@ -1849,6 +1851,41 @@ class WeixinAdapter(BasePlatformAdapter):
         assert last_error is not None
         raise last_error
 
+    def _record_send(self) -> None:
+        """Record that a send was attempted (for idle-tracking)."""
+        self._last_send_time = time.monotonic()
+
+    async def _ensure_send_session_alive(self) -> None:
+        """Recreate the send session if it has been idle beyond the threshold.
+
+        After long idle periods (e.g. 2+ hours), intermediate network devices
+        (NAT gateways, firewalls, Cloudflare Warp) may silently drop TCP
+        connections. The aiohttp connection pool is unaware of this, so a POST
+        appears to succeed (HTTP 200) while iLink silently discards the message.
+
+        Rebuilding the session forces a fresh TCP handshake, which either
+        succeeds (healthy) or fails immediately (no false-positive delivery).
+        """
+        if not self._send_session or self._send_session.closed:
+            # Already disconnected — connect() will recreate on next run.
+            return
+        idle = time.monotonic() - self._last_send_time
+        if idle >= SEND_SESSION_MAX_IDLE_SECONDS:
+            logger.info(
+                "[%s] send_session idle for %.0fs (threshold %ds); recreating",
+                self.name, idle, SEND_SESSION_MAX_IDLE_SECONDS,
+            )
+            try:
+                await self._send_session.close()
+            except Exception:
+                pass
+            _no_aiohttp_timeout = aiohttp.ClientTimeout(
+                total=None, connect=None, sock_connect=None, sock_read=None,
+            )
+            self._send_session = aiohttp.ClientSession(
+                trust_env=True, connector=_make_ssl_connector(), timeout=_no_aiohttp_timeout,
+            )
+
     async def send(
         self,
         chat_id: str,
@@ -1858,6 +1895,9 @@ class WeixinAdapter(BasePlatformAdapter):
     ) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
+
+        # Ensure the underlying TCP connection is not stale before sending.
+        await self._ensure_send_session_alive()
         context_token = self._token_store.get(self._account_id, chat_id)
         last_message_id: Optional[str] = None
 
@@ -1911,6 +1951,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 last_message_id = client_id
                 if idx < len(chunks) - 1 and self._send_chunk_delay_seconds > 0:
                     await asyncio.sleep(self._send_chunk_delay_seconds)
+            self._record_send()
             return SendResult(success=True, message_id=last_message_id)
         except Exception as exc:
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)
@@ -2178,7 +2219,6 @@ class WeixinAdapter(BasePlatformAdapter):
             item_kwargs["bits_per_sample"] = 16
         media_item = item_builder(**item_kwargs)
 
-        last_message_id = None
         if caption:
             last_message_id = f"hermes-weixin-{uuid.uuid4().hex}"
             await _send_message(
@@ -2190,6 +2230,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 context_token=context_token,
                 client_id=last_message_id,
             )
+            self._record_send()
 
         last_message_id = f"hermes-weixin-{uuid.uuid4().hex}"
         await _api_post(
@@ -2210,6 +2251,7 @@ class WeixinAdapter(BasePlatformAdapter):
             token=self._token,
             timeout_ms=API_TIMEOUT_MS,
         )
+        self._record_send()
         return last_message_id
 
     def _outbound_media_builder(self, path: str, force_file_attachment: bool = False):

--- a/tests/gateway/test_weixin_idle_session.py
+++ b/tests/gateway/test_weixin_idle_session.py
@@ -1,0 +1,191 @@
+"""Tests for WeChat iLink idle send-session health check (issue #74852).
+
+The bug: after long idle periods (hours), intermediate network devices
+(NAT, firewalls, Cloudflare Warp) silently drop TCP connections.
+The aiohttp connection pool is unaware, so POST requests appear to succeed
+(HTTP 200) while iLink silently discards messages.
+
+The fix: track the last send time and recreate the aiohttp session
+when it exceeds the idle threshold (SEND_SESSION_MAX_IDLE_SECONDS).
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def weixin_adapter():
+    """Create a minimal WeixinAdapter with mocked internals for session tests."""
+    from gateway.platforms.weixin import WeixinAdapter, SEND_SESSION_MAX_IDLE_SECONDS
+
+    config = MagicMock()
+    config.extra = {"account_id": "test-account"}
+    config.name = "weixin"
+    config.token = "test-token"
+
+    with patch.object(WeixinAdapter, "__init__", lambda self, cfg: None):
+        adapter = WeixinAdapter.__new__(WeixinAdapter)
+        adapter._send_session = AsyncMock()
+        adapter._send_session.closed = False
+        adapter._token = "test-token"
+        adapter._base_url = "https://ilinkai.weixin.qq.com"
+        adapter._account_id = "test-account"
+        adapter._typing_cache = MagicMock()
+        adapter._token_store = MagicMock()
+        adapter._token_store.get.return_value = None
+        adapter.config = config
+        # Mock platform so that adapter.name (which reads platform.value.title()) works
+        platform_mock = MagicMock()
+        platform_value_mock = MagicMock()
+        platform_value_mock.title.return_value = "Weixin"
+        platform_mock.value = platform_value_mock
+        adapter.platform = platform_mock
+        adapter._last_send_time = time.monotonic()
+        adapter._send_chunk_delay_seconds = 0
+        adapter._send_text_gate = asyncio.Lock()
+        adapter._split_multiline_messages = False
+        adapter.MAX_MESSAGE_LENGTH = 2000
+        adapter._send_chunk_retries = 4
+        adapter._send_chunk_retry_delay_seconds = 1.0
+        adapter._rate_limit_circuit_threshold = 1
+        adapter._rate_limit_circuit_window_seconds = 30.0
+        adapter._rate_limit_circuit_open_seconds = 30.0
+        adapter._rate_limit_circuit_until = 0.0
+        adapter._rate_limit_events = []
+
+    return adapter
+
+
+class TestEnsureSendSessionAlive:
+    """Tests for _ensure_send_session_alive — the fix for silent message drops."""
+
+    @pytest.mark.asyncio
+    async def test_no_recreate_when_session_fresh(self, weixin_adapter):
+        """If the session was recently used, do NOT recreate it."""
+        weixin_adapter._last_send_time = time.monotonic()  # just now
+        old_session = weixin_adapter._send_session
+
+        await weixin_adapter._ensure_send_session_alive()
+
+        assert weixin_adapter._send_session is old_session
+        old_session.close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_recreate_when_session_idle_too_long(self, weixin_adapter):
+        """When idle beyond the threshold, recreate the session."""
+        weixin_adapter._last_send_time = time.monotonic() - 200  # 200s ago (> 120s threshold)
+        old_session = weixin_adapter._send_session
+
+        with patch("gateway.platforms.weixin._make_ssl_connector") as mock_connector:
+            mock_connector.return_value = MagicMock()
+            with patch("aiohttp.ClientSession") as mock_session_cls:
+                new_session = AsyncMock()
+                new_session.closed = False
+                mock_session_cls.return_value = new_session
+
+                await weixin_adapter._ensure_send_session_alive()
+
+                old_session.close.assert_called_once()
+                mock_session_cls.assert_called_once()
+                assert weixin_adapter._send_session is new_session
+
+    @pytest.mark.asyncio
+    async def test_no_recreate_when_session_already_closed(self, weixin_adapter):
+        """If the session is already closed, do nothing (connect() recreates)."""
+        weixin_adapter._last_send_time = time.monotonic() - 200
+        weixin_adapter._send_session.closed = True
+        old_session = weixin_adapter._send_session
+
+        await weixin_adapter._ensure_send_session_alive()
+
+        # Should not attempt to recreate when already closed
+        assert weixin_adapter._send_session is old_session
+
+    @pytest.mark.asyncio
+    async def test_no_recreate_when_session_is_none(self, weixin_adapter):
+        """If there is no session, do nothing."""
+        weixin_adapter._send_session = None
+        weixin_adapter._last_send_time = time.monotonic() - 200
+
+        await weixin_adapter._ensure_send_session_alive()
+
+        assert weixin_adapter._send_session is None
+
+    @pytest.mark.asyncio
+    async def test_send_calls_ensure_session_alive(self, weixin_adapter):
+        """The send() method should call _ensure_send_session_alive before delivering."""
+        weixin_adapter._ensure_send_session_alive = AsyncMock()
+
+        with patch.object(weixin_adapter, "_split_text", return_value=["hello"]), \
+             patch.object(weixin_adapter, "format_message", return_value="hello"), \
+             patch.object(weixin_adapter, "extract_media", return_value=([], "hello")), \
+             patch.object(weixin_adapter, "filter_media_delivery_paths", return_value=[]), \
+             patch.object(weixin_adapter, "extract_images", return_value=([], "hello")), \
+             patch.object(weixin_adapter, "extract_local_files", return_value=([], "hello")), \
+             patch.object(weixin_adapter, "filter_local_delivery_paths", return_value=[]), \
+             patch.object(weixin_adapter, "_send_text_chunk", new_callable=AsyncMock):
+
+            result = await weixin_adapter.send("user-123", "hello")
+
+            weixin_adapter._ensure_send_session_alive.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_returns_error_when_not_connected(self, weixin_adapter):
+        """send() returns failure when _send_session is None."""
+        weixin_adapter._send_session = None
+
+        result = await weixin_adapter.send("user-123", "hello")
+
+        assert result.success is False
+        assert result.error == "Not connected"
+
+    @pytest.mark.asyncio
+    async def test_send_returns_error_when_no_token(self, weixin_adapter):
+        """send() returns failure when _token is missing."""
+        weixin_adapter._token = ""
+
+        result = await weixin_adapter.send("user-123", "hello")
+
+        assert result.success is False
+        assert result.error == "Not connected"
+
+
+class TestRecordSend:
+    """Tests for _record_send — tracks last send time for idle detection."""
+
+    def test_record_send_updates_timestamp(self, weixin_adapter):
+        """_record_send should set _last_send_time to current monotonic time."""
+        old_time = time.monotonic() - 1000
+        weixin_adapter._last_send_time = old_time
+
+        weixin_adapter._record_send()
+
+        assert abs(weixin_adapter._last_send_time - time.monotonic()) < 1.0
+
+    def test_record_send_value_is_monotonic(self, weixin_adapter):
+        """Recorded time should increase (or stay same) after each call."""
+        weixin_adapter._last_send_time = 0.0
+
+        weixin_adapter._record_send()
+        t1 = weixin_adapter._last_send_time
+        time.sleep(0.01)
+        weixin_adapter._record_send()
+        t2 = weixin_adapter._last_send_time
+
+        assert t2 >= t1
+
+
+class TestSendSessionMaxIdleConstant:
+    """Verify the idle threshold constant is reasonable."""
+
+    def test_threshold_is_positive(self):
+        from gateway.platforms.weixin import SEND_SESSION_MAX_IDLE_SECONDS
+        assert SEND_SESSION_MAX_IDLE_SECONDS > 0
+
+    def test_threshold_less_than_one_hour(self):
+        """Threshold should be well under an hour to catch stale connections early."""
+        from gateway.platforms.weixin import SEND_SESSION_MAX_IDLE_SECONDS
+        assert SEND_SESSION_MAX_IDLE_SECONDS < 3600


### PR DESCRIPTION
## 背景

修复 #74852: Weixin (WeChat) via iLink 网关在长时间空闲后（2+小时），发送的消息被 iLink 静默丢弃，Gateway 日志显示发送成功但用户永远收不到。

## 根因分析

Weixin adapter 使用 aiohttp.ClientSession 发送消息到 iLink。当连接空闲超过2小时，中间网络设备（NAT/防火墙/Cloudflare Warp）会静默丢弃TCP连接，但 aiohttp 连接池对此毫无感知。POST 请求在 HTTP 层返回 200 OK，但 iLink 已无法将消息转发给微信用户。

## 修复方式

1. 新增 `SEND_SESSION_MAX_IDLE_SECONDS=120` 常量，定义最大空闲时间阈值
2. 新增 `_last_send_time` 字段，每次成功发送后记录单调时间戳
3. 新增 `_ensure_send_session_alive()` 方法：若上次发送已超过阈值，关闭旧 session 并创建新 session，强制重新 TCP 握手
4. 在 `send()` 入口处调用 `_ensure_send_session_alive()`，确保发送前连接健康
5. 在 `_send_file()` 和文本发送完成后调用 `_record_send()` 更新最后发送时间
6. 附带 11 个回归测试覆盖空闲检测、会话重建、发送记录等场景

## 验证

- [x] 代码变更已在本地验证
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更
- [x] 已有 weixin 测试全部通过（24/24）

Closes #74852