### PR TITLE
fix(computer-use): restart CUA session after timeout

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1031,7 +1031,7 @@ class TestCuaDriverWindowResultShapes:
 
 
 class TestCuaDriverSessionReconnect:
-    """Verify reconnect-once on a closed-resource error. After the
+    """Verify recovery after a closed-resource error or timeout. After the
     lifecycle-owner refactor (Sun Jun 21 2026) the session no longer goes
     through bridge.run(_aenter/_aexit); instead, reconnect calls
     `_stop_lifecycle_locked` + `_start_lifecycle_locked` directly. The
@@ -1088,6 +1088,47 @@ class TestCuaDriverSessionReconnect:
         assert session._reconnect_log == ["stop", "start"]
         assert bridge.calls[1][0] == ("call", "list_apps", {})
         assert len(bridge.calls) == 2
+
+
+    def test_call_tool_restarts_after_timeout_without_retrying(self):
+        """Recycle a timed-out session without repeating an ambiguous tool call."""
+        import concurrent.futures
+
+        class FakeBridge:
+            def __init__(self):
+                self.calls = []
+                self.effects = [
+                    concurrent.futures.TimeoutError(),
+                    {"ok": True},
+                ]
+
+            def run(self, value, timeout=None):
+                self.calls.append((value, timeout))
+                effect = self.effects.pop(0)
+                if isinstance(effect, Exception):
+                    raise effect
+                return effect
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+
+        with pytest.raises(
+            RuntimeError,
+            match="cua-driver MCP timed out on get_window_state",
+        ) as exc_info:
+            session.call_tool("get_window_state", {"window_id": 42})
+
+        assert isinstance(exc_info.value.__cause__, concurrent.futures.TimeoutError)
+        assert session._reconnect_log == ["stop", "start"]
+        assert [call[0] for call in bridge.calls] == [
+            ("call", "get_window_state", {"window_id": 42}),
+        ]
+
+        assert session.call_tool("list_apps", {}) == {"ok": True}
+        assert [call[0] for call in bridge.calls] == [
+            ("call", "get_window_state", {"window_id": 42}),
+            ("call", "list_apps", {}),
+        ]
 
 
     def test_cli_fallback_reads_screenshot_from_file(self, tmp_path, monkeypatch):

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1501,8 +1501,8 @@ class _CuaDriverSession:
         )
 
     def _restart_session_locked(self) -> None:
-        """Recreate the MCP session after the daemon/stdin transport was closed.
-        Caller must hold self._lock (the reconnect-once retry path holds it)."""
+        """Recreate the MCP session after its transport closes or a call times out.
+        Caller must hold self._lock (the recovery paths hold it)."""
         if self._started:
             try:
                 self._stop_lifecycle_locked()
@@ -1670,6 +1670,15 @@ class _CuaDriverSession:
                 timeout=timeout,
             )
         except Exception as e:
+            if isinstance(e, concurrent.futures.TimeoutError):
+                logger.warning(
+                    "cua-driver MCP timed out on %s; restarting session", name
+                )
+                with self._lock:
+                    self._restart_session_locked()
+                raise RuntimeError(
+                    f"cua-driver MCP timed out on {name}; session restarted"
+                ) from e
             if self._is_transient_daemon_error(e):
                 logger.warning(
                     "cua-driver MCP transport failed on %s (%s); "


### PR DESCRIPTION
Fixes #74799

## What does this PR do?

When a cua-driver MCP call reaches the bridge timeout, the old session can stay marked as active even though it is no longer usable. Later computer-use calls then keep using the same broken session.

This change restarts the MCP session after a timeout and returns a clear error that names the timed-out tool. It does not retry that tool because the action may have completed before the timeout, and repeating it could perform the action twice. The next separate call can use the new session.

## Related Issue

Fixes #74799

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Restart the cua-driver MCP session when the bridge raises a timeout.
- Raise a named `RuntimeError` after the restart without retrying the timed-out tool call.
- Keep the original timeout as the exception cause.
- Add a regression test for one restart, no duplicate call, and a successful later call.

## How to Test

The new regression test failed before the implementation because the raw `TimeoutError` escaped and the session was not restarted.

Verification run with the project virtual environment:

```bash
python -m pytest tests/tools/test_computer_use.py::TestCuaDriverSessionReconnect -q -p no:cacheprovider
# 3 passed

python -m pytest tests/tools/test_computer_use.py tests/tools/test_computer_use_delivery_ladder.py tests/tools/test_computer_use_cua_0_9.py tests/computer_use/test_cua_spawn_env_sanitization.py tests/computer_use/test_cua_cli_fallback_env.py -q -p no:cacheprovider -k "not test_linux_default_capture_skips_gnome_shell_helper"
# 134 passed, 1 deselected

ruff check --no-cache tools/computer_use/cua_backend.py tests/tools/test_computer_use.py
# All checks passed

git diff --check origin/main...HEAD
```

The deselected Linux-only window-selection test fails on macOS 26.5.1 because it does not replace `sys.platform`. The same failure was reproduced on a clean `origin/main` checkout at `b4f8c491d`, so this PR leaves it unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 with focused pytest

### Documentation & Housekeeping

- [x] User documentation is N/A; the adjacent session-restart docstring was updated
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] Cross-platform impact was considered; this uses the existing Python session-restart path
- [x] Tool descriptions and schemas are N/A because no model-facing schema or instruction changed
