### PR TITLE
fix(desktop): skip hermes-setup binary on macOS/Linux updater path

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2601,9 +2601,17 @@ let quitConfirmedWithActiveWork = false
 // the desktop never touches its own bits while running. Returns null when the
 // updater isn't staged (e.g. a dev/source run that never went through the
 // installer); callers degrade gracefully.
+//
+// hermes-setup is the Tauri Windows-installer self-copy path. On macOS/Linux
+// the drag-and-drop .app uses applyUpdatesPosixInApp instead, so a stale
+// hermes-setup (e.g. from an old macOS install, #74836) must not route the
+// update into the Windows-style handoff.
 function resolveUpdaterBinary() {
-  const name = IS_WINDOWS ? 'hermes-setup.exe' : 'hermes-setup'
-  const candidate = path.join(HERMES_HOME, name)
+  if (!IS_WINDOWS) {
+    return null
+  }
+
+  const candidate = path.join(HERMES_HOME, 'hermes-setup.exe')
 
   return fileExists(candidate) ? candidate : null
 }


### PR DESCRIPTION
Closes #74836

resolveUpdaterBinary() returned a path on macOS if hermes-setup existed in HERMES_HOME, routing macOS into the Windows-style quit→hand-off→rebuild update dance. A stale hermes-setup (e.g. from 2026-06-08, predating the applyUpdatesPosixInApp path) permanently breaks the in-app Update button.

The Tauri hermes-setup binary is a Windows-specific mechanism; macOS and Linux use applyUpdatesPosixInApp instead. Always return null on non-Windows so the native drag-and-drop updater is used on those platforms.