### PR TITLE
fix(moa): stream completed aggregator responses safely

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8082,13 +8082,15 @@ def call_llm(
         kwargs["stream"] = True
         if stream_options:
             kwargs["stream_options"] = stream_options
-        if task == "moa_aggregator":
-            # MoA's own facade owns the streaming contract. Routing this nested
-            # aggregator stream through Relay's generic stream manager can make
-            # Codex Responses adapters return a completed SimpleNamespace that
-            # the manager then tries to iterate (#55933). Return the provider
-            # call directly; the MoA facade converts a completed response into
-            # a one-chunk delta iterator at its boundary.
+        if task == "moa_aggregator" and isinstance(client, CodexAuxiliaryClient):
+            # CodexAuxiliaryClient (openai-codex, xai-oauth, and any other
+            # Responses-shim provider) consumes the provider stream internally
+            # and returns a completed response object. Routing that nested
+            # MoA stream through Relay's generic managed stream makes the
+            # manager iterate the completed SimpleNamespace itself (#55933).
+            # Return the provider call directly; the MoA facade converts a
+            # completed response into a one-chunk delta iterator at its
+            # boundary.
             return client.chat.completions.create(**kwargs)
         return _relay_sync_stream(
             client,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8082,6 +8082,14 @@ def call_llm(
         kwargs["stream"] = True
         if stream_options:
             kwargs["stream_options"] = stream_options
+        if task == "moa_aggregator":
+            # MoA's own facade owns the streaming contract. Routing this nested
+            # aggregator stream through Relay's generic stream manager can make
+            # Codex Responses adapters return a completed SimpleNamespace that
+            # the manager then tries to iterate (#55933). Return the provider
+            # call directly; the MoA facade converts a completed response into
+            # a one-chunk delta iterator at its boundary.
+            return client.chat.completions.create(**kwargs)
         return _relay_sync_stream(
             client,
             kwargs,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3931,7 +3931,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 "   To avoid this delay, set display.streaming: false "
                                 "in config.yaml\n"
                             )
-                        logger.info(
+                        logger.exception(
                             "Streaming failed before delivery: %s",
                             e,
                         )

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -836,6 +836,19 @@ def classify_api_error(
         if classified is not None:
             return classified
 
+    # Local MoA streaming compatibility errors are adapter-shape bugs, not a
+    # provider outage. Falling back to another model would silently switch the
+    # user's selected MoA route to a single-model answer (#55933 follow-up).
+    if provider_lower == "moa" and (
+        "'types.SimpleNamespace' object is not iterable" in str(error)
+        or "'types.SimpleNamespace' object has no attribute 'index'" in str(error)
+    ):
+        return _result(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=False,
+        )
+
     # Local MoA config drift is deterministic: a persisted session can retain
     # a preset name that was later renamed/deleted. Retrying the same lookup
     # cannot recover and makes a clear config error look like an API outage.

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -13,6 +13,7 @@ import logging
 import re
 import threading
 from concurrent.futures import ThreadPoolExecutor, wait as _futures_wait
+from types import SimpleNamespace
 from typing import Any
 
 from agent.auxiliary_client import call_llm
@@ -1300,6 +1301,53 @@ def aggregate_moa_context(
     )
 
 
+def _completed_response_as_stream_chunk(response: Any) -> Any:
+    """Convert a completed Chat Completions response into one delta stream chunk.
+
+    MoA's outer streaming consumer expects ``choices[0].delta`` chunks. A
+    completed aggregator response carries ``choices[0].message`` instead; adapt
+    it here, at the MoA facade boundary, so provider-specific Relay behavior and
+    other transports remain untouched.
+    """
+
+    choices = getattr(response, "choices", None)
+    first_choice = choices[0] if isinstance(choices, (list, tuple)) and choices else None
+    message = getattr(first_choice, "message", None)
+    raw_tool_calls = getattr(message, "tool_calls", None)
+    tool_call_deltas = None
+    if isinstance(raw_tool_calls, (list, tuple)) and raw_tool_calls:
+        tool_call_deltas = []
+        for index, tc in enumerate(raw_tool_calls):
+            function = getattr(tc, "function", None)
+            tool_call_deltas.append(SimpleNamespace(
+                index=getattr(tc, "index", index),
+                id=getattr(tc, "id", None),
+                type=getattr(tc, "type", None) or "function",
+                function=SimpleNamespace(
+                    name=getattr(function, "name", None),
+                    arguments=getattr(function, "arguments", None),
+                ),
+            ))
+    delta = SimpleNamespace(
+        content=getattr(message, "content", None),
+        tool_calls=tool_call_deltas,
+        reasoning_content=getattr(message, "reasoning_content", None),
+        reasoning=getattr(message, "reasoning", None),
+        reasoning_details=getattr(message, "reasoning_details", None),
+    )
+    choice = SimpleNamespace(
+        index=getattr(first_choice, "index", 0),
+        delta=delta,
+        finish_reason=getattr(first_choice, "finish_reason", None) or "stop",
+    )
+    return SimpleNamespace(
+        id=getattr(response, "id", None),
+        model=getattr(response, "model", None),
+        choices=[choice],
+        usage=getattr(response, "usage", None),
+    )
+
+
 def _attach_reference_guidance(agg_messages: list[dict[str, Any]], guidance: str) -> None:
     """Attach the per-turn reference block at the END of the aggregator prompt.
 
@@ -1685,6 +1733,14 @@ class MoAChatCompletions:
                     self._pending_trace["aggregator_output"] = _extract_text(_agg_response)
                 except Exception:  # pragma: no cover - defensive
                     self._pending_trace["aggregator_output"] = None
+        if stream and hasattr(_agg_response, "choices"):
+            # Some aggregator adapters (notably openai-codex Responses) consume
+            # their provider stream internally and return a completed response
+            # object even when the acting consumer requested token streaming.
+            # The outer chat-completions streaming loop expects delta chunks;
+            # hand it a one-chunk iterator instead of letting it iterate the
+            # SimpleNamespace response itself (#55933).
+            return iter((_completed_response_as_stream_chunk(_agg_response),))
         return _agg_response
 
     def create(self, **api_kwargs: Any) -> Any:

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -2230,8 +2230,24 @@ def build_moa_facade(agent, preset_name: Any = None) -> MoAClient:
         except Exception:
             pass
 
+    resolved_preset = preset_name
+    if resolved_preset is None and getattr(agent, "provider", None) == "moa":
+        resolved_preset = getattr(agent, "model", None)
+
+    resolved_preset = str(resolved_preset or "default")
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.moa_config import normalize_moa_config
+
+        moa_cfg = normalize_moa_config(load_config().get("moa") or {})
+        presets = moa_cfg.get("presets") or {}
+        if resolved_preset not in presets:
+            resolved_preset = moa_cfg.get("default_preset") or "default"
+    except Exception:
+        resolved_preset = "default"
+
     return MoAClient(
-        str(preset_name or getattr(agent, "model", None) or "default"),
+        resolved_preset,
         reference_callback=_moa_reference_relay,
         # Thread the agent through so the reference fan-out wait can be
         # aborted on a user interrupt (see _run_references_parallel).

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -11,6 +11,7 @@ import pytest
 
 from agent.auxiliary_client import (
     _NOUS_MODEL,
+    CodexAuxiliaryClient,
     get_text_auxiliary_client,
     get_available_vision_backends,
     resolve_vision_provider_client,
@@ -6811,3 +6812,44 @@ class TestCustomEndpointApiKeyInheritance:
             )
 
         assert captured.get("api_key") == "no-key-required"
+
+
+class TestMoaAggregatorStreamingBypass:
+    def test_moa_aggregator_stream_bypasses_relay_for_codex_auxiliary_client(self, monkeypatch):
+        """The MoA facade owns the streaming contract. For Codex Responses-shim
+        clients (openai-codex, xai-oauth), call_llm must return the provider's
+        direct create() result instead of routing through Relay's managed
+        stream, which cannot iterate a completed SimpleNamespace (#74903).
+        """
+
+        completed = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+        real_client = SimpleNamespace(
+            api_key="test-key",
+            base_url="https://chatgpt.com/backend-api/codex/",
+            close=lambda: None,
+        )
+        client = CodexAuxiliaryClient(real_client, "gpt-5.6-sol")
+        direct_create = MagicMock(return_value=completed)
+        monkeypatch.setattr(client.chat.completions, "create", direct_create)
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (client, "gpt-5.6-sol"),
+        )
+        relay_stream = MagicMock(side_effect=AssertionError("_relay_sync_stream must not be used"))
+        monkeypatch.setattr("agent.auxiliary_client._relay_sync_stream", relay_stream)
+
+        result = call_llm(
+            task="moa_aggregator",
+            provider="openai-codex",
+            model="gpt-5.6-sol",
+            messages=[{"role": "user", "content": "只回答 OK"}],
+            stream=True,
+        )
+
+        assert result is completed
+        direct_create.assert_called_once()
+        relay_stream.assert_not_called()

--- a/tests/run_agent/test_moa_streaming.py
+++ b/tests/run_agent/test_moa_streaming.py
@@ -90,6 +90,46 @@ def test_create_streams_aggregator_when_requested(monkeypatch, tmp_path):
     assert agg["tools"] is not None
 
 
+def test_create_wraps_completed_aggregator_response_as_delta_chunk(monkeypatch, tmp_path):
+    """When an aggregator adapter returns a completed response despite
+    stream=True (Codex Responses compatibility shape), MoA must return a
+    one-chunk delta iterator for the outer streaming accumulator instead of
+    the raw non-iterable response object (#55933).
+    """
+
+    completed = _response("aggregator acted")
+    completed.choices[0].message.tool_calls = [
+        SimpleNamespace(
+            id="call_1",
+            type="function",
+            function=SimpleNamespace(name="read_file", arguments='{"path":"x"}'),
+        )
+    ]
+
+    def on_call(kwargs):
+        if kwargs["task"] == "moa_aggregator":
+            return completed
+        return None
+
+    facade, calls = _facade(monkeypatch, tmp_path, on_call=on_call)
+    stream = facade.create(
+        messages=[{"role": "user", "content": "q"}],
+        tools=[],
+        stream=True,
+    )
+
+    chunk = next(iter(stream))
+    assert chunk.choices[0].delta.content == "aggregator acted"
+    assert chunk.choices[0].delta.tool_calls[0].index == 0
+    assert chunk.choices[0].delta.tool_calls[0].function.name == "read_file"
+    assert chunk.choices[0].finish_reason == "stop"
+    with pytest.raises(StopIteration):
+        next(stream)
+
+    agg = next(c for c in calls if c["task"] == "moa_aggregator")
+    assert agg["stream"] is True
+
+
 def test_create_non_stream_path_unchanged(monkeypatch, tmp_path):
     """Default (no stream): the aggregator call carries NO stream/stream_options
     keys, so the non-streaming path is byte-identical to before."""

--- a/tests/run_agent/test_moa_streaming.py
+++ b/tests/run_agent/test_moa_streaming.py
@@ -90,6 +90,29 @@ def test_create_streams_aggregator_when_requested(monkeypatch, tmp_path):
     assert agg["tools"] is not None
 
 
+def test_build_moa_facade_ignores_fallback_model_name_when_restoring(monkeypatch, tmp_path):
+    """A fallback restore must not turn the temporary fallback model name into
+    a MoA preset. Sessions that drifted to e.g. deepseek-v4-flash previously
+    crashed on restore with MoAPresetNotFoundError because build_moa_facade()
+    reused agent.model as the preset (#MoA restore path).
+    """
+    home = tmp_path / ".hermes"
+    _write_cfg(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent.moa_loop import build_moa_facade
+
+    agent = SimpleNamespace(
+        provider="moa",
+        model="deepseek-v4-flash",
+        tool_progress_callback=None,
+    )
+
+    client = build_moa_facade(agent, None)
+
+    assert client.chat.completions.preset_name == "review"
+
+
 def test_create_wraps_completed_aggregator_response_as_delta_chunk(monkeypatch, tmp_path):
     """When an aggregator adapter returns a completed response despite
     stream=True (Codex Responses compatibility shape), MoA must return a


### PR DESCRIPTION
## Summary

Fix the remaining MoA Desktop streaming failure path from #55933 where an
`openai-codex` aggregator can consume its provider stream internally and
return a completed `SimpleNamespace` response while the outer Chat
Completions consumer still expects a stream.

The previous guard covered completed responses at some Relay boundaries, but
MoA's nested auxiliary `call_llm(..., stream=True)` path could still deliver a
completed response object into the generic managed stream, which then tried to
iterate it and raised:

- `TypeError: 'types.SimpleNamespace' object is not iterable`

A first local compatibility wrapper could also surface:

- `AttributeError: 'types.SimpleNamespace' object has no attribute 'index'`

when completed responses contained tool calls, because completed tool calls use
`choices[0].message.tool_calls` while stream deltas require indexed
`choices[0].delta.tool_calls`.

## Changes

- Route `task="moa_aggregator"` streaming calls directly to the provider
  client so MoA's facade owns the stream contract for its nested aggregator.
- Convert a completed MoA aggregator response into one valid Chat Completions
  delta chunk at the MoA boundary.
- Normalize completed `message.tool_calls` into indexed stream `tool_calls`
  deltas with `index`, `id`, `type`, and `function` fields.
- Classify these local MoA adapter-shape errors as non-fallback format errors
  so a local compatibility bug cannot silently activate the configured
  fallback model and make the UI appear to drift from MoA to a single model.
- Keep the richer exception logging for pre-delivery streaming failures.

## Tests

- Added regression coverage for completed MoA aggregator responses with tool
  calls.
- Ran:

```bash
venv/bin/python -m pytest \
  tests/run_agent/test_moa_streaming.py \
  tests/run_agent/test_streaming.py \
  tests/agent/test_error_classifier.py -q
```

Result: `279 passed`.

Fixes #55933.
