### PR TITLE
fix(desktop): avoid ASAR paths in getAppIconPath for BrowserWindow icon

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5207,7 +5207,20 @@ function registerPowerResumeListeners() {
 }
 
 function getAppIconPath() {
-  return APP_ICON_PATHS.find(fileExists)
+  // nativeImage.createFromPath (used by BrowserWindow's `icon` option) does
+  // not support ASAR paths — fileExists sees inside the ASAR archive, but
+  // the image loader cannot read from it. Prefer the unpacked mirror when
+  // the candidate lives inside app.asar; skip it when there is no mirror.
+  for (const candidate of APP_ICON_PATHS) {
+    if (!fileExists(candidate)) continue
+    if (candidate.includes('app.asar') && !candidate.includes('app.asar.unpacked')) {
+      const unpacked = unpackedPathFor(candidate)
+      if (fileExists(unpacked)) return unpacked
+      continue
+    }
+    return candidate
+  }
+  return undefined
 }
 
 function sendOpenUpdatesRequested() {


### PR DESCRIPTION
## Problem
Desktop app crashes on launch with:
```
Error: Failed to load image from path ".../app.asar/public/apple-touch-icon.png"
at createWindow (electron/main.cjs:13520:17)
```

## Root Cause
`getAppIconPath()` used `APP_ICON_PATHS.find(fileExists)` — `fileExists` uses `fs.statSync` which Electron transparently extends to see inside ASAR archives, so it returned the first in-ASAR path. But `BrowserWindow`'s `icon` option calls `nativeImage.createFromPath()` which does **not** support ASAR paths.

## Fix
Changed `getAppIconPath()` to iterate candidates instead of using `.find()`. When a candidate lives inside `app.asar` (but not `app.asar.unpacked`), it computes the unpacked mirror via `unpackedPathFor()` and returns that if it exists. ASAR-only paths with no unpacked equivalent are skipped.