### PR TITLE
docs: qualify TUI development commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,16 +464,17 @@ Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. Se
 
 ### Dev Commands
 
+Run these commands from the repository root:
+
 ```bash
-cd ui-tui
-npm install       # first time
-npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm start         # production
-npm run build     # full build (hermes-ink + tsc)
-npm run typecheck # typecheck only (tsc --noEmit)
-npm run lint      # eslint
-npm run fmt       # prettier
-npm test          # vitest
+npm run install:tui                  # first time
+npm run dev --workspace ui-tui       # watch mode (rebuilds hermes-ink + tsx --watch)
+npm run start --workspace ui-tui     # production
+npm run build --workspace ui-tui     # bundle TUI entrypoint with esbuild
+npm run typecheck --workspace ui-tui # typecheck only (tsc --noEmit)
+npm run lint --workspace ui-tui      # eslint
+npm run fmt --workspace ui-tui       # prettier
+npm run test --workspace ui-tui      # vitest
 ```
 
 ### TUI in the Dashboard (`hermes dashboard` → `/chat`)


### PR DESCRIPTION
## Summary

- Run the documented TUI development commands from the repository root.
- Use the root `install:tui` script for installation and qualify each TUI lifecycle command with `--workspace ui-tui`.
- Correct the build command description to match the workspace's esbuild bundle.

## Verification

- PASS: package-manifest validator resolved all 8 documented commands to `package.json` or `ui-tui/package.json` scripts.
- PASS: `npm run build --workspace ui-tui`.
- PASS: `npm run typecheck --workspace ui-tui`.
- PASS: `npm run lint --workspace ui-tui`.
- PASS: `git diff --check upstream/main...HEAD`.
- NOT AVAILABLE: `npm run verify` is not defined in the root package manifest.
- BASELINE WINDOWS FAILURES: `npm run check --workspace ui-tui` reached 1,423 passing and 8 skipped tests, with 8 failures in three terminal/path suites that are unrelated to this AGENTS.md-only diff. Required CI on Linux remains authoritative.

## Pre-Landing Review

- Scope check: clean; only `AGENTS.md` changes.
- No code, security, data-safety, or runtime findings.

## Base freshness

- The task branch was created from freshly fetched fork `origin/main` at `1001cd2d3469236219ae25ddea131299bd48258f` with distance 0.
- Because the fork base was stale relative to the upstream target, the docs commit was rebased onto freshly fetched `upstream/main` at `36e41c09ed02bd783c1186564bf08cca5c8e821d` before push.
- Final distance from `upstream/main`: 0 commits behind, 1 commit ahead.
