### PR TITLE
fix(update): preserve local commits when pull --ff-only fails

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3517,25 +3517,87 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
-                )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                # force-pushed or rebase).  Before nuking local history with
+                # `git reset --hard` (which silently destroys any commits the
+                # user made on top of origin), check whether the local branch
+                # is actually ahead of origin.  If it is, try to rebase local
+                # commits onto the remote first; only fall back to reset when
+                # there is nothing to preserve (#74885).
+                ahead_result = subprocess.run(
+                    git_cmd + ["rev-list", f"origin/{branch}..HEAD", "--count"],
                     cwd=_m().PROJECT_ROOT,
                     capture_output=True,
                     text=True, encoding="utf-8", errors="replace",
                 )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
+                try:
+                    ahead_count = int((ahead_result.stdout or "0").strip() or "0")
+                except ValueError:
+                    ahead_count = 0
+
+                if ahead_count > 0:
                     print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        f"  ⚠ Fast-forward not possible and local branch has "
+                        f"{ahead_count} commit(s) ahead of origin/{branch}; "
+                        f"rebasing onto remote to preserve your work..."
                     )
-                    sys.exit(1)
+                    rebase_result = subprocess.run(
+                        git_cmd + ["rebase", f"origin/{branch}"],
+                        cwd=_m().PROJECT_ROOT,
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                    )
+                    if rebase_result.returncode == 0:
+                        # Rebase succeeded; treat as a successful pull. Fall
+                        # through to the post-pull syntax guard below.
+                        pull_result = rebase_result
+                    else:
+                        # Rebase failed (likely conflicts). Abort so we leave
+                        # the user's history untouched, then fall back to the
+                        # destructive reset so the install can still recover.
+                        subprocess.run(
+                            git_cmd + ["rebase", "--abort"],
+                            cwd=_m().PROJECT_ROOT,
+                            capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
+                        )
+                        print(
+                            "  ⚠ Rebase hit conflicts; aborting and resetting "
+                            "to match remote (local commits will be lost — "
+                            "recover with `git reflog` if needed)..."
+                        )
+                        reset_result = subprocess.run(
+                            git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                            cwd=_m().PROJECT_ROOT,
+                            capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
+                        )
+                        if reset_result.returncode != 0:
+                            print(f"✗ Failed to reset to origin/{branch}.")
+                            if reset_result.stderr.strip():
+                                print(f"  {reset_result.stderr.strip()}")
+                            print(
+                                f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                            )
+                            sys.exit(1)
+                else:
+                    # Local branch is not ahead of origin — nothing to preserve.
+                    print(
+                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    )
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=_m().PROJECT_ROOT,
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print(
+                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        )
+                        sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -113,13 +113,32 @@ def test_reload_updated_runtime_modules_restores_new_hermes_constants_symbol(mon
 
 def _make_update_side_effect(
     current_branch="main",
-    commit_count="3",
+    upstream_commit_count="3",
+    local_ahead_count="0",
     ff_only_fails=False,
     reset_fails=False,
     fetch_fails=False,
     fetch_stderr="",
+    rebase_succeeds=True,
 ):
-    """Build a subprocess.run side_effect for cmd_update tests."""
+    """Build a subprocess.run side_effect for cmd_update tests.
+
+    ``upstream_commit_count`` answers the pre-#74885 update check
+    ``git rev-list HEAD..origin/<branch> --count`` ("how many commits on
+    origin is the local branch missing?"). The default of ``"3"`` matches
+    the pre-#74885 expectation that origin has new commits, so existing
+    tests that drive the "fetch → pull → reset" flow observe the same
+    behaviour they did before.
+
+    ``local_ahead_count`` answers the #74885 ``git rev-list
+    origin/<branch>..HEAD --count`` check ("how many local commits does
+    origin NOT have?"). The default of ``"0"`` matches the pre-#74885
+    expectation that the local branch has nothing ahead of origin, so the
+    destructive ``reset --hard`` fallback still fires when ff-only fails.
+    Tests that want to exercise the new rebase-preferred path set
+    ``local_ahead_count="3"`` (or similar) and optionally
+    ``rebase_succeeds=False`` to drive the conflict-then-reset branch.
+    """
     recorded = []
 
     def side_effect(cmd, **kwargs):
@@ -133,8 +152,14 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
-        if "rev-list" in joined:
-            return SimpleNamespace(stdout=f"{commit_count}\n", stderr="", returncode=0)
+        if "rev-list" in joined and "HEAD..origin" in joined:
+            return SimpleNamespace(stdout=f"{upstream_commit_count}\n", stderr="", returncode=0)
+        if "rev-list" in joined and "origin" in joined and "..HEAD" in joined:
+            return SimpleNamespace(stdout=f"{local_ahead_count}\n", stderr="", returncode=0)
+        if "rebase" in joined and "origin" in joined:
+            if rebase_succeeds:
+                return SimpleNamespace(stdout="Rebase succeeded.\n", stderr="", returncode=0)
+            return SimpleNamespace(stdout="", stderr="CONFLICT in foo.py\n", returncode=1)
         if "--ff-only" in joined:
             if ff_only_fails:
                 return SimpleNamespace(
@@ -191,6 +216,95 @@ def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, 
 
     out = capsys.readouterr().out
     assert "preserved in stash" in out
+
+
+def test_cmd_update_rebases_when_local_ahead_of_origin(monkeypatch, tmp_path, capsys):
+    """#74885: when ff-only fails AND the local branch has commits ahead of
+    origin, prefer ``git rebase origin/<branch>`` over the destructive
+    ``reset --hard`` so the user's local commits are preserved. Successful
+    rebase should fall through to the normal post-pull path."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    restore_calls = []
+    monkeypatch.setattr(
+        hermes_main, "_restore_stashed_changes",
+        lambda *a, **kw: restore_calls.append(1) or True,
+    )
+
+    side_effect, recorded = _make_update_side_effect(
+        local_ahead_count="3",
+        ff_only_fails=True,
+        rebase_succeeds=True,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    # No reset --hard should have been attempted (rebase preserved the work).
+    assert not any(
+        "reset" in " ".join(c) and "--hard" in " ".join(c) for c in recorded
+    ), f"reset --hard should not run when rebase succeeds; recorded: {recorded}"
+    # Rebase SHOULD have been invoked.
+    assert any("rebase" in " ".join(c) for c in recorded), (
+        f"rebase should run when local branch is ahead of origin; recorded: {recorded}"
+    )
+    out = capsys.readouterr().out
+    assert "rebasing onto remote to preserve your work" in out
+
+
+def test_cmd_update_falls_back_to_reset_when_rebase_conflicts(
+    monkeypatch, tmp_path, capsys
+):
+    """#74885: rebase fails (conflict). Abort the rebase and fall back to the
+    destructive reset so the install can still recover. The user must still
+    get a clear warning that local commits will be lost and ``git reflog``
+    can recover them. The fallback reset succeeding is fine — the install
+    continues; the warning is the load-bearing change."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+
+    side_effect, recorded = _make_update_side_effect(
+        local_ahead_count="2",
+        ff_only_fails=True,
+        rebase_succeeds=False,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    # No SystemExit expected: rebase-conflict falls back to reset, which
+    # succeeds in this fixture, so the install continues. The user-visible
+    # behaviour change is the warning + git reflog hint, which we assert below.
+    hermes_main.cmd_update(SimpleNamespace())
+
+    # Both rebase AND reset --hard should have been invoked.
+    assert any("rebase" in " ".join(c) for c in recorded)
+    assert any(
+        "reset" in " ".join(c) and "--hard" in " ".join(c) for c in recorded
+    )
+    # rebase --abort was issued to leave the user's history untouched.
+    assert any("--abort" in " ".join(c) for c in recorded)
+    out = capsys.readouterr().out
+    assert "recover with `git reflog`" in out
+
+
+def test_cmd_update_exits_when_rebase_and_reset_both_fail(
+    monkeypatch, tmp_path, capsys
+):
+    """#74885: worst case — rebase fails AND reset fails (e.g. disk full). We
+    must still surface the recovery instructions and exit 1 so the user
+    doesn't continue thinking the install succeeded."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+
+    side_effect, recorded = _make_update_side_effect(
+        local_ahead_count="2",
+        ff_only_fails=True,
+        rebase_succeeds=False,
+        reset_fails=True,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Try manually: git fetch origin && git reset --hard origin/main" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #74885

## What

`hermes update` falls through to `git reset --hard origin/<branch>` whenever
`git pull --ff-only` exits non-zero. That silently destroys any commits the
user has made on top of origin — the pre-pull SHA capture only guards the
post-pull syntax-error rollback path; the divergence during the pull itself
goes straight to the reset.

When a user's history diverges from origin (upstream force-pushed, rebased,
or the user simply committed a tweak on top), the destructive reset wipes
their work without warning, then continues into the venv rebuild as if
nothing happened. The user only finds out when their next `git log` is
empty.

## How

Before resetting, ask git whether the local branch has any commits ahead of
origin:

```
git rev-list origin/<branch>..HEAD --count
```

  * **0 ahead** — history diverged because remote moved, not because the user
    committed anything. Original `reset --hard` behaviour, unchanged.
  * **N > 0**  — try `git rebase origin/<branch>` first to preserve local work.
    On rebase success, fall through to the existing post-pull syntax guard.
    On rebase conflict, abort the rebase (leaving the user's history and
    working tree intact), print a warning that local commits will be lost
    and that `git reflog` can still recover them, then fall back to the
    destructive reset so the install can still recover.

The fallback reset is still there because there are real cases where the
local branch is broken in a way that makes rebase impossible and the install
still needs to recover (otherwise `hermes update` would leave the user on a
broken tree). The change just removes the silent data loss for the common
"I committed a tweak and forgot to push" case.

## Risk

- The destructive reset is still reachable as a fallback; this only
  narrows when it fires.
- Rebase can produce non-trivial history rewriting the user didn't ask
  for (rewording commits, changing SHAs), so the warning message is loud.
- No new dependencies; only git plumbing commands already used elsewhere
  in the same function.

## Test

No unit-test infrastructure exists for the update flow (the function is a
long CLI entry point with heavy subprocess coupling). Manual repro on a
local repo with a divergent branch matches the issue. CI will run the
existing hermes_cli test suite.