### PR TITLE
fix(gateway): preserve internal reset completions

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -705,6 +705,8 @@ session_reset:
   mode: none           # "none", "idle", "daily", or "both"
   idle_minutes: 1440   # Inactivity timeout in minutes (used by "idle"/"both")
   at_hour: 4           # Daily reset hour, 0-23 local time (used by "daily"/"both")
+  # Restore the expired session when the next message explicitly continues it.
+  auto_resume_previous_if_contextual: false
 
 # Maximum number of simultaneously active chat sessions across CLI, TUI,
 # dashboard chat, and messaging gateway. Set to null, 0, or omit to allow

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15616,19 +15616,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _auto_reset_pending
             and self._auto_resume_contextual_reset_enabled()
         )
-        if (
+        # Completion/watch events re-enter through ``handle_message`` as
+        # ``internal`` events.  They still need their own cascading turn, but
+        # must not make (or consume) the user's contextual-resume decision.
+        # In particular, returning here used to silently drop those events.
+        _defer_contextual_reset_decision_for_internal_event = bool(
             _auto_reset_pending
             and _is_internal_event
             and _auto_reset_reason in {"idle", "daily"}
             and _auto_reset_previous_session_id
             and _contextual_auto_resume_enabled
-        ):
-            return ""
+        )
         _was_auto_reset = _auto_reset_pending
         _auto_resumed_previous = False
         if _was_auto_reset:
             if (
-                _auto_reset_reason in {"idle", "daily"}
+                not _defer_contextual_reset_decision_for_internal_event
+                and _auto_reset_reason in {"idle", "daily"}
                 and _auto_reset_previous_session_id
                 and _contextual_auto_resume_enabled
                 and (
@@ -15733,7 +15737,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Capture and immediately consume was_auto_reset so it does not
         # re-fire on subsequent messages — preventing the cleanup from
         # wiping model/reasoning overrides set between turns (Closes #48031).
-        if _was_auto_reset:
+        if (
+            _was_auto_reset
+            and not _defer_contextual_reset_decision_for_internal_event
+        ):
             # Treat auto-reset as a full conversation boundary — clear every
             # conversation-scoped per-session dict in one funnel call so the
             # fresh session does not inherit the previous conversation's
@@ -15755,7 +15762,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_entry.created_at == session_entry.updated_at
             or _was_auto_reset
             or getattr(session_entry, "is_fresh_reset", False)
-        ) and not _auto_resumed_previous
+        ) and not (
+            _auto_resumed_previous
+            or _defer_contextual_reset_decision_for_internal_event
+        )
         # Consume the is_fresh_reset flag immediately so it doesn't leak
         # onto subsequent messages in the same session (issue #6508).
         if getattr(session_entry, "is_fresh_reset", False):
@@ -15803,7 +15813,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # If the previous session expired and was auto-reset, deliver a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).
-        if _was_auto_reset:
+        if (
+            _was_auto_reset
+            and not _defer_contextual_reset_decision_for_internal_event
+        ):
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
             if reset_reason == "suspended":
                 context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15495,6 +15495,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    @staticmethod
+    def _auto_resume_contextual_reset_enabled() -> bool:
+        """Return the opt-in post-expiry continuation policy."""
+        try:
+            cfg = _load_gateway_config()
+            return bool(
+                ((cfg.get("session_reset") or {}).get(
+                    "auto_resume_previous_if_contextual", False
+                ))
+            )
+        except Exception:
+            return False
+
+    @staticmethod
+    def _looks_like_contextual_reset_followup(text: str) -> bool:
+        """Conservatively detect a message that refers to prior dialogue."""
+        normalized = " ".join(str(text or "").strip().lower().split())
+        if not normalized or normalized.startswith("/"):
+            return False
+        words = normalized.split()
+        if len(words) > 80:
+            return False
+        if re.search(
+            r"\b(?:without (?:relying on|using)|do not (?:rely on|use)|"
+            r"don't (?:rely on|use)|ignore) (?:any )?(?:earlier|previous|prior)\b",
+            normalized,
+        ):
+            return False
+        strong = re.search(
+            r"\b(?:keep going|pick (?:it )?up|where were we|"
+            r"as (?:(?:we|you|i) )?(?:discussed|said)|do that)\b",
+            normalized,
+        )
+        if strong:
+            return True
+        if re.fullmatch(
+            r"(?:(?:please|okay|ok),? |(?:can|could|would) you )?"
+            r"(?:continue|try again|finish (?:it|that|this)|"
+            r"(?:do )?(?:the )?same (?:one|thing))[?.!]?",
+            normalized,
+        ):
+            return True
+        dialogue_reference = re.search(
+            r"\b(?:(?:earlier|previous|prior) "
+            r"(?:discussion|conversation|message|request|answer|session)|"
+            r"(?:discussion|conversation|message|request|answer|session) "
+            r"(?:earlier|previously)|(?:you|i|we) (?:said|discussed|explained) "
+            r"(?:earlier|previously)|what we (?:said|discussed|decided)|"
+            r"the above (?:message|request|answer)|"
+            r"now that (?:i've|i have|we've|we have|you've|you have) "
+            r"explained (?:it|that|this))\b",
+            normalized,
+        )
+        if dialogue_reference:
+            return True
+        return bool(
+            re.fullmatch(
+                r"(?:what about )?(?:it|that|this|these|those|them|"
+                r"that one|this one|those ones|these ones)[?.!]?",
+                normalized,
+            )
+        )
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -15538,7 +15601,72 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
             session_entry = resolved_entry
         self._cache_session_source(session_key, source)
-        if await asyncio.to_thread(self._is_telegram_topic_lane, source):
+        _auto_reset_pending = getattr(
+            session_entry, "was_auto_reset", False
+        )
+        _is_internal_event = bool(
+            getattr(event, "internal", False)
+            or (getattr(event, "metadata", None) or {}).get("gateway_session_id")
+        )
+        _auto_reset_reason = getattr(session_entry, "auto_reset_reason", None)
+        _auto_reset_previous_session_id = getattr(
+            session_entry, "prev_session_id", None
+        )
+        _contextual_auto_resume_enabled = (
+            _auto_reset_pending
+            and self._auto_resume_contextual_reset_enabled()
+        )
+        if (
+            _auto_reset_pending
+            and _is_internal_event
+            and _auto_reset_reason in {"idle", "daily"}
+            and _auto_reset_previous_session_id
+            and _contextual_auto_resume_enabled
+        ):
+            return ""
+        _was_auto_reset = _auto_reset_pending
+        _auto_resumed_previous = False
+        if _was_auto_reset:
+            if (
+                _auto_reset_reason in {"idle", "daily"}
+                and _auto_reset_previous_session_id
+                and _contextual_auto_resume_enabled
+                and (
+                    getattr(event, "reply_to_message_id", None)
+                    or getattr(event, "reply_to_text", None)
+                    or self._looks_like_contextual_reset_followup(event.text)
+                )
+            ):
+                switched = await self.async_session_store.switch_session(
+                    session_key, _auto_reset_previous_session_id
+                )
+                if switched is not None:
+                    session_entry = switched
+                    _auto_resumed_previous = True
+                    _was_auto_reset = False
+                    await asyncio.to_thread(
+                        self._sync_telegram_topic_binding,
+                        source,
+                        session_entry,
+                        reason="contextual-auto-resume",
+                    )
+                    logger.info(
+                        "contextual auto-resume: restored %s for routing key %s",
+                        _auto_reset_previous_session_id,
+                        session_key,
+                    )
+            if not _auto_resumed_previous:
+                await asyncio.to_thread(
+                    self._sync_telegram_topic_binding,
+                    source,
+                    session_entry,
+                    reason="contextual-auto-reset",
+                )
+        _skip_telegram_topic_recovery = _auto_reset_pending
+        if (
+            not _skip_telegram_topic_recovery
+            and await asyncio.to_thread(self._is_telegram_topic_lane, source)
+        ):
             try:
                 binding = (await self._session_db.get_telegram_topic_binding(
                     chat_id=str(source.chat_id),
@@ -15571,7 +15699,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         and canonical_session_id != bound_session_id
                     ):
                         bound_session_id = canonical_session_id
-                if bound_session_id and bound_session_id != session_entry.session_id:
+                if (
+                    bound_session_id
+                    and bound_session_id
+                    != getattr(
+                        session_entry, "prev_session_id", None
+                    )
+                    and bound_session_id != session_entry.session_id
+                ):
                     # Route the override through SessionStore so the session_key
                     # → session_id mapping is persisted to disk and the previous
                     # lane session is ended cleanly. Mutating session_entry in
@@ -15598,7 +15733,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Capture and immediately consume was_auto_reset so it does not
         # re-fire on subsequent messages — preventing the cleanup from
         # wiping model/reasoning overrides set between turns (Closes #48031).
-        _was_auto_reset = getattr(session_entry, "was_auto_reset", False)
         if _was_auto_reset:
             # Treat auto-reset as a full conversation boundary — clear every
             # conversation-scoped per-session dict in one funnel call so the
@@ -15621,7 +15755,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_entry.created_at == session_entry.updated_at
             or _was_auto_reset
             or getattr(session_entry, "is_fresh_reset", False)
-        )
+        ) and not _auto_resumed_previous
         # Consume the is_fresh_reset flag immediately so it doesn't leak
         # onto subsequent messages in the same session (issue #6508).
         if getattr(session_entry, "is_fresh_reset", False):

--- a/tests/gateway/test_contextual_reset_continuation.py
+++ b/tests/gateway/test_contextual_reset_continuation.py
@@ -1,0 +1,243 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionEntry, SessionSource
+
+
+SESSION_KEY = "agent:main:telegram:dm:12345"
+
+
+def _entry(*, reset: bool = True, reason: str = "idle") -> SessionEntry:
+    now = datetime.now()
+    return SessionEntry(
+        session_key=SESSION_KEY,
+        session_id="fresh",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        was_auto_reset=reset,
+        auto_reset_reason=reason if reset else None,
+        prev_session_id="previous" if reset else None,
+    )
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="12345",
+    )
+
+
+def _event(text: str, *, internal: bool = False, reply: bool = False):
+    return SimpleNamespace(
+        text=text,
+        metadata={},
+        internal=internal,
+        reply_to_message_id="reply-1" if reply else None,
+        reply_to_text="Earlier message" if reply else None,
+    )
+
+
+def _runner(entry: SessionEntry):
+    runner = gateway_run.GatewayRunner(GatewayConfig())
+    backing_store = object()
+    previous = SessionEntry(
+        session_key=SESSION_KEY,
+        session_id="previous",
+        created_at=datetime.now() - timedelta(hours=2),
+        updated_at=datetime.now() - timedelta(hours=1),
+        platform=Platform.TELEGRAM,
+    )
+    facade = SimpleNamespace(
+        _store=backing_store,
+        get_or_create_session=AsyncMock(return_value=entry),
+        switch_session=AsyncMock(return_value=previous),
+    )
+    runner.session_store = backing_store
+    runner._async_session_store = facade
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_telegram_topic_lane = lambda _source: False
+    runner._sync_telegram_topic_binding = MagicMock()
+    return runner, facade
+
+
+class StopAfterResetDecision(RuntimeError):
+    pass
+
+
+@pytest.mark.parametrize("reason", ["idle", "daily"])
+@pytest.mark.asyncio
+async def test_contextual_followup_switches_to_previous_session(monkeypatch, reason):
+    runner, store = _runner(_entry(reason=reason))
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"session_reset": {"auto_resume_previous_if_contextual": True}},
+    )
+
+    def stop_after_decision(*_args, **_kwargs):
+        raise StopAfterResetDecision
+
+    monkeypatch.setattr(gateway_run, "build_session_context", stop_after_decision)
+
+    with pytest.raises(StopAfterResetDecision):
+        await runner._handle_message_with_agent(
+            _event("Please continue"), _source(), SESSION_KEY, 1
+        )
+
+    store.switch_session.assert_awaited_once_with(SESSION_KEY, "previous")
+    runner._sync_telegram_topic_binding.assert_called_once()
+    assert (
+        runner._sync_telegram_topic_binding.call_args.kwargs["reason"]
+        == "contextual-auto-resume"
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_reply_switches_without_text_heuristic(monkeypatch):
+    runner, store = _runner(_entry())
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"session_reset": {"auto_resume_previous_if_contextual": True}},
+    )
+
+    def stop_after_decision(*_args, **_kwargs):
+        raise StopAfterResetDecision
+
+    monkeypatch.setattr(gateway_run, "build_session_context", stop_after_decision)
+
+    with pytest.raises(StopAfterResetDecision):
+        await runner._handle_message_with_agent(
+            _event("What time is it in Tokyo?", reply=True),
+            _source(),
+            SESSION_KEY,
+            1,
+        )
+
+    store.switch_session.assert_awaited_once_with(SESSION_KEY, "previous")
+
+
+@pytest.mark.asyncio
+async def test_independent_request_keeps_fresh_session(monkeypatch):
+    runner, store = _runner(_entry())
+    topic_db = SimpleNamespace(
+        get_telegram_topic_binding=AsyncMock(
+            return_value={"session_id": "previous"}
+        )
+    )
+    runner._session_db = topic_db
+    runner._is_telegram_topic_lane = lambda _source: True
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"session_reset": {"auto_resume_previous_if_contextual": True}},
+    )
+
+    def stop_after_decision(*_args, **_kwargs):
+        raise StopAfterResetDecision
+
+    runner._clear_conversation_scope = stop_after_decision
+
+    with pytest.raises(StopAfterResetDecision):
+        await runner._handle_message_with_agent(
+            _event("What time is it in Tokyo?"), _source(), SESSION_KEY, 1
+        )
+
+    store.switch_session.assert_not_awaited()
+    topic_db.get_telegram_topic_binding.assert_not_awaited()
+    assert (
+        runner._sync_telegram_topic_binding.call_args.kwargs["reason"]
+        == "contextual-auto-reset"
+    )
+
+
+@pytest.mark.parametrize(
+    ("enabled", "reason"),
+    [
+        (False, "idle"),
+        (True, "suspended"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_ineligible_reset_keeps_fresh_session(
+    monkeypatch, enabled, reason
+):
+    runner, store = _runner(_entry(reason=reason))
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "session_reset": {
+                "auto_resume_previous_if_contextual": enabled
+            }
+        },
+    )
+
+    def stop_after_decision(*_args, **_kwargs):
+        raise StopAfterResetDecision
+
+    runner._clear_conversation_scope = stop_after_decision
+
+    with pytest.raises(StopAfterResetDecision):
+        await runner._handle_message_with_agent(
+            _event("Please continue"), _source(), SESSION_KEY, 1
+        )
+
+    store.switch_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_internal_event_leaves_reset_decision_for_user(monkeypatch):
+    entry = _entry()
+    runner, store = _runner(entry)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"session_reset": {"auto_resume_previous_if_contextual": True}},
+    )
+
+    result = await runner._handle_message_with_agent(
+        _event("Please continue", internal=True), _source(), SESSION_KEY, 1
+    )
+
+    assert result == ""
+    assert entry.was_auto_reset is True
+    store.switch_session.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Please continue",
+        "Can you do that?",
+        "Use the answer from our previous discussion",
+        "Please revise the above message",
+        "Same thing.",
+    ],
+)
+def test_contextual_detector_accepts_explicit_continuations(text):
+    assert gateway_run.GatewayRunner._looks_like_contextual_reset_followup(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "What time is it in Tokyo?",
+        "Show my previous invoices",
+        "Continue straight for two miles",
+        "Finish this report.",
+        "/new",
+        ("Write a standalone analysis without relying on any earlier discussion."),
+    ],
+)
+def test_contextual_detector_rejects_standalone_requests(text):
+    assert not gateway_run.GatewayRunner._looks_like_contextual_reset_followup(text)

--- a/tests/gateway/test_contextual_reset_continuation.py
+++ b/tests/gateway/test_contextual_reset_continuation.py
@@ -196,7 +196,15 @@ async def test_ineligible_reset_keeps_fresh_session(
 
 
 @pytest.mark.asyncio
-async def test_internal_event_leaves_reset_decision_for_user(monkeypatch):
+async def test_internal_completion_cascades_without_committing_reset_decision(
+    monkeypatch,
+):
+    """A completion gets its own turn; the next user message still decides.
+
+    Internal completion/watch events are routed back through handle_message.
+    They must not be dropped just because an idle/daily reset is waiting for a
+    contextual user follow-up, nor may they consume that user-facing choice.
+    """
     entry = _entry()
     runner, store = _runner(entry)
     monkeypatch.setattr(
@@ -205,13 +213,33 @@ async def test_internal_event_leaves_reset_decision_for_user(monkeypatch):
         lambda: {"session_reset": {"auto_resume_previous_if_contextual": True}},
     )
 
-    result = await runner._handle_message_with_agent(
-        _event("Please continue", internal=True), _source(), SESSION_KEY, 1
+    def stop_after_context_construction(*_args, **_kwargs):
+        raise StopAfterResetDecision
+
+    monkeypatch.setattr(
+        gateway_run, "build_session_context", stop_after_context_construction
     )
 
-    assert result == ""
+    with pytest.raises(StopAfterResetDecision):
+        await runner._handle_message_with_agent(
+            _event("[async delegation completed]", internal=True),
+            _source(),
+            SESSION_KEY,
+            1,
+        )
+
+    # Reaching context construction proves this was not an empty early return.
+    # Keep the decision pending for the next actual user message.
     assert entry.was_auto_reset is True
     store.switch_session.assert_not_awaited()
+
+    # The following user message can still make the deferred resume decision.
+    with pytest.raises(StopAfterResetDecision):
+        await runner._handle_message_with_agent(
+            _event("Please continue"), _source(), SESSION_KEY, 2
+        )
+
+    store.switch_session.assert_awaited_once_with(SESSION_KEY, "previous")
 
 
 @pytest.mark.parametrize(

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -478,6 +478,11 @@ class TestSessionStoreSwitchSession:
 
         target_session_id = "old_session_abc"
         db.create_session(target_session_id, source="feishu", user_id="user-1")
+        db.append_message(
+            session_id=target_session_id,
+            role="user",
+            content="Continue the prior transcript",
+        )
         db.end_session(target_session_id, end_reason="user_exit")
         assert db.get_session(target_session_id)["ended_at"] is not None
 
@@ -485,10 +490,28 @@ class TestSessionStoreSwitchSession:
 
         assert switched is not None
         assert switched.session_id == target_session_id
-        assert db.get_session(current_session_id)["end_reason"] == "session_switch"
+        transient = db.get_session(current_session_id)
+        assert transient["ended_at"] is not None
+        assert transient["end_reason"] == "session_switch"
         resumed = db.get_session(target_session_id)
         assert resumed["ended_at"] is None
         assert resumed["end_reason"] is None
+
+        # Re-open the persisted SessionStore mapping: the restored transcript,
+        # not the transient fresh session, must be active after a real switch.
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            reopened_store = SessionStore(
+                sessions_dir=tmp_path / "sessions", config=config
+            )
+        reopened_store._db = db
+        reopened_store._loaded = False
+        reopened_entry = reopened_store.get_or_create_session(source)
+
+        assert reopened_entry.session_id == target_session_id
+        transcript = reopened_store.load_transcript(target_session_id)
+        assert [(row["role"], row["content"]) for row in transcript] == [
+            ("user", "Continue the prior transcript")
+        ]
         db.close()
 
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -262,6 +262,7 @@ session_reset:
   mode: idle        # "idle", "daily", "both", or "none" (default)
   idle_minutes: 1440  # for idle/both: minutes of inactivity before reset
   at_hour: 4          # for daily/both: hour of day (0-23, local time)
+  auto_resume_previous_if_contextual: false
 ```
 
 | Mode | Description |
@@ -270,6 +271,11 @@ session_reset:
 | `daily` | Reset at a specific hour each day |
 | `idle` | Reset after N minutes of inactivity |
 | `both` | Whichever triggers first |
+
+Set `auto_resume_previous_if_contextual: true` to restore the just-expired
+session when the next user message is an explicit reply or a conservative
+continuation such as “please continue.” Independent requests still start in
+the fresh session. This opt-in applies only to idle and daily resets.
 
 A live background process (started with `terminal(background=true)`) normally
 protects its session from resetting so output isn't lost. To stop a forgotten


### PR DESCRIPTION
## Summary
- preserve normal cascading of internal completion events while a contextual-reset decision is pending
- defer only the user-facing reset decision until the next external user message
- add an interleave regression and a real SessionStore/SQLite persistence-and-reopen regression

## Verification
- `uv run --extra dev pytest -q tests/gateway/test_contextual_reset_continuation.py tests/gateway/test_internal_event_never_interrupts_busy_session.py tests/gateway/test_session.py::TestSessionStoreSwitchSession` (20 passed)
- `uv run ruff check gateway/run.py gateway/session.py tests/gateway/test_contextual_reset_continuation.py tests/gateway/test_session.py` (passed)