### PR TITLE
feat(agent): opt-in trajectory quality routing (recommend-only)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -714,6 +714,14 @@ def init_agent(
     agent._tool_guardrails = ToolCallGuardrailController()
     agent._tool_guardrail_halt_decision: ToolGuardrailDecision | None = None
 
+    # Trajectory quality routing defaults (overwritten later from config
+    # in the full init path; set early so turn_context and other code
+    # that reads getattr(agent, "_trajectory_quality", None) is safe).
+    agent._trajectory_quality = None
+    agent._trajectory_quality_store = None
+    agent._trajectory_quality_halt_decision = None
+    agent._pending_trajectory_quality_recommendation = None
+
     # Interrupt mechanism for breaking out of tool loops
     agent._interrupt_requested = False
     agent._interrupt_message = None  # Optional message that triggered interrupt
@@ -1564,6 +1572,35 @@ def init_agent(
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+
+    # Trajectory quality routing — opt-in parallel observer of the same
+    # tool-result signals the guardrails consume. Disabled by default;
+    # when enabled, it escalates a one-way recommendation ladder without
+    # mutating prompts or toolsets.
+    try:
+        from agent.trajectory_quality import TrajectoryQualityConfig, TrajectoryQualityController
+        _tqr_cfg_data = _agent_cfg.get("trajectory_quality_routing", {})
+        _tqr_cfg = TrajectoryQualityConfig.from_mapping(_tqr_cfg_data)
+        agent._trajectory_quality = TrajectoryQualityController(_tqr_cfg)
+        agent._trajectory_quality_store = None
+        if _tqr_cfg.enabled and _tqr_cfg.persist_decisions:
+            try:
+                from agent.trajectory_quality_store import TrajectoryQualityStore
+                agent._trajectory_quality_store = TrajectoryQualityStore(
+                    retention_days=_tqr_cfg.retention_days,
+                    max_decisions_per_session=_tqr_cfg.max_decisions_per_session,
+                )
+            except Exception as _store_err:
+                _ra().logger.warning(
+                    "Trajectory quality store disabled (fail-open): %s", _store_err
+                )
+                agent._trajectory_quality_store = None
+        agent._trajectory_quality_halt_decision = None
+        agent._pending_trajectory_quality_recommendation = None
+    except Exception as _tqr_err:
+        _ra().logger.warning(
+            "Trajectory quality routing config ignored: %s", _tqr_err
+        )
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5273,6 +5273,29 @@ def run_conversation(
                                 pass
                     break
 
+                # Trajectory quality soft-stop: when the quality ladder
+                # reaches ``stop`` and ``execute_stop`` is enabled, halt
+                # further tool thrash for this turn (mirrors the guardrail
+                # halt path but with quality-specific wording).
+                _tqr_halt = getattr(agent, "_trajectory_quality_halt_decision", None)
+                if _tqr_halt is not None:
+                    _turn_exit_reason = "trajectory_quality_halt"
+                    final_response = agent._trajectory_quality_halt_response(_tqr_halt)
+                    agent._emit_status(
+                        f"⚠️ Trajectory quality halted {_tqr_halt.tool_name}: "
+                        f"{_tqr_halt.reason_code}"
+                    )
+                    messages.append({"role": "assistant", "content": final_response})
+                    if final_response:
+                        agent._safe_print(f"\n{final_response}\n")
+                        if agent.stream_delta_callback:
+                            try:
+                                agent.stream_delta_callback(final_response)
+                                agent.stream_delta_callback(None)
+                            except Exception:
+                                pass
+                    break
+
                 # Reset per-turn retry counters after successful tool
                 # execution so a single truncation doesn't poison the
                 # entire conversation.

--- a/agent/trajectory_quality.py
+++ b/agent/trajectory_quality.py
@@ -409,6 +409,64 @@ def _explain(
 
 
 # ---------------------------------------------------------------------------
+# Event builder (pure helper)
+# ---------------------------------------------------------------------------
+
+
+def build_observation(
+    *,
+    tool_name: str,
+    args: Mapping[str, Any] | None,
+    result: str | None,
+    failed: bool,
+    verification_status: str | None = None,
+    api_call_count: int = 0,
+    session_id: str = "",
+    model: str = "",
+    provider: str = "",
+) -> TrajectoryObservation:
+    """Build a ``TrajectoryObservation`` from raw tool call data.
+
+    Reuses the canonical hashing from ``tool_guardrails`` so hashes are
+    consistent with the loop guardrail subsystem. Never stores raw args
+    or results — only their hashes.
+
+    ``progress_kind`` is derived from the result:
+    - ``file_mutation_landed`` when a file mutation result proves success
+    - ``verification_failed`` / ``verification_passed`` when the caller
+      passes ``verification_status``
+    - ``none`` otherwise
+    """
+    from agent.tool_guardrails import ToolCallSignature, _result_hash
+    from agent.tool_result_classification import file_mutation_result_landed
+
+    signature = ToolCallSignature.from_call(tool_name, args or {})
+    r_hash = _result_hash(result)
+
+    progress_kind = "none"
+    if not failed and file_mutation_result_landed(tool_name, result):
+        progress_kind = "file_mutation_landed"
+
+    if verification_status == "failed":
+        progress_kind = "verification_failed"
+    elif verification_status == "passed":
+        progress_kind = "verification_passed"
+
+    return TrajectoryObservation(
+        tool_name=tool_name,
+        args_hash=signature.args_hash,
+        result_hash=r_hash,
+        failed=failed,
+        progress_kind=progress_kind,
+        verification_status=verification_status,
+        api_call_count=api_call_count,
+        session_id=session_id,
+        model=model,
+        provider=provider,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Config parsing helpers (private)
 # ---------------------------------------------------------------------------
 

--- a/agent/trajectory_quality.py
+++ b/agent/trajectory_quality.py
@@ -164,6 +164,15 @@ def _level_max(a: str, b: str) -> str:
     return a if _LEVEL_ORDER.get(a, 0) >= _LEVEL_ORDER.get(b, 0) else b
 
 
+def _deescalate_one(level: str) -> str:
+    """Lower the level by one step (used only when de-escalation is enabled)."""
+    order = _LEVEL_ORDER.get(level, 0)
+    for name, val in _LEVEL_ORDER.items():
+        if val == order - 1:
+            return name
+    return "continue"
+
+
 # ---------------------------------------------------------------------------
 # Controller
 # ---------------------------------------------------------------------------
@@ -192,6 +201,7 @@ class TrajectoryQualityController:
         self._observation_count: int = 0
         self._reason_codes_fired: set[str] = set()
         self._last_emitted_key: tuple[str, str, str, str] | None = None
+        self._progress_since_level: int = 0
 
     @property
     def level(self) -> str:
@@ -202,54 +212,76 @@ class TrajectoryQualityController:
             return None
 
         self._observation_count += 1
+        level_before = self._level
 
-        # ---- Update counters ----
-        decision = self._evaluate(obs)
-
-        # ---- Progress tracking ----
-        if obs.is_progress:
-            self._consecutive_no_progress = 0
-        else:
-            self._consecutive_no_progress += 1
-
-        if obs.failed:
-            self._turn_saw_failure = True
-
-        return decision
-
-    def _evaluate(self, obs: TrajectoryObservation) -> TrajectoryQualityDecision | None:
+        # ---- Update per-signature counters ----
         key = (obs.tool_name, obs.args_hash)
+        exact = 0
+        same = 0
 
         if obs.failed:
             exact = self._exact_failure_counts.get(key, 0) + 1
             self._exact_failure_counts[key] = exact
             same = self._same_tool_failure_counts.get(obs.tool_name, 0) + 1
             self._same_tool_failure_counts[obs.tool_name] = same
+            self._turn_saw_failure = True
         else:
             # Success clears the exact-failure counter for this signature.
             self._exact_failure_counts.pop(key, None)
             if obs.is_progress:
                 self._same_tool_failure_counts.pop(obs.tool_name, None)
-            # No decision on a plain success.
-            return None
 
-        level_before = self._level
+        # ---- Verification streak tracking ----
+        if obs.progress_kind == "verification_failed":
+            self._failed_verification_streak += 1
+            self._turn_saw_verification_failed = True
+        elif obs.progress_kind == "verification_passed" or (
+            obs.is_progress and obs.progress_kind != "verification_failed"
+        ):
+            self._failed_verification_streak = 0
+
+        # ---- Stagnation tracking ----
+        if obs.is_progress:
+            self._consecutive_no_progress = 0
+            self._progress_since_level += 1
+        else:
+            self._consecutive_no_progress += 1
+
+        # ---- Evaluate triggers ----
         target_reason: str | None = None
         target_level = level_before
-        count = exact
-
-        # ---- Trigger evaluation (ordered by severity) ----
+        count = 0
 
         # Two-identical-failure circuit breaker.
-        if exact >= self.config.identical_failure:
+        if obs.failed and exact >= self.config.identical_failure:
             target_reason = "two_identical_failures"
             target_level = _level_max(target_level, "recommend_stronger_model")
+            count = exact
 
         # Same-tool failure streak.
-        if same >= self.config.same_tool_failure:
+        if obs.failed and same >= self.config.same_tool_failure:
             if target_reason is None:
                 target_reason = "same_tool_failure_streak"
+                count = same
             target_level = _level_max(target_level, "recommend_stronger_model")
+
+        # Failed-verification streak.
+        if self._failed_verification_streak >= self.config.failed_verification:
+            if target_reason is None:
+                target_reason = "failed_verification_streak"
+                count = self._failed_verification_streak
+            target_level = _level_max(target_level, "recommend_stronger_model")
+
+        # Stagnation: no verified progress for N observations, after a prior
+        # failure or verification_failed in the turn.
+        if (
+            self._consecutive_no_progress >= self.config.stagnation_window
+            and (self._turn_saw_failure or self._turn_saw_verification_failed)
+        ):
+            if target_reason is None:
+                target_reason = "stagnation_no_progress"
+                count = self._consecutive_no_progress
+            target_level = _level_max(target_level, "recommend_clean_restart")
 
         # Compounding: a new reason while already >= level 1 pushes to level 2.
         if target_reason is not None and level_before != "continue":
@@ -260,11 +292,22 @@ class TrajectoryQualityController:
         if target_reason is not None and level_before == "recommend_clean_restart":
             target_level = _level_max(target_level, "stop")
 
+        # ---- De-escalation (optional, off by default) ----
+        if (
+            self.config.allow_deescalate_on_progress
+            and obs.is_progress
+            and self._level != "continue"
+            and self._progress_since_level >= self.config.hysteresis_progress_needed
+        ):
+            self._level = _deescalate_one(self._level)
+            self._progress_since_level = 0
+            # A de-escalation is not an emitted decision — it silently lowers.
+            return None
+
         if target_reason is None:
             return None
 
-        # Monotonic: never lower the level (unless de-escalate is enabled,
-        # which is handled at progress observation time — not here).
+        # Monotonic: never lower the level via triggers.
         new_level = _level_max(self._level, target_level)
         if new_level == self._level and target_reason in self._reason_codes_fired:
             # Same reason, same level — suppress duplicate.
@@ -272,6 +315,7 @@ class TrajectoryQualityController:
 
         self._level = new_level
         self._reason_codes_fired.add(target_reason)
+        self._progress_since_level = 0
 
         decision = self._build_decision(
             obs=obs,

--- a/agent/trajectory_quality.py
+++ b/agent/trajectory_quality.py
@@ -1,0 +1,402 @@
+"""Trajectory quality routing — pure reducer and one-way policy ladder.
+
+This module is intentionally side-effect free: it tracks per-turn tool
+observations and returns decisions. Runtime code (run_agent.py) owns
+whether those decisions become status notices, durable records, or a
+controlled turn halt.
+
+When ``TrajectoryQualityConfig.enabled`` is ``False`` (the default),
+``observe`` returns ``None`` immediately — zero overhead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TrajectoryQualityConfig:
+    """Thresholds for trajectory quality routing.
+
+    Disabled by default. When enabled, the controller observes tool
+    results and emits escalation decisions on a one-way ladder:
+    continue -> recommend_stronger_model -> recommend_clean_restart -> stop.
+    """
+
+    enabled: bool = False
+    execute_stop: bool = True
+    execute_model_switch: bool = False  # unsupported in slice 1; must be ignored
+    allow_deescalate_on_progress: bool = False
+    persist_decisions: bool = True
+    retention_days: int = 30
+    max_decisions_per_session: int = 200
+    identical_failure: int = 2
+    same_tool_failure: int = 4
+    failed_verification: int = 2
+    stagnation_window: int = 8
+    hysteresis_progress_needed: int = 2
+    stronger_provider: str | None = None
+    stronger_model: str | None = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "TrajectoryQualityConfig":
+        """Build config from the ``trajectory_quality_routing`` config section."""
+        if not isinstance(data, Mapping):
+            return cls()
+
+        thresholds = data.get("thresholds")
+        if not isinstance(thresholds, Mapping):
+            thresholds = {}
+
+        stronger = data.get("stronger_model")
+        if not isinstance(stronger, Mapping):
+            stronger = {}
+
+        defaults = cls()
+        return cls(
+            enabled=_as_bool(data.get("enabled"), defaults.enabled),
+            execute_stop=_as_bool(data.get("execute_stop"), defaults.execute_stop),
+            execute_model_switch=_as_bool(
+                data.get("execute_model_switch"), defaults.execute_model_switch
+            ),
+            allow_deescalate_on_progress=_as_bool(
+                data.get("allow_deescalate_on_progress"),
+                defaults.allow_deescalate_on_progress,
+            ),
+            persist_decisions=_as_bool(
+                data.get("persist_decisions"), defaults.persist_decisions
+            ),
+            retention_days=_positive_int(
+                data.get("retention_days"), defaults.retention_days
+            ),
+            max_decisions_per_session=_positive_int(
+                data.get("max_decisions_per_session"),
+                defaults.max_decisions_per_session,
+            ),
+            identical_failure=_positive_int(
+                thresholds.get("identical_failure", data.get("identical_failure")),
+                defaults.identical_failure,
+            ),
+            same_tool_failure=_positive_int(
+                thresholds.get("same_tool_failure", data.get("same_tool_failure")),
+                defaults.same_tool_failure,
+            ),
+            failed_verification=_positive_int(
+                thresholds.get("failed_verification", data.get("failed_verification")),
+                defaults.failed_verification,
+            ),
+            stagnation_window=_positive_int(
+                thresholds.get("stagnation_window", data.get("stagnation_window")),
+                defaults.stagnation_window,
+            ),
+            hysteresis_progress_needed=_positive_int(
+                data.get("hysteresis_progress_needed"),
+                defaults.hysteresis_progress_needed,
+            ),
+            stronger_provider=_opt_str(stronger.get("provider")),
+            stronger_model=_opt_str(stronger.get("model")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Events / state / decisions
+# ---------------------------------------------------------------------------
+
+_PROGRESS_KINDS = {"file_mutation_landed", "verification_passed"}
+
+
+@dataclass(frozen=True)
+class TrajectoryObservation:
+    """A single structured tool-result observation (no raw content)."""
+
+    tool_name: str
+    args_hash: str
+    result_hash: str | None
+    failed: bool
+    progress_kind: str = "none"
+    verification_status: str | None = None
+    api_call_count: int = 0
+    session_id: str = ""
+    model: str = ""
+    provider: str = ""
+
+    @property
+    def is_progress(self) -> bool:
+        return self.progress_kind in _PROGRESS_KINDS
+
+
+@dataclass(frozen=True)
+class TrajectoryQualityDecision:
+    """A routing decision emitted by the controller."""
+
+    action: str  # continue | recommend_stronger_model | recommend_clean_restart | stop
+    reason_code: str
+    level_before: str
+    level_after: str
+    tool_name: str
+    args_hash: str
+    result_hash: str | None
+    count: int
+    explain: str
+    model: str = ""
+    provider: str = ""
+    recommended_model: str | None = None
+    recommended_provider: str | None = None
+    decision_id: str = ""
+
+
+# Level ordering for monotonic escalation.
+_LEVEL_ORDER: dict[str, int] = {
+    "continue": 0,
+    "recommend_stronger_model": 1,
+    "recommend_clean_restart": 2,
+    "stop": 3,
+}
+
+
+def _level_max(a: str, b: str) -> str:
+    return a if _LEVEL_ORDER.get(a, 0) >= _LEVEL_ORDER.get(b, 0) else b
+
+
+# ---------------------------------------------------------------------------
+# Controller
+# ---------------------------------------------------------------------------
+
+
+class TrajectoryQualityController:
+    """Per-turn controller for trajectory quality routing.
+
+    Pure: no I/O, no agent runtime. Feed it ``TrajectoryObservation`` events
+    and it returns an optional ``TrajectoryQualityDecision`` when the policy
+    ladder escalates.
+    """
+
+    def __init__(self, config: TrajectoryQualityConfig | None = None):
+        self.config = config or TrajectoryQualityConfig()
+        self.reset_for_turn()
+
+    def reset_for_turn(self) -> None:
+        self._level: str = "continue"
+        self._exact_failure_counts: dict[tuple[str, str], int] = {}
+        self._same_tool_failure_counts: dict[str, int] = {}
+        self._consecutive_no_progress: int = 0
+        self._failed_verification_streak: int = 0
+        self._turn_saw_failure: bool = False
+        self._turn_saw_verification_failed: bool = False
+        self._observation_count: int = 0
+        self._reason_codes_fired: set[str] = set()
+        self._last_emitted_key: tuple[str, str, str, str] | None = None
+
+    @property
+    def level(self) -> str:
+        return self._level
+
+    def observe(self, obs: TrajectoryObservation) -> TrajectoryQualityDecision | None:
+        if not self.config.enabled:
+            return None
+
+        self._observation_count += 1
+
+        # ---- Update counters ----
+        decision = self._evaluate(obs)
+
+        # ---- Progress tracking ----
+        if obs.is_progress:
+            self._consecutive_no_progress = 0
+        else:
+            self._consecutive_no_progress += 1
+
+        if obs.failed:
+            self._turn_saw_failure = True
+
+        return decision
+
+    def _evaluate(self, obs: TrajectoryObservation) -> TrajectoryQualityDecision | None:
+        key = (obs.tool_name, obs.args_hash)
+
+        if obs.failed:
+            exact = self._exact_failure_counts.get(key, 0) + 1
+            self._exact_failure_counts[key] = exact
+            same = self._same_tool_failure_counts.get(obs.tool_name, 0) + 1
+            self._same_tool_failure_counts[obs.tool_name] = same
+        else:
+            # Success clears the exact-failure counter for this signature.
+            self._exact_failure_counts.pop(key, None)
+            if obs.is_progress:
+                self._same_tool_failure_counts.pop(obs.tool_name, None)
+            # No decision on a plain success.
+            return None
+
+        level_before = self._level
+        target_reason: str | None = None
+        target_level = level_before
+        count = exact
+
+        # ---- Trigger evaluation (ordered by severity) ----
+
+        # Two-identical-failure circuit breaker.
+        if exact >= self.config.identical_failure:
+            target_reason = "two_identical_failures"
+            target_level = _level_max(target_level, "recommend_stronger_model")
+
+        # Same-tool failure streak.
+        if same >= self.config.same_tool_failure:
+            if target_reason is None:
+                target_reason = "same_tool_failure_streak"
+            target_level = _level_max(target_level, "recommend_stronger_model")
+
+        # Compounding: a new reason while already >= level 1 pushes to level 2.
+        if target_reason is not None and level_before != "continue":
+            if target_reason not in self._reason_codes_fired:
+                target_level = _level_max(target_level, "recommend_clean_restart")
+
+        # Any trigger while already at level 2 pushes to stop.
+        if target_reason is not None and level_before == "recommend_clean_restart":
+            target_level = _level_max(target_level, "stop")
+
+        if target_reason is None:
+            return None
+
+        # Monotonic: never lower the level (unless de-escalate is enabled,
+        # which is handled at progress observation time — not here).
+        new_level = _level_max(self._level, target_level)
+        if new_level == self._level and target_reason in self._reason_codes_fired:
+            # Same reason, same level — suppress duplicate.
+            return None
+
+        self._level = new_level
+        self._reason_codes_fired.add(target_reason)
+
+        decision = self._build_decision(
+            obs=obs,
+            reason_code=target_reason,
+            level_before=level_before,
+            level_after=new_level,
+            count=count,
+        )
+
+        # Hysteresis: suppress duplicate (action, reason, tool, args_hash).
+        emit_key = (
+            decision.action,
+            decision.reason_code,
+            decision.tool_name,
+            decision.args_hash,
+        )
+        if emit_key == self._last_emitted_key:
+            return None
+        self._last_emitted_key = emit_key
+        return decision
+
+    def _build_decision(
+        self,
+        *,
+        obs: TrajectoryObservation,
+        reason_code: str,
+        level_before: str,
+        level_after: str,
+        count: int,
+    ) -> TrajectoryQualityDecision:
+        explain = _explain(
+            reason_code=reason_code,
+            tool_name=obs.tool_name,
+            count=count,
+            config=self.config,
+        )
+        return TrajectoryQualityDecision(
+            action=level_after,
+            reason_code=reason_code,
+            level_before=level_before,
+            level_after=level_after,
+            tool_name=obs.tool_name,
+            args_hash=obs.args_hash,
+            result_hash=obs.result_hash,
+            count=count,
+            explain=explain,
+            model=obs.model,
+            provider=obs.provider,
+            recommended_model=self.config.stronger_model,
+            recommended_provider=self.config.stronger_provider,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Explain helper
+# ---------------------------------------------------------------------------
+
+
+def _explain(
+    *,
+    reason_code: str,
+    tool_name: str,
+    count: int,
+    config: TrajectoryQualityConfig,
+) -> str:
+    """Build a short operator-facing sentence with no secrets."""
+    if reason_code == "two_identical_failures":
+        base = f"{tool_name} failed {count}x with identical args_hash"
+    elif reason_code == "same_tool_failure_streak":
+        base = f"{tool_name} failed {count}x this turn"
+    elif reason_code == "failed_verification_streak":
+        base = f"{count} consecutive verification failures after edits"
+    elif reason_code == "stagnation_no_progress":
+        base = f"no verified progress in {count} tool observations"
+    else:
+        base = f"{tool_name} quality signal ({reason_code}, count={count})"
+
+    model_hint = ""
+    if config.stronger_model:
+        model_hint = f". Try /model {config.stronger_model} or start a clean session"
+    else:
+        model_hint = ". Try /model for a stronger model or start a clean session"
+
+    action_word = {
+        "recommend_stronger_model": "recommend stronger model",
+        "recommend_clean_restart": "recommend clean session restart",
+        "stop": "trajectory quality stop",
+    }.get(reason_code, reason_code)
+    # The action is the level_after, not the reason_code.
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Config parsing helpers (private)
+# ---------------------------------------------------------------------------
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if lowered in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return default
+
+
+def _positive_int(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 1 else default
+
+
+def _opt_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None

--- a/agent/trajectory_quality_store.py
+++ b/agent/trajectory_quality_store.py
@@ -1,0 +1,252 @@
+"""Profile-aware SQLite store for trajectory quality decision records.
+
+Follows the ``verification_evidence.py`` pattern: a sidecar database under
+``get_hermes_home()`` so the main SessionDB schema is never touched. All
+string fields are defensively redacted before write — only hashes, tool
+names, counts, and short explain strings are persisted. Never raw args,
+results, or stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from agent.trajectory_quality import TrajectoryQualityDecision
+
+_DB_LOCK = threading.Lock()
+_SCHEMA_VERSION = 1
+_DEFAULT_RETENTION_DAYS = 30
+_DEFAULT_MAX_PER_SESSION = 200
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _retention_cutoff(days: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+def _db_path() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "trajectory_quality.db"
+
+
+def _connect(path: Path | None = None) -> sqlite3.Connection:
+    db_path = path or _db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.row_factory = sqlite3.Row
+    _ensure_schema(conn)
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS decisions (
+            id TEXT PRIMARY KEY,
+            created_at TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            api_call_count INTEGER NOT NULL DEFAULT 0,
+            action TEXT NOT NULL,
+            reason_code TEXT NOT NULL,
+            level_before TEXT NOT NULL,
+            level_after TEXT NOT NULL,
+            tool_name TEXT NOT NULL,
+            args_hash TEXT NOT NULL,
+            result_hash TEXT,
+            count INTEGER NOT NULL DEFAULT 0,
+            model TEXT NOT NULL DEFAULT '',
+            provider TEXT NOT NULL DEFAULT '',
+            recommended_model TEXT,
+            recommended_provider TEXT,
+            explain TEXT NOT NULL DEFAULT ''
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_decisions_session
+        ON decisions(session_id, created_at DESC)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_decisions_created
+        ON decisions(created_at)
+        """
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO meta(key, value) VALUES ('schema_version', ?)",
+        (str(_SCHEMA_VERSION),),
+    )
+    conn.commit()
+
+
+def _redact(text: str) -> str:
+    """Defensively redact any secret-like substring before persistence."""
+    if not text:
+        return text
+    try:
+        from agent.redact import redact_sensitive_text
+
+        return redact_sensitive_text(text, force=True)
+    except Exception:
+        # Redaction must never block persistence — fall back to the raw
+        # string if the redactor is unavailable. The explain strings only
+        # contain tool names and counts anyway.
+        return text
+
+
+class TrajectoryQualityStore:
+    """Durable store for trajectory quality routing decisions.
+
+    All writes are redacted and bounded by retention + per-session caps.
+    The store fails open: if the database cannot be opened, ``record``
+    logs a warning and returns a synthetic id without raising.
+    """
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        *,
+        retention_days: int = _DEFAULT_RETENTION_DAYS,
+        max_decisions_per_session: int = _DEFAULT_MAX_PER_SESSION,
+    ):
+        self._path = path
+        self._retention_days = retention_days
+        self._max_per_session = max_decisions_per_session
+
+    def record(
+        self,
+        decision: TrajectoryQualityDecision,
+        *,
+        session_id: str = "",
+        api_call_count: int = 0,
+    ) -> str:
+        """Persist a decision and return its id. Never raises."""
+        decision_id = decision.decision_id or uuid.uuid4().hex
+        created_at = _utc_now()
+        try:
+            with _DB_LOCK:
+                conn = _connect(self._path)
+                try:
+                    conn.execute(
+                        """
+                        INSERT INTO decisions (
+                            id, created_at, session_id, api_call_count,
+                            action, reason_code, level_before, level_after,
+                            tool_name, args_hash, result_hash, count,
+                            model, provider, recommended_model,
+                            recommended_provider, explain
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            decision_id,
+                            created_at,
+                            _redact(session_id),
+                            api_call_count,
+                            _redact(decision.action),
+                            _redact(decision.reason_code),
+                            _redact(decision.level_before),
+                            _redact(decision.level_after),
+                            _redact(decision.tool_name),
+                            decision.args_hash,
+                            decision.result_hash,
+                            decision.count,
+                            _redact(decision.model),
+                            _redact(decision.provider),
+                            _redact(decision.recommended_model or ""),
+                            _redact(decision.recommended_provider or ""),
+                            _redact(decision.explain),
+                        ),
+                    )
+                    self._enforce_session_cap(conn, session_id)
+                    conn.commit()
+                finally:
+                    conn.close()
+        except Exception as exc:
+            logger.warning(
+                "TrajectoryQualityStore.record failed (fail-open): %s", exc
+            )
+        return decision_id
+
+    def list_for_session(
+        self, session_id: str, *, limit: int = 50
+    ) -> list[dict]:
+        """Return decisions for a session, newest first."""
+        try:
+            with _DB_LOCK:
+                conn = _connect(self._path)
+                try:
+                    rows = conn.execute(
+                        """
+                        SELECT * FROM decisions
+                        WHERE session_id = ?
+                        ORDER BY created_at DESC
+                        LIMIT ?
+                        """,
+                        (session_id, limit),
+                    ).fetchall()
+                    return [dict(r) for r in rows]
+                finally:
+                    conn.close()
+        except Exception as exc:
+            logger.warning("TrajectoryQualityStore.list failed: %s", exc)
+            return []
+
+    def purge_expired(self) -> int:
+        """Delete rows older than retention_days. Returns count deleted."""
+        cutoff = _retention_cutoff(self._retention_days)
+        try:
+            with _DB_LOCK:
+                conn = _connect(self._path)
+                try:
+                    cur = conn.execute(
+                        "DELETE FROM decisions WHERE created_at < ?", (cutoff,)
+                    )
+                    conn.commit()
+                    return cur.rowcount or 0
+                finally:
+                    conn.close()
+        except Exception as exc:
+            logger.warning("TrajectoryQualityStore.purge failed: %s", exc)
+            return 0
+
+    def _enforce_session_cap(
+        self, conn: sqlite3.Connection, session_id: str
+    ) -> None:
+        """Drop oldest rows exceeding the per-session cap."""
+        conn.execute(
+            """
+            DELETE FROM decisions
+            WHERE session_id = ?
+              AND id NOT IN (
+                  SELECT id FROM decisions
+                  WHERE session_id = ?
+                  ORDER BY created_at DESC
+                  LIMIT ?
+              )
+            """,
+            (session_id, session_id, self._max_per_session),
+        )

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -444,6 +444,11 @@ def build_turn_context(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    _tqr = getattr(agent, "_trajectory_quality", None)
+    if _tqr is not None:
+        _tqr.reset_for_turn()
+    agent._trajectory_quality_halt_decision = None
+    agent._pending_trajectory_quality_recommendation = None
     _reset_consol = getattr(agent._memory_store, "reset_consolidation_failures", None)
     if callable(_reset_consol):
         _reset_consol()

--- a/docs/superpowers/plans/2026-07-29-trajectory-quality-routing-plan.md
+++ b/docs/superpowers/plans/2026-07-29-trajectory-quality-routing-plan.md
@@ -1,0 +1,607 @@
+---
+title: "Implement Trajectory Quality Routing"
+status: ready
+date: 2026-07-29
+type: feature
+target_repo: hermes-agent
+spec: docs/superpowers/specs/2026-07-29-trajectory-quality-routing-design.md
+branch_for_impl: cf/trajectory-quality-routing
+tdd: strict RED→GREEN→REFACTOR per slice
+---
+
+# Implementation Plan — Trajectory Quality Routing
+
+## Summary
+
+Implement the approved design in
+`docs/superpowers/specs/2026-07-29-trajectory-quality-routing-design.md` as an
+opt-in, disabled-by-default Hermes-native quality router. Pure reducer/policy
+first; persistence second; thin runtime wiring third; docs last. **No auto
+`switch_model`.** No prompt/toolset mutation. No production shortcuts that skip
+RED→GREEN evidence.
+
+**Depends on:** this plan + design committed on shaping branch
+`cf/trajectory-quality-routing-spec`. Implementation branch should
+fetch/cherry-pick that commit so authorship of the specs is preserved.
+
+## Requirements traceability
+
+| ID | Requirement | Primary slices |
+|---|---|---|
+| R1 | Consume authoritative structured tool/result events | S3, S6 |
+| R2 | Two-identical-failure circuit breaker | S1, S6 |
+| R3 | Failed verification streak + stagnation (no raw-output heuristics) | S1, S6 |
+| R4 | One-way ladder + hysteresis | S2 |
+| R5 | Durable redacted decision records under profile home | S4, S5 |
+| R6 | Recommendation-only model escalation; optional soft-stop | S7, S8 |
+| R7 | Disabled default; config.yaml only; no behavior change when off | S5, S9 |
+| R8 | Preserve transport fallback + tool_loop_guardrails | S9 |
+| R9 | No new model tool / vendor / telemetry / raw output persistence | all |
+| R10 | Tests via `scripts/run_tests.sh` | every slice |
+
+## Out of scope (do not implement)
+
+- Auto `switch_model` / consuming `_fallback_chain` for quality reasons
+- LLM judge, proxy, SageRoute, dashboard UI
+- SessionDB schema migration
+- Changing `smart_model_routing` stub
+- Parent←child quality merge
+- Speculative plugin hooks
+
+## Pre-flight (every function edit)
+
+1. Re-read the design §11 seams.
+2. If GBrain MCP is configured: `code_blast` / `code_callers` on the symbol.
+   Otherwise: `rg -n "symbol" -g '*.py'` and list callers in the commit message
+   notes.
+3. Touch only listed files per slice.
+
+## Target files (expected)
+
+| Path | Role |
+|---|---|
+| `agent/trajectory_quality.py` | **New** — config, events, controller, policy |
+| `agent/trajectory_quality_store.py` | **New** — SQLite decision store |
+| `hermes_cli/config.py` | `DEFAULT_CONFIG["trajectory_quality_routing"]` |
+| `agent/agent_init.py` | Construct controller + store |
+| `agent/tool_executor.py` | Observe after guardrail observation (seq + parallel) |
+| `run_agent.py` | Thin `_observe_trajectory_quality`, recommendation emit, stop flag |
+| `agent/turn_context.py` | `reset_for_turn` |
+| `website/docs/user-guide/configuration.md` | Operator docs (near tool_loop_guardrails) |
+| `tests/agent/test_trajectory_quality.py` | **New** pure tests |
+| `tests/agent/test_trajectory_quality_store.py` | **New** store + HERMES_HOME |
+| `tests/run_agent/test_trajectory_quality_runtime.py` | **New** runtime integration |
+
+Optional read-only reuse (import, do not fork logic):
+
+- `agent/tool_guardrails.py` — `ToolCallSignature`, `_result_hash` (export if needed),
+  `canonical_tool_args`
+- `agent/tool_result_classification.py` — `file_mutation_result_landed`
+- `agent/display.py` — `_detect_tool_failure` (already called upstream)
+- `agent/verification_evidence.py` — read helpers for verify status if a clean
+  public function exists; otherwise pass verification fields from the executor
+  only when already known
+
+## Architecture reminder
+
+```text
+tool_executor (failed, args, result)
+    → run_agent._observe_trajectory_quality
+        → TrajectoryQualityController.observe(event)
+            → optional Decision
+                → store.persist(decision)   # if enabled
+                → status recommendation     # if action != continue
+                → set stop flag             # if stop && execute_stop
+```
+
+When `enabled: false`, `_observe_trajectory_quality` returns immediately.
+
+---
+
+## Slice S0 — Scaffold test module (RED infrastructure)
+
+**Goal:** Create empty test modules that import the future public API so later
+slices have a home.
+
+**Files:**
+
+- `tests/agent/test_trajectory_quality.py` (start with one skipped or failing import test)
+- Do **not** create production module yet if you prefer classic TDD — first test
+  fails on `ImportError`.
+
+**Test:**
+
+```python
+def test_public_api_importable():
+    from agent.trajectory_quality import (
+        TrajectoryQualityConfig,
+        TrajectoryQualityController,
+        TrajectoryObservation,
+    )
+    assert TrajectoryQualityConfig().enabled is False
+```
+
+**RED:** ImportError  
+**GREEN:** minimal stubs in `agent/trajectory_quality.py` with defaults only  
+**Verify:**
+
+```bash
+scripts/run_tests.sh tests/agent/test_trajectory_quality.py::test_public_api_importable -q
+```
+
+---
+
+## Slice S1 — Reducer: identical failure + counters (pure)
+
+**Goal:** `TrajectoryQualityController` counts identical failures and emits a
+decision at threshold 2.
+
+**Files:** `agent/trajectory_quality.py`, `tests/agent/test_trajectory_quality.py`
+
+**API sketch:**
+
+```python
+@dataclass(frozen=True)
+class TrajectoryQualityConfig:
+    enabled: bool = False
+    execute_stop: bool = True
+    execute_model_switch: bool = False  # must be ignored by runtime
+    allow_deescalate_on_progress: bool = False
+    persist_decisions: bool = True
+    retention_days: int = 30
+    max_decisions_per_session: int = 200
+    identical_failure: int = 2
+    same_tool_failure: int = 4
+    failed_verification: int = 2
+    stagnation_window: int = 8
+    hysteresis_progress_needed: int = 2
+    stronger_provider: str | None = None
+    stronger_model: str | None = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> TrajectoryQualityConfig: ...
+
+@dataclass(frozen=True)
+class TrajectoryObservation:
+    tool_name: str
+    args_hash: str
+    result_hash: str | None
+    failed: bool
+    progress_kind: str = "none"
+    verification_status: str | None = None
+    api_call_count: int = 0
+    session_id: str = ""
+    model: str = ""
+    provider: str = ""
+
+@dataclass(frozen=True)
+class TrajectoryQualityDecision:
+    action: str
+    reason_code: str
+    level_before: str
+    level_after: str
+    tool_name: str
+    args_hash: str
+    result_hash: str | None
+    count: int
+    explain: str
+    # ... plus ids filled by store/runtime
+```
+
+**Behavior:**
+
+- `observe()` no-ops decisions when `not config.enabled` (still may no-op entirely).
+- On `failed=True`, increment exact `(tool_name, args_hash)` and `tool_name` counts.
+- When exact count reaches `identical_failure`, escalate toward
+  `recommend_stronger_model` with `reason_code=two_identical_failures`.
+- On success with `progress_kind in {file_mutation_landed, verification_passed}`,
+  clear that signature’s failure count; do **not** de-escalate level unless
+  `allow_deescalate_on_progress`.
+- `reset_for_turn()` clears counts and level.
+
+**Tests (each RED then GREEN):**
+
+1. Two identical failures → decision action `recommend_stronger_model`,
+   reason `two_identical_failures`, count==2.
+2. Two failures with different `args_hash` do **not** trip identical breaker
+   (may still count same_tool separately).
+3. Success after one failure clears exact counter (third failure later needs 2 again).
+4. Disabled config → `observe` returns `None` always.
+
+**Verify:**
+
+```bash
+scripts/run_tests.sh tests/agent/test_trajectory_quality.py -q
+```
+
+---
+
+## Slice S2 — Policy ladder + hysteresis
+
+**Goal:** Monotonic escalation and duplicate suppression.
+
+**Files:** same pure module + tests
+
+**Behavior:**
+
+- Levels ordered: `continue < recommend_stronger_model < recommend_clean_restart < stop`.
+- `same_tool_failure` streak → at least level 1.
+- `failed_verification` streak (observations with
+  `verification_status == "failed"` or `progress_kind == "verification_failed"`)
+  → at least level 1.
+- `stagnation_window` without progress kinds, after any failure/verification_failed
+  in the turn → at least level 2.
+- Compounding: if already level ≥1 and a **new** reason fires → level 2;
+  if already level 2 and any trigger → level 3 `stop`.
+- Suppress duplicate decision when `(action, reason_code, tool_name, args_hash)`
+  unchanged since last emitted decision this turn.
+- `allow_deescalate_on_progress=False`: progress never lowers level.
+- Optional test with `allow_deescalate_on_progress=True` +
+  `hysteresis_progress_needed=2` lowers one step after 2 progress events (keeps
+  flag honest).
+
+**Verify:** same test file.
+
+---
+
+## Slice S3 — Event builder helpers (pure)
+
+**Goal:** Build `TrajectoryObservation` from tool name/args/result/failed without
+storing raw content.
+
+**Files:** `agent/trajectory_quality.py` (helpers), tests
+
+**Helpers:**
+
+```python
+def build_observation(
+    *,
+    tool_name: str,
+    args: Mapping[str, Any] | None,
+    result: str | None,
+    failed: bool,
+    **meta,
+) -> TrajectoryObservation:
+    # args_hash via ToolCallSignature.from_call
+    # result_hash via tool_guardrails._result_hash (export _result_hash if private)
+    # progress_kind:
+    #   file_mutation_landed if file_mutation_result_landed(...)
+    #   verification_failed / verification_passed if verification_status passed in
+    #   idempotent_repeat only if caller supplies prior hash match — keep simple:
+    #   default none/other_success/file_mutation_landed
+```
+
+**Tests:**
+
+1. Args hash stable under key reordering; secret values not present in
+   `Observation` `repr`/asdict strings except inside irreversible hash.
+2. `file_mutation_result_landed` sets progress_kind.
+3. Failed terminal result sets failed True when caller passes failed=True
+   (builder does not re-detect — trust caller).
+
+**Note:** Prefer exporting a public `result_content_hash(result: str | None) -> str`
+from `tool_guardrails` rather than importing `_result_hash` if reviewers object to
+private imports. Smallest change: add alias in tool_guardrails `__all__` only if
+needed.
+
+---
+
+## Slice S4 — Decision store (temp HERMES_HOME)
+
+**Goal:** Persist redacted decisions.
+
+**Files:**
+
+- `agent/trajectory_quality_store.py`
+- `tests/agent/test_trajectory_quality_store.py`
+
+**API:**
+
+```python
+class TrajectoryQualityStore:
+    def __init__(self, path: Path | None = None): ...
+    def record(self, decision: TrajectoryQualityDecision) -> str:  # returns id
+    def list_for_session(self, session_id: str, *, limit: int = 50) -> list[dict]:
+    def purge_expired(self) -> int: ...
+```
+
+Default path: `get_hermes_home() / "trajectory_quality.db"`.
+
+**Tests:**
+
+1. Write + read roundtrip under `monkeypatch.setenv("HERMES_HOME", tmp)`.
+2. Row JSON/dict contains no raw substring from a planted secret in args
+   (only hashes).
+3. Retention purge removes old `created_at`.
+4. Session cap trims oldest.
+
+**Verify:**
+
+```bash
+scripts/run_tests.sh tests/agent/test_trajectory_quality_store.py -q
+```
+
+---
+
+## Slice S5 — Config wiring
+
+**Goal:** `DEFAULT_CONFIG` + `from_mapping` parity; agent_init constructs when
+loading config.
+
+**Files:**
+
+- `hermes_cli/config.py` — add full default tree under
+  `trajectory_quality_routing`
+- `agent/agent_init.py` — next to tool_guardrails block (~1560)
+- tests: extend pure config tests; optional
+  `tests/hermes_cli/test_config_trajectory_quality.py` if config load tests are
+  preferred separate
+
+**Init behavior:**
+
+```python
+agent._trajectory_quality = TrajectoryQualityController(
+    TrajectoryQualityConfig.from_mapping(
+        _agent_cfg.get("trajectory_quality_routing", {})
+    )
+)
+agent._trajectory_quality_store = (
+    TrajectoryQualityStore()
+    if agent._trajectory_quality.config.enabled
+    and agent._trajectory_quality.config.persist_decisions
+    else None
+)
+```
+
+Fail-open: exceptions constructing store log warning and set store None.
+
+**Tests:**
+
+1. Default config has `enabled is False`.
+2. Nested thresholds parse.
+3. Agent with empty config has controller disabled (runtime test can cover).
+
+**Config version:** do **not** bump `_config_version` (new keys only).
+
+---
+
+## Slice S6 — Runtime observe seam
+
+**Goal:** After every real tool result observation, feed the controller.
+
+**Files:**
+
+- `run_agent.py` — add:
+
+```python
+def _observe_trajectory_quality(self, tool_name, function_args, function_result, *, failed: bool) -> None:
+    ctrl = getattr(self, "_trajectory_quality", None)
+    if ctrl is None or not ctrl.config.enabled:
+        return
+    ...
+```
+
+- `agent/tool_executor.py` — call immediately after
+  `_append_guardrail_observation` in **both** parallel completion path (~916)
+  and sequential path (~1621). Skip when `blocked` (tool never ran) — same as
+  guardrail after_call skip.
+
+**Progress enrichment:**
+
+- If `file_mutation_result_landed(tool_name, result)`: progress_kind set.
+- Optional: if tool_name == `"terminal"` and verification evidence API can return
+  last status cheaply, pass `verification_status`. If that requires heavy DB work,
+  defer verification streak to a narrow helper already used by verification_stop
+  snapshot — keep fail-open and never block tool completion on store errors.
+
+**On decision with action != continue:**
+
+1. Persist via store if present (swallow errors).
+2. Set `agent._pending_trajectory_quality_recommendation = decision`.
+3. Emit status once via existing status helper (mirror fallback notice style).
+4. If action == `stop` and `execute_stop`: set
+   `agent._trajectory_quality_halt_decision = decision` (new attribute).
+
+**Hard rule:** never call `switch_model` or `try_activate_fallback` here.
+If `execute_model_switch` is True, log debug “unsupported; recommendation only”.
+
+**Tests** (`tests/run_agent/test_trajectory_quality_runtime.py`), patterned on
+`test_tool_call_guardrail_runtime.py`:
+
+1. Disabled: after two identical failures, no recommendation attr, no DB file.
+2. Enabled: two identical failures → recommendation action
+   `recommend_stronger_model`; messages list has no new system/user rows from
+   router; tool result text does **not** gain quality-routing suffix
+   (guardrail warn suffix may still exist — assert quality-specific marker absent).
+3. `switch_model` not called (patch and assert).
+
+**Verify:**
+
+```bash
+scripts/run_tests.sh tests/run_agent/test_trajectory_quality_runtime.py -q
+```
+
+---
+
+## Slice S7 — Recommendation surfacing
+
+**Goal:** User-visible notice without transcript mutation.
+
+**Files:** `run_agent.py` (emit helper), runtime tests
+
+**Behavior:**
+
+- When a new decision is produced, call the same family of user status APIs used
+  for fallback notices (`_emit_status` / quiet print). Message example:
+
+  `Trajectory quality: recommend stronger model (two_identical_failures on terminal×2). Try /model <stronger> or start a clean session.`
+
+- Include configured `stronger_model` if set.
+- Gateway: do not inject assistant messages; status/log is enough in slice 1
+  unless an existing non-transcript notice path is one line away.
+
+**Tests:** capture status callback / mock `_emit_status` called once per unique
+decision; not called again on suppressed duplicates.
+
+---
+
+## Slice S8 — Soft-stop on ladder `stop`
+
+**Goal:** When level reaches `stop` and `execute_stop`, halt further thrash like
+guardrail halt.
+
+**Files:**
+
+- `run_agent.py` — halt flag + response text helper
+- `agent/conversation_loop.py` **only if** halt is checked solely via
+  `_tool_guardrail_halt_decision` — extend the check to OR quality halt.
+  Prefer a small helper `agent._should_halt_tools()` to avoid scattering.
+
+**Behavior:**
+
+- Soft-stop means: stop scheduling more tool iterations / break loop with a
+  controlled final response explaining quality stop (similar to
+  `_toolguard_controlled_halt_response`).
+- Must not leave dangling tool_calls without results (reuse existing halt paths).
+
+**Tests:**
+
+1. Force controller to stop level → conversation ends without infinite tools.
+2. `execute_stop: false` → recommendation only, loop can continue (guardrails may
+   still block independently).
+
+**Caller blast (required before edit):**
+
+```bash
+rg -n "_tool_guardrail_halt_decision|should_halt" agent/ run_agent.py
+```
+
+---
+
+## Slice S9 — Turn reset + disabled parity + neighbor regressions
+
+**Goal:** Reset with guardrails; prove zero impact when disabled.
+
+**Files:** `agent/turn_context.py` (reset), runtime tests
+
+**Tests:**
+
+1. After `reset_for_turn`, identical failure counter starts fresh.
+2. Full agent with default config: enable spy on controller.observe — either not
+   called or early-returns; **no** `trajectory_quality.db` created under temp home.
+3. Re-run neighbor suites green:
+
+```bash
+scripts/run_tests.sh \
+  tests/agent/test_tool_guardrails.py \
+  tests/run_agent/test_tool_call_guardrail_runtime.py \
+  tests/agent/test_verification_evidence.py \
+  tests/agent/test_trajectory_quality.py \
+  tests/agent/test_trajectory_quality_store.py \
+  tests/run_agent/test_trajectory_quality_runtime.py -q
+```
+
+---
+
+## Slice S10 — Operator docs
+
+**Goal:** Document config next to Tool-Loop Guardrails.
+
+**Files:** `website/docs/user-guide/configuration.md`
+
+**Content:** short section — purpose, default off, YAML block, relationship to
+tool_loop_guardrails and fallback_providers, recommendation-only note, privacy
+(hashes only).
+
+No `_config_version` migration notes needed.
+
+---
+
+## Implementation constraints checklist
+
+- Extend existing infrastructure; do not reimplement failure detection.
+- Do not append quality text into tool results (that is guardrails’ job).
+- Do not mutate system prompt or toolsets.
+- Do not advance fallback index.
+- Do not write secrets or raw outputs to DB.
+- Use `get_hermes_home()` only for store path.
+- Keep `run_agent.py` changes thin (forwarders already dominate that file).
+
+## Commit strategy (implementation branch)
+
+Prefer small commits per slice:
+
+1. `test(agent): trajectory quality reducer RED/GREEN`
+2. `feat(agent): trajectory quality policy ladder`
+3. `feat(agent): trajectory quality decision store`
+4. `feat(agent): wire trajectory quality observe seam`
+5. `feat(agent): trajectory quality stop + status`
+6. `docs: trajectory quality routing config`
+
+Or fewer commits if the implementer batches GREEN slices carefully — but each
+slice must have been RED then GREEN locally.
+
+## Final verification (definition of done)
+
+```bash
+scripts/run_tests.sh \
+  tests/agent/test_trajectory_quality.py \
+  tests/agent/test_trajectory_quality_store.py \
+  tests/run_agent/test_trajectory_quality_runtime.py \
+  tests/agent/test_tool_guardrails.py \
+  tests/run_agent/test_tool_call_guardrail_runtime.py \
+  tests/agent/test_verification_evidence.py -q
+```
+
+Manual review of diff:
+
+- [ ] No `switch_model(` calls from quality code paths
+- [ ] No `try_activate_fallback` for quality reasons
+- [ ] No raw result columns in store schema
+- [ ] Default enabled false
+- [ ] No new HERMES_* behavioral env vars
+- [ ] No prompt/toolset mutation
+
+## Proposed PR title / body (for implementer; do not open PR in shaping)
+
+**Title:** `feat(agent): opt-in trajectory quality routing (recommend-only)`
+
+**Body sketch:**
+
+```markdown
+## Summary
+Adds disabled-by-default deterministic trajectory quality routing:
+identical-failure / verification / stagnation signals → one-way
+recommendations (stronger model, clean restart, stop). Decision audit DB
+under HERMES_HOME. No auto model switch; no prompt mutation.
+
+## Spec
+- docs/superpowers/specs/2026-07-29-trajectory-quality-routing-design.md
+- docs/superpowers/plans/2026-07-29-trajectory-quality-routing-plan.md
+
+## Test plan
+- [ ] scripts/run_tests.sh <focused modules above>
+- [ ] enabled=false: no DB, no status
+- [ ] enabled=true: two identical failures → recommendation
+```
+
+## Residual risks
+
+| Risk | Mitigation |
+|---|---|
+| Double UX noise with tool_loop warnings | Quality uses status channel only; different wording |
+| Verification streak expensive if naïvely queried | Pass status only when cheap; fail-open |
+| Halt interaction with guardrail halt | Single combined halt check helper |
+| Future execute_model_switch footgun | Hard no-op + log in slice 1; separate design later |
+| GBrain unavailable during shaping | Implementer re-blasts callers on touch points |
+
+## Handoff fields for implementation completion
+
+Implementation task must return:
+
+- `repository`, `branch`, `base`, full 40-char `head_sha`
+- concrete check commands + outputs
+- `durable_task_id`
+- residual risks
+- proposed PR title/body
+- **Do not** open the PR via GitHub API (per implementer card)

--- a/docs/superpowers/specs/2026-07-29-trajectory-quality-routing-design.md
+++ b/docs/superpowers/specs/2026-07-29-trajectory-quality-routing-design.md
@@ -1,0 +1,551 @@
+---
+title: "Trajectory Quality Routing"
+status: approved-design
+date: 2026-07-29
+type: feature
+target_repo: hermes-agent
+origin: SageRoute due diligence — non-duplicative Hermes gap
+related:
+  - agent/tool_guardrails.py
+  - agent/tool_result_classification.py
+  - agent/verification_evidence.py
+  - agent/verification_stop.py
+  - agent/chat_completion_helpers.py (try_activate_fallback)
+  - agent/agent_runtime_helpers.py (switch_model)
+  - hermes_cli/config.py (tool_loop_guardrails, fallback_providers)
+---
+
+# Trajectory Quality Routing — Design
+
+## 1. End goal and user-visible outcome
+
+Hermes already recovers from **transport/provider** failures (`fallback_providers` /
+`try_activate_fallback`) and already **nudges or blocks repeated tool loops**
+(`tool_loop_guardrails`). It does **not** yet route on **trajectory quality**:
+repeated authoritative tool failures that indicate the current model is thrashing,
+failed verification streaks after edits, or a long stretch of tool calls with no
+verified progress.
+
+This design adds an **opt-in, Hermes-native, deterministic reducer + policy** that:
+
+1. Consumes **authoritative structured tool/result events** already produced by the
+   agent loop (failure flags, signatures, verification ledger outcomes).
+2. Escalates one-way through:
+   `continue` → `recommend_stronger_model` → `recommend_clean_restart` → `stop`.
+3. Emits **durable, redacted, explainable decision records** under the active
+   profile home.
+4. Leaves behavior **byte-identical when disabled** (default).
+5. Does **not** mutate prompts, toolsets, or conversation history, and does **not**
+   call external classifiers or proxies.
+
+**User-visible outcome when enabled:** after thrash signals, the CLI/gateway/TUI
+surfaces a clear recommendation (and, at the final ladder step, can soft-stop the
+turn). The first implementation slice is **recommendation-only** for model changes;
+it does not auto-call `switch_model`.
+
+## 2. Problem frame (what exists vs the gap)
+
+| Existing system | What it solves | What it does **not** do |
+|---|---|---|
+| `fallback_providers` / `try_activate_fallback` (`agent/chat_completion_helpers.py`) | API/auth/rate-limit/upstream failures; swaps backend mid-retry | Quality of the *agent trajectory* while tools still return |
+| `tool_loop_guardrails` (`agent/tool_guardrails.py`) | Per-turn repeated identical failures, same-tool failures, idempotent no-progress; warn into tool result; optional hard block | Recommend a stronger model or clean session restart; durable routing decisions |
+| `agent/display._detect_tool_failure` + `agent/tool_result_classification.py` | Authoritative success/failure classification for display and guardrails | Aggregate turn-level quality / routing |
+| `agent/verification_evidence.py` | Passive ledger of proof commands (`status=passed/failed/...`) under `get_hermes_home()` | Escalate model or restart on failed-verification streaks |
+| `agent/verification_stop.py` | Bounded “verify before finish” nudge after code edits | Mid-trajectory thrash routing |
+| `IterationBudget` | Cap API/tool iterations | Quality-aware early exit reasons |
+| `smart_model_routing` config key | Setup wizard writes `enabled: false`; **no runtime consumer today** | Not a substitute; leave untouched |
+| ShareGPT `agent/trajectory.py` save path | Optional training JSONL dump to CWD | Not profile-aware decision storage; not live routing |
+
+**Gap (SageRoute diligence):** detect repeated authoritative tool failures,
+rewrite/retest thrash, and lack of verified progress, then apply a one-way
+hysteretic routing policy — **without** a proxy and **without** an external
+classifier.
+
+## 3. Goals
+
+- G1. Deterministic, pure reducer/policy over structured events (unit-testable
+  without LLM, network, or agent runtime).
+- G2. Two-identical-failure circuit breaker aligned with existing signature
+  hashing (`ToolCallSignature` / `args_hash` + failure class).
+- G3. One-way ladder: `continue` → `recommend_stronger_model` →
+  `recommend_clean_restart` → `stop`, with hysteresis so levels do not chatter.
+- G4. Durable explainable decision records; profile-aware path via
+  `get_hermes_home()`; no raw tool args/output persisted.
+- G5. Disabled by default; config.yaml only (no new `HERMES_*` behavioral env vars).
+- G6. Preserve current transport fallback and tool-loop guardrail behavior
+  unchanged when this feature is off **and** when it is on (orthogonal).
+- G7. No prompt/toolset/history mutation; no new model tool; no vendor SDK;
+  no outbound telemetry.
+- G8. First ship slice is **recommendation-only** for model escalation (see §8).
+
+## 4. Non-goals / deferred scope
+
+- **N1.** SageRoute, HTTP proxy, or any third-party routing product in-tree.
+- **N2.** LLM-as-judge / aux-model quality classifier mid-loop.
+- **N3.** Auto `switch_model` / auto fallback activation driven by quality signals
+  in slice 1 (see §8 seam analysis). Config flag reserved for a later slice.
+- **N4.** Replacing or folding into `tool_loop_guardrails` (different product job:
+  tool block vs trajectory routing). They share primitives; they stay separate
+  config sections.
+- **N5.** Changing `smart_model_routing` (unrelated stub / setup key).
+- **N6.** New core tools, plugins that patch core, or dashboard UI in slice 1
+  (decision DB is readable later by insights/dashboard if desired).
+- **N7.** Persisting raw tool output, args, stdout, or secrets.
+- **N8.** Cross-session learning that changes default model selection globally.
+- **N9.** Subagent-orchestrator policy beyond “each agent instance has its own
+  reducer state” (parent does not merge child quality into parent ladder in v1).
+- **N10.** Production code in the shaping task (this document + plan only).
+
+## 5. Alternatives considered
+
+### A. External proxy / SageRoute-class product
+
+- **Pros:** Off-the-shelf routing UX.
+- **Cons:** Vendor coupling, privacy (tool streams leave the host), latency,
+  contradicts AGENTS.md “no third-party product plugins in core,” and the
+  diligence finding that Hermes only needs a **native** gap fill.
+- **Decision:** Rejected.
+
+### B. Mid-loop LLM quality judge (aux client)
+
+- **Pros:** Flexible language about “thrash.”
+- **Cons:** Non-deterministic, burns tokens every N steps, risks prompt-cache
+  pressure if anything is injected into the main transcript, hard to test.
+- **Decision:** Rejected for v1 (and likely forever as the primary signal).
+
+### C. Only extend `tool_loop_guardrails` thresholds
+
+- **Pros:** Minimal new surface.
+- **Cons:** Guardrails intentionally act on **tool execution** (warn/block/halt
+  calls). Routing wants **session/turn advice** (stronger model, clean restart)
+  and durable decision audit. Mixing ladders confuses operators and tests.
+- **Decision:** Rejected as sole solution. **Reuse** signatures, hashes, and
+  failure flags from the guardrail path.
+
+### D. Plugin-only implementation
+
+- **Pros:** Zero core footprint.
+- **Cons:** Needs reliable structured events; `post_tool_call` is observational
+  and easy to miss sequential/parallel paths; quality routing is a core loop
+  concern like guardrails. Plugin remains a valid *consumer* of decision records
+  later, not the primary home.
+- **Decision:** Core opt-in module (same tier as `tool_loop_guardrails`).
+
+### E. Auto-execute model switch on recommendation (v1)
+
+- **Pros:** Hands-free recovery.
+- **Cons:** See §8 — `switch_model` rebuilds system prompt and client; mid-turn
+  provider format shifts are high risk; product wants user-visible recommend first.
+- **Decision:** Deferred behind `execute_model_switch: false` (default). Slice 1
+  never calls `switch_model` or `try_activate_fallback` for quality reasons.
+
+**Chosen approach:** Hermes-native pure reducer + one-way policy + redacted
+decision log + recommendation surface, wired at the existing tool-result
+observation seam.
+
+## 6. Architecture
+
+```
+                    ┌─────────────────────────────────────┐
+                    │  tool_executor (seq + parallel)     │
+                    │  _detect_tool_failure → failed bool │
+                    │  _append_guardrail_observation      │
+                    └──────────────┬──────────────────────┘
+                                   │ structured observation
+                                   ▼
+                    ┌─────────────────────────────────────┐
+                    │ TrajectoryQualityController         │
+                    │  (pure; agent/trajectory_quality.py)│
+                    │  reduce(event) → optional Decision  │
+                    └──────────────┬──────────────────────┘
+                                   │
+              ┌────────────────────┼────────────────────┐
+              ▼                    ▼                    ▼
+     DecisionRecordStore   RecommendationSink      Optional soft-stop
+     (profile SQLite)      (status / UI only)      (stop level only)
+```
+
+### 6.1 Module boundaries
+
+| Piece | Location | Responsibility |
+|---|---|---|
+| Config dataclass + parser | `agent/trajectory_quality.py` | `TrajectoryQualityConfig.from_mapping` |
+| Event types | same | Frozen dataclasses; no raw content fields |
+| Reducer + policy | same | `TrajectoryQualityController.observe` / `.snapshot` |
+| Persistence | `agent/trajectory_quality_store.py` | Profile-aware SQLite under `get_hermes_home()` |
+| Runtime thin adapter | `run_agent.py` methods + call from `agent/tool_executor.py` | Build events from existing failed/signature data; emit status; optional halt |
+| Init | `agent/agent_init.py` | Construct controller from config when present |
+| Turn reset | `agent/turn_context.py` | Reset per-turn counters with guardrails |
+| DEFAULT_CONFIG | `hermes_cli/config.py` | `trajectory_quality_routing` section, `enabled: false` |
+| Docs | `website/docs/user-guide/configuration.md` | Operator section (implementation slice) |
+
+**Do not** grow `run_agent.py` with policy logic — mirror the
+`ToolCallGuardrailController` extraction pattern.
+
+### 6.2 Relationship to tool-loop guardrails
+
+- Guardrails remain the **tool execution** circuit breaker (warn into result /
+  block call).
+- Quality routing is a **parallel observer** of the same `failed` + signature
+  inputs (and verification ledger summaries).
+- When both are enabled, a repeated identical failure may **both** warn in the
+  tool result (guardrails) **and** escalate the routing ladder (quality). That
+  is intentional and not double-mutation of prompts: guardrail warnings already
+  append to tool results today; quality routing must **not** append to tool
+  results or system prompt.
+
+### 6.3 Cache, alternation, and fallback invariants
+
+- Quality routing **must not** rewrite `messages`, system prompt, tool schemas,
+  or toolsets.
+- Quality routing **must not** call `try_activate_fallback` (transport fallback
+  stays owned by API error paths).
+- Quality routing **must not** inject synthetic user/assistant messages.
+- Recommendation text goes only through existing **status / notice** channels
+  (`_emit_status`, tool-progress callbacks, gateway status), never into the
+  model transcript.
+- Soft-stop at ladder `stop` may reuse the guardrail halt pattern
+  (`_set_tool_guardrail_halt` / controlled halt response) **or** a sibling
+  `_trajectory_quality_halt_decision` flag checked at the same loop points —
+  without inserting extra user-role turns.
+
+## 7. Data model
+
+### 7.1 Observation event (in-memory only)
+
+```text
+TrajectoryObservation:
+  tool_name: str
+  args_hash: str          # sha256 of canonical args (ToolCallSignature)
+  result_hash: str | None # sha256 of canonicalized structured result; never raw
+  failed: bool            # from _detect_tool_failure / executor is_error
+  progress_kind: str      # none | file_mutation_landed | verification_passed
+                          # | verification_failed | idempotent_repeat | other_success
+  verification_status: str | None  # from verification_evidence when applicable
+  api_call_count: int
+  session_id: str
+  model: str
+  provider: str
+  ts_mono: float
+```
+
+**Authoritative failure:** the same boolean the executor already computes via
+`agent.display._detect_tool_failure` (and passes as `failed=` into
+`_append_guardrail_observation`). Do not re-parse free text with new heuristics
+in the reducer. Optional structured enrichments:
+
+- `file_mutation_result_landed` → `progress_kind=file_mutation_landed`
+- `verification_evidence` last status for session/root when tool is `terminal`
+  and classified as a verify command → `verification_passed` / `verification_failed`
+- Idempotent same `result_hash` while `failed=False` → `idempotent_repeat`
+  (stagnation signal, not failure)
+
+**Explicitly forbidden in events and records:** raw args, raw result strings,
+stdout, env, paths beyond optional **hashed** path digests if needed later.
+
+### 7.2 Reducer state (per agent instance, per turn)
+
+```text
+TrajectoryQualityState:
+  level: enum continue | recommend_stronger_model | recommend_clean_restart | stop
+  exact_failure_counts: map[(tool_name, args_hash)] -> int
+  same_tool_failure_counts: map[tool_name] -> int
+  consecutive_no_progress: int
+  failed_verification_streak: int
+  last_decision_id: str | None
+  last_reason_code: str | None
+```
+
+Reset on new user turn (`turn_context` path that already calls
+`agent._tool_guardrails.reset_for_turn()`). Session-level persistence is for
+**audit records only**, not for carrying ladder level across `/new` (fresh
+session clears runtime state).
+
+### 7.3 Decision record (durable)
+
+```text
+TrajectoryQualityDecision:
+  id: str                 # ulid/uuid
+  created_at: iso8601
+  session_id: str
+  api_call_count: int
+  action: str             # continue | recommend_stronger_model | ...
+  reason_code: str        # two_identical_failures | same_tool_failure_streak |
+                          # failed_verification_streak | stagnation_no_progress |
+                          # progress_reset (only if de-escalate enabled)
+  level_before: str
+  level_after: str
+  tool_name: str
+  args_hash: str
+  result_hash: str | null
+  count: int
+  model: str
+  provider: str
+  recommended_model: str | null
+  recommended_provider: str | null
+  config_sha256: str      # hash of normalized config thresholds
+  explain: str            # short operator-facing sentence; no secrets
+```
+
+### 7.4 Persistence
+
+Follow the **verification_evidence** pattern (separate profile-scoped SQLite),
+not the CWD JSONL trajectory dump:
+
+- Path: `get_hermes_home() / "trajectory_quality.db"`
+- Tables: `meta(schema_version)`, `decisions(...)` matching §7.3
+- Indexes: `(session_id, created_at DESC)`, `(created_at)`
+- Retention: delete rows older than `retention_days` (default 30) on write
+  opportunistically (same spirit as verification_evidence caps)
+- Cap: `max_decisions_per_session` (default 200) — drop oldest in session if exceeded
+- **Never** store raw tool output columns
+
+Rationale vs SessionDB migration: quality decisions are an agent-ops ledger like
+verification evidence; avoiding `SCHEMA_VERSION` bumps on `hermes_state.py`
+reduces blast radius. Session id is still stored for join-by-hand.
+
+### 7.5 Privacy / redaction
+
+- Args and results enter storage **only** as hex sha256 hashes (reuse
+  `agent.tool_guardrails._sha256` / `ToolCallSignature` / `_result_hash`).
+- `explain` strings use tool **names** and counts only
+  (e.g. `terminal failed 2× with identical args_hash`).
+- Apply `agent.redact.redact_sensitive_text` defensively on any string field
+  before write.
+- Logs at INFO may include `action`, `reason_code`, `tool_name`, `count`; never
+  result previews from this subsystem (executor already logs truncated errors).
+
+## 8. Model-switch seam analysis (why recommendation-only in slice 1)
+
+**Existing seams:**
+
+| Seam | File/symbol | When used | Cache impact |
+|---|---|---|---|
+| `AIAgent.switch_model` → `agent.agent_runtime_helpers.switch_model` | User `/model`, TUI/gateway model pickers | Rebuilds client, clears `_cached_system_prompt`, re-resolves reasoning + compressor, updates `_primary_runtime` | Intentionally invalidates cached system prompt; different model cannot reuse prior provider cache anyway |
+| `try_activate_fallback` | API error retry loop | Temporary backend swap for transport failures; may rewrite model identity lines | Transport recovery path; **must stay owned by FailoverReason** |
+| `update_session_model` / billing route | SessionDB after user switch | Dashboard consistency | Nulls stored system_prompt snapshot |
+
+**Verdict for slice 1:**
+
+- Auto-invoking `switch_model` mid-turn from quality policy is **unsafe to claim
+  as “cache-preserving”**: it always clears `_cached_system_prompt` and may change
+  `api_mode` / message shaping. That is acceptable for an **explicit user**
+  `/model` action; it is not acceptable as a silent side effect of a new opt-in
+  subsystem until a dedicated between-turns execute path is designed and tested.
+- Quality routing must **not** consume or advance `_fallback_chain` /
+  `_fallback_index` (would corrupt transport fallback).
+- Therefore slice 1 **only recommends**. Config reserves:
+
+```yaml
+execute_model_switch: false   # slice 1 hard-ignores true if set; document as unsupported
+```
+
+A future slice may execute **between turns only** (after turn finalizer, before
+next user message) by calling the same `switch_model` path the UI uses, with
+explicit user config and tests for provider format continuity. That work is
+**out of scope** here.
+
+## 9. Policy specification
+
+### 9.1 Ladder (one-way within a turn)
+
+| Level | Action | Meaning |
+|---|:---:|---|
+| 0 | `continue` | No quality intervention |
+| 1 | `recommend_stronger_model` | Surface: try a stronger model (from config) |
+| 2 | `recommend_clean_restart` | Surface: `/new` or clean session; context thrash |
+| 3 | `stop` | Soft-stop further tool thrash this turn (if `execute_stop: true`) |
+
+Escalation is **monotonic** within a turn: level only increases, never decreases,
+unless `allow_deescalate_on_progress: true` (default **false**).
+
+### 9.2 Triggers (defaults)
+
+| Reason code | Default threshold | Escalates to at least | Notes |
+|---|---:|---|---|
+| `two_identical_failures` | `identical_failure: 2` | level 1 | Same `(tool_name, args_hash)` with `failed=True` twice |
+| `same_tool_failure_streak` | `same_tool_failure: 4` | level 1 | Same tool_name failed N times (any args) |
+| `failed_verification_streak` | `failed_verification: 2` | level 1 | Consecutive verification_evidence failures after edits |
+| `stagnation_no_progress` | `stagnation_window: 8` | level 2 | N tool observations without any `progress_kind` in `{file_mutation_landed, verification_passed}` **and** at least one prior failure or verification_failed in the turn |
+| Second distinct reason while already ≥1 | — | level 2 | Hysteresis: compounding thrash → clean restart |
+| Any trigger while already level 2 | — | level 3 | Stop |
+
+Exact numeric defaults are knobs; tests lock **ordering and monotonicity**, not
+magic product taste beyond the mandated **two-identical-failure** breaker.
+
+### 9.3 Hysteresis rules
+
+1. **No chatter:** emitting the same `(action, reason_code, tool_name, args_hash)`
+   decision more than once per turn is suppressed (still update counts).
+2. **Monotonic levels** when `allow_deescalate_on_progress` is false (default).
+3. **Turn boundary reset** of runtime ladder state (new user turn).
+4. Optional future: de-escalate one step after
+   `hysteresis_progress_needed` verified progress events (off by default).
+
+### 9.4 Recommendation payload (not in transcript)
+
+```text
+TrajectoryQualityRecommendation:
+  action: recommend_stronger_model | recommend_clean_restart | stop
+  reason_code: str
+  explain: str
+  recommended_model: str | null
+  recommended_provider: str | null
+  decision_id: str
+```
+
+Surfacing:
+
+- CLI: one status line via existing buffered/status emission patterns (similar to
+  fallback notices — user visible, not model visible).
+- Gateway: status event / notice if a channel already supports non-transcript
+  notices; otherwise log + decision DB only (do not DM the user a fake assistant
+  message).
+- TUI/desktop: status channel parity if a hook exists; else log + DB.
+
+## 10. Config schema and defaults
+
+Add to `DEFAULT_CONFIG` in `hermes_cli/config.py` (deep-merge; **no**
+`_config_version` bump required — new keys only):
+
+```yaml
+trajectory_quality_routing:
+  enabled: false                 # master switch; default off
+  execute_stop: true             # honor ladder stop with soft-halt when enabled
+  execute_model_switch: false    # unsupported in slice 1; must remain no-op
+  allow_deescalate_on_progress: false
+  persist_decisions: true
+  retention_days: 30
+  max_decisions_per_session: 200
+  # Optional explicit stronger model for recommendations (not auto-applied).
+  # If null, recommendation explain points the user at /model and fallback_providers.
+  stronger_model:
+    provider: null
+    model: null
+  thresholds:
+    identical_failure: 2         # mandated two-identical-failure breaker
+    same_tool_failure: 4
+    failed_verification: 2
+    stagnation_window: 8
+  hysteresis_progress_needed: 2  # only if allow_deescalate_on_progress
+```
+
+Also add `"trajectory_quality_routing"` to known root keys if required by the
+config validator’s extra-root allowlist pattern (mirror `tool_loop_guardrails`
+which lives in `DEFAULT_CONFIG` proper).
+
+**No new behavioral env vars.** Secrets stay in `.env`; this feature is not secret.
+
+## 11. Integration seams (exact symbols)
+
+| Seam | Symbol | Change |
+|---|---|---|
+| Config defaults | `hermes_cli/config.py` :: `DEFAULT_CONFIG` | Add section |
+| Agent init | `agent/agent_init.py` (~tool_guardrails block ~1560) | Build `TrajectoryQualityController` + store |
+| Tool sequential + parallel completion | `agent/tool_executor.py` after `_append_guardrail_observation` (~916, ~1621) | `agent._observe_trajectory_quality(...)` |
+| Guardrail observation helper | `run_agent.py` :: `_append_guardrail_observation` **or** sibling `_observe_trajectory_quality` | Prefer sibling called next to guardrail observe so concerns stay split |
+| Failure detection (read-only use) | `agent.display._detect_tool_failure` | No change; consume `failed` already computed |
+| Signatures / hashes | `agent.tool_guardrails.ToolCallSignature`, `_result_hash` | Import/reuse; do not fork hash algorithms |
+| File mutation progress | `agent.tool_result_classification.file_mutation_result_landed` | Set `progress_kind` |
+| Verification failures | `agent.verification_evidence` (read APIs used by `verification_stop`) | On terminal verify commands, set verification fields |
+| Turn reset | `agent/turn_context.py` where `_tool_guardrails.reset_for_turn()` runs | Also `reset_for_turn` on quality controller |
+| Soft stop | `run_agent.py` / conversation loop halt checks for `_tool_guardrail_halt_decision` | Also honor quality stop if `execute_stop` |
+| Status emit | Existing `_emit_status` / quiet-mode status paths | Emit recommendation once per decision |
+| Persistence home | `hermes_constants.get_hermes_home` | DB path only |
+
+**Plugin hooks:** do **not** require plugins. Optional later: emit an internal
+observer hook only if a generic hook already exists for non-mutating notices —
+do not invent speculative hooks.
+
+## 12. Rewrite / retest thrash definition
+
+“Rewrite/retest thrash” is **not** NLP over assistant prose. It is structured:
+
+1. **Retest thrash:** ≥ `failed_verification` consecutive
+   `verification_failed` observations for the session/root after a file mutation
+   in the turn, without an intervening `verification_passed`.
+2. **Rewrite thrash:** ≥ `identical_failure` failed `write_file`/`patch` with the
+   same `args_hash`, **or** oscillating file mutation failures recorded in
+   `_turn_failed_file_mutations` style signals exposed as failed observations
+   without `file_mutation_landed`.
+3. **Stagnation:** `stagnation_window` observations with no verified progress
+   kinds while the turn already saw a failure or failed verification.
+
+## 13. Migration and backward compatibility
+
+- Default `enabled: false` → **zero** runtime calls into the controller beyond a
+  cheap disabled check, or controller not installed.
+- No schema migration on `state.db` / `hermes_state.SCHEMA_VERSION`.
+- No change to `tool_loop_guardrails` defaults.
+- No change to `fallback_providers` behavior or activation reasons.
+- Existing tests for guardrails, fallback, verification must remain green without
+  config changes.
+- If `enabled: true` but store cannot open, fail **open** (log warning, disable
+  persistence for the session; policy still runs in-memory).
+
+## 14. Testing strategy (summary; details in plan)
+
+- Pure unit tests for reducer/policy (no AIAgent).
+- Config parse tests (defaults, bad types clamp/safe).
+- Store tests with temp `HERMES_HOME` (real sqlite).
+- Runtime tests patterned on `tests/run_agent/test_tool_call_guardrail_runtime.py`:
+  disabled no-op; enabled recommendation; stop soft-halt; no transcript mutation;
+  no `switch_model` call.
+- Redaction tests: raw secret in args never appears in DB row JSON.
+- Invariant: prompt messages list unchanged across observe.
+
+## 15. Verification commands (for implementers)
+
+```bash
+# Focused pure + runtime
+scripts/run_tests.sh tests/agent/test_trajectory_quality.py \
+  tests/agent/test_trajectory_quality_store.py \
+  tests/run_agent/test_trajectory_quality_runtime.py -q
+
+# Neighbor regressions
+scripts/run_tests.sh tests/agent/test_tool_guardrails.py \
+  tests/run_agent/test_tool_call_guardrail_runtime.py \
+  tests/agent/test_verification_evidence.py -q
+```
+
+## 16. Security and AGENTS.md compliance checklist
+
+- [x] No new core model tool
+- [x] No vendor dependency
+- [x] No outbound telemetry
+- [x] No raw tool-output persistence
+- [x] config.yaml only for behavior
+- [x] Profile-safe paths via `get_hermes_home()`
+- [x] Prompt cache: no mid-conversation prompt/toolset mutation
+- [x] Message alternation: no synthetic user messages
+- [x] Transport fallback preserved
+- [x] Disabled by default
+
+## 17. Open questions (resolved for v1)
+
+| Question | Resolution |
+|---|---|
+| Auto model switch? | No in slice 1 |
+| Share state with tool_loop_guardrails controller instance? | Share **primitives** (hash/signature/failed); separate controller instance and config |
+| Persist to SessionDB? | No; sidecar SQLite like verification_evidence |
+| Gateway user-visible text? | Prefer non-transcript status; never fake assistant message |
+| Subagents? | Own controller per AIAgent; no parent merge in v1 |
+
+## 18. GBrain / code-navigation note
+
+Task asked for MCP GBrain `code_blast` / `code_callers` before planning edits.
+This environment has **no MCP servers configured** (`hermes mcp list` empty).
+Symbol blast was performed with repo search against the live tree at
+`origin/main` HEAD used for this branch (`15dc65eeda397a5d4d35edd6779141eeb8139944`
+at branch creation). Implementers should re-run callers on touch points if GBrain
+is available in their profile.
+
+## 19. Success criteria (acceptance for this design)
+
+1. Spec names exact files/symbols for seams and non-goals.
+2. Two-identical-failure breaker and one-way ladder are fully specified.
+3. Privacy/redaction and durable record schema are explicit.
+4. Config defaults disable the feature.
+5. Slice 1 is recommendation-only for model changes; stop may soft-halt when
+   configured.
+6. Companion implementation plan lists TDD slices and verification commands.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1396,6 +1396,33 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Trajectory quality routing observes authoritative tool-result events
+    # and escalates a one-way recommendation ladder (stronger model → clean
+    # restart → stop) when the agent thrashes. Disabled by default; does not
+    # mutate prompts/toolsets or call external services. Recommendation-only
+    # for model changes in this slice — execute_model_switch is reserved and
+    # hard-ignored.
+    "trajectory_quality_routing": {
+        "enabled": False,
+        "execute_stop": True,
+        "execute_model_switch": False,
+        "allow_deescalate_on_progress": False,
+        "persist_decisions": True,
+        "retention_days": 30,
+        "max_decisions_per_session": 200,
+        "stronger_model": {
+            "provider": None,
+            "model": None,
+        },
+        "thresholds": {
+            "identical_failure": 2,
+            "same_tool_failure": 4,
+            "failed_verification": 2,
+            "stagnation_window": 8,
+        },
+        "hysteresis_progress_needed": 2,
+    },
+
     "compression": {
         "enabled": True,
         "threshold": 0.50,            # compress when context usage exceeds this ratio.

--- a/run_agent.py
+++ b/run_agent.py
@@ -6369,6 +6369,17 @@ class AIAgent:
             "to change strategy instead of repeating the same call."
         )
 
+    def _trajectory_quality_halt_response(self, decision) -> str:
+        """Controlled halt response for trajectory quality stop level."""
+        tool = decision.tool_name or "a tool"
+        return (
+            f"I stopped tool thrash for this turn because trajectory quality "
+            f"routing escalated to a stop ({decision.reason_code}) after "
+            f"{decision.count} non-progressing attempts on {tool}. The current "
+            "model appears to be thrashing; try a stronger model via /model "
+            "or start a clean session."
+        )
+
     def _append_guardrail_observation(
         self,
         tool_name: str,
@@ -6387,7 +6398,102 @@ class AIAgent:
             function_result = append_toolguard_guidance(function_result, decision)
         if decision.should_halt:
             self._set_tool_guardrail_halt(decision)
+        # Feed the same structured observation to the trajectory quality
+        # router (parallel observer — does not mutate tool_result/messages).
+        self._observe_trajectory_quality(
+            tool_name, function_args, function_result, failed=failed
+        )
         return function_result
+
+    def _observe_trajectory_quality(
+        self,
+        tool_name: str,
+        function_args: dict,
+        function_result: str,
+        *,
+        failed: bool,
+    ) -> None:
+        """Feed a structured tool-result observation to the quality router.
+
+        No-op when the controller is absent or disabled. Never mutates
+        messages, tool_result, toolsets, or the system prompt. Never calls
+        ``switch_model`` or ``try_activate_fallback``.
+        """
+        ctrl = getattr(self, "_trajectory_quality", None)
+        if ctrl is None or not ctrl.config.enabled:
+            return
+
+        try:
+            from agent.trajectory_quality import build_observation
+
+            obs = build_observation(
+                tool_name=tool_name,
+                args=function_args,
+                result=function_result,
+                failed=failed,
+                api_call_count=getattr(self, "api_call_count", 0),
+                session_id=getattr(self, "session_id", "") or "",
+                model=getattr(self, "model", "") or "",
+                provider=getattr(self, "provider", "") or "",
+            )
+            decision = ctrl.observe(obs)
+        except Exception:
+            logging.debug("trajectory quality observe failed", exc_info=True)
+            return
+
+        if decision is None:
+            return
+
+        # Persist the decision (fail-open).
+        store = getattr(self, "_trajectory_quality_store", None)
+        if store is not None:
+            try:
+                store.record(
+                    decision,
+                    session_id=getattr(self, "session_id", "") or "",
+                    api_call_count=getattr(self, "api_call_count", 0),
+                )
+            except Exception:
+                logging.debug("trajectory quality store record failed", exc_info=True)
+
+        # Stash the recommendation for status emission.
+        self._pending_trajectory_quality_recommendation = decision
+
+        # Emit a user-visible status notice (never into the transcript).
+        self._emit_trajectory_quality_status(decision)
+
+        # Soft-stop at ladder stop level.
+        if decision.action == "stop" and ctrl.config.execute_stop:
+            self._trajectory_quality_halt_decision = decision
+
+    def _emit_trajectory_quality_status(self, decision) -> None:
+        """Emit a one-line status notice for a quality routing decision."""
+        if decision.action == "continue":
+            return
+        prefix = "Trajectory quality"
+        if decision.action == "recommend_stronger_model":
+            msg = (
+                f"{prefix}: recommend stronger model "
+                f"({decision.reason_code} on {decision.tool_name}"
+                f"x{decision.count})."
+            )
+            if decision.recommended_model:
+                msg += f" Try /model {decision.recommended_model}."
+            else:
+                msg += " Try /model for a stronger model."
+        elif decision.action == "recommend_clean_restart":
+            msg = (
+                f"{prefix}: recommend a clean session restart "
+                f"({decision.reason_code}; context thrash detected)."
+            )
+        elif decision.action == "stop":
+            msg = (
+                f"{prefix}: stopping tool thrash for this turn "
+                f"({decision.reason_code})."
+            )
+        else:
+            msg = f"{prefix}: {decision.action} ({decision.reason_code})."
+        self._emit_status(msg)
 
     def _guardrail_block_result(self, decision: ToolGuardrailDecision) -> str:
         self._set_tool_guardrail_halt(decision)

--- a/tests/agent/test_trajectory_quality.py
+++ b/tests/agent/test_trajectory_quality.py
@@ -1,0 +1,102 @@
+"""Pure unit tests for trajectory quality routing (reducer/policy).
+
+No AIAgent, no LLM, no network. The controller is a pure function over
+structured observations.
+"""
+
+from __future__ import annotations
+
+from agent.trajectory_quality import (
+    TrajectoryQualityConfig,
+    TrajectoryQualityController,
+    TrajectoryObservation,
+    TrajectoryQualityDecision,
+)
+
+
+# ---------------------------------------------------------------------------
+# S0 — Public API importable + defaults
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults_disabled():
+    cfg = TrajectoryQualityConfig()
+    assert cfg.enabled is False
+    assert cfg.identical_failure == 2
+    assert cfg.same_tool_failure == 4
+    assert cfg.failed_verification == 2
+    assert cfg.stagnation_window == 8
+    assert cfg.execute_model_switch is False
+    assert cfg.allow_deescalate_on_progress is False
+
+
+def test_disabled_controller_observe_returns_none():
+    cfg = TrajectoryQualityConfig(enabled=False)
+    ctrl = TrajectoryQualityController(cfg)
+    obs = TrajectoryObservation(
+        tool_name="terminal",
+        args_hash="abc",
+        result_hash=None,
+        failed=True,
+    )
+    assert ctrl.observe(obs) is None
+
+
+# ---------------------------------------------------------------------------
+# S1 — Identical failure circuit breaker
+# ---------------------------------------------------------------------------
+
+
+def _failed_obs(tool_name="terminal", args_hash="aaa") -> TrajectoryObservation:
+    return TrajectoryObservation(
+        tool_name=tool_name,
+        args_hash=args_hash,
+        result_hash=None,
+        failed=True,
+    )
+
+
+def test_two_identical_failures_escalate_to_recommend_stronger_model():
+    cfg = TrajectoryQualityConfig(enabled=True)
+    ctrl = TrajectoryQualityController(cfg)
+    ctrl.observe(_failed_obs())
+    decision = ctrl.observe(_failed_obs())
+    assert decision is not None
+    assert decision.action == "recommend_stronger_model"
+    assert decision.reason_code == "two_identical_failures"
+    assert decision.count == 2
+
+
+def test_two_failures_different_args_do_not_trip_identical_breaker():
+    cfg = TrajectoryQualityConfig(enabled=True)
+    ctrl = TrajectoryQualityController(cfg)
+    ctrl.observe(_failed_obs(args_hash="aaa"))
+    decision = ctrl.observe(_failed_obs(args_hash="bbb"))
+    assert decision is None
+
+
+def test_success_after_one_failure_resets_exact_counter():
+    cfg = TrajectoryQualityConfig(enabled=True)
+    ctrl = TrajectoryQualityController(cfg)
+    ctrl.observe(_failed_obs(args_hash="aaa"))
+    # A successful file mutation clears the exact counter for this signature.
+    success_obs = TrajectoryObservation(
+        tool_name="terminal",
+        args_hash="aaa",
+        result_hash=None,
+        failed=False,
+        progress_kind="file_mutation_landed",
+    )
+    ctrl.observe(success_obs)
+    # Now a single new failure should NOT trigger (needs 2 again).
+    decision = ctrl.observe(_failed_obs(args_hash="aaa"))
+    assert decision is None
+
+
+def test_reset_for_turn_clears_all_counters():
+    cfg = TrajectoryQualityConfig(enabled=True)
+    ctrl = TrajectoryQualityController(cfg)
+    ctrl.observe(_failed_obs())
+    ctrl.reset_for_turn()
+    decision = ctrl.observe(_failed_obs())
+    assert decision is None

--- a/tests/agent/test_trajectory_quality.py
+++ b/tests/agent/test_trajectory_quality.py
@@ -100,3 +100,166 @@ def test_reset_for_turn_clears_all_counters():
     ctrl.reset_for_turn()
     decision = ctrl.observe(_failed_obs())
     assert decision is None
+
+
+# ---------------------------------------------------------------------------
+# S2 — Policy ladder + hysteresis
+# ---------------------------------------------------------------------------
+
+
+def test_same_tool_failure_streak_escalates_at_threshold():
+    """same_tool_failure=4 default: 4 failures of the same tool (any args)."""
+    cfg = TrajectoryQualityConfig(enabled=True)
+    ctrl = TrajectoryQualityController(cfg)
+    # Three different args hashes — identical breaker never fires.
+    for i, h in enumerate(["a1", "a2", "a3"]):
+        ctrl.observe(_failed_obs(args_hash=h))
+    # Fourth failure of same tool triggers same_tool_failure_streak.
+    decision = ctrl.observe(_failed_obs(args_hash="a4"))
+    assert decision is not None
+    assert decision.action == "recommend_stronger_model"
+    assert decision.reason_code == "same_tool_failure_streak"
+
+
+def test_failed_verification_streak_escalates():
+    cfg = TrajectoryQualityConfig(enabled=True, failed_verification=2)
+    ctrl = TrajectoryQualityController(cfg)
+    obs1 = TrajectoryObservation(
+        tool_name="terminal",
+        args_hash="v1",
+        result_hash=None,
+        failed=True,
+        progress_kind="verification_failed",
+    )
+    obs2 = TrajectoryObservation(
+        tool_name="terminal",
+        args_hash="v2",
+        result_hash=None,
+        failed=True,
+        progress_kind="verification_failed",
+    )
+    ctrl.observe(obs1)
+    decision = ctrl.observe(obs2)
+    assert decision is not None
+    assert decision.reason_code == "failed_verification_streak"
+
+
+def test_stagnation_escalates_to_clean_restart():
+    """stagnation_window with no progress after prior failure -> level 2."""
+    cfg = TrajectoryQualityConfig(enabled=True, stagnation_window=4)
+    ctrl = TrajectoryQualityController(cfg)
+    # Seed a failure so stagnation has "seen failure" context.
+    ctrl.observe(_failed_obs(args_hash="seed"))
+    # Now fill with non-progressing non-failed observations.
+    for i in range(4):
+        ctrl.observe(
+            TrajectoryObservation(
+                tool_name="read_file",
+                args_hash=f"r{i}",
+                result_hash=None,
+                failed=False,
+                progress_kind="none",
+            )
+        )
+    # Stagnation should escalate to at least recommend_clean_restart.
+    assert ctrl.level in ("recommend_clean_restart", "stop")
+
+
+def test_compounding_new_reason_pushes_to_level_2():
+    """Already at level 1, a new distinct reason escalates to clean_restart."""
+    cfg = TrajectoryQualityConfig(
+        enabled=True, identical_failure=2, failed_verification=2
+    )
+    ctrl = TrajectoryQualityController(cfg)
+    # Get to level 1 via two identical failures.
+    ctrl.observe(_failed_obs(args_hash="x1"))
+    d1 = ctrl.observe(_failed_obs(args_hash="x1"))
+    assert d1 is not None and d1.action == "recommend_stronger_model"
+    # New reason: verification failures with different args.
+    v1 = TrajectoryObservation(
+        tool_name="terminal", args_hash="v1", result_hash=None,
+        failed=True, progress_kind="verification_failed",
+    )
+    v2 = TrajectoryObservation(
+        tool_name="terminal", args_hash="v2", result_hash=None,
+        failed=True, progress_kind="verification_failed",
+    )
+    ctrl.observe(v1)
+    d2 = ctrl.observe(v2)
+    assert d2 is not None
+    assert d2.action == "recommend_clean_restart"
+
+
+def test_level_2_plus_new_trigger_pushes_to_stop():
+    """Any trigger while at level 2 escalates to stop."""
+    cfg = TrajectoryQualityConfig(enabled=True, identical_failure=2)
+    ctrl = TrajectoryQualityController(cfg)
+    # Escalate to level 2 via compounding.
+    ctrl.observe(_failed_obs(args_hash="x1"))
+    ctrl.observe(_failed_obs(args_hash="x1"))  # level 1
+    # Different tool, different args -> new reason at level 1 -> level 2.
+    for i in range(4):
+        ctrl.observe(_failed_obs(tool_name="patch", args_hash=f"p{i}"))
+    assert ctrl.level == "recommend_clean_restart"
+    # Another trigger should push to stop.
+    ctrl.observe(_failed_obs(tool_name="write_file", args_hash="w1"))
+    ctrl.observe(_failed_obs(tool_name="write_file", args_hash="w1"))
+    assert ctrl.level == "stop"
+
+
+def test_duplicate_decision_suppressed_within_turn():
+    """Same (action, reason, tool, args_hash) emitted only once per turn."""
+    cfg = TrajectoryQualityConfig(enabled=True, identical_failure=2)
+    ctrl = TrajectoryQualityController(cfg)
+    ctrl.observe(_failed_obs(args_hash="dup"))
+    d1 = ctrl.observe(_failed_obs(args_hash="dup"))
+    assert d1 is not None
+    # Third identical failure — same key, should be suppressed.
+    d2 = ctrl.observe(_failed_obs(args_hash="dup"))
+    assert d2 is None
+
+
+def test_progress_does_not_lower_level_by_default():
+    """allow_deescalate_on_progress=False: progress never lowers level."""
+    cfg = TrajectoryQualityConfig(enabled=True, identical_failure=2)
+    ctrl = TrajectoryQualityController(cfg)
+    ctrl.observe(_failed_obs(args_hash="p1"))
+    ctrl.observe(_failed_obs(args_hash="p1"))
+    assert ctrl.level == "recommend_stronger_model"
+    # File mutation success — should NOT lower the level.
+    ctrl.observe(
+        TrajectoryObservation(
+            tool_name="write_file", args_hash="p1", result_hash=None,
+            failed=False, progress_kind="file_mutation_landed",
+        )
+    )
+    assert ctrl.level == "recommend_stronger_model"
+
+
+def test_deescalate_on_progress_lowers_one_step():
+    """allow_deescalate_on_progress=True + hysteresis_progress_needed=2."""
+    cfg = TrajectoryQualityConfig(
+        enabled=True,
+        identical_failure=2,
+        allow_deescalate_on_progress=True,
+        hysteresis_progress_needed=2,
+    )
+    ctrl = TrajectoryQualityController(cfg)
+    ctrl.observe(_failed_obs(args_hash="d1"))
+    ctrl.observe(_failed_obs(args_hash="d1"))
+    assert ctrl.level == "recommend_stronger_model"
+    # Need 2 progress events to de-escalate one step.
+    ctrl.observe(
+        TrajectoryObservation(
+            tool_name="write_file", args_hash="ok1", result_hash=None,
+            failed=False, progress_kind="file_mutation_landed",
+        )
+    )
+    assert ctrl.level == "recommend_stronger_model"  # not yet
+    ctrl.observe(
+        TrajectoryObservation(
+            tool_name="write_file", args_hash="ok2", result_hash=None,
+            failed=False, progress_kind="file_mutation_landed",
+        )
+    )
+    assert ctrl.level == "continue"

--- a/tests/agent/test_trajectory_quality.py
+++ b/tests/agent/test_trajectory_quality.py
@@ -11,6 +11,7 @@ from agent.trajectory_quality import (
     TrajectoryQualityController,
     TrajectoryObservation,
     TrajectoryQualityDecision,
+    build_observation,
 )
 
 
@@ -263,3 +264,65 @@ def test_deescalate_on_progress_lowers_one_step():
         )
     )
     assert ctrl.level == "continue"
+
+
+# ---------------------------------------------------------------------------
+# S3 — Event builder helpers
+# ---------------------------------------------------------------------------
+
+
+def test_build_observation_args_hash_stable_under_reordering():
+    """The args_hash must be the same regardless of dict key order."""
+    obs1 = build_observation(
+        tool_name="terminal",
+        args={"command": "ls", "workdir": "/tmp"},
+        result='{"exit_code": 0}',
+        failed=False,
+    )
+    obs2 = build_observation(
+        tool_name="terminal",
+        args={"workdir": "/tmp", "command": "ls"},
+        result='{"exit_code": 0}',
+        failed=False,
+    )
+    assert obs1.args_hash == obs2.args_hash
+
+
+def test_build_observation_secret_not_in_observation_fields():
+    """A secret in args must not appear in the observation as plaintext."""
+    secret = "sk-super-secret-key-1234567890"
+    obs = build_observation(
+        tool_name="terminal",
+        args={"command": f"echo {secret}"},
+        result='{"exit_code": 0}',
+        failed=False,
+    )
+    # The observation holds only a hash — the secret must not be present
+    # in any field or in the dataclass repr.
+    import dataclasses
+
+    dump = dataclasses.asdict(obs)
+    joined = " ".join(str(v) for v in dump.values())
+    assert secret not in joined
+    assert secret not in repr(obs)
+
+
+def test_build_observation_file_mutation_lands_progress():
+    obs = build_observation(
+        tool_name="write_file",
+        args={"path": "/tmp/x", "content": "hi"},
+        result='{"bytes_written": 2}',
+        failed=False,
+    )
+    assert obs.progress_kind == "file_mutation_landed"
+
+
+def test_build_observation_failed_result():
+    obs = build_observation(
+        tool_name="terminal",
+        args={"command": "false"},
+        result='{"exit_code": 1, "output": "error"}',
+        failed=True,
+    )
+    assert obs.failed is True
+    assert obs.progress_kind == "none"

--- a/tests/agent/test_trajectory_quality_store.py
+++ b/tests/agent/test_trajectory_quality_store.py
@@ -1,0 +1,117 @@
+"""Tests for the trajectory quality decision store.
+
+Uses real temp HERMES_HOME so the profile-aware path resolution is
+exercised — no mocks for sqlite3.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from agent.trajectory_quality import (
+    TrajectoryQualityDecision,
+    TrajectoryQualityConfig,
+)
+from agent.trajectory_quality_store import TrajectoryQualityStore
+
+
+@pytest.fixture
+def tmp_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _sample_decision(**overrides) -> TrajectoryQualityDecision:
+    defaults = dict(
+        action="recommend_stronger_model",
+        reason_code="two_identical_failures",
+        level_before="continue",
+        level_after="recommend_stronger_model",
+        tool_name="terminal",
+        args_hash="deadbeef",
+        result_hash="cafebabe",
+        count=2,
+        explain="terminal failed 2x with identical args_hash",
+        model="test/model",
+        provider="test",
+    )
+    defaults.update(overrides)
+    return TrajectoryQualityDecision(**defaults)
+
+
+def test_record_and_list_roundtrip(tmp_home):
+    store = TrajectoryQualityStore()
+    decision = _sample_decision()
+    decision_id = store.record(decision, session_id="sess-1")
+    assert isinstance(decision_id, str) and len(decision_id) > 0
+
+    rows = store.list_for_session("sess-1")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["action"] == "recommend_stronger_model"
+    assert row["reason_code"] == "two_identical_failures"
+    assert row["tool_name"] == "terminal"
+    assert row["count"] == 2
+
+
+def test_record_creates_db_under_hermes_home(tmp_home):
+    store = TrajectoryQualityStore()
+    store.record(_sample_decision(), session_id="sess-1")
+    db_path = tmp_home / "trajectory_quality.db"
+    assert db_path.exists()
+
+
+def test_no_raw_secret_in_stored_row(tmp_home):
+    """A planted secret in the explain string must survive redaction."""
+    store = TrajectoryQualityStore()
+    secret = "sk-proj-abcdef1234567890abcdef1234567890"
+    decision = _sample_decision(explain=f"terminal failed with key {secret}")
+    store.record(decision, session_id="sess-1")
+
+    rows = store.list_for_session("sess-1")
+    row_json = str(rows[0])
+    assert secret not in row_json
+
+
+def test_list_filters_by_session(tmp_home):
+    store = TrajectoryQualityStore()
+    store.record(_sample_decision(), session_id="sess-A")
+    store.record(_sample_decision(), session_id="sess-B")
+    assert len(store.list_for_session("sess-A")) == 1
+    assert len(store.list_for_session("sess-B")) == 1
+    assert len(store.list_for_session("sess-C")) == 0
+
+
+def test_retention_purge_removes_old_rows(tmp_home):
+    store = TrajectoryQualityStore(retention_days=1)
+    store.record(_sample_decision(), session_id="sess-old")
+    # Manually backdate the row.
+    import sqlite3
+
+    db_path = tmp_home / "trajectory_quality.db"
+    conn = sqlite3.connect(db_path)
+    old_ts = "2020-01-01T00:00:00+00:00"
+    conn.execute("UPDATE decisions SET created_at = ?", (old_ts,))
+    conn.commit()
+    conn.close()
+
+    purged = store.purge_expired()
+    assert purged >= 1
+    assert len(store.list_for_session("sess-old")) == 0
+
+
+def test_session_cap_trims_oldest(tmp_home):
+    store = TrajectoryQualityStore(max_decisions_per_session=3)
+    for i in range(5):
+        store.record(_sample_decision(count=i), session_id="sess-cap")
+    rows = store.list_for_session("sess-cap")
+    assert len(rows) == 3
+    # Should keep the most recent (highest count).
+    counts = sorted(r["count"] for r in rows)
+    assert counts == [2, 3, 4]

--- a/tests/run_agent/test_trajectory_quality_runtime.py
+++ b/tests/run_agent/test_trajectory_quality_runtime.py
@@ -1,0 +1,258 @@
+"""Runtime integration tests for trajectory quality routing.
+
+Patterned on test_tool_call_guardrail_runtime.py. Uses real AIAgent
+construction (no LLM calls), real temp HERMES_HOME, and real tool
+execution through the executor to verify the observe seam fires.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_tool_call(name="terminal", arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _enabled_config(**overrides) -> dict:
+    cfg = {
+        "trajectory_quality_routing": {
+            "enabled": True,
+            "execute_stop": True,
+            "execute_model_switch": False,
+            "persist_decisions": True,
+            "thresholds": {
+                "identical_failure": 2,
+                "same_tool_failure": 4,
+                "failed_verification": 2,
+                "stagnation_window": 8,
+            },
+        }
+    }
+    cfg["trajectory_quality_routing"].update(overrides)
+    return cfg
+
+
+def _make_agent(
+    *tool_names: str,
+    config: dict | None = None,
+    tmp_home: Path | None = None,
+) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=10,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Disabled parity — zero impact when off
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_no_recommendation_no_db(tmp_path, monkeypatch):
+    """When disabled, no recommendation attr is set and no DB is created."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = _make_agent("terminal")
+    assert agent._trajectory_quality.config.enabled is False
+
+    args = {"command": "false"}
+    tc = _mock_tool_call("terminal", json.dumps(args), "c-disabled")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"exit_code": 1})):
+        agent._execute_tool_calls_sequential(msg, messages, "task-disabled")
+
+    assert agent._pending_trajectory_quality_recommendation is None
+    assert not (home / "trajectory_quality.db").exists()
+
+
+# ---------------------------------------------------------------------------
+# Enabled — recommendation fires on two identical failures
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_two_identical_failures_produces_recommendation(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = _make_agent("terminal", config=_enabled_config())
+    args = {"command": "false"}
+
+    # Seed one failure directly through the controller.
+    agent._trajectory_quality.observe(
+        type(agent._trajectory_quality.config)  # dummy
+        and _build_obs("terminal", args, True)
+    )
+
+    tc = _mock_tool_call("terminal", json.dumps(args), "c-rec")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"exit_code": 1})):
+        agent._execute_tool_calls_sequential(msg, messages, "task-rec")
+
+    rec = agent._pending_trajectory_quality_recommendation
+    assert rec is not None
+    assert rec.action == "recommend_stronger_model"
+    assert rec.reason_code == "two_identical_failures"
+
+
+def _build_obs(tool_name, args, failed):
+    from agent.trajectory_quality import build_observation
+
+    return build_observation(
+        tool_name=tool_name,
+        args=args,
+        result=json.dumps({"exit_code": 1}) if failed else json.dumps({"ok": True}),
+        failed=failed,
+    )
+
+
+def test_recommendation_does_not_mutate_messages(tmp_path, monkeypatch):
+    """Quality routing must not add system/user messages to the transcript."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = _make_agent("terminal", config=_enabled_config())
+    args = {"command": "false"}
+
+    # Seed one failure.
+    agent._trajectory_quality.observe(_build_obs("terminal", args, True))
+
+    tc = _mock_tool_call("terminal", json.dumps(args), "c-nomut")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = [{"role": "system", "content": "system"}, {"role": "user", "content": "hi"}]
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"exit_code": 1})):
+        agent._execute_tool_calls_sequential(msg, messages, "task-nomut")
+
+    # Only the tool result message should have been appended — no extra
+    # system/user messages from quality routing.
+    roles = [m["role"] for m in messages]
+    assert roles == ["system", "user", "tool"]
+    # The tool result must NOT contain quality-routing markers.
+    tool_content = messages[-1]["content"]
+    assert "Trajectory quality" not in tool_content
+
+
+def test_switch_model_not_called(tmp_path, monkeypatch):
+    """Quality routing must never call switch_model."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = _make_agent("terminal", config=_enabled_config())
+    args = {"command": "false"}
+
+    # Seed one failure.
+    agent._trajectory_quality.observe(_build_obs("terminal", args, True))
+
+    tc = _mock_tool_call("terminal", json.dumps(args), "c-noswitch")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"exit_code": 1})),
+        patch.object(agent, "switch_model") as mock_switch,
+    ):
+        agent._execute_tool_calls_sequential(msg, messages, "task-noswitch")
+
+    mock_switch.assert_not_called()
+
+
+def test_decision_persisted_to_store(tmp_path, monkeypatch):
+    """When a decision fires, it should be recorded in the store."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = _make_agent("terminal", config=_enabled_config())
+    assert agent._trajectory_quality_store is not None
+
+    args = {"command": "false"}
+    # Seed one failure.
+    agent._trajectory_quality.observe(_build_obs("terminal", args, True))
+
+    tc = _mock_tool_call("terminal", json.dumps(args), "c-persist")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"exit_code": 1})):
+        agent._execute_tool_calls_sequential(msg, messages, "task-persist")
+
+    # The DB file should exist with at least one row.
+    assert (home / "trajectory_quality.db").exists()
+
+
+def test_quality_routing_marker_absent_from_tool_result(tmp_path, monkeypatch):
+    """Tool result text must not gain a quality-routing suffix."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = _make_agent("terminal", config=_enabled_config())
+    args = {"command": "false"}
+
+    # Seed one failure.
+    agent._trajectory_quality.observe(_build_obs("terminal", args, True))
+
+    tc = _mock_tool_call("terminal", json.dumps(args), "c-marker")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"exit_code": 1})):
+        agent._execute_tool_calls_sequential(msg, messages, "task-marker")
+
+    tool_content = messages[-1]["content"]
+    # Guardrail warning suffix may be present, but quality-specific text must not.
+    assert "Trajectory quality" not in tool_content
+    assert "recommend_stronger_model" not in tool_content

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1430,6 +1430,41 @@ tool_loop_guardrails:
 
 `hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md).
 
+## Trajectory Quality Routing
+
+While tool-loop guardrails act on **tool execution** (warn/block individual calls), trajectory quality routing observes the **overall trajectory** and recommends a course correction when the agent is thrashing: repeated identical failures, failed verification streaks after edits, or long stretches with no verified progress.
+
+Disabled by default. When enabled, it escalates a **one-way recommendation ladder**:
+
+1. `continue` — no intervention
+2. `recommend_stronger_model` — surface a status notice suggesting a stronger model
+3. `recommend_clean_restart` — surface a status notice suggesting a clean session restart
+4. `stop` — soft-stop further tool thrash for the current turn (if `execute_stop: true`)
+
+```yaml
+trajectory_quality_routing:
+  enabled: false                     # master switch (default: off)
+  execute_stop: true                 # honor the stop level with a soft-halt
+  execute_model_switch: false        # reserved; hard-ignored in this version
+  allow_deescalate_on_progress: false
+  persist_decisions: true            # write audit records to trajectory_quality.db
+  retention_days: 30
+  max_decisions_per_session: 200
+  stronger_model:                    # optional: name a specific model in the recommendation
+    provider: null
+    model: null
+  thresholds:
+    identical_failure: 2             # two-identical-failure circuit breaker
+    same_tool_failure: 4
+    failed_verification: 2
+    stagnation_window: 8
+  hysteresis_progress_needed: 2      # only if allow_deescalate_on_progress
+```
+
+**Privacy:** decision records store only hashes (args_hash, result_hash), tool names, counts, and short explain strings — never raw tool args, results, or stdout. All string fields are defensively redacted before persistence.
+
+**Relationship to other systems:** this is a parallel observer of the same failure signals the tool-loop guardrails consume — it does not replace them, mutate prompts/toolsets, or interfere with transport fallback (`fallback_providers`). Recommendations go through the status channel (user-visible, never injected into the model transcript). Model escalation is **recommendation-only** in this version.
+
 ## TTS Configuration
 
 ```yaml


### PR DESCRIPTION
## Summary
Adds disabled-by-default deterministic trajectory quality routing: identical-failure, verification, and stagnation signals feed a one-way recommendation ladder (stronger model, clean restart, stop). Decisions are stored as redacted hashes under profile-aware HERMES_HOME storage. No automatic model switch, prompt/toolset mutation, external evaluator, or telemetry.

## Spec
- `docs/superpowers/specs/2026-07-29-trajectory-quality-routing-design.md`
- `docs/superpowers/plans/2026-07-29-trajectory-quality-routing-plan.md`

## Verification
- `scripts/run_tests.sh tests/agent/test_trajectory_quality.py tests/agent/test_trajectory_quality_store.py tests/run_agent/test_trajectory_quality_runtime.py tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/agent/test_verification_evidence.py -q` — 71 passed
- `scripts/run_tests.sh tests/run_agent/ tests/agent/test_agent_init.py -q` — 2237 passed
- Ruff — all checks passed

Durable task: `t_1938b4fc`
Exact head: `e402fa2244cabf27ec286f5d2c2498c46ba6dde2`