### PR TITLE
fix(gateway): guard _status_adapter null-deref in approval notify

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4811,7 +4811,10 @@ class TurnRunner:
             # is active.  The approval message send auto-clears the Slack
             # status; pausing prevents _keep_typing from re-setting it.
             # Typing resumes in _handle_approve_command/_handle_deny_command.
-            ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
+            try:
+                ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
+            except Exception:
+                pass
 
             cmd = approval_data.get("command", "")
             desc = approval_data.get("description", "dangerous command")


### PR DESCRIPTION
Closes #74787

ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id) was dereferenced without a null check inside _approval_notify_sync. When a multiplex_profiles deployment serves a profile that owns no adapter for the receiving platform, _status_adapter is None and this crashes with:

  'NoneType' object has no attribute 'pause_typing_for_chat'

The same call is already correctly guarded ~150 lines earlier (line 4663). Add the identical try/except here so the approval prompt is delivered even when the profile has no adapter for the platform.