### PR TITLE
fix(gateway): support stacked skill commands

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -464,6 +464,60 @@ def test_slash_exec_rejects_skill_commands(server):
     assert "skill command" in resp["error"]["message"]
 
 
+def test_command_dispatch_expands_stacked_skills_from_temp_home(
+    server, tmp_path, monkeypatch
+):
+    """Desktop/TUI dispatch scans and expands every real leading skill."""
+    import agent.skill_commands as skill_commands
+    import tools.skills_tool as skills_tool
+
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    for name, instructions in (
+        ("nature-figure", "Render figures with natural colors."),
+        ("academic-plotting", "Label every axis and include units."),
+    ):
+        skill_dir = skills_dir / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: Test {name}.\n---\n\n{instructions}\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # skills_tool is imported by the gateway fixture before HERMES_HOME is set;
+    # point its import-time compatibility constant at the same temporary home.
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skill_commands, "_skill_commands", {})
+    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid, "agent": None}
+    resp = server.handle_request({
+        "id": "stacked-skills",
+        "method": "command.dispatch",
+        "params": {
+            "name": "nature-figure",
+            "arg": "/academic-plotting Plot the results",
+            "session_id": sid,
+        },
+    })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "skill"
+    assert result["notice"] == (
+        "⚡ Loading 2 stacked skills: nature-figure, academic-plotting"
+    )
+    assert "Skills loaded: nature-figure, academic-plotting" in result["message"]
+    assert "Render figures with natural colors." in result["message"]
+    assert "Label every axis and include units." in result["message"]
+    assert "User instruction: Plot the results" in result["message"]
+    assert result["display"] == (
+        "/nature-figure /academic-plotting Plot the results"
+    )
+
+
 def test_command_dispatch_queue_sends_message(server):
     """command.dispatch /queue returns {type: 'send', message: ...} for the TUI."""
     sid = "test-session"

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1122,6 +1122,58 @@ def test_slash_exec_scopes_skill_lookup_to_session_profile(server, tmp_path):
     assert "skill command" in resp["error"]["message"]
 
 
+def test_command_dispatch_expands_stacked_skills_from_temp_home(
+    server, tmp_path, monkeypatch
+):
+    """Desktop/TUI dispatch scans and expands every real leading skill."""
+    import agent.skill_commands as skill_commands
+    import tools.skills_tool as skills_tool
+
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    for name, instructions in (
+        ("nature-figure", "Render figures with natural colors."),
+        ("academic-plotting", "Label every axis and include units."),
+    ):
+        skill_dir = skills_dir / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: Test {name}.\n---\n\n{instructions}\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skill_commands, "_skill_commands", {})
+    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid, "agent": None}
+    resp = server.handle_request({
+        "id": "stacked-skills",
+        "method": "command.dispatch",
+        "params": {
+            "name": "nature-figure",
+            "arg": "/academic-plotting Plot the results",
+            "session_id": sid,
+        },
+    })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "skill"
+    assert result["notice"] == (
+        "⚡ Loading 2 stacked skills: nature-figure, academic-plotting"
+    )
+    assert "Skills loaded: nature-figure, academic-plotting" in result["message"]
+    assert "Render figures with natural colors." in result["message"]
+    assert "Label every axis and include units." in result["message"]
+    assert "User instruction: Plot the results" in result["message"]
+    assert result["display"] == (
+        "/nature-figure /academic-plotting Plot the results"
+    )
+
+
 def test_command_dispatch_queue_sends_message(server):
     """command.dispatch /queue returns {type: 'send', message: ...} for the TUI."""
     sid = "test-session"

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -543,15 +543,42 @@ def _(rid, params: dict) -> dict:
 
     try:
         from agent.skill_commands import (
-            scan_skill_commands,
             build_skill_invocation_message,
+            build_stacked_skill_invocation_message,
+            scan_skill_commands,
+            split_stacked_skill_commands,
         )
 
         cmds = scan_skill_commands()
         key = f"/{name}"
         if key in cmds:
+            extra_keys, user_instruction = split_stacked_skill_commands(arg)
+            if extra_keys:
+                stacked = build_stacked_skill_invocation_message(
+                    [key, *extra_keys],
+                    user_instruction,
+                    task_id=session.get("session_key", "") if session else "",
+                )
+                if stacked:
+                    msg, loaded_names, missing = stacked
+                    notice = f"⚡ Loading {len(loaded_names)} stacked skills: {', '.join(loaded_names)}"
+                    if missing:
+                        notice += f"\nSkipped missing skills: {', '.join(missing)}"
+                    return _ok(
+                        rid,
+                        {
+                            "type": "skill",
+                            "message": msg,
+                            "name": cmds[key].get("name", name),
+                            "notice": notice,
+                            "display": _skill_scaffold_projection(msg),
+                        },
+                    )
+
             msg = build_skill_invocation_message(
-                key, arg, task_id=session.get("session_key", "") if session else ""
+                key,
+                user_instruction,
+                task_id=session.get("session_key", "") if session else "",
             )
             if msg:
                 return _ok(

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -580,15 +580,42 @@ def _(rid, params: dict) -> dict:
 
     try:
         from agent.skill_commands import (
-            scan_skill_commands,
             build_skill_invocation_message,
+            build_stacked_skill_invocation_message,
+            scan_skill_commands,
+            split_stacked_skill_commands,
         )
 
         cmds = scan_skill_commands()
         key = f"/{name}"
         if key in cmds:
+            extra_keys, user_instruction = split_stacked_skill_commands(arg)
+            if extra_keys:
+                stacked = build_stacked_skill_invocation_message(
+                    [key, *extra_keys],
+                    user_instruction,
+                    task_id=session.get("session_key", "") if session else "",
+                )
+                if stacked:
+                    msg, loaded_names, missing = stacked
+                    notice = f"⚡ Loading {len(loaded_names)} stacked skills: {', '.join(loaded_names)}"
+                    if missing:
+                        notice += f"\nSkipped missing skills: {', '.join(missing)}"
+                    return _ok(
+                        rid,
+                        {
+                            "type": "skill",
+                            "message": msg,
+                            "name": cmds[key].get("name", name),
+                            "notice": notice,
+                            "display": _skill_scaffold_projection(msg),
+                        },
+                    )
+
             msg = build_skill_invocation_message(
-                key, arg, task_id=session.get("session_key", "") if session else ""
+                key,
+                user_instruction,
+                task_id=session.get("session_key", "") if session else "",
             )
             if msg:
                 return _ok(


### PR DESCRIPTION
## Summary

- make the gateway `command.dispatch` path recognize stacked leading skill commands
- reuse the existing `split_stacked_skill_commands` and `build_stacked_skill_invocation_message` helpers already used by the CLI
- preserve the existing single-skill dispatch path and return a safe display projection for Desktop/TUI clients
- add a regression test covering `/nature-figure /academic-plotting Plot the results`

## Root cause

Desktop parses the first slash token as the command name and sends the remaining text as `arg`. The gateway's `command.dispatch` skill branch passed that entire argument to `build_skill_invocation_message`, so subsequent `/skill` tokens were treated as user instruction text instead of additional skills.

The CLI already handles the same input by splitting leading skill commands and building one stacked invocation. This change applies that established behavior to the shared Desktop/TUI gateway dispatch path.

## Verification

```text
uv run --no-project --with pytest --with pytest-xdist python -m pytest tests/tui_gateway/test_protocol.py -q -n 0
38 passed in 9.50s

uvx ruff check tui_gateway/methods_tools.py tests/tui_gateway/test_protocol.py
All checks passed!

git diff --check
passed
```

Fixes #74705
