### PR TITLE
feat: Agent Hub — direct chat with coding agents + Discord channel bindings

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -168,6 +168,51 @@ class GatewaySlashCommandsMixin:
             new_entry = self.session_store.get_or_create_session(source, force_new=True)
             header = self._telegram_topic_new_header(source) or t("gateway.reset.header_new")
 
+        # Discord's /new must start with the configured default, rather than
+        # inheriting a /model override from the conversation it just closed.
+        # Resolve it here (after reset_session created the replacement) so the
+        # next message builds a fresh agent with a complete provider bundle.
+        if (
+            new_entry
+            and source.platform
+            and source.platform.value == "discord"
+        ):
+            try:
+                from gateway.run import _load_gateway_config, _resolve_gateway_model, _resolve_runtime_agent_kwargs
+                from hermes_cli.model_switch import switch_model
+
+                config = _load_gateway_config()
+                model_config = config.get("model") if isinstance(config.get("model"), dict) else {}
+                default_model = _resolve_gateway_model(config)
+                default_provider = str(model_config.get("provider") or "")
+                if default_model:
+                    runtime = _resolve_runtime_agent_kwargs()
+                    result = switch_model(
+                        raw_input=default_model,
+                        current_provider=default_provider,
+                        current_model=default_model,
+                        current_base_url=str(runtime.get("base_url") or ""),
+                        current_api_key=runtime.get("api_key") or "",
+                        is_global=False,
+                        explicit_provider=default_provider,
+                        user_providers=config.get("providers") if isinstance(config.get("providers"), dict) else None,
+                        custom_providers=config.get("custom_providers") if isinstance(config.get("custom_providers"), list) else None,
+                    )
+                    if result.success:
+                        self._session_model_overrides[session_key] = {
+                            "model": result.new_model,
+                            "provider": result.target_provider,
+                            "api_key": result.api_key,
+                            "base_url": result.base_url,
+                            "api_mode": result.api_mode,
+                        }
+                        if self._session_db:
+                            self._session_db.update_session_model(new_entry.session_id, result.new_model)
+                    else:
+                        logger.warning("Could not apply configured Discord default model: %s", result.error_message)
+            except Exception:
+                logger.warning("Could not apply configured Discord default model", exc_info=True)
+
         # Set session title if provided with /new <title>
         _title_arg = event.get_command_args().strip()
         _title_note = ""

--- a/hermes_cli/agent_hub.py
+++ b/hermes_cli/agent_hub.py
@@ -1,0 +1,445 @@
+"""Direct coding-harness sessions for the dashboard Agent Hub.
+
+This module deliberately wraps the installed CLIs instead of adding another
+model/tool implementation to Hermes core.  Conversations retain the native
+harness session id, so every turn goes through Codex/Claude's own agent loop,
+skills, repository instructions, and tool policy.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+
+_STORE_LOCK = threading.RLock()
+_TURN_LOCKS_LOCK = threading.Lock()
+_TURN_LOCKS: Dict[str, threading.Lock] = {}
+_MAX_PROMPT_CHARS = 200_000
+_MAX_HISTORY_MESSAGES = 200
+
+HARNESSES: Dict[str, Dict[str, str]] = {
+    "codex": {
+        "name": "Codex",
+        "description": "OpenAI's coding agent with repository-aware tools.",
+        "command": "codex",
+    },
+    "claude": {
+        "name": "Claude Code",
+        "description": "Anthropic's coding agent with native skills and tools.",
+        "command": "claude",
+    },
+    "antigravity": {
+        "name": "Antigravity",
+        "description": "Antigravity coding harness.",
+        "command": "antigravity",
+    },
+}
+
+
+def _hub_dir() -> Path:
+    path = get_hermes_home() / "agent-hub"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _store_path() -> Path:
+    return _hub_dir() / "conversations.json"
+
+
+def _load_store() -> Dict[str, Dict[str, Any]]:
+    path = _store_path()
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return payload if isinstance(payload, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_store(store: Dict[str, Dict[str, Any]]) -> None:
+    atomic_json_write(_store_path(), store)
+
+
+def harness_catalog() -> List[Dict[str, Any]]:
+    rows = []
+    for harness_id, definition in HARNESSES.items():
+        executable = shutil.which(definition["command"])
+        rows.append(
+            {
+                "id": harness_id,
+                "name": definition["name"],
+                "description": definition["description"],
+                "available": bool(executable),
+                "executable": executable,
+            }
+        )
+    return rows
+
+
+def list_conversations() -> List[Dict[str, Any]]:
+    with _STORE_LOCK:
+        values = list(_load_store().values())
+    values.sort(key=lambda row: float(row.get("updated_at") or 0), reverse=True)
+    return [_conversation_summary(row) for row in values]
+
+
+def get_conversation(conversation_id: str) -> Optional[Dict[str, Any]]:
+    with _STORE_LOCK:
+        row = _load_store().get(conversation_id)
+    return dict(row) if isinstance(row, dict) else None
+
+
+def delete_conversation(conversation_id: str) -> bool:
+    with _STORE_LOCK:
+        store = _load_store()
+        removed = store.pop(conversation_id, None) is not None
+        if removed:
+            _save_store(store)
+    return removed
+
+
+def _conversation_summary(row: Dict[str, Any]) -> Dict[str, Any]:
+    messages = row.get("messages") or []
+    last = messages[-1].get("content", "") if messages else ""
+    return {
+        "id": row.get("id"),
+        "title": row.get("title") or "New coding session",
+        "harness": row.get("harness"),
+        "cwd": row.get("cwd"),
+        "skills": list(row.get("skills") or []),
+        "created_at": row.get("created_at"),
+        "updated_at": row.get("updated_at"),
+        "message_count": len(messages),
+        "preview": str(last)[:160],
+    }
+
+
+def _resolve_skill_files(names: Iterable[str], profile_home: Optional[Path]) -> List[Path]:
+    """Resolve selected skill names to SKILL.md paths without reading them."""
+    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+
+    wanted = {str(name).strip() for name in names if str(name).strip()}
+    if not wanted:
+        return []
+    roots: List[Path] = []
+    local = (profile_home or get_hermes_home()) / "skills"
+    if local.is_dir():
+        roots.append(local)
+    roots.extend(Path(p) for p in get_external_skills_dirs())
+
+    matches: Dict[str, Path] = {}
+    for root in roots:
+        for skill_md in iter_skill_index_files(root, "SKILL.md"):
+            fallback = skill_md.parent.name
+            name = fallback
+            try:
+                head = skill_md.read_text(encoding="utf-8")[:4000]
+                if head.startswith("---"):
+                    for line in head.splitlines()[1:]:
+                        if line.strip() == "---":
+                            break
+                        if line.lower().startswith("name:"):
+                            name = line.split(":", 1)[1].strip().strip("\"'")
+                            break
+            except OSError:
+                continue
+            if name in wanted and name not in matches:
+                matches[name] = skill_md.resolve()
+    return [matches[name] for name in names if name in matches]
+
+
+def _augmented_prompt(
+    prompt: str,
+    skill_files: Iterable[Path],
+    attachments: Iterable[str],
+) -> str:
+    prompt = (prompt or "").strip()
+    if not prompt:
+        raise ValueError("Prompt is required")
+    if len(prompt) > _MAX_PROMPT_CHARS:
+        raise ValueError("Prompt is too long")
+
+    prelude: List[str] = []
+    paths = list(skill_files)
+    if paths:
+        prelude.append(
+            "Use all of the following skills for this task. Read each SKILL.md "
+            "completely before acting, follow its instructions, and combine the "
+            "skills where useful:\n"
+            + "\n".join(f"- {path}" for path in paths)
+        )
+    attached = [str(path) for path in attachments if str(path).strip()]
+    if attached:
+        prelude.append(
+            "The user attached these files. Inspect them as needed:\n"
+            + "\n".join(f"- {path}" for path in attached)
+        )
+    return "\n\n".join([*prelude, prompt])
+
+
+def _extract_codex_output(stdout: str) -> tuple[str, Optional[str]]:
+    final = ""
+    session_id: Optional[str] = None
+    plain: List[str] = []
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except ValueError:
+            if line.strip():
+                plain.append(line)
+            continue
+        event_type = str(event.get("type") or "")
+        if event_type in {"thread.started", "session.started"}:
+            session_id = str(
+                event.get("thread_id") or event.get("session_id") or ""
+            ) or session_id
+        item = event.get("item")
+        if isinstance(item, dict) and item.get("type") == "agent_message":
+            final = str(item.get("text") or final)
+        if event_type in {"turn.completed", "message.completed"}:
+            message = event.get("message")
+            if isinstance(message, str) and message.strip():
+                final = message
+    return final or "\n".join(plain).strip(), session_id
+
+
+def _extract_claude_output(stdout: str) -> tuple[str, Optional[str]]:
+    try:
+        payload = json.loads(stdout)
+    except ValueError:
+        return stdout.strip(), None
+    result = payload.get("result")
+    if not isinstance(result, str):
+        result = payload.get("message") if isinstance(payload.get("message"), str) else ""
+    session_id = payload.get("session_id")
+    return result.strip(), str(session_id) if session_id else None
+
+
+def _build_command(
+    harness: str,
+    native_session_id: Optional[str],
+    cwd: Path,
+    model: Optional[str],
+) -> List[str]:
+    if harness == "codex":
+        if native_session_id:
+            command = ["codex", "exec", "resume", "--json", native_session_id]
+        else:
+            command = [
+                "codex",
+                "exec",
+                "--json",
+                "--sandbox",
+                "workspace-write",
+                "--skip-git-repo-check",
+                "-C",
+                str(cwd),
+            ]
+        if model:
+            command.extend(["--model", model])
+        return command
+    if harness == "claude":
+        command = [
+            "claude",
+            "--print",
+            "--output-format",
+            "json",
+            "--permission-mode",
+            "acceptEdits",
+        ]
+        if native_session_id:
+            command.extend(["--resume", native_session_id])
+        else:
+            command.extend(["--session-id", str(uuid.uuid4())])
+        if model:
+            command.extend(["--model", model])
+        return command
+    if harness == "antigravity":
+        # Antigravity distributions expose a Claude-compatible print mode.
+        command = ["antigravity", "--print"]
+        if native_session_id:
+            command.extend(["--resume", native_session_id])
+        if model:
+            command.extend(["--model", model])
+        command.append("-")
+        return command
+    raise ValueError(f"Unknown coding harness: {harness}")
+
+
+def _run_turn_unlocked(
+    *,
+    harness: str,
+    prompt: str,
+    conversation_id: Optional[str] = None,
+    cwd: Optional[str] = None,
+    skills: Optional[List[str]] = None,
+    attachments: Optional[List[str]] = None,
+    model: Optional[str] = None,
+    profile_home: Optional[Path] = None,
+    timeout_seconds: int = 1800,
+) -> Dict[str, Any]:
+    definition = HARNESSES.get(harness)
+    if not definition:
+        raise ValueError(f"Unknown coding harness: {harness}")
+    if not shutil.which(definition["command"]):
+        raise RuntimeError(f"{definition['name']} is not installed or not on PATH")
+
+    workdir = Path(cwd or os.getcwd()).expanduser().resolve()
+    if not workdir.is_dir():
+        raise ValueError("Working directory does not exist")
+    selected_skills = list(dict.fromkeys(skills or []))
+    skill_files = _resolve_skill_files(selected_skills, profile_home)
+    full_prompt = _augmented_prompt(prompt, skill_files, attachments or [])
+
+    with _STORE_LOCK:
+        store = _load_store()
+        row = store.get(conversation_id or "")
+        if row is not None and row.get("harness") != harness:
+            raise ValueError("A conversation cannot switch coding harnesses")
+        now = time.time()
+        if row is None:
+            conversation_id = conversation_id or str(uuid.uuid4())
+            row = {
+                "id": conversation_id,
+                "title": prompt.strip().splitlines()[0][:72] or "New coding session",
+                "harness": harness,
+                "native_session_id": None,
+                "cwd": str(workdir),
+                "skills": selected_skills,
+                "model": model or "",
+                "created_at": now,
+                "updated_at": now,
+                "messages": [],
+            }
+        native_session_id = row.get("native_session_id")
+
+    command = _build_command(harness, native_session_id, workdir, model)
+    command_session_id = None
+    if harness == "claude" and "--session-id" in command:
+        command_session_id = command[command.index("--session-id") + 1]
+    completed = subprocess.run(
+        command,
+        input=full_prompt,
+        text=True,
+        cwd=str(workdir),
+        capture_output=True,
+        timeout=max(30, min(int(timeout_seconds), 3600)),
+        env=os.environ.copy(),
+    )
+    if harness == "codex":
+        response, returned_session_id = _extract_codex_output(completed.stdout)
+    elif harness == "claude":
+        response, returned_session_id = _extract_claude_output(completed.stdout)
+    else:
+        response, returned_session_id = completed.stdout.strip(), None
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or response or "Coding harness failed"
+        raise RuntimeError(detail[-4000:])
+    if not response:
+        raise RuntimeError("Coding harness returned an empty response")
+
+    with _STORE_LOCK:
+        store = _load_store()
+        live = store.get(str(conversation_id), row)
+        live["native_session_id"] = (
+            returned_session_id or native_session_id or command_session_id
+        )
+        live["cwd"] = str(workdir)
+        live["skills"] = selected_skills
+        live["model"] = model or ""
+        live["updated_at"] = time.time()
+        messages = list(live.get("messages") or [])
+        messages.extend(
+            [
+                {
+                    "role": "user",
+                    "content": prompt.strip(),
+                    "attachments": list(attachments or []),
+                    "created_at": now,
+                },
+                {
+                    "role": "assistant",
+                    "content": response,
+                    "created_at": live["updated_at"],
+                },
+            ]
+        )
+        live["messages"] = messages[-_MAX_HISTORY_MESSAGES:]
+        store[str(conversation_id)] = live
+        _save_store(store)
+    return live
+
+
+def run_turn(**kwargs) -> Dict[str, Any]:
+    """Run one native turn, serialized per conversation.
+
+    Discord can deliver multiple messages almost simultaneously. Native
+    harness session files are not safe to resume concurrently, so preserve
+    turn order for one conversation while allowing unrelated channels/chats
+    to run in parallel.
+    """
+    key = str(kwargs.get("conversation_id") or "new")
+    with _TURN_LOCKS_LOCK:
+        lock = _TURN_LOCKS.setdefault(key, threading.Lock())
+    with lock:
+        return _run_turn_unlocked(**kwargs)
+
+
+def load_bindings() -> Dict[str, Dict[str, Any]]:
+    path = _hub_dir() / "discord-bindings.json"
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return payload if isinstance(payload, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def save_binding(
+    channel_id: str,
+    harness: str,
+    *,
+    channel_name: str = "",
+    skills: Optional[List[str]] = None,
+    cwd: Optional[str] = None,
+) -> Dict[str, Any]:
+    if harness not in HARNESSES:
+        raise ValueError(f"Unknown coding harness: {harness}")
+    channel_id = str(channel_id).strip()
+    if not channel_id:
+        raise ValueError("Discord channel is required")
+    with _STORE_LOCK:
+        bindings = load_bindings()
+        binding = {
+            "channel_id": channel_id,
+            "channel_name": channel_name.strip(),
+            "harness": harness,
+            "skills": list(dict.fromkeys(skills or [])),
+            "cwd": str(Path(cwd or os.getcwd()).expanduser().resolve()),
+            "updated_at": time.time(),
+        }
+        bindings[channel_id] = binding
+        atomic_json_write(_hub_dir() / "discord-bindings.json", bindings)
+    return binding
+
+
+def delete_binding(channel_id: str) -> bool:
+    with _STORE_LOCK:
+        bindings = load_bindings()
+        removed = bindings.pop(str(channel_id), None) is not None
+        if removed:
+            atomic_json_write(_hub_dir() / "discord-bindings.json", bindings)
+    return removed

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -752,6 +752,7 @@ _AUDIO_MIME_EXTENSIONS: Dict[str, str] = {
     "video/webm": ".webm",
 }
 _MAX_TRANSCRIPTION_UPLOAD_BYTES = 25 * 1024 * 1024
+_MAX_AGENT_HUB_UPLOAD_BYTES = 25 * 1024 * 1024
 
 
 def _audio_extension_for_mime(mime_type: str) -> str:
@@ -2673,6 +2674,201 @@ async def transcribe_audio_upload(payload: AudioTranscriptionRequest):
         "transcript": str(result.get("transcript") or "").strip(),
         "provider": result.get("provider"),
     }
+
+
+# ---------------------------------------------------------------------------
+# Agent Hub — direct chat over installed coding-agent harnesses.
+#
+# This remains a dashboard/service surface rather than a new model tool:
+# Codex, Claude Code, and Antigravity keep their native agent loops and session
+# state. Hermes provides the authenticated UI, uploads, selected-skill paths,
+# and Discord channel routing around them.
+# ---------------------------------------------------------------------------
+
+
+class AgentHubTurnRequest(BaseModel):
+    harness: str
+    prompt: str
+    conversation_id: Optional[str] = None
+    cwd: Optional[str] = None
+    skills: List[str] = []
+    attachments: List[str] = []
+    model: Optional[str] = None
+    profile: Optional[str] = None
+
+
+class AgentHubBindingRequest(BaseModel):
+    channel_id: str
+    channel_name: str = ""
+    harness: str
+    skills: List[str] = []
+    cwd: Optional[str] = None
+
+
+@app.get("/api/agent-hub")
+async def get_agent_hub(profile: Optional[str] = None):
+    from hermes_cli.agent_hub import harness_catalog, list_conversations, load_bindings
+
+    profile_home = None
+    if profile and profile.strip().lower() != "current":
+        profile_home = _resolve_profile_dir(profile)
+    return {
+        "harnesses": harness_catalog(),
+        "conversations": list_conversations(),
+        "bindings": list(load_bindings().values()),
+        "default_cwd": str(PROJECT_ROOT),
+        "profile_home": str(profile_home) if profile_home else str(get_hermes_home()),
+    }
+
+
+@app.get("/api/agent-hub/conversations/{conversation_id}")
+async def get_agent_hub_conversation(conversation_id: str):
+    from hermes_cli.agent_hub import get_conversation
+
+    conversation = get_conversation(conversation_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Agent Hub conversation not found")
+    return conversation
+
+
+@app.delete("/api/agent-hub/conversations/{conversation_id}")
+async def delete_agent_hub_conversation(conversation_id: str):
+    from hermes_cli.agent_hub import delete_conversation
+
+    if not delete_conversation(conversation_id):
+        raise HTTPException(status_code=404, detail="Agent Hub conversation not found")
+    return {"ok": True}
+
+
+@app.post("/api/agent-hub/turn")
+async def run_agent_hub_turn(body: AgentHubTurnRequest):
+    from hermes_cli.agent_hub import run_turn
+
+    profile_home = None
+    if body.profile and body.profile.strip().lower() != "current":
+        profile_home = _resolve_profile_dir(body.profile)
+    try:
+        return await asyncio.to_thread(
+            run_turn,
+            harness=(body.harness or "").strip().lower(),
+            prompt=body.prompt,
+            conversation_id=body.conversation_id,
+            cwd=body.cwd,
+            skills=body.skills,
+            attachments=body.attachments,
+            model=(body.model or "").strip() or None,
+            profile_home=profile_home,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise HTTPException(
+            status_code=504, detail="The coding agent turn timed out."
+        ) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@app.post("/api/agent-hub/uploads")
+async def upload_agent_hub_file(
+    file: UploadFile = File(...),
+    conversation_id: str = Form("draft"),
+):
+    safe_conversation = re.sub(r"[^a-zA-Z0-9_-]", "", conversation_id)[:80] or "draft"
+    safe_name = Path(file.filename or "attachment").name
+    safe_name = re.sub(r"[^a-zA-Z0-9._ -]", "_", safe_name)[:180] or "attachment"
+    upload_dir = get_hermes_home() / "agent-hub" / "uploads" / safe_conversation
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    destination = upload_dir / safe_name
+    if destination.exists():
+        destination = upload_dir / f"{destination.stem}-{secrets.token_hex(3)}{destination.suffix}"
+
+    size = 0
+    try:
+        with destination.open("wb") as output:
+            while chunk := await file.read(1024 * 1024):
+                size += len(chunk)
+                if size > _MAX_AGENT_HUB_UPLOAD_BYTES:
+                    raise HTTPException(
+                        status_code=413, detail="Attachment exceeds the 25 MB limit"
+                    )
+                output.write(chunk)
+    except Exception:
+        try:
+            destination.unlink()
+        except OSError:
+            pass
+        raise
+    finally:
+        await file.close()
+    return {
+        "name": safe_name,
+        "path": str(destination.resolve()),
+        "size": size,
+        "mime_type": file.content_type or mimetypes.guess_type(safe_name)[0],
+    }
+
+
+def _agent_hub_discord_channels() -> List[Dict[str, Any]]:
+    from gateway.channel_directory import DIRECTORY_PATH
+
+    try:
+        payload = json.loads(DIRECTORY_PATH.read_text(encoding="utf-8"))
+        channels = payload.get("platforms", {}).get("discord", [])
+    except (OSError, ValueError, AttributeError):
+        channels = []
+    result = []
+    seen = set()
+    for channel in channels if isinstance(channels, list) else []:
+        if not isinstance(channel, dict):
+            continue
+        channel_id = str(channel.get("id") or "").strip()
+        if not channel_id or channel_id in seen:
+            continue
+        seen.add(channel_id)
+        result.append(
+            {
+                "id": channel_id,
+                "name": str(channel.get("name") or channel_id),
+                "guild": str(channel.get("guild") or ""),
+                "type": str(channel.get("type") or "channel"),
+            }
+        )
+    return sorted(result, key=lambda row: (row["guild"].lower(), row["name"].lower()))
+
+
+@app.get("/api/agent-hub/discord/channels")
+async def list_agent_hub_discord_channels():
+    return {"channels": _agent_hub_discord_channels()}
+
+
+@app.put("/api/agent-hub/discord/bindings/{channel_id}")
+async def set_agent_hub_discord_binding(
+    channel_id: str, body: AgentHubBindingRequest
+):
+    from hermes_cli.agent_hub import save_binding
+
+    if channel_id != body.channel_id:
+        raise HTTPException(status_code=400, detail="Channel id does not match URL")
+    try:
+        return save_binding(
+            channel_id,
+            (body.harness or "").strip().lower(),
+            channel_name=body.channel_name,
+            skills=body.skills,
+            cwd=body.cwd,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.delete("/api/agent-hub/discord/bindings/{channel_id}")
+async def remove_agent_hub_discord_binding(channel_id: str):
+    from hermes_cli.agent_hub import delete_binding
+
+    if not delete_binding(channel_id):
+        raise HTTPException(status_code=404, detail="Discord binding not found")
+    return {"ok": True}
 
 
 class TTSSpeakRequest(BaseModel):

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -180,6 +180,7 @@ openrouter = OpenRouterProfile(
         "anthropic/claude-sonnet-4.6",
         "openai/gpt-5.4",
         "deepseek/deepseek-chat",
+        "deepseek/deepseek-v4-flash",
         "google/gemini-3-flash-preview",
         "qwen/qwen3-plus",
     ),

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5166,6 +5166,32 @@ class DiscordAdapter(BasePlatformAdapter):
             thread_id = str(message.channel.id)
             parent_channel_id = self._get_parent_channel_id(message.channel)
 
+        # Resolve Agent Hub bindings before mention gating. A bound channel is
+        # intentionally a direct coding-agent surface, so it behaves like a
+        # free-response channel instead of requiring an @mention every turn.
+        agent_hub_binding = None
+        try:
+            from hermes_cli.agent_hub import load_bindings
+
+            _early_bindings = load_bindings()
+            _early_channel_id = str(getattr(message.channel, "id", ""))
+            _early_combined_id = (
+                f"{parent_channel_id}:{_early_channel_id}"
+                if parent_channel_id
+                else ""
+            )
+            agent_hub_binding = (
+                _early_bindings.get(_early_combined_id)
+                or _early_bindings.get(_early_channel_id)
+                or (
+                    _early_bindings.get(parent_channel_id)
+                    if parent_channel_id
+                    else None
+                )
+            )
+        except Exception:
+            logger.debug("[%s] Agent Hub binding lookup failed", self.name, exc_info=True)
+
         is_voice_linked_channel = False
 
         # Save mention-stripped text before auto-threading since create_thread()
@@ -5223,6 +5249,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 "*" in free_channels
                 or bool(channel_ids & free_channels)
                 or is_voice_linked_channel
+                or agent_hub_binding is not None
             )
 
             # Skip the mention check if the message is in a thread where
@@ -5534,6 +5561,64 @@ class DiscordAdapter(BasePlatformAdapter):
         _chan = message.channel
         _parent_id = str(getattr(_chan, "parent_id", "") or "")
         _chan_id = str(getattr(_chan, "id", ""))
+
+        # Agent Hub channel binding: a configured Discord channel talks
+        # directly to its selected coding harness instead of entering the
+        # ordinary Hermes conversation loop. Parent-channel bindings apply to
+        # threads as well, which keeps Discord's auto-thread isolation useful.
+        try:
+            from hermes_cli.agent_hub import run_turn
+
+            _binding = agent_hub_binding
+            if _binding:
+                _binding_channel = str(_binding.get("channel_id") or _chan_id)
+                _attachment_paths = [
+                    str(path)
+                    for path in media_urls
+                    if isinstance(path, str) and not path.startswith(("http://", "https://"))
+                ]
+                await self._add_reaction(message, "👀")
+                try:
+                    _reply = await asyncio.to_thread(
+                        run_turn,
+                        harness=str(_binding.get("harness") or ""),
+                        prompt=event_text,
+                        conversation_id=(
+                            f"discord-{_binding_channel}-"
+                            f"{str(_binding.get('harness') or '')}"
+                        ),
+                        cwd=_binding.get("cwd"),
+                        skills=list(_binding.get("skills") or []),
+                        attachments=_attachment_paths,
+                    )
+                    _response = str((_reply.get("messages") or [{}])[-1].get("content") or "")
+                    _send_chat_id = _parent_id if is_thread and _parent_id else _chan_id
+                    await self.send(
+                        _send_chat_id,
+                        _response,
+                        reply_to=str(message.id),
+                        metadata={"thread_id": _chan_id} if is_thread else None,
+                    )
+                    await self._remove_reaction(message, "👀")
+                    await self._add_reaction(message, "✅")
+                except Exception:
+                    logger.exception(
+                        "[%s] Agent Hub binding failed for channel %s",
+                        self.name,
+                        _binding_channel,
+                    )
+                    await self._remove_reaction(message, "👀")
+                    await self._add_reaction(message, "❌")
+                    await effective_channel.send(
+                        "The bound coding agent could not complete this turn. "
+                        "Check the Hermes gateway logs for details."
+                    )
+                return
+        except Exception:
+            # Binding lookup is best-effort. A malformed/missing Agent Hub
+            # state file must never break normal Discord message handling.
+            logger.debug("[%s] Agent Hub binding lookup failed", self.name, exc_info=True)
+
         _skills = self._resolve_channel_skills(_chan_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(_chan_id, _parent_id or None)
 

--- a/tests/hermes_cli/test_agent_hub.py
+++ b/tests/hermes_cli/test_agent_hub.py
@@ -1,0 +1,130 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import agent_hub
+
+
+@pytest.fixture
+def isolated_hub(tmp_path, monkeypatch):
+    monkeypatch.setattr(agent_hub, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(agent_hub, "_resolve_skill_files", lambda names, home: [])
+    return tmp_path
+
+
+def test_harness_catalog_reports_runtime_availability(monkeypatch):
+    monkeypatch.setattr(
+        agent_hub.shutil,
+        "which",
+        lambda command: f"/usr/bin/{command}" if command == "codex" else None,
+    )
+
+    catalog = {item["id"]: item for item in agent_hub.harness_catalog()}
+
+    assert catalog["codex"]["available"] is True
+    assert catalog["claude"]["available"] is False
+    assert catalog["antigravity"]["available"] is False
+
+
+def test_codex_conversation_persists_and_resumes(isolated_hub, monkeypatch):
+    monkeypatch.setattr(agent_hub.shutil, "which", lambda command: f"/bin/{command}")
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        turn = len(calls)
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": "native-123"}),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "agent_message",
+                            "text": f"answer {turn}",
+                        },
+                    }
+                ),
+            ]
+        )
+        return agent_hub.subprocess.CompletedProcess(command, 0, stdout, "")
+
+    monkeypatch.setattr(agent_hub.subprocess, "run", fake_run)
+
+    first = agent_hub.run_turn(
+        harness="codex",
+        prompt="Build the feature",
+        conversation_id="conversation-1",
+        cwd=str(isolated_hub),
+    )
+    second = agent_hub.run_turn(
+        harness="codex",
+        prompt="Now test it",
+        conversation_id="conversation-1",
+        cwd=str(isolated_hub),
+    )
+
+    assert first["native_session_id"] == "native-123"
+    assert second["messages"][-1]["content"] == "answer 2"
+    assert calls[0][0][:3] == ["codex", "exec", "--json"]
+    assert calls[1][0][:4] == ["codex", "exec", "resume", "--json"]
+    assert "native-123" in calls[1][0]
+    assert [row["id"] for row in agent_hub.list_conversations()] == [
+        "conversation-1"
+    ]
+
+
+def test_selected_skills_and_attachments_are_added_to_native_prompt(
+    isolated_hub, monkeypatch
+):
+    skill_path = isolated_hub / "skills" / "review" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Review", encoding="utf-8")
+    monkeypatch.setattr(agent_hub.shutil, "which", lambda command: f"/bin/{command}")
+    monkeypatch.setattr(
+        agent_hub,
+        "_resolve_skill_files",
+        lambda names, home: [skill_path],
+    )
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["prompt"] = kwargs["input"]
+        stdout = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": "done"},
+            }
+        )
+        return agent_hub.subprocess.CompletedProcess(command, 0, stdout, "")
+
+    monkeypatch.setattr(agent_hub.subprocess, "run", fake_run)
+
+    agent_hub.run_turn(
+        harness="codex",
+        prompt="Review this",
+        conversation_id="with-context",
+        cwd=str(isolated_hub),
+        skills=["review"],
+        attachments=["/tmp/example.patch"],
+    )
+
+    assert str(skill_path) in captured["prompt"]
+    assert "/tmp/example.patch" in captured["prompt"]
+    assert captured["prompt"].endswith("Review this")
+
+
+def test_discord_binding_round_trip(isolated_hub):
+    saved = agent_hub.save_binding(
+        "123",
+        "claude",
+        channel_name="Guild / #dev",
+        skills=["review", "tests"],
+        cwd=str(isolated_hub),
+    )
+
+    assert saved["harness"] == "claude"
+    assert agent_hub.load_bindings()["123"]["skills"] == ["review", "tests"]
+    assert agent_hub.delete_binding("123") is True
+    assert agent_hub.load_bindings() == {}

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -251,6 +251,15 @@ class TestDetectProviderForModel:
         # Provider is deepseek (direct) or openrouter (fallback) depending on creds
         assert result[0] in {"deepseek", "openrouter"}
 
+    def test_deepseek_v4_flash_openrouter_routing(self):
+        """deepseek/deepseek-v4-flash should route to openrouter, not deepseek."""
+        live_models = [("deepseek/deepseek-v4-flash", "")]
+        with patch("hermes_cli.models.fetch_openrouter_models", return_value=live_models):
+            result = detect_provider_for_model("deepseek/deepseek-v4-flash", "openai")
+        assert result is not None
+        assert result[0] == "openrouter"
+        assert result[1] == "deepseek/deepseek-v4-flash"
+
     def test_current_provider_model_returns_none(self):
         """Models belonging to the current provider should not trigger a switch."""
         assert detect_provider_for_model("gpt-5.3-codex", "openai-codex") is None

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import {
   Activity,
   BarChart3,
   BookOpen,
+  Bot,
   Clock,
   Code,
   Cpu,
@@ -91,6 +92,7 @@ import ChannelsPage from "@/pages/ChannelsPage";
 import WebhooksPage from "@/pages/WebhooksPage";
 import SystemPage from "@/pages/SystemPage";
 import ChatPage from "@/pages/ChatPage";
+import AgentHubPage from "@/pages/AgentHubPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -133,6 +135,7 @@ const CHAT_NAV_ITEM: NavItem = {
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
+  "/agent-hub": AgentHubPage,
   "/files": FilesPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
@@ -161,6 +164,11 @@ function ChatRouteSink() {
 }
 
 const BUILTIN_NAV_REST: NavItem[] = [
+  {
+    path: "/agent-hub",
+    label: "Agent Hub",
+    icon: Bot,
+  },
   {
     path: "/sessions",
     labelKey: "sessions",
@@ -203,6 +211,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
 const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Activity,
   BarChart3,
+  Bot,
   Clock,
   Cpu,
   FileText,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -71,6 +71,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/config",
   "/api/env",
   "/api/mcp",
+  "/api/agent-hub",
   "/api/messaging/platforms",
   "/api/messaging/telegram/onboarding",
   "/api/model/info",
@@ -661,6 +662,56 @@ export const api = {
   // runs under. Omitted/empty profile = the dashboard's own profile.
   getSkills: (profile?: string) =>
     fetchJSON<SkillInfo[]>(`/api/skills${profileQuery(profile)}`),
+  getAgentHub: (profile?: string) =>
+    fetchJSON<AgentHubResponse>(`/api/agent-hub${profileQuery(profile)}`),
+  getAgentHubConversation: (id: string) =>
+    fetchJSON<AgentHubConversation>(
+      `/api/agent-hub/conversations/${encodeURIComponent(id)}`,
+    ),
+  deleteAgentHubConversation: (id: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/agent-hub/conversations/${encodeURIComponent(id)}`,
+      { method: "DELETE" },
+    ),
+  runAgentHubTurn: (turn: AgentHubTurnRequest) =>
+    fetchJSON<AgentHubConversation>("/api/agent-hub/turn", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(turn),
+    }),
+  uploadAgentHubFile: (file: File, conversationId = "draft") => {
+    const form = new FormData();
+    form.append("conversation_id", conversationId);
+    form.append("file", file, file.name);
+    return fetchJSON<AgentHubAttachment>("/api/agent-hub/uploads", {
+      method: "POST",
+      body: form,
+    });
+  },
+  getAgentHubDiscordChannels: () =>
+    fetchJSON<{ channels: AgentHubDiscordChannel[] }>(
+      "/api/agent-hub/discord/channels",
+    ),
+  setAgentHubDiscordBinding: (binding: AgentHubDiscordBinding) =>
+    fetchJSON<AgentHubDiscordBinding>(
+      `/api/agent-hub/discord/bindings/${encodeURIComponent(binding.channel_id)}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(binding),
+      },
+    ),
+  deleteAgentHubDiscordBinding: (channelId: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/agent-hub/discord/bindings/${encodeURIComponent(channelId)}`,
+      { method: "DELETE" },
+    ),
+  transcribeAudio: (dataUrl: string, mimeType?: string) =>
+    fetchJSON<AudioTranscriptionResponse>("/api/audio/transcribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ data_url: dataUrl, mime_type: mimeType }),
+    }),
   toggleSkill: (name: string, enabled: boolean, profile?: string) =>
     fetchJSON<{ ok: boolean }>("/api/skills/toggle", {
       method: "PUT",
@@ -1938,6 +1989,88 @@ export interface SkillInfo {
   description: string;
   category: string;
   enabled: boolean;
+}
+
+export interface AgentHubHarness {
+  id: "codex" | "claude" | "antigravity";
+  name: string;
+  description: string;
+  available: boolean;
+  executable: string | null;
+}
+
+export interface AgentHubAttachment {
+  name: string;
+  path: string;
+  size: number;
+  mime_type: string | null;
+}
+
+export interface AgentHubMessage {
+  role: "user" | "assistant";
+  content: string;
+  attachments?: string[];
+  created_at: number;
+}
+
+export interface AgentHubConversationSummary {
+  id: string;
+  title: string;
+  harness: AgentHubHarness["id"];
+  cwd: string;
+  skills: string[];
+  created_at: number;
+  updated_at: number;
+  message_count: number;
+  preview: string;
+}
+
+export interface AgentHubConversation
+  extends Omit<AgentHubConversationSummary, "message_count" | "preview"> {
+  native_session_id: string | null;
+  model: string;
+  messages: AgentHubMessage[];
+}
+
+export interface AgentHubDiscordChannel {
+  id: string;
+  name: string;
+  guild: string;
+  type: string;
+}
+
+export interface AgentHubDiscordBinding {
+  channel_id: string;
+  channel_name: string;
+  harness: AgentHubHarness["id"];
+  skills: string[];
+  cwd?: string;
+  updated_at?: number;
+}
+
+export interface AgentHubResponse {
+  harnesses: AgentHubHarness[];
+  conversations: AgentHubConversationSummary[];
+  bindings: AgentHubDiscordBinding[];
+  default_cwd: string;
+  profile_home: string;
+}
+
+export interface AgentHubTurnRequest {
+  harness: AgentHubHarness["id"];
+  prompt: string;
+  conversation_id?: string;
+  cwd?: string;
+  skills?: string[];
+  attachments?: string[];
+  model?: string;
+  profile?: string;
+}
+
+export interface AudioTranscriptionResponse {
+  ok: boolean;
+  transcript: string;
+  provider?: string;
 }
 
 export interface SkillContent {

--- a/web/src/pages/AgentHubPage.tsx
+++ b/web/src/pages/AgentHubPage.tsx
@@ -1,0 +1,862 @@
+import {
+  Bot,
+  Check,
+  ChevronDown,
+  CircleStop,
+  Clipboard,
+  Code2,
+  File,
+  Link2,
+  Mic,
+  Paperclip,
+  Plus,
+  Send,
+  Settings2,
+  Sparkles,
+  Trash2,
+  Unlink,
+  X,
+} from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from "react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Card, CardContent } from "@nous-research/ui/ui/components/card";
+import { Checkbox } from "@nous-research/ui/ui/components/checkbox";
+import { Input } from "@nous-research/ui/ui/components/input";
+import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Toast } from "@nous-research/ui/ui/components/toast";
+import { useToast } from "@nous-research/ui/hooks/use-toast";
+import { Markdown } from "@/components/Markdown";
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { api } from "@/lib/api";
+import type {
+  AgentHubAttachment,
+  AgentHubConversation,
+  AgentHubConversationSummary,
+  AgentHubDiscordBinding,
+  AgentHubDiscordChannel,
+  AgentHubHarness,
+  AgentHubResponse,
+  SkillInfo,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type HubMode = "chat" | "discord";
+
+function draftId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `hub-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function harnessIcon(id: AgentHubHarness["id"]) {
+  if (id === "codex") return Code2;
+  if (id === "claude") return Sparkles;
+  return Bot;
+}
+
+function formatTime(epoch: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(epoch * 1000));
+}
+
+function toDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || ""));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
+interface SkillsMenuProps {
+  skills: SkillInfo[];
+  selected: string[];
+  onChange: (skills: string[]) => void;
+  compact?: boolean;
+}
+
+function SkillsMenu({ skills, selected, onChange, compact = false }: SkillsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return skills
+      .filter((skill) => skill.enabled)
+      .filter(
+        (skill) =>
+          !needle ||
+          skill.name.toLowerCase().includes(needle) ||
+          skill.description.toLowerCase().includes(needle),
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [query, skills]);
+
+  return (
+    <div className="relative">
+      <Button
+        type="button"
+        ghost
+        size="sm"
+        className={cn(
+          "border border-border text-text-secondary hover:text-foreground",
+          compact ? "h-8" : "h-9",
+        )}
+        onClick={() => setOpen((value) => !value)}
+        prefix={<Sparkles className="h-3.5 w-3.5" />}
+      >
+        {selected.length ? `${selected.length} skills` : "Skills"}
+        <ChevronDown className="ml-1 h-3.5 w-3.5" />
+      </Button>
+      {open && (
+        <>
+          <button
+            type="button"
+            aria-label="Close skills"
+            className="fixed inset-0 z-30 cursor-default"
+            onClick={() => setOpen(false)}
+          />
+          <Card className="absolute bottom-[calc(100%+0.5rem)] left-0 z-40 w-[min(22rem,calc(100vw-2rem))] border-border bg-background-base shadow-2xl">
+            <CardContent className="p-3">
+              <Input
+                autoFocus
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Find a skill…"
+                className="mb-2"
+              />
+              <div className="max-h-64 space-y-1 overflow-y-auto pr-1">
+                {filtered.map((skill) => {
+                  const checked = selectedSet.has(skill.name);
+                  return (
+                    <label
+                      key={skill.name}
+                      className="flex cursor-pointer items-start gap-2 rounded-sm px-2 py-2 hover:bg-foreground/5"
+                    >
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={(value) =>
+                          onChange(
+                            value === true
+                              ? [...selected, skill.name]
+                              : selected.filter((name) => name !== skill.name),
+                          )
+                        }
+                      />
+                      <span className="min-w-0">
+                        <span className="block text-sm text-foreground">{skill.name}</span>
+                        <span className="line-clamp-2 text-xs text-muted-foreground">
+                          {skill.description}
+                        </span>
+                      </span>
+                    </label>
+                  );
+                })}
+                {!filtered.length && (
+                  <p className="px-2 py-6 text-center text-xs text-muted-foreground">
+                    No enabled skills found.
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function AgentHubPage() {
+  const { profile } = useProfileScope();
+  const { toast, showToast } = useToast();
+  const [mode, setMode] = useState<HubMode>("chat");
+  const [hub, setHub] = useState<AgentHubResponse | null>(null);
+  const [skills, setSkills] = useState<SkillInfo[]>([]);
+  const [channels, setChannels] = useState<AgentHubDiscordChannel[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [conversation, setConversation] = useState<AgentHubConversation | null>(null);
+  const [conversationDraftId, setConversationDraftId] = useState(draftId);
+  const [harness, setHarness] = useState<AgentHubHarness["id"]>("codex");
+  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+  const [cwd, setCwd] = useState("");
+  const [model, setModel] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [attachments, setAttachments] = useState<AgentHubAttachment[]>([]);
+  const [sending, setSending] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const [bindingChannel, setBindingChannel] = useState("");
+  const [bindingHarness, setBindingHarness] =
+    useState<AgentHubHarness["id"]>("codex");
+  const [bindingSkills, setBindingSkills] = useState<string[]>([]);
+  const [bindingCwd, setBindingCwd] = useState("");
+  const [savingBinding, setSavingBinding] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+  const transcriptEndRef = useRef<HTMLDivElement | null>(null);
+
+  const reloadHub = useCallback(async () => {
+    const [nextHub, nextSkills, channelResult] = await Promise.all([
+      api.getAgentHub(profile || undefined),
+      api.getSkills(profile || undefined),
+      api.getAgentHubDiscordChannels(),
+    ]);
+    setHub(nextHub);
+    setSkills(nextSkills);
+    setChannels(channelResult.channels);
+    setCwd((value) => value || nextHub.default_cwd);
+    setBindingCwd((value) => value || nextHub.default_cwd);
+    const preferred = nextHub.harnesses.find((item) => item.available);
+    if (preferred) {
+      setHarness((value) =>
+        nextHub.harnesses.some((item) => item.id === value && item.available)
+          ? value
+          : preferred.id,
+      );
+      setBindingHarness((value) =>
+        nextHub.harnesses.some((item) => item.id === value && item.available)
+          ? value
+          : preferred.id,
+      );
+    }
+  }, [profile]);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.resolve()
+      .then(reloadHub)
+      .catch((error) => !cancelled && showToast(`Could not load Agent Hub: ${error}`, "error"))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadHub, showToast]);
+
+  useEffect(() => {
+    transcriptEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [conversation?.messages.length, sending]);
+
+  const availableHarnesses = hub?.harnesses ?? [];
+  const currentHarness = availableHarnesses.find((item) => item.id === harness);
+  const selectedChannel = channels.find((channel) => channel.id === bindingChannel);
+
+  const newConversation = () => {
+    setConversation(null);
+    setConversationDraftId(draftId());
+    setPrompt("");
+    setAttachments([]);
+    setSelectedSkills([]);
+    setModel("");
+    if (hub) setCwd(hub.default_cwd);
+  };
+
+  const openConversation = async (summary: AgentHubConversationSummary) => {
+    try {
+      const detail = await api.getAgentHubConversation(summary.id);
+      setConversation(detail);
+      setConversationDraftId(detail.id);
+      setHarness(detail.harness);
+      setSelectedSkills(detail.skills);
+      setCwd(detail.cwd);
+      setModel(detail.model || "");
+      setAttachments([]);
+    } catch (error) {
+      showToast(`Could not open session: ${error}`, "error");
+    }
+  };
+
+  const deleteConversation = async (id: string) => {
+    try {
+      await api.deleteAgentHubConversation(id);
+      if (conversation?.id === id) newConversation();
+      await reloadHub();
+    } catch (error) {
+      showToast(`Could not delete session: ${error}`, "error");
+    }
+  };
+
+  const submit = async () => {
+    const text = prompt.trim();
+    if (!text || sending || !currentHarness?.available) return;
+    const optimistic: AgentHubConversation = conversation ?? {
+      id: conversationDraftId,
+      title: text.split("\n")[0].slice(0, 72),
+      harness,
+      native_session_id: null,
+      cwd,
+      skills: selectedSkills,
+      model,
+      created_at: Date.now() / 1000,
+      updated_at: Date.now() / 1000,
+      messages: [],
+    };
+    setConversation({
+      ...optimistic,
+      messages: [
+        ...optimistic.messages,
+        {
+          role: "user",
+          content: text,
+          attachments: attachments.map((item) => item.path),
+          created_at: Date.now() / 1000,
+        },
+      ],
+    });
+    setPrompt("");
+    setSending(true);
+    try {
+      const result = await api.runAgentHubTurn({
+        harness,
+        prompt: text,
+        conversation_id: conversation?.id || conversationDraftId,
+        cwd,
+        skills: selectedSkills,
+        attachments: attachments.map((item) => item.path),
+        model: model.trim() || undefined,
+        profile: profile || undefined,
+      });
+      setConversation(result);
+      setAttachments([]);
+      await reloadHub();
+    } catch (error) {
+      setPrompt(text);
+      setConversation(conversation);
+      showToast(`Coding agent failed: ${error}`, "error");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const onPromptKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      void submit();
+    }
+  };
+
+  const uploadFiles = async (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    event.target.value = "";
+    if (!files.length) return;
+    setUploading(true);
+    try {
+      const uploaded = await Promise.all(
+        files.map((file) => api.uploadAgentHubFile(file, conversation?.id || conversationDraftId)),
+      );
+      setAttachments((current) => [...current, ...uploaded]);
+    } catch (error) {
+      showToast(`Upload failed: ${error}`, "error");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const stopRecording = () => mediaRecorderRef.current?.stop();
+
+  const toggleRecording = async () => {
+    if (recording) {
+      stopRecording();
+      return;
+    }
+    if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === "undefined") {
+      showToast("Voice recording is not supported in this browser.", "error");
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const recorder = new MediaRecorder(stream);
+      audioChunksRef.current = [];
+      recorder.ondataavailable = (event) => {
+        if (event.data.size) audioChunksRef.current.push(event.data);
+      };
+      recorder.onstop = () => {
+        stream.getTracks().forEach((track) => track.stop());
+        setRecording(false);
+        const blob = new Blob(audioChunksRef.current, {
+          type: recorder.mimeType || "audio/webm",
+        });
+        setTranscribing(true);
+        void toDataUrl(blob)
+          .then((dataUrl) => api.transcribeAudio(dataUrl, blob.type))
+          .then((result) =>
+            setPrompt((current) =>
+              [current.trim(), result.transcript].filter(Boolean).join(current.trim() ? " " : ""),
+            ),
+          )
+          .catch((error) => showToast(`Transcription failed: ${error}`, "error"))
+          .finally(() => setTranscribing(false));
+      };
+      mediaRecorderRef.current = recorder;
+      recorder.start();
+      setRecording(true);
+    } catch (error) {
+      showToast(`Microphone unavailable: ${error}`, "error");
+    }
+  };
+
+  const saveBinding = async () => {
+    if (!selectedChannel) return;
+    setSavingBinding(true);
+    try {
+      await api.setAgentHubDiscordBinding({
+        channel_id: selectedChannel.id,
+        channel_name: [selectedChannel.guild, `#${selectedChannel.name}`]
+          .filter(Boolean)
+          .join(" / "),
+        harness: bindingHarness,
+        skills: bindingSkills,
+        cwd: bindingCwd,
+      });
+      showToast("Discord channel bound to coding agent.", "success");
+      setBindingChannel("");
+      setBindingSkills([]);
+      await reloadHub();
+    } catch (error) {
+      showToast(`Could not save binding: ${error}`, "error");
+    } finally {
+      setSavingBinding(false);
+    }
+  };
+
+  const removeBinding = async (binding: AgentHubDiscordBinding) => {
+    try {
+      await api.deleteAgentHubDiscordBinding(binding.channel_id);
+      await reloadHub();
+      showToast("Discord binding removed.", "success");
+    } catch (error) {
+      showToast(`Could not remove binding: ${error}`, "error");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <Spinner className="text-2xl text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <Toast toast={toast} />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="mb-1 flex items-center gap-2">
+            <Code2 className="h-5 w-5 text-primary" />
+            <h1 className="font-mondwest text-display text-xl tracking-wide">Agent Hub</h1>
+          </div>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            Work directly with native coding agents, combine skills, and carry files into the session.
+          </p>
+        </div>
+        <div className="flex rounded-sm border border-border bg-background/30 p-1">
+          <Button
+            size="sm"
+            ghost={mode !== "chat"}
+            onClick={() => setMode("chat")}
+            prefix={<Bot className="h-4 w-4" />}
+          >
+            Direct chat
+          </Button>
+          <Button
+            size="sm"
+            ghost={mode !== "discord"}
+            onClick={() => setMode("discord")}
+            prefix={<Link2 className="h-4 w-4" />}
+          >
+            Discord binding
+          </Button>
+        </div>
+      </div>
+
+      {mode === "chat" ? (
+        <div className="grid min-h-[38rem] flex-1 gap-3 lg:grid-cols-[16rem_minmax(0,1fr)]">
+          <Card className="min-h-0 border-border bg-background/25">
+            <CardContent className="flex h-full max-h-[72dvh] flex-col p-3">
+              <Button
+                className="mb-3 w-full uppercase"
+                size="sm"
+                onClick={newConversation}
+                prefix={<Plus className="h-4 w-4" />}
+              >
+                New session
+              </Button>
+              <p className="mb-2 px-1 font-mondwest text-xs uppercase tracking-wider text-muted-foreground">
+                Recent
+              </p>
+              <div className="flex gap-2 overflow-x-auto lg:flex-1 lg:flex-col lg:overflow-y-auto">
+                {(hub?.conversations ?? []).map((item) => (
+                  <div
+                    key={item.id}
+                    className={cn(
+                      "group relative min-w-56 rounded-sm border p-3 text-left transition-colors lg:min-w-0",
+                      conversation?.id === item.id
+                        ? "border-primary/50 bg-primary/10"
+                        : "border-transparent hover:border-border hover:bg-foreground/5",
+                    )}
+                  >
+                    <button type="button" className="w-full pr-6 text-left" onClick={() => void openConversation(item)}>
+                      <span className="block truncate text-sm font-medium text-foreground">
+                        {item.title}
+                      </span>
+                      <span className="mt-1 block truncate text-xs text-muted-foreground">
+                        {item.harness === "claude" ? "Claude Code" : item.harness} · {formatTime(item.updated_at)}
+                      </span>
+                    </button>
+                    <Button
+                      ghost
+                      size="icon"
+                      aria-label={`Delete ${item.title}`}
+                      className="absolute right-1 top-1 h-7 w-7 opacity-0 group-hover:opacity-100"
+                      onClick={() => void deleteConversation(item.id)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ))}
+                {!hub?.conversations.length && (
+                  <p className="px-2 py-8 text-center text-xs text-muted-foreground">
+                    Your coding sessions will appear here.
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="min-h-0 overflow-hidden border-border bg-background/20">
+            <CardContent className="flex h-full min-h-[38rem] flex-col p-0">
+              <div className="border-b border-border p-3 sm:p-4">
+                <div className="grid gap-2 sm:grid-cols-3">
+                  {availableHarnesses.map((item) => {
+                    const Icon = harnessIcon(item.id);
+                    const active = harness === item.id;
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        disabled={!item.available || Boolean(conversation)}
+                        onClick={() => setHarness(item.id)}
+                        className={cn(
+                          "flex items-center gap-3 rounded-sm border px-3 py-2 text-left transition-colors",
+                          active ? "border-primary/60 bg-primary/10" : "border-border bg-background/20",
+                          !item.available && "cursor-not-allowed opacity-40",
+                          conversation && !active && "opacity-40",
+                        )}
+                      >
+                        <span className="grid h-8 w-8 shrink-0 place-items-center rounded-sm bg-foreground/5">
+                          <Icon className="h-4 w-4" />
+                        </span>
+                        <span className="min-w-0">
+                          <span className="flex items-center gap-1.5 text-sm font-medium">
+                            {item.name}
+                            {active && <Check className="h-3.5 w-3.5 text-primary" />}
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {item.available ? "Ready" : "Not installed"}
+                          </span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+                <details className="mt-3 text-xs text-muted-foreground">
+                  <summary className="flex cursor-pointer list-none items-center gap-1.5">
+                    <Settings2 className="h-3.5 w-3.5" />
+                    Session options
+                  </summary>
+                  <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                    <label className="grid gap-1">
+                      <span>Working directory</span>
+                      <Input value={cwd} onChange={(event) => setCwd(event.target.value)} disabled={Boolean(conversation)} />
+                    </label>
+                    <label className="grid gap-1">
+                      <span>Model override (optional)</span>
+                      <Input
+                        value={model}
+                        onChange={(event) => setModel(event.target.value)}
+                        placeholder="Use harness default"
+                        disabled={Boolean(conversation)}
+                      />
+                    </label>
+                  </div>
+                </details>
+              </div>
+
+              <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-3 py-5 sm:px-6">
+                {!conversation?.messages.length && (
+                  <div className="mx-auto flex max-w-lg flex-col items-center py-16 text-center">
+                    <div className="mb-4 grid h-12 w-12 place-items-center rounded-full border border-primary/30 bg-primary/10">
+                      <Bot className="h-5 w-5 text-primary" />
+                    </div>
+                    <h2 className="font-mondwest text-display text-base">A direct line to {currentHarness?.name ?? "your agent"}</h2>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      Attach context, select one or more skills, then describe the outcome you want.
+                    </p>
+                  </div>
+                )}
+                {conversation?.messages.map((message, index) => (
+                  <div
+                    key={`${message.created_at}-${index}`}
+                    className={cn("flex", message.role === "user" ? "justify-end" : "justify-start")}
+                  >
+                    <div
+                      className={cn(
+                        "max-w-[92%] rounded-sm border px-4 py-3 sm:max-w-[82%]",
+                        message.role === "user"
+                          ? "border-primary/30 bg-primary/10"
+                          : "border-border bg-background/45",
+                      )}
+                    >
+                      <div className="mb-2 flex items-center justify-between gap-4 text-[11px] uppercase tracking-wider text-muted-foreground">
+                        <span>{message.role === "user" ? "You" : currentHarness?.name}</span>
+                        {message.role === "assistant" && (
+                          <Button
+                            ghost
+                            size="icon"
+                            className="h-6 w-6"
+                            aria-label="Copy response"
+                            onClick={() => {
+                              void navigator.clipboard.writeText(message.content);
+                              showToast("Response copied.", "success");
+                            }}
+                          >
+                            <Clipboard className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                      </div>
+                      {message.role === "assistant" ? (
+                        <Markdown content={message.content} />
+                      ) : (
+                        <p className="whitespace-pre-wrap text-sm leading-6">{message.content}</p>
+                      )}
+                      {!!message.attachments?.length && (
+                        <div className="mt-2 flex flex-wrap gap-1">
+                          {message.attachments.map((path) => (
+                            <Badge key={path}>{path.split("/").pop()}</Badge>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+                {sending && (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Spinner />
+                    {currentHarness?.name} is working in the repository…
+                  </div>
+                )}
+                <div ref={transcriptEndRef} />
+              </div>
+
+              <div className="border-t border-border bg-background-base/75 p-3 backdrop-blur sm:p-4">
+                {!!attachments.length && (
+                  <div className="mb-2 flex flex-wrap gap-2">
+                    {attachments.map((attachment) => (
+                      <Badge key={attachment.path} className="flex items-center gap-1.5">
+                        <File className="h-3 w-3" />
+                        {attachment.name}
+                        <button
+                          type="button"
+                          aria-label={`Remove ${attachment.name}`}
+                          onClick={() =>
+                            setAttachments((current) =>
+                              current.filter((item) => item.path !== attachment.path),
+                            )
+                          }
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+                {!!selectedSkills.length && (
+                  <div className="mb-2 flex flex-wrap gap-1">
+                    {selectedSkills.map((name) => (
+                      <Badge key={name}>{name}</Badge>
+                    ))}
+                  </div>
+                )}
+                <div className="rounded-sm border border-border bg-background/45 focus-within:border-primary/50">
+                  <textarea
+                    value={prompt}
+                    onChange={(event) => setPrompt(event.target.value)}
+                    onKeyDown={onPromptKeyDown}
+                    placeholder={`Message ${currentHarness?.name ?? "coding agent"}…`}
+                    className="min-h-24 w-full resize-none bg-transparent px-3 pt-3 text-sm outline-none placeholder:text-muted-foreground"
+                    disabled={sending}
+                  />
+                  <div className="flex flex-wrap items-center justify-between gap-2 px-2 pb-2">
+                    <div className="flex items-center gap-1">
+                      <input ref={fileInputRef} type="file" multiple className="hidden" onChange={uploadFiles} />
+                      <Button
+                        ghost
+                        size="icon"
+                        className="h-8 w-8"
+                        aria-label="Attach files"
+                        disabled={uploading || sending}
+                        onClick={() => fileInputRef.current?.click()}
+                      >
+                        {uploading ? <Spinner /> : <Paperclip className="h-4 w-4" />}
+                      </Button>
+                      <Button
+                        ghost
+                        size="icon"
+                        className={cn("h-8 w-8", recording && "text-red-400")}
+                        aria-label={recording ? "Stop recording" : "Transcribe voice"}
+                        disabled={transcribing || sending}
+                        onClick={() => void toggleRecording()}
+                      >
+                        {transcribing ? (
+                          <Spinner />
+                        ) : recording ? (
+                          <CircleStop className="h-4 w-4" />
+                        ) : (
+                          <Mic className="h-4 w-4" />
+                        )}
+                      </Button>
+                      <SkillsMenu skills={skills} selected={selectedSkills} onChange={setSelectedSkills} compact />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="hidden text-xs text-muted-foreground sm:inline">Enter to send · Shift+Enter for newline</span>
+                      <Button
+                        size="sm"
+                        className="uppercase"
+                        disabled={!prompt.trim() || sending || !currentHarness?.available}
+                        onClick={() => void submit()}
+                        prefix={sending ? <Spinner /> : <Send className="h-4 w-4" />}
+                      >
+                        Send
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.8fr)]">
+          <Card className="border-border bg-background/25">
+            <CardContent className="p-5">
+              <div className="mb-5">
+                <h2 className="font-mondwest text-display text-base">Bind a Discord channel</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Messages in the channel go straight to the selected coding harness. Existing unbound channels keep using Hermes normally.
+                </p>
+              </div>
+              <div className="grid gap-4">
+                <label className="grid gap-1.5 text-sm">
+                  <span className="text-muted-foreground">Discord channel</span>
+                  <Select value={bindingChannel} onValueChange={setBindingChannel}>
+                    <SelectOption value="">Select a channel</SelectOption>
+                    {channels.map((channel) => (
+                      <SelectOption key={channel.id} value={channel.id}>
+                        {[channel.guild, `#${channel.name}`].filter(Boolean).join(" / ")}
+                      </SelectOption>
+                    ))}
+                  </Select>
+                  {!channels.length && (
+                    <span className="text-xs text-muted-foreground">
+                      No Discord channels discovered yet. Start the configured gateway so Hermes can load the channel directory.
+                    </span>
+                  )}
+                </label>
+                <label className="grid gap-1.5 text-sm">
+                  <span className="text-muted-foreground">Coding agent</span>
+                  <Select
+                    value={bindingHarness}
+                    onValueChange={(value) => setBindingHarness(value as AgentHubHarness["id"])}
+                  >
+                    {availableHarnesses
+                      .filter((item) => item.available)
+                      .map((item) => (
+                        <SelectOption key={item.id} value={item.id}>
+                          {item.name}
+                        </SelectOption>
+                      ))}
+                  </Select>
+                </label>
+                <label className="grid gap-1.5 text-sm">
+                  <span className="text-muted-foreground">Working directory</span>
+                  <Input value={bindingCwd} onChange={(event) => setBindingCwd(event.target.value)} />
+                </label>
+                <div>
+                  <p className="mb-1.5 text-sm text-muted-foreground">Skills available in this channel</p>
+                  <SkillsMenu skills={skills} selected={bindingSkills} onChange={setBindingSkills} />
+                  {!!bindingSkills.length && (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {bindingSkills.map((name) => <Badge key={name}>{name}</Badge>)}
+                    </div>
+                  )}
+                </div>
+                <Button
+                  className="mt-2 uppercase sm:w-fit"
+                  disabled={!bindingChannel || savingBinding}
+                  onClick={() => void saveBinding()}
+                  prefix={savingBinding ? <Spinner /> : <Link2 className="h-4 w-4" />}
+                >
+                  Bind channel
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="border-border bg-background/25">
+            <CardContent className="p-5">
+              <h2 className="font-mondwest text-display text-base">Active bindings</h2>
+              <div className="mt-4 space-y-2">
+                {(hub?.bindings ?? []).map((binding) => {
+                  const boundHarness = availableHarnesses.find((item) => item.id === binding.harness);
+                  return (
+                    <div key={binding.channel_id} className="flex items-start justify-between gap-3 rounded-sm border border-border bg-background/30 p-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">
+                          {binding.channel_name || `Channel ${binding.channel_id}`}
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {boundHarness?.name ?? binding.harness}
+                          {binding.skills.length ? ` · ${binding.skills.length} skills` : ""}
+                        </p>
+                      </div>
+                      <Button
+                        ghost
+                        size="icon"
+                        aria-label="Remove binding"
+                        onClick={() => void removeBinding(binding)}
+                      >
+                        <Unlink className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  );
+                })}
+                {!hub?.bindings.length && (
+                  <div className="py-12 text-center text-sm text-muted-foreground">
+                    No channels are bound to coding agents.
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds an **Agent Hub** page to the Hermes dashboard at `/agent-hub` with two modes:

### Direct Chat
- Chat directly with Codex, Claude Code, or Antigravity from a polished UI
- File upload, voice recording/transcription, skills selector, model override
- Session history with resume/delete
- Markdown rendering for agent responses

### Discord Binding
- Bind a Discord channel to a specific coding agent harness
- Messages in bound channels route directly to the agent (bypasses normal Hermes loop)
- Per-binding skills + working directory configuration
- Emoji feedback (👀 → ✅/❌)

## Changes

| File | Change |
|------|--------|
| `web/src/pages/AgentHubPage.tsx` | New — full Agent Hub page (862 lines) |
| `hermes_cli/agent_hub.py` | New — backend logic for harness invocation, conversation store, Discord bindings (445 lines) |
| `web/src/App.tsx` | Added `/agent-hub` route + nav item |
| `web/src/lib/api.ts` | New API methods + TypeScript types |
| `hermes_cli/web_server.py` | New API endpoints for agent hub |
| `plugins/platforms/discord/adapter.py` | Discord channel binding routing |
| `gateway/slash_commands.py` | Discord /new model reset fix |
| `tests/hermes_cli/test_agent_hub.py` | New tests |
| `tests/hermes_cli/test_models.py` | Updated