### PR TITLE
fix(matrix): update HTML sanitizer for current spec

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -214,58 +214,171 @@ def _strip_reply_fallback(body: str) -> str:
 
 
 class _MatrixHtmlSanitizer(HTMLParser):
-    """Allowlist sanitizer for Matrix-compatible formatted HTML."""
+    """Allowlist sanitizer for Matrix-compatible formatted HTML.
 
-    _ALLOWED_TAGS = {
-        "a", "b", "blockquote", "br", "code", "del", "em", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "li", "ol",
-        "p", "pre", "s", "strike", "strong", "table", "tbody", "td", "th", "thead", "tr", "ul"}
-    _VOID_TAGS = {"br", "hr"}
+    The allowlist and attribute rules mirror Matrix Client-Server API v1.19:
+    https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
+    """
+
+    _SPEC_ALLOWED_TAGS = {
+        "a", "b", "blockquote", "br", "caption", "code", "del", "details",
+        "div", "em", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img",
+        "li", "ol", "p", "pre", "s", "span", "strong", "sub", "summary", "sup",
+        "table", "tbody", "td", "th", "thead", "tr", "u", "ul",
+    }
+    # Compatibility with HTML previously emitted by Hermes. Canonicalizing the
+    # obsolete tag keeps the sanitized output within the v1.19 allowlist.
+    _COMPAT_TAG_ALIASES = {"strike": "s"}
+    _VOID_TAGS = {"br", "hr", "img"}
+    _SKIP_CONTENT_TAGS = {"mx-reply", "script", "style"}
+    _MAX_DEPTH = 100
+    _SPEC_LINK_SCHEMES = {"ftp", "http", "https", "magnet", "mailto"}
+    # Compatibility divergence: Matrix URI deep links were supported by the
+    # previous Hermes sanitizer, but are not named in v1.19's recommended list.
+    _COMPAT_LINK_SCHEMES = {"matrix"}
+    _COLOR_ATTRIBUTES = {"data-mx-bg-color", "data-mx-color"}
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=False)
         self._parts: list[str] = []
-        self._skip_depth = 0
+        self._skip_tags: list[str] = []
+        self._open_tags: list[tuple[str, bool]] = []
+        self._render_depth = 0
 
-    @staticmethod
-    def _safe_url(value: str) -> str:
+    @classmethod
+    def _safe_link_url(cls, value: str) -> str:
         stripped = re.sub(r"[\x00-\x1f\x7f]+", "", value or "").strip()
         match = re.match(r"^([A-Za-z][A-Za-z0-9+.-]*):", stripped)
         scheme = match.group(1).lower() if match else ""
-        if scheme and scheme not in {"http", "https", "matrix", "mailto"}:
+        allowed_schemes = cls._SPEC_LINK_SCHEMES | cls._COMPAT_LINK_SCHEMES
+        return stripped if scheme in allowed_schemes else ""
+
+    @staticmethod
+    def _safe_mxc_url(value: str) -> str:
+        stripped = re.sub(r"[\x00-\x1f\x7f]+", "", value or "").strip()
+        try:
+            parsed = urlsplit(stripped)
+            port = parsed.port
+        except ValueError:
             return ""
-        return stripped
+        return stripped if (
+            parsed.scheme.lower() == "mxc"
+            and re.fullmatch(
+                r"(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?",
+                parsed.netloc,
+            )
+            and port != 0
+            and not parsed.query
+            and not parsed.fragment
+            and re.fullmatch(r"/[A-Za-z0-9_-]+", parsed.path)
+        ) else ""
 
     def _safe_attrs(self, tag: str, attrs: list[tuple[str, str | None]]) -> str:
         safe: list[str] = []
+        seen: set[str] = set()
         for key, value in attrs:
             attr = str(key or "").lower()
+            if not attr or attr in seen:
+                continue
+            seen.add(attr)
             raw_value = "" if value is None else str(value)
             if tag == "a" and attr == "href":
-                href = self._safe_url(raw_value)
+                href = self._safe_link_url(raw_value)
                 if href:
                     safe.append(f' href="{_html_escape(href, quote=True)}"')
-            elif tag == "code" and attr == "class" and re.fullmatch(r"language-[A-Za-z0-9_+.-]{1,64}", raw_value):
-                safe.append(f' class="{_html_escape(raw_value, quote=True)}"')
+            elif tag == "a" and attr == "target":
+                safe.append(f' target="{_html_escape(raw_value, quote=True)}"')
+            elif tag == "code" and attr == "class":
+                classes = [
+                    item
+                    for item in raw_value.split()
+                    if re.fullmatch(r"language-[A-Za-z0-9_+.-]{1,64}", item)
+                ]
+                if classes:
+                    safe.append(
+                        f' class="{_html_escape(" ".join(classes), quote=True)}"'
+                    )
+            elif tag == "div" and attr == "data-mx-maths":
+                safe.append(
+                    f' data-mx-maths="{_html_escape(raw_value, quote=True)}"'
+                )
+            elif tag == "img" and attr == "src":
+                src = self._safe_mxc_url(raw_value)
+                if src:
+                    safe.append(f' src="{_html_escape(src, quote=True)}"')
+            elif tag == "img" and attr in {"alt", "title"}:
+                safe.append(f' {attr}="{_html_escape(raw_value, quote=True)}"')
+            elif (
+                tag == "img"
+                and attr in {"height", "width"}
+                and re.fullmatch(r"[0-9]+", raw_value)
+            ):
+                safe.append(f' {attr}="{raw_value}"')
+            elif (
+                tag == "ol"
+                and attr == "start"
+                and re.fullmatch(r"[+-]?[0-9]+", raw_value)
+            ):
+                safe.append(f' start="{raw_value}"')
+            elif tag == "span" and attr in self._COLOR_ATTRIBUTES:
+                if re.fullmatch(r"#[0-9A-Fa-f]{6}", raw_value):
+                    safe.append(f' {attr}="{raw_value}"')
+            elif tag == "span" and attr in {"data-mx-maths", "data-mx-spoiler"}:
+                safe.append(f' {attr}="{_html_escape(raw_value, quote=True)}"')
         return "".join(safe)
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         tag = tag.lower()
-        if tag in {"script", "style"}:
-            self._skip_depth += 1
-        elif not self._skip_depth and tag in self._ALLOWED_TAGS:
-            self._parts.append(f"<{tag}>" if tag in self._VOID_TAGS else f"<{tag}{self._safe_attrs(tag, attrs)}>")
+        if self._skip_tags:
+            if tag == self._skip_tags[-1]:
+                self._skip_tags.append(tag)
+            return
+        if tag in self._SKIP_CONTENT_TAGS:
+            self._skip_tags.append(tag)
+            return
+        tag = self._COMPAT_TAG_ALIASES.get(tag, tag)
+        if tag not in self._SPEC_ALLOWED_TAGS:
+            return
+        if tag in self._VOID_TAGS:
+            if self._render_depth < self._MAX_DEPTH:
+                self._parts.append(f"<{tag}{self._safe_attrs(tag, attrs)}>")
+            return
+        rendered = self._render_depth < self._MAX_DEPTH
+        self._open_tags.append((tag, rendered))
+        if rendered:
+            self._parts.append(f"<{tag}{self._safe_attrs(tag, attrs)}>")
+            self._render_depth += 1
 
     def handle_endtag(self, tag: str) -> None:
         tag = tag.lower()
-        if tag in {"script", "style"} and self._skip_depth:
-            self._skip_depth -= 1
+        if self._skip_tags:
+            if tag == self._skip_tags[-1]:
+                self._skip_tags.pop()
             return
-        if self._skip_depth or tag not in self._ALLOWED_TAGS or tag in self._VOID_TAGS:
+        tag = self._COMPAT_TAG_ALIASES.get(tag, tag)
+        if tag not in self._SPEC_ALLOWED_TAGS or tag in self._VOID_TAGS:
             return
-        self._parts.append(f"</{tag}>")
+
+        match_index = next(
+            (
+                index
+                for index in range(len(self._open_tags) - 1, -1, -1)
+                if self._open_tags[index][0] == tag
+            ),
+            None,
+        )
+        if match_index is None:
+            return
+
+        closing = self._open_tags[match_index:]
+        del self._open_tags[match_index:]
+        for open_tag, rendered in reversed(closing):
+            if rendered:
+                self._parts.append(f"</{open_tag}>")
+                self._render_depth -= 1
 
     def _emit(self, text: str) -> None:
-        if not self._skip_depth:
+        if not self._skip_tags:
             self._parts.append(text)
 
     def handle_data(self, data: str) -> None:
@@ -278,6 +391,11 @@ class _MatrixHtmlSanitizer(HTMLParser):
         self._emit(f"&#{name};")
 
     def get_html(self) -> str:
+        for tag, rendered in reversed(self._open_tags):
+            if rendered:
+                self._parts.append(f"</{tag}>")
+        self._open_tags.clear()
+        self._render_depth = 0
         return "".join(self._parts)
 
 
@@ -2642,8 +2760,12 @@ class MatrixAdapter(BasePlatformAdapter):
             msg_content["m.mentions"] = {"user_ids": mention_user_ids}
         if self._allow_room_mentions and self._has_outbound_room_mention(text):
             msg_content.setdefault("m.mentions", {})["room"] = True
-        html = self._markdown_to_html(self._inject_outbound_mention_links(text))
-        if html and html != text:
+
+        html_source = self._inject_outbound_mention_links(text)
+        html = self._markdown_to_html(html_source)
+        # Raw HTML can be unchanged by conversion but still requires the
+        # formatted_body field for Matrix clients to render it as HTML.
+        if html and (html != text or ("<" in html_source and ">" in html_source)):
             msg_content["format"] = "org.matrix.custom.html"
             msg_content["formatted_body"] = html
         return msg_content
@@ -2747,20 +2869,33 @@ class MatrixAdapter(BasePlatformAdapter):
             return mxc_url
         return f"{self._homeserver}/_matrix/client/v1/media/download/{mxc_url[6:]}"
 
-    def _markdown_to_html(self, text: str) -> str:
+    @staticmethod
+    def _markdown_to_html(text: str) -> str:
         """Markdown → org.matrix.custom.html via ``markdown`` when installed, else the regex fallback."""
         text = _pre_sanitize_matrix_markdown(text)
         with suppress(ImportError):
             import markdown as _md
-            md = _md.Markdown(extensions=["fenced_code", "tables", "nl2br", "sane_lists"])
-            if "html_block" in md.preprocessors:
-                md.preprocessors.deregister("html_block")
+
+            md = _md.Markdown(
+                extensions=["fenced_code", "tables", "nl2br", "sane_lists"],
+            )
+
+            # Keep raw HTML enabled so Matrix-supported structures such as
+            # <details> survive conversion. The final sanitizer below remains
+            # the security boundary for all Markdown and raw HTML output.
             html = md.convert(text)
             md.reset()
-            if html.count("<p>") == 1:
-                html = html.replace("<p>", "").replace("</p>", "")
+
+            if (
+                html.startswith("<p>")
+                and html.endswith("</p>")
+                and html.count("<p>") == 1
+                and html.count("</p>") == 1
+            ):
+                html = html[3:-4]
             return _sanitize_matrix_html(html)
-        return _sanitize_matrix_html(self._markdown_to_html_fallback(text))
+
+        return _sanitize_matrix_html(MatrixAdapter._markdown_to_html_fallback(text))
 
     @staticmethod
     def _sanitize_link_url(url: str) -> str:
@@ -2864,11 +2999,11 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
         url = f"{homeserver}/_matrix/client/v3/rooms/{quote(chat_id, safe='')}/send/m.room.message/{txn_id}"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         payload = {"msgtype": "m.text", "body": message}
-        with suppress(ImportError):
-            import markdown as _md
-            html = _md.markdown(message, extensions=["fenced_code", "tables"])
+        html = MatrixAdapter._markdown_to_html(message)
+        if html:
             payload["format"] = "org.matrix.custom.html"
-            payload["formatted_body"] = re.sub(r"<h[1-6]>(.*?)</h[1-6]>", r"<strong>\1</strong>", html)
+            payload["formatted_body"] = html
+
         # asyncio.wait_for, not aiohttp.ClientTimeout: cron invokes this via
         # run_coroutine_threadsafe ("Timeout context manager should be used inside a task").
         async with aiohttp.ClientSession() as session:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -344,81 +344,189 @@ def _normalize_matrix_bang_command(text: str) -> str:
 
 
 class _MatrixHtmlSanitizer(HTMLParser):
-    """Allowlist sanitizer for Matrix-compatible formatted HTML."""
+    """Allowlist sanitizer for Matrix-compatible formatted HTML.
 
-    _ALLOWED_TAGS = {
-        "a", "b", "blockquote", "br", "code", "del", "em", "h1", "h2", "h3",
-        "h4", "h5", "h6", "hr", "i", "li", "ol", "p", "pre", "s", "strike",
-        "strong", "table", "tbody", "td", "th", "thead", "tr", "ul",
+    The allowlist and attribute rules mirror Matrix Client-Server API v1.19:
+    https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
+    """
+
+    _SPEC_ALLOWED_TAGS = {
+        "a", "b", "blockquote", "br", "caption", "code", "del", "details",
+        "div", "em", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img",
+        "li", "ol", "p", "pre", "s", "span", "strong", "sub", "summary", "sup",
+        "table", "tbody", "td", "th", "thead", "tr", "u", "ul",
     }
-    _VOID_TAGS = {"br", "hr"}
+    # Compatibility with HTML previously emitted by Hermes. Canonicalizing the
+    # obsolete tag keeps the sanitized output within the v1.19 allowlist.
+    _COMPAT_TAG_ALIASES = {"strike": "s"}
+    _VOID_TAGS = {"br", "hr", "img"}
+    _SKIP_CONTENT_TAGS = {"mx-reply", "script", "style"}
+    _MAX_DEPTH = 100
+    _SPEC_LINK_SCHEMES = {"ftp", "http", "https", "magnet", "mailto"}
+    # Compatibility divergence: Matrix URI deep links were supported by the
+    # previous Hermes sanitizer, but are not named in v1.19's recommended list.
+    _COMPAT_LINK_SCHEMES = {"matrix"}
+    _COLOR_ATTRIBUTES = {"data-mx-bg-color", "data-mx-color"}
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=False)
         self._parts: list[str] = []
-        self._skip_depth = 0
+        self._skip_tags: list[str] = []
+        self._open_tags: list[tuple[str, bool]] = []
+        self._render_depth = 0
 
-    @staticmethod
-    def _safe_url(value: str) -> str:
+    @classmethod
+    def _safe_link_url(cls, value: str) -> str:
         stripped = re.sub(r"[\x00-\x1f\x7f]+", "", value or "").strip()
         match = re.match(r"^([A-Za-z][A-Za-z0-9+.-]*):", stripped)
         scheme = match.group(1).lower() if match else ""
-        if scheme and scheme not in {"http", "https", "matrix", "mailto"}:
+        allowed_schemes = cls._SPEC_LINK_SCHEMES | cls._COMPAT_LINK_SCHEMES
+        return stripped if scheme in allowed_schemes else ""
+
+    @staticmethod
+    def _safe_mxc_url(value: str) -> str:
+        stripped = re.sub(r"[\x00-\x1f\x7f]+", "", value or "").strip()
+        try:
+            parsed = urlsplit(stripped)
+            port = parsed.port
+        except ValueError:
             return ""
-        return stripped
+        return stripped if (
+            parsed.scheme.lower() == "mxc"
+            and re.fullmatch(
+                r"(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?",
+                parsed.netloc,
+            )
+            and port != 0
+            and not parsed.query
+            and not parsed.fragment
+            and re.fullmatch(r"/[A-Za-z0-9_-]+", parsed.path)
+        ) else ""
 
     def _safe_attrs(self, tag: str, attrs: list[tuple[str, str | None]]) -> str:
         safe: list[str] = []
+        seen: set[str] = set()
         for key, value in attrs:
             attr = str(key or "").lower()
+            if not attr or attr in seen:
+                continue
+            seen.add(attr)
             raw_value = "" if value is None else str(value)
             if attr.startswith("on"):
                 continue
             if tag == "a" and attr == "href":
-                href = self._safe_url(raw_value)
+                href = self._safe_link_url(raw_value)
                 if href:
                     safe.append(f' href="{_html_escape(href, quote=True)}"')
+            elif tag == "a" and attr == "target":
+                safe.append(f' target="{_html_escape(raw_value, quote=True)}"')
             elif tag == "code" and attr == "class":
-                if re.fullmatch(r"language-[A-Za-z0-9_+.-]{1,64}", raw_value):
-                    safe.append(f' class="{_html_escape(raw_value, quote=True)}"')
+                classes = [
+                    item
+                    for item in raw_value.split()
+                    if re.fullmatch(r"language-[A-Za-z0-9_+.-]{1,64}", item)
+                ]
+                if classes:
+                    safe.append(
+                        f' class="{_html_escape(" ".join(classes), quote=True)}"'
+                    )
+            elif tag == "div" and attr == "data-mx-maths":
+                safe.append(
+                    f' data-mx-maths="{_html_escape(raw_value, quote=True)}"'
+                )
+            elif tag == "img" and attr == "src":
+                src = self._safe_mxc_url(raw_value)
+                if src:
+                    safe.append(f' src="{_html_escape(src, quote=True)}"')
+            elif tag == "img" and attr in {"alt", "title"}:
+                safe.append(f' {attr}="{_html_escape(raw_value, quote=True)}"')
+            elif (
+                tag == "img"
+                and attr in {"height", "width"}
+                and re.fullmatch(r"[0-9]+", raw_value)
+            ):
+                safe.append(f' {attr}="{raw_value}"')
+            elif (
+                tag == "ol"
+                and attr == "start"
+                and re.fullmatch(r"[+-]?[0-9]+", raw_value)
+            ):
+                safe.append(f' start="{raw_value}"')
+            elif tag == "span" and attr in self._COLOR_ATTRIBUTES:
+                if re.fullmatch(r"#[0-9A-Fa-f]{6}", raw_value):
+                    safe.append(f' {attr}="{raw_value}"')
+            elif tag == "span" and attr in {"data-mx-maths", "data-mx-spoiler"}:
+                safe.append(f' {attr}="{_html_escape(raw_value, quote=True)}"')
         return "".join(safe)
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         tag = tag.lower()
-        if tag in {"script", "style"}:
-            self._skip_depth += 1
+        if self._skip_tags:
+            if tag == self._skip_tags[-1]:
+                self._skip_tags.append(tag)
             return
-        if self._skip_depth:
+        if tag in self._SKIP_CONTENT_TAGS:
+            self._skip_tags.append(tag)
             return
-        if tag not in self._ALLOWED_TAGS:
+        tag = self._COMPAT_TAG_ALIASES.get(tag, tag)
+        if tag not in self._SPEC_ALLOWED_TAGS:
             return
         if tag in self._VOID_TAGS:
-            self._parts.append(f"<{tag}>")
+            if self._render_depth < self._MAX_DEPTH:
+                self._parts.append(f"<{tag}{self._safe_attrs(tag, attrs)}>")
             return
-        self._parts.append(f"<{tag}{self._safe_attrs(tag, attrs)}>")
+        rendered = self._render_depth < self._MAX_DEPTH
+        self._open_tags.append((tag, rendered))
+        if rendered:
+            self._parts.append(f"<{tag}{self._safe_attrs(tag, attrs)}>")
+            self._render_depth += 1
 
     def handle_endtag(self, tag: str) -> None:
         tag = tag.lower()
-        if tag in {"script", "style"} and self._skip_depth:
-            self._skip_depth -= 1
+        if self._skip_tags:
+            if tag == self._skip_tags[-1]:
+                self._skip_tags.pop()
             return
-        if self._skip_depth or tag not in self._ALLOWED_TAGS or tag in self._VOID_TAGS:
+        tag = self._COMPAT_TAG_ALIASES.get(tag, tag)
+        if tag not in self._SPEC_ALLOWED_TAGS or tag in self._VOID_TAGS:
             return
-        self._parts.append(f"</{tag}>")
+
+        match_index = next(
+            (
+                index
+                for index in range(len(self._open_tags) - 1, -1, -1)
+                if self._open_tags[index][0] == tag
+            ),
+            None,
+        )
+        if match_index is None:
+            return
+
+        closing = self._open_tags[match_index:]
+        del self._open_tags[match_index:]
+        for open_tag, rendered in reversed(closing):
+            if rendered:
+                self._parts.append(f"</{open_tag}>")
+                self._render_depth -= 1
 
     def handle_data(self, data: str) -> None:
-        if not self._skip_depth:
+        if not self._skip_tags:
             self._parts.append(_html_escape(data))
 
     def handle_entityref(self, name: str) -> None:
-        if not self._skip_depth:
+        if not self._skip_tags:
             self._parts.append(f"&{name};")
 
     def handle_charref(self, name: str) -> None:
-        if not self._skip_depth:
+        if not self._skip_tags:
             self._parts.append(f"&#{name};")
 
     def get_html(self) -> str:
+        for tag, rendered in reversed(self._open_tags):
+            if rendered:
+                self._parts.append(f"</{tag}>")
+        self._open_tags.clear()
+        self._render_depth = 0
         return "".join(self._parts)
 
 
@@ -4370,7 +4478,9 @@ class MatrixAdapter(BasePlatformAdapter):
 
         html_source = self._inject_outbound_mention_links(text)
         html = self._markdown_to_html(html_source)
-        if html and html != text:
+        # Raw HTML can be unchanged by conversion but still requires the
+        # formatted_body field for Matrix clients to render it as HTML.
+        if html and (html != text or ("<" in html_source and ">" in html_source)):
             msg_content["format"] = "org.matrix.custom.html"
             msg_content["formatted_body"] = html
 
@@ -4549,7 +4659,8 @@ class MatrixAdapter(BasePlatformAdapter):
         parts = mxc_url[6:]  # strip mxc://
         return f"{self._homeserver}/_matrix/client/v1/media/download/{parts}"
 
-    def _markdown_to_html(self, text: str) -> str:
+    @staticmethod
+    def _markdown_to_html(text: str) -> str:
         """Convert Markdown to Matrix-compatible HTML (org.matrix.custom.html).
 
         Uses the ``markdown`` library (a core dependency) when available.
@@ -4565,19 +4676,21 @@ class MatrixAdapter(BasePlatformAdapter):
             md = _md.Markdown(
                 extensions=["fenced_code", "tables", "nl2br", "sane_lists"],
             )
-            if "html_block" in md.preprocessors:
-                md.preprocessors.deregister("html_block")
 
+            # Keep raw HTML enabled so Matrix-supported structures such as
+            # <details> survive conversion. The final sanitizer below remains
+            # the security boundary for all Markdown and raw HTML output.
             html = md.convert(text)
             md.reset()
 
-            if html.count("<p>") == 1:
-                html = html.replace("<p>", "").replace("</p>", "")
+            paragraph = re.fullmatch(r"<p>(.*)</p>", html, flags=re.DOTALL)
+            if paragraph:
+                html = paragraph.group(1)
             return _sanitize_matrix_html(html)
         except ImportError:
             pass
 
-        return _sanitize_matrix_html(self._markdown_to_html_fallback(text))
+        return _sanitize_matrix_html(MatrixAdapter._markdown_to_html_fallback(text))
 
     # ------------------------------------------------------------------
     # Regex-based Markdown -> HTML (no extra dependencies)
@@ -4763,9 +4876,9 @@ async def _standalone_send(
     """Out-of-process Matrix delivery via the Client-Server API.
 
     Implements the standalone_sender_fn contract so deliver=matrix cron jobs
-    succeed when cron runs separately from the gateway. Converts markdown to
-    HTML for rich rendering, falling back to plain text when the markdown
-    library is absent. Replaces the legacy _send_matrix helper.
+    succeed when cron runs separately from the gateway. Uses the live adapter's
+    shared Matrix renderer and sanitizer, including its regex fallback when the
+    markdown library is absent. Replaces the legacy _send_matrix helper.
     """
     extra = getattr(pconfig, "extra", {}) or {}
     token = getattr(pconfig, "token", None)
@@ -4785,14 +4898,10 @@ async def _standalone_send(
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
         payload = {"msgtype": "m.text", "body": message}
-        try:
-            import markdown as _md
-            html = _md.markdown(message, extensions=["fenced_code", "tables"])
-            html = re.sub(r"<h[1-6]>(.*?)</h[1-6]>", r"<strong>\1</strong>", html)
+        html = MatrixAdapter._markdown_to_html(message)
+        if html:
             payload["format"] = "org.matrix.custom.html"
             payload["formatted_body"] = html
-        except ImportError:
-            pass
 
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
             async with session.put(url, headers=headers, json=payload) as resp:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -700,6 +700,39 @@ class TestMatrixMarkdownToHtml:
         result = self.adapter._markdown_to_html("Hello world")
         assert "Hello world" in result
 
+    def test_multiple_paragraphs_remain_well_formed(self):
+        result = self.adapter._markdown_to_html("First paragraph.\n\nSecond paragraph.")
+
+        assert result == "<p>First paragraph.</p>\n<p>Second paragraph.</p>"
+
+    def test_plain_text_payload_omits_unnecessary_formatted_body(self):
+        payload = self.adapter._build_text_message_content("Hello world")
+
+        assert payload == {"msgtype": "m.text", "body": "Hello world"}
+
+    def test_details_and_summary_html_is_preserved(self):
+        source = "<details><summary>More</summary><p>Body</p></details>"
+
+        result = self.adapter._markdown_to_html(source)
+        payload = self.adapter._build_text_message_content(source)
+
+        assert result == source
+        assert payload["format"] == "org.matrix.custom.html"
+        assert payload["formatted_body"] == source
+
+    def test_raw_html_is_sanitized_end_to_end(self):
+        result = self.adapter._markdown_to_html(
+            '<details open onclick="boom"><summary>More</summary>'
+            '<a href="javascript:alert(1)">link</a>'
+            '<script>alert("unsafe")</script>'
+            '<img src="mxc://example.org/media-id" onerror="boom">'
+            "</details>"
+        )
+
+        assert result == (
+            "<details><summary>More</summary><a>link</a>"
+            '<img src="mxc://example.org/media-id"></details>'
+        )
 
     def test_matrix_markdown_preserves_table_structure(self):
         table = "\n".join(
@@ -718,6 +751,184 @@ class TestMatrixMarkdownToHtml:
         assert "<tbody>" in result
         assert "<th>Item</th>" in result
         assert "<td>Apples</td>" in result
+
+
+# ---------------------------------------------------------------------------
+# Matrix HTML sanitizer conformance
+# ---------------------------------------------------------------------------
+
+class TestMatrixHtmlSanitizerConformance:
+    def sanitize(self, html: str) -> str:
+        from plugins.platforms.matrix.adapter import _sanitize_matrix_html
+
+        return _sanitize_matrix_html(html)
+
+    def test_current_spec_tags_are_preserved(self):
+        html = (
+            "<details><summary>More</summary><div><u>under</u>"
+            "<sup>up</sup><sub>down</sub><span>inline</span></div></details>"
+            "<table><caption>Title</caption><tbody><tr><td>cell</td></tr>"
+            "</tbody></table><img src=\"mxc://example.org/media-id\" alt=\"image\">"
+        )
+
+        result = self.sanitize(html)
+
+        for tag in (
+            "caption",
+            "details",
+            "div",
+            "img",
+            "span",
+            "sub",
+            "summary",
+            "sup",
+            "u",
+        ):
+            assert f"<{tag}" in result
+
+    def test_unsafe_tags_are_removed(self):
+        result = self.sanitize(
+            "<font color=\"red\">legacy</font>"
+            "<script>alert(1)</script><style>body{display:none}</style>"
+        )
+
+        assert result == "legacy"
+
+    def test_compatibility_markup_is_preserved(self):
+        result = self.sanitize(
+            '<strike>old</strike>'
+            '<a href="matrix:roomid/example:example.org">room</a>'
+        )
+
+        assert result == (
+            '<s>old</s><a href="matrix:roomid/example:example.org">room</a>'
+        )
+
+    def test_mx_reply_tag_and_content_are_removed(self):
+        result = self.sanitize(
+            "<mx-reply><blockquote>old reply</blockquote></mx-reply>"
+            "<p>new message</p>"
+        )
+
+        assert result == "<p>new message</p>"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.org/file",
+            "http://example.org",
+            "https://example.org",
+            "magnet:?xt=urn:btih:abc",
+            "mailto:user@example.org",
+        ],
+    )
+    def test_spec_link_schemes_are_preserved(self, url):
+        result = self.sanitize(f'<a href="{url}" target="_blank">link</a>')
+
+        assert f'href="{url}"' in result
+        assert 'target="_blank"' in result
+
+    @pytest.mark.parametrize(
+        "url",
+        ["/relative", "javascript:alert(1)", "data:text/html,boom"],
+    )
+    def test_non_spec_link_schemes_are_removed(self, url):
+        result = self.sanitize(f'<a href="{url}">link</a>')
+
+        assert result == "<a>link</a>"
+
+    def test_spec_attributes_are_filtered_by_tag_and_value(self):
+        result = self.sanitize(
+            '<span data-mx-bg-color="#A1b2C3" data-mx-color="red" '
+            'data-mx-spoiler="reason" data-mx-maths="x&lt;y" style="color:red">'
+            '<code class="language-python unsafe language-rust">code</code></span>'
+            '<div data-mx-maths="x^2" class="unsafe">math</div>'
+            '<ol start="-3" onclick="boom"><li>item</li></ol>'
+        )
+
+        assert 'data-mx-bg-color="#A1b2C3"' in result
+        assert "data-mx-color" not in result
+        assert 'data-mx-spoiler="reason"' in result
+        assert 'data-mx-maths="x&lt;y"' in result
+        assert 'class="language-python language-rust"' in result
+        assert '<div data-mx-maths="x^2">' in result
+        assert '<ol start="-3">' in result
+        assert "style=" not in result
+        assert "onclick=" not in result
+
+    def test_image_requires_mxc_source_and_filters_attributes(self):
+        safe = self.sanitize(
+            '<img src="mxc://example.org/media-id" width="640" height="480" '
+            'alt="preview" title="Preview" onerror="boom">'
+        )
+        unsafe = self.sanitize(
+            '<img src="https://example.org/image.png" width="wide" alt="preview">'
+            '<img src="mxc://example.org/../secret" alt="traversal">'
+        )
+
+        assert safe == (
+            '<img src="mxc://example.org/media-id" width="640" height="480" '
+            'alt="preview" title="Preview">'
+        )
+        assert unsafe == '<img alt="preview"><img alt="traversal">'
+
+    @pytest.mark.parametrize(
+        ("url", "allowed"),
+        [
+            ("mxc://example.org:8448/media-id", True),
+            ("mxc://[2001:db8::1]:8448/media_id", True),
+            ("mxc://not a server/id", False),
+            ("mxc://user@example.org/id", False),
+            ("mxc://example.org:99999/id", False),
+            ("mxc://[not-ipv6]/id", False),
+        ],
+    )
+    def test_image_mxc_authority_validation(self, url, allowed):
+        expected = f'<img src="{url}">' if allowed else "<img>"
+        assert self.sanitize(f'<img src="{url}">') == expected
+
+    def test_nesting_is_limited_to_100_levels(self):
+        result = self.sanitize("<div>" * 101 + "content" + "</div>" * 101)
+
+        assert result.count("<div>") == 100
+        assert result.count("</div>") == 100
+        assert "content" in result
+
+
+class TestMatrixStandaloneRendering:
+    @pytest.mark.asyncio
+    async def test_standalone_delivery_uses_shared_matrix_renderer(self):
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        rendered = "<details><summary>More</summary><p>Body</p></details>"
+        config = types.SimpleNamespace(
+            token="token",
+            extra={"homeserver": "https://matrix.example.org"},
+        )
+
+        with (
+            patch.object(
+                matrix_mod.MatrixAdapter,
+                "_markdown_to_html",
+                return_value=rendered,
+            ) as render,
+            patch("aiohttp.ClientSession") as client_session,
+        ):
+            session = client_session.return_value.__aenter__.return_value
+            session.put = MagicMock()
+            response = session.put.return_value.__aenter__.return_value
+            response.status = 200
+            response.json = AsyncMock(return_value={"event_id": "$event"})
+            result = await matrix_mod._standalone_send(
+                config,
+                "!room:example.org",
+                "<details>message</details>",
+            )
+
+        assert result["success"] is True
+        render.assert_called_once_with("<details>message</details>")
+        payload = session.put.call_args.kwargs["json"]
+        assert payload["formatted_body"] == rendered
 
 
 # ---------------------------------------------------------------------------
@@ -1519,7 +1730,7 @@ class TestMatrixDiagnostics:
         from plugins.platforms.matrix.adapter import MatrixAdapter
 
         output_path = tmp_path / "matrix-recovery-key.txt"
-        output_path.write_text("existing\n")
+        output_path.write_text("existing\n", encoding="utf-8")
         monkeypatch.delenv("MATRIX_RECOVERY_KEY", raising=False)
         monkeypatch.setenv("MATRIX_RECOVERY_KEY_OUTPUT_FILE", str(output_path))
         config = PlatformConfig(
@@ -1578,7 +1789,7 @@ class TestMatrixDiagnostics:
         mock_olm.generate_recovery_key.assert_not_called()
         assert "already exists" in caplog.text
         assert "super-secret-key" not in caplog.text
-        assert output_path.read_text() == "existing\n"
+        assert output_path.read_text(encoding="utf-8") == "existing\n"
         await adapter.disconnect()
 
     def test_matrix_diagnostics_redacts_recovery_key(self, monkeypatch):

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -700,6 +700,34 @@ class TestMatrixMarkdownToHtml:
         result = self.adapter._markdown_to_html("Hello world")
         assert "Hello world" in result
 
+    def test_plain_text_payload_omits_unnecessary_formatted_body(self):
+        payload = self.adapter._build_text_message_content("Hello world")
+
+        assert payload == {"msgtype": "m.text", "body": "Hello world"}
+
+    def test_details_and_summary_html_is_preserved(self):
+        source = "<details><summary>More</summary><p>Body</p></details>"
+
+        result = self.adapter._markdown_to_html(source)
+        payload = self.adapter._build_text_message_content(source)
+
+        assert result == source
+        assert payload["format"] == "org.matrix.custom.html"
+        assert payload["formatted_body"] == source
+
+    def test_raw_html_is_sanitized_end_to_end(self):
+        result = self.adapter._markdown_to_html(
+            '<details open onclick="boom"><summary>More</summary>'
+            '<a href="javascript:alert(1)">link</a>'
+            '<script>alert("unsafe")</script>'
+            '<img src="mxc://example.org/media-id" onerror="boom">'
+            "</details>"
+        )
+
+        assert result == (
+            "<details><summary>More</summary><a>link</a>"
+            '<img src="mxc://example.org/media-id"></details>'
+        )
 
     def test_matrix_markdown_preserves_table_structure(self):
         table = "\n".join(
@@ -718,6 +746,184 @@ class TestMatrixMarkdownToHtml:
         assert "<tbody>" in result
         assert "<th>Item</th>" in result
         assert "<td>Apples</td>" in result
+
+
+# ---------------------------------------------------------------------------
+# Matrix HTML sanitizer conformance
+# ---------------------------------------------------------------------------
+
+class TestMatrixHtmlSanitizerConformance:
+    def sanitize(self, html: str) -> str:
+        from plugins.platforms.matrix.adapter import _sanitize_matrix_html
+
+        return _sanitize_matrix_html(html)
+
+    def test_current_spec_tags_are_preserved(self):
+        html = (
+            "<details><summary>More</summary><div><u>under</u>"
+            "<sup>up</sup><sub>down</sub><span>inline</span></div></details>"
+            "<table><caption>Title</caption><tbody><tr><td>cell</td></tr>"
+            "</tbody></table><img src=\"mxc://example.org/media-id\" alt=\"image\">"
+        )
+
+        result = self.sanitize(html)
+
+        for tag in (
+            "caption",
+            "details",
+            "div",
+            "img",
+            "span",
+            "sub",
+            "summary",
+            "sup",
+            "u",
+        ):
+            assert f"<{tag}" in result
+
+    def test_unsafe_tags_are_removed(self):
+        result = self.sanitize(
+            "<font color=\"red\">legacy</font>"
+            "<script>alert(1)</script><style>body{display:none}</style>"
+        )
+
+        assert result == "legacy"
+
+    def test_compatibility_markup_is_preserved(self):
+        result = self.sanitize(
+            '<strike>old</strike>'
+            '<a href="matrix:roomid/example:example.org">room</a>'
+        )
+
+        assert result == (
+            '<s>old</s><a href="matrix:roomid/example:example.org">room</a>'
+        )
+
+    def test_mx_reply_tag_and_content_are_removed(self):
+        result = self.sanitize(
+            "<mx-reply><blockquote>old reply</blockquote></mx-reply>"
+            "<p>new message</p>"
+        )
+
+        assert result == "<p>new message</p>"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.org/file",
+            "http://example.org",
+            "https://example.org",
+            "magnet:?xt=urn:btih:abc",
+            "mailto:user@example.org",
+        ],
+    )
+    def test_spec_link_schemes_are_preserved(self, url):
+        result = self.sanitize(f'<a href="{url}" target="_blank">link</a>')
+
+        assert f'href="{url}"' in result
+        assert 'target="_blank"' in result
+
+    @pytest.mark.parametrize(
+        "url",
+        ["/relative", "javascript:alert(1)", "data:text/html,boom"],
+    )
+    def test_non_spec_link_schemes_are_removed(self, url):
+        result = self.sanitize(f'<a href="{url}">link</a>')
+
+        assert result == "<a>link</a>"
+
+    def test_spec_attributes_are_filtered_by_tag_and_value(self):
+        result = self.sanitize(
+            '<span data-mx-bg-color="#A1b2C3" data-mx-color="red" '
+            'data-mx-spoiler="reason" data-mx-maths="x&lt;y" style="color:red">'
+            '<code class="language-python unsafe language-rust">code</code></span>'
+            '<div data-mx-maths="x^2" class="unsafe">math</div>'
+            '<ol start="-3" onclick="boom"><li>item</li></ol>'
+        )
+
+        assert 'data-mx-bg-color="#A1b2C3"' in result
+        assert "data-mx-color" not in result
+        assert 'data-mx-spoiler="reason"' in result
+        assert 'data-mx-maths="x&lt;y"' in result
+        assert 'class="language-python language-rust"' in result
+        assert '<div data-mx-maths="x^2">' in result
+        assert '<ol start="-3">' in result
+        assert "style=" not in result
+        assert "onclick=" not in result
+
+    def test_image_requires_mxc_source_and_filters_attributes(self):
+        safe = self.sanitize(
+            '<img src="mxc://example.org/media-id" width="640" height="480" '
+            'alt="preview" title="Preview" onerror="boom">'
+        )
+        unsafe = self.sanitize(
+            '<img src="https://example.org/image.png" width="wide" alt="preview">'
+            '<img src="mxc://example.org/../secret" alt="traversal">'
+        )
+
+        assert safe == (
+            '<img src="mxc://example.org/media-id" width="640" height="480" '
+            'alt="preview" title="Preview">'
+        )
+        assert unsafe == '<img alt="preview"><img alt="traversal">'
+
+    @pytest.mark.parametrize(
+        ("url", "allowed"),
+        [
+            ("mxc://example.org:8448/media-id", True),
+            ("mxc://[2001:db8::1]:8448/media_id", True),
+            ("mxc://not a server/id", False),
+            ("mxc://user@example.org/id", False),
+            ("mxc://example.org:99999/id", False),
+            ("mxc://[not-ipv6]/id", False),
+        ],
+    )
+    def test_image_mxc_authority_validation(self, url, allowed):
+        expected = f'<img src="{url}">' if allowed else "<img>"
+        assert self.sanitize(f'<img src="{url}">') == expected
+
+    def test_nesting_is_limited_to_100_levels(self):
+        result = self.sanitize("<div>" * 101 + "content" + "</div>" * 101)
+
+        assert result.count("<div>") == 100
+        assert result.count("</div>") == 100
+        assert "content" in result
+
+
+class TestMatrixStandaloneRendering:
+    @pytest.mark.asyncio
+    async def test_standalone_delivery_uses_shared_matrix_renderer(self):
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        rendered = "<details><summary>More</summary><p>Body</p></details>"
+        config = types.SimpleNamespace(
+            token="token",
+            extra={"homeserver": "https://matrix.example.org"},
+        )
+
+        with (
+            patch.object(
+                matrix_mod.MatrixAdapter,
+                "_markdown_to_html",
+                return_value=rendered,
+            ) as render,
+            patch("aiohttp.ClientSession") as client_session,
+        ):
+            session = client_session.return_value.__aenter__.return_value
+            session.put = MagicMock()
+            response = session.put.return_value.__aenter__.return_value
+            response.status = 200
+            response.json = AsyncMock(return_value={"event_id": "$event"})
+            result = await matrix_mod._standalone_send(
+                config,
+                "!room:example.org",
+                "<details>message</details>",
+            )
+
+        assert result["success"] is True
+        render.assert_called_once_with("<details>message</details>")
+        payload = session.put.call_args.kwargs["json"]
+        assert payload["formatted_body"] == rendered
 
 
 # ---------------------------------------------------------------------------
@@ -1445,7 +1651,7 @@ class TestMatrixDiagnostics:
         from plugins.platforms.matrix.adapter import MatrixAdapter
 
         output_path = tmp_path / "matrix-recovery-key.txt"
-        output_path.write_text("existing\n")
+        output_path.write_text("existing\n", encoding="utf-8")
         monkeypatch.delenv("MATRIX_RECOVERY_KEY", raising=False)
         monkeypatch.setenv("MATRIX_RECOVERY_KEY_OUTPUT_FILE", str(output_path))
         config = PlatformConfig(


### PR DESCRIPTION
# fix(matrix): align formatted HTML sanitizer with the current spec

## What does this PR do?

Updates Matrix `org.matrix.custom.html` generation and sanitization to match the [Matrix Client-Server API v1.19 recommendations for `m.room.message` HTML](https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes).

The existing sanitizer predated several spec changes. In particular, it discarded `<details>` and `<summary>`, omitted other recommended elements and attributes, accepted relative links, and did not enforce the 100-level nesting limit. The standalone/cron delivery path also generated HTML separately without using the adapter's sanitizer.

This change keeps the existing stdlib `HTMLParser` approach, updates its allowlist and value validation, and makes both outbound delivery paths share the same Markdown-to-Matrix-HTML renderer.

## Related upstream work

This PR does not claim to close an existing issue. The closest upstream work found is:

- #68199 is an open PR that independently adds `details` and `summary` to support collapsible Matrix approval cards. This PR provides those tags as part of the general v1.19 allowlist update.
- #31594 is an open PR that emits `span` and `div` with `data-mx-maths`; this PR adds the sanitizer support those elements and attributes require, but does not implement LaTeX conversion.
- #42667 / #42759 / #42681 cover the existing Matrix HTML sanitizer and complementary URL-scheme regression tests. This PR builds on the sanitizer already present in `main`.
- #45631 is the merged table-tag allowlist update and is the closest precedent for bringing the Matrix allowlist in line with supported formatted HTML.
- #38036 is a closed, unmerged proposal to route standalone Matrix delivery through the adapter's sanitization path; this PR applies that consolidation to the current plugin implementation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Newly permitted tags

Compared with `main`, this change permits exactly these nine additional tag names:

- `caption`
- `details`
- `div`
- `img`
- `span`
- `sub`
- `summary`
- `sup`
- `u`

No other tag names are newly permitted. After this change, the complete spec-derived allowlist is:

```text
a, b, blockquote, br, caption, code, del, details, div, em, h1, h2, h3, h4, h5, h6, hr, i, img, li, ol, p, pre, s, span, strong, sub, summary, sup, table, tbody, td, th, thead, tr, u, ul
```

`strike` is handled separately as backwards compatibility: input using the legacy tag is rewritten to the allowed `s` tag, so `strike` itself is never emitted.

### Other behavior changes

- Added tag-specific validation for Matrix's permitted attributes: `data-mx-*`, safe absolute link schemes, `mxc://` image sources, ordered-list starts, and syntax-highlighting classes.
- Retained the pre-existing `matrix:` deep-link behavior as explicitly labelled compatibility outside the v1.19 recommended link-scheme list.
- Stripped `mx-reply` together with its fallback content, balanced emitted tags, and capped nesting at 100 levels.
- Preserved safe raw HTML blocks through Markdown conversion so supported structures such as `<details>` reach the final sanitizer, with end-to-end coverage confirming disallowed tags, attributes, and URLs are removed.
- Ensured already-valid raw HTML is included in live gateway payloads as `formatted_body`, rather than appearing only in the plain-text fallback.
- Limited paragraph unwrapping to a single top-level `<p>` so multiple adjacent paragraphs and paragraphs nested inside `<details>` or other block structures remain intact.
- Routed standalone/cron Matrix sends through the same renderer and sanitizer used by the live adapter.
- Added conformance, sanitizer, nesting, `<details>` rendering, and standalone delivery regression coverage in `tests/gateway/test_matrix.py`.
- Made the existing recovery-key fixture reads and writes use explicit UTF-8 so the touched test file passes the repository's Windows-footgun gate.

## How to Test

1. Run the Matrix-focused test suite:

   ```bash
   scripts/run_tests.sh -j 4 tests/gateway/test_matrix*.py \
     tests/tools/test_send_message_missing_platforms.py
   ```

2. Confirm the Matrix-focused tests pass. Latest result: `223 tests passed, 0 failed` across 14 files.
3. Send this through a configured Matrix gateway and confirm the body renders as a collapsible section in a compatible client:

   ```html
   <details><summary>More</summary><p>Body</p></details>
   ```

The full-suite run via `scripts/run_tests.sh -j 8` is incomplete. It was stopped after two provider-test failures caused by the test environment lacking `anthropic`; both failures also reproduce on unchanged `main`. Windows-footgun and plugin-compat checks pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior and sanitizer docstring only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
=== Summary: 14 files, 223 tests passed, 0 failed (100% complete) in 8.5s (4 workers) ===
```

<img width="710" height="741" alt="Monosnap Element 2026-07-30 11-46-32" src="https://github.com/user-attachments/assets/e0e3a449-72c1-4d35-b8f7-e18070a4bb52" />


