### PR TITLE
fix(sanitize): re-run empty-message repair after tool_call dedup

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3128,7 +3128,14 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    # All tool_calls were duplicates of earlier ids — drop
+                    # the key entirely so we never emit ``tool_calls: []`` to
+                    # the API. Strict providers (DeepSeek) reject empty
+                    # arrays outright with HTTP 400 (#58755).
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()
@@ -3146,6 +3153,17 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # --- Re-run repair after dedup: dedup can empty a previously payload-
+    # bearing assistant message (when every tool_call was a duplicate).
+    # repair_empty_non_final_messages runs before dedup so the placeholder
+    # check ("_msg_has_payload") sees tool_calls present and skips the
+    # message; dedup then strips tool_calls and leaves an empty-content
+    # turn that strict non-empty-content providers (Anthropic native,
+    # litellm/Bedrock) reject. Re-run repair now so the post-dedup shape
+    # also gets the "[response interrupted]" placeholder injected.
+    messages = repair_empty_non_final_messages(messages)
+
     return messages
 
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3968,6 +3968,18 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # --- Re-run repair after dedup: dedup can empty a previously payload-
+    # bearing assistant message (when every tool_call was a duplicate).
+    # repair_empty_non_final_messages runs before dedup so the placeholder
+    # check ("_msg_has_payload") sees tool_calls present and skips the
+    # message; dedup then strips tool_calls (dropping the key entirely,
+    # per #64335) and leaves an empty-content turn that strict
+    # non-empty-content providers (Anthropic native, litellm/Bedrock)
+    # reject. Re-run repair now so the post-dedup shape also gets the
+    # "[response interrupted]" placeholder injected.
+    messages = repair_empty_non_final_messages(messages)
+
     return messages
 
 

--- a/tests/agent/test_sanitize_empty_tool_calls.py
+++ b/tests/agent/test_sanitize_empty_tool_calls.py
@@ -1,0 +1,177 @@
+"""Regression tests for sanitize_api_messages() empty-content / empty-tool_calls
+healing (PR #74906 + follow-up).
+
+When dedup of duplicate tool_call_ids empties an assistant message's
+``tool_calls`` list, the previous pre-call sanitizer pass
+(``repair_empty_non_final_messages``, runs first in
+``sanitize_api_messages``) saw the message as "has payload" and skipped
+it. Dedup then stripped ``tool_calls``, leaving
+``{role: assistant, content: null}`` on the wire — which strict
+non-empty-content providers (Anthropic native, litellm/Bedrock) reject
+with HTTP 400.
+
+The dedup fix from PR #74906 drops ``tool_calls`` instead of writing an
+empty array. The follow-up re-runs ``repair_empty_non_final_messages``
+after dedup so the placeholder ("[response interrupted]" on upstream
+main) is also injected into the post-dedup shape.
+"""
+
+from agent.agent_runtime_helpers import sanitize_api_messages
+
+
+def _user(content="hi"):
+    return {"role": "user", "content": content}
+
+
+def _assistant_tool_call(call_id, *, content=""):
+    return {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [{
+            "id": call_id, "type": "function",
+            "function": {"name": "read_file", "arguments": "{}"},
+        }],
+    }
+
+
+def _tool_result(call_id, content="ok"):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def _has_visible_content(msg):
+    content = msg.get("content")
+    return isinstance(content, str) and content.strip()
+
+
+class TestSanitizeEmptyToolCalls:
+    def test_cross_message_all_duplicates_healed(self):
+        """Reviewer's exact scenario from the PR #74906 review.
+
+        Transcript shape:
+            [user,
+             assistant(content:'', tool_calls:[call_X]),  # live
+             tool(call_X),
+             assistant(content:None, tool_calls:[call_X]),  # non-final, all dups
+             user]
+
+        After sanitize:
+            - idx 1 keeps its tool_calls (the live call_X).
+            - idx 3 has no tool_calls (dedup stripped them) AND must have
+              visible content (post-dedup repair re-runs and substitutes the
+              placeholder).
+        """
+        messages = [
+            _user("first question"),
+            _assistant_tool_call("call_X"),
+            _tool_result("call_X"),
+            _assistant_tool_call("call_X", content=None),  # dup + content-null
+            _user("follow up"),
+        ]
+        out = sanitize_api_messages(messages)
+        healed = out[3]
+        assert "tool_calls" not in healed, (
+            "dedup should strip empty tool_calls; instead got: "
+            f"{healed.get('tool_calls')!r}"
+        )
+        assert _has_visible_content(healed), (
+            "post-dedup repair should inject visible content; instead "
+            f"got: {healed.get('content')!r}"
+        )
+        # Earlier call's assistant turn keeps its tool_calls intact.
+        assert out[1]["tool_calls"][0]["id"] == "call_X"
+        # Both user turns preserved verbatim.
+        assert out[0]["role"] == "user" and out[0]["content"] == "first question"
+        assert out[4]["role"] == "user" and out[4]["content"] == "follow up"
+
+    def test_in_message_all_duplicates_healed(self):
+        """Single non-final assistant turn whose two tool_calls share one id.
+
+        After dedup, the message loses both tool_calls (the id was
+        already-seen from a prior turn). Post-dedup repair then injects
+        the placeholder content.
+        """
+        messages = [
+            _user("q"),
+            _assistant_tool_call("call_A"),
+            _tool_result("call_A"),
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_A", "type": "function",
+                     "function": {"name": "read_file", "arguments": "{}"}},
+                    {"id": "call_A", "type": "function",
+                     "function": {"name": "read_file", "arguments": "{}"}},
+                ],
+            },
+            _user("next"),
+        ]
+        out = sanitize_api_messages(messages)
+        healed = out[3]
+        assert "tool_calls" not in healed, (
+            "all tool_calls in the message were duplicates of an earlier "
+            f"turn; expected stripped: {healed.get('tool_calls')!r}"
+        )
+        assert _has_visible_content(healed), (
+            "post-dedup repair should inject visible content; instead "
+            f"got: {healed.get('content')!r}"
+        )
+
+    def test_pre_existing_empty_tool_calls_with_null_content(self):
+        """Dict already has ``tool_calls: []`` and ``content: null``.
+
+        Pass 0 (drop empty tool_calls) and repair_empty_non_final_messages
+        together produce a non-empty placeholder turn.
+        """
+        messages = [
+            _user("q"),
+            {"role": "assistant", "content": None, "tool_calls": []},
+            _user("next"),
+        ]
+        out = sanitize_api_messages(messages)
+        healed = out[1]
+        assert "tool_calls" not in healed
+        assert _has_visible_content(healed)
+
+    def test_assistant_with_visible_content_unchanged(self):
+        """Guard rail: messages with legitimate visible content are
+        not touched by either pass.
+        """
+        messages = [
+            _user("q"),
+            {"role": "assistant", "content": "好的，我来处理。"},
+            _user("next"),
+        ]
+        out = sanitize_api_messages(messages)
+        assert out[1]["content"] == "好的，我来处理。"
+        assert "tool_calls" not in out[1]
+
+    def test_user_messages_with_content_unchanged(self):
+        """Guard rail: user messages with content are never substituted.
+        repair_empty_non_final_messages runs over (assistant, user) but
+        only inserts a placeholder when the message has no payload; a
+        user turn with text must stay untouched.
+        """
+        messages = [
+            _user("middle"),
+            {"role": "assistant", "content": "hi"},
+            _user("end"),
+        ]
+        out = sanitize_api_messages(messages)
+        assert out[0]["content"] == "middle"
+        assert out[2]["content"] == "end"
+
+    def test_final_message_exempt_from_repair(self):
+        """The final assistant message is exempt from
+        repair_empty_non_final_messages by design (an empty final
+        assistant turn is legal). Our fix must preserve that.
+        """
+        messages = [
+            _user("q"),
+            {"role": "assistant", "content": None, "tool_calls": []},
+        ]
+        out = sanitize_api_messages(messages)
+        assert out[-1]["role"] == "assistant"
+        # No placeholder injected — final empty assistant is allowed.
+        assert out[-1].get("content") is None
+        assert "tool_calls" not in out[-1]

--- a/tests/agent/test_sanitize_empty_tool_calls.py
+++ b/tests/agent/test_sanitize_empty_tool_calls.py
@@ -1,0 +1,195 @@
+"""Regression tests for sanitize_api_messages() post-dedup content repair.
+
+When dedup of duplicate tool_call_ids empties an assistant message's
+``tool_calls`` list, the pre-call sanitizer pass
+(``repair_empty_non_final_messages``, runs first in
+``sanitize_api_messages``) saw the message as "has payload" and skipped
+it. Dedup then dropped the ``tool_calls`` key (upstream #64335), leaving
+``{role: assistant, content: null}`` on the wire — which strict
+non-empty-content providers (Anthropic native, litellm/Bedrock) reject
+with HTTP 400.
+
+The key-drop behavior itself is already covered upstream by
+``test_sanitize_dedup_drops_tool_calls_key_when_all_removed``
+(tests/run_agent/test_message_sequence_repair.py, #64335). These tests
+cover the follow-up: re-running ``repair_empty_non_final_messages``
+after dedup so the placeholder ("[response interrupted]") is also
+injected into the post-dedup shape.
+
+Note on trigger scope after #93251: the dedup pass re-arms a
+tool_call_id once its tool result arrives, so a later assistant turn
+reusing an ANSWERED id is no longer deduplicated (that is a legal
+id-reuse provider, #70724), and the pairing pass stubs any outstanding
+call the transcript never answers. The emptying path below therefore
+fires when a resume replay re-emits the assistant call BEFORE the
+delayed tool result arrives — the same trigger as upstream's
+``test_sanitize_dedup_drops_tool_calls_key_when_all_removed``.
+"""
+
+from agent.agent_runtime_helpers import sanitize_api_messages
+
+
+def _user(content="hi"):
+    return {"role": "user", "content": content}
+
+
+def _assistant_tool_call(call_id, *, content=""):
+    return {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [{
+            "id": call_id, "type": "function",
+            "function": {"name": "read_file", "arguments": "{}"},
+        }],
+    }
+
+
+def _tool_result(call_id, content="ok"):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def _has_visible_content(msg):
+    content = msg.get("content")
+    return isinstance(content, str) and content.strip()
+
+
+class TestSanitizeEmptyToolCalls:
+    def test_cross_message_all_duplicates_healed(self):
+        """Reviewer's scenario from the PR #74906 review, adapted to the
+        post-#93251 dedup semantics.
+
+        Transcript shape (a crash/resume replay re-emits the assistant
+        call BEFORE the tool result arrives, so call_X is still
+        outstanding — the same trigger as upstream
+        test_sanitize_dedup_drops_tool_calls_key_when_all_removed):
+            [user,
+             assistant(content:'', tool_calls:[call_X]),  # live, outstanding
+             assistant(content:None, tool_calls:[call_X]),  # non-final, all dups
+             tool(call_X),   # the delayed result, answers the live call
+             user]
+
+        After sanitize:
+            - the live assistant keeps its tool_calls; the tool result
+              survives (no stub needed — the real result follows).
+            - the replayed assistant has no tool_calls (dedup stripped
+              them) AND must have visible content (post-dedup repair
+              re-runs and substitutes the placeholder).
+        """
+        messages = [
+            _user("first question"),
+            _assistant_tool_call("call_X"),
+            _assistant_tool_call("call_X", content=None),  # dup + content-null
+            _tool_result("call_X"),
+            _user("follow up"),
+        ]
+        out = sanitize_api_messages(messages)
+        healed = out[2]
+        assert "tool_calls" not in healed, (
+            "dedup should strip empty tool_calls; instead got: "
+            f"{healed.get('tool_calls')!r}"
+        )
+        assert _has_visible_content(healed), (
+            "post-dedup repair should inject visible content; instead "
+            f"got: {healed.get('content')!r}"
+        )
+        # Earlier call's assistant turn keeps its tool_calls intact, and
+        # the real tool result survives to answer it.
+        assert out[1]["tool_calls"][0]["id"] == "call_X"
+        assert out[3]["role"] == "tool" and out[3]["tool_call_id"] == "call_X"
+        # Both user turns preserved verbatim.
+        assert out[0]["role"] == "user" and out[0]["content"] == "first question"
+        assert out[4]["role"] == "user" and out[4]["content"] == "follow up"
+
+    def test_in_message_all_duplicates_healed(self):
+        """Single non-final assistant turn whose two tool_calls share one
+        id that an earlier, still-outstanding assistant turn already
+        registered (the delayed result follows the replay).
+
+        After dedup, the message loses both tool_calls. Post-dedup repair
+        then injects the placeholder content.
+        """
+        messages = [
+            _user("q"),
+            _assistant_tool_call("call_A"),  # registers call_A, outstanding
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_A", "type": "function",
+                     "function": {"name": "read_file", "arguments": "{}"}},
+                    {"id": "call_A", "type": "function",
+                     "function": {"name": "read_file", "arguments": "{}"}},
+                ],
+            },
+            _tool_result("call_A"),
+            _user("next"),
+        ]
+        out = sanitize_api_messages(messages)
+        healed = out[2]
+        assert "tool_calls" not in healed, (
+            "all tool_calls in the message were duplicates of an earlier "
+            f"turn; expected stripped: {healed.get('tool_calls')!r}"
+        )
+        assert _has_visible_content(healed), (
+            "post-dedup repair should inject visible content; instead "
+            f"got: {healed.get('content')!r}"
+        )
+
+    def test_pre_existing_empty_tool_calls_with_null_content(self):
+        """Dict already has ``tool_calls: []`` and ``content: null``.
+
+        Pass 0 (drop empty tool_calls) and repair_empty_non_final_messages
+        together produce a non-empty placeholder turn.
+        """
+        messages = [
+            _user("q"),
+            {"role": "assistant", "content": None, "tool_calls": []},
+            _user("next"),
+        ]
+        out = sanitize_api_messages(messages)
+        healed = out[1]
+        assert "tool_calls" not in healed
+        assert _has_visible_content(healed)
+
+    def test_assistant_with_visible_content_unchanged(self):
+        """Guard rail: messages with legitimate visible content are
+        not touched by either pass.
+        """
+        messages = [
+            _user("q"),
+            {"role": "assistant", "content": "好的，我来处理。"},
+            _user("next"),
+        ]
+        out = sanitize_api_messages(messages)
+        assert out[1]["content"] == "好的，我来处理。"
+        assert "tool_calls" not in out[1]
+
+    def test_user_messages_with_content_unchanged(self):
+        """Guard rail: user messages with content are never substituted.
+        repair_empty_non_final_messages runs over (assistant, user) but
+        only inserts a placeholder when the message has no payload; a
+        user turn with text must stay untouched.
+        """
+        messages = [
+            _user("middle"),
+            {"role": "assistant", "content": "hi"},
+            _user("end"),
+        ]
+        out = sanitize_api_messages(messages)
+        assert out[0]["content"] == "middle"
+        assert out[2]["content"] == "end"
+
+    def test_final_message_exempt_from_repair(self):
+        """The final assistant message is exempt from
+        repair_empty_non_final_messages by design (an empty final
+        assistant turn is legal). Our fix must preserve that.
+        """
+        messages = [
+            _user("q"),
+            {"role": "assistant", "content": None, "tool_calls": []},
+        ]
+        out = sanitize_api_messages(messages)
+        assert out[-1]["role"] == "assistant"
+        # No placeholder injected — final empty assistant is allowed.
+        assert out[-1].get("content") is None
+        assert "tool_calls" not in out[-1]


### PR DESCRIPTION
## Summary

Rebased and **rescoped**: the original PR had two fixes; the first one —
dropping the `tool_calls` key when dedup empties the list — landed
upstream independently in #64335 (`b2453b5894`). This PR now contains
**only the second fix**, rebased onto current `main` (`64a6f42cb3`):

> Re-run `repair_empty_non_final_messages` at the END of
> `sanitize_api_messages`, after the duplicate-`tool_call_id` dedup pass.

## The bug

`repair_empty_non_final_messages` runs at the START of
`sanitize_api_messages` (`agent/agent_runtime_helpers.py:3717`). Its
`_msg_has_payload()` check treats a non-empty `tool_calls` list as
payload, so an assistant turn carrying tool calls is skipped. When the
dedup pass later empties that turn — every call was a duplicate of a
still-outstanding earlier id — it drops the key (#64335) and leaves

    {"role": "assistant", "content": null}

on the wire. Strict non-empty-content providers (Anthropic native,
litellm/Bedrock) reject that with HTTP 400 *"all messages must have
non-empty content except for the optional final assistant message"*.
The session then 400s on every subsequent request until the poisoned
turn scrolls out.

## Trigger scope after #93251

The dedup pass is variant-aware and **re-arms** an id once its tool
result arrives, so a reuse AFTER the result is a legal id-reuse
(llama.cpp / Kimi K3 constant ids, #70724) and is no longer deduped;
the pairing pass also stubs calls the transcript never answers. The
emptying path still fires for a **resume replay that re-emits the
assistant call BEFORE the delayed tool result arrives** — the exact
trigger of upstream's own
`test_sanitize_dedup_drops_tool_calls_key_when_all_removed`. That test
covers the DeepSeek-side key drop with `content: "retrying"`; when the
replayed turn instead carries `content: null`, the leak above is the
result.

## Fix

One call at the end of `sanitize_api_messages` (after the
`removed_dupes` bookkeeping):

```python
messages = repair_empty_non_final_messages(messages)
return messages
```

Stored history is never mutated — the helper shallow-copies per message
before rewriting, so byte-stable prompt caching on local-inference
servers (vLLM/Ollama) is preserved. The final-message exemption is
preserved (`test_final_message_exempt_from_repair`).

## Tests

`tests/agent/test_sanitize_empty_tool_calls.py` — six cases:

  - cross-message all-duplicates (reviewer scenario, adapted to the
    post-#93251 semantics: the replay precedes the delayed result)
  - in-message all-duplicates within one assistant turn
  - pre-existing `tool_calls: []` + `content: null` (Pass 0 + repair)
  - guard rail: visible-content messages untouched
  - guard rail: user messages with content not substituted
  - guard rail: final assistant message exempt from repair

Verified both directions: on upstream/main HEAD the two healing cases
fail; with this branch all six pass, and the eight dedup/repair tests in
`tests/run_agent/test_message_sequence_repair.py` stay green.

## Refs

- #64335 — upstream key-drop fix (`b2453b5894`), covers fix (a) of the
  original PR; this PR is the follow-up
- #58327 — the dedup pass itself
- #58755 — empty-`tool_calls`-array HTTP 400 (Pass 0)
- #93251 — variant-aware dedup + re-arm semantics
- #70724 — legal cross-turn id reuse