### PR TITLE
feat(cron): add canonical JSON lifecycle output

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1778,16 +1778,12 @@ def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any
             invalid("CRON_RESTORE_SCHEDULE_MISMATCH")
         if snapshot.get("repeat_state") != record.get("repeat"):
             invalid("CRON_RESTORE_REPEAT_MISMATCH")
-        if snapshot.get("schedule") != record.get("schedule_display"):
-            invalid("CRON_RESTORE_SCHEDULE_MISMATCH")
         repeat_state = record.get("repeat")
         expected_repeat = repeat_state.get("times") if isinstance(repeat_state, dict) else None
         if snapshot.get("repeat") != expected_repeat:
             invalid("CRON_RESTORE_REPEAT_MISMATCH")
         if snapshot.get("run_at") != (record.get("schedule") or {}).get("run_at"):
             invalid("CRON_RESTORE_RUN_AT_MISMATCH")
-        if snapshot.get("delivery") != record.get("deliver"):
-            invalid("CRON_RESTORE_DELIVERY_MISMATCH")
         snapshot = record
     else:
         # Keep the pre-v2 input path for existing callers, but apply the same

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1614,41 +1614,78 @@ def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any
     interchange format, not a bag of updates. Validate and translate it before
     taking the store lock so malformed input cannot cause a partial mutation.
     """
-    if not isinstance(job_id, str) or not job_id or not isinstance(snapshot, dict):
-        raise ValueError("cron restore requires a job id and object snapshot")
-    if snapshot.get("id") != job_id:
-        raise ValueError("cron restore snapshot id does not match job id")
+    def invalid(code: str):
+        raise ValueError(code)
+    if not isinstance(job_id, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", job_id):
+        invalid("CRON_RESTORE_INVALID_ID")
+    if not isinstance(snapshot, dict):
+        invalid("CRON_RESTORE_INVALID_SNAPSHOT")
+    versioned = snapshot.get("schema_version") == 2 and isinstance(snapshot.get("record"), dict)
+    if versioned:
+        versioned_keys = {
+            "schema_version", "record", "presence", "id", "name", "enabled", "state",
+            "schedule", "run_at", "next_run_at", "repeat", "repeat_state", "delivery",
+            "deliver", "platform", "recipient", "thread", "script", "skills", "no_agent",
+            "prompt", "model", "provider", "workdir",
+        }
+        if set(snapshot) - versioned_keys:
+            invalid("CRON_RESTORE_UNKNOWN_FIELD")
+        record = snapshot["record"]
+        for field in ("id", "name", "enabled", "state", "script", "skills", "no_agent", "prompt", "model", "provider", "workdir"):
+            if field in snapshot and snapshot.get(field) != record.get(field):
+                invalid("CRON_RESTORE_RECORD_MISMATCH")
+        record = copy.deepcopy(snapshot["record"])
+        if snapshot.get("presence") != sorted(record):
+            invalid("CRON_RESTORE_INVALID_PRESENCE")
+        if record.get("id") != job_id:
+            invalid("CRON_RESTORE_ID_MISMATCH")
+        snapshot = record
+    elif snapshot.get("id") != job_id:
+        invalid("CRON_RESTORE_ID_MISMATCH")
     allowed = {
         "id", "name", "enabled", "state", "schedule", "run_at", "next_run_at",
         "repeat", "delivery", "deliver", "platform", "recipient", "thread",
         "script", "skills", "no_agent", "prompt", "model", "provider", "workdir",
     }
     unknown = set(snapshot) - allowed
+    if versioned:
+        unknown = set()
     if unknown:
-        raise ValueError(f"cron restore snapshot has unknown fields: {', '.join(sorted(unknown))}")
+        invalid("CRON_RESTORE_UNKNOWN_FIELD")
     if not isinstance(snapshot.get("name"), (str, type(None))):
-        raise ValueError("cron restore name must be a string or null")
+        invalid("CRON_RESTORE_INVALID_NAME")
     if not isinstance(snapshot.get("enabled"), bool):
-        raise ValueError("cron restore enabled must be boolean")
+        invalid("CRON_RESTORE_INVALID_ENABLED")
     state = snapshot.get("state")
     if state not in {"scheduled", "paused", "completed"}:
-        raise ValueError("cron restore state is invalid")
+        invalid("CRON_RESTORE_INVALID_STATE")
     if state == "paused" and snapshot["enabled"]:
-        raise ValueError("cron restore paused job cannot be enabled")
+        invalid("CRON_RESTORE_INVALID_STATE")
     if state in {"scheduled", "completed"} and not snapshot["enabled"]:
-        raise ValueError("cron restore scheduled/completed job must be enabled")
+        invalid("CRON_RESTORE_INVALID_STATE")
     if state == "completed":
-        raise ValueError("cron restore cannot restore a completed job")
+        invalid("CRON_RESTORE_INVALID_STATE")
     schedule = snapshot.get("schedule")
-    if not isinstance(schedule, str) or not schedule.strip():
-        raise ValueError("cron restore schedule must be a non-empty string")
-    try:
-        parsed_schedule = parse_schedule(schedule)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"cron restore schedule is invalid: {exc}") from exc
+    if versioned and isinstance(schedule, dict):
+        parsed_schedule = copy.deepcopy(schedule)
+        if parsed_schedule.get("kind") not in {"once", "interval", "cron"}:
+            invalid("CRON_RESTORE_INVALID_SCHEDULE")
+    else:
+        if not isinstance(schedule, str) or not schedule.strip():
+            invalid("CRON_RESTORE_INVALID_SCHEDULE")
+        try:
+            parsed_schedule = parse_schedule(schedule)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("CRON_RESTORE_INVALID_SCHEDULE") from exc
     repeat = snapshot.get("repeat")
+    repeat_completed = 0
+    if versioned and isinstance(repeat, dict):
+        repeat_completed = repeat.get("completed", 0)
+        repeat = repeat.get("times")
     if repeat is not None and (isinstance(repeat, bool) or not isinstance(repeat, int) or repeat < 0):
-        raise ValueError("cron restore repeat must be a non-negative integer or null")
+        raise ValueError("CRON_RESTORE_INVALID_REPEAT")
+    if isinstance(repeat_completed, bool) or not isinstance(repeat_completed, int) or repeat_completed < 0:
+        raise ValueError("CRON_RESTORE_INVALID_REPEAT")
     skills = snapshot.get("skills")
     if not isinstance(skills, list) or any(not isinstance(skill, str) for skill in skills):
         raise ValueError("cron restore skills must be a list of strings")
@@ -1670,11 +1707,23 @@ def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any
         raise ValueError("cron restore no_agent job requires a non-empty script")
     if snapshot.get("no_agent") is not True and not str(snapshot.get("prompt") or "").strip() and not skills:
         raise ValueError("cron restore active agent requires a non-empty prompt or skills")
+    if versioned:
+        # The versioned record is already the persisted representation.  Do not
+        # rebuild it through the legacy create/edit projection: that would
+        # silently drop accepted metadata and collapse absent/null fields.
+        with _jobs_lock():
+            jobs = load_jobs()
+            for index, current in enumerate(jobs):
+                if current.get("id") == job_id:
+                    jobs[index] = copy.deepcopy(snapshot)
+                    save_jobs(jobs)
+                    return copy.deepcopy(snapshot)
+        return None
     restored = {
         "id": job_id, "name": snapshot["name"], "enabled": snapshot["enabled"],
         "state": state, "schedule": parsed_schedule,
-        "schedule_display": schedule, "next_run_at": next_run_at,
-        "repeat": None if repeat is None else {"times": repeat, "completed": 0},
+        "schedule_display": (schedule if isinstance(schedule, str) else parsed_schedule.get("display", parsed_schedule.get("value", "?"))), "next_run_at": next_run_at,
+        "repeat": None if repeat is None else {"times": repeat, "completed": repeat_completed},
         "deliver": delivery, "script": snapshot.get("script"), "skills": list(skills),
         "no_agent": snapshot.get("no_agent", False), "prompt": snapshot.get("prompt"),
         "model": snapshot.get("model"), "provider": snapshot.get("provider"),

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -370,6 +370,26 @@ def _jobs_lock():
 # into output writes/deletes.
 _IMMUTABLE_JOB_FIELDS = frozenset({"id"})
 
+# Persisted job fields are deliberately explicit.  The JSON store is user
+# editable, so restore must not treat an arbitrary nested mapping as a job
+# record and silently discard fields that happen not to be projected by the
+# CLI.  Keep this list in lockstep with create_job(), mark_job_run(), and the
+# scheduler's claim bookkeeping.
+PERSISTED_JOB_FIELDS = frozenset({
+    "id", "name", "prompt", "skills", "skill", "model", "provider",
+    "provider_snapshot", "model_snapshot", "base_url", "script", "no_agent",
+    "context_from", "enabled_toolsets", "workdir", "attach_to_session",
+    "schedule", "schedule_display", "repeat", "enabled", "state", "paused_at",
+    "paused_reason", "created_at", "next_run_at", "last_run_at", "last_status",
+    "last_error", "last_delivery_error", "deliver", "origin", "fire_claim",
+    "run_claim",
+})
+CANONICAL_SNAPSHOT_FIELDS = frozenset(
+    {"schema_version", "record", "presence", "schedule_state", "repeat_state"}
+    | PERSISTED_JOB_FIELDS
+    | {"delivery", "platform", "recipient", "thread", "run_at"}
+)
+
 
 def _job_output_dir(job_id: str) -> Path:
     """Resolve a job's output directory, rejecting any path-escape attempt.
@@ -1616,59 +1636,140 @@ def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any
     """
     def invalid(code: str):
         raise ValueError(code)
+
     if not isinstance(job_id, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", job_id):
         invalid("CRON_RESTORE_INVALID_ID")
     if not isinstance(snapshot, dict):
         invalid("CRON_RESTORE_INVALID_SNAPSHOT")
-    versioned = snapshot.get("schema_version") == 2 and isinstance(snapshot.get("record"), dict)
+
+    # Validate the object graph before deepcopy. Direct callers can supply
+    # cycles or non-JSON objects even though the CLI accepts JSON only.
+    seen: set[int] = set()
+    def bounded(value: Any, depth: int = 0, nodes: list[int] | None = None) -> None:
+        if nodes is None:
+            nodes = [0]
+        if depth > 12 or nodes[0] >= 1000:
+            invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
+        nodes[0] += 1
+        if isinstance(value, (dict, list, tuple, set)):
+            marker = id(value)
+            if marker in seen:
+                invalid("CRON_RESTORE_CYCLE")
+            seen.add(marker)
+            try:
+                if isinstance(value, dict):
+                    if len(value) > 256:
+                        invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
+                    for key, item in value.items():
+                        if not isinstance(key, str) or len(key) > 256:
+                            invalid("CRON_RESTORE_INVALID_KEY")
+                        bounded(item, depth + 1, nodes)
+                else:
+                    if len(value) > 256:
+                        invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
+                    for item in value:
+                        bounded(item, depth + 1, nodes)
+            finally:
+                seen.remove(marker)
+        elif isinstance(value, str):
+            if len(value) > 16384:
+                invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
+        elif value is None or isinstance(value, (bool, int, float)):
+            return
+        else:
+            invalid("CRON_RESTORE_NON_SERIALIZABLE")
+    bounded(snapshot)
+
+    versioned = snapshot.get("schema_version") == 2
     if versioned:
-        versioned_keys = {
-            "schema_version", "record", "presence", "id", "name", "enabled", "state",
-            "schedule", "run_at", "next_run_at", "repeat", "repeat_state", "delivery",
-            "deliver", "platform", "recipient", "thread", "script", "skills", "no_agent",
-            "prompt", "model", "provider", "workdir",
-        }
-        if set(snapshot) - versioned_keys:
+        if not isinstance(snapshot.get("record"), dict):
+            invalid("CRON_RESTORE_INVALID_RECORD")
+        if set(snapshot) - CANONICAL_SNAPSHOT_FIELDS:
             invalid("CRON_RESTORE_UNKNOWN_FIELD")
-        record = snapshot["record"]
-        for field in ("id", "name", "enabled", "state", "script", "skills", "no_agent", "prompt", "model", "provider", "workdir"):
-            if field in snapshot and snapshot.get(field) != record.get(field):
-                invalid("CRON_RESTORE_RECORD_MISMATCH")
         record = copy.deepcopy(snapshot["record"])
-        if snapshot.get("presence") != sorted(record):
+        if set(record) - PERSISTED_JOB_FIELDS:
+            invalid("CRON_RESTORE_UNKNOWN_RECORD_FIELD")
+        presence = snapshot.get("presence")
+        if (not isinstance(presence, list)
+                or any(not isinstance(field, str) for field in presence)
+                or len(set(presence)) != len(presence)
+                or presence != sorted(record)):
             invalid("CRON_RESTORE_INVALID_PRESENCE")
         if record.get("id") != job_id:
             invalid("CRON_RESTORE_ID_MISMATCH")
+        # Convenience fields are checked against the exact record.  The two
+        # intentionally projected fields have their own lossless companions.
+        for field in PERSISTED_JOB_FIELDS - {"schedule", "repeat"}:
+            if field in snapshot and snapshot[field] != record.get(field):
+                invalid("CRON_RESTORE_RECORD_MISMATCH")
+        if snapshot.get("schedule_state") != record.get("schedule"):
+            invalid("CRON_RESTORE_SCHEDULE_MISMATCH")
+        if snapshot.get("repeat_state") != record.get("repeat"):
+            invalid("CRON_RESTORE_REPEAT_MISMATCH")
+        if snapshot.get("schedule") != record.get("schedule_display"):
+            invalid("CRON_RESTORE_SCHEDULE_MISMATCH")
+        repeat_state = record.get("repeat")
+        expected_repeat = repeat_state.get("times") if isinstance(repeat_state, dict) else None
+        if snapshot.get("repeat") != expected_repeat:
+            invalid("CRON_RESTORE_REPEAT_MISMATCH")
+        if snapshot.get("run_at") != (record.get("schedule") or {}).get("run_at"):
+            invalid("CRON_RESTORE_RUN_AT_MISMATCH")
+        if snapshot.get("delivery") != record.get("deliver"):
+            invalid("CRON_RESTORE_DELIVERY_MISMATCH")
         snapshot = record
-    elif snapshot.get("id") != job_id:
-        invalid("CRON_RESTORE_ID_MISMATCH")
-    allowed = {
-        "id", "name", "enabled", "state", "schedule", "run_at", "next_run_at",
-        "repeat", "delivery", "deliver", "platform", "recipient", "thread",
-        "script", "skills", "no_agent", "prompt", "model", "provider", "workdir",
-    }
-    unknown = set(snapshot) - allowed
-    if versioned:
-        unknown = set()
-    if unknown:
-        invalid("CRON_RESTORE_UNKNOWN_FIELD")
+    else:
+        # Keep the pre-v2 input path for existing callers, but apply the same
+        # bounded field/type checks and stable error codes.
+        if snapshot.get("id") != job_id:
+            invalid("CRON_RESTORE_ID_MISMATCH")
+        if set(snapshot) - {"id", "name", "enabled", "state", "schedule", "next_run_at",
+                             "repeat", "delivery", "deliver", "script", "skills", "no_agent",
+                             "prompt", "model", "provider", "workdir"}:
+            invalid("CRON_RESTORE_UNKNOWN_FIELD")
+
     if not isinstance(snapshot.get("name"), (str, type(None))):
         invalid("CRON_RESTORE_INVALID_NAME")
     if not isinstance(snapshot.get("enabled"), bool):
         invalid("CRON_RESTORE_INVALID_ENABLED")
     state = snapshot.get("state")
-    if state not in {"scheduled", "paused", "completed"}:
+    if state not in {"scheduled", "paused", "completed", "error"}:
         invalid("CRON_RESTORE_INVALID_STATE")
     if state == "paused" and snapshot["enabled"]:
         invalid("CRON_RESTORE_INVALID_STATE")
-    if state in {"scheduled", "completed"} and not snapshot["enabled"]:
+    if state in {"scheduled", "error"} and not snapshot["enabled"]:
         invalid("CRON_RESTORE_INVALID_STATE")
-    if state == "completed":
+    if state == "completed" and snapshot["enabled"]:
         invalid("CRON_RESTORE_INVALID_STATE")
+
     schedule = snapshot.get("schedule")
-    if versioned and isinstance(schedule, dict):
+    if versioned:
+        if not isinstance(schedule, dict) or set(schedule) - {"kind", "minutes", "expr", "run_at", "display"}:
+            invalid("CRON_RESTORE_INVALID_SCHEDULE")
         parsed_schedule = copy.deepcopy(schedule)
-        if parsed_schedule.get("kind") not in {"once", "interval", "cron"}:
+        kind = parsed_schedule.get("kind")
+        if kind == "interval":
+            if (set(parsed_schedule) - {"kind", "minutes", "display"}
+                    or isinstance(parsed_schedule.get("minutes"), bool)
+                    or not isinstance(parsed_schedule.get("minutes"), int)
+                    or parsed_schedule["minutes"] <= 0):
+                invalid("CRON_RESTORE_INVALID_SCHEDULE")
+        elif kind == "cron":
+            if (set(parsed_schedule) - {"kind", "expr", "display"}
+                    or not isinstance(parsed_schedule.get("expr"), str)
+                    or not parsed_schedule["expr"].strip()):
+                invalid("CRON_RESTORE_INVALID_SCHEDULE")
+        elif kind == "once":
+            if (set(parsed_schedule) - {"kind", "run_at", "display"}
+                    or not isinstance(parsed_schedule.get("run_at"), str)
+                    or not parsed_schedule["run_at"].strip()):
+                invalid("CRON_RESTORE_INVALID_SCHEDULE")
+            try:
+                datetime.fromisoformat(parsed_schedule["run_at"].replace("Z", "+00:00"))
+            except (TypeError, ValueError):
+                invalid("CRON_RESTORE_INVALID_SCHEDULE")
+        else:
+            invalid("CRON_RESTORE_INVALID_SCHEDULE")
+        if not isinstance(parsed_schedule.get("display"), str):
             invalid("CRON_RESTORE_INVALID_SCHEDULE")
     else:
         if not isinstance(schedule, str) or not schedule.strip():
@@ -1677,53 +1778,75 @@ def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any
             parsed_schedule = parse_schedule(schedule)
         except (TypeError, ValueError) as exc:
             raise ValueError("CRON_RESTORE_INVALID_SCHEDULE") from exc
-    repeat = snapshot.get("repeat")
+
+    repeat_value = snapshot.get("repeat")
     repeat_completed = 0
-    if versioned and isinstance(repeat, dict):
-        repeat_completed = repeat.get("completed", 0)
-        repeat = repeat.get("times")
-    if repeat is not None and (isinstance(repeat, bool) or not isinstance(repeat, int) or repeat < 0):
-        raise ValueError("CRON_RESTORE_INVALID_REPEAT")
-    if isinstance(repeat_completed, bool) or not isinstance(repeat_completed, int) or repeat_completed < 0:
-        raise ValueError("CRON_RESTORE_INVALID_REPEAT")
+    if versioned:
+        if repeat_value is not None:
+            if (not isinstance(repeat_value, dict)
+                    or set(repeat_value) - {"times", "completed"}):
+                invalid("CRON_RESTORE_INVALID_REPEAT")
+            repeat_completed = repeat_value.get("completed", 0)
+            repeat_value = repeat_value.get("times")
+    if (repeat_value is not None and (isinstance(repeat_value, bool)
+                                      or not isinstance(repeat_value, int)
+                                      or repeat_value < 0)):
+        invalid("CRON_RESTORE_INVALID_REPEAT")
+    if (isinstance(repeat_completed, bool) or not isinstance(repeat_completed, int)
+            or repeat_completed < 0):
+        invalid("CRON_RESTORE_INVALID_REPEAT")
+
     skills = snapshot.get("skills")
     if not isinstance(skills, list) or any(not isinstance(skill, str) for skill in skills):
-        raise ValueError("cron restore skills must be a list of strings")
+        invalid("CRON_RESTORE_INVALID_SKILLS")
     for field in ("run_at", "next_run_at", "script", "prompt", "model", "provider", "workdir"):
         if field in snapshot and snapshot[field] is not None and not isinstance(snapshot[field], str):
-            raise ValueError(f"cron restore {field} must be a string or null")
+            invalid("CRON_RESTORE_INVALID_TEXT_FIELD")
+    if not isinstance(snapshot.get("no_agent"), bool):
+        invalid("CRON_RESTORE_INVALID_NO_AGENT")
     delivery = snapshot.get("deliver", snapshot.get("delivery"))
-    if "deliver" in snapshot and "delivery" in snapshot and snapshot["deliver"] != snapshot["delivery"]:
-        raise ValueError("cron restore deliver and delivery disagree")
-    if not isinstance(delivery, (str, list)) or (isinstance(delivery, list) and any(not isinstance(item, str) for item in delivery)):
-        raise ValueError("cron restore delivery must be a string or list of strings")
+    if ("deliver" in snapshot and "delivery" in snapshot
+            and snapshot["deliver"] != snapshot["delivery"]):
+        invalid("CRON_RESTORE_DELIVERY_MISMATCH")
+    if (not isinstance(delivery, (str, list))
+            or (isinstance(delivery, list) and any(not isinstance(item, str) for item in delivery))):
+        invalid("CRON_RESTORE_INVALID_DELIVERY")
+    for field in ("context_from", "enabled_toolsets"):
+        value = snapshot.get(field)
+        if value is not None and (not isinstance(value, list) or any(not isinstance(item, str) for item in value)):
+            invalid("CRON_RESTORE_INVALID_METADATA")
+    if snapshot.get("attach_to_session") is not None and not isinstance(snapshot["attach_to_session"], bool):
+        invalid("CRON_RESTORE_INVALID_METADATA")
+    if snapshot.get("origin") is not None and not isinstance(snapshot["origin"], dict):
+        invalid("CRON_RESTORE_INVALID_METADATA")
     next_run_at = snapshot.get("next_run_at")
     if parsed_schedule.get("kind") == "once":
-        if not parsed_schedule.get("run_at"):
-            raise ValueError("cron restore one-shot schedule has no run_at")
         if state == "scheduled" and snapshot["enabled"] and not isinstance(next_run_at, str):
-            raise ValueError("cron restore scheduled one-shot requires next_run_at")
-    if snapshot.get("no_agent") is True and not str(snapshot.get("script") or "").strip():
-        raise ValueError("cron restore no_agent job requires a non-empty script")
-    if snapshot.get("no_agent") is not True and not str(snapshot.get("prompt") or "").strip() and not skills:
-        raise ValueError("cron restore active agent requires a non-empty prompt or skills")
+            invalid("CRON_RESTORE_INVALID_NEXT_RUN")
+    if snapshot.get("no_agent") and not str(snapshot.get("script") or "").strip():
+        invalid("CRON_RESTORE_SCRIPT_REQUIRED")
+    if not snapshot.get("no_agent") and not str(snapshot.get("prompt") or "").strip() and not skills:
+        invalid("CRON_RESTORE_AGENT_INPUT_REQUIRED")
+
     if versioned:
-        # The versioned record is already the persisted representation.  Do not
-        # rebuild it through the legacy create/edit projection: that would
-        # silently drop accepted metadata and collapse absent/null fields.
         with _jobs_lock():
             jobs = load_jobs()
             for index, current in enumerate(jobs):
                 if current.get("id") == job_id:
                     jobs[index] = copy.deepcopy(snapshot)
                     save_jobs(jobs)
+                    try:
+                        from cron.scheduler import _notify_provider_jobs_changed
+                        _notify_provider_jobs_changed()
+                    except Exception:
+                        pass
                     return copy.deepcopy(snapshot)
         return None
     restored = {
         "id": job_id, "name": snapshot["name"], "enabled": snapshot["enabled"],
         "state": state, "schedule": parsed_schedule,
         "schedule_display": (schedule if isinstance(schedule, str) else parsed_schedule.get("display", parsed_schedule.get("value", "?"))), "next_run_at": next_run_at,
-        "repeat": None if repeat is None else {"times": repeat, "completed": repeat_completed},
+        "repeat": None if repeat_value is None else {"times": repeat_value, "completed": repeat_completed},
         "deliver": delivery, "script": snapshot.get("script"), "skills": list(skills),
         "no_agent": snapshot.get("no_agent", False), "prompt": snapshot.get("prompt"),
         "model": snapshot.get("model"), "provider": snapshot.get("provider"),

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -11,6 +11,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 import json
 import logging
+import math
 import shutil
 import tempfile
 import threading
@@ -1643,42 +1644,71 @@ def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any
         invalid("CRON_RESTORE_INVALID_SNAPSHOT")
 
     # Validate the object graph before deepcopy. Direct callers can supply
-    # cycles or non-JSON objects even though the CLI accepts JSON only.
-    seen: set[int] = set()
-    def bounded(value: Any, depth: int = 0, nodes: list[int] | None = None) -> None:
-        if nodes is None:
-            nodes = [0]
-        if depth > 12 or nodes[0] >= 1000:
+    # cycles or non-JSON objects even though the CLI accepts JSON only. Keep
+    # this iterative so malicious nesting cannot consume the Python stack.
+    active: set[int] = set()
+    stack: list[tuple[str, Any, int]] = [("enter", snapshot, 0)]
+    node_count = 0
+    while stack:
+        action, value, depth = stack.pop()
+        if action == "exit":
+            active.remove(id(value))
+            continue
+        if depth > 12:
             invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
-        nodes[0] += 1
-        if isinstance(value, (dict, list, tuple, set)):
+        node_count += 1
+        if node_count > 1000:
+            invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
+        if isinstance(value, dict):
             marker = id(value)
-            if marker in seen:
+            if marker in active:
                 invalid("CRON_RESTORE_CYCLE")
-            seen.add(marker)
-            try:
-                if isinstance(value, dict):
-                    if len(value) > 256:
-                        invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
-                    for key, item in value.items():
-                        if not isinstance(key, str) or len(key) > 256:
-                            invalid("CRON_RESTORE_INVALID_KEY")
-                        bounded(item, depth + 1, nodes)
-                else:
-                    if len(value) > 256:
-                        invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
-                    for item in value:
-                        bounded(item, depth + 1, nodes)
-            finally:
-                seen.remove(marker)
+            if len(value) > 256:
+                invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
+            active.add(marker)
+            stack.append(("exit", value, depth))
+            for key, item in reversed(list(value.items())):
+                if not isinstance(key, str):
+                    invalid("CRON_RESTORE_INVALID_KEY")
+                if len(key) > 256:
+                    invalid("CRON_RESTORE_INVALID_KEY")
+                stack.append(("enter", item, depth + 1))
+        elif isinstance(value, list):
+            marker = id(value)
+            if marker in active:
+                invalid("CRON_RESTORE_CYCLE")
+            if len(value) > 256:
+                invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
+            active.add(marker)
+            stack.append(("exit", value, depth))
+            for item in reversed(value):
+                stack.append(("enter", item, depth + 1))
+        elif isinstance(value, (tuple, set)):
+            invalid("CRON_RESTORE_NON_SERIALIZABLE")
         elif isinstance(value, str):
             if len(value) > 16384:
                 invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
-        elif value is None or isinstance(value, (bool, int, float)):
-            return
+        elif isinstance(value, bool) or value is None:
+            continue
+        elif isinstance(value, int):
+            if abs(value) > 2**63 - 1:
+                invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
+        elif isinstance(value, float):
+            if not math.isfinite(value):
+                invalid("CRON_RESTORE_NON_SERIALIZABLE")
         else:
             invalid("CRON_RESTORE_NON_SERIALIZABLE")
-    bounded(snapshot)
+
+    canonical_json = b""
+    try:
+        canonical_json = json.dumps(
+            snapshot, ensure_ascii=False, allow_nan=False, sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeError):
+        invalid("CRON_RESTORE_NON_SERIALIZABLE")
+    if len(canonical_json) > 64 * 1024:
+        invalid("CRON_RESTORE_BOUNDS_EXCEEDED")
 
     versioned = snapshot.get("schema_version") == 2
     if versioned:
@@ -1835,11 +1865,6 @@ def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any
                 if current.get("id") == job_id:
                     jobs[index] = copy.deepcopy(snapshot)
                     save_jobs(jobs)
-                    try:
-                        from cron.scheduler import _notify_provider_jobs_changed
-                        _notify_provider_jobs_changed()
-                    except Exception:
-                        pass
                     return copy.deepcopy(snapshot)
         return None
     restored = {

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1660,10 +1660,20 @@ def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any
         raise ValueError("cron restore deliver and delivery disagree")
     if not isinstance(delivery, (str, list)) or (isinstance(delivery, list) and any(not isinstance(item, str) for item in delivery)):
         raise ValueError("cron restore delivery must be a string or list of strings")
+    next_run_at = snapshot.get("next_run_at")
+    if parsed_schedule.get("kind") == "once":
+        if not parsed_schedule.get("run_at"):
+            raise ValueError("cron restore one-shot schedule has no run_at")
+        if state == "scheduled" and snapshot["enabled"] and not isinstance(next_run_at, str):
+            raise ValueError("cron restore scheduled one-shot requires next_run_at")
+    if snapshot.get("no_agent") is True and not str(snapshot.get("script") or "").strip():
+        raise ValueError("cron restore no_agent job requires a non-empty script")
+    if snapshot.get("no_agent") is not True and not str(snapshot.get("prompt") or "").strip() and not skills:
+        raise ValueError("cron restore active agent requires a non-empty prompt or skills")
     restored = {
         "id": job_id, "name": snapshot["name"], "enabled": snapshot["enabled"],
         "state": state, "schedule": parsed_schedule,
-        "schedule_display": schedule, "next_run_at": snapshot.get("next_run_at"),
+        "schedule_display": schedule, "next_run_at": next_run_at,
         "repeat": None if repeat is None else {"times": repeat, "completed": 0},
         "deliver": delivery, "script": snapshot.get("script"), "skills": list(skills),
         "no_agent": snapshot.get("no_agent", False), "prompt": snapshot.get("prompt"),

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1605,6 +1605,36 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
     return None
 
 
+def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Atomically restore a complete canonical job snapshot in place."""
+    if not isinstance(snapshot, dict):
+        raise ValueError("cron restore snapshot must be an object")
+    restored = copy.deepcopy(snapshot)
+    restored["id"] = job_id
+    if "deliver" not in restored and "delivery" in restored:
+        restored["deliver"] = restored["delivery"]
+    if isinstance(restored.get("schedule"), str):
+        restored["schedule"] = parse_schedule(restored["schedule"])
+    if not isinstance(restored.get("schedule"), dict):
+        raise ValueError("cron restore snapshot requires schedule")
+    restored = _apply_skill_fields(restored)
+    if restored.get("repeat") is None:
+        restored["repeat"] = {"times": None, "completed": 0}
+    elif isinstance(restored.get("repeat"), int):
+        restored["repeat"] = {"times": restored["repeat"], "completed": 0}
+    restored.setdefault("repeat", {"times": None, "completed": 0})
+    restored.setdefault("enabled", True)
+    restored["state"] = restored.get("state") or ("scheduled" if restored["enabled"] else "paused")
+    with _jobs_lock():
+        jobs = load_jobs()
+        for index, current in enumerate(jobs):
+            if current.get("id") == job_id:
+                jobs[index] = restored
+                save_jobs(jobs)
+                return _normalize_job_record(restored)
+    return None
+
+
 def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """Pause a job without deleting it. Accepts a job ID or name."""
     job = resolve_job_ref(job_id)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -392,6 +392,45 @@ CANONICAL_SNAPSHOT_FIELDS = frozenset(
 )
 
 
+def _canonical_restore_projection(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the CLI convenience projection from a persisted record."""
+    schedule = record.get("schedule")
+    repeat = record.get("repeat")
+    repeat_mapping = repeat if isinstance(repeat, dict) else {}
+    raw_delivery = record.get("deliver") or "local"
+    if isinstance(raw_delivery, str):
+        targets = [part.strip() for part in raw_delivery.split(",") if part.strip()]
+    elif isinstance(raw_delivery, (list, tuple)):
+        targets = []
+        for value in raw_delivery:
+            targets.extend(part.strip() for part in str(value).split(",") if part.strip())
+    else:
+        targets = [str(raw_delivery).strip()] if raw_delivery else ["local"]
+    if not targets:
+        targets = ["local"]
+    delivery = targets[0] if len(targets) == 1 else targets
+    platform = recipient = thread = None
+    if len(targets) == 1:
+        parts = targets[0].split(":", 2)
+        if len(parts) >= 2 and parts[0] in {"telegram", "discord", "signal"}:
+            platform, recipient = parts[0], parts[1]
+            thread = parts[2] if len(parts) == 3 else None
+    return {
+        "id": record.get("id"), "name": record.get("name"),
+        "enabled": record.get("enabled", True),
+        "state": record.get("state", "scheduled"),
+        "schedule": record.get("schedule_display") or (schedule.get("display") if isinstance(schedule, dict) else None),
+        "run_at": schedule.get("run_at") if isinstance(schedule, dict) else None,
+        "next_run_at": record.get("next_run_at"),
+        "repeat": repeat_mapping.get("times"), "delivery": delivery, "deliver": delivery,
+        "platform": platform, "recipient": recipient, "thread": thread,
+        "script": record.get("script"), "skills": list(record.get("skills") or []),
+        "no_agent": record.get("no_agent", False), "prompt": record.get("prompt"),
+        "model": record.get("model"), "provider": record.get("provider"),
+        "workdir": record.get("workdir"),
+    }
+
+
 def _job_output_dir(job_id: str) -> Path:
     """Resolve a job's output directory, rejecting any path-escape attempt.
 
@@ -1727,10 +1766,13 @@ def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any
             invalid("CRON_RESTORE_INVALID_PRESENCE")
         if record.get("id") != job_id:
             invalid("CRON_RESTORE_ID_MISMATCH")
-        # Convenience fields are checked against the exact record.  The two
-        # intentionally projected fields have their own lossless companions.
-        for field in PERSISTED_JOB_FIELDS - {"schedule", "repeat"}:
-            if field in snapshot and snapshot[field] != record.get(field):
+        # ``record`` plus ``presence`` is the lossless source of truth.  Check
+        # only the display/convenience projection here; comparing it directly
+        # with raw record values rejects valid legacy shapes (notably delivery
+        # comma strings) and absent/defaulted optional fields.
+        projection = _canonical_restore_projection(record)
+        for field in projection:
+            if field in snapshot and snapshot[field] != projection[field]:
                 invalid("CRON_RESTORE_RECORD_MISMATCH")
         if snapshot.get("schedule_state") != record.get("schedule"):
             invalid("CRON_RESTORE_SCHEDULE_MISMATCH")

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -446,7 +446,9 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     """
     normalized = _apply_skill_fields(job)
     job_id = _coerce_job_text(normalized.get("id"), "unknown")
-    prompt = _coerce_job_text(normalized.get("prompt"))
+    # A canonical restore can intentionally clear prompt. Preserve that null
+    # through readback instead of applying the legacy display default.
+    prompt = normalized.get("prompt") if "prompt" in normalized else _coerce_job_text(normalized.get("prompt"))
     normalized["id"] = job_id
     normalized["prompt"] = prompt
 
@@ -1606,25 +1608,75 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
 
 def restore_job(job_id: str, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Atomically restore a complete canonical job snapshot in place."""
-    if not isinstance(snapshot, dict):
-        raise ValueError("cron restore snapshot must be an object")
-    restored = copy.deepcopy(snapshot)
-    restored["id"] = job_id
-    if "deliver" not in restored and "delivery" in restored:
-        restored["deliver"] = restored["delivery"]
-    if isinstance(restored.get("schedule"), str):
-        restored["schedule"] = parse_schedule(restored["schedule"])
-    if not isinstance(restored.get("schedule"), dict):
-        raise ValueError("cron restore snapshot requires schedule")
+    """Atomically restore one complete canonical job snapshot in place.
+
+    This is deliberately stricter than the edit API: the snapshot is an
+    interchange format, not a bag of updates. Validate and translate it before
+    taking the store lock so malformed input cannot cause a partial mutation.
+    """
+    if not isinstance(job_id, str) or not job_id or not isinstance(snapshot, dict):
+        raise ValueError("cron restore requires a job id and object snapshot")
+    if snapshot.get("id") != job_id:
+        raise ValueError("cron restore snapshot id does not match job id")
+    allowed = {
+        "id", "name", "enabled", "state", "schedule", "run_at", "next_run_at",
+        "repeat", "delivery", "deliver", "platform", "recipient", "thread",
+        "script", "skills", "no_agent", "prompt", "model", "provider", "workdir",
+    }
+    unknown = set(snapshot) - allowed
+    if unknown:
+        raise ValueError(f"cron restore snapshot has unknown fields: {', '.join(sorted(unknown))}")
+    if not isinstance(snapshot.get("name"), (str, type(None))):
+        raise ValueError("cron restore name must be a string or null")
+    if not isinstance(snapshot.get("enabled"), bool):
+        raise ValueError("cron restore enabled must be boolean")
+    state = snapshot.get("state")
+    if state not in {"scheduled", "paused", "completed"}:
+        raise ValueError("cron restore state is invalid")
+    if state == "paused" and snapshot["enabled"]:
+        raise ValueError("cron restore paused job cannot be enabled")
+    if state in {"scheduled", "completed"} and not snapshot["enabled"]:
+        raise ValueError("cron restore scheduled/completed job must be enabled")
+    if state == "completed":
+        raise ValueError("cron restore cannot restore a completed job")
+    schedule = snapshot.get("schedule")
+    if not isinstance(schedule, str) or not schedule.strip():
+        raise ValueError("cron restore schedule must be a non-empty string")
+    try:
+        parsed_schedule = parse_schedule(schedule)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"cron restore schedule is invalid: {exc}") from exc
+    repeat = snapshot.get("repeat")
+    if repeat is not None and (isinstance(repeat, bool) or not isinstance(repeat, int) or repeat < 0):
+        raise ValueError("cron restore repeat must be a non-negative integer or null")
+    skills = snapshot.get("skills")
+    if not isinstance(skills, list) or any(not isinstance(skill, str) for skill in skills):
+        raise ValueError("cron restore skills must be a list of strings")
+    for field in ("run_at", "next_run_at", "script", "prompt", "model", "provider", "workdir"):
+        if field in snapshot and snapshot[field] is not None and not isinstance(snapshot[field], str):
+            raise ValueError(f"cron restore {field} must be a string or null")
+    delivery = snapshot.get("deliver", snapshot.get("delivery"))
+    if "deliver" in snapshot and "delivery" in snapshot and snapshot["deliver"] != snapshot["delivery"]:
+        raise ValueError("cron restore deliver and delivery disagree")
+    if not isinstance(delivery, (str, list)) or (isinstance(delivery, list) and any(not isinstance(item, str) for item in delivery)):
+        raise ValueError("cron restore delivery must be a string or list of strings")
+    restored = {
+        "id": job_id, "name": snapshot["name"], "enabled": snapshot["enabled"],
+        "state": state, "schedule": parsed_schedule,
+        "schedule_display": schedule, "next_run_at": snapshot.get("next_run_at"),
+        "repeat": None if repeat is None else {"times": repeat, "completed": 0},
+        "deliver": delivery, "script": snapshot.get("script"), "skills": list(skills),
+        "no_agent": snapshot.get("no_agent", False), "prompt": snapshot.get("prompt"),
+        "model": snapshot.get("model"), "provider": snapshot.get("provider"),
+        "workdir": snapshot.get("workdir"),
+    }
+    if not isinstance(restored["no_agent"], bool):
+        raise ValueError("cron restore no_agent must be boolean")
     restored = _apply_skill_fields(restored)
-    if restored.get("repeat") is None:
-        restored["repeat"] = {"times": None, "completed": 0}
-    elif isinstance(restored.get("repeat"), int):
-        restored["repeat"] = {"times": restored["repeat"], "completed": 0}
-    restored.setdefault("repeat", {"times": None, "completed": 0})
-    restored.setdefault("enabled", True)
-    restored["state"] = restored.get("state") or ("scheduled" if restored["enabled"] else "paused")
+    # Normalization intentionally supplies edit-time defaults; restore must
+    # retain explicit nulls from the canonical interchange record.
+    for field in ("prompt", "model", "provider", "workdir", "script"):
+        restored[field] = snapshot.get(field)
     with _jobs_lock():
         jobs = load_jobs()
         for index, current in enumerate(jobs):

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -98,9 +98,19 @@ def _warn_if_gateway_not_running() -> None:
 
 def _canonical_job(job: dict) -> dict:
     """Return a lossless, versioned persisted-job shape."""
-    record = json.loads(json.dumps(job, ensure_ascii=False))
-    repeat = job.get("repeat") or {}
-    schedule = job.get("schedule") or {}
+    from cron.jobs import PERSISTED_JOB_FIELDS
+
+    # list_jobs() adds latest_execution as a derived display field.  Never put
+    # that projection into a restore record, and never copy arbitrary keys from
+    # a hand-edited jobs.json into the interchange format.
+    record = {
+        key: json.loads(json.dumps(job[key], ensure_ascii=False))
+        for key in sorted(PERSISTED_JOB_FIELDS)
+        if key in job
+    }
+    repeat = record.get("repeat")
+    repeat_mapping = repeat if isinstance(repeat, dict) else {}
+    schedule = record.get("schedule")
     raw_deliver = job.get("deliver") or job.get("delivery") or "local"
     if isinstance(raw_deliver, str):
         delivery_targets = [part.strip() for part in raw_deliver.split(",") if part.strip()]
@@ -125,20 +135,25 @@ def _canonical_job(job: dict) -> dict:
         "schema_version": 2,
         "record": record,
         "presence": sorted(record),
-        "id": job.get("id"), "name": job.get("name"),
-        "enabled": bool(job.get("enabled", True)),
-        "state": job.get("state", "scheduled"),
-        "schedule": job.get("schedule_display") or schedule.get("display"),
-        "run_at": schedule.get("run_at"), "next_run_at": job.get("next_run_at"),
-        "repeat": repeat.get("times"), "delivery": deliver, "deliver": deliver,
+        "id": record.get("id"), "name": record.get("name"),
+        "enabled": record.get("enabled", True),
+        "state": record.get("state", "scheduled"),
+        "schedule": record.get("schedule_display") or (schedule or {}).get("display"),
+        "schedule_state": json.loads(json.dumps(schedule, ensure_ascii=False)),
+        "run_at": (schedule or {}).get("run_at"), "next_run_at": record.get("next_run_at"),
+        "repeat": repeat_mapping.get("times"), "delivery": deliver, "deliver": deliver,
         "platform": platform, "recipient": recipient, "thread": thread,
-        "script": job.get("script"), "skills": list(job.get("skills") or []),
-        "no_agent": bool(job.get("no_agent", False)),
-        "prompt": job.get("prompt"), "model": job.get("model"),
-        "provider": job.get("provider"), "workdir": job.get("workdir"),
+        "script": record.get("script"), "skills": list(record.get("skills") or []),
+        "no_agent": record.get("no_agent", False),
+        "prompt": record.get("prompt"), "model": record.get("model"),
+        "provider": record.get("provider"), "workdir": record.get("workdir"),
     }
-    result["schedule"] = json.loads(json.dumps(job.get("schedule")))
-    result["repeat_state"] = json.loads(json.dumps(job.get("repeat")))
+    result["repeat_state"] = json.loads(json.dumps(record.get("repeat"), ensure_ascii=False))
+    # Keep all supported persisted metadata visible at the canonical surface;
+    # ``presence`` is the authoritative distinction between absent and null.
+    for field in sorted(PERSISTED_JOB_FIELDS):
+        result.setdefault(field, json.loads(json.dumps(record[field], ensure_ascii=False))
+                           if field in record else None)
     return result
 
 
@@ -553,17 +568,26 @@ def cron_restore(args):
             raise ValueError("cron restore snapshot exceeds 64 KiB")
         snapshot_text = raw.decode("utf-8")
         restored = restore_job(args.job_id, json.loads(snapshot_text))
-    except json.JSONDecodeError:
-        print(color("Failed to restore job: invalid JSON", Colors.RED))
+    except UnicodeDecodeError:
+        print(color("Failed to restore job: CRON_RESTORE_INVALID_UTF8", Colors.RED))
         return 1
-    except (ValueError, TypeError):
-        print(color("Failed to restore job: invalid snapshot", Colors.RED))
+    except json.JSONDecodeError:
+        print(color("Failed to restore job: CRON_RESTORE_INVALID_JSON", Colors.RED))
+        return 1
+    except (ValueError, TypeError) as exc:
+        code = str(exc)
+        if not code.startswith("CRON_RESTORE_"):
+            code = "CRON_RESTORE_INVALID_SNAPSHOT"
+        print(color(f"Failed to restore job: {code}", Colors.RED))
         return 1
     if restored is None:
-        print(color(f"Job not found: {args.job_id}", Colors.RED))
+        print(color("Failed to restore job: CRON_RESTORE_JOB_NOT_FOUND", Colors.RED))
         return 1
-    from cron.scheduler import _notify_provider_jobs_changed
-    _notify_provider_jobs_changed()
+    try:
+        from cron.scheduler import _notify_provider_jobs_changed
+        _notify_provider_jobs_changed()
+    except Exception:
+        pass
     if getattr(args, "json", False):
         print(json.dumps(_canonical_job(restored), ensure_ascii=False, sort_keys=True))
     else:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -523,13 +523,22 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
 def cron_restore(args):
     from cron.jobs import restore_job
     try:
-        restored = restore_job(args.job_id, json.loads(args.snapshot))
+        if getattr(args, "snapshot_stdin", False):
+            raw = sys.stdin.buffer.read(64 * 1024 + 1)
+            if len(raw) > 64 * 1024:
+                raise ValueError("cron restore snapshot exceeds 64 KiB")
+            snapshot_text = raw.decode("utf-8")
+        else:
+            snapshot_text = args.snapshot
+        restored = restore_job(args.job_id, json.loads(snapshot_text))
     except (ValueError, TypeError, json.JSONDecodeError) as exc:
         print(color(f"Failed to restore job: {exc}", Colors.RED))
         return 1
     if restored is None:
         print(color(f"Job not found: {args.job_id}", Colors.RED))
         return 1
+    from cron.scheduler import _notify_provider_jobs_changed
+    _notify_provider_jobs_changed()
     if getattr(args, "json", False):
         print(json.dumps(_canonical_job(restored), ensure_ascii=False, sort_keys=True))
     else:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -96,11 +96,40 @@ def _warn_if_gateway_not_running() -> None:
     print(color("     Check status:  hermes cron status", Colors.DIM))
 
 
-def cron_list(show_all: bool = False):
+def _canonical_job(job: dict) -> dict:
+    """Return the stable persisted-job shape used by automation clients."""
+    repeat = job.get("repeat") or {}
+    schedule = job.get("schedule") or {}
+    deliver = job.get("deliver") or "local"
+    platform = recipient = thread = None
+    if isinstance(deliver, str):
+        parts = deliver.split(":", 2)
+        if len(parts) >= 2 and parts[0] in {"telegram", "discord", "signal"}:
+            platform, recipient = parts[0], parts[1]
+            thread = parts[2] if len(parts) == 3 else None
+    return {
+        "id": job.get("id"), "name": job.get("name"),
+        "enabled": bool(job.get("enabled", True)),
+        "state": job.get("state", "scheduled"),
+        "schedule": job.get("schedule_display") or schedule.get("display"),
+        "run_at": schedule.get("run_at"), "next_run_at": job.get("next_run_at"),
+        "repeat": repeat.get("times"), "delivery": deliver, "deliver": deliver,
+        "platform": platform, "recipient": recipient, "thread": thread,
+        "script": job.get("script"), "skills": list(job.get("skills") or []),
+        "no_agent": bool(job.get("no_agent", False)),
+        "prompt": job.get("prompt"), "model": job.get("model"),
+        "provider": job.get("provider"), "workdir": job.get("workdir"),
+    }
+
+
+def cron_list(show_all: bool = False, *, json_mode: bool = False):
     """List all scheduled jobs."""
     from cron.jobs import list_jobs
 
     jobs = list_jobs(include_disabled=show_all)
+    if json_mode:
+        print(json.dumps([_canonical_job(job) for job in jobs], ensure_ascii=False, sort_keys=True))
+        return
 
     if not jobs:
         print(color("No scheduled jobs.", Colors.DIM))
@@ -356,6 +385,10 @@ def cron_create(args):
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
         return 1
+    if getattr(args, "json", False):
+        from cron.jobs import get_job
+        print(json.dumps(_canonical_job(get_job(result["job_id"]) or {}), ensure_ascii=False, sort_keys=True))
+        return 0
     print(color(f"Created job: {result['job_id']}", Colors.GREEN))
     print(f"  Name: {result['name']}")
     print(f"  Schedule: {result['schedule']}")
@@ -422,6 +455,11 @@ def cron_edit(args):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
         return 1
 
+    if getattr(args, "json", False):
+        from cron.jobs import get_job
+        print(json.dumps(_canonical_job(get_job(args.job_id) or {}), ensure_ascii=False, sort_keys=True))
+        return 0
+
     updated = result["job"]
     print(color(f"Updated job: {updated['job_id']}", Colors.GREEN))
     print(f"  Name: {updated['name']}")
@@ -466,7 +504,7 @@ def cron_command(args):
 
     if subcmd is None or subcmd == "list":
         show_all = getattr(args, 'all', False)
-        cron_list(show_all)
+        cron_list(show_all, json_mode=bool(getattr(args, "json", False)))
         return 0
 
     if subcmd == "status":

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -25,6 +25,25 @@ from cron.lifecycle_guard import (  # noqa: F401  (re-exported for terminal_tool
     contains_gateway_lifecycle_command as _contains_gateway_lifecycle_command,
 )
 
+_CRON_RESTORE_ERROR_CODES = frozenset({
+    "CRON_RESTORE_INVALID_ID", "CRON_RESTORE_INVALID_SNAPSHOT",
+    "CRON_RESTORE_INVALID_UTF8", "CRON_RESTORE_INVALID_JSON",
+    "CRON_RESTORE_BOUNDS_EXCEEDED", "CRON_RESTORE_CYCLE",
+    "CRON_RESTORE_NON_SERIALIZABLE", "CRON_RESTORE_INVALID_KEY",
+    "CRON_RESTORE_INVALID_RECORD", "CRON_RESTORE_UNKNOWN_FIELD",
+    "CRON_RESTORE_UNKNOWN_RECORD_FIELD", "CRON_RESTORE_INVALID_PRESENCE",
+    "CRON_RESTORE_ID_MISMATCH", "CRON_RESTORE_RECORD_MISMATCH",
+    "CRON_RESTORE_SCHEDULE_MISMATCH", "CRON_RESTORE_REPEAT_MISMATCH",
+    "CRON_RESTORE_RUN_AT_MISMATCH", "CRON_RESTORE_DELIVERY_MISMATCH",
+    "CRON_RESTORE_INVALID_NAME", "CRON_RESTORE_INVALID_ENABLED",
+    "CRON_RESTORE_INVALID_STATE", "CRON_RESTORE_INVALID_SCHEDULE",
+    "CRON_RESTORE_INVALID_REPEAT", "CRON_RESTORE_INVALID_SKILLS",
+    "CRON_RESTORE_INVALID_TEXT_FIELD", "CRON_RESTORE_INVALID_NO_AGENT",
+    "CRON_RESTORE_INVALID_DELIVERY", "CRON_RESTORE_INVALID_METADATA",
+    "CRON_RESTORE_INVALID_NEXT_RUN", "CRON_RESTORE_SCRIPT_REQUIRED",
+    "CRON_RESTORE_AGENT_INPUT_REQUIRED", "CRON_RESTORE_JOB_NOT_FOUND",
+})
+
 
 def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None) -> Optional[List[str]]:
     if skills is None:
@@ -96,8 +115,8 @@ def _warn_if_gateway_not_running() -> None:
     print(color("     Check status:  hermes cron status", Colors.DIM))
 
 
-def _canonical_job(job: dict) -> dict:
-    """Return a lossless, versioned persisted-job shape."""
+def _canonical_job(job: dict, *, include_snapshot: bool = False) -> dict:
+    """Return the stable CLI projection, optionally with restore data."""
     from cron.jobs import PERSISTED_JOB_FIELDS
 
     # list_jobs() adds latest_execution as a derived display field.  Never put
@@ -132,14 +151,11 @@ def _canonical_job(job: dict) -> dict:
             platform, recipient = parts[0], parts[1]
             thread = parts[2] if len(parts) == 3 else None
     result = {
-        "schema_version": 2,
-        "record": record,
-        "presence": sorted(record),
         "id": record.get("id"), "name": record.get("name"),
         "enabled": record.get("enabled", True),
         "state": record.get("state", "scheduled"),
         "schedule": record.get("schedule_display") or (schedule or {}).get("display"),
-        "schedule_state": json.loads(json.dumps(schedule, ensure_ascii=False)),
+
         "run_at": (schedule or {}).get("run_at"), "next_run_at": record.get("next_run_at"),
         "repeat": repeat_mapping.get("times"), "delivery": deliver, "deliver": deliver,
         "platform": platform, "recipient": recipient, "thread": thread,
@@ -148,12 +164,12 @@ def _canonical_job(job: dict) -> dict:
         "prompt": record.get("prompt"), "model": record.get("model"),
         "provider": record.get("provider"), "workdir": record.get("workdir"),
     }
-    result["repeat_state"] = json.loads(json.dumps(record.get("repeat"), ensure_ascii=False))
-    # Keep all supported persisted metadata visible at the canonical surface;
-    # ``presence`` is the authoritative distinction between absent and null.
-    for field in sorted(PERSISTED_JOB_FIELDS):
-        result.setdefault(field, json.loads(json.dumps(record[field], ensure_ascii=False))
-                           if field in record else None)
+    if include_snapshot:
+        result["schema_version"] = 2
+        result["record"] = record
+        result["presence"] = sorted(record)
+        result["schedule_state"] = json.loads(json.dumps(schedule, ensure_ascii=False))
+        result["repeat_state"] = json.loads(json.dumps(record.get("repeat"), ensure_ascii=False))
     return result
 
 
@@ -163,7 +179,7 @@ def cron_show(job_id: str, *, json_mode: bool = False) -> int:
     if job is None:
         print(color("Job not found", Colors.RED))
         return 1
-    canonical = _canonical_job(job)
+    canonical = _canonical_job(job, include_snapshot=True)
     if json_mode:
         print(json.dumps(canonical, ensure_ascii=False, sort_keys=True))
     else:
@@ -442,7 +458,7 @@ def cron_create(args):
         if not job:
             print("Failed to create job: canonical readback missing", file=sys.stderr)
             return 1
-        print(json.dumps(_canonical_job(job), ensure_ascii=False, sort_keys=True))
+        print(json.dumps(_canonical_job(job, include_snapshot=True), ensure_ascii=False, sort_keys=True))
         return 0
     print(color(f"Created job: {result['job_id']}", Colors.GREEN))
     print(f"  Name: {result['name']}")
@@ -517,7 +533,7 @@ def cron_edit(args):
         if not updated_job:
             print("Failed to update job: canonical readback missing", file=sys.stderr)
             return 1
-        print(json.dumps(_canonical_job(updated_job), ensure_ascii=False, sort_keys=True))
+        print(json.dumps(_canonical_job(updated_job, include_snapshot=True), ensure_ascii=False, sort_keys=True))
         return 0
 
     updated = result["job"]
@@ -576,7 +592,7 @@ def cron_restore(args):
         return 1
     except (ValueError, TypeError) as exc:
         code = str(exc)
-        if not code.startswith("CRON_RESTORE_"):
+        if code not in _CRON_RESTORE_ERROR_CODES:
             code = "CRON_RESTORE_INVALID_SNAPSHOT"
         print(color(f"Failed to restore job: {code}", Colors.RED))
         return 1
@@ -589,7 +605,7 @@ def cron_restore(args):
     except Exception:
         pass
     if getattr(args, "json", False):
-        print(json.dumps(_canonical_job(restored), ensure_ascii=False, sort_keys=True))
+        print(json.dumps(_canonical_job(restored, include_snapshot=True), ensure_ascii=False, sort_keys=True))
     else:
         print(color(f"Restored job: {args.job_id}", Colors.GREEN))
     return 0

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -523,13 +523,12 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
 def cron_restore(args):
     from cron.jobs import restore_job
     try:
-        if getattr(args, "snapshot_stdin", False):
-            raw = sys.stdin.buffer.read(64 * 1024 + 1)
-            if len(raw) > 64 * 1024:
-                raise ValueError("cron restore snapshot exceeds 64 KiB")
-            snapshot_text = raw.decode("utf-8")
-        else:
-            snapshot_text = args.snapshot
+        if not getattr(args, "snapshot_stdin", False):
+            raise ValueError("cron restore requires --snapshot-stdin")
+        raw = sys.stdin.buffer.read(64 * 1024 + 1)
+        if len(raw) > 64 * 1024:
+            raise ValueError("cron restore snapshot exceeds 64 KiB")
+        snapshot_text = raw.decode("utf-8")
         restored = restore_job(args.job_id, json.loads(snapshot_text))
     except (ValueError, TypeError, json.JSONDecodeError) as exc:
         print(color(f"Failed to restore job: {exc}", Colors.RED))

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -100,10 +100,23 @@ def _canonical_job(job: dict) -> dict:
     """Return the stable persisted-job shape used by automation clients."""
     repeat = job.get("repeat") or {}
     schedule = job.get("schedule") or {}
-    deliver = job.get("deliver") or "local"
+    raw_deliver = job.get("deliver") or job.get("delivery") or "local"
+    if isinstance(raw_deliver, str):
+        delivery_targets = [part.strip() for part in raw_deliver.split(",") if part.strip()]
+    elif isinstance(raw_deliver, (list, tuple)):
+        delivery_targets = []
+        for value in raw_deliver:
+            delivery_targets.extend(
+                part.strip() for part in str(value).split(",") if part.strip()
+            )
+    else:
+        delivery_targets = [str(raw_deliver).strip()] if raw_deliver else ["local"]
+    if not delivery_targets:
+        delivery_targets = ["local"]
+    deliver = delivery_targets[0] if len(delivery_targets) == 1 else delivery_targets
     platform = recipient = thread = None
-    if isinstance(deliver, str):
-        parts = deliver.split(":", 2)
+    if len(delivery_targets) == 1:
+        parts = delivery_targets[0].split(":", 2)
         if len(parts) >= 2 and parts[0] in {"telegram", "discord", "signal"}:
             platform, recipient = parts[0], parts[1]
             thread = parts[2] if len(parts) == 3 else None
@@ -387,7 +400,11 @@ def cron_create(args):
         return 1
     if getattr(args, "json", False):
         from cron.jobs import get_job
-        print(json.dumps(_canonical_job(get_job(result["job_id"]) or {}), ensure_ascii=False, sort_keys=True))
+        job = get_job(result["job_id"])
+        if not job:
+            print("Failed to create job: canonical readback missing", file=sys.stderr)
+            return 1
+        print(json.dumps(_canonical_job(job), ensure_ascii=False, sort_keys=True))
         return 0
     print(color(f"Created job: {result['job_id']}", Colors.GREEN))
     print(f"  Name: {result['name']}")
@@ -436,9 +453,10 @@ def cron_edit(args):
             if skill not in final_skills:
                 final_skills.append(skill)
 
+    job_id = job["id"]
     result = _cron_api(
         action="update",
-        job_id=args.job_id,
+        job_id=job_id,
         schedule=getattr(args, "schedule", None),
         prompt=getattr(args, "prompt", None),
         name=getattr(args, "name", None),
@@ -457,7 +475,11 @@ def cron_edit(args):
 
     if getattr(args, "json", False):
         from cron.jobs import get_job
-        print(json.dumps(_canonical_job(get_job(args.job_id) or {}), ensure_ascii=False, sort_keys=True))
+        updated_job = get_job(job_id)
+        if not updated_job:
+            print("Failed to update job: canonical readback missing", file=sys.stderr)
+            return 1
+        print(json.dumps(_canonical_job(updated_job), ensure_ascii=False, sort_keys=True))
         return 0
 
     updated = result["job"]

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -97,7 +97,8 @@ def _warn_if_gateway_not_running() -> None:
 
 
 def _canonical_job(job: dict) -> dict:
-    """Return the stable persisted-job shape used by automation clients."""
+    """Return a lossless, versioned persisted-job shape."""
+    record = json.loads(json.dumps(job, ensure_ascii=False))
     repeat = job.get("repeat") or {}
     schedule = job.get("schedule") or {}
     raw_deliver = job.get("deliver") or job.get("delivery") or "local"
@@ -120,7 +121,10 @@ def _canonical_job(job: dict) -> dict:
         if len(parts) >= 2 and parts[0] in {"telegram", "discord", "signal"}:
             platform, recipient = parts[0], parts[1]
             thread = parts[2] if len(parts) == 3 else None
-    return {
+    result = {
+        "schema_version": 2,
+        "record": record,
+        "presence": sorted(record),
         "id": job.get("id"), "name": job.get("name"),
         "enabled": bool(job.get("enabled", True)),
         "state": job.get("state", "scheduled"),
@@ -133,6 +137,25 @@ def _canonical_job(job: dict) -> dict:
         "prompt": job.get("prompt"), "model": job.get("model"),
         "provider": job.get("provider"), "workdir": job.get("workdir"),
     }
+    result["schedule"] = json.loads(json.dumps(job.get("schedule")))
+    result["repeat_state"] = json.loads(json.dumps(job.get("repeat")))
+    return result
+
+
+def cron_show(job_id: str, *, json_mode: bool = False) -> int:
+    from cron.jobs import load_jobs
+    job = next((item for item in load_jobs() if item.get("id") == job_id), None)
+    if job is None:
+        print(color("Job not found", Colors.RED))
+        return 1
+    canonical = _canonical_job(job)
+    if json_mode:
+        print(json.dumps(canonical, ensure_ascii=False, sort_keys=True))
+    else:
+        print(f"{canonical['id']}  {canonical['name']}")
+        print(f"  Schedule: {canonical.get('schedule_display', '?')}")
+        print(f"  State: {canonical.get('state', '?')}")
+    return 0
 
 
 def cron_list(show_all: bool = False, *, json_mode: bool = False):
@@ -530,8 +553,11 @@ def cron_restore(args):
             raise ValueError("cron restore snapshot exceeds 64 KiB")
         snapshot_text = raw.decode("utf-8")
         restored = restore_job(args.job_id, json.loads(snapshot_text))
-    except (ValueError, TypeError, json.JSONDecodeError) as exc:
-        print(color(f"Failed to restore job: {exc}", Colors.RED))
+    except json.JSONDecodeError:
+        print(color("Failed to restore job: invalid JSON", Colors.RED))
+        return 1
+    except (ValueError, TypeError):
+        print(color("Failed to restore job: invalid snapshot", Colors.RED))
         return 1
     if restored is None:
         print(color(f"Job not found: {args.job_id}", Colors.RED))
@@ -574,6 +600,9 @@ def cron_command(args):
 
     if subcmd == "restore":
         return cron_restore(args)
+
+    if subcmd == "show":
+        return cron_show(args.job_id, json_mode=bool(getattr(args, "json", False)))
 
     if subcmd == "pause":
         return _job_action("pause", args.job_id, "Paused")

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -520,6 +520,23 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
     return 0
 
 
+def cron_restore(args):
+    from cron.jobs import restore_job
+    try:
+        restored = restore_job(args.job_id, json.loads(args.snapshot))
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        print(color(f"Failed to restore job: {exc}", Colors.RED))
+        return 1
+    if restored is None:
+        print(color(f"Job not found: {args.job_id}", Colors.RED))
+        return 1
+    if getattr(args, "json", False):
+        print(json.dumps(_canonical_job(restored), ensure_ascii=False, sort_keys=True))
+    else:
+        print(color(f"Restored job: {args.job_id}", Colors.GREEN))
+    return 0
+
+
 def cron_command(args):
     """Handle cron subcommands."""
     subcmd = getattr(args, 'cron_command', None)
@@ -546,6 +563,9 @@ def cron_command(args):
 
     if subcmd == "edit":
         return cron_edit(args)
+
+    if subcmd == "restore":
+        return cron_restore(args)
 
     if subcmd == "pause":
         return _job_action("pause", args.job_id, "Paused")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4537,7 +4537,7 @@ def cmd_cron(args):
     """Cron job management."""
     from hermes_cli.cron import cron_command
 
-    cron_command(args)
+    return cron_command(args)
 
 
 def cmd_sync(args):

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -7,7 +7,6 @@ import ``main`` (cycle avoidance).
 
 from __future__ import annotations
 
-import argparse
 from typing import Callable
 
 from hermes_cli.subcommands._shared import add_accept_hooks_flag
@@ -169,9 +168,7 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
 
     cron_restore = cron_subparsers.add_parser("restore", help="Atomically restore a canonical job snapshot")
     cron_restore.add_argument("job_id", help="Job ID to restore")
-    snapshot_group = cron_restore.add_mutually_exclusive_group(required=True)
-    snapshot_group.add_argument("--snapshot", help=argparse.SUPPRESS)
-    snapshot_group.add_argument("--snapshot-stdin", action="store_true", help="Read bounded canonical JSON from stdin")
+    cron_restore.add_argument("--snapshot-stdin", action="store_true", help="Read bounded canonical JSON from stdin")
     cron_restore.add_argument("--json", action="store_true", help="Emit canonical JSON")
 
     # lifecycle actions

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -7,6 +7,7 @@ import ``main`` (cycle avoidance).
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
 
 from hermes_cli.subcommands._shared import add_accept_hooks_flag
@@ -168,7 +169,9 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
 
     cron_restore = cron_subparsers.add_parser("restore", help="Atomically restore a canonical job snapshot")
     cron_restore.add_argument("job_id", help="Job ID to restore")
-    cron_restore.add_argument("--snapshot", required=True, help="Canonical JSON object")
+    snapshot_group = cron_restore.add_mutually_exclusive_group(required=True)
+    snapshot_group.add_argument("--snapshot", help=argparse.SUPPRESS)
+    snapshot_group.add_argument("--snapshot-stdin", action="store_true", help="Read bounded canonical JSON from stdin")
     cron_restore.add_argument("--json", action="store_true", help="Emit canonical JSON")
 
     # lifecycle actions

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -22,6 +22,7 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     # cron list
     cron_list = cron_subparsers.add_parser("list", help="List scheduled jobs")
     cron_list.add_argument("--all", action="store_true", help="Include disabled jobs")
+    cron_list.add_argument("--json", action="store_true", help="Emit canonical JSON")
 
     # cron create/add
     cron_create = cron_subparsers.add_parser(
@@ -83,6 +84,8 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="model_provider",
         help="Inference provider paired with --model (e.g. 'openrouter', 'nous').",
     )
+
+    cron_create.add_argument("--json", action="store_true", help="Emit canonical JSON")
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -160,6 +163,8 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="model_provider",
         help="Inference provider paired with --model. Pass empty string to clear.",
     )
+
+    cron_edit.add_argument("--json", action="store_true", help="Emit canonical JSON")
 
     # lifecycle actions
     cron_pause = cron_subparsers.add_parser("pause", help="Pause a scheduled job")

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -166,6 +166,11 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
 
     cron_edit.add_argument("--json", action="store_true", help="Emit canonical JSON")
 
+    cron_restore = cron_subparsers.add_parser("restore", help="Atomically restore a canonical job snapshot")
+    cron_restore.add_argument("job_id", help="Job ID to restore")
+    cron_restore.add_argument("--snapshot", required=True, help="Canonical JSON object")
+    cron_restore.add_argument("--json", action="store_true", help="Emit canonical JSON")
+
     # lifecycle actions
     cron_pause = cron_subparsers.add_parser("pause", help="Pause a scheduled job")
     cron_pause.add_argument("job_id", help="Job ID to pause")

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -24,6 +24,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_list.add_argument("--all", action="store_true", help="Include disabled jobs")
     cron_list.add_argument("--json", action="store_true", help="Emit canonical JSON")
 
+    cron_show = cron_subparsers.add_parser("show", help="Show one scheduled job")
+    cron_show.add_argument("job_id", help="Exact job ID")
+    cron_show.add_argument("--json", action="store_true", help="Emit canonical JSON")
+
     # cron create/add
     cron_create = cron_subparsers.add_parser(
         "create", aliases=["add"], help="Create a scheduled job"

--- a/tests/cron/test_cron_restore.py
+++ b/tests/cron/test_cron_restore.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -39,12 +40,13 @@ def read_rows() -> list[dict]:
 def test_subprocess_restore_roundtrip_and_missing_error_is_redacted(temp_home):
     snapshot = create_snapshot()
     job_id = snapshot["id"]
+    before = read_rows()
     assert cli("cron", "edit", job_id, "--name", "mutated", "--json").returncode == 0
     restored = cli("cron", "restore", job_id, "--snapshot-stdin", "--json",
                    input_text=json.dumps(snapshot))
     assert restored.returncode == 0, restored.stdout
     assert json.loads(restored.stdout) == snapshot
-    assert read_rows() == [snapshot]
+    assert read_rows() == before
     missing = cli("cron", "restore", "missing", "--snapshot-stdin", "--json",
                   input_text=json.dumps(snapshot))
     assert missing.returncode != 0
@@ -105,3 +107,89 @@ def test_one_shot_and_cron_snapshots_are_versioned_and_restoreable(temp_home, sc
                    input_text=json.dumps(snapshot))
     assert restored.returncode == 0, restored.stdout
     assert json.loads(restored.stdout) == snapshot
+
+
+def test_direct_restore_rejects_non_json_graphs_before_mutation(temp_home):
+    from cron.jobs import restore_job
+
+    snapshot = create_snapshot()
+    job_id = snapshot["id"]
+    before = read_rows()
+    cases = [
+        ({**snapshot, "record": {**snapshot["record"], "skills": ("x",)}},
+         "CRON_RESTORE_NON_SERIALIZABLE"),
+        ({**snapshot, "record": {**snapshot["record"], "origin": {"value": float("nan")}}},
+         "CRON_RESTORE_NON_SERIALIZABLE"),
+        ({**snapshot, "record": {**snapshot["record"], "origin": {"value": 2**10000}}},
+         "CRON_RESTORE_BOUNDS_EXCEEDED"),
+    ]
+    cycle = {}
+    cycle["self"] = cycle
+    cases.append(({**snapshot, "record": {**snapshot["record"], "origin": cycle}},
+                  "CRON_RESTORE_CYCLE"))
+
+    for invalid_snapshot, code in cases:
+        with pytest.raises(ValueError, match=code):
+            restore_job(job_id, invalid_snapshot)
+        assert read_rows() == before
+
+
+def test_direct_restore_rejects_canonical_utf8_payload_over_64k_before_mutation(temp_home):
+    from cron.jobs import restore_job
+
+    snapshot = create_snapshot()
+    before = read_rows()
+    record = dict(snapshot["record"])
+    record["origin"] = {f"k{i}": "x" * 14_000 for i in range(5)}
+    with pytest.raises(ValueError, match="CRON_RESTORE_BOUNDS_EXCEEDED"):
+        restore_job(snapshot["id"], {**snapshot, "record": record})
+    assert read_rows() == before
+
+
+def test_cli_restore_maps_only_explicit_restore_codes(monkeypatch, capsys):
+    from hermes_cli import cron as cron_cli
+
+    class Stdin:
+        buffer = type("Buffer", (), {"read": lambda self, limit: b"{}"})()
+
+    monkeypatch.setattr(sys, "stdin", Stdin())
+    monkeypatch.setattr("cron.jobs.restore_job", lambda *_args: (_ for _ in ()).throw(
+        ValueError("CRON_RESTORE_INVENTED_SECRET")
+    ))
+    rc = cron_cli.cron_restore(SimpleNamespace(
+        job_id="job-1", snapshot_stdin=True, json=False,
+    ))
+    assert rc == 1
+    output = capsys.readouterr().out
+    assert "CRON_RESTORE_INVALID_SNAPSHOT" in output
+    assert "INVENTED_SECRET" not in output
+
+
+def test_cli_restore_notifies_provider_once_only_after_success(temp_home, monkeypatch, capsys):
+    from hermes_cli import cron as cron_cli
+
+    snapshot = create_snapshot()
+    calls = []
+    monkeypatch.setattr("cron.scheduler._notify_provider_jobs_changed",
+                        lambda: calls.append("notified"))
+    monkeypatch.setattr(sys, "stdin", type("Stdin", (), {
+        "buffer": type("Buffer", (), {
+            "read": lambda self, limit: json.dumps(snapshot).encode("utf-8")
+        })()
+    })())
+    assert cron_cli.cron_restore(SimpleNamespace(
+        job_id=snapshot["id"], snapshot_stdin=True, json=True,
+    )) == 0
+    capsys.readouterr()
+    assert calls == ["notified"]
+
+    monkeypatch.setattr(sys, "stdin", type("Stdin", (), {
+        "buffer": type("Buffer", (), {
+            "read": lambda self, limit: json.dumps(snapshot).encode("utf-8")
+        })()
+    })())
+    assert cron_cli.cron_restore(SimpleNamespace(
+        job_id="missing", snapshot_stdin=True, json=False,
+    )) == 1
+    capsys.readouterr()
+    assert calls == ["notified"]

--- a/tests/cron/test_cron_restore.py
+++ b/tests/cron/test_cron_restore.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import io
 import os
 import subprocess
 import sys
@@ -12,6 +11,7 @@ import pytest
 @pytest.fixture
 def temp_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("PYTHONPYCACHEPREFIX", str(tmp_path / "pyc"))
     return tmp_path
 
 
@@ -22,42 +22,45 @@ def cli(*args: str, input_text: str | None = None):
     )
 
 
-def create_snapshot():
-    created = cli("cron", "create", "every 1m", "", "--name", "restore-me",
-                   "--script", "restore.sh", "--no-agent", "--json")
+def create_snapshot(schedule: str = "every 5m", *, repeat: str = "0") -> dict:
+    created = cli("cron", "create", schedule, "", "--name", "restore-me",
+                   "--script", "restore.sh", "--no-agent", "--provider", "openai-codex",
+                   "--repeat", repeat, "--json")
     assert created.returncode == 0, created.stderr
     return json.loads(created.stdout)
 
 
-def read_rows():
+def read_rows() -> list[dict]:
     result = cli("cron", "list", "--all", "--json")
     assert result.returncode == 0, result.stderr
     return json.loads(result.stdout)
 
 
-def test_top_level_stdin_restore_exact_rollback_and_main_exit(temp_home):
+def test_subprocess_restore_roundtrip_and_missing_error_is_redacted(temp_home):
     snapshot = create_snapshot()
     job_id = snapshot["id"]
     assert cli("cron", "edit", job_id, "--name", "mutated", "--json").returncode == 0
     restored = cli("cron", "restore", job_id, "--snapshot-stdin", "--json",
                    input_text=json.dumps(snapshot))
-    assert restored.returncode == 0, restored.stderr
+    assert restored.returncode == 0, restored.stdout
     assert json.loads(restored.stdout) == snapshot
     assert read_rows() == [snapshot]
-    assert cli("cron", "restore", "missing", "--snapshot-stdin", "--json",
-               input_text=json.dumps(snapshot)).returncode != 0
+    missing = cli("cron", "restore", "missing", "--snapshot-stdin", "--json",
+                  input_text=json.dumps(snapshot))
+    assert missing.returncode != 0
+    assert "missing" not in missing.stdout
+    assert "CRON_RESTORE_ID_MISMATCH" in missing.stdout
 
 
-def test_restore_rejects_bad_input_without_mutation(temp_home):
+def test_versioned_restore_rejects_unknown_nested_fields_without_mutation(temp_home):
     snapshot = create_snapshot()
     before = read_rows()
     cases = [
-        {**snapshot, "id": "other"},
-        {**snapshot, "unknown_dangerous_field": "x"},
-        {**snapshot, "enabled": "yes"},
-        {**snapshot, "state": "running"},
-        {**snapshot, "repeat": True},
-        {**snapshot, "skills": [1]},
+        {**snapshot, "record": {**snapshot["record"], "unknown_dangerous_field": "x"}},
+        {**snapshot, "record": {**snapshot["record"], "skills": [1]}},
+        {**snapshot, "presence": snapshot["presence"] + ["not_a_field"]},
+        {**snapshot, "schedule_state": {"kind": "interval", "minutes": 1,
+                                          "display": "every 1m", "unexpected": True}},
     ]
     for value in cases:
         result = cli("cron", "restore", snapshot["id"], "--snapshot-stdin", "--json",
@@ -71,27 +74,34 @@ def test_restore_rejects_bad_input_without_mutation(temp_home):
     assert read_rows() == before
 
 
-def test_restore_preserves_explicit_nulls_and_notifies_provider(temp_home, monkeypatch):
-    snapshot = create_snapshot()
-    calls = []
-    import cron.scheduler as scheduler
-    import cron.jobs as jobs
-    import hermes_cli.cron as cron_cli
-    monkeypatch.setattr(scheduler, "_notify_provider_jobs_changed", lambda: calls.append(1))
-    snapshot.update({"prompt": None, "model": None, "provider": None, "workdir": None,
-                     "next_run_at": None, "repeat": None})
-    result = cli("cron", "restore", snapshot["id"], "--snapshot-stdin", "--json",
-                 input_text=json.dumps(snapshot))
-    assert result.returncode == 0
-    monkeypatch.setattr(jobs, "restore_job", lambda job_id, value: value)
-    monkeypatch.setattr(cron_cli, "_canonical_job", lambda value: value)
-    from argparse import Namespace
-    monkeypatch.setattr(
-        cron_cli.sys,
-        "stdin",
-        io.TextIOWrapper(io.BytesIO(json.dumps(snapshot).encode("utf-8"))),
-    )
-    assert cron_cli.cron_restore(Namespace(job_id=snapshot["id"],
-                                            snapshot_stdin=True, json=True)) == 0
-    assert calls == [1]
-    assert read_rows() == [snapshot]
+def test_restore_preserves_repeat_progress_presence_null_and_notification_evidence(temp_home):
+    snapshot = create_snapshot(repeat="3")
+    record = dict(snapshot["record"])
+    record["repeat"] = {"times": 3, "completed": 2}
+    record["provider"] = None
+    record["model"] = None
+    record["workdir"] = None
+    snapshot["record"] = record
+    snapshot["presence"] = sorted(record)
+    snapshot["repeat_state"] = record["repeat"]
+    snapshot["repeat"] = 3
+    snapshot["provider"] = None
+    snapshot["model"] = None
+    snapshot["workdir"] = None
+    restored = cli("cron", "restore", snapshot["id"], "--snapshot-stdin", "--json",
+                   input_text=json.dumps(snapshot))
+    assert restored.returncode == 0, restored.stdout
+    assert json.loads(restored.stdout) == snapshot
+    # Provider notification is an in-process hook, not a production log file.
+    assert not (temp_home / "cron" / "provider_notifications.jsonl").exists()
+
+
+@pytest.mark.parametrize("schedule", ["2026-07-31T10:00:00-04:00", "0 7 * * *"])
+def test_one_shot_and_cron_snapshots_are_versioned_and_restoreable(temp_home, schedule):
+    snapshot = create_snapshot(schedule)
+    assert snapshot["schema_version"] == 2
+    assert snapshot["record"]["schedule"] == snapshot["schedule_state"]
+    restored = cli("cron", "restore", snapshot["id"], "--snapshot-stdin", "--json",
+                   input_text=json.dumps(snapshot))
+    assert restored.returncode == 0, restored.stdout
+    assert json.loads(restored.stdout) == snapshot

--- a/tests/cron/test_cron_restore.py
+++ b/tests/cron/test_cron_restore.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def cli(*args: str, input_text: str | None = None):
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", *args],
+        env=os.environ.copy(), input=input_text, capture_output=True, text=True,
+    )
+
+
+def create_snapshot():
+    created = cli("cron", "create", "every 1m", "", "--name", "restore-me",
+                   "--script", "restore.sh", "--no-agent", "--json")
+    assert created.returncode == 0, created.stderr
+    return json.loads(created.stdout)
+
+
+def read_rows():
+    result = cli("cron", "list", "--all", "--json")
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_top_level_stdin_restore_exact_rollback_and_main_exit(temp_home):
+    snapshot = create_snapshot()
+    job_id = snapshot["id"]
+    assert cli("cron", "edit", job_id, "--name", "mutated", "--json").returncode == 0
+    restored = cli("cron", "restore", job_id, "--snapshot-stdin", "--json",
+                   input_text=json.dumps(snapshot))
+    assert restored.returncode == 0, restored.stderr
+    assert json.loads(restored.stdout) == snapshot
+    assert read_rows() == [snapshot]
+    assert cli("cron", "restore", "missing", "--snapshot-stdin", "--json",
+               input_text=json.dumps(snapshot)).returncode != 0
+
+
+def test_restore_rejects_bad_input_without_mutation(temp_home):
+    snapshot = create_snapshot()
+    before = read_rows()
+    cases = [
+        {**snapshot, "id": "other"},
+        {**snapshot, "unknown_dangerous_field": "x"},
+        {**snapshot, "enabled": "yes"},
+        {**snapshot, "state": "running"},
+        {**snapshot, "repeat": True},
+        {**snapshot, "skills": [1]},
+    ]
+    for value in cases:
+        result = cli("cron", "restore", snapshot["id"], "--snapshot-stdin", "--json",
+                     input_text=json.dumps(value))
+        assert result.returncode != 0
+        assert read_rows() == before
+    oversized = json.dumps({**snapshot, "prompt": "x" * (64 * 1024)})
+    result = cli("cron", "restore", snapshot["id"], "--snapshot-stdin", "--json",
+                 input_text=oversized)
+    assert result.returncode != 0
+    assert read_rows() == before
+
+
+def test_restore_preserves_explicit_nulls_and_notifies_provider(temp_home, monkeypatch):
+    snapshot = create_snapshot()
+    calls = []
+    import cron.scheduler as scheduler
+    import cron.jobs as jobs
+    import hermes_cli.cron as cron_cli
+    monkeypatch.setattr(scheduler, "_notify_provider_jobs_changed", lambda: calls.append(1))
+    snapshot.update({"prompt": None, "model": None, "provider": None, "workdir": None,
+                     "next_run_at": None, "repeat": None})
+    result = cli("cron", "restore", snapshot["id"], "--snapshot-stdin", "--json",
+                 input_text=json.dumps(snapshot))
+    assert result.returncode == 0
+    monkeypatch.setattr(jobs, "restore_job", lambda job_id, value: value)
+    monkeypatch.setattr(cron_cli, "_canonical_job", lambda value: value)
+    from argparse import Namespace
+    assert cron_cli.cron_restore(Namespace(job_id=snapshot["id"], snapshot=json.dumps(snapshot),
+                                            snapshot_stdin=False, json=True)) == 0
+    assert calls == [1]
+    assert read_rows() == [snapshot]

--- a/tests/cron/test_cron_restore.py
+++ b/tests/cron/test_cron_restore.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import io
 import os
 import subprocess
 import sys
@@ -85,7 +86,12 @@ def test_restore_preserves_explicit_nulls_and_notifies_provider(temp_home, monke
     monkeypatch.setattr(jobs, "restore_job", lambda job_id, value: value)
     monkeypatch.setattr(cron_cli, "_canonical_job", lambda value: value)
     from argparse import Namespace
-    assert cron_cli.cron_restore(Namespace(job_id=snapshot["id"], snapshot=json.dumps(snapshot),
-                                            snapshot_stdin=False, json=True)) == 0
+    monkeypatch.setattr(
+        cron_cli.sys,
+        "stdin",
+        io.TextIOWrapper(io.BytesIO(json.dumps(snapshot).encode("utf-8"))),
+    )
+    assert cron_cli.cron_restore(Namespace(job_id=snapshot["id"],
+                                            snapshot_stdin=True, json=True)) == 0
     assert calls == [1]
     assert read_rows() == [snapshot]

--- a/tests/cron/test_cron_restore.py
+++ b/tests/cron/test_cron_restore.py
@@ -98,6 +98,34 @@ def test_restore_preserves_repeat_progress_presence_null_and_notification_eviden
     assert not (temp_home / "cron" / "provider_notifications.jsonl").exists()
 
 
+def test_restore_roundtrip_accepts_comma_separated_delivery_from_lossless_record(temp_home):
+    snapshot = create_snapshot()
+    record = dict(snapshot["record"])
+    record["deliver"] = "telegram:123,discord:456"
+    snapshot["record"] = record
+    snapshot["presence"] = sorted(record)
+    snapshot["delivery"] = ["telegram:123", "discord:456"]
+    snapshot["deliver"] = ["telegram:123", "discord:456"]
+
+    restored = cli("cron", "restore", snapshot["id"], "--snapshot-stdin", "--json",
+                   input_text=json.dumps(snapshot))
+    assert restored.returncode == 0, restored.stdout
+    assert json.loads(restored.stdout) == snapshot
+
+
+def test_restore_roundtrip_accepts_absent_schedule_display_from_lossless_record(temp_home):
+    snapshot = create_snapshot()
+    record = dict(snapshot["record"])
+    record.pop("schedule_display")
+    snapshot["record"] = record
+    snapshot["presence"] = sorted(record)
+
+    restored = cli("cron", "restore", snapshot["id"], "--snapshot-stdin", "--json",
+                   input_text=json.dumps(snapshot))
+    assert restored.returncode == 0, restored.stdout
+    assert json.loads(restored.stdout) == snapshot
+
+
 @pytest.mark.parametrize("schedule", ["2026-07-31T10:00:00-04:00", "0 7 * * *"])
 def test_one_shot_and_cron_snapshots_are_versioned_and_restoreable(temp_home, schedule):
     snapshot = create_snapshot(schedule)

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -283,3 +283,42 @@ def test_json_create_and_edit_emit_canonical_job(tmp_cron_dir, capsys):
     assert updated["thread"] == "4" and updated["no_agent"] is True
     assert updated["prompt"] == "" and updated["skills"] == []
     assert updated["model"] is None and updated["provider"] is None and updated["workdir"] is None
+
+
+def test_json_mutations_fail_closed_when_canonical_readback_is_missing(monkeypatch, capsys):
+    monkeypatch.setattr(cron_cli, "_cron_api", lambda **kwargs: {
+        "success": True, "job_id": "job-1", "name": "x", "schedule": "every 1m",
+        "next_run_at": None, "job": {"job_id": "job-1", "name": "x", "schedule": "every 1m"},
+    })
+    monkeypatch.setattr("cron.jobs.get_job", lambda job_id: None)
+    args = SimpleNamespace(schedule="every 1m", prompt="", name="x", deliver=None,
+                           repeat=None, skill=None, skills=None, script="x.py", workdir=None,
+                           no_agent=True, json=True)
+    assert cron_cli.cron_create(args) == 1
+    assert "canonical readback missing" in capsys.readouterr().err
+
+
+def test_json_delivery_normalizes_legacy_and_multi_target_shapes():
+    single = cron_cli._canonical_job({"id": "1", "deliver": ["telegram:chat:7"]})
+    assert single["delivery"] == "telegram:chat:7"
+    assert single["platform"] == "telegram" and single["thread"] == "7"
+    multi = cron_cli._canonical_job({"id": "2", "deliver": "telegram:chat:7, discord:room"})
+    assert multi["delivery"] == ["telegram:chat:7", "discord:room"]
+    assert multi["platform"] is None and multi["recipient"] is None and multi["thread"] is None
+
+
+def test_edit_by_name_uses_canonical_id_for_mutation_and_readback(tmp_cron_dir, capsys):
+    job = create_job(prompt="old", schedule="every 1m", name="Recovery")
+    args = SimpleNamespace(cron_command="edit", job_id="Recovery", schedule=None, prompt="new",
+                           name=None, deliver=None, repeat=None, skill=None, skills=None,
+                           clear_skills=False, add_skills=None, remove_skills=None, script=None,
+                           workdir=None, no_agent=None, model=None, model_provider=None, json=True)
+    assert cron_cli.cron_edit(args) == 0
+    value = json.loads(capsys.readouterr().out)
+    assert value["id"] == job["id"] and value["prompt"] == "new"
+
+
+def test_top_level_cmd_cron_propagates_handler_return_code(monkeypatch):
+    from hermes_cli import main
+    monkeypatch.setattr("hermes_cli.cron.cron_command", lambda args: 7)
+    assert main.cmd_cron(SimpleNamespace(cron_command="list")) == 7

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -2,6 +2,7 @@
 
 from argparse import Namespace
 from types import SimpleNamespace
+import json
 
 import pytest
 
@@ -234,3 +235,47 @@ def test_cron_create_failure_returns_nonzero(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert rc == 1
     assert "Failed to create job: boom" in out
+
+
+def test_json_list_exposes_canonical_persisted_fields(tmp_cron_dir, capsys):
+    job = create_job(
+        prompt="",
+        schedule="every 1m",
+        name="Recovery",
+        repeat=0,
+        deliver="telegram:-1004416879179:4",
+        script="kanban_blocked_recovery_controller.py",
+        skills=[],
+        no_agent=True,
+    )
+    cron_command(SimpleNamespace(cron_command="list", all=True, json=True))
+    value = json.loads(capsys.readouterr().out)
+    assert value == [{
+        "delivery": "telegram:-1004416879179:4", "deliver": "telegram:-1004416879179:4",
+        "enabled": True, "id": job["id"], "model": None, "name": "Recovery",
+        "no_agent": True, "next_run_at": job["next_run_at"], "platform": "telegram",
+        "prompt": "", "provider": None, "recipient": "-1004416879179", "repeat": None,
+        "run_at": None, "schedule": "every 1m", "script": "kanban_blocked_recovery_controller.py",
+        "skills": [], "state": "scheduled", "thread": "4", "workdir": None,
+    }]
+
+
+def test_json_create_and_edit_emit_canonical_job(tmp_cron_dir, capsys):
+    args = SimpleNamespace(
+        cron_command="create", schedule="every 1m", prompt="", name="Recovery",
+        deliver="telegram:-1004416879179:4", repeat=0, skill=None, skills=None,
+        script="recovery.py", workdir=None, no_agent=True, model=None,
+        model_provider=None, json=True,
+    )
+    assert cron_cli.cron_create(args) == 0
+    created = json.loads(capsys.readouterr().out)
+    assert created["id"] and created["repeat"] is None and created["no_agent"] is True
+    edit = SimpleNamespace(
+        cron_command="edit", job_id=created["id"], schedule=None, prompt=None, name="Recovery",
+        deliver="telegram:-1004416879179:4", repeat=0, skill=None, skills=None,
+        clear_skills=True, add_skills=None, remove_skills=None, script="recovery.py",
+        workdir="", no_agent=True, model="", model_provider="", json=True,
+    )
+    assert cron_cli.cron_edit(edit) == 0
+    updated = json.loads(capsys.readouterr().out)
+    assert updated["id"] == created["id"] and updated["repeat"] is None

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -279,3 +279,7 @@ def test_json_create_and_edit_emit_canonical_job(tmp_cron_dir, capsys):
     assert cron_cli.cron_edit(edit) == 0
     updated = json.loads(capsys.readouterr().out)
     assert updated["id"] == created["id"] and updated["repeat"] is None
+    assert updated["delivery"] == "telegram:-1004416879179:4"
+    assert updated["thread"] == "4" and updated["no_agent"] is True
+    assert updated["prompt"] == "" and updated["skills"] == []
+    assert updated["model"] is None and updated["provider"] is None and updated["workdir"] is None

--- a/tests/hermes_cli/test_cron_contract_cli.py
+++ b/tests/hermes_cli/test_cron_contract_cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+
+
+def run_cli(home: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "HERMES_HOME": str(home), "PYTHONPATH": str(ROOT)}
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "cron", *args],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_rejects_impossible_shapes_without_mutation(tmp_path):
+    home = tmp_path / ".hermes"
+    (home / "scripts").mkdir(parents=True)
+    cases = (
+        ("create", "every 5m", "--no-agent"),
+        ("create", "every 5m", ""),
+    )
+    for args in cases:
+        result = run_cli(home, *args)
+        assert result.returncode != 0
+    jobs = home / "cron" / "jobs.json"
+    assert not jobs.exists() or jobs.read_text(encoding="utf-8") in {"[]", ""}
+
+
+def test_cli_rejects_disagreeing_restore_aliases_without_mutation(tmp_path):
+    home = tmp_path / ".hermes"
+    (home / "cron").mkdir(parents=True)
+    snapshot = '{"id":"job-1","name":"x","enabled":true,"state":"scheduled","schedule":"every 5m","next_run_at":"2026-01-01T00:00:00","repeat":null,"delivery":"local","deliver":"telegram:1","skills":[],"no_agent":true,"script":"watch.sh","prompt":null}'
+    result = run_cli(home, "restore", "job-1", "--snapshot", snapshot, "--json")
+    assert result.returncode != 0
+    jobs = home / "cron" / "jobs.json"
+    assert not jobs.exists() or jobs.read_text(encoding="utf-8") == "[]"
+
+
+def test_cli_rejects_invalid_one_shot_next_run_shape_without_mutation(tmp_path):
+    home = tmp_path / ".hermes"
+    (home / "cron").mkdir(parents=True)
+    snapshot = '{"id":"job-1","name":"x","enabled":true,"state":"scheduled","schedule":"2026-01-01T00:00:00","next_run_at":null,"repeat":1,"delivery":"local","skills":[],"no_agent":true,"script":"watch.sh","prompt":null}'
+    result = run_cli(home, "restore", "job-1", "--snapshot", snapshot, "--json")
+    assert result.returncode != 0
+    jobs = home / "cron" / "jobs.json"
+    assert not jobs.exists() or jobs.read_text(encoding="utf-8") == "[]"

--- a/tests/hermes_cli/test_cron_contract_cli.py
+++ b/tests/hermes_cli/test_cron_contract_cli.py
@@ -35,12 +35,13 @@ def test_cli_rejects_impossible_shapes_without_mutation(tmp_path):
     assert not jobs.exists() or jobs.read_text(encoding="utf-8") in {"[]", ""}
 
 
-def test_cli_rejects_disagreeing_restore_aliases_without_mutation(tmp_path):
+def test_cli_rejects_raw_snapshot_argument_without_mutation(tmp_path):
     home = tmp_path / ".hermes"
     (home / "cron").mkdir(parents=True)
-    snapshot = '{"id":"job-1","name":"x","enabled":true,"state":"scheduled","schedule":"every 5m","next_run_at":"2026-01-01T00:00:00","repeat":null,"delivery":"local","deliver":"telegram:1","skills":[],"no_agent":true,"script":"watch.sh","prompt":null}'
-    result = run_cli(home, "restore", "job-1", "--snapshot", snapshot, "--json")
+    secret_snapshot = "secret-snapshot-never-in-argv"
+    result = run_cli(home, "restore", "job-1", "--snapshot", secret_snapshot, "--json")
     assert result.returncode != 0
+    assert "unrecognized arguments:" in result.stderr
     jobs = home / "cron" / "jobs.json"
     assert not jobs.exists() or jobs.read_text(encoding="utf-8") == "[]"
 

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -8,6 +8,7 @@ god-file Phase 2 extraction.
 from __future__ import annotations
 
 import argparse
+import pytest
 
 from hermes_cli.subcommands.cron import build_cron_parser
 
@@ -48,3 +49,9 @@ def test_cron_accept_hooks_flag_on_run_and_tick():
     assert ns.accept_hooks is True
     ns2 = parser.parse_args(["cron", "tick", "--accept-hooks"])
     assert ns2.accept_hooks is True
+
+
+def test_cron_restore_rejects_raw_snapshot_argument():
+    parser = _build()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["cron", "restore", "jobid", "--snapshot", "secret-snapshot"])

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -926,6 +926,14 @@ def cronjob(
                     updates["enabled"] = True
             if not updates:
                 return tool_error("No updates provided.", success=False)
+            effective_no_agent = bool(updates.get("no_agent", job.get("no_agent", False)))
+            effective_script = updates.get("script", job.get("script"))
+            effective_prompt = updates.get("prompt", job.get("prompt"))
+            effective_skills = updates.get("skills", job.get("skills") or [])
+            if effective_no_agent and not effective_script:
+                return tool_error("no_agent=True requires a non-empty script", success=False)
+            if not effective_no_agent and not str(effective_prompt or "").strip() and not effective_skills:
+                return tool_error("active agent jobs require a non-empty prompt or at least one skill", success=False)
             updated = update_job(job_id, updates)
             _notify_provider_jobs_changed_safe()
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)


### PR DESCRIPTION
Adds the smallest runtime-owned structured JSON surface for cron list/create/edit. Human output is unchanged without --json. Canonical output includes persisted identity, schedule, normalized repeat=null, Telegram delivery parts, no-agent/script, and legacy fields; tests cover create/edit/list behavior and scripts/run_tests.sh passes.