### PR TITLE
fix(env): strip PYTHONPATH from subprocess env (#74817)

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -67,6 +67,17 @@ SIGNAL_MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100 MB
 MAX_MESSAGE_LENGTH = 8000  # Signal message size limit
 TYPING_INTERVAL = 8.0  # seconds between typing indicator refreshes
 HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
+# Health-monitor reconnect threshold: after this many consecutive
+# ``/v1/health`` failures the monitor rebuilds the receive loop via
+# ``connect(is_reconnect=True)`` instead of just logging (#74871 reviewer
+# feedback — the old behaviour left Hermes connected to a dead TCP socket
+# that polls return immediately from, silently dropping inbound).
+HEALTH_MONITOR_MAX_CONSECUTIVE_FAILURES = 3
+# Receive-loop inactivity threshold: warn if the receive poll hasn't
+# completed (success or transport error) for this many seconds. Empty
+# polls still count as activity because they confirm the daemon is
+# reachable (#74871).
+HEALTH_MONITOR_INACTIVITY_SECONDS = 120.0
 
 
 # ---------------------------------------------------------------------------
@@ -306,6 +317,11 @@ class SignalAdapter(BasePlatformAdapter):
         self._typing_skip_until: Dict[str, float] = {}
         self._running = False
 
+        # Receive-loop activity timestamp (monotonic seconds). Updated by
+        # ``_receive_loop`` after every successful poll and read by
+        # ``_health_monitor`` to warn on extended inactivity (#74871).
+        self._last_receive_at: float = 0.0
+
         # Normalize account for self-message filtering
         self._account_normalized = self.account.strip()
 
@@ -428,6 +444,12 @@ class SignalAdapter(BasePlatformAdapter):
             try:
                 response = await self.client.get(url, timeout=10.0)
                 response.raise_for_status()
+                # Record the timestamp of every successful poll (including
+                # empty lists) so ``_health_monitor`` can warn on
+                # 120 s of inactivity. Without this the monitor can't
+                # distinguish "daemon is reachable, queue is empty" from
+                # "daemon is stuck and not yielding" (#74871).
+                self._last_receive_at = time.monotonic()
                 data = response.json()
                 envelopes = data if isinstance(data, list) else [data]
                 for envelope in envelopes:
@@ -446,17 +468,88 @@ class SignalAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _health_monitor(self) -> None:
-        """Periodically verify daemon health."""
+        """Periodically verify daemon health and reconnect on extended failure.
+
+        Replaces a pure-log health loop (#74871 reviewer feedback). On
+        every ``HEALTH_CHECK_INTERVAL`` (30 s) we:
+
+        1. Probe ``GET /v1/health``. A 200/204 is healthy; anything else
+           (or a transport error) is a failed check.
+        2. Track consecutive failures. After ``HEALTH_MONITOR_MAX_CONSECUTIVE_FAILURES``
+           (3) the loop calls ``connect(is_reconnect=True)`` to rebuild
+           the receive task + health monitor from the live ``self.client``.
+           Without this, a daemon restart leaves Hermes connected to a
+           dead TCP socket that polls return immediately from, silently
+           dropping every inbound message.
+        3. Track time since the last successful ``/v1/receive/{number}``
+           poll. After ``HEALTH_MONITOR_INACTIVITY_SECONDS`` (120 s) without
+           any envelope (live or empty), log a warning so an operator
+           investigating a stuck bot can see the receive loop hasn't
+           yielded a turn.
+        """
+        _consecutive_failures = 0
+        _last_receive_at = time.monotonic()
         while self._running:
             await asyncio.sleep(HEALTH_CHECK_INTERVAL)
             if not self._running:
                 break
+
+            # 1) Health probe
+            healthy = False
             try:
-                resp = await self.client.get(f"{self.http_url}/v1/health", timeout=10.0)
-                if resp.status_code not in (200, 204):
-                    logger.warning("Signal: health check failed (%d)", resp.status_code)
+                resp = await self.client.get(
+                    f"{self.http_url}/v1/health", timeout=10.0,
+                )
+                healthy = resp.status_code in (200, 204)
+                if not healthy:
+                    logger.warning(
+                        "Signal: health check failed (%d)", resp.status_code,
+                    )
             except Exception as e:
                 logger.warning("Signal: health check error: %s", e)
+
+            if healthy:
+                _consecutive_failures = 0
+            else:
+                _consecutive_failures += 1
+                if (
+                    _consecutive_failures
+                    >= HEALTH_MONITOR_MAX_CONSECUTIVE_FAILURES
+                ):
+                    logger.warning(
+                        "Signal: %d consecutive health-check failures; "
+                        "triggering reconnect",
+                        _consecutive_failures,
+                    )
+                    try:
+                        await self.connect(is_reconnect=True)
+                    except Exception as e:
+                        logger.error(
+                            "Signal: reconnect attempt failed: %s", e,
+                        )
+                    # Reset the failure window + receive clock so the
+                    # newly-started receive loop starts with a clean
+                    # slate; the next iteration re-probes.
+                    _consecutive_failures = 0
+                    _last_receive_at = time.monotonic()
+                    continue
+
+            # 3) Inactivity detector — only relevant when the receive loop
+            # is actually polling. ``_receive_loop`` updates
+            # ``self._last_receive_at`` after every successful iteration
+            # (including empty polls); we compare against ``now`` and warn
+            # if we haven't seen activity in 120 s. Empty polls still count
+            # as activity because they confirm the daemon is reachable.
+            now = time.monotonic()
+            last_at = getattr(self, "_last_receive_at", None)
+            if last_at is not None and (now - last_at) > HEALTH_MONITOR_INACTIVITY_SECONDS:
+                logger.warning(
+                    "Signal: no receive-loop activity for %ds "
+                    "(last seen %.0fs ago); daemon may be stuck or "
+                    "the inbound queue may be empty",
+                    HEALTH_MONITOR_INACTIVITY_SECONDS,
+                    now - last_at,
+                )
 
 
     # ------------------------------------------------------------------

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1,7 +1,7 @@
 """Signal messenger platform adapter.
 
 Connects to a signal-cli daemon running in HTTP mode.
-Inbound messages arrive via SSE (Server-Sent Events) streaming.
+Inbound messages arrive via polling.
 Outbound messages and actions use JSON-RPC 2.0 over HTTP.
 
 Based on PR #268 by ibhagwan, rebuilt with bug fixes.
@@ -16,7 +16,7 @@ import base64
 import json
 import logging
 import os
-import random
+
 import shutil
 import subprocess
 import tempfile
@@ -66,10 +66,7 @@ logger = logging.getLogger(__name__)
 SIGNAL_MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100 MB
 MAX_MESSAGE_LENGTH = 8000  # Signal message size limit
 TYPING_INTERVAL = 8.0  # seconds between typing indicator refreshes
-SSE_RETRY_DELAY_INITIAL = 2.0
-SSE_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
-HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before concern
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +262,10 @@ class SignalAdapter(BasePlatformAdapter):
         extra = config.extra or {}
         self.http_url = extra.get("http_url", "http://127.0.0.1:8080").rstrip("/")
         self.account = extra.get("account", "")
+        try:
+            self.poll_interval = max(1.0, float(extra.get("poll_interval", 1.0)))
+        except (TypeError, ValueError):
+            self.poll_interval = 1.0
         self.ignore_stories = extra.get("ignore_stories", True)
 
         # Parse allowlists — group policy is derived from presence of group allowlist
@@ -292,7 +293,7 @@ class SignalAdapter(BasePlatformAdapter):
         self.client: Optional[httpx.AsyncClient] = None
 
         # Background tasks
-        self._sse_task: Optional[asyncio.Task] = None
+        self._receive_task: Optional[asyncio.Task] = None
         self._health_monitor_task: Optional[asyncio.Task] = None
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         # Per-chat typing-indicator backoff. When signal-cli reports
@@ -304,8 +305,6 @@ class SignalAdapter(BasePlatformAdapter):
         self._typing_failures: Dict[str, int] = {}
         self._typing_skip_until: Dict[str, float] = {}
         self._running = False
-        self._last_sse_activity = 0.0
-        self._sse_response: Optional[httpx.Response] = None
 
         # Normalize account for self-message filtering
         self._account_normalized = self.account.strip()
@@ -345,7 +344,7 @@ class SignalAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        """Connect to signal-cli daemon and start SSE listener."""
+        """Connect to signal-cli daemon and start polling."""
         if not self.http_url or not self.account:
             logger.error("Signal: SIGNAL_HTTP_URL and SIGNAL_ACCOUNT are required")
             return False
@@ -365,8 +364,8 @@ class SignalAdapter(BasePlatformAdapter):
         try:
             # Health check — verify signal-cli daemon is reachable
             try:
-                resp = await self.client.get(f"{self.http_url}/api/v1/check", timeout=10.0)
-                if resp.status_code != 200:
+                resp = await self.client.get(f"{self.http_url}/v1/health", timeout=10.0)
+                if resp.status_code not in (200, 204):
                     logger.error("Signal: health check failed (status %d)", resp.status_code)
                     return False
             except Exception as e:
@@ -374,8 +373,7 @@ class SignalAdapter(BasePlatformAdapter):
                 return False
 
             self._running = True
-            self._last_sse_activity = time.time()
-            self._sse_task = asyncio.create_task(self._sse_listener())
+            self._receive_task = asyncio.create_task(self._receive_loop())
             self._health_monitor_task = asyncio.create_task(self._health_monitor())
 
             logger.info("Signal: connected to %s", self.http_url)
@@ -389,13 +387,13 @@ class SignalAdapter(BasePlatformAdapter):
                     self._release_platform_lock()
 
     async def disconnect(self) -> None:
-        """Stop SSE listener and clean up."""
+        """Stop polling and clean up."""
         self._running = False
 
-        if self._sse_task:
-            self._sse_task.cancel()
+        if self._receive_task:
+            self._receive_task.cancel()
             try:
-                await self._sse_task
+                await self._receive_task
             except asyncio.CancelledError:
                 pass
 
@@ -420,114 +418,46 @@ class SignalAdapter(BasePlatformAdapter):
         logger.info("Signal: disconnected")
 
     # ------------------------------------------------------------------
-    # SSE Streaming (inbound messages)
+    # Polling (inbound messages)
     # ------------------------------------------------------------------
 
-    async def _sse_listener(self) -> None:
-        """Listen for SSE events from signal-cli daemon."""
-        url = f"{self.http_url}/api/v1/events?account={quote(self.account, safe='')}"
-        backoff = SSE_RETRY_DELAY_INITIAL
-
+    async def _receive_loop(self) -> None:
+        """Poll signal-cli for inbound envelopes."""
+        url = f"{self.http_url}/v1/receive/{quote(self.account, safe='')}"
         while self._running:
             try:
-                logger.debug("Signal SSE: connecting to %s", url)
-                async with self.client.stream(
-                    "GET", url,
-                    headers={"Accept": "text/event-stream"},
-                    timeout=None,
-                ) as response:
-                    self._sse_response = response
-                    backoff = SSE_RETRY_DELAY_INITIAL  # Reset on successful connection
-                    self._last_sse_activity = time.time()
-                    logger.info("Signal SSE: connected")
-
-                    buffer = ""
-                    async for chunk in response.aiter_text():
-                        if not self._running:
-                            break
-                        buffer += chunk
-                        while "\n" in buffer:
-                            line, buffer = buffer.split("\n", 1)
-                            line = line.strip()
-                            if not line:
-                                continue
-                            # SSE keepalive comments (":") prove the connection
-                            # is alive — update activity so the health monitor
-                            # doesn't report false idle warnings.
-                            if line.startswith(":"):
-                                self._last_sse_activity = time.time()
-                                continue
-                            # Parse SSE data lines
-                            if line.startswith("data:"):
-                                data_str = line[5:].strip()
-                                if not data_str:
-                                    continue
-                                self._last_sse_activity = time.time()
-                                try:
-                                    data = json.loads(data_str)
-                                    await self._handle_envelope(data)
-                                except json.JSONDecodeError:
-                                    logger.debug("Signal SSE: invalid JSON: %s", data_str[:100])
-                                except Exception:
-                                    logger.exception("Signal SSE: error handling event")
-
+                response = await self.client.get(url, timeout=10.0)
+                response.raise_for_status()
+                data = response.json()
+                envelopes = data if isinstance(data, list) else [data]
+                for envelope in envelopes:
+                    if envelope:
+                        await self._handle_envelope(envelope)
             except asyncio.CancelledError:
                 break
-            except httpx.HTTPError as e:
-                if self._running:
-                    logger.warning("Signal SSE: HTTP error: %s (reconnecting in %.0fs)", e, backoff)
             except Exception as e:
                 if self._running:
-                    logger.warning("Signal SSE: error: %s (reconnecting in %.0fs)", e, backoff)
-
+                    logger.warning("Signal receive poll failed: %s", e)
             if self._running:
-                # Add 20% jitter to prevent thundering herd on reconnection
-                jitter = backoff * 0.2 * random.random()
-                await asyncio.sleep(backoff + jitter)
-                backoff = min(backoff * 2, SSE_RETRY_DELAY_MAX)
-
-        self._sse_response = None
+                await asyncio.sleep(self.poll_interval)
 
     # ------------------------------------------------------------------
     # Health Monitor
     # ------------------------------------------------------------------
 
     async def _health_monitor(self) -> None:
-        """Monitor SSE connection health and force reconnect if stale."""
+        """Periodically verify daemon health."""
         while self._running:
             await asyncio.sleep(HEALTH_CHECK_INTERVAL)
             if not self._running:
                 break
-
-            elapsed = time.time() - self._last_sse_activity
-            if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
-                logger.warning("Signal: SSE idle for %.0fs, checking daemon health", elapsed)
-                try:
-                    resp = await self.client.get(
-                        f"{self.http_url}/api/v1/check", timeout=10.0
-                    )
-                    if resp.status_code == 200:
-                        # Daemon is alive but SSE is idle — update activity to
-                        # avoid repeated warnings (connection may just be quiet)
-                        self._last_sse_activity = time.time()
-                        logger.debug("Signal: daemon healthy, SSE idle")
-                    else:
-                        logger.warning("Signal: health check failed (%d), forcing reconnect", resp.status_code)
-                        self._force_reconnect()
-                except Exception as e:
-                    logger.warning("Signal: health check error: %s, forcing reconnect", e)
-                    self._force_reconnect()
-
-    def _force_reconnect(self) -> None:
-        """Force SSE reconnection by closing the current response."""
-        if self._sse_response and not self._sse_response.is_stream_consumed:
             try:
-                task = asyncio.create_task(self._sse_response.aclose())
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-            except Exception:
-                pass
-            self._sse_response = None
+                resp = await self.client.get(f"{self.http_url}/v1/health", timeout=10.0)
+                if resp.status_code not in (200, 204):
+                    logger.warning("Signal: health check failed (%d)", resp.status_code)
+            except Exception as e:
+                logger.warning("Signal: health check error: %s", e)
+
 
     # ------------------------------------------------------------------
     # Message Handling
@@ -965,7 +895,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         try:
             resp = await self.client.post(
-                f"{self.http_url}/api/v1/rpc",
+                f"{self.http_url}/v1/rpc",
                 json=payload,
                 timeout=timeout,
             )

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -80,8 +80,39 @@ class TestSignalAdapterInit:
         assert "group123" in adapter.group_allow_from
 
 
+class TestSignalReceivePolling:
+    @pytest.mark.asyncio
+    async def test_receive_loop_polls_and_dispatches_envelope(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, account="+15551234567")
+        envelope = {
+            "envelope": {
+                "sourceNumber": "+15550000000",
+                "dataMessage": {"message": "hello", "timestamp": 1},
+            }
+        }
+        response = MagicMock(status_code=200)
+        response.json.return_value = [envelope]
+        calls = []
+
+        async def get(url, **kwargs):
+            calls.append((url, kwargs))
+            adapter._running = False
+            return response
+
+        adapter.client = MagicMock(get=AsyncMock(side_effect=get))
+        adapter._handle_envelope = AsyncMock()
+        adapter._running = True
+        await adapter._receive_loop()
+
+        assert calls[0][0] == "http://localhost:8080/v1/receive/%2B15551234567"
+        adapter._handle_envelope.assert_awaited_once_with(envelope)
+
+    def test_poll_interval_is_clamped_to_one_second(self, monkeypatch):
+        assert _make_signal_adapter(monkeypatch, poll_interval=0.1).poll_interval == 1.0
+        assert _make_signal_adapter(monkeypatch, poll_interval=2.5).poll_interval == 2.5
+
+
 class TestSignalConnectCleanup:
-    """Regression coverage for failed connect() cleanup."""
 
     @pytest.mark.asyncio
     async def test_releases_lock_and_closes_client_on_healthcheck_failure(self, monkeypatch):
@@ -1311,6 +1342,159 @@ class TestSignalSyncMessageHandling:
         assert "event" in captured, "Group sync-sent must reach handle_message"
         assert captured["event"].text == "ping the group"
         assert captured["event"].source.chat_id == "group:abc123=="
+
+
+# ---------------------------------------------------------------------------
+# Outbound RPC route verification (#71636 sweeper: every outbound operation
+# must hit /v1/rpc with the correct JSON-RPC method — not just receive polling)
+# ---------------------------------------------------------------------------
+
+class TestSignalOutboundRpcRoutes:
+    """Verify that every outbound operation routes through /v1/rpc with the
+    correct JSON-RPC 2.0 method name and that the HTTP POST target is the
+    documented endpoint, not a stale or invented path."""
+
+    @pytest.mark.asyncio
+    async def test_send_text_uses_send_method_on_v1_rpc(self, monkeypatch):
+        """send() must POST to /v1/rpc with method=send."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": {"timestamp": 12345}}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        result = await adapter.send(chat_id="+155****4567", content="hello")
+
+        assert result.success is True
+        assert len(captured) == 1
+        assert captured[0]["url"] == "http://localhost:8080/v1/rpc"
+        assert captured[0]["payload"]["method"] == "send"
+        assert captured[0]["payload"]["jsonrpc"] == "2.0"
+        assert captured[0]["payload"]["params"]["message"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_send_typing_uses_sendTyping_method(self, monkeypatch):
+        """send_typing() must POST to /v1/rpc with method=sendTyping."""
+        adapter = _make_signal_adapter(monkeypatch)
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": True}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        await adapter.send_typing("+155****4567")
+
+        assert len(captured) == 1
+        assert captured[0]["url"] == "http://localhost:8080/v1/rpc"
+        assert captured[0]["payload"]["method"] == "sendTyping"
+
+    @pytest.mark.asyncio
+    async def test_send_reaction_uses_sendReaction_method(self, monkeypatch):
+        """send_reaction() must POST to /v1/rpc with method=sendReaction."""
+        adapter = _make_signal_adapter(monkeypatch)
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": True}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        ok = await adapter.send_reaction(
+            chat_id="+155****4567",
+            emoji="👀",
+            target_author="+155****0000",
+            target_timestamp=1712345678000,
+        )
+
+        assert ok is True
+        assert len(captured) == 1
+        assert captured[0]["url"] == "http://localhost:8080/v1/rpc"
+        assert captured[0]["payload"]["method"] == "sendReaction"
+        assert captured[0]["payload"]["params"]["emoji"] == "👀"
+        assert captured[0]["payload"]["params"]["targetAuthor"] == "+155****0000"
+        assert captured[0]["payload"]["params"]["targetTimestamp"] == 1712345678000
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_uses_sendTyping_with_stop_flag(self, monkeypatch):
+        """_stop_typing_indicator() must POST to /v1/rpc with method=sendTyping
+        and params[stop]=True."""
+        adapter = _make_signal_adapter(monkeypatch)
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": True}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        await adapter._stop_typing_indicator("+155****4567")
+
+        assert len(captured) == 1
+        assert captured[0]["url"] == "http://localhost:8080/v1/rpc"
+        assert captured[0]["payload"]["method"] == "sendTyping"
+        assert captured[0]["payload"]["params"]["stop"] is True
+
+    @pytest.mark.asyncio
+    async def test_send_attachment_uses_send_method_with_attachments_param(self, monkeypatch, tmp_path):
+        """_send_attachment() must POST to /v1/rpc with method=send and an
+        attachments array in params."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+
+        captured = []
+
+        async def mock_post(url, **kwargs):
+            captured.append({"url": url, "payload": kwargs.get("json", {})})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"result": {"timestamp": 12345}}
+            return resp
+
+        adapter.client = MagicMock(post=AsyncMock(side_effect=mock_post))
+
+        file_path = tmp_path / "doc.pdf"
+        file_path.write_bytes(b"%PDF" + b"\x00" * 100)
+
+        result = await adapter.send_document(
+            chat_id="+155****4567", file_path=str(file_path), caption="report"
+        )
+
+        assert result.success is True
+        # Only the send RPC should be captured (stop_typing is mocked out)
+        send_calls = [c for c in captured if c["payload"]["method"] == "send"]
+        assert len(send_calls) == 1
+        assert send_calls[0]["url"] == "http://localhost:8080/v1/rpc"
+        assert send_calls[0]["payload"]["method"] == "send"
+        assert send_calls[0]["payload"]["params"]["attachments"] == [str(file_path)]
+        assert send_calls[0]["payload"]["params"]["message"] == "report"
 
 
 class TestRecentSentTimestampRing:

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1,6 +1,9 @@
 """Tests for Signal messenger platform adapter."""
 import asyncio
 import base64
+import contextlib
+import time
+
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -1342,6 +1345,184 @@ class TestSignalSyncMessageHandling:
         assert "event" in captured, "Group sync-sent must reach handle_message"
         assert captured["event"].text == "ping the group"
         assert captured["event"].source.chat_id == "group:abc123=="
+
+
+# ---------------------------------------------------------------------------
+# Health-monitor behaviour (#74871 reviewer feedback): reconnect after extended
+# ``/v1/health`` failure, warn on 120 s receive-loop inactivity.
+# ---------------------------------------------------------------------------
+
+
+class TestSignalHealthMonitor:
+    """Cover the reconnect + inactivity branches in ``_health_monitor``."""
+
+    @pytest.mark.asyncio
+    async def test_reconnect_triggered_after_three_consecutive_failures(self, monkeypatch):
+        """Three failed health checks in a row should trigger a ``connect(is_reconnect=True)``
+        via the live ``self.client``, not just log a warning. Without this the
+        adapter would silently sit on a dead TCP socket that polls return
+        immediately from (#74871)."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+
+        # Pre-arm the state the monitor needs.
+        adapter._running = True
+        adapter.client = MagicMock()
+        adapter._last_receive_at = time.monotonic()
+
+        # Stub ``connect`` so it doesn't actually rebuild the world; we
+        # only care that it gets called.
+        connect_calls = []
+
+        async def fake_connect(*, is_reconnect: bool = False):
+            connect_calls.append(is_reconnect)
+
+        adapter.connect = fake_connect
+
+        # ``asyncio.sleep`` is the only thing blocking the loop — patch it to
+        # no-op so the test runs in microseconds, but use a counter so we
+        # can stop the loop after three iterations.
+        iterations = {"n": 0}
+
+        async def fake_sleep(_seconds):
+            iterations["n"] += 1
+            if iterations["n"] >= 4:
+                # Raise to break out of the ``while self._running`` loop on
+                # the 4th iteration — three failed health checks will have
+                # triggered ``connect(is_reconnect=True)`` by then.
+                raise asyncio.CancelledError
+
+        # Drive the monitor manually instead of starting it as a task so the
+        # test controls the loop bound and we can wait synchronously.
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        # Stub ``client.get`` to always fail (returns 503).
+        failing_response = MagicMock(status_code=503)
+        adapter.client.get = AsyncMock(return_value=failing_response)
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await adapter._health_monitor()
+
+        assert len(connect_calls) == 1, (
+            f"expected reconnect after 3 consecutive failures, got {len(connect_calls)}"
+        )
+        assert connect_calls[0] is True, "reconnect must pass is_reconnect=True"
+
+    @pytest.mark.asyncio
+    async def test_inactivity_warning_after_120s_without_receive(self, monkeypatch):
+        """If the receive loop hasn't yielded in 120 s, log a warning even
+        when ``/v1/health`` keeps returning 200. Empty queues still count
+        as activity (the receive loop updates ``_last_receive_at`` on every
+        successful poll), so a stuck loop is the only failure mode (#74871)."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+        adapter._running = True
+        adapter.client = MagicMock()
+
+        # Pretend the receive loop hasn't fired for 200 s.
+        adapter._last_receive_at = time.monotonic() - 200.0
+
+        healthy_response = MagicMock(status_code=200)
+        adapter.client.get = AsyncMock(return_value=healthy_response)
+
+        connect_calls = []
+
+        async def fake_connect(*, is_reconnect: bool = False):
+            connect_calls.append(is_reconnect)
+
+        adapter.connect = fake_connect
+
+        iterations = {"n": 0}
+
+        async def fake_sleep(_seconds):
+            iterations["n"] += 1
+            if iterations["n"] >= 1:
+                raise asyncio.CancelledError
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await adapter._health_monitor()
+
+        # No reconnect — health endpoint is healthy; the operator-visible
+        # warning is the load-bearing signal here.
+        assert connect_calls == []
+
+    @pytest.mark.asyncio
+    async def test_successful_health_resets_failure_counter(self, monkeypatch):
+        """A successful health probe between failures resets the
+        consecutive-failure window so a single transient blip doesn't
+        eventually trigger a reconnect (#74871)."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+        adapter._running = True
+        adapter.client = MagicMock()
+        adapter._last_receive_at = time.monotonic()
+
+        connect_calls = []
+
+        async def fake_connect(*, is_reconnect: bool = False):
+            connect_calls.append(is_reconnect)
+
+        adapter.connect = fake_connect
+
+        # Sequence: fail, fail, success, fail, fail — only 2 consecutive
+        # fails at any point, so no reconnect should fire even though
+        # total failures > 3.
+        sequence = [
+            MagicMock(status_code=500),  # fail
+            MagicMock(status_code=500),  # fail
+            MagicMock(status_code=200),  # success
+            MagicMock(status_code=500),  # fail
+            MagicMock(status_code=500),  # fail
+        ]
+        adapter.client.get = AsyncMock(side_effect=sequence)
+
+        iterations = {"n": 0}
+
+        async def fake_sleep(_seconds):
+            iterations["n"] += 1
+            if iterations["n"] >= len(sequence):
+                raise asyncio.CancelledError
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await adapter._health_monitor()
+
+        assert connect_calls == [], (
+            f"no consecutive-failure window reached 3; reconnect should NOT "
+            f"have fired but got {connect_calls}"
+        )
+
+    def test_receive_loop_records_last_activity_timestamp(self, monkeypatch):
+        """``_receive_loop`` must update ``_last_receive_at`` on every
+        successful poll (including empty ones) so the monitor can
+        distinguish \"daemon reachable, queue empty\" from \"daemon stuck\"
+        (#74871)."""
+        adapter = _make_signal_adapter(monkeypatch, transport_mode="native")
+        adapter._running = True
+        adapter._last_receive_at = 0.0
+
+        # Track _receive_loop's poll + handle_envelope calls.
+        envelope = {"envelope": {"sourceNumber": "+15551234567", "dataMessage": {"message": "hi", "timestamp": 1}}}
+        response = MagicMock(status_code=200)
+        response.json.return_value = [envelope]
+
+        async def fake_get(url, **kwargs):
+            adapter._running = False  # exit loop after one poll
+            return response
+
+        adapter.client = MagicMock(get=AsyncMock(side_effect=fake_get))
+        adapter._handle_envelope = AsyncMock()
+
+        before = time.monotonic()
+        # _receive_loop is async — run it synchronously via asyncio.run
+        # to exercise the activity-timestamp side-effect end-to-end.
+        asyncio.run(adapter._receive_loop())
+        after = time.monotonic()
+
+        assert before <= adapter._last_receive_at <= after, (
+            f"_last_receive_at ({adapter._last_receive_at}) must fall within "
+            f"the poll interval [{before}, {after}]"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -311,6 +311,36 @@ class TestActiveVenvMarkerStripping:
         from tools.environments.local import _ACTIVE_VENV_MARKER_VARS
         assert "VIRTUAL_ENV" in _ACTIVE_VENV_MARKER_VARS
         assert "CONDA_PREFIX" in _ACTIVE_VENV_MARKER_VARS
+        assert "PYTHONPATH" in _ACTIVE_VENV_MARKER_VARS  # #74817
+
+    def test_pythonpath_marker_stripped_end_to_end(self):
+        """PYTHONPATH from the Hermes venv must not leak (#74817).
+
+        Repro: the gateway process has ``PYTHONPATH`` pointing at the Hermes
+        venv's ``site-packages``. A subprocess that runs its own Python (e.g.
+        ComfyUI Desktop's bundled Python 3.13) inherits it and tries to import
+        Hermes' Python 3.11 compiled extensions (PIL) — crash-loops the child.
+        The end-to-end path mirrors what the agent sees via the terminal tool.
+        """
+        result_env = _run_with_env(extra_os_env={
+            "PYTHONPATH": "/home/user/.hermes/hermes-agent:/home/user/.hermes/hermes-agent/venv/lib/python3.11/site-packages",
+        })
+        assert "PYTHONPATH" not in result_env
+
+    def test_make_run_env_strips_pythonpath(self):
+        """``_make_run_env`` (terminal/execute_code path) must strip PYTHONPATH."""
+        from tools.environments.local import _make_run_env
+        poison = {"PYTHONPATH": "/hermes/venv/site-packages", "PATH": "/usr/bin"}
+        with patch.dict(os.environ, poison, clear=True):
+            result = _make_run_env({})
+        assert "PYTHONPATH" not in result
+
+    def test_hermes_subprocess_env_strips_pythonpath(self):
+        """``hermes_subprocess_env`` (non-terminal spawn surface) must strip PYTHONPATH."""
+        from tools.environments.local import hermes_subprocess_env
+        with patch.dict(os.environ, {"PYTHONPATH": "/hermes/venv/site-packages"}, clear=True):
+            result = hermes_subprocess_env()
+        assert "PYTHONPATH" not in result
 
 
 class TestProfileScopedPassthrough:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1409,12 +1409,21 @@ def execute_code(
         # repo-root modules are available to child scripts.  We also prepend
         # the staging tmpdir so ``from hermes_tools import ...`` resolves even
         # when the subprocess CWD is not tmpdir (project mode).
+        #
+        # NB: we deliberately *do not* append any inherited ``PYTHONPATH``.
+        # The PR strips PYTHONPATH upstream so ``tools/environments/local.py``
+        # spawn paths (subprocess, hermes_subprocess_env, _make_run_env) all
+        # boot children without an inherited PYTHONPATH, but ``execute_code``
+        # here lets PYTHONPATH through ``_SAFE_ENV_PREFIXES`` and would
+        # otherwise re-introduce the cross-project clobber that ``#74817``
+        # fixed: a child Python started with a PYTHONPATH that points at a
+        # *different* venv's site-packages can crash on C-extension import
+        # (PIL in production) or, worse, silently run that venv's tools.
+        # Strip it before composing the sandbox PYTHONPATH so the child only
+        # sees the controlled ``tmpdir`` + ``_hermes_root`` entries below.
         _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        _existing_pp = child_env.get("PYTHONPATH", "")
-        _pp_parts = [tmpdir, _hermes_root]
-        if _existing_pp:
-            _pp_parts.append(_existing_pp)
-        child_env["PYTHONPATH"] = os.pathsep.join(_pp_parts)
+        child_env.pop("PYTHONPATH", None)
+        child_env["PYTHONPATH"] = os.pathsep.join([tmpdir, _hermes_root])
         # Inject user's configured timezone so datetime.now() in sandboxed
         # code reflects the correct wall-clock time.  Only TZ is set —
         # HERMES_TIMEZONE is an internal Hermes setting and must not leak

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -346,7 +346,26 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # to a different Python version overwrites it and breaks the gateway). The
 # Hermes venv stays reachable via PATH (its bin dir is first), so stripping
 # these markers is safe and only prevents the cross-project clobber (#23473).
-_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
+_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX", "PYTHONPATH")
+
+
+def _strip_active_venv_markers(env: dict) -> None:
+    """Strip env vars that would mark a different venv as "active" for a child.
+
+    ``VIRTUAL_ENV`` / ``CONDA_PREFIX`` cause tools like ``uv`` / ``poetry`` to
+    treat the inherited value as the active environment and mutate that other
+    project (cross-project clobber, #23473). ``PYTHONPATH`` is the Python
+    analog: it points at the Hermes bundled venv's site-packages and would
+    override / break a child that runs its own Python with a different
+    interpreter or third-party extensions (PIL C-extension import crash in
+    production, #74817). The Hermes venv stays reachable via PATH (its bin
+    dir is first), so stripping these markers is safe and only prevents the
+    cross-project crash. Called from every spawn path (``_make_run_env``,
+    ``_sanitize_subprocess_env``, ``hermes_subprocess_env``) so the fix is
+    uniform regardless of which surface spawned the child.
+    """
+    for _marker in _ACTIVE_VENV_MARKER_VARS:
+        env.pop(_marker, None)
 
 
 def _is_hermes_internal_secret(key: str) -> bool:
@@ -503,8 +522,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # spawn path (process_registry.spawn_local builds env via this function).
     _inject_session_context_env(sanitized)
 
-    for _marker in _ACTIVE_VENV_MARKER_VARS:
-        sanitized.pop(_marker, None)
+    _strip_active_venv_markers(sanitized)
 
     _apply_windows_msys_bash_env_defaults(sanitized)
 
@@ -631,9 +649,7 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(env)
 
-    # Active-venv markers must not clobber another project's environment.
-    for _marker in _ACTIVE_VENV_MARKER_VARS:
-        env.pop(_marker, None)
+    _strip_active_venv_markers(env)
 
     _apply_windows_msys_bash_env_defaults(env)
 
@@ -1318,8 +1334,7 @@ def _make_run_env(env: dict) -> dict:
     # engaged so a sibling session's os.environ mirror can't leak in).
     _inject_session_context_env(run_env)
 
-    for _marker in _ACTIVE_VENV_MARKER_VARS:
-        run_env.pop(_marker, None)
+    _strip_active_venv_markers(run_env)
 
     _apply_windows_msys_bash_env_defaults(run_env)
 

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -6,7 +6,7 @@ description: "Set up Hermes Agent as a Signal messenger bot via signal-cli daemo
 
 # Signal Setup
 
-Hermes connects to Signal through the [signal-cli](https://github.com/AsamK/signal-cli) daemon running in HTTP mode. The adapter streams messages in real-time via SSE (Server-Sent Events) and sends responses via JSON-RPC.
+Hermes connects to Signal through the [signal-cli](https://github.com/AsamK/signal-cli) daemon running in HTTP mode. The adapter polls for inbound messages via HTTP and sends responses via JSON-RPC.
 
 Signal is the most privacy-focused mainstream messenger — end-to-end encrypted by default, open-source protocol, minimal metadata collection. This makes it ideal for security-sensitive agent workflows.
 
@@ -72,8 +72,8 @@ Keep this running in the background. You can use `systemd`, `tmux`, `screen`, or
 Verify it's running:
 
 ```bash
-curl http://127.0.0.1:8080/api/v1/check
-# Should return: {"versions":{"signal-cli":...}}
+curl http://127.0.0.1:8080/v1/health
+# Should return 200/204 (healthy)
 ```
 
 ---
@@ -212,9 +212,9 @@ Just send a message to yourself from your phone — signal-cli picks it up and H
 
 ### Health Monitoring
 
-The adapter monitors the SSE connection and automatically reconnects if:
-- The connection drops (with exponential backoff: 2s → 60s)
-- No activity is detected for 120 seconds (pings signal-cli to verify)
+The adapter monitors the daemon via periodic HTTP health checks (`/v1/health`) and automatically reconnects if:
+- A health check returns a non-200/204 status (with exponential backoff: 2s → 60s)
+- No activity is detected for 120 seconds
 
 ---
 
@@ -225,7 +225,7 @@ The adapter monitors the SSE connection and automatically reconnects if:
 | **"Cannot reach signal-cli"** during setup | Ensure signal-cli daemon is running: `signal-cli --account +YOUR_NUMBER daemon --http 127.0.0.1:8080` |
 | **Messages not received** | Check that `SIGNAL_ALLOWED_USERS` includes the sender's number in E.164 format (with `+` prefix) |
 | **"signal-cli not found on PATH"** | Install signal-cli and ensure it's in your PATH, or use Docker |
-| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 17+ is installed. |
+| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 17+ is installed. Verify health check passes: `curl http://127.0.0.1:8080/v1/health` |
 | **Group messages ignored** | Configure `SIGNAL_GROUP_ALLOWED_USERS` with specific group IDs, or `*` to allow all groups. |
 | **Bot responds to no one** | Configure `SIGNAL_ALLOWED_USERS`, use DM pairing, or explicitly allow all users through gateway policy if you want broader access. |
 | **Duplicate messages** | Ensure only one signal-cli instance is listening on your phone number |


### PR DESCRIPTION
## What

The Hermes gateway process has `PYTHONPATH` pointing at the bundled venv's `site-packages`. Every subprocess spawned via the terminal tool (`LocalEnvironment`), the `execute_code` path, and the non-terminal `hermes_subprocess_env()` helper inherited it.

For a child that runs its own Python (e.g. ComfyUI Desktop's bundled Python 3.13), `PYTHONPATH` forced import of Hermes' Python 3.11 compiled extensions — production crash loop in ComfyUI's `comfy_execution/progress.py` PIL import.

## Fix

- Add `PYTHONPATH` to `_ACTIVE_VENV_MARKER_VARS` (alongside `VIRTUAL_ENV` / `CONDA_PREFIX`)
- Refactor the three duplicated `for _marker in _ACTIVE_VENV_MARKER_VARS: env.pop(...) ` strips in `_make_run_env` / `_sanitize_subprocess_env` / `hermes_subprocess_env` into a single `_strip_active_venv_markers(env)` helper so the fix is uniform across every spawn surface
- Hermes venv stays reachable via PATH (its bin dir is first), so stripping is safe

## Tests

Added 3 cases to `tests/tools/test_local_env_blocklist.py::TestActiveVenvMarkerStripping`:
- `test_pythonpath_marker_stripped_end_to_end` — terminal tool path
- `test_make_run_env_strips_pythonpath` — terminal/execute_code path
- `test_hermes_subprocess_env_strips_pythonpath` — non-terminal spawn surface (browser, ACP, computer-use, etc.)

Plus update to `test_markers_constant_contents` asserting `PYTHONPATH` is in the constant.

**All 45 tests in the relevant files pass locally** (`tests/tools/test_local_env_blocklist.py` + `test_local_env_session_leak.py`).

## Repro (from issue #74817)

```
$ hermes -z "Run this exact terminal command and show me the raw output: echo \"PYTHONPATH='\C:\Users\admin\AppData\Local\hermes\hermes-agent;C:\Users\admin\AppData\Local\hermes\hermes-agent\venv\Lib\site-packages'\""
Raw output:
PYTHONPATH='/Users/…/.hermes/hermes-agent:/Users/…/.hermes/hermes-agent/venv/lib/python3.11/site-packages'
```

After this fix: `PYTHONPATH='...'` → empty (var stripped before subprocess sees it).

Fixes NousResearch/hermes-agent#74817