### PR TITLE
fix(kanban): prevent invalid image retry loops

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8944,14 +8944,14 @@ def _default_spawn(
     cmd.extend([
         "chat",
         "-q", prompt,
+        # All dispatcher workers are headless and must use the failure-aware
+        # query path. The human-facing single-query branch renders failed agent
+        # results but returns success, which the dispatcher misclassifies as a
+        # clean-exit protocol violation. Quiet mode maps ``result.failed`` to a
+        # non-zero exit (and preserves the rate-limit sentinel) instead. Goal
+        # mode also depends on this branch for _run_kanban_goal_loop_q.
+        "-Q",
     ])
-    if task.goal_mode:
-        # Goal-mode workers must take the fully-quiet single-query path:
-        # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
-        # cli.py's quiet branch. Without -Q the worker gets exactly one
-        # turn, prints text, exits rc=0, and the dispatcher records a
-        # protocol violation (incident 2026-06-09 t_d9cbe312).
-        cmd.append("-Q")
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -133,18 +133,33 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
     ]
 
 
-def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatch):
+@pytest.mark.parametrize(
+    ("failure_reason", "kanban_task", "expected_exit_code"),
+    [
+        (None, None, 1),
+        (None, "t_generic_failure", 1),
+        ("rate_limit", None, 1),
+        ("rate_limit", "t_rate_limited", 75),
+        ("billing", "t_billing_limited", 75),
+    ],
+)
+def test_quiet_single_query_main_finalizes_while_preserving_exit_code(
+    monkeypatch, failure_reason, kanban_task, expected_exit_code,
+):
     calls = []
 
     import cli as cli_mod
 
     def run_conversation(*, user_message, conversation_history):
         calls.append(("run", user_message, conversation_history))
-        return {
+        result = {
             "final_response": "",
             "error": "provider failed",
             "failed": True,
         }
+        if failure_reason:
+            result["failure_reason"] = failure_reason
+        return result
 
     class FakeCLI:
         def __init__(self, **_kwargs):
@@ -184,7 +199,10 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
             calls.append(("init", kwargs))
             return True
 
-    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    if kanban_task:
+        monkeypatch.setenv("HERMES_KANBAN_TASK", kanban_task)
+    else:
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
     monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
     monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
@@ -197,7 +215,7 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     with pytest.raises(SystemExit) as exc_info:
         cli_mod.main(query="hello", quiet=True, toolsets="terminal")
 
-    assert exc_info.value.code == 1
+    assert exc_info.value.code == expected_exit_code
     assert ("claim", "cli", True) in calls
     assert ("run", "hello", []) in calls
     assert calls[-1] == ("finalize", "quiet-session")

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -736,6 +736,13 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     assert cmd.index("--accept-hooks") < cmd.index("chat"), (
         f"--accept-hooks must come before 'chat' in argv: {cmd}"
     )
+    # Every headless worker must use the failure-aware quiet query path. The
+    # human-facing ``chat -q`` branch renders failed agent results but returns
+    # success, which turns provider/input failures into clean-exit protocol
+    # violations at the dispatcher boundary.
+    assert cmd.count("-Q") == 1, (
+        f"spawn argv must contain exactly one quiet flag: {cmd}"
+    )
     # Assignee + task env are still present
     assert "some-profile" in cmd
     env = captured["env"]

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -94,6 +94,39 @@ def test_legacy_db_migrates_goal_columns(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_goal_mode_spawn_keeps_single_quiet_flag_and_goal_env(
+    kanban_home, monkeypatch,
+):
+    captured = {}
+
+    class FakeProc:
+        pid = 99999
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="goal spawn compatibility",
+            assignee="goal-profile",
+            goal_mode=True,
+            goal_max_turns=7,
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        workspace = kb.resolve_workspace(task)
+        assert kb._default_spawn(task, str(workspace)) == 99999
+
+    assert captured["cmd"].count("-Q") == 1
+    assert captured["env"]["HERMES_KANBAN_GOAL_MODE"] == "1"
+    assert captured["env"]["HERMES_KANBAN_GOAL_MAX_TURNS"] == "7"
+
+
 
 # ---------------------------------------------------------------------------
 # Goal loop logic (callback-injected, no live model)

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -13,6 +13,7 @@ import base64
 import json
 from unittest.mock import patch
 
+import pytest
 
 from tools.vision_tools import (
     _build_native_vision_tool_result,
@@ -103,6 +104,57 @@ class TestVisionAnalyzeNative:
         )
         assert isinstance(result, dict)
         assert result.get("_multimodal") is True
+
+    def test_corrupt_supported_image_is_rejected_before_embedding(self, tmp_path):
+        """A PNG header alone must not let corrupt bytes poison tool history.
+
+        Native vision tool results are replayed on the next provider request.
+        If malformed bytes reach that immutable history, the provider returns a
+        non-retryable HTTP 400 on every resume instead of letting the worker
+        handle the bad artifact as a normal tool error.
+        """
+        corrupt = tmp_path / "corrupt.png"
+        corrupt.write_bytes(_TINY_PNG[:-12])
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(corrupt), "describe")
+        )
+
+        assert isinstance(result, str), result
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "invalid or corrupt" in payload["error"].lower()
+
+    def test_image_that_verifies_but_cannot_decode_is_rejected(self, tmp_path):
+        """Pillow ``verify()`` alone must not admit corrupt pixel data."""
+        from io import BytesIO
+
+        from PIL import Image
+
+        encoded = BytesIO()
+        Image.effect_noise((128, 128), 80).convert("RGB").save(
+            encoded, format="JPEG", quality=90,
+        )
+        corrupt_bytes = encoded.getvalue()[:-1]
+
+        # This is the load-bearing shape: Pillow's structural check succeeds,
+        # but decoding the pixels fails and providers reject the same payload.
+        with Image.open(BytesIO(corrupt_bytes)) as image:
+            image.verify()
+        with pytest.raises(OSError, match="truncated"):
+            with Image.open(BytesIO(corrupt_bytes)) as image:
+                image.load()
+
+        corrupt = tmp_path / "corrupt.jpg"
+        corrupt.write_bytes(corrupt_bytes)
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(corrupt), "describe")
+        )
+
+        assert isinstance(result, str), result
+        payload = json.loads(result)
+        assert payload["success"] is False
+        assert "invalid or corrupt" in payload["error"].lower()
 
     def test_oversized_image_resized_under_embed_cap(self, tmp_path):
         """Regression for the wedged-session incident (May 2026).

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -379,6 +379,46 @@ def _normalize_to_supported_image(
     )
 
 
+def _validate_image_for_embedding(image_path: Path) -> Optional[str]:
+    """Return an actionable error when image bytes are malformed.
+
+    Magic bytes identify a claimed format but do not prove that the complete
+    payload is decodable. Native vision results become immutable conversation
+    history, so embedding a truncated PNG (or equivalent corrupt raster) makes
+    every following provider request fail with a non-retryable HTTP 400. Use
+    Pillow's structural verification and then fully decode every frame. Pillow
+    is a core dependency because native image embedding must fail closed when
+    validation is unavailable.
+    """
+    try:
+        from PIL import Image as _PILImage
+        from PIL import ImageSequence as _PILImageSequence
+    except ImportError as exc:
+        return (
+            "Image validation is unavailable because Pillow could not be "
+            f"imported ({exc}). Repair the Hermes installation before sending "
+            "images to a vision model."
+        )
+
+    try:
+        with _PILImage.open(image_path) as image:
+            image.verify()
+        # ``verify()`` checks container structure but deliberately does not
+        # decode pixels. Reopen after verify() (which invalidates the decoder)
+        # and force every frame through its codec so truncated JPEG entropy or
+        # a corrupt later GIF/WebP frame cannot reach immutable tool history.
+        with _PILImage.open(image_path) as image:
+            for frame in _PILImageSequence.Iterator(image):
+                frame.load()
+    except Exception as exc:
+        return (
+            "Image data is invalid or corrupt and cannot be sent to a vision "
+            f"model ({type(exc).__name__}: {exc}). Recreate or re-download the "
+            "image, then run vision_analyze again."
+        )
+    return None
+
+
 def _is_retryable_download_error(error: Exception) -> bool:
     """Return True only for transient image-download failures worth retrying.
 
@@ -1025,6 +1065,15 @@ async def _vision_analyze_native(
             temp_image_path = normalized_path
             should_cleanup = True
             image_size_bytes = temp_image_path.stat().st_size
+
+        # A supported MIME type is not enough: truncated or mutated image bytes
+        # can still carry a valid PNG/JPEG header. Reject them before they enter
+        # immutable multimodal tool history and wedge every subsequent request.
+        _validation_error = await _run_encode_on_cpu_executor(
+            _validate_image_for_embedding, temp_image_path,
+        )
+        if _validation_error:
+            return tool_error(_validation_error, success=False)
 
         image_data_url = await _run_encode_on_cpu_executor(
             _image_to_base64_data_url,


### PR DESCRIPTION
## What does this PR do?

Prevents a malformed image from wedging a Kanban worker session and then being misclassified as a clean-exit protocol violation.

The incident required two conditions:

1. `vision_analyze` accepted header-valid but corrupt PNG/JPEG bytes and embedded them in immutable native tool-result history. The provider then rejected every subsequent request with a non-retryable 400.
2. Ordinary dispatcher workers used human-facing `chat -q`, which rendered structured agent failures but still exited with rc=0. The dispatcher therefore saw a protocol violation rather than a real worker failure and retried the same broken input.

This change validates and fully decodes native vision input before embedding it, and launches every headless dispatcher worker through the existing failure-aware quiet path.

## Related Issue

No public issue; reproduced from a real Kanban worker failure loop.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/vision_tools.py`
  - Run Pillow structural verification and full frame decoding on the bounded vision CPU executor before native embedding.
  - Fail closed if Pillow validation is unavailable.
  - Return an actionable tool error for corrupt input so malformed bytes never enter immutable model history.
- `hermes_cli/kanban_db.py`
  - Add exactly one `-Q` to every dispatcher worker, not only `goal_mode` workers.
  - Reuse the existing quiet-path exit contract: generic failures exit 1; Kanban rate-limit/billing failures retain exit 75.
- Tests cover truncated PNGs, JPEGs that pass `verify()` but fail pixel decoding, ordinary and goal-mode spawn argv, and rate-limit/billing exit boundaries.

## How to Test

1. Run the focused behavior suites:
   ```bash
   scripts/run_tests.sh tests/tools/test_vision_native_fast_path.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_goal_mode.py tests/cli/test_single_query_session_finalize.py
   ```
   Expected: `52 tests passed, 0 failed`.
2. Run the broader vision regression suites:
   ```bash
   scripts/run_tests.sh tests/tools/test_vision_tools.py tests/tools/test_image_source.py
   ```
   Expected: `45 tests passed, 0 failed`.
3. Verify style and patch integrity:
   ```bash
   ruff check hermes_cli/kanban_db.py tools/vision_tools.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_vision_native_fast_path.py tests/hermes_cli/test_kanban_goal_mode.py tests/cli/test_single_query_session_finalize.py
   git diff --check origin/main...HEAD
   ```
4. The isolated spawn→exit→reclaim harness produced two rc=1 attempts and a terminal `blocked` state at the configured failure limit; no provider, network delivery, gateway restart, or production state was involved.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused and adjacent suites pass: 97 tests total; full suite not run locally)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; implementation docstrings/comments updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python/Pillow path and existing cross-platform argv construction
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no schema change

## Screenshots / Logs

Focused local verification:

```text
52 tests passed, 0 failed
45 tests passed, 0 failed
All checks passed!  # ruff
REGRESSION PROBE PASSED
INCIDENT VERIFICATION PASSED
ISOLATED KANBAN E2E PASSED
```
