### PR TITLE
feat(api): project declarative tool start events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -52,6 +52,7 @@ import os
 import re
 import sqlite3
 import sys
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -127,6 +128,7 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+MAX_RUN_START_EVENT_FIELD_LENGTH = 160
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 
@@ -5989,6 +5991,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
+        projected_event_sequence = 0
+        projected_event_lock = threading.Lock()
+
         def _push(event: Dict[str, Any]) -> None:
             self._set_run_status(
                 run_id,
@@ -6004,8 +6009,36 @@ class APIServerAdapter(BasePlatformAdapter):
                 pass
 
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
+            nonlocal projected_event_sequence
             ts = time.time()
             if event_type == "tool.started":
+                from tools.registry import registry
+
+                projection = registry.get_run_start_event(tool_name or "")
+                if projection is not None:
+                    if not isinstance(args, dict):
+                        return
+                    projected_fields = {}
+                    for field in projection["fields"]:
+                        value = args.get(field)
+                        if not isinstance(value, str):
+                            return
+                        value = redact_sensitive_text(
+                            value,
+                            force=True,
+                            redact_url_credentials=True,
+                        )
+                        projected_fields[field] = value[:MAX_RUN_START_EVENT_FIELD_LENGTH]
+                    with projected_event_lock:
+                        projected_event_sequence += 1
+                        _push({
+                            "event": projection["event"],
+                            "run_id": run_id,
+                            "sequence": projected_event_sequence,
+                            "timestamp": time.time(),
+                            **projected_fields,
+                        })
+                    return
                 _push({
                     "event": "tool.started",
                     "run_id": run_id,
@@ -6014,6 +6047,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     "preview": preview,
                 })
             elif event_type == "tool.completed":
+                from tools.registry import registry
+
+                if registry.get_run_start_event(tool_name or "") is not None:
+                    return
                 _push({
                     "event": "tool.completed",
                     "run_id": run_id,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -419,6 +419,8 @@ class PluginContext:
         description: str = "",
         emoji: str = "",
         override: bool = False,
+        *,
+        run_start_event: dict | None = None,
     ) -> None:
         """Register a tool in the global registry **and** track it as plugin-provided.
 
@@ -456,6 +458,7 @@ class PluginContext:
             is_async=is_async,
             description=description,
             emoji=emoji,
+            run_start_event=run_start_event,
             override=override,
         )
         self._manager._plugin_tool_names.add(name)

--- a/tests/gateway/test_api_server_run_start_events.py
+++ b/tests/gateway/test_api_server_run_start_events.py
@@ -1,0 +1,209 @@
+import asyncio
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from tools.registry import registry
+
+
+TOOL_NAME = "test_projected_run_start_event"
+
+
+@pytest.fixture
+def adapter():
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+@pytest.fixture
+def projected_tool():
+    registry.register(
+        name=TOOL_NAME,
+        toolset="test",
+        schema={
+            "name": TOOL_NAME,
+            "description": "Report intent",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda args, **kwargs: "ok",
+        run_start_event={"event": "agent.intent", "fields": ("text", "speech")},
+    )
+    try:
+        yield TOOL_NAME
+    finally:
+        registry.deregister(TOOL_NAME)
+
+
+@pytest.mark.asyncio
+async def test_projected_tool_emits_only_declared_redacted_string_fields(
+    adapter, projected_tool
+):
+    run_id = "run_projected_tool"
+    loop = asyncio.get_running_loop()
+    queue = asyncio.Queue()
+    adapter._run_streams[run_id] = queue
+    callback = adapter._make_run_event_callback(run_id, loop)
+    secret = "sk-proj-abcdef1234567890abcdef1234567890abcdef12"
+
+    callback(
+        "tool.started",
+        projected_tool,
+        f"generic preview leaks {secret}",
+        {
+            "text": (
+                f"Use {secret} and "
+                "https://user:password@example.test/run?token=private " + "x" * 1_000
+            ),
+            "speech": "brief",
+            "extra": "must not cross the boundary",
+            "nested": {"private": True},
+        },
+    )
+    callback(
+        "tool.completed",
+        projected_tool,
+        result="private result",
+        duration=1.0,
+    )
+
+    event = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert event["event"] == "agent.intent"
+    assert event["run_id"] == run_id
+    assert event["sequence"] == 1
+    assert event["speech"] == "brief"
+    assert secret not in event["text"]
+    assert "password" not in event["text"]
+    assert "token=private" not in event["text"]
+    assert len(event["text"]) <= 160
+    assert set(event) == {
+        "event",
+        "run_id",
+        "sequence",
+        "timestamp",
+        "text",
+        "speech",
+    }
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(queue.get(), timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_projected_tool_ignores_missing_or_non_string_fields(
+    adapter, projected_tool
+):
+    run_id = "run_projected_invalid_args"
+    loop = asyncio.get_running_loop()
+    queue = asyncio.Queue()
+    adapter._run_streams[run_id] = queue
+    callback = adapter._make_run_event_callback(run_id, loop)
+
+    callback(
+        "tool.started",
+        projected_tool,
+        args={"text": {"nested": "private"}, "speech": "brief"},
+    )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(queue.get(), timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_projected_sequences_match_concurrent_enqueue_order(
+    adapter, projected_tool
+):
+    run_id = "run_projected_concurrent"
+    loop = asyncio.get_running_loop()
+    queue = asyncio.Queue()
+    adapter._run_streams[run_id] = queue
+    first_status_entered = threading.Event()
+    second_status_entered = threading.Event()
+    original_set_status = adapter._set_run_status
+
+    def delayed_set_status(*args, **kwargs):
+        if threading.current_thread().name == "first-intent":
+            first_status_entered.set()
+            second_status_entered.wait(timeout=0.2)
+        else:
+            second_status_entered.set()
+        return original_set_status(*args, **kwargs)
+
+    callback = adapter._make_run_event_callback(run_id, loop)
+    with patch.object(adapter, "_set_run_status", side_effect=delayed_set_status):
+        first = threading.Thread(
+            name="first-intent",
+            target=callback,
+            args=(
+                "tool.started",
+                projected_tool,
+                None,
+                {"text": "first", "speech": "brief"},
+            ),
+        )
+        second = threading.Thread(
+            name="second-intent",
+            target=callback,
+            args=(
+                "tool.started",
+                projected_tool,
+                None,
+                {"text": "second", "speech": "brief"},
+            ),
+        )
+        first.start()
+        assert first_status_entered.wait(timeout=1.0)
+        second.start()
+        first.join(timeout=1.0)
+        second.join(timeout=1.0)
+        assert not first.is_alive()
+        assert not second.is_alive()
+
+    events = [
+        await asyncio.wait_for(queue.get(), timeout=1.0),
+        await asyncio.wait_for(queue.get(), timeout=1.0),
+    ]
+    assert [(event["text"], event["sequence"]) for event in events] == [
+        ("first", 1),
+        ("second", 2),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_projected_sequence_restarts_for_each_run(adapter, projected_tool):
+    loop = asyncio.get_running_loop()
+    events = []
+    for run_id in ("run-a", "run-b"):
+        queue = asyncio.Queue()
+        adapter._run_streams[run_id] = queue
+        callback = adapter._make_run_event_callback(run_id, loop)
+        callback(
+            "tool.started",
+            projected_tool,
+            args={"text": run_id, "speech": "brief"},
+        )
+        events.append(await asyncio.wait_for(queue.get(), timeout=1.0))
+
+    assert [(event["run_id"], event["sequence"]) for event in events] == [
+        ("run-a", 1),
+        ("run-b", 1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ordinary_tool_lifecycle_is_unchanged(adapter):
+    run_id = "run_ordinary_tool"
+    loop = asyncio.get_running_loop()
+    queue = asyncio.Queue()
+    adapter._run_streams[run_id] = queue
+    callback = adapter._make_run_event_callback(run_id, loop)
+
+    callback("tool.started", "ordinary", "safe preview", {"value": "safe"})
+    callback("tool.completed", "ordinary", duration=1.25, is_error=False)
+
+    started = await asyncio.wait_for(queue.get(), timeout=1.0)
+    completed = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert started["event"] == "tool.started"
+    assert started["preview"] == "safe preview"
+    assert completed["event"] == "tool.completed"
+    assert completed["duration"] == 1.25

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -25,6 +26,7 @@ from gateway.platforms.api_server import (
     security_headers_middleware,
 )
 from tools import approval as approval_mod
+from tools.registry import registry
 
 
 # ---------------------------------------------------------------------------
@@ -330,6 +332,93 @@ class TestRunEvents:
                 # Should contain run.completed
                 assert "run.completed" in body
                 assert "Hello!" in body
+
+    @pytest.mark.asyncio
+    async def test_projected_tool_start_event_flows_through_runs_sse(self, adapter):
+        """The HTTP run path must wire projected events without generic duplicates."""
+        tool_name = "test_runs_projected_start_event"
+        registry.register(
+            name=tool_name,
+            toolset="test",
+            schema={
+                "name": tool_name,
+                "description": "Report client intent",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kwargs: "ok",
+            run_start_event={
+                "event": "client.intent",
+                "fields": ("text", "speech"),
+            },
+        )
+        try:
+            app = _create_runs_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(adapter, "_create_agent") as mock_create:
+
+                    def _create_agent(**kwargs):
+                        callback = kwargs["tool_progress_callback"]
+                        mock_agent = MagicMock()
+
+                        def _run_conversation(*_args, **_kwargs):
+                            callback(
+                                "tool.started",
+                                tool_name,
+                                "generic preview",
+                                {
+                                    "text": "Prepare the requested action",
+                                    "speech": "brief",
+                                    "private": "not projected",
+                                },
+                            )
+                            callback(
+                                "tool.completed",
+                                tool_name,
+                                result="private result",
+                                duration=0.1,
+                            )
+                            return {"final_response": "done"}
+
+                        mock_agent.run_conversation.side_effect = _run_conversation
+                        mock_agent.session_prompt_tokens = 0
+                        mock_agent.session_completion_tokens = 0
+                        mock_agent.session_total_tokens = 0
+                        return mock_agent
+
+                    mock_create.side_effect = _create_agent
+
+                    start_resp = await cli.post("/v1/runs", json={"input": "hello"})
+                    assert start_resp.status == 202
+                    run_id = (await start_resp.json())["run_id"]
+
+                    events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                    assert events_resp.status == 200
+                    body = await events_resp.text()
+        finally:
+            registry.deregister(tool_name)
+
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in body.splitlines()
+            if line.startswith("data: ")
+        ]
+        projected = [event for event in events if event["event"] == "client.intent"]
+        assert len(projected) == 1
+        projected_event = projected[0]
+        assert projected_event == {
+            "event": "client.intent",
+            "run_id": run_id,
+            "sequence": 1,
+            "timestamp": projected_event["timestamp"],
+            "text": "Prepare the requested action",
+            "speech": "brief",
+        }
+        assert not any(
+            event["event"] in {"tool.started", "tool.completed"}
+            and event.get("tool") == tool_name
+            for event in events
+        )
+        assert events[-1]["event"] == "run.completed"
 
 
     @pytest.mark.asyncio

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -543,8 +543,72 @@ class TestThreadToolWhitelist:
 class TestPluginContext:
     """Tests for the PluginContext facade."""
 
+    def test_register_tool_forwards_run_start_event(self):
+        from hermes_cli.plugins import PluginContext, PluginManifest
+        from tools.registry import registry
 
+        manager = PluginManager()
+        context = PluginContext(
+            PluginManifest(name="intent-plugin", source="user"),
+            manager,
+        )
+        try:
+            context.register_tool(
+                name="test_plugin_report_intent",
+                toolset="intent-plugin",
+                schema={
+                    "name": "test_plugin_report_intent",
+                    "description": "Report intent",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                handler=lambda args, **kwargs: "ok",
+                run_start_event={
+                    "event": "agent.intent",
+                    "fields": ("text", "speech"),
+                },
+            )
 
+            assert registry.get_run_start_event("test_plugin_report_intent") == {
+                "event": "agent.intent",
+                "fields": ("text", "speech"),
+            }
+            assert "test_plugin_report_intent" in manager._plugin_tool_names
+        finally:
+            registry.deregister("test_plugin_report_intent")
+
+    def test_register_tool_preserves_positional_override_compatibility(self):
+        from hermes_cli.plugins import PluginContext, PluginManifest
+        from tools.registry import registry
+
+        manager = PluginManager()
+        context = PluginContext(
+            PluginManifest(name="positional-plugin", source="user"),
+            manager,
+        )
+        try:
+            context.register_tool(
+                "test_plugin_positional_override",
+                "positional-plugin",
+                {
+                    "name": "test_plugin_positional_override",
+                    "description": "Compatibility probe",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                lambda args, **kwargs: "ok",
+                None,
+                None,
+                False,
+                "",
+                "",
+                False,
+            )
+
+            entry = registry.get_entry("test_plugin_positional_override")
+            assert entry is not None
+            assert entry.run_start_event is None
+            assert "test_plugin_positional_override" in manager._plugin_tool_names
+        finally:
+            registry.deregister("test_plugin_positional_override")
 
     def test_register_tool_override_blocked_without_operator_opt_in(self, tmp_path, monkeypatch):
         """override=True must be rejected when the operator hasn't opted in.

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -95,7 +95,6 @@ class TestPlanToolBatchSegments:
         assert _kinds(segments) == ["parallel", "sequential"]
         assert [tc.id for tc in segments[1][1]] == ["b1", "r3"]
 
-
     def test_never_parallel_tool_is_a_barrier(self):
         calls = [
             _tc("web_search", call_id="r1"),
@@ -106,7 +105,15 @@ class TestPlanToolBatchSegments:
         assert _kinds(segments) == ["parallel", "sequential"]
         assert [tc.id for tc in segments[1][1]] == ["c1"]
 
-
+    def test_unrecognized_plugin_tool_is_a_barrier_before_safe_work(self):
+        calls = [
+            _tc("report_intent", call_id="intent"),
+            _tc("web_search", call_id="search-1"),
+            _tc("web_search", call_id="search-2"),
+        ]
+        segments = _plan_tool_batch_segments(calls)
+        assert _kinds(segments) == ["sequential", "parallel"]
+        assert _flatten_ids(segments) == ["intent", "search-1", "search-2"]
 
     def test_overlapping_paths_split_across_segments(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -196,6 +203,45 @@ def agent():
 
 
 class TestSegmentedDispatchIntegration:
+    def test_plugin_start_callback_precedes_following_safe_work(self, agent):
+        calls = [
+            _tc(
+                "report_intent",
+                '{"text":"I will inspect the tests.","speech":"brief"}',
+                call_id="intent",
+            ),
+            _tc("web_search", '{"query":"a"}', call_id="search-1"),
+            _tc("web_search", '{"query":"b"}', call_id="search-2"),
+        ]
+        msg = SimpleNamespace(content="", tool_calls=calls)
+        events = []
+        events_lock = threading.Lock()
+
+        def record_progress(event, name, preview, args, **kwargs):
+            if event == "tool.started":
+                with events_lock:
+                    events.append(("projected", name))
+
+        def fake_handle(name, args, task_id, **kwargs):
+            with events_lock:
+                events.append(("dispatched", name))
+            return json.dumps({"ok": True})
+
+        agent.tool_progress_callback = record_progress
+        with patch("run_agent.handle_function_call", side_effect=fake_handle):
+            agent._execute_tool_calls(msg, [], "task-1")
+
+        intent_projection = events.index(("projected", "report_intent"))
+        search_dispatches = [
+            index
+            for index, event in enumerate(events)
+            if event in {
+                ("dispatched", "web_search"),
+            }
+        ]
+        assert len(search_dispatches) == 2
+        assert all(intent_projection < index for index in search_dispatches)
+
     def test_mixed_batch_runs_safe_prefix_concurrently_and_barrier_after(self, agent):
         """Two web_search calls must overlap in time; terminal must start only
         after both finish; results land in the model's emission order."""

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -6,6 +6,8 @@ import threading
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from tools.registry import ToolRegistry, _module_registers_tools, discover_builtin_tools
 
 
@@ -32,6 +34,95 @@ class TestRegisterAndDispatch:
         )
         result = json.loads(reg.dispatch("alpha", {}))
         assert result == {"ok": True}
+
+    def test_run_start_event_metadata_is_normalized_and_defensively_copied(self):
+        reg = ToolRegistry()
+        metadata = {"event": "agent.intent", "fields": ["text", "speech"]}
+        reg.register(
+            name="report_intent",
+            toolset="plugin",
+            schema=_make_schema("report_intent"),
+            handler=_dummy_handler,
+            run_start_event=metadata,
+        )
+
+        metadata["event"] = "changed.after.registration"
+        metadata["fields"].append("extra")
+        first = reg.get_run_start_event("report_intent")
+        assert first == {
+            "event": "agent.intent",
+            "fields": ("text", "speech"),
+        }
+
+        first["event"] = "changed.after.lookup"
+        assert reg.get_run_start_event("report_intent") == {
+            "event": "agent.intent",
+            "fields": ("text", "speech"),
+        }
+
+    def test_run_start_event_preserves_positional_override_compatibility(self):
+        reg = ToolRegistry()
+        reg.register(
+            "replaceable",
+            "base",
+            _make_schema("replaceable"),
+            _dummy_handler,
+        )
+
+        replacement = lambda args, **kwargs: json.dumps({"replacement": True})
+        reg.register(
+            "replaceable",
+            "replacement",
+            _make_schema("replaceable"),
+            replacement,
+            None,
+            None,
+            False,
+            "",
+            "",
+            None,
+            None,
+            True,
+        )
+
+        entry = reg.get_entry("replaceable")
+        assert entry is not None
+        assert entry.toolset == "replacement"
+        assert entry.handler is replacement
+        assert entry.run_start_event is None
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            {"event": "intent", "fields": ("text",)},
+            {"event": "approval.responded", "fields": ("text",)},
+            {"event": "message.delta", "fields": ("text",)},
+            {"event": "run.started", "fields": ("text",)},
+            {"event": "run.stopping", "fields": ("text",)},
+            {"event": "tool.failed", "fields": ("text",)},
+            {"event": "tool.progress", "fields": ("text",)},
+            {"event": "tool.started", "fields": ("text",)},
+            {"event": "agent.intent", "fields": ()},
+            {"event": "agent.intent", "fields": ("text", "text")},
+            {"event": "agent.intent", "fields": ("run_id",)},
+            {"event": "agent.intent", "fields": ("type",)},
+            {"event": "agent.intent", "fields": ("not-valid",)},
+            {"event": "agent.intent", "fields": ("text",), "projector": object()},
+        ],
+    )
+    def test_invalid_run_start_event_metadata_is_rejected(self, metadata):
+        reg = ToolRegistry()
+
+        with pytest.raises(ValueError):
+            reg.register(
+                name="report_intent",
+                toolset="plugin",
+                schema=_make_schema("report_intent"),
+                handler=_dummy_handler,
+                run_start_event=metadata,
+            )
+
+        assert reg.get_entry("report_intent") is None
 
 
     def test_cross_mcp_toolsets_do_not_overwrite_atomically(self, caplog):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -18,6 +18,7 @@ import ast
 import importlib
 import json
 import logging
+import re
 import sys
 import threading
 import time
@@ -25,6 +26,58 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
+
+_RUN_START_EVENT_NAME_RE = re.compile(
+    r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$"
+)
+_RUN_START_EVENT_FIELD_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_RUN_START_EVENT_RESERVED_NAMESPACES = frozenset({
+    "approval",
+    "message",
+    "reasoning",
+    "run",
+    "subagent",
+    "tool",
+})
+_RUN_START_EVENT_RESERVED_FIELDS = frozenset({
+    "event",
+    "run_id",
+    "sequence",
+    "timestamp",
+    "type",
+})
+
+
+def _normalize_run_start_event(value: Optional[dict]) -> Optional[dict]:
+    """Validate and copy declarative public-event metadata for a tool."""
+    if value is None:
+        return None
+    if not isinstance(value, dict) or set(value) != {"event", "fields"}:
+        raise ValueError(
+            "run_start_event must contain exactly 'event' and 'fields'"
+        )
+    event = value["event"]
+    fields = value["fields"]
+    if (
+        not isinstance(event, str)
+        or not _RUN_START_EVENT_NAME_RE.fullmatch(event)
+        or event.partition(".")[0] in _RUN_START_EVENT_RESERVED_NAMESPACES
+    ):
+        raise ValueError(
+            "run_start_event.event must be a non-reserved namespaced event name"
+        )
+    if not isinstance(fields, (list, tuple)) or not fields:
+        raise ValueError("run_start_event.fields must be a non-empty list or tuple")
+    if any(
+        not isinstance(field, str)
+        or not _RUN_START_EVENT_FIELD_RE.fullmatch(field)
+        or field in _RUN_START_EVENT_RESERVED_FIELDS
+        for field in fields
+    ):
+        raise ValueError("run_start_event.fields contains an invalid field name")
+    if len(set(fields)) != len(fields):
+        raise ValueError("run_start_event.fields must not contain duplicates")
+    return {"event": event, "fields": tuple(fields)}
 
 
 def _is_registry_register_call(node: ast.AST) -> bool:
@@ -164,11 +217,13 @@ class ToolEntry:
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
         "max_result_size_chars", "dynamic_schema_overrides",
+        "run_start_event",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 run_start_event=None):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -179,6 +234,7 @@ class ToolEntry:
         self.description = description
         self.emoji = emoji
         self.max_result_size_chars = max_result_size_chars
+        self.run_start_event = run_start_event
         # Optional zero-arg callable returning a dict of schema overrides
         # applied at get_definitions() time. Use for fields that depend on
         # runtime config (e.g. delegate_task's description must reflect the
@@ -449,6 +505,8 @@ class ToolRegistry:
         max_result_size_chars: int | float | None = None,
         dynamic_schema_overrides: Callable = None,
         override: bool = False,
+        *,
+        run_start_event: dict | None = None,
     ):
         """Register a tool.  Called at module-import time by each tool file.
 
@@ -458,6 +516,7 @@ class ToolRegistry:
         registrations that would shadow an existing tool from a different
         toolset are rejected to prevent accidental overwrites.
         """
+        normalized_run_start_event = _normalize_run_start_event(run_start_event)
         with self._lock:
             existing = self._tools.get(name)
             if existing and existing.toolset != toolset:
@@ -508,6 +567,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                run_start_event=normalized_run_start_event,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -732,6 +792,16 @@ class ToolRegistry:
         """
         entry = self.get_entry(name)
         return entry.schema if entry else None
+
+    def get_run_start_event(self, name: str) -> Optional[dict]:
+        """Return a defensive copy of a tool's public run-start event metadata."""
+        entry = self.get_entry(name)
+        if entry is None or entry.run_start_event is None:
+            return None
+        return {
+            "event": entry.run_start_event["event"],
+            "fields": tuple(entry.run_start_event["fields"]),
+        }
 
     def get_toolset_for_tool(self, name: str) -> Optional[str]:
         """Return the toolset a tool belongs to, or None."""

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -279,6 +279,44 @@ def register(ctx):
 - `ctx.dispatch_tool(name, arguments)` — call any other tool (built-in or from another plugin) with the parent agent's context (approvals, credentials, task_id) wired up automatically. Useful from slash-command handlers that need to invoke `terminal`, `read_file`, or any other tool as if the model had called it directly.
 - If this function crashes, the plugin is disabled but Hermes continues fine
 
+### Project a declarative run-start event
+
+A plugin tool can opt into one small, user-facing event when it starts in the
+[`/v1/runs`](../../user-guide/features/api-server.md#runs-api-streaming-friendly-alternative)
+SSE API:
+
+```python
+ctx.register_tool(
+    name="report_intent",
+    toolset="example",
+    schema=REPORT_INTENT_SCHEMA,
+    handler=report_intent,
+    run_start_event={
+        "event": "client.intent",
+        "fields": ["text", "speech"],
+    },
+)
+```
+
+`run_start_event` must contain exactly `event` and `fields`. The event name is
+lowercase and namespaced (for example, `client.intent`); the reserved
+`approval`, `message`, `reasoning`, `run`, `subagent`, and `tool` namespaces
+cannot be used. `fields` is a non-empty, duplicate-free list or tuple of
+lowercase argument names. The SSE envelope fields `event`, `run_id`,
+`sequence`, `timestamp`, and `type` are reserved.
+
+When the tool starts, every declared field must be present in the tool-call
+arguments and be a string. Hermes omits undeclared arguments, force-redacts
+secrets and URL credentials, truncates each projected value to 160 characters,
+and emits the custom event with a per-run sequence number. If a declared value
+is missing or is not a string, the projected event is suppressed. The opted-in
+tool's generic `tool.started` and `tool.completed` events are also suppressed
+to avoid duplicate narration.
+
+Projection is limited to `GET /v1/runs/{run_id}/events`; it does not change the
+CLI, messaging gateways, chat-completions streams, Responses API, or session
+chat streams. It projects tool-call arguments only, never handler results.
+
 **`dispatch_tool` example — a slash command that runs a tool:**
 
 ```python

--- a/website/docs/developer-guide/tools-runtime.md
+++ b/website/docs/developer-guide/tools-runtime.md
@@ -37,10 +37,29 @@ registry.register(
     is_async=False,                # Whether the handler is an async coroutine
     description="Run commands",    # Human-readable description
     emoji="💻",                    # Emoji for spinner/progress display
+    run_start_event={              # Optional /v1/runs SSE projection
+        "event": "client.intent",
+        "fields": ["text", "speech"],
+    },
 )
 ```
 
 Each call creates a `ToolEntry` stored in the singleton `ToolRegistry._tools` dict keyed by tool name. A registration that would shadow an existing tool from a **different** toolset is rejected (with an error log) unless the caller passes `override=True`; plugin overrides of built-in tools additionally require the operator opt-in `plugins.entries.<plugin_id>.allow_tool_override: true` in `config.yaml`.
+
+`run_start_event` is an optional declarative projection for the
+`GET /v1/runs/{run_id}/events` SSE stream. It must contain exactly a
+non-reserved lowercase namespaced `event` and a non-empty, duplicate-free
+`fields` list or tuple. Reserved lifecycle namespaces are `approval`,
+`message`, `reasoning`, `run`, `subagent`, and `tool`; reserved envelope fields
+are `event`, `run_id`, `sequence`, `timestamp`, and `type`.
+
+At `tool.started`, Hermes copies only the declared string arguments, applies
+forced secret and URL-credential redaction, and truncates each value to 160
+characters. Missing or non-string declared fields suppress the projection.
+For an opted-in tool, the normal `tool.started` and `tool.completed` events are
+suppressed to avoid duplicates. This metadata affects only the `/v1/runs` SSE
+surface and never projects handler output. Plugins pass the same keyword to
+`ctx.register_tool()`; see the [plugin guide](./plugins/#project-a-declarative-run-start-event).
 
 ### Discovery: `discover_builtin_tools()`
 


### PR DESCRIPTION
## What does this PR do?

Adds a narrow, declarative `run_start_event` contract for registered tools so an API client can receive a safe user-facing event when an opted-in tool starts. The registry validates and copies fixed event metadata; the Runs adapter projects only declared string arguments, force-redacts sensitive text before a 160-character bound, and sequences projection and enqueue atomically per run. Ordinary tool lifecycle events remain unchanged.

This is a generic producer-side primitive for clients that need accessible, user-facing intent narration. Client policy, speech output, controls, and external consumer integrations remain outside Hermes.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add validated `run_start_event` metadata to `ToolRegistry`, with reserved namespaces/envelope fields and defensive copying.
- Forward the metadata through plugin tool registration.
- Project only allowlisted string fields from `tool.started`; redact before truncation, start sequences at 1 per run, and suppress duplicate lifecycle events for projected tools.
- Preserve sequential plugin tools as barriers in mixed tool batches.
- Add focused registry, plugin, Runs API, concurrency, and batch-order coverage.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_api_server_runs.py tests/gateway/test_api_server_run_start_events.py tests/hermes_cli/test_plugins.py tests/run_agent/test_tool_batch_segmentation.py tests/tools/test_registry.py -q` — 121 passed.
2. Run `uvx ruff check` on the eight changed Python files — all checks passed.
3. Run `npm run build --prefix website` — the Docusaurus production build completed for both locales.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — API and registry change only.
