### PR TITLE
chore: add contato@webtecnica.com.br → webtecnica to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -76,6 +76,7 @@ LEGACY_AUTHOR_MAP = {
     "41409874+2751738943@users.noreply.github.com": "2751738943",  # PR #54785 salvage (tui: post-turn completion ownership routing)
     "Burgunthy@users.noreply.github.com": "Burgunthy",  # PR #20096 salvage (gateway: profile-based routing for inbound messages)
     "75556242+webtecnica@users.noreply.github.com": "webtecnica",  # PR #63360 salvage (nous: restore inference-api base_url)
+    "contato@webtecnica.com.br": "webtecnica",  # PR #70888 salvage
     "skosarevivan@yandex.ru": "Epoxidex",  # PR #29820 salvage (ollama: top-level reasoning_effort=none; #25758)
     "jdjiayou@163.com": "JiaDe-Wu",  # PR #34742 salvage (bedrock: bearer routing + streaming fallback + image decode; #28156)
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)


### PR DESCRIPTION
## Summary
Adds `contato@webtecnica.com.br` → `webtecnica` mapping to AUTHOR_MAP, required for the attribution audit on the upcoming PR #70888 salvage.

webtecnica already has a noreply entry (`75556242+webtecnica@users.noreply.github.com`); this adds their commit-email identity.

## Validation
- `check-attribution` will pass on PR #70888 salvage after this merges.