### PR TITLE
fix(update): handle Windows reserved-device-name files during autostash

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -923,7 +923,9 @@ def _restore_reserved_renames(
                 )
 
 
-def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
+def _stash_local_changes_if_needed(
+    git_cmd: list[str], cwd: Path
+) -> tuple[Optional[str], list[tuple[Path, Path]]]:
     status = subprocess.run(
         git_cmd + ["status", "--porcelain"],
         cwd=cwd,
@@ -932,7 +934,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         check=True,
     )
     if not status.stdout.strip():
-        return None
+        return None, []
 
     # If the index has unmerged entries (e.g. from an interrupted merge/rebase),
     # git stash will fail with "needs merge / could not write index".  Clear the
@@ -1046,7 +1048,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
                 push.returncode, push.args, output=push.stdout, stderr=push.stderr
             )
 
-    return stash_ref
+    return stash_ref, _reserved_name_backups
 
 def _resolve_stash_selector(
     git_cmd: list[str], cwd: Path, stash_ref: str
@@ -1113,6 +1115,7 @@ def _restore_stashed_changes(
     stash_ref: str,
     prompt_user: bool = False,
     input_fn=None,
+    reserved_renames: list[tuple[Path, Path]] | None = None,
 ) -> bool:
     if prompt_user:
         print()
@@ -1150,7 +1153,10 @@ def _restore_stashed_changes(
     )
 
     # Restore any files that were renamed before stash due to Windows reserved names
-    _restore_reserved_renames(cwd)
+    if reserved_renames is not None:
+        _restore_reserved_renames(cwd, reserved_renames)
+    else:
+        _restore_reserved_renames(cwd)
 
     # Check for unmerged (conflicted) files — can happen even when returncode is 0
     unmerged = subprocess.run(
@@ -3489,7 +3495,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             print(f"  ⚠ Currently on {label} — switching to {branch} for update...")
             # Stash before checkout so uncommitted work isn't lost
-            auto_stash_ref = _m()._stash_local_changes_if_needed(git_cmd, _m().PROJECT_ROOT)
+            auto_stash_ref, reserved_renames = _m()._stash_local_changes_if_needed(
+                git_cmd, _m().PROJECT_ROOT
+            )
             checkout_result = subprocess.run(
                 git_cmd + ["checkout", branch],
                 cwd=_m().PROJECT_ROOT,
@@ -3517,13 +3525,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             auto_stash_ref,
                             prompt_user=False,
                             input_fn=gw_input_fn,
+                            reserved_renames=reserved_renames,
                         )
                     print(f"✗ Branch '{branch}' does not exist locally or on origin.")
                     if track_result.stderr.strip():
                         print(f"  {track_result.stderr.strip().splitlines()[0]}")
                     sys.exit(1)
         else:
-            auto_stash_ref = _m()._stash_local_changes_if_needed(git_cmd, _m().PROJECT_ROOT)
+            auto_stash_ref, reserved_renames = _m()._stash_local_changes_if_needed(
+                git_cmd, _m().PROJECT_ROOT
+            )
 
         prompt_for_restore = (
             auto_stash_ref is not None
@@ -3556,6 +3567,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     auto_stash_ref,
                     prompt_user=prompt_for_restore,
                     input_fn=gw_input_fn,
+                    reserved_renames=reserved_renames,
                 )
             if current_branch not in {branch, "HEAD"}:
                 subprocess.run(
@@ -3731,6 +3743,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
             update_succeeded = True
         finally:
+            # Always restore temporarily-renamed reserved files, regardless of
+            # whether the update succeeded — the rename is purely temporary and
+            # has no bearing on the stash contents.
+            if reserved_renames:
+                _restore_reserved_renames(_m().PROJECT_ROOT, reserved_renames)
+                _load_and_clear_reserved_rename_map(_m().PROJECT_ROOT)
+
             if auto_stash_ref is not None:
                 # Don't attempt stash restore if the code update itself failed —
                 # working tree is in an unknown state.
@@ -3755,6 +3774,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         auto_stash_ref,
                         prompt_user=prompt_for_restore,
                         input_fn=gw_input_fn,
+                        reserved_renames=reserved_renames,
                     )
 
         _invalidate_update_cache()

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -831,6 +831,9 @@ _RESERVED_DEVICE_NAMES = frozenset({
 _RESERVED_RENAME_PREFIX = ".hermes_reserved_name_"
 
 
+_RESERVED_RENAME_MAP_FILE = ".hermes_autostash_reserved_rename_map"
+
+
 def _is_reserved_device_name(name: str) -> bool:
     """True if *name* (without extension) matches a Windows reserved device name."""
     base = name.split(".")[0].upper()
@@ -867,23 +870,57 @@ def _rename_reserved_untracked(cwd: Path, ls_files_output: str) -> list[tuple[Pa
     return renames
 
 
-def _restore_reserved_renames(cwd: Path) -> None:
-    """Undo the temporary renames done by _rename_reserved_untracked."""
-    if not _m()._is_windows():
+def _save_reserved_rename_map(cwd: Path, renames: list[tuple[Path, Path]]) -> None:
+    """Persist rename pairs so manual ``git stash apply`` can recover them."""
+    if not renames:
         return
-    for child in cwd.rglob(f"{_RESERVED_RENAME_PREFIX}*"):
-        if not child.is_file():
-            continue
-        original_name = child.name[len(_RESERVED_RENAME_PREFIX):]
-        original = child.with_name(original_name)
-        try:
-            child.rename(original)
-            print(f"  ✓ Restored reserved file name: {original_name}")
-        except OSError as exc:
-            print(
-                f"  ⚠ Could not restore reserved file name: {child.name} → "
-                f"{original_name}: {exc}"
-            )
+    map_file = cwd / _RESERVED_RENAME_MAP_FILE
+    data = {
+        str(orig.relative_to(cwd)): str(renamed.relative_to(cwd))
+        for orig, renamed in renames
+    }
+    map_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _load_and_clear_reserved_rename_map(cwd: Path) -> list[tuple[Path, Path]]:
+    """Load rename pairs from the sidecar file and remove it."""
+    map_file = cwd / _RESERVED_RENAME_MAP_FILE
+    if not map_file.exists():
+        return []
+    try:
+        data = json.loads(map_file.read_text(encoding="utf-8"))
+        renames = [(cwd / k, cwd / v) for k, v in data.items()]
+    except (json.JSONDecodeError, OSError):
+        renames = []
+    try:
+        map_file.unlink(missing_ok=True)
+    except OSError:
+        pass
+    return renames
+
+
+def _restore_reserved_renames(
+    cwd: Path, renames: list[tuple[Path, Path]] | None = None
+) -> None:
+    """Undo the temporary renames done by _rename_reserved_untracked.
+
+    If *renames* is not provided, reads the sidecar map written by
+    _save_reserved_rename_map (for manual ``git stash apply`` recovery).
+    """
+    if renames is None:
+        renames = _load_and_clear_reserved_rename_map(cwd)
+    if not renames:
+        return
+    for original, renamed in renames:
+        if renamed.exists() and not original.exists():
+            try:
+                renamed.rename(original)
+                print(f"  ✓ Restored reserved file name: {original.name}")
+            except OSError as exc:
+                print(
+                    f"  ⚠ Could not restore reserved file name: {renamed.name} → "
+                    f"{original.name}: {exc}"
+                )
 
 
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
@@ -933,6 +970,8 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
                 check=True,
             )
             _reserved_name_backups = _rename_reserved_untracked(cwd, untracked.stdout)
+            if _reserved_name_backups:
+                _save_reserved_rename_map(cwd, _reserved_name_backups)
         except subprocess.CalledProcessError:
             pass
 
@@ -991,6 +1030,11 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         else:
             # No stash entry was created: the changes were NOT saved.  This
             # is a real failure — bail out before the update touches HEAD.
+            # Restore any temporarily-renamed reserved files first so the
+            # user doesn't lose data.
+            if _reserved_name_backups:
+                _restore_reserved_renames(cwd, _reserved_name_backups)
+                _load_and_clear_reserved_rename_map(cwd)
             print("✗ Could not stash local changes — update aborted.")
             if push.stderr.strip():
                 print(f"  {push.stderr.strip().splitlines()[0]}")
@@ -1086,6 +1130,15 @@ def _restore_stashed_changes(
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")
             print(f"Restore manually with: git stash apply {stash_ref}")
+            # If reserved files were renamed, remind the user to recover them.
+            map_file = cwd / _RESERVED_RENAME_MAP_FILE
+            if map_file.exists():
+                print(
+                    "  ⚠ Reserved-device-name files were renamed before stash. "
+                    "After manual `git stash apply`, delete the sidecar file "
+                    f"`{_RESERVED_RENAME_MAP_FILE}` to keep the prefixed names, "
+                    "or rename `.hermes_reserved_name_*` files back manually."
+                )
             return False
 
     print("→ Restoring local changes...")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -810,6 +810,82 @@ def _update_via_zip(args):
     # git-update path for rationale (#30271).
     _finish_dashboard_update_cleanup(node_failures)
 
+# ---------------------------------------------------------------------------
+# Windows reserved-device-name guard
+# ---------------------------------------------------------------------------
+# git stash cannot handle files whose basename matches a Windows reserved
+# device name (CON, PRN, AUX, NUL, COM1-9, LPT1-9).  On Windows these names
+# are special at the OS level and git errors out when trying to stage them.
+# We temporarily rename matching untracked files before stash, then restore
+# the original names after the stash is applied.
+# ---------------------------------------------------------------------------
+
+_RESERVED_DEVICE_NAMES = frozenset({
+    "CON", "PRN", "AUX", "NUL",
+    "COM1", "COM2", "COM3", "COM4", "COM5",
+    "COM6", "COM7", "COM8", "COM9",
+    "LPT1", "LPT2", "LPT3", "LPT4", "LPT5",
+    "LPT6", "LPT7", "LPT8", "LPT9",
+})
+
+_RESERVED_RENAME_PREFIX = ".hermes_reserved_name_"
+
+
+def _is_reserved_device_name(name: str) -> bool:
+    """True if *name* (without extension) matches a Windows reserved device name."""
+    base = name.split(".")[0].upper()
+    return base in _RESERVED_DEVICE_NAMES
+
+
+def _rename_reserved_untracked(cwd: Path, ls_files_output: str) -> list[tuple[Path, Path]]:
+    """Rename untracked files with reserved names so git stash can handle them.
+
+    Returns list of (original_path, renamed_path) pairs for later restore.
+    """
+    renames: list[tuple[Path, Path]] = []
+    if not ls_files_output or not _m()._is_windows():
+        return renames
+
+    for path_str in ls_files_output.splitlines():
+        if not path_str:
+            continue
+        path = cwd / path_str
+        if not path.exists():
+            continue
+        name = path.name
+        if _is_reserved_device_name(name):
+            renamed = path.with_name(f"{_RESERVED_RENAME_PREFIX}{name}")
+            try:
+                path.rename(renamed)
+                renames.append((path, renamed))
+                print(
+                    f"  ⚠ Temporarily renamed Windows reserved-device-name file: "
+                    f"{path_str} → {renamed.name}"
+                )
+            except OSError as exc:
+                print(f"  ✗ Could not rename reserved file {path_str}: {exc}")
+    return renames
+
+
+def _restore_reserved_renames(cwd: Path) -> None:
+    """Undo the temporary renames done by _rename_reserved_untracked."""
+    if not _m()._is_windows():
+        return
+    for child in cwd.rglob(f"{_RESERVED_RENAME_PREFIX}*"):
+        if not child.is_file():
+            continue
+        original_name = child.name[len(_RESERVED_RENAME_PREFIX):]
+        original = child.with_name(original_name)
+        try:
+            child.rename(original)
+            print(f"  ✓ Restored reserved file name: {original_name}")
+        except OSError as exc:
+            print(
+                f"  ⚠ Could not restore reserved file name: {child.name} → "
+                f"{original_name}: {exc}"
+            )
+
+
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
     status = subprocess.run(
         git_cmd + ["status", "--porcelain"],
@@ -841,6 +917,25 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         "hermes-update-autostash-%Y%m%d-%H%M%S"
     )
     print("→ Local changes detected — stashing before update...")
+
+    # ── Windows reserved-device-name guard ───────────────────────────────
+    # git stash cannot handle files whose basename matches a Windows reserved
+    # device name (CON, PRN, AUX, NUL, COM1-9, LPT1-9). Rename them temporarily
+    # so the stash can proceed; _restore_stashed_changes will rename them back.
+    _reserved_name_backups: list[tuple[Path, Path]] = []
+    if _m()._is_windows():
+        try:
+            untracked = subprocess.run(
+                git_cmd + ["ls-files", "--others", "--exclude-standard"],
+                cwd=cwd,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                check=True,
+            )
+            _reserved_name_backups = _rename_reserved_untracked(cwd, untracked.stdout)
+        except subprocess.CalledProcessError:
+            pass
+
     prev_stash = subprocess.run(
         git_cmd + ["rev-parse", "--verify", "refs/stash"],
         cwd=cwd,
@@ -1000,6 +1095,9 @@ def _restore_stashed_changes(
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
     )
+
+    # Restore any files that were renamed before stash due to Windows reserved names
+    _restore_reserved_renames(cwd)
 
     # Check for unmerged (conflicted) files — can happen even when returncode is 0
     unmerged = subprocess.run(

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1499,8 +1499,65 @@ function Install-Repository {
                     }
                     $stashName = "hermes-install-autostash-" + (Get-Date -Format "yyyyMMdd-HHmmss")
                     Write-Info "Local changes detected, stashing before update..."
+
+                    # -- Windows reserved-device-name guard ----------------------------------
+                    # git stash cannot handle files whose basename matches a Windows reserved
+                    # device name (CON, PRN, AUX, NUL, COM1-9, LPT1-9). Rename them temporarily
+                    # so the stash can proceed; restore after stash apply.
+                    $reservedDeviceNames = @(
+                        "CON","PRN","AUX","NUL",
+                        "COM1","COM2","COM3","COM4","COM5",
+                        "COM6","COM7","COM8","COM9",
+                        "LPT1","LPT2","LPT3","LPT4","LPT5",
+                        "LPT6","LPT7","LPT8","LPT9"
+                    )
+                    $reservedRenameMapFile = Join-Path $pwd ".hermes_autostash_reserved_rename_map"
+                    $reservedRenameMap = @{}
+                    $untrackedFiles = @(git -c windows.appendAtomically=false ls-files --others --exclude-standard 2>$null) | Where-Object { $_ }
+                    foreach ($f in $untrackedFiles) {
+                        $base = [System.IO.Path]::GetFileNameWithoutExtension($f).ToUpper()
+                        if ($reservedDeviceNames -contains $base) {
+                            $src = Join-Path $pwd $f
+                            $dstName = ".hermes_reserved_name_$([System.IO.Path]::GetFileName($f))"
+                            $dst = Join-Path $pwd $dstName
+                            if (Test-Path $src) {
+                                try {
+                                    Rename-Item -LiteralPath $src -NewName $dstName -ErrorAction Stop
+                                    $reservedRenameMap[$f] = $dstName
+                                    Write-Warn "Temporarily renamed Windows reserved-device-name file: $f -> $dstName"
+                                } catch {
+                                    Write-Warn "Could not rename reserved file ${f}: $_"
+                                }
+                            }
+                        }
+                    }
+                    if ($reservedRenameMap.Count -gt 0) {
+                        $reservedRenameMap | ConvertTo-Json | Set-Content $reservedRenameMapFile -Encoding UTF8
+                    }
+
                     git -c windows.appendAtomically=false stash push --include-untracked -m "$stashName"
-                    if ($LASTEXITCODE -eq 0) { $autostashRef = "stash@{0}" }
+                    $stashPushExit = $LASTEXITCODE
+                    if ($stashPushExit -eq 0) {
+                        $autostashRef = "stash@{0}"
+                    } else {
+                        # Stash push failed - restore temporarily-renamed files so user data is not lost.
+                        if ($reservedRenameMap.Count -gt 0) {
+                            foreach ($entry in $reservedRenameMap.GetEnumerator()) {
+                                $src = Join-Path $pwd $entry.Value
+                                $dst = Join-Path $pwd $entry.Key
+                                if ((Test-Path $src) -and -not (Test-Path $dst)) {
+                                    try {
+                                        Rename-Item -LiteralPath $src -NewName $entry.Key -ErrorAction Stop
+                                    } catch {
+                                        Write-Warn "Could not restore reserved file name: $($entry.Value) -> $($entry.Key)"
+                                    }
+                                }
+                            }
+                            if (Test-Path $reservedRenameMapFile) {
+                                Remove-Item $reservedRenameMapFile -ErrorAction SilentlyContinue
+                            }
+                        }
+                    }
                 }
                 git -c windows.appendAtomically=false fetch origin $Branch
                 if ($LASTEXITCODE -ne 0) { throw "git fetch failed (exit $LASTEXITCODE)" }
@@ -1590,6 +1647,30 @@ function Install-Repository {
                         ) | Where-Object { $_ -and $_.ToString().Trim() }
                         if (($restoreExit -eq 0) -and ($conflictedFiles.Count -eq 0)) {
                             git -c windows.appendAtomically=false stash drop $autostashRef 2>$null
+
+                            # -- Windows reserved-device-name restore --------------------------------
+                            $reservedRenameMapFileRestore = Join-Path $pwd ".hermes_autostash_reserved_rename_map"
+                            if (Test-Path $reservedRenameMapFileRestore) {
+                                try {
+                                    $mapData = Get-Content $reservedRenameMapFileRestore -Raw | ConvertFrom-Json
+                                    foreach ($entry in $mapData.PSObject.Properties) {
+                                        $src = Join-Path $pwd $entry.Value
+                                        $dst = Join-Path $pwd $entry.Name
+                                        if ((Test-Path $src) -and -not (Test-Path $dst)) {
+                                            try {
+                                                Rename-Item -LiteralPath $src -NewName $entry.Name -ErrorAction Stop
+                                                Write-Warn "Restored reserved file name: $($entry.Name)"
+                                            } catch {
+                                                Write-Warn "Could not restore reserved file name: $($entry.Value) -> $($entry.Name)"
+                                            }
+                                        }
+                                    }
+                                    Remove-Item $reservedRenameMapFileRestore -ErrorAction SilentlyContinue
+                                } catch {
+                                    Write-Warn "Could not process reserved rename map: $_"
+                                }
+                            }
+
                             Write-Warn "Local changes were restored on top of the updated codebase."
                             Write-Warn "Review git diff / git status if Hermes behaves unexpectedly."
                         } else {

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -59,7 +59,7 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     """Common setup for cmd_update tests."""
     (tmp_path / ".git").mkdir()
     monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
-    monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: (None, []))
     monkeypatch.setattr(hermes_main, "_restore_stashed_changes", lambda *a, **kw: True)
     monkeypatch.setattr(hermes_config, "get_missing_env_vars", lambda required_only=True: [])
     monkeypatch.setattr(hermes_config, "get_missing_config_fields", lambda: [])
@@ -172,7 +172,7 @@ def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, 
     # Re-enable stash so it actually returns a ref
     monkeypatch.setattr(
         hermes_main, "_stash_local_changes_if_needed",
-        lambda *a, **kw: "abc123deadbeef",
+        lambda *a, **kw: ("abc123deadbeef", []),
     )
     restore_calls = []
     monkeypatch.setattr(
@@ -208,7 +208,7 @@ def _setup_setting_test(monkeypatch, tmp_path, mode):
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
     monkeypatch.setattr(
         hermes_main, "_stash_local_changes_if_needed",
-        lambda *a, **kw: "abc123deadbeef",
+        lambda *a, **kw: ("abc123deadbeef", []),
     )
     restore_calls = []
     discard_calls = []
@@ -323,7 +323,7 @@ def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
     (pkg / "hermes-agent.rb").write_text("formula\n")
     os.chmod(pkg, 0o555)  # undeletable contents, like a root-owned dir
     try:
-        stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+        stash_ref, _ = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
         assert stash_ref
 
         # The tracked change is stashed; simulate the updater's checkout window.
@@ -483,7 +483,7 @@ def test_stash_local_changes_renames_reserved_untracked_on_windows(
     # Create a reserved-name untracked file
     (tmp_path / "CON.txt").write_text("con content")
 
-    stash_ref = _stash_local_changes_if_needed(["git"], tmp_path)
+    stash_ref, _ = _stash_local_changes_if_needed(["git"], tmp_path)
     assert stash_ref is not None
 
     # The reserved file was renamed before stash, then the renamed file
@@ -528,12 +528,13 @@ def test_restore_stashed_changes_restores_reserved_names_after_apply(
     # Create a reserved-name untracked file
     (tmp_path / "CON.txt").write_text("con content")
 
-    stash_ref = _stash_local_changes_if_needed(["git"], tmp_path)
+    stash_ref, reserved_renames = _stash_local_changes_if_needed(["git"], tmp_path)
     assert stash_ref is not None
 
     # After restore, original name should be back
     restored = _restore_stashed_changes(
-        ["git"], tmp_path, stash_ref, prompt_user=False
+        ["git"], tmp_path, stash_ref, prompt_user=False,
+        reserved_renames=reserved_renames,
     )
     assert restored is True
 
@@ -671,7 +672,7 @@ def test_manual_stash_apply_recovery_via_sidecar(
     # Create a reserved-name untracked file
     (tmp_path / "CON.txt").write_text("con content")
 
-    stash_ref = _stash_local_changes_if_needed(["git"], tmp_path)
+    stash_ref, _ = _stash_local_changes_if_needed(["git"], tmp_path)
     assert stash_ref is not None
     assert not (tmp_path / "CON.txt").exists()
     # Sidecar was stashed along with the renamed file; not in working tree.

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -417,7 +417,7 @@ def test_rename_reserved_untracked_noop_on_non_windows(tmp_path, monkeypatch):
 
 
 def test_restore_reserved_renames_restores_original_names(tmp_path, monkeypatch):
-    """Renamed files are restored to their original names."""
+    """Renamed files are restored to their original names when passed explicitly."""
     from hermes_cli.update_cmd import _restore_reserved_renames
     from hermes_cli import main as hermes_main
 
@@ -427,7 +427,11 @@ def test_restore_reserved_renames_restores_original_names(tmp_path, monkeypatch)
     (tmp_path / ".hermes_reserved_name_CON.txt").write_text("con content")
     (tmp_path / ".hermes_reserved_name_AUX.md").write_text("aux content")
 
-    _restore_reserved_renames(tmp_path)
+    renames = [
+        (tmp_path / "CON.txt", tmp_path / ".hermes_reserved_name_CON.txt"),
+        (tmp_path / "AUX.md", tmp_path / ".hermes_reserved_name_AUX.md"),
+    ]
+    _restore_reserved_renames(tmp_path, renames)
 
     assert (tmp_path / "CON.txt").exists()
     assert (tmp_path / "AUX.md").exists()
@@ -539,3 +543,149 @@ def test_restore_stashed_changes_restores_reserved_names_after_apply(
 
     out = capsys.readouterr().out
     assert "Restored reserved file name: CON.txt" in out
+
+
+def test_restore_reserved_renames_via_sidecar_file(tmp_path, monkeypatch):
+    """Renamed files are restored from the sidecar map when no explicit list is given."""
+    import json
+    from hermes_cli.update_cmd import (
+        _restore_reserved_renames,
+        _RESERVED_RENAME_MAP_FILE,
+    )
+    from hermes_cli import main as hermes_main
+
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+
+    (tmp_path / ".hermes_reserved_name_CON.txt").write_text("con content")
+    (tmp_path / ".hermes_reserved_name_PRN.md").write_text("prn content")
+
+    map_data = {
+        "CON.txt": ".hermes_reserved_name_CON.txt",
+        "PRN.md": ".hermes_reserved_name_PRN.md",
+    }
+    (tmp_path / _RESERVED_RENAME_MAP_FILE).write_text(
+        json.dumps(map_data), encoding="utf-8"
+    )
+
+    _restore_reserved_renames(tmp_path)
+
+    assert (tmp_path / "CON.txt").exists()
+    assert (tmp_path / "PRN.md").exists()
+    assert not (tmp_path / ".hermes_reserved_name_CON.txt").exists()
+    assert not (tmp_path / ".hermes_reserved_name_PRN.md").exists()
+    assert not (tmp_path / _RESERVED_RENAME_MAP_FILE).exists()
+
+
+def test_stash_push_failure_restores_reserved_names(
+    tmp_path, monkeypatch
+):
+    """If stash push fails, temporarily-renamed files are restored immediately."""
+    import shutil
+    import subprocess
+    from unittest.mock import MagicMock
+
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+
+    from hermes_cli import main as hermes_main
+    from hermes_cli.update_cmd import _stash_local_changes_if_needed
+
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=check
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "tracked.txt").write_text("v1\n")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    # Create a reserved-name untracked file
+    (tmp_path / "CON.txt").write_text("con content")
+
+    orig_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        # Intercept only the stash push call to make it fail.
+        if (
+            isinstance(cmd, list)
+            and len(cmd) >= 5
+            and cmd[1:5] == ["stash", "push", "--include-untracked", "-m"]
+        ):
+            mock = MagicMock()
+            mock.returncode = 1
+            mock.stdout = ""
+            mock.stderr = "stash push failed"
+            mock.args = cmd
+            return mock
+        return orig_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        _stash_local_changes_if_needed(["git"], tmp_path)
+
+    # The original file should have been restored
+    assert (tmp_path / "CON.txt").exists()
+    assert (tmp_path / "CON.txt").read_text() == "con content"
+    assert not (tmp_path / ".hermes_reserved_name_CON.txt").exists()
+
+
+def test_manual_stash_apply_recovery_via_sidecar(
+    tmp_path, monkeypatch
+):
+    """Simulate manual `git stash apply` then recover via sidecar map."""
+    import shutil
+    import subprocess
+    import json
+
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+
+    from hermes_cli import main as hermes_main
+    from hermes_cli.update_cmd import (
+        _stash_local_changes_if_needed,
+        _restore_stashed_changes,
+        _restore_reserved_renames,
+        _RESERVED_RENAME_MAP_FILE,
+    )
+
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=check
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "tracked.txt").write_text("v1\n")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    # Create a reserved-name untracked file
+    (tmp_path / "CON.txt").write_text("con content")
+
+    stash_ref = _stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref is not None
+    assert not (tmp_path / "CON.txt").exists()
+    # Sidecar was stashed along with the renamed file; not in working tree.
+    assert not (tmp_path / _RESERVED_RENAME_MAP_FILE).exists()
+
+    # Simulate user manually applying the stash (the renamed file and sidecar come back)
+    git("stash", "apply", "stash@{0}")
+    # After manual apply, the prefixed file and sidecar exist again.
+    assert (tmp_path / ".hermes_reserved_name_CON.txt").exists()
+    assert (tmp_path / _RESERVED_RENAME_MAP_FILE).exists()
+
+    # Recovery via sidecar (no explicit list → reads sidecar)
+    _restore_reserved_renames(tmp_path)
+
+    assert (tmp_path / "CON.txt").exists()
+    assert not (tmp_path / ".hermes_reserved_name_CON.txt").exists()
+    assert not (tmp_path / _RESERVED_RENAME_MAP_FILE).exists()

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -337,3 +337,205 @@ def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
         assert (pkg / "hermes-agent.rb").read_text() == "formula\n"
     finally:
         os.chmod(pkg, 0o755)
+
+
+# ---------------------------------------------------------------------------
+# Windows reserved-device-name guard
+# ---------------------------------------------------------------------------
+
+def test_is_reserved_device_name_matches_all_reserved_names():
+    """Every Windows reserved device name is detected, case-insensitive."""
+    from hermes_cli.update_cmd import _is_reserved_device_name
+
+    reserved = [
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5",
+        "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5",
+        "LPT6", "LPT7", "LPT8", "LPT9",
+    ]
+    for name in reserved:
+        assert _is_reserved_device_name(name) is True
+        assert _is_reserved_device_name(name.lower()) is True
+        assert _is_reserved_device_name(name + ".txt") is True
+        assert _is_reserved_device_name(name + ".TXT") is True
+
+    # Non-matching names should return False
+    assert _is_reserved_device_name("README") is False
+    assert _is_reserved_device_name("convention") is False
+    assert _is_reserved_device_name("com10") is False
+    assert _is_reserved_device_name("lpt0") is False
+    assert _is_reserved_device_name("") is False
+
+
+def test_rename_reserved_untracked_renames_only_matching_files(tmp_path, monkeypatch):
+    """Only untracked files matching reserved names are renamed."""
+    from hermes_cli.update_cmd import _rename_reserved_untracked
+    from hermes_cli import main as hermes_main
+
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+
+    # Create files
+    (tmp_path / "CON.txt").write_text("con content")
+    (tmp_path / "README.md").write_text("readme content")
+    (tmp_path / "PRN").write_text("prn content")
+
+    ls_output = "CON.txt\nREADME.md\nPRN\n"
+    renames = _rename_reserved_untracked(tmp_path, ls_output)
+
+    # CON.txt and PRN should be renamed
+    assert len(renames) == 2
+    renamed_names = [r[1].name for r in renames]
+    assert ".hermes_reserved_name_CON.txt" in renamed_names
+    assert ".hermes_reserved_name_PRN" in renamed_names
+
+    # Original files should no longer exist
+    assert not (tmp_path / "CON.txt").exists()
+    assert not (tmp_path / "PRN").exists()
+
+    # README.md should be untouched
+    assert (tmp_path / "README.md").exists()
+
+    # Renamed files should exist
+    assert (tmp_path / ".hermes_reserved_name_CON.txt").exists()
+    assert (tmp_path / ".hermes_reserved_name_PRN").exists()
+
+
+def test_rename_reserved_untracked_noop_on_non_windows(tmp_path, monkeypatch):
+    """On non-Windows platforms, no renaming happens."""
+    from hermes_cli.update_cmd import _rename_reserved_untracked
+    from hermes_cli import main as hermes_main
+
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: False)
+
+    (tmp_path / "CON.txt").write_text("con content")
+    ls_output = "CON.txt\n"
+    renames = _rename_reserved_untracked(tmp_path, ls_output)
+
+    assert renames == []
+    assert (tmp_path / "CON.txt").exists()
+
+
+def test_restore_reserved_renames_restores_original_names(tmp_path, monkeypatch):
+    """Renamed files are restored to their original names."""
+    from hermes_cli.update_cmd import _restore_reserved_renames
+    from hermes_cli import main as hermes_main
+
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+
+    # Simulate pre-stash renamed files
+    (tmp_path / ".hermes_reserved_name_CON.txt").write_text("con content")
+    (tmp_path / ".hermes_reserved_name_AUX.md").write_text("aux content")
+
+    _restore_reserved_renames(tmp_path)
+
+    assert (tmp_path / "CON.txt").exists()
+    assert (tmp_path / "AUX.md").exists()
+    assert not (tmp_path / ".hermes_reserved_name_CON.txt").exists()
+    assert not (tmp_path / ".hermes_reserved_name_AUX.md").exists()
+
+
+def test_restore_reserved_renames_noop_on_non_windows(tmp_path, monkeypatch):
+    """On non-Windows platforms, restore is a no-op."""
+    from hermes_cli.update_cmd import _restore_reserved_renames
+    from hermes_cli import main as hermes_main
+
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: False)
+
+    (tmp_path / ".hermes_reserved_name_CON.txt").write_text("con content")
+    _restore_reserved_renames(tmp_path)
+
+    # File should still be there (no rename happened)
+    assert (tmp_path / ".hermes_reserved_name_CON.txt").exists()
+
+
+def test_stash_local_changes_renames_reserved_untracked_on_windows(
+    tmp_path, monkeypatch, capsys
+):
+    """E2E: _stash_local_changes_if_needed renames reserved files before stash."""
+    import shutil
+    import subprocess
+
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+
+    from hermes_cli import main as hermes_main
+    from hermes_cli.update_cmd import _stash_local_changes_if_needed
+
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=check
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "tracked.txt").write_text("v1\n")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    # Create a reserved-name untracked file
+    (tmp_path / "CON.txt").write_text("con content")
+
+    stash_ref = _stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref is not None
+
+    # The reserved file was renamed before stash, then the renamed file
+    # was stashed (as untracked) and removed from the working tree.
+    assert not (tmp_path / "CON.txt").exists()
+    assert not (tmp_path / ".hermes_reserved_name_CON.txt").exists()
+
+    out = capsys.readouterr().out
+    assert "Temporarily renamed Windows reserved-device-name file" in out
+
+
+def test_restore_stashed_changes_restores_reserved_names_after_apply(
+    tmp_path, monkeypatch, capsys
+):
+    """E2E: _restore_stashed_changes restores reserved file names after stash apply."""
+    import shutil
+    import subprocess
+
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+
+    from hermes_cli import main as hermes_main
+    from hermes_cli.update_cmd import (
+        _stash_local_changes_if_needed,
+        _restore_stashed_changes,
+    )
+
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: True)
+
+    def git(*args, check=True):
+        return subprocess.run(
+            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=check
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "tracked.txt").write_text("v1\n")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    # Create a reserved-name untracked file
+    (tmp_path / "CON.txt").write_text("con content")
+
+    stash_ref = _stash_local_changes_if_needed(["git"], tmp_path)
+    assert stash_ref is not None
+
+    # After restore, original name should be back
+    restored = _restore_stashed_changes(
+        ["git"], tmp_path, stash_ref, prompt_user=False
+    )
+    assert restored is True
+
+    assert (tmp_path / "CON.txt").exists()
+    assert not (tmp_path / ".hermes_reserved_name_CON.txt").exists()
+    assert (tmp_path / "CON.txt").read_text() == "con content"
+
+    out = capsys.readouterr().out
+    assert "Restored reserved file name: CON.txt" in out


### PR DESCRIPTION
Windows reserves device names (CON, PRN, AUX, NUL, COM1-9, LPT1-9) at the OS level. git stash push --include-untracked fails when trying to stage files with these basenames on Windows.

Instead of silently deleting untracked reserved-name files (which could lose user data), we temporarily rename them before stash and restore the original names after stash apply.

- Add _rename_reserved_untracked() to detect and rename matching files
- Add _restore_reserved_renames() to undo the temporary renames  
- Hook into _stash_local_changes_if_needed (before stash push)
- Hook into _restore_stashed_changes (after stash apply)
- Add 7 tests covering detection, renaming, restore, non-Windows noop, and full E2E round-trip with real git

Fixes review feedback on PR #71841.