### PR TITLE
feat(kanban): allow frozen implementation heads into review

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2250,7 +2250,7 @@ def _cmd_submit_review(args: argparse.Namespace) -> int:
         return 2
     try:
         with kb.connect_closing() as conn:
-            kb.submit_task_for_review(
+            kb.submit_frozen_head_for_review(
                 conn,
                 args.task_id,
                 head_sha=args.head_sha,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -601,6 +601,18 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                             help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
                                  '"tests_run": 12}\'). Stored on the closing run.')
 
+    p_review = sub.add_parser(
+        "submit-review",
+        help="Submit a completed immutable exact implementation head for review",
+    )
+    p_review.add_argument("task_id")
+    p_review.add_argument("--head-sha", required=True, help="Exact 40-character implementation HEAD")
+    p_review.add_argument("--worktree", required=True, dest="worktree_path",
+                          help="Worktree containing the frozen implementation HEAD")
+    p_review.add_argument("--evidence", required=True,
+                          help="JSON evidence object; must repeat exact head/worktree and completion facts")
+    p_review.add_argument("--actor", default=None, help="Audit actor (default: active profile/user)")
+
     p_edit = sub.add_parser(
         "edit",
         help="Edit recovery fields on an already-completed task",
@@ -1062,6 +1074,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "attachments": _cmd_attachments,
             "attach-rm": _cmd_attach_rm,
             "complete": _cmd_complete,
+            "submit-review": _cmd_submit_review,
             "edit":     _cmd_edit,
             "block":    _cmd_block,
             "schedule": _cmd_schedule,
@@ -2225,6 +2238,31 @@ def _cmd_complete(args: argparse.Namespace) -> int:
             else:
                 print(f"Completed {tid}")
     return 0 if not failed else 1
+
+
+def _cmd_submit_review(args: argparse.Namespace) -> int:
+    try:
+        evidence = json.loads(args.evidence)
+        if not isinstance(evidence, dict):
+            raise ValueError("must be a JSON object")
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"kanban: --evidence: {exc}", file=sys.stderr)
+        return 2
+    try:
+        with kb.connect_closing() as conn:
+            kb.submit_task_for_review(
+                conn,
+                args.task_id,
+                head_sha=args.head_sha,
+                worktree_path=args.worktree_path,
+                evidence=evidence,
+                actor=args.actor or _profile_author(),
+            )
+    except kb.FrozenHeadReviewError as exc:
+        print(f"cannot submit {args.task_id} for review: {exc}", file=sys.stderr)
+        return 1
+    print(f"Submitted {args.task_id} for review (frozen head {args.head_sha})")
+    return 0
 
 
 def _cmd_edit(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4693,6 +4693,92 @@ class FrozenHeadReviewError(ValueError):
 def submit_task_for_review(
     conn: sqlite3.Connection,
     task_id: str,
+    reviewer: str,
+) -> Optional[Task]:
+    """Atomically hand a running or legacy review-required block to a reviewer."""
+    reviewer = _canonical_assignee(reviewer)
+    if not reviewer:
+        raise ValueError("reviewer is required")
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, claim_lock, current_run_id, assignee FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if not row:
+            return None
+        if row["status"] not in {"running", "blocked"}:
+            raise RuntimeError(
+                f"cannot submit {task_id} for review from status {row['status']!r}"
+            )
+        if row["status"] == "blocked":
+            legacy = conn.execute(
+                "SELECT payload FROM task_events WHERE task_id=? AND kind='blocked' "
+                "ORDER BY id DESC LIMIT 1", (task_id,),
+            ).fetchone()
+            try:
+                blocked_payload = json.loads(legacy["payload"] or "{}") if legacy else {}
+            except (TypeError, ValueError):
+                blocked_payload = {}
+            if not str(blocked_payload.get("reason") or "").startswith("review-required:"):
+                raise RuntimeError(
+                    f"cannot submit {task_id} for review from unrelated blocked state"
+                )
+        if row["status"] == "running" and row["claim_lock"] is None:
+            raise RuntimeError(f"cannot submit {task_id}: running task is unclaimed")
+        old_run_id = _end_run(conn, task_id, outcome="review_submitted", status="review")
+        conn.execute(
+            "UPDATE tasks SET status='review', assignee=?, claim_lock=NULL, "
+            "claim_expires=NULL, worker_pid=NULL, block_kind=NULL, block_recurrences=0 "
+            "WHERE id=?", (reviewer, task_id),
+        )
+        _append_event(
+            conn, task_id, "submitted_for_review",
+            {"reviewer": reviewer, "previous_assignee": row["assignee"]},
+            run_id=old_run_id,
+        )
+        return get_task(conn, task_id)
+
+
+def _worktree_writer_pids(worktree: Path) -> list[int]:
+    """Return non-control processes with a writable relationship to worktree."""
+    target = worktree.resolve()
+    control_pid = os.getpid()
+    found: set[int] = set()
+    try:
+        pids = [int(p.name) for p in Path("/proc").iterdir() if p.name.isdigit()]
+    except OSError:
+        return []
+    for pid in pids:
+        if pid == control_pid:
+            continue
+        base = Path("/proc") / str(pid)
+        try:
+            cwd = (base / "cwd").resolve()
+            if cwd == target or target in cwd.parents:
+                found.add(pid)
+            for fd in (base / "fd").iterdir():
+                resolved = fd.resolve()
+                if resolved != target and target not in resolved.parents:
+                    continue
+                fdinfo = (base / "fdinfo" / fd.name).read_text()
+                flags_line = next((line for line in fdinfo.splitlines() if line.startswith("flags:")), "")
+                if flags_line and int(flags_line.split()[1], 8) & (os.O_WRONLY | os.O_RDWR):
+                    found.add(pid)
+            for line in (base / "maps").read_text().splitlines():
+                fields = line.split()
+                if len(fields) < 6 or "w" not in fields[1]:
+                    continue
+                mapped = Path(" ".join(fields[5:])).resolve()
+                if mapped == target or target in mapped.parents:
+                    found.add(pid)
+        except (OSError, ValueError, RuntimeError):
+            continue
+    return sorted(found)
+
+
+def submit_frozen_head_for_review(
+    conn: sqlite3.Connection,
+    task_id: str,
     *,
     head_sha: str,
     worktree_path: str,
@@ -4708,7 +4794,14 @@ def submit_task_for_review(
     the transition.  Every rejection is recorded, but no task state is
     changed on rejection.
     """
+    row = conn.execute(
+        "SELECT status, workspace_path, current_run_id, claim_lock, worker_pid "
+        "FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+
     def reject(reason: str) -> NoReturn:
+        if row is None:
+            raise FrozenHeadReviewError(reason)
         with write_txn(conn):
             _append_event(conn, task_id, "review_submission_rejected", {
                 "route": "frozen_head",
@@ -4728,8 +4821,15 @@ def submit_task_for_review(
     evidence = dict(evidence)
     if evidence.get("head_sha") != head_sha:
         reject("evidence head_sha must exactly match head_sha")
-    if evidence.get("worktree_path") != worktree_path:
-        reject("evidence worktree_path must exactly match worktree_path")
+    if evidence.get("worktree_path"):
+        try:
+            evidence_path = Path(evidence["worktree_path"]).expanduser().resolve(strict=True)
+        except (OSError, TypeError):
+            reject("evidence worktree_path is not a resolvable directory")
+    else:
+        evidence_path = None
+    if evidence_path is not None and evidence_path != Path(worktree_path).expanduser().resolve():
+        reject("evidence worktree_path is unrelated to the submitted worktree")
     if evidence.get("clean") is not True:
         reject("evidence clean must be true")
     if evidence.get("implementation_complete") is not True:
@@ -4754,16 +4854,26 @@ def submit_task_for_review(
     if dirty:
         reject("worktree is dirty")
 
-    row = conn.execute(
-        "SELECT status, current_run_id, claim_lock, claim_expires, worker_pid "
-        "FROM tasks WHERE id = ?", (task_id,),
-    ).fetchone()
     if row is None:
         reject(f"task {task_id} not found")
-    if row["status"] != "done":
-        reject(f"task must be done; current status is {row['status']!r}")
+    if row["status"] in {"triage", "running", "archived"}:
+        reject(f"frozen head cannot be submitted from status {row['status']!r}")
+    if row["status"] not in {"scheduled", "ready", "todo", "done"}:
+        reject(f"frozen head cannot be submitted from status {row['status']!r}")
+    if not row["workspace_path"]:
+        reject("task has no canonical workspace")
+    try:
+        canonical_path = Path(row["workspace_path"]).expanduser().resolve(strict=True)
+        submitted_path = path.resolve(strict=True)
+    except OSError as exc:
+        reject(f"unable to resolve canonical workspace: {exc}")
+    if submitted_path != canonical_path:
+        reject("worktree is unrelated to the task canonical workspace")
     if row["current_run_id"] is not None or row["claim_lock"] is not None or row["worker_pid"] is not None:
         reject("task has a live claim or current writer")
+    writer_pids = _worktree_writer_pids(submitted_path)
+    if writer_pids:
+        reject(f"worktree has active OS writers: {writer_pids}")
 
     run = conn.execute(
         "SELECT id, metadata FROM task_runs WHERE task_id = ? "
@@ -4780,11 +4890,14 @@ def submit_task_for_review(
         reject("completed implementation evidence metadata is malformed")
     if not run_metadata.get("changed_files") or "tests_run" not in run_metadata:
         reject("completed implementation evidence requires changed_files and tests_run")
+    if run_metadata.get("head_sha") and str(run_metadata["head_sha"]).lower() != head_sha.lower():
+        reject("completed implementation evidence head_sha does not match exact head_sha")
 
     try:
         with write_txn(conn):
             cur = conn.execute(
-                "UPDATE tasks SET status = 'review' WHERE id = ? AND status = 'done' "
+                "UPDATE tasks SET status = 'review' WHERE id = ? "
+                "AND status IN ('scheduled', 'ready', 'todo', 'done') "
                 "AND current_run_id IS NULL AND claim_lock IS NULL AND worker_pid IS NULL",
                 (task_id,),
             )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -87,7 +87,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, NoReturn, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -4684,6 +4684,123 @@ class HallucinatedCardsError(ValueError):
 
 class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
+
+
+class FrozenHeadReviewError(ValueError):
+    """Raised when an exact frozen implementation head cannot enter review."""
+
+
+def submit_task_for_review(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    head_sha: str,
+    worktree_path: str,
+    evidence: Optional[dict[str, Any]],
+    actor: str = "operator",
+) -> bool:
+    """Move a completed, immutable implementation head into ``review``.
+
+    This is deliberately separate from the worker ``running`` and legacy
+    ``blocked`` review handoffs.  The caller must provide a duplicated,
+    explicit evidence record; the database then verifies the record against
+    the live git worktree and the completed implementation run before making
+    the transition.  Every rejection is recorded, but no task state is
+    changed on rejection.
+    """
+    def reject(reason: str) -> NoReturn:
+        with write_txn(conn):
+            _append_event(conn, task_id, "review_submission_rejected", {
+                "route": "frozen_head",
+                "reason": reason,
+                "head_sha": head_sha,
+                "worktree_path": worktree_path,
+                "actor": actor,
+            })
+        raise FrozenHeadReviewError(reason)
+
+    if not isinstance(head_sha, str) or not re.fullmatch(r"[0-9a-fA-F]{40}", head_sha):
+        reject("head_sha must be a full 40-character commit id")
+    if not isinstance(worktree_path, str) or not worktree_path.strip():
+        reject("worktree_path is required")
+    if not isinstance(evidence, dict):
+        reject("explicit evidence object is required")
+    evidence = dict(evidence)
+    if evidence.get("head_sha") != head_sha:
+        reject("evidence head_sha must exactly match head_sha")
+    if evidence.get("worktree_path") != worktree_path:
+        reject("evidence worktree_path must exactly match worktree_path")
+    if evidence.get("clean") is not True:
+        reject("evidence clean must be true")
+    if evidence.get("implementation_complete") is not True:
+        reject("evidence implementation_complete must be true")
+
+    path = Path(worktree_path).expanduser()
+    if not path.is_dir():
+        reject("worktree_path is not a directory")
+    try:
+        verified_head = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--verify", "HEAD"],
+            check=True, capture_output=True, text=True, timeout=10,
+        ).stdout.strip()
+        dirty = subprocess.run(
+            ["git", "-C", str(path), "status", "--porcelain=v1", "--untracked-files=all"],
+            check=True, capture_output=True, text=True, timeout=10,
+        ).stdout
+    except (OSError, subprocess.SubprocessError) as exc:
+        reject(f"unable to verify git worktree: {exc}")
+    if verified_head.lower() != head_sha.lower():
+        reject("worktree HEAD does not match exact head_sha")
+    if dirty:
+        reject("worktree is dirty")
+
+    row = conn.execute(
+        "SELECT status, current_run_id, claim_lock, claim_expires, worker_pid "
+        "FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    if row is None:
+        reject(f"task {task_id} not found")
+    if row["status"] != "done":
+        reject(f"task must be done; current status is {row['status']!r}")
+    if row["current_run_id"] is not None or row["claim_lock"] is not None or row["worker_pid"] is not None:
+        reject("task has a live claim or current writer")
+
+    run = conn.execute(
+        "SELECT id, metadata FROM task_runs WHERE task_id = ? "
+        "AND outcome = 'completed' AND ended_at IS NOT NULL "
+        "ORDER BY ended_at DESC, id DESC LIMIT 1", (task_id,),
+    ).fetchone()
+    if run is None:
+        reject("completed implementation evidence is absent")
+    try:
+        run_metadata = json.loads(run["metadata"] or "null")
+    except (TypeError, json.JSONDecodeError):
+        run_metadata = None
+    if not isinstance(run_metadata, dict):
+        reject("completed implementation evidence metadata is malformed")
+    if not run_metadata.get("changed_files") or "tests_run" not in run_metadata:
+        reject("completed implementation evidence requires changed_files and tests_run")
+
+    try:
+        with write_txn(conn):
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'review' WHERE id = ? AND status = 'done' "
+                "AND current_run_id IS NULL AND claim_lock IS NULL AND worker_pid IS NULL",
+                (task_id,),
+            )
+            if cur.rowcount != 1:
+                raise FrozenHeadReviewError("task state changed while submitting frozen head")
+            _append_event(conn, task_id, "review_submitted_frozen_head", {
+                "route": "frozen_head",
+                "actor": actor,
+                "head_sha": head_sha,
+                "worktree_path": str(path.resolve()),
+                "evidence": evidence,
+                "implementation_run_id": int(run["id"]),
+            }, run_id=int(run["id"]))
+    except FrozenHeadReviewError as exc:
+        reject(str(exc))
+    return True
 
 
 def complete_task(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4739,19 +4739,31 @@ def submit_task_for_review(
         return get_task(conn, task_id)
 
 
-def _worktree_writer_pids(worktree: Path) -> list[int]:
-    """Return non-control processes with a writable relationship to worktree."""
-    target = worktree.resolve()
-    control_pid = os.getpid()
-    found: set[int] = set()
+@dataclass(frozen=True)
+class _WorktreeWriterScan:
+    writers: tuple[int, ...]
+    complete: bool
+    unsupported: bool
+    errors: tuple[str, ...]
+
+
+def _worktree_writer_pids(worktree: Path) -> _WorktreeWriterScan:
+    """Inspect process writers; never report an empty result without proof."""
+    if sys.platform != "linux":
+        return _WorktreeWriterScan((), False, True, (f"unsupported platform: {sys.platform}",))
+    proc = Path("/proc")
     try:
-        pids = [int(p.name) for p in Path("/proc").iterdir() if p.name.isdigit()]
-    except OSError:
-        return []
-    for pid in pids:
-        if pid == control_pid:
+        entries = list(proc.iterdir())
+    except OSError as exc:
+        return _WorktreeWriterScan((), False, False, (f"cannot enumerate /proc: {exc}",))
+    target = worktree.resolve()
+    found: set[int] = set()
+    errors: list[str] = []
+    for entry in entries:
+        if not entry.name.isdigit() or int(entry.name) == os.getpid():
             continue
-        base = Path("/proc") / str(pid)
+        pid = int(entry.name)
+        base = proc / str(pid)
         try:
             cwd = (base / "cwd").resolve()
             if cwd == target or target in cwd.parents:
@@ -4760,20 +4772,48 @@ def _worktree_writer_pids(worktree: Path) -> list[int]:
                 resolved = fd.resolve()
                 if resolved != target and target not in resolved.parents:
                     continue
-                fdinfo = (base / "fdinfo" / fd.name).read_text()
-                flags_line = next((line for line in fdinfo.splitlines() if line.startswith("flags:")), "")
+                flags_line = next(
+                    (line for line in (base / "fdinfo" / fd.name).read_text().splitlines()
+                     if line.startswith("flags:")), ""
+                )
                 if flags_line and int(flags_line.split()[1], 8) & (os.O_WRONLY | os.O_RDWR):
                     found.add(pid)
             for line in (base / "maps").read_text().splitlines():
                 fields = line.split()
-                if len(fields) < 6 or "w" not in fields[1]:
+                if len(fields) < 6 or "w" not in fields[1] or "s" not in fields[1]:
                     continue
-                mapped = Path(" ".join(fields[5:])).resolve()
+                mapped_name = fields[5]
+                if not mapped_name.startswith("/"):
+                    continue
+                mapped = Path(mapped_name.removesuffix(" (deleted)")).resolve()
                 if mapped == target or target in mapped.parents:
                     found.add(pid)
-        except (OSError, ValueError, RuntimeError):
+        except FileNotFoundError:
             continue
-    return sorted(found)
+        except PermissionError as exc:
+            # hidepid/procfs policy can hide unrelated processes. Keep the
+            # diagnostic in the scan result; the proc mount remains usable.
+            errors.append(f"pid {pid}: {exc}")
+        except (OSError, ValueError, RuntimeError) as exc:
+            errors.append(f"pid {pid}: {exc}")
+    # Per-process permission diagnostics are retained, but the proc mount is
+    # still usable; only inability to enumerate or inspect the target process
+    # itself makes the scan incomplete.
+    return _WorktreeWriterScan(tuple(sorted(found)), True, False, tuple(errors))
+
+
+def _git_worktree_snapshot(path: Path) -> tuple[str, str, str]:
+    """Return exact HEAD, committed tree id, and complete porcelain status."""
+    def run(*args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(path), *args], check=True, capture_output=True,
+            text=True, timeout=10,
+        ).stdout
+    return (
+        run("rev-parse", "--verify", "HEAD").strip(),
+        run("rev-parse", "--verify", "HEAD^{tree}").strip(),
+        run("status", "--porcelain=v1", "--untracked-files=all"),
+    )
 
 
 def submit_frozen_head_for_review(
@@ -4821,6 +4861,9 @@ def submit_frozen_head_for_review(
     evidence = dict(evidence)
     if evidence.get("head_sha") != head_sha:
         reject("evidence head_sha must exactly match head_sha")
+    submitted_tree_sha = evidence.get("tree_sha", evidence.get("tree_hash"))
+    if submitted_tree_sha is not None and not isinstance(submitted_tree_sha, str):
+        reject("evidence tree_sha must be a string when supplied")
     if evidence.get("worktree_path"):
         try:
             evidence_path = Path(evidence["worktree_path"]).expanduser().resolve(strict=True)
@@ -4839,18 +4882,13 @@ def submit_frozen_head_for_review(
     if not path.is_dir():
         reject("worktree_path is not a directory")
     try:
-        verified_head = subprocess.run(
-            ["git", "-C", str(path), "rev-parse", "--verify", "HEAD"],
-            check=True, capture_output=True, text=True, timeout=10,
-        ).stdout.strip()
-        dirty = subprocess.run(
-            ["git", "-C", str(path), "status", "--porcelain=v1", "--untracked-files=all"],
-            check=True, capture_output=True, text=True, timeout=10,
-        ).stdout
+        verified_head, tree_sha, dirty = _git_worktree_snapshot(path)
     except (OSError, subprocess.SubprocessError) as exc:
         reject(f"unable to verify git worktree: {exc}")
     if verified_head.lower() != head_sha.lower():
         reject("worktree HEAD does not match exact head_sha")
+    if submitted_tree_sha is not None and tree_sha.lower() != submitted_tree_sha.lower():
+        reject("worktree tree_sha does not match exact tree_sha")
     if dirty:
         reject("worktree is dirty")
 
@@ -4871,9 +4909,18 @@ def submit_frozen_head_for_review(
         reject("worktree is unrelated to the task canonical workspace")
     if row["current_run_id"] is not None or row["claim_lock"] is not None or row["worker_pid"] is not None:
         reject("task has a live claim or current writer")
-    writer_pids = _worktree_writer_pids(submitted_path)
-    if writer_pids:
-        reject(f"worktree has active OS writers: {writer_pids}")
+    first_snapshot = (verified_head.lower(), tree_sha.lower(), dirty)
+    writer_scan = _worktree_writer_pids(submitted_path)
+    if not writer_scan.complete or writer_scan.unsupported:
+        reject(f"OS writer inspection incomplete or unsupported: {list(writer_scan.errors)}")
+    if writer_scan.writers:
+        reject(f"worktree has active OS writers: {list(writer_scan.writers)}")
+    try:
+        second_head, second_tree_sha, second_dirty = _git_worktree_snapshot(submitted_path)
+    except (OSError, subprocess.SubprocessError) as exc:
+        reject(f"unable to re-verify git worktree: {exc}")
+    if (second_head.lower(), second_tree_sha.lower(), second_dirty) != first_snapshot:
+        reject("git HEAD, tree, or full clean status changed during verification")
 
     run = conn.execute(
         "SELECT id, metadata FROM task_runs WHERE task_id = ? "
@@ -4892,14 +4939,25 @@ def submit_frozen_head_for_review(
         reject("completed implementation evidence requires changed_files and tests_run")
     if run_metadata.get("head_sha") and str(run_metadata["head_sha"]).lower() != head_sha.lower():
         reject("completed implementation evidence head_sha does not match exact head_sha")
+    run_tree_sha = run_metadata.get("tree_sha", run_metadata.get("tree_hash"))
+    if run_tree_sha is not None and str(run_tree_sha).lower() != second_tree_sha.lower():
+        reject("completed implementation evidence tree_sha does not match exact tree_sha")
+
+    original_identity = {
+        "status": row["status"], "workspace_path": row["workspace_path"],
+        "current_run_id": row["current_run_id"], "claim_lock": row["claim_lock"],
+        "worker_pid": row["worker_pid"],
+    }
 
     try:
         with write_txn(conn):
             cur = conn.execute(
-                "UPDATE tasks SET status = 'review' WHERE id = ? "
-                "AND status IN ('scheduled', 'ready', 'todo', 'done') "
-                "AND current_run_id IS NULL AND claim_lock IS NULL AND worker_pid IS NULL",
-                (task_id,),
+                "UPDATE tasks SET status = 'review' WHERE id = ? AND status = ? "
+                "AND workspace_path IS ? AND current_run_id IS ? "
+                "AND claim_lock IS ? AND worker_pid IS ?",
+                (task_id, original_identity["status"], original_identity["workspace_path"],
+                 original_identity["current_run_id"], original_identity["claim_lock"],
+                 original_identity["worker_pid"]),
             )
             if cur.rowcount != 1:
                 raise FrozenHeadReviewError("task state changed while submitting frozen head")
@@ -4907,6 +4965,9 @@ def submit_frozen_head_for_review(
                 "route": "frozen_head",
                 "actor": actor,
                 "head_sha": head_sha,
+                "tree_sha": second_tree_sha,
+                "stable_head_sha": second_head,
+                "stable_tree_sha": second_tree_sha,
                 "worktree_path": str(path.resolve()),
                 "evidence": evidence,
                 "implementation_run_id": int(run["id"]),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4748,14 +4748,21 @@ class _WorktreeWriterScan:
 
 
 def _worktree_writer_pids(worktree: Path) -> _WorktreeWriterScan:
-    """Inspect process writers; never report an empty result without proof."""
+    """Inspect process writers; never report an empty result without proof.
+
+    This is intentionally fail-closed. A process that cannot be completely
+    inspected is not silently treated as irrelevant: its cwd, descriptors,
+    and mappings are all part of the proof that the worktree is quiescent.
+    """
     if sys.platform != "linux":
         return _WorktreeWriterScan((), False, True, (f"unsupported platform: {sys.platform}",))
     proc = Path("/proc")
     try:
         entries = list(proc.iterdir())
-    except OSError as exc:
-        return _WorktreeWriterScan((), False, False, (f"cannot enumerate /proc: {exc}",))
+    except FileNotFoundError:
+        return _WorktreeWriterScan((), False, False, ("proc unavailable",))
+    except OSError:
+        return _WorktreeWriterScan((), False, False, ("proc enumeration denied",))
     target = worktree.resolve()
     found: set[int] = set()
     errors: list[str] = []
@@ -4773,14 +4780,21 @@ def _worktree_writer_pids(worktree: Path) -> _WorktreeWriterScan:
                 if resolved != target and target not in resolved.parents:
                     continue
                 flags_line = next(
-                    (line for line in (base / "fdinfo" / fd.name).read_text().splitlines()
-                     if line.startswith("flags:")), ""
+                    (line for line in (base / "fdinfo" / fd.name).read_text(
+                        encoding="utf-8", errors="replace"
+                    ).splitlines() if line.startswith("flags:")), ""
                 )
-                if flags_line and int(flags_line.split()[1], 8) & (os.O_WRONLY | os.O_RDWR):
+                if not flags_line:
+                    raise OSError("fd access mode unavailable")
+                if int(flags_line.split()[1], 8) & (os.O_WRONLY | os.O_RDWR):
                     found.add(pid)
-            for line in (base / "maps").read_text().splitlines():
+            for line in (base / "maps").read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines():
                 fields = line.split()
-                if len(fields) < 6 or "w" not in fields[1] or "s" not in fields[1]:
+                # Shared writable mappings can modify the worktree. Private
+                # writable mappings are copy-on-write and are not writers.
+                if len(fields) < 6 or fields[1] != "rw-s":
                     continue
                 mapped_name = fields[5]
                 if not mapped_name.startswith("/"):
@@ -4790,16 +4804,13 @@ def _worktree_writer_pids(worktree: Path) -> _WorktreeWriterScan:
                     found.add(pid)
         except FileNotFoundError:
             continue
-        except PermissionError as exc:
-            # hidepid/procfs policy can hide unrelated processes. Keep the
-            # diagnostic in the scan result; the proc mount remains usable.
-            errors.append(f"pid {pid}: {exc}")
-        except (OSError, ValueError, RuntimeError) as exc:
-            errors.append(f"pid {pid}: {exc}")
-    # Per-process permission diagnostics are retained, but the proc mount is
-    # still usable; only inability to enumerate or inspect the target process
-    # itself makes the scan incomplete.
-    return _WorktreeWriterScan(tuple(sorted(found)), True, False, tuple(errors))
+        except PermissionError:
+            errors.append(f"pid {pid}: permission denied")
+        except (OSError, ValueError, RuntimeError):
+            errors.append(f"pid {pid}: inspection failed")
+    return _WorktreeWriterScan(
+        tuple(sorted(found)), not errors, False, tuple(errors[:32])
+    )
 
 
 def _git_worktree_snapshot(path: Path) -> tuple[str, str, str]:
@@ -4861,9 +4872,11 @@ def submit_frozen_head_for_review(
     evidence = dict(evidence)
     if evidence.get("head_sha") != head_sha:
         reject("evidence head_sha must exactly match head_sha")
-    submitted_tree_sha = evidence.get("tree_sha", evidence.get("tree_hash"))
-    if submitted_tree_sha is not None and not isinstance(submitted_tree_sha, str):
-        reject("evidence tree_sha must be a string when supplied")
+    submitted_tree_sha = evidence.get("tree_sha")
+    if not isinstance(submitted_tree_sha, str) or not re.fullmatch(
+        r"[0-9a-fA-F]{40}", submitted_tree_sha
+    ):
+        reject("evidence tree_sha must be a full 40-character tree id")
     if evidence.get("worktree_path"):
         try:
             evidence_path = Path(evidence["worktree_path"]).expanduser().resolve(strict=True)
@@ -4887,16 +4900,27 @@ def submit_frozen_head_for_review(
         reject(f"unable to verify git worktree: {exc}")
     if verified_head.lower() != head_sha.lower():
         reject("worktree HEAD does not match exact head_sha")
-    if submitted_tree_sha is not None and tree_sha.lower() != submitted_tree_sha.lower():
+    if tree_sha.lower() != submitted_tree_sha.lower():
         reject("worktree tree_sha does not match exact tree_sha")
     if dirty:
         reject("worktree is dirty")
 
     if row is None:
         reject(f"task {task_id} not found")
-    if row["status"] in {"triage", "running", "archived"}:
+    if row["status"] in {"triage", "running", "review", "archived"}:
         reject(f"frozen head cannot be submitted from status {row['status']!r}")
-    if row["status"] not in {"scheduled", "ready", "todo", "done"}:
+    if row["status"] == "blocked":
+        legacy = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id=? AND kind='blocked' "
+            "ORDER BY id DESC LIMIT 1", (task_id,),
+        ).fetchone()
+        try:
+            blocked_payload = json.loads(legacy["payload"] or "{}") if legacy else {}
+        except (TypeError, ValueError):
+            blocked_payload = {}
+        if not str(blocked_payload.get("reason") or "").startswith("review-required:"):
+            reject("frozen head cannot be submitted from unrelated blocked state")
+    if row["status"] not in {"scheduled", "ready", "todo", "blocked", "done"}:
         reject(f"frozen head cannot be submitted from status {row['status']!r}")
     if not row["workspace_path"]:
         reject("task has no canonical workspace")
@@ -4911,10 +4935,10 @@ def submit_frozen_head_for_review(
         reject("task has a live claim or current writer")
     first_snapshot = (verified_head.lower(), tree_sha.lower(), dirty)
     writer_scan = _worktree_writer_pids(submitted_path)
-    if not writer_scan.complete or writer_scan.unsupported:
-        reject(f"OS writer inspection incomplete or unsupported: {list(writer_scan.errors)}")
     if writer_scan.writers:
         reject(f"worktree has active OS writers: {list(writer_scan.writers)}")
+    if not writer_scan.complete or writer_scan.unsupported:
+        reject(f"OS writer inspection incomplete or unsupported: {list(writer_scan.errors)}")
     try:
         second_head, second_tree_sha, second_dirty = _git_worktree_snapshot(submitted_path)
     except (OSError, subprocess.SubprocessError) as exc:
@@ -4939,8 +4963,12 @@ def submit_frozen_head_for_review(
         reject("completed implementation evidence requires changed_files and tests_run")
     if run_metadata.get("head_sha") and str(run_metadata["head_sha"]).lower() != head_sha.lower():
         reject("completed implementation evidence head_sha does not match exact head_sha")
-    run_tree_sha = run_metadata.get("tree_sha", run_metadata.get("tree_hash"))
-    if run_tree_sha is not None and str(run_tree_sha).lower() != second_tree_sha.lower():
+    run_tree_sha = run_metadata.get("tree_sha")
+    if not isinstance(run_tree_sha, str) or not re.fullmatch(
+        r"[0-9a-fA-F]{40}", run_tree_sha
+    ):
+        reject("completed implementation evidence requires a full 40-character tree_sha")
+    if run_tree_sha.lower() != second_tree_sha.lower():
         reject("completed implementation evidence tree_sha does not match exact tree_sha")
 
     original_identity = {
@@ -4951,6 +4979,15 @@ def submit_frozen_head_for_review(
 
     try:
         with write_txn(conn):
+            latest_run = conn.execute(
+                "SELECT id, metadata FROM task_runs WHERE task_id = ? "
+                "AND outcome = 'completed' AND ended_at IS NOT NULL "
+                "ORDER BY ended_at DESC, id DESC LIMIT 1", (task_id,),
+            ).fetchone()
+            if latest_run is None or int(latest_run["id"]) != int(run["id"]):
+                raise FrozenHeadReviewError("completed implementation evidence changed while submitting")
+            if latest_run["metadata"] != run["metadata"]:
+                raise FrozenHeadReviewError("completed implementation metadata changed while submitting")
             cur = conn.execute(
                 "UPDATE tasks SET status = 'review' WHERE id = ? AND status = ? "
                 "AND workspace_path IS ? AND current_run_id IS ? "

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -81,6 +81,8 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+import stat
+import tempfile
 import threading
 import logging
 import time
@@ -90,6 +92,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, NoReturn, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
+from hermes_constants import get_hermes_home
 from toolsets import get_toolset_names
 
 _log = logging.getLogger(__name__)
@@ -4076,6 +4079,48 @@ def recompute_ready(
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
+def _frozen_head_identity(
+    conn: sqlite3.Connection, task_id: str,
+) -> Optional[tuple[str, Path, bool]]:
+    """Return verified ``(head, root, manifest_present)`` for frozen review."""
+    event = _latest_frozen_event(conn, task_id)
+    row = conn.execute(
+        "SELECT workspace_path FROM tasks WHERE id=?", (task_id,)
+    ).fetchone()
+    if not event or not row or not row["workspace_path"]:
+        return None
+    try:
+        root = Path(row["workspace_path"]).resolve(strict=True)
+        info = root.stat()
+        identity = (int(info.st_dev), int(info.st_ino))
+        if str(root) != str(row["workspace_path"]) or identity != event["root_identity"]:
+            return event["head_sha"], root, False
+        locks_fd, manifests_fd = _open_admission_dirs()
+        os.close(locks_fd)
+        try:
+            name = _manifest_name(task_id, event["head_sha"], identity)
+            manifest = _read_manifest(manifests_fd, name)
+            _validate_manifest(manifest, task_id, event["head_sha"], root)
+            return event["head_sha"], root, True
+        except FileNotFoundError:
+            return event["head_sha"], root, False
+        finally:
+            os.close(manifests_fd)
+    except (OSError, RuntimeError, FrozenHeadReviewError):
+        return event["head_sha"], Path(row["workspace_path"]), False
+
+
+def _reject_frozen_claim(conn: sqlite3.Connection, task_id: str) -> None:
+    with write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='blocked', claim_lock=NULL, claim_expires=NULL, "
+            "worker_pid=NULL WHERE id=? AND status='ready'", (task_id,),
+        )
+        _append_event(conn, task_id, "frozen_head_claim_rejected", {
+            "code": "FROZEN_HEAD_REVIEW_CLAIM_REJECTED",
+            "message": "FROZEN_HEAD_REVIEW_CLAIM_REJECTED",
+        })
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4091,6 +4136,21 @@ def claim_task(
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
+    try:
+        reconcile_frozen_workspace(conn, task_id)
+    except (FrozenHeadReviewError, OSError, RuntimeError):
+        _reject_frozen_claim(conn, task_id)
+        return None
+    frozen = _frozen_head_identity(conn, task_id)
+    if frozen is not None:
+        frozen_head, _, manifest_present = frozen
+        try:
+            if not manifest_present:
+                raise FrozenHeadReviewError("claim")
+            _thaw_frozen_manifest(conn, task_id, head_sha=frozen_head)
+        except (FrozenHeadReviewError, OSError, RuntimeError):
+            _reject_frozen_claim(conn, task_id)
+            return None
     with write_txn(conn):
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
@@ -4220,6 +4280,14 @@ def claim_review_task(
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
+    frozen = _frozen_head_identity(conn, task_id)
+    if frozen is not None and not frozen[2]:
+        with write_txn(conn):
+            _append_event(conn, task_id, "frozen_head_claim_rejected", {
+                "code": "FROZEN_HEAD_REVIEW_CLAIM_REJECTED",
+                "message": "FROZEN_HEAD_REVIEW_CLAIM_REJECTED",
+            })
+        return None
     with write_txn(conn):
         cur = conn.execute(
             """
@@ -4689,6 +4757,71 @@ class ArtifactPreservationError(RuntimeError):
 class FrozenHeadReviewError(ValueError):
     """Raised when an exact frozen implementation head cannot enter review."""
 
+    MESSAGES = {
+        "rejected": "FROZEN_HEAD_REVIEW_REJECTED",
+        "not_found": "FROZEN_HEAD_REVIEW_NOT_FOUND: not found",
+        "cleanup": "FROZEN_HEAD_REVIEW_CLEANUP_INCOMPLETE",
+        "claim": "FROZEN_HEAD_REVIEW_CLAIM_REJECTED",
+    }
+    HINT_MESSAGES = (
+        ("full 40-character", "FROZEN_HEAD_REVIEW_REJECTED: full 40-character identity required"),
+        ("evidence head_sha", "FROZEN_HEAD_REVIEW_REJECTED: evidence head_sha mismatch"),
+        ("clean must be true", "FROZEN_HEAD_REVIEW_REJECTED: evidence clean must be true"),
+        ("implementation_complete", "FROZEN_HEAD_REVIEW_REJECTED: implementation_complete required"),
+        ("metadata is malformed", "FROZEN_HEAD_REVIEW_REJECTED: metadata is malformed"),
+        ("requires changed_files and tests_run", "FROZEN_HEAD_REVIEW_REJECTED: metadata is malformed"),
+        ("completed implementation evidence is absent", "FROZEN_HEAD_REVIEW_REJECTED: completed implementation evidence is absent"),
+        ("completed implementation evidence", "FROZEN_HEAD_REVIEW_REJECTED: completed implementation evidence invalid"),
+        ("changed during verification", "FROZEN_HEAD_REVIEW_REJECTED: changed during verification"),
+        ("unrelated blocked state", "FROZEN_HEAD_REVIEW_REJECTED: unrelated blocked state"),
+        ("active OS writers", "FROZEN_HEAD_REVIEW_REJECTED: active OS writers"),
+        ("live claim", "FROZEN_HEAD_REVIEW_REJECTED: live claim"),
+        ("dirty", "FROZEN_HEAD_REVIEW_REJECTED: dirty worktree"),
+        ("status 'review'", "FROZEN_HEAD_REVIEW_REJECTED: status 'review'"),
+        ("cannot be submitted", "FROZEN_HEAD_REVIEW_REJECTED: cannot be submitted"),
+        ("not found", "FROZEN_HEAD_REVIEW_NOT_FOUND: not found"),
+    )
+
+    def __init__(self, message: str = "rejected", *, code: str | None = None):
+        reverse = {value: name for name, value in self.MESSAGES.items()}
+        key = code if code in self.MESSAGES else reverse.get(message, message if message in self.MESSAGES else "rejected")
+        text = self.MESSAGES[key]
+        if key == "rejected" and isinstance(message, str):
+            for hint, fixed in self.HINT_MESSAGES:
+                if hint in message:
+                    text = fixed
+                    break
+        self.code = key
+        super().__init__(text)
+
+
+def _validate_bounded_json_shape(value: Any) -> None:
+    """Bound direct-Python evidence before any serializer traverses it."""
+    pending: list[tuple[Any, int]] = [(value, 0)]
+    nodes = 0
+    while pending:
+        current, depth = pending.pop()
+        nodes += 1
+        if depth > 32 or nodes > 4096:
+            raise FrozenHeadReviewError("rejected")
+        if isinstance(current, str):
+            if len(current) > 8192 or "\x00" in current:
+                raise FrozenHeadReviewError("rejected")
+        elif isinstance(current, list):
+            if len(current) > 256:
+                raise FrozenHeadReviewError("rejected")
+            pending.extend((item, depth + 1) for item in current)
+        elif isinstance(current, dict):
+            if len(current) > 128:
+                raise FrozenHeadReviewError("rejected")
+            for key, item in current.items():
+                if not isinstance(key, str) or len(key) > 256 or "\x00" in key:
+                    raise FrozenHeadReviewError("rejected")
+                pending.append((item, depth + 1))
+        elif current is not None and not isinstance(current, (bool, int, float)):
+            raise FrozenHeadReviewError("rejected")
+
+
 
 def submit_task_for_review(
     conn: sqlite3.Connection,
@@ -4747,12 +4880,713 @@ class _WorktreeWriterScan:
     errors: tuple[str, ...]
 
 
+@dataclass
+class _WorkspaceAdmissionLease:
+    """Cross-process lease; commit makes the read-only state durable."""
+
+    handle: Any
+    parent_fd: int
+    manifest_path: Path
+    original_modes: tuple[tuple[str, int], ...]
+    root_identity: tuple[int, int] = (0, 0)
+    parent_identity: tuple[int, int] = (0, 0)
+    committed: bool = False
+    root_fd: int = -1
+    manifest_dir_fd: int = -1
+    manifest_name: str = ""
+    prepared: bool = False
+
+    def commit(self) -> None:
+        if self.prepared and self.manifest_dir_fd >= 0 and self.manifest_name:
+            manifest = _read_manifest(self.manifest_dir_fd, self.manifest_name)
+            manifest["phase"] = "frozen_committed"
+            _atomic_manifest_write(self.manifest_dir_fd, self.manifest_name, manifest)
+        self.committed = True
+
+
+_ADMISSION_MAX_MANIFEST_BYTES = 8 * 1024 * 1024
+_ADMISSION_MAX_ENTRIES = 100_000
+_ADMISSION_MANIFEST_VERSION = 2
+_ADMISSION_DIR_MODE = 0o700
+_ADMISSION_FILE_MODE = 0o600
+
+
+def _verify_private_dir(fd: int, *, private: bool = True) -> None:
+    info = os.fstat(fd)
+    if (
+        not stat.S_ISDIR(info.st_mode)
+        or (private and (info.st_uid != os.getuid() or info.st_mode & 0o077))
+    ):
+        raise FrozenHeadReviewError("rejected")
+
+
+def _open_nofollow_dir(
+    path: Path, *, create: bool = False, private_final: bool = True,
+) -> int:
+    """Open a directory through dirfds, refusing symlink ancestors."""
+    path = Path(path).expanduser()
+    if not path.is_absolute() or "\x00" in str(path):
+        raise FrozenHeadReviewError("rejected")
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    current = os.open(os.sep, flags)
+    try:
+        for component in path.parts[1:]:
+            if component in {"", ".", ".."}:
+                raise FrozenHeadReviewError("rejected")
+            try:
+                child = os.open(component, flags, dir_fd=current)
+            except FileNotFoundError:
+                if not create:
+                    raise FrozenHeadReviewError("rejected")
+                os.mkdir(component, _ADMISSION_DIR_MODE, dir_fd=current)
+                child = os.open(component, flags, dir_fd=current)
+            _verify_private_dir(
+                child,
+                private=(private_final and component == path.parts[-1]),
+            )
+            os.close(current)
+            current = child
+        return current
+    except Exception:
+        os.close(current)
+        raise
+
+
+def _open_admission_dirs() -> tuple[int, int]:
+    home_fd = _open_nofollow_dir(
+        get_hermes_home(), create=False, private_final=False,
+    )
+    try:
+        # Do not chmod the profile home (or any ancestor).  Only the dedicated
+        # admission directories below it are security boundaries.
+        kanban_fd = _open_child_dir(home_fd, "kanban")
+        admission_fd = _open_child_dir(kanban_fd, "admission")
+        locks_fd = _open_child_dir(admission_fd, "locks")
+        manifests_fd = _open_child_dir(admission_fd, "manifests")
+        os.close(home_fd)
+        os.close(kanban_fd)
+        os.close(admission_fd)
+        return locks_fd, manifests_fd
+    except Exception:
+        os.close(home_fd)
+        raise
+
+
+def _open_child_dir(parent_fd: int, name: str) -> int:
+    if not name or "/" in name or "\\x00" in name:
+        raise FrozenHeadReviewError("rejected")
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(name, flags, dir_fd=parent_fd)
+    except FileNotFoundError:
+        os.mkdir(name, _ADMISSION_DIR_MODE, dir_fd=parent_fd)
+        fd = os.open(name, flags, dir_fd=parent_fd)
+    _verify_private_dir(fd)
+    return fd
+
+
+def _admission_state_root() -> Path:
+    """Return the profile-aware admission directory after secure setup."""
+    locks_fd, manifests_fd = _open_admission_dirs()
+    os.close(locks_fd)
+    os.close(manifests_fd)
+    return get_hermes_home() / "kanban" / "admission"
+
+
+def _secure_admission_file(path: Path, *, mode: int = _ADMISSION_FILE_MODE) -> int:
+    parent_fd = _open_nofollow_dir(path.parent, create=False)
+    try:
+        name = path.name
+        if not name or name in {".", ".."} or "/" in name or "\x00" in name:
+            raise FrozenHeadReviewError("rejected")
+        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(name, flags, mode, dir_fd=parent_fd)
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid():
+            os.close(fd)
+            raise FrozenHeadReviewError("rejected")
+        os.fchmod(fd, mode)
+        return fd
+    finally:
+        os.close(parent_fd)
+
+
+def _manifest_name(task_id: str, head_sha: str, identity: tuple[int, int]) -> str:
+    return hashlib.sha256(
+        f"{task_id}:{head_sha.lower()}:{identity[0]}:{identity[1]}".encode()
+    ).hexdigest() + ".json"
+
+
+def _fsync_dir(fd: int) -> None:
+    os.fsync(fd)
+
+
+def _full_write(fd: int, data: bytes) -> None:
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise OSError("short admission write")
+        view = view[written:]
+
+
+def _atomic_manifest_write(dir_fd: int, name: str, payload: dict) -> None:
+    raw = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+    if len(raw) > _ADMISSION_MAX_MANIFEST_BYTES:
+        raise FrozenHeadReviewError("rejected")
+    tmp_name = f".{name}.{secrets.token_hex(12)}.tmp"
+    fd = os.open(
+        tmp_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        _ADMISSION_FILE_MODE,
+        dir_fd=dir_fd,
+    )
+    try:
+        _full_write(fd, raw)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    try:
+        os.replace(tmp_name, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+        _fsync_dir(dir_fd)
+    except Exception:
+        try:
+            os.unlink(tmp_name, dir_fd=dir_fd)
+        except OSError:
+            pass
+        raise
+
+
+def _read_manifest(dir_fd: int, name: str) -> dict:
+    fd = os.open(name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=dir_fd)
+    try:
+        info = os.fstat(fd)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_uid != os.getuid()
+            or info.st_mode & 0o077
+            or info.st_size > _ADMISSION_MAX_MANIFEST_BYTES
+        ):
+            raise FrozenHeadReviewError("rejected")
+        data = bytearray()
+        while len(data) <= _ADMISSION_MAX_MANIFEST_BYTES:
+            chunk = os.read(fd, min(65536, _ADMISSION_MAX_MANIFEST_BYTES + 1 - len(data)))
+            if not chunk:
+                break
+            data.extend(chunk)
+        if len(data) > _ADMISSION_MAX_MANIFEST_BYTES:
+            raise FrozenHeadReviewError("rejected")
+        value = json.loads(bytes(data))
+        if not isinstance(value, dict):
+            raise FrozenHeadReviewError("rejected")
+        return value
+    finally:
+        os.close(fd)
+
+
+def _valid_relative_entry(value: Any) -> bool:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        return False
+    p = Path(value)
+    return not p.is_absolute() and ".." not in p.parts and value not in {".", ""}
+
+
+def _open_relative_parent(root_fd: int, relative: str) -> tuple[int, str]:
+    parts = relative.split("/")
+    if not parts or any(part in {"", ".", ".."} or "\x00" in part for part in parts):
+        raise FrozenHeadReviewError("rejected")
+    current = os.dup(root_fd)
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        for component in parts[:-1]:
+            child = os.open(component, flags, dir_fd=current)
+            info = os.fstat(child)
+            if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid():
+                os.close(child)
+                raise FrozenHeadReviewError("rejected")
+            os.close(current)
+            current = child
+        return current, parts[-1]
+    except Exception:
+        os.close(current)
+        raise
+
+
+def _entry_stat(root_fd: int, relative: str) -> os.stat_result:
+    parent_fd, name = _open_relative_parent(root_fd, relative)
+    try:
+        return os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    finally:
+        os.close(parent_fd)
+
+
+def _chmod_relative(root_fd: int, relative: str, mode: int) -> None:
+    parent_fd, name = _open_relative_parent(root_fd, relative)
+    try:
+        os.chmod(name, mode, dir_fd=parent_fd, follow_symlinks=False)
+    finally:
+        os.close(parent_fd)
+
+
+def _tree_modes(root_fd: int) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    stack: list[tuple[int, str]] = [(os.dup(root_fd), "")]
+    try:
+        while stack:
+            directory_fd, prefix = stack.pop()
+            try:
+                with os.scandir(directory_fd) as scan:
+                    children = list(scan)
+                for entry in children:
+                    relative = f"{prefix}/{entry.name}" if prefix else entry.name
+                    if not _valid_relative_entry(relative):
+                        raise FrozenHeadReviewError("rejected")
+                    info = entry.stat(follow_symlinks=False)
+                    is_link = stat.S_ISLNK(info.st_mode)
+                    item = {
+                        "path": relative,
+                        "mode": int(info.st_mode & 0o7777),
+                        "frozen_mode": int(info.st_mode & 0o7777 & ~0o222),
+                        "kind": "symlink" if is_link else "dir" if stat.S_ISDIR(info.st_mode) else "file",
+                        "dev": int(info.st_dev),
+                        "ino": int(info.st_ino),
+                    }
+                    entries.append(item)
+                    if len(entries) > _ADMISSION_MAX_ENTRIES:
+                        raise FrozenHeadReviewError("rejected")
+                    if stat.S_ISDIR(info.st_mode) and not is_link:
+                        child_fd = os.open(
+                            entry.name,
+                            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+                            dir_fd=directory_fd,
+                        )
+                        stack.append((child_fd, relative))
+            finally:
+                os.close(directory_fd)
+        return entries
+    except Exception:
+        for fd, _ in stack:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        raise
+
+
+def _workspace_admission_lock_path(worktree: Path) -> Path:
+    """Return a profile-scoped lock keyed by canonical root identity."""
+    root = worktree.resolve(strict=True)
+    st = root.stat()
+    digest = hashlib.sha256(f"{st.st_dev}:{st.st_ino}:{root}".encode()).hexdigest()
+    return _admission_state_root() / "locks" / f"{digest}.lock"
+
+
+@contextlib.contextmanager
+def _workspace_admission_lock(
+    worktree: Path, *, exclusive: bool, task_id: str | None = None,
+    head_sha: str | None = None,
+):
+    """Hold a dirfd-backed lease and persist a relative-mode freeze."""
+    if sys.platform != "linux" and exclusive:
+        raise FrozenHeadReviewError("rejected")
+    import fcntl
+
+    root = Path(worktree).resolve(strict=True)
+    parent_fd = _open_nofollow_dir(root.parent, create=False, private_final=False)
+    root_fd = -1
+    lock_fd = -1
+    locks_fd = manifests_fd = -1
+    handle = None
+    protected: list[tuple[str, int]] = []
+    manifest_name = ""
+    manifest_path = Path()
+    try:
+        root_name = root.name
+        root_fd = os.open(
+            root_name,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent_fd,
+        )
+        root_info = os.fstat(root_fd)
+        parent_info = os.fstat(parent_fd)
+        root_identity = (int(root_info.st_dev), int(root_info.st_ino))
+        parent_identity = (int(parent_info.st_dev), int(parent_info.st_ino))
+        path_stat = os.stat(root_name, dir_fd=parent_fd, follow_symlinks=False)
+        if (path_stat.st_dev, path_stat.st_ino) != root_identity:
+            raise FrozenHeadReviewError("rejected")
+        locks_fd, manifests_fd = _open_admission_dirs()
+        lock_name = hashlib.sha256(
+            f"{root_identity[0]}:{root_identity[1]}:{root}".encode()
+        ).hexdigest() + ".lock"
+        lock_fd = os.open(
+            lock_name,
+            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+            _ADMISSION_FILE_MODE,
+            dir_fd=locks_fd,
+        )
+        lock_info = os.fstat(lock_fd)
+        if not stat.S_ISREG(lock_info.st_mode) or lock_info.st_uid != os.getuid():
+            raise FrozenHeadReviewError("rejected")
+        os.fchmod(lock_fd, _ADMISSION_FILE_MODE)
+        handle = os.fdopen(lock_fd, "a+b", buffering=0)
+        lock_fd = -1
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        if task_id and head_sha:
+            manifest_name = _manifest_name(task_id, head_sha, root_identity)
+            manifest_path = _admission_state_root() / "manifests" / manifest_name
+        lease = _WorkspaceAdmissionLease(
+            handle, parent_fd, manifest_path, (), root_identity, parent_identity,
+            root_fd=root_fd, manifest_dir_fd=manifests_fd, manifest_name=manifest_name,
+        )
+        if exclusive and task_id and head_sha:
+            entries = _tree_modes(root_fd)
+            root_mode = int(root_info.st_mode & 0o7777)
+            protected = [("", root_mode)] + [
+                (item["path"], int(item["mode"])) for item in entries
+            ]
+            lease.original_modes = tuple(protected)
+            # This is the first durable state transition.  It must precede
+            # every chmod so a kill on any subsequent line is recoverable.
+            manifest = {
+                    "version": _ADMISSION_MANIFEST_VERSION,
+                    "phase": "freeze_prepared",
+                    "task_id": task_id,
+                    "head_sha": head_sha.lower(),
+                    "root_path_hash": hashlib.sha256(str(root).encode()).hexdigest(),
+                    "root_identity": [root_identity[0], root_identity[1]],
+                    "parent_identity": [parent_identity[0], parent_identity[1]],
+                    "root_mode": root_mode,
+                    "root_frozen_mode": root_mode & ~0o222,
+                    "entries": entries,
+                }
+            _atomic_manifest_write(manifests_fd, manifest_name, manifest)
+            lease.prepared = True
+            try:
+                if root_mode & 0o222:
+                    os.fchmod(root_fd, root_mode & ~0o222)
+                for item in entries:
+                    if item["kind"] != "symlink" and item["mode"] & 0o222:
+                        _chmod_relative(root_fd, item["path"], item["frozen_mode"])
+            except Exception:
+                for relative, mode in reversed(protected):
+                    try:
+                        if relative:
+                            _chmod_relative(root_fd, relative, mode)
+                        else:
+                            os.fchmod(root_fd, mode)
+                    except OSError:
+                        pass
+                raise
+        yield lease
+    finally:
+        restore_error = False
+        lease = locals().get("lease")
+        if lease is not None and not lease.committed:
+            for relative, original_mode in reversed(protected):
+                try:
+                    if relative:
+                        _chmod_relative(root_fd, relative, original_mode)
+                    else:
+                        os.fchmod(root_fd, original_mode)
+                except OSError:
+                    restore_error = True
+            if lease.prepared and manifests_fd >= 0:
+                try:
+                    os.unlink(manifest_name, dir_fd=manifests_fd)
+                    _fsync_dir(manifests_fd)
+                except OSError:
+                    restore_error = True
+        if handle is not None:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            finally:
+                handle.close()
+        for fd in (root_fd, parent_fd, locks_fd, manifests_fd):
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+        if restore_error:
+            raise FrozenHeadReviewError("cleanup")
+
+
+def _latest_frozen_event(conn: sqlite3.Connection, task_id: str) -> Optional[dict]:
+    row = conn.execute(
+        "SELECT id, payload FROM task_events WHERE task_id=? "
+        "AND kind='review_submitted_frozen_head' ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if not row:
+        return None
+    terminal = conn.execute(
+        "SELECT 1 FROM task_events WHERE task_id=? AND id>? "
+        "AND kind IN ('frozen_head_thawed', 'frozen_head_cleanup_complete') LIMIT 1",
+        (task_id, row["id"]),
+    ).fetchone()
+    if terminal:
+        return None
+    try:
+        payload = json.loads(row["payload"] or "null")
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("code") != "FROZEN_HEAD_REVIEW_SUBMITTED":
+        return None
+    head = payload.get("head_sha")
+    root_identity = payload.get("root_identity")
+    parent_identity = payload.get("parent_identity")
+    if not isinstance(head, str) or not re.fullmatch(r"[0-9a-fA-F]{40}", head):
+        return None
+    if any(
+        not isinstance(identity, list) or len(identity) != 2
+        or any(not isinstance(value, int) or value < 0 for value in identity)
+        for identity in (root_identity, parent_identity)
+    ):
+        return None
+    return {
+        "head_sha": head.lower(),
+        "root_identity": (int(root_identity[0]), int(root_identity[1])),
+        "parent_identity": (int(parent_identity[0]), int(parent_identity[1])),
+    }
+
+
+def _validate_manifest(manifest: dict, task_id: str, head_sha: str, root: Path) -> None:
+    if (
+        manifest.get("version") != _ADMISSION_MANIFEST_VERSION
+        or manifest.get("task_id") != task_id
+        or manifest.get("head_sha") != head_sha.lower()
+        or manifest.get("phase") not in {"freeze_prepared", "frozen_committed", "thaw_prepared"}
+        or manifest.get("root_path_hash") != hashlib.sha256(str(root).encode()).hexdigest()
+    ):
+        raise FrozenHeadReviewError("cleanup")
+    for key in ("root_identity", "parent_identity"):
+        value = manifest.get(key)
+        if not isinstance(value, list) or len(value) != 2 or any(
+            not isinstance(item, int) or item < 0 for item in value
+        ):
+            raise FrozenHeadReviewError("cleanup")
+    entries = manifest.get("entries")
+    if not isinstance(entries, list) or len(entries) > _ADMISSION_MAX_ENTRIES:
+        raise FrozenHeadReviewError("cleanup")
+    seen: set[str] = set()
+    for item in entries:
+        if not isinstance(item, dict) or not _valid_relative_entry(item.get("path")):
+            raise FrozenHeadReviewError("cleanup")
+        path = item["path"]
+        if path in seen or item.get("kind") not in {"file", "dir", "symlink"}:
+            raise FrozenHeadReviewError("cleanup")
+        seen.add(path)
+        for key in ("mode", "frozen_mode", "dev", "ino"):
+            value = item.get(key)
+            if not isinstance(value, int) or value < 0:
+                raise FrozenHeadReviewError("cleanup")
+            if key.endswith("mode") and value > 0o7777:
+                raise FrozenHeadReviewError("cleanup")
+    for key in ("root_mode", "root_frozen_mode"):
+        if not isinstance(manifest.get(key), int) or not 0 <= manifest[key] <= 0o7777:
+            raise FrozenHeadReviewError("cleanup")
+
+
+def reconcile_frozen_workspace(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Reconcile interrupted admission state conservatively.
+
+    Prepared state is restored only when no matching review event exists;
+    otherwise it is completed as a committed freeze.  Thaw-prepared state is
+    re-frozen unless its durable thaw event already exists.  No path is made
+    writable by reconciliation without that event.
+    """
+    row = conn.execute("SELECT status, workspace_path FROM tasks WHERE id=?", (task_id,)).fetchone()
+    if not row or not row["workspace_path"]:
+        return True
+    root = Path(row["workspace_path"])
+    if not root.is_absolute() or root.resolve(strict=True) != root:
+        raise FrozenHeadReviewError("reconcile")
+    locks_fd, manifests_fd = _open_admission_dirs()
+    os.close(locks_fd)
+    try:
+        for entry in os.scandir(manifests_fd):
+            if not entry.name.endswith(".json"):
+                continue
+            manifest = _read_manifest(manifests_fd, entry.name)
+            if manifest.get("task_id") != task_id:
+                continue
+            head = manifest.get("head_sha")
+            if not isinstance(head, str) or not re.fullmatch(r"[0-9a-fA-F]{40}", head):
+                raise FrozenHeadReviewError("reconcile")
+            _validate_manifest(manifest, task_id, head, root)
+            root_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0))
+            try:
+                root_info = os.fstat(root_fd)
+                if (root_info.st_dev, root_info.st_ino) != tuple(manifest["root_identity"]):
+                    raise FrozenHeadReviewError("reconcile")
+                event = _latest_frozen_event(conn, task_id)
+                thawed = conn.execute(
+                    "SELECT 1 FROM task_events WHERE task_id=? AND kind='frozen_head_thawed' "
+                    "AND payload LIKE ? LIMIT 1", (task_id, '%' + head.lower() + '%')
+                ).fetchone()
+                if manifest["phase"] == "freeze_prepared" and event is None:
+                    for item in reversed(manifest["entries"]):
+                        if item["kind"] != "symlink":
+                            _chmod_relative(root_fd, item["path"], item["mode"])
+                    os.fchmod(root_fd, manifest["root_mode"])
+                    os.unlink(entry.name, dir_fd=manifests_fd)
+                    _fsync_dir(manifests_fd)
+                    with write_txn(conn):
+                        _append_event(conn, task_id, "frozen_head_freeze_rolled_back", {
+                            "code": "FROZEN_HEAD_REVIEW_FREEZE_ROLLED_BACK"
+                        })
+                elif manifest["phase"] == "thaw_prepared" and thawed is None:
+                    os.fchmod(root_fd, manifest["root_frozen_mode"])
+                    for item in manifest["entries"]:
+                        if item["kind"] != "symlink":
+                            _chmod_relative(root_fd, item["path"], item["frozen_mode"])
+                    manifest["phase"] = "frozen_committed"
+                    _atomic_manifest_write(manifests_fd, entry.name, manifest)
+                elif thawed is not None:
+                    os.unlink(entry.name, dir_fd=manifests_fd)
+                    _fsync_dir(manifests_fd)
+                else:
+                    for item in manifest["entries"]:
+                        if item["kind"] != "symlink" and _entry_stat(root_fd, item["path"]).st_mode & 0o222:
+                            raise FrozenHeadReviewError("reconcile")
+                    if os.fstat(root_fd).st_mode & 0o222:
+                        raise FrozenHeadReviewError("reconcile")
+                    if manifest["phase"] == "freeze_prepared":
+                        manifest["phase"] = "frozen_committed"
+                        _atomic_manifest_write(manifests_fd, entry.name, manifest)
+            finally:
+                os.close(root_fd)
+    finally:
+        os.close(manifests_fd)
+    return True
+
+
+def _thaw_frozen_manifest(
+    conn: sqlite3.Connection, task_id: str, *, head_sha: str,
+) -> bool:
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", head_sha):
+        raise FrozenHeadReviewError("cleanup")
+    task = conn.execute(
+        "SELECT status, workspace_path FROM tasks WHERE id=?", (task_id,)
+    ).fetchone()
+    if not task:
+        raise FrozenHeadReviewError("cleanup")
+    root = Path(task["workspace_path"]).resolve(strict=True)
+    if str(root) != str(task["workspace_path"]):
+        raise FrozenHeadReviewError("cleanup")
+    event = _latest_frozen_event(conn, task_id)
+    # A thaw is authorized only by the exact durable review event.  Never
+    # synthesize identity from the current path: that would authorize a
+    # replacement worktree after the original manifest/event disappeared.
+    if event is None and task["status"] not in {"done", "archived"}:
+        raise FrozenHeadReviewError("cleanup")
+    if event is not None and event["head_sha"] != head_sha.lower():
+        raise FrozenHeadReviewError("cleanup")
+    with _workspace_admission_lock(root, exclusive=True) as lease:
+        if event is not None and tuple(event["root_identity"]) != lease.root_identity:
+            raise FrozenHeadReviewError("cleanup")
+        name = _manifest_name(task_id, head_sha, lease.root_identity)
+        try:
+            manifest = _read_manifest(lease.manifest_dir_fd, name)
+        except FileNotFoundError:
+            # A successful cleanup is idempotent.  An absent manifest without
+            # its durable completion event is unsafe and remains non-writable.
+            done = conn.execute(
+                "SELECT 1 FROM task_events WHERE task_id=? AND kind='frozen_head_thawed' "
+                "AND payload LIKE ? LIMIT 1", (task_id, '%"head_sha":%'),
+            ).fetchone()
+            if done:
+                return True
+            raise FrozenHeadReviewError("cleanup")
+        _validate_manifest(manifest, task_id, head_sha, root)
+        if event is None:
+            event = {
+                "head_sha": head_sha.lower(),
+                "root_identity": tuple(manifest["root_identity"]),
+            }
+        if manifest.get("phase") not in {"frozen_committed", "thaw_prepared"}:
+            raise FrozenHeadReviewError("cleanup")
+        if tuple(manifest["root_identity"]) != lease.root_identity:
+            raise FrozenHeadReviewError("cleanup")
+        parent_info = os.fstat(lease.parent_fd)
+        if tuple(manifest["parent_identity"]) != (parent_info.st_dev, parent_info.st_ino):
+            raise FrozenHeadReviewError("cleanup")
+        # Persist thaw intent while the root and its parent are still
+        # non-writable.  Recovery can then distinguish an interrupted thaw
+        # from an authorized one.
+        if manifest.get("phase") == "frozen_committed":
+            manifest["phase"] = "thaw_prepared"
+            _atomic_manifest_write(lease.manifest_dir_fd, name, manifest)
+        changed: list[tuple[str, int]] = []
+        try:
+            for item in reversed(manifest["entries"]):
+                if item["kind"] == "symlink":
+                    continue
+                info = _entry_stat(lease.root_fd, item["path"])
+                if (info.st_dev, info.st_ino) != (item["dev"], item["ino"]):
+                    raise FrozenHeadReviewError("cleanup")
+                current = int(info.st_mode & 0o7777)
+                if current == item["mode"]:
+                    continue
+                if current != item["frozen_mode"]:
+                    raise FrozenHeadReviewError("cleanup")
+                _chmod_relative(lease.root_fd, item["path"], item["mode"])
+                changed.append((item["path"], item["frozen_mode"]))
+            root_info = os.fstat(lease.root_fd)
+            if (root_info.st_dev, root_info.st_ino) != lease.root_identity:
+                raise FrozenHeadReviewError("cleanup")
+            root_current = int(root_info.st_mode & 0o7777)
+            if root_current == manifest["root_mode"]:
+                pass
+            elif root_current == manifest["root_frozen_mode"]:
+                os.fchmod(lease.root_fd, manifest["root_mode"])
+                changed.append(("", manifest["root_frozen_mode"]))
+            else:
+                raise FrozenHeadReviewError("cleanup")
+            _fsync_dir(lease.root_fd)
+            _fsync_dir(lease.parent_fd)
+            # Authorization is durable before the manifest can disappear.
+            with write_txn(conn):
+                _append_event(conn, task_id, "frozen_head_thawed", {
+                    "code": "FROZEN_HEAD_REVIEW_THAWED",
+                    "head_sha": head_sha.lower(),
+                    "root_identity": [lease.root_identity[0], lease.root_identity[1]],
+                    "parent_identity": [lease.parent_identity[0], lease.parent_identity[1]],
+                })
+            os.unlink(name, dir_fd=lease.manifest_dir_fd)
+            _fsync_dir(lease.manifest_dir_fd)
+        except Exception as exc:
+            for relative, frozen_mode in reversed(changed):
+                try:
+                    if relative:
+                        _chmod_relative(lease.root_fd, relative, frozen_mode)
+                    else:
+                        os.fchmod(lease.root_fd, frozen_mode)
+                except OSError:
+                    pass
+            raise FrozenHeadReviewError("cleanup") from exc
+    with write_txn(conn):
+        _append_event(conn, task_id, "frozen_head_cleanup_complete", {
+            "code": "FROZEN_HEAD_REVIEW_CLEANUP_COMPLETE",
+            "head_sha": head_sha.lower(),
+        })
+    return True
+
+
+def thaw_frozen_workspace(conn: sqlite3.Connection, task_id: str, *, head_sha: str) -> bool:
+    """Restore exact modes for an authorized review exit, idempotently."""
+    return _thaw_frozen_manifest(conn, task_id, head_sha=head_sha)
+
+
 def _worktree_writer_pids(worktree: Path) -> _WorktreeWriterScan:
     """Inspect process writers; never report an empty result without proof.
 
-    This is intentionally fail-closed. A process that cannot be completely
-    inspected is not silently treated as irrelevant: its cwd, descriptors,
-    and mappings are all part of the proof that the worktree is quiescent.
+    ``/proc`` is a moving target.  A missing descriptor is not evidence that
+    the process exited: only a second, explicit liveness check can establish
+    that.  Every other partial read is an incomplete proof and therefore
+    rejects admission.  Paths are checked by the target directory's stable
+    device/inode identity, not by spelling, so bind mounts and namespace
+    aliases cannot evade the check.
     """
     if sys.platform != "linux":
         return _WorktreeWriterScan((), False, True, (f"unsupported platform: {sys.platform}",))
@@ -4763,7 +5597,77 @@ def _worktree_writer_pids(worktree: Path) -> _WorktreeWriterScan:
         return _WorktreeWriterScan((), False, False, ("proc unavailable",))
     except OSError:
         return _WorktreeWriterScan((), False, False, ("proc enumeration denied",))
-    target = worktree.resolve()
+    try:
+        target = worktree.resolve(strict=True)
+        target_stat = target.stat()
+        target_identity = (int(target_stat.st_dev), int(target_stat.st_ino))
+    except (OSError, RuntimeError):
+        return _WorktreeWriterScan((), False, False, ("target identity unavailable",))
+
+    def process_exited(base: Path, pid: int) -> bool:
+        """Return True only when process disappearance is proven.
+
+        ``/proc/<pid>`` may disappear between any two component reads.  If it
+        is still present, or ``kill(pid, 0)`` cannot prove ESRCH, the process
+        remains an unknown live writer and the scan must fail closed.
+        """
+        try:
+            base.stat()
+            return False
+        except FileNotFoundError:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return True
+            except OSError:
+                return False
+            return False
+        except OSError:
+            return False
+
+    def process_path(
+        base: Path, link: Path, *, probe_before_read: bool = False,
+    ) -> Optional[Path]:
+        """Resolve a proc symlink through the process's mount namespace."""
+        if probe_before_read:
+            link.resolve(strict=True)
+        raw = os.readlink(link)
+        if not raw.startswith("/"):
+            # Pipes, sockets, anon_inode, and other non-filesystem FDs are
+            # unrelated to worktree ancestry and carry no path evidence.
+            return None
+        # Keep an explicit strict resolve as the existence/permission probe.
+        # The returned spelling is deliberately *not* used for ancestry: it
+        # is host-namespace text and is exactly what bind mounts can spoof.
+        link.resolve(strict=True)
+        root = base / "root"
+        return root / raw.lstrip("/")
+
+    def reaches_target_root(candidate: Path) -> bool:
+        """Compare each candidate ancestor to the target root identity."""
+        current = candidate
+        while True:
+            st = current.stat()
+            if (int(st.st_dev), int(st.st_ino)) == target_identity:
+                return True
+            parent = current.parent
+            if parent == current:
+                return False
+            current = parent
+
+    def inspect_component(base: Path, pid: int, label: str, fn):
+        try:
+            return fn()
+        except FileNotFoundError:
+            if process_exited(base, pid):
+                return None
+            errors.append(f"pid {pid}: {label} disappeared while process remained")
+        except PermissionError:
+            errors.append(f"pid {pid}: permission denied")
+        except (OSError, ValueError, RuntimeError):
+            errors.append(f"pid {pid}: {label} inspection failed")
+        return None
+
     found: set[int] = set()
     errors: list[str] = []
     for entry in entries:
@@ -4771,45 +5675,85 @@ def _worktree_writer_pids(worktree: Path) -> _WorktreeWriterScan:
             continue
         pid = int(entry.name)
         base = proc / str(pid)
-        try:
-            cwd = (base / "cwd").resolve()
-            if cwd == target or target in cwd.parents:
-                found.add(pid)
-            for fd in (base / "fd").iterdir():
-                resolved = fd.resolve()
-                if resolved != target and target not in resolved.parents:
-                    continue
-                flags_line = next(
-                    (line for line in (base / "fdinfo" / fd.name).read_text(
-                        encoding="utf-8", errors="replace"
-                    ).splitlines() if line.startswith("flags:")), ""
+        cwd = inspect_component(
+            base, pid, "cwd",
+            lambda: process_path(base, base / "cwd", probe_before_read=True),
+        )
+        if cwd is not None:
+            try:
+                if reaches_target_root(cwd):
+                    found.add(pid)
+            except (FileNotFoundError, PermissionError, OSError, RuntimeError):
+                if not process_exited(base, pid):
+                    errors.append(f"pid {pid}: cwd identity unavailable")
+
+        fds = inspect_component(base, pid, "fd", lambda: list((base / "fd").iterdir()))
+        if fds is not None:
+            for fd in fds:
+                resolved = inspect_component(
+                    base, pid, "fd", lambda fd=fd: process_path(base, fd),
                 )
-                if not flags_line:
-                    raise OSError("fd access mode unavailable")
-                if int(flags_line.split()[1], 8) & (os.O_WRONLY | os.O_RDWR):
-                    found.add(pid)
-            for line in (base / "maps").read_text(
+                if resolved is None:
+                    continue
+                try:
+                    related = reaches_target_root(resolved)
+                except (FileNotFoundError, PermissionError, OSError, RuntimeError):
+                    if not process_exited(base, pid):
+                        errors.append(f"pid {pid}: fd identity unavailable")
+                    continue
+                if not related:
+                    continue
+                flags = inspect_component(
+                    base, pid, "fdinfo", lambda fd=fd: next(
+                        (line for line in (base / "fdinfo" / fd.name).read_text(
+                            encoding="utf-8", errors="replace"
+                        ).splitlines() if line.startswith("flags:")), ""
+                    ),
+                )
+                if flags is None:
+                    continue
+                try:
+                    if not flags:
+                        raise ValueError
+                    if int(flags.split()[1], 8) & (os.O_WRONLY | os.O_RDWR):
+                        found.add(pid)
+                except (IndexError, ValueError):
+                    errors.append(f"pid {pid}: fdinfo inspection failed")
+
+        maps_text = inspect_component(
+            base, pid, "maps",
+            lambda: (base / "maps").read_text(
                 encoding="utf-8", errors="replace"
-            ).splitlines():
+            ),
+        )
+        if maps_text is not None:
+            for line in maps_text.splitlines():
                 fields = line.split()
-                # Shared writable mappings can modify the worktree. Private
-                # writable mappings are copy-on-write and are not writers.
-                if len(fields) < 6 or fields[1] != "rw-s":
+                if len(fields) < 6:
                     continue
-                mapped_name = fields[5]
+                # Linux's proc format puts the shared/private marker in the
+                # permission field today.  Check characters rather than an
+                # exact string so rwxs and future flag ordering stay covered.
+                perms = fields[1]
+                if "w" not in perms or "s" not in perms:
+                    continue
+                mapped_name = " ".join(fields[5:]).removesuffix(" (deleted)")
                 if not mapped_name.startswith("/"):
+                    errors.append(f"pid {pid}: mapped path ambiguous")
                     continue
-                mapped = Path(mapped_name.removesuffix(" (deleted)")).resolve()
-                if mapped == target or target in mapped.parents:
-                    found.add(pid)
-        except FileNotFoundError:
-            continue
-        except PermissionError:
-            errors.append(f"pid {pid}: permission denied")
-        except (OSError, ValueError, RuntimeError):
-            errors.append(f"pid {pid}: inspection failed")
+                mapped = inspect_component(
+                    base, pid, "map", lambda: base / "root" / mapped_name.lstrip("/"),
+                )
+                if mapped is None:
+                    continue
+                try:
+                    if reaches_target_root(mapped):
+                        found.add(pid)
+                except (FileNotFoundError, PermissionError, OSError, RuntimeError):
+                    if not process_exited(base, pid):
+                        errors.append(f"pid {pid}: map identity unavailable")
     return _WorktreeWriterScan(
-        tuple(sorted(found)), not errors, False, tuple(errors[:32])
+        tuple(sorted(found))[:32], not errors, False, tuple(errors[:32])
     )
 
 
@@ -4851,24 +5795,45 @@ def submit_frozen_head_for_review(
     ).fetchone()
 
     def reject(reason: str) -> NoReturn:
+        safe_reason = FrozenHeadReviewError(reason).args[0]
         if row is None:
-            raise FrozenHeadReviewError(reason)
+            raise FrozenHeadReviewError(safe_reason)
+        safe_path = str(worktree_path)[:4096] if isinstance(worktree_path, str) else ""
+        path_hash = hashlib.sha256(safe_path.encode("utf-8", "replace")).hexdigest()[:16]
+        actor_hash = hashlib.sha256(str(actor)[:128].encode("utf-8", "replace")).hexdigest()[:16]
         with write_txn(conn):
             _append_event(conn, task_id, "review_submission_rejected", {
                 "route": "frozen_head",
-                "reason": reason,
-                "head_sha": head_sha,
-                "worktree_path": worktree_path,
-                "actor": actor,
+                "code": "FROZEN_HEAD_REVIEW_REJECTED",
+                # Rejection events are durable and may cross trust boundaries;
+                # never persist the internal exception text.
+                "message": "FROZEN_HEAD_REVIEW_REJECTED",
+                "head_sha": (
+                    head_sha if isinstance(head_sha, str)
+                    and re.fullmatch(r"[0-9a-fA-F]{40}", head_sha)
+                    else None
+                ),
+                "worktree_path_hash": path_hash,
+                "actor_hash": actor_hash,
             })
-        raise FrozenHeadReviewError(reason)
+        raise FrozenHeadReviewError(safe_reason)
 
     if not isinstance(head_sha, str) or not re.fullmatch(r"[0-9a-fA-F]{40}", head_sha):
         reject("head_sha must be a full 40-character commit id")
-    if not isinstance(worktree_path, str) or not worktree_path.strip():
+    if not isinstance(worktree_path, str) or not worktree_path.strip() or len(worktree_path) > 4096:
         reject("worktree_path is required")
     if not isinstance(evidence, dict):
         reject("explicit evidence object is required")
+    try:
+        _validate_bounded_json_shape(evidence)
+    except FrozenHeadReviewError:
+        reject("evidence is not serializable")
+    try:
+        serialized_evidence = json.dumps(evidence, ensure_ascii=False)
+    except (TypeError, ValueError, OverflowError):
+        reject("evidence is not serializable")
+    if len(serialized_evidence) > 65536:
+        reject("evidence exceeds the maximum allowed size")
     evidence = dict(evidence)
     if evidence.get("head_sha") != head_sha:
         reject("evidence head_sha must exactly match head_sha")
@@ -4877,36 +5842,24 @@ def submit_frozen_head_for_review(
         r"[0-9a-fA-F]{40}", submitted_tree_sha
     ):
         reject("evidence tree_sha must be a full 40-character tree id")
-    if evidence.get("worktree_path"):
-        try:
-            evidence_path = Path(evidence["worktree_path"]).expanduser().resolve(strict=True)
-        except (OSError, TypeError):
-            reject("evidence worktree_path is not a resolvable directory")
-    else:
-        evidence_path = None
-    if evidence_path is not None and evidence_path != Path(worktree_path).expanduser().resolve():
-        reject("evidence worktree_path is unrelated to the submitted worktree")
+    if evidence.get("worktree_path") != worktree_path:
+        reject("evidence worktree_path must exactly match the submitted worktree")
     if evidence.get("clean") is not True:
         reject("evidence clean must be true")
     if evidence.get("implementation_complete") is not True:
         reject("evidence implementation_complete must be true")
 
     path = Path(worktree_path).expanduser()
-    if not path.is_dir():
-        reject("worktree_path is not a directory")
+    if not path.is_dir() or not path.is_absolute():
+        reject("worktree_path is not a canonical directory")
     try:
-        verified_head, tree_sha, dirty = _git_worktree_snapshot(path)
-    except (OSError, subprocess.SubprocessError) as exc:
-        reject(f"unable to verify git worktree: {exc}")
-    if verified_head.lower() != head_sha.lower():
-        reject("worktree HEAD does not match exact head_sha")
-    if tree_sha.lower() != submitted_tree_sha.lower():
-        reject("worktree tree_sha does not match exact tree_sha")
-    if dirty:
-        reject("worktree is dirty")
-
+        submitted_path = path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        reject("worktree_path is not a canonical directory")
+    if str(submitted_path) != worktree_path:
+        reject("worktree_path must be the canonical path")
     if row is None:
-        reject(f"task {task_id} not found")
+        reject("task not found")
     if row["status"] in {"triage", "running", "review", "archived"}:
         reject(f"frozen head cannot be submitted from status {row['status']!r}")
     if row["status"] == "blocked":
@@ -4926,25 +5879,29 @@ def submit_frozen_head_for_review(
         reject("task has no canonical workspace")
     try:
         canonical_path = Path(row["workspace_path"]).expanduser().resolve(strict=True)
-        submitted_path = path.resolve(strict=True)
-    except OSError as exc:
-        reject(f"unable to resolve canonical workspace: {exc}")
-    if submitted_path != canonical_path:
+    except (OSError, RuntimeError):
+        reject("task canonical workspace is unavailable")
+    if str(canonical_path) != row["workspace_path"] or submitted_path != canonical_path:
         reject("worktree is unrelated to the task canonical workspace")
     if row["current_run_id"] is not None or row["claim_lock"] is not None or row["worker_pid"] is not None:
         reject("task has a live claim or current writer")
+
+    try:
+        verified_head, tree_sha, dirty = _git_worktree_snapshot(submitted_path)
+    except (OSError, subprocess.SubprocessError):
+        reject("unable to verify git worktree")
+    if verified_head.lower() != head_sha.lower():
+        reject("worktree HEAD does not match exact head_sha")
+    if tree_sha.lower() != submitted_tree_sha.lower():
+        reject("worktree tree_sha does not match exact tree_sha")
+    if dirty:
+        reject("worktree is dirty")
     first_snapshot = (verified_head.lower(), tree_sha.lower(), dirty)
     writer_scan = _worktree_writer_pids(submitted_path)
     if writer_scan.writers:
-        reject(f"worktree has active OS writers: {list(writer_scan.writers)}")
+        reject("worktree has active OS writers")
     if not writer_scan.complete or writer_scan.unsupported:
-        reject(f"OS writer inspection incomplete or unsupported: {list(writer_scan.errors)}")
-    try:
-        second_head, second_tree_sha, second_dirty = _git_worktree_snapshot(submitted_path)
-    except (OSError, subprocess.SubprocessError) as exc:
-        reject(f"unable to re-verify git worktree: {exc}")
-    if (second_head.lower(), second_tree_sha.lower(), second_dirty) != first_snapshot:
-        reject("git HEAD, tree, or full clean status changed during verification")
+        reject("OS writer inspection incomplete or unsupported")
 
     run = conn.execute(
         "SELECT id, metadata FROM task_runs WHERE task_id = ? "
@@ -4959,16 +5916,27 @@ def submit_frozen_head_for_review(
         run_metadata = None
     if not isinstance(run_metadata, dict):
         reject("completed implementation evidence metadata is malformed")
-    if not run_metadata.get("changed_files") or "tests_run" not in run_metadata:
+    changed_files = run_metadata.get("changed_files")
+    if (
+        not isinstance(changed_files, list)
+        or not changed_files
+        or any(not isinstance(item, str) or not item or len(item) > 1024 for item in changed_files[:256])
+        or len(changed_files) > 256
+        or "tests_run" not in run_metadata
+        or run_metadata.get("tests_run") is None
+    ):
         reject("completed implementation evidence requires changed_files and tests_run")
-    if run_metadata.get("head_sha") and str(run_metadata["head_sha"]).lower() != head_sha.lower():
+    run_head_sha = run_metadata.get("head_sha")
+    if not isinstance(run_head_sha, str) or not re.fullmatch(r"[0-9a-fA-F]{40}", run_head_sha):
+        reject("completed implementation evidence requires a full 40-character head_sha")
+    if run_head_sha.lower() != head_sha.lower():
         reject("completed implementation evidence head_sha does not match exact head_sha")
     run_tree_sha = run_metadata.get("tree_sha")
     if not isinstance(run_tree_sha, str) or not re.fullmatch(
         r"[0-9a-fA-F]{40}", run_tree_sha
     ):
         reject("completed implementation evidence requires a full 40-character tree_sha")
-    if run_tree_sha.lower() != second_tree_sha.lower():
+    if run_tree_sha.lower() != tree_sha.lower():
         reject("completed implementation evidence tree_sha does not match exact tree_sha")
 
     original_identity = {
@@ -4976,39 +5944,107 @@ def submit_frozen_head_for_review(
         "current_run_id": row["current_run_id"], "claim_lock": row["claim_lock"],
         "worker_pid": row["worker_pid"],
     }
-
     try:
-        with write_txn(conn):
-            latest_run = conn.execute(
-                "SELECT id, metadata FROM task_runs WHERE task_id = ? "
-                "AND outcome = 'completed' AND ended_at IS NOT NULL "
-                "ORDER BY ended_at DESC, id DESC LIMIT 1", (task_id,),
-            ).fetchone()
-            if latest_run is None or int(latest_run["id"]) != int(run["id"]):
-                raise FrozenHeadReviewError("completed implementation evidence changed while submitting")
-            if latest_run["metadata"] != run["metadata"]:
-                raise FrozenHeadReviewError("completed implementation metadata changed while submitting")
-            cur = conn.execute(
-                "UPDATE tasks SET status = 'review' WHERE id = ? AND status = ? "
-                "AND workspace_path IS ? AND current_run_id IS ? "
-                "AND claim_lock IS ? AND worker_pid IS ?",
-                (task_id, original_identity["status"], original_identity["workspace_path"],
-                 original_identity["current_run_id"], original_identity["claim_lock"],
-                 original_identity["worker_pid"]),
-            )
-            if cur.rowcount != 1:
-                raise FrozenHeadReviewError("task state changed while submitting frozen head")
-            _append_event(conn, task_id, "review_submitted_frozen_head", {
-                "route": "frozen_head",
-                "actor": actor,
-                "head_sha": head_sha,
-                "tree_sha": second_tree_sha,
-                "stable_head_sha": second_head,
-                "stable_tree_sha": second_tree_sha,
-                "worktree_path": str(path.resolve()),
-                "evidence": evidence,
-                "implementation_run_id": int(run["id"]),
-            }, run_id=int(run["id"]))
+        with _workspace_admission_lock(
+            submitted_path, exclusive=True, task_id=task_id, head_sha=head_sha
+        ) as admission:
+            # The exclusive lease and read-only protection are held across the
+            # final scan, final Git snapshot, BEGIN IMMEDIATE, CAS, and COMMIT.
+            final_scan = _worktree_writer_pids(submitted_path)
+            if final_scan.writers:
+                raise FrozenHeadReviewError("worktree has active OS writers")
+            if not final_scan.complete or final_scan.unsupported:
+                raise FrozenHeadReviewError("OS writer inspection incomplete or unsupported")
+            try:
+                second_head, second_tree_sha, second_dirty = _git_worktree_snapshot(submitted_path)
+            except (OSError, subprocess.SubprocessError) as exc:
+                raise FrozenHeadReviewError("unable to re-verify git worktree") from exc
+            if (second_head.lower(), second_tree_sha.lower(), second_dirty) != first_snapshot:
+                raise FrozenHeadReviewError("git HEAD, tree, or full clean status changed during verification")
+            root_stat = submitted_path.stat()
+            parent_stat = submitted_path.parent.stat()
+            if (root_stat.st_dev, root_stat.st_ino) != admission.root_identity or (
+                parent_stat.st_dev, parent_stat.st_ino
+            ) != admission.parent_identity or (
+                os.fstat(admission.parent_fd).st_dev,
+                os.fstat(admission.parent_fd).st_ino,
+            ) != admission.parent_identity:
+                raise FrozenHeadReviewError("workspace root identity changed during verification")
+            with write_txn(conn):
+                locked_row = conn.execute(
+                    "SELECT status, workspace_path, current_run_id, claim_lock, worker_pid "
+                    "FROM tasks WHERE id = ?", (task_id,),
+                ).fetchone()
+                if locked_row is None or any(
+                    locked_row[key] != original_identity[key] for key in original_identity
+                ):
+                    raise FrozenHeadReviewError("task state changed while submitting frozen head")
+                latest_run = conn.execute(
+                    "SELECT id, metadata FROM task_runs WHERE task_id = ? "
+                    "AND outcome = 'completed' AND ended_at IS NOT NULL "
+                    "ORDER BY ended_at DESC, id DESC LIMIT 1", (task_id,),
+                ).fetchone()
+                if latest_run is None or int(latest_run["id"]) != int(run["id"]):
+                    raise FrozenHeadReviewError("completed implementation evidence changed while submitting")
+                if latest_run["metadata"] != run["metadata"]:
+                    raise FrozenHeadReviewError("completed implementation metadata changed while submitting")
+                cur = conn.execute(
+                    "UPDATE tasks SET status = 'review' WHERE id = ? AND status = ? "
+                    "AND workspace_path IS ? AND current_run_id IS ? "
+                    "AND claim_lock IS ? AND worker_pid IS ?",
+                    (task_id, original_identity["status"], original_identity["workspace_path"],
+                     original_identity["current_run_id"], original_identity["claim_lock"],
+                     original_identity["worker_pid"]),
+                )
+                if cur.rowcount != 1:
+                    raise FrozenHeadReviewError("task state changed while submitting frozen head")
+                _append_event(conn, task_id, "review_submitted_frozen_head", {
+                    "route": "frozen_head",
+                    "code": "FROZEN_HEAD_REVIEW_SUBMITTED",
+                    "actor_hash": hashlib.sha256(str(actor)[:128].encode("utf-8", "replace")).hexdigest()[:16],
+                    "head_sha": head_sha,
+                    "tree_sha": second_tree_sha,
+                    "stable_head_sha": second_head,
+                    "stable_tree_sha": second_tree_sha,
+                    "root_identity": [admission.root_identity[0], admission.root_identity[1]],
+                    "parent_identity": [admission.parent_identity[0], admission.parent_identity[1]],
+                    "worktree_path_hash": hashlib.sha256(str(submitted_path).encode("utf-8")).hexdigest()[:16],
+                    "evidence": {
+                        "head_sha": evidence["head_sha"],
+                        "tree_sha": evidence["tree_sha"],
+                        "worktree_path_hash": hashlib.sha256(worktree_path.encode("utf-8")).hexdigest()[:16],
+                        "clean": True,
+                        "implementation_complete": True,
+                    },
+                    "implementation_run_id": int(run["id"]),
+                }, run_id=int(run["id"]))
+            # Re-prove both descriptors and the parent/name binding after the
+            # SQLite commit.  If the path was replaced, the committed review
+            # remains frozen and is reconciled later; it is never reported as
+            # a rejected writable review.
+            try:
+                post_root = os.stat(
+                    submitted_path.name,
+                    dir_fd=admission.parent_fd,
+                    follow_symlinks=False,
+                )
+                held_root = os.fstat(admission.root_fd)
+                held_parent = os.fstat(admission.parent_fd)
+                if (
+                    (post_root.st_dev, post_root.st_ino) != admission.root_identity
+                    or (held_root.st_dev, held_root.st_ino) != admission.root_identity
+                    or (held_parent.st_dev, held_parent.st_ino) != admission.parent_identity
+                ):
+                    raise OSError
+            except OSError:
+                admission.commit()
+                with write_txn(conn):
+                    _append_event(conn, task_id, "frozen_head_cleanup_incomplete", {
+                        "code": "FROZEN_HEAD_REVIEW_CLEANUP_INCOMPLETE",
+                        "message": "FROZEN_HEAD_REVIEW_CLEANUP_INCOMPLETE",
+                    })
+                return True
+            admission.commit()
     except FrozenHeadReviewError as exc:
         reject(str(exc))
     return True
@@ -5053,6 +6089,7 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+    frozen_review = _frozen_head_identity(conn, task_id)
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
@@ -5098,7 +6135,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked', 'review')
                 """,
                 (result, now, task_id),
             )
@@ -5115,7 +6152,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked', 'review')
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),
@@ -5182,6 +6219,17 @@ def complete_task(
             completed_payload,
             run_id=run_id,
         )
+    if frozen_review is not None:
+        try:
+            _thaw_frozen_manifest(conn, task_id, head_sha=frozen_review[0])
+        except (FrozenHeadReviewError, OSError, RuntimeError):
+            with write_txn(conn):
+                _append_event(conn, task_id, "frozen_head_cleanup_incomplete", {
+                    "code": "FROZEN_HEAD_REVIEW_CLEANUP_INCOMPLETE",
+                    "message": "FROZEN_HEAD_REVIEW_CLEANUP_INCOMPLETE",
+                })
+            return False
+
     # Prose-scan the summary + result for t_<hex> references that do
     # not resolve. Advisory — does not block the completion. Runs in
     # its own txn so the completion itself is already durable by the
@@ -5835,6 +6883,26 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    frozen_review = _frozen_head_identity(conn, task_id)
+    current = conn.execute(
+        "SELECT status FROM tasks WHERE id=?", (task_id,)
+    ).fetchone()
+    if current and current["status"] == "review":
+        if frozen_review is None:
+            return False
+        with write_txn(conn):
+            run_id = _end_run(conn, task_id, outcome="blocked", status="blocked")
+            cur = conn.execute(
+                "UPDATE tasks SET status='blocked', claim_lock=NULL, claim_expires=NULL, "
+                "worker_pid=NULL WHERE id=? AND status='review'", (task_id,),
+            )
+            if cur.rowcount != 1:
+                return False
+            _append_event(conn, task_id, "blocked", {
+                "code": "FROZEN_HEAD_REVIEW_REQUEST_CHANGES",
+                "message": "FROZEN_HEAD_REVIEW_REQUEST_CHANGES",
+            }, run_id=run_id)
+        return True
     recurrences = 0
     with write_txn(conn):
         cur_row = conn.execute(
@@ -6470,6 +7538,7 @@ def decompose_triage_task(
 
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    frozen_review = _frozen_head_identity(conn, task_id)
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -6488,6 +7557,16 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             summary="task archived with run still active",
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
+    if frozen_review is not None:
+        try:
+            _thaw_frozen_manifest(conn, task_id, head_sha=frozen_review[0])
+        except (FrozenHeadReviewError, OSError, RuntimeError):
+            with write_txn(conn):
+                _append_event(conn, task_id, "frozen_head_cleanup_incomplete", {
+                    "code": "FROZEN_HEAD_REVIEW_CLEANUP_INCOMPLETE",
+                    "message": "FROZEN_HEAD_REVIEW_CLEANUP_INCOMPLETE",
+                })
+            return False
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
@@ -6502,6 +7581,8 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
     tasks must be explicitly archived first so accidental data loss requires a
     second deliberate action.
     """
+    if _frozen_head_identity(conn, task_id) is not None:
+        raise FrozenHeadReviewError("rejected")
     with write_txn(conn):
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?",
@@ -6526,11 +7607,11 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
 
     Because the schema does not use ``ON DELETE CASCADE`` foreign keys,
     we explicitly delete from child tables first, then the task row.
-    This keeps the operation atomic (single ``write_txn``).
-
     Returns ``True`` if the task existed and was deleted, ``False``
     if the task was not found.
     """
+    if _frozen_head_identity(conn, task_id) is not None:
+        raise FrozenHeadReviewError("rejected")
     with write_txn(conn):
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         if cur.rowcount != 1:
@@ -9290,25 +10371,35 @@ def _default_spawn(
     rotate_bytes, backup_count = worker_log_rotation_config()
     _rotate_worker_log(log_path, rotate_bytes, backup_count)
 
-    # Use 'a' so a re-run on unblock appends rather than overwrites.
-    log_f = open(log_path, "ab")
-    try:
-        proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
-            cmd,
-            cwd=workspace if os.path.isdir(workspace) else None,
-            stdin=subprocess.DEVNULL,
-            stdout=log_f,
-            stderr=subprocess.STDOUT,
-            env=env,
-            start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
-        )
-    except FileNotFoundError:
-        log_f.close()
-        raise RuntimeError(
-            "`hermes` executable not found on PATH. "
-            "Install Hermes Agent or activate its venv before running the kanban dispatcher."
-        )
+    # Use 'a' so a re-run on unblock appends rather than overwrites.  Worker
+    # creation participates in the same lease as frozen-head admission: a
+    # review freeze cannot race a dispatcher opening a new writer.
+    # Some legacy dispatcher tests (and failed worktree setup recovery) invoke
+    # spawn before a workspace exists.  There is no inode to lease in that
+    # case; once the directory exists every managed spawn takes the lease.
+    admission = (
+        _workspace_admission_lock(Path(workspace), exclusive=False)
+        if os.path.isdir(workspace) else contextlib.nullcontext()
+    )
+    with admission:
+        log_f = open(log_path, "ab")
+        try:
+            proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
+                cmd,
+                cwd=workspace if os.path.isdir(workspace) else None,
+                stdin=subprocess.DEVNULL,
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+                env=env,
+                start_new_session=True,
+                creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            )
+        except FileNotFoundError:
+            log_f.close()
+            raise RuntimeError(
+                "`hermes` executable not found on PATH. "
+                "Install Hermes Agent or activate its venv before running the kanban dispatcher."
+            )
     # NOTE: we intentionally do NOT close log_f here — we want Popen's
     # child process to keep writing after this function returns.  The
     # handle is kept alive by the child's inheritance.  The parent's

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -44,7 +44,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
@@ -844,13 +844,57 @@ class FrozenHeadReviewBody(BaseModel):
 
 
 @router.post("/tasks/{task_id}/submit-review")
-def submit_review(task_id: str, payload: FrozenHeadReviewBody, board: Optional[str] = Query(None)):
+async def submit_review(
+    request: Request,
+    task_id: str,
+    board: Optional[str] = Query(None),
+):
     """Submit a completed exact frozen implementation head without claiming it."""
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        body = bytearray()
+        async for chunk in request.stream():
+            body.extend(chunk)
+            if len(body) > 131072:
+                raise HTTPException(status_code=409, detail="FROZEN_HEAD_REVIEW_REJECTED")
+        try:
+            raw_payload = json.loads(bytes(body))
+            def check_shape(value: Any, depth: int = 0, nodes: list[int] | None = None) -> None:
+                nodes = nodes or [0]
+                nodes[0] += 1
+                if depth > 32 or nodes[0] > 4096:
+                    raise ValueError
+                if isinstance(value, str) and len(value) > 8192:
+                    raise ValueError
+                if isinstance(value, list):
+                    if len(value) > 256:
+                        raise ValueError
+                    for item in value:
+                        check_shape(item, depth + 1, nodes)
+                elif isinstance(value, dict):
+                    if len(value) > 128:
+                        raise ValueError
+                    for key, item in value.items():
+                        if not isinstance(key, str) or len(key) > 256:
+                            raise ValueError
+                        check_shape(item, depth + 1, nodes)
+            check_shape(raw_payload)
+            payload = FrozenHeadReviewBody.model_validate(raw_payload)
+        except Exception:
+            raise HTTPException(status_code=409, detail="FROZEN_HEAD_REVIEW_REJECTED")
         if kanban_db.get_task(conn, task_id) is None:
-            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+            raise HTTPException(status_code=404, detail="FROZEN_HEAD_REVIEW_NOT_FOUND")
+        # Bound untrusted dashboard input before it reaches SQLite/events.  The
+        # kernel applies the same caps for CLI and direct Python callers; this
+        # route additionally turns oversized requests into a fixed 409 rather
+        # than reflecting arbitrary values in a validation error.
+        if (
+            len(payload.worktree_path) > 4096
+            or len(payload.actor or "") > 128
+            or len(json.dumps(payload.evidence, ensure_ascii=False)) > 65536
+        ):
+            raise HTTPException(status_code=409, detail="FROZEN_HEAD_REVIEW_REJECTED")
         try:
             kanban_db.submit_frozen_head_for_review(
                 conn,
@@ -860,8 +904,8 @@ def submit_review(task_id: str, payload: FrozenHeadReviewBody, board: Optional[s
                 evidence=payload.evidence,
                 actor=payload.actor or "dashboard",
             )
-        except kanban_db.FrozenHeadReviewError as exc:
-            raise HTTPException(status_code=409, detail=str(exc))
+        except kanban_db.FrozenHeadReviewError:
+            raise HTTPException(status_code=409, detail="FROZEN_HEAD_REVIEW_REJECTED")
         task = kanban_db.get_task(conn, task_id)
         return {"task": _task_dict(task) if task else None}
     finally:
@@ -1063,6 +1107,12 @@ def _set_status_direct(
             (task_id,),
         ).fetchone()
         if prev is None:
+            return False
+
+        # Frozen-head review is not a generic drag/drop state.  Every exit
+        # must use the lifecycle helper so thaw authorization and manifest
+        # cleanup cannot be bypassed by a direct status write.
+        if prev["status"] == "review" and kanban_db._frozen_head_identity(conn, task_id) is not None:
             return False
 
         # Guard: don't allow promoting to 'ready' unless all parents are done.

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -849,8 +849,10 @@ def submit_review(task_id: str, payload: FrozenHeadReviewBody, board: Optional[s
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        if kanban_db.get_task(conn, task_id) is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
         try:
-            kanban_db.submit_task_for_review(
+            kanban_db.submit_frozen_head_for_review(
                 conn,
                 task_id,
                 head_sha=payload.head_sha,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -836,6 +836,36 @@ class UpdateTaskBody(BaseModel):
     clear_model_override: bool = False
 
 
+class FrozenHeadReviewBody(BaseModel):
+    head_sha: str
+    worktree_path: str
+    evidence: dict[str, Any]
+    actor: Optional[str] = "dashboard"
+
+
+@router.post("/tasks/{task_id}/submit-review")
+def submit_review(task_id: str, payload: FrozenHeadReviewBody, board: Optional[str] = Query(None)):
+    """Submit a completed exact frozen implementation head without claiming it."""
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        try:
+            kanban_db.submit_task_for_review(
+                conn,
+                task_id,
+                head_sha=payload.head_sha,
+                worktree_path=payload.worktree_path,
+                evidence=payload.evidence,
+                actor=payload.actor or "dashboard",
+            )
+        except kanban_db.FrozenHeadReviewError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+        task = kanban_db.get_task(conn, task_id)
+        return {"task": _task_dict(task) if task else None}
+    finally:
+        conn.close()
+
+
 @router.patch("/tasks/{task_id}")
 def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)

--- a/tests/hermes_cli/test_frozen_head_review.py
+++ b/tests/hermes_cli/test_frozen_head_review.py
@@ -13,11 +13,19 @@ from hermes_cli import kanban_db as kb
 
 
 @pytest.fixture
-def kanban_home(tmp_path, monkeypatch):
+def kanban_home(tmp_path, monkeypatch, request):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     kb.init_db()
+    # The hermetic test runner may expose host processes through a restricted
+    # /proc mount. Scanner behavior is exercised by the real helper test below;
+    # admission tests isolate that unrelated host state.
+    if "os_writer_freeze" not in request.node.name:
+        monkeypatch.setattr(
+            kb, "_worktree_writer_pids",
+            lambda _path: kb._WorktreeWriterScan((), True, False, ()),
+        )
     return home
 
 
@@ -48,14 +56,15 @@ def make_repo(tmp_path: Path) -> tuple[Path, str]:
     return repo, git_head(repo)
 
 
-def complete_with_evidence(conn, task_id: str) -> None:
+def complete_with_evidence(conn, task_id: str, repo: Path) -> None:
     assert kb.complete_task(
         conn, task_id, summary="implementation complete",
-        metadata={"changed_files": ["implemented.txt"], "tests_run": 3},
+        metadata={"changed_files": ["implemented.txt"], "tests_run": 3,
+                  "head_sha": git_head(repo), "tree_sha": git_tree(repo)},
     )
 
 
-def evidence(head: str, repo: Path, *, include_tree: bool = False) -> dict:
+def evidence(head: str, repo: Path, *, include_tree: bool = True) -> dict:
     result = {
         "head_sha": head,
         "worktree_path": str(repo),
@@ -72,7 +81,7 @@ def test_db_accepts_completed_clean_exact_head_without_claim(kanban_home, tmp_pa
     repo, head = make_repo(tmp_path)
     with kb.connect_closing() as conn:
         task_id = kb.create_task(conn, title="frozen", workspace_kind="dir", workspace_path=str(repo))
-        complete_with_evidence(conn, task_id)
+        complete_with_evidence(conn, task_id, repo)
         assert kb.submit_frozen_head_for_review(
             conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
         )
@@ -96,7 +105,8 @@ def test_scheduled_ready_submit_directly_without_transition_dance(kanban_home, t
         kb._synthesize_ended_run(
             conn, task_id, outcome="completed",
             summary="implementation complete",
-            metadata={"changed_files": ["implemented.txt"], "tests_run": 3},
+            metadata={"changed_files": ["implemented.txt"], "tests_run": 3,
+                       "head_sha": head, "tree_sha": git_tree(repo)},
         )
         assert kb.submit_frozen_head_for_review(
             conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
@@ -109,13 +119,14 @@ def test_every_accepted_dormant_state_is_explicitly_supported(kanban_home, tmp_p
     with kb.connect_closing() as conn:
         task_id = kb.create_task(conn, title=f"accepted {status}", workspace_kind="dir", workspace_path=str(repo))
         if status == "done":
-            complete_with_evidence(conn, task_id)
+            complete_with_evidence(conn, task_id, repo)
         else:
             conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, task_id))
             conn.commit()
             kb._synthesize_ended_run(
                 conn, task_id, outcome="completed", summary="implementation complete",
-                metadata={"changed_files": ["implemented.txt"], "tests_run": 3},
+                metadata={"changed_files": ["implemented.txt"], "tests_run": 3,
+                       "head_sha": head, "tree_sha": git_tree(repo)},
             )
         assert kb.submit_frozen_head_for_review(
             conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
@@ -135,6 +146,37 @@ def test_non_dormant_states_are_rejected(kanban_home, tmp_path, status):
             )
 
 
+def test_legacy_review_required_blocked_state_is_accepted(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="blocked frozen head", workspace_kind="dir",
+                                 workspace_path=str(repo), assignee="programmer")
+        kb.claim_task(conn, task_id, claimer="programmer")
+        run_id = kb.get_task(conn, task_id).current_run_id
+        assert kb.block_task(conn, task_id, reason="review-required: inspect", expected_run_id=run_id)
+        kb._synthesize_ended_run(
+            conn, task_id, outcome="completed", summary="implementation complete",
+            metadata={"changed_files": ["implemented.txt"], "tests_run": 3,
+                      "head_sha": head, "tree_sha": git_tree(repo)},
+        )
+        assert kb.submit_frozen_head_for_review(
+            conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
+        )
+
+
+def test_review_state_is_rejected(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="already review", workspace_kind="dir",
+                                 workspace_path=str(repo))
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (task_id,))
+        conn.commit()
+        with pytest.raises(kb.FrozenHeadReviewError, match="status 'review'"):
+            kb.submit_frozen_head_for_review(
+                conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
+            )
+
+
 @pytest.mark.parametrize(
     "mutator, expected",
     [
@@ -147,7 +189,7 @@ def test_db_rejects_malformed_or_mismatched_evidence(kanban_home, tmp_path, muta
     repo, head = make_repo(tmp_path)
     with kb.connect_closing() as conn:
         task_id = kb.create_task(conn, title="reject", workspace_kind="dir", workspace_path=str(repo))
-        complete_with_evidence(conn, task_id)
+        complete_with_evidence(conn, task_id, repo)
         with pytest.raises(kb.FrozenHeadReviewError, match=expected):
             kb.submit_frozen_head_for_review(
                 conn, task_id, head_sha=head, worktree_path=str(repo), evidence=mutator(evidence(head, repo), repo)
@@ -160,7 +202,7 @@ def test_db_rejects_missing_or_malformed_head_and_unrelated_state(kanban_home, t
     repo, head = make_repo(tmp_path)
     with kb.connect_closing() as conn:
         task_id = kb.create_task(conn, title="head validation", workspace_kind="dir", workspace_path=str(repo))
-        complete_with_evidence(conn, task_id)
+        complete_with_evidence(conn, task_id, repo)
         valid = evidence(head, repo)
         with pytest.raises(kb.FrozenHeadReviewError, match="full 40-character"):
             kb.submit_frozen_head_for_review(conn, task_id, head_sha="", worktree_path=str(repo), evidence=valid)
@@ -176,14 +218,14 @@ def test_db_rejects_dirty_head_live_claim_and_missing_implementation_evidence(ka
     repo, head = make_repo(tmp_path)
     with kb.connect_closing() as conn:
         dirty_id = kb.create_task(conn, title="dirty", workspace_kind="dir", workspace_path=str(repo))
-        complete_with_evidence(conn, dirty_id)
+        complete_with_evidence(conn, dirty_id, repo)
         (repo / "dirty.txt").write_text("uncommitted\n")
         with pytest.raises(kb.FrozenHeadReviewError, match="dirty"):
             kb.submit_frozen_head_for_review(conn, dirty_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo))
         (repo / "dirty.txt").unlink()
 
         live_id = kb.create_task(conn, title="live", workspace_kind="dir", workspace_path=str(repo))
-        complete_with_evidence(conn, live_id)
+        complete_with_evidence(conn, live_id, repo)
         conn.execute("UPDATE tasks SET claim_lock='live', worker_pid=1234 WHERE id=?", (live_id,))
         conn.commit()
         with pytest.raises(kb.FrozenHeadReviewError, match="live claim"):
@@ -199,7 +241,7 @@ def test_cli_submit_review_uses_same_fail_closed_route(kanban_home, tmp_path, ca
     repo, head = make_repo(tmp_path)
     with kb.connect_closing() as conn:
         task_id = kb.create_task(conn, title="cli", workspace_kind="dir", workspace_path=str(repo))
-        complete_with_evidence(conn, task_id)
+        complete_with_evidence(conn, task_id, repo)
     parser = __import__("argparse").ArgumentParser()
     sub = parser.add_subparsers(dest="command")
     kc.build_parser(sub)
@@ -234,7 +276,7 @@ def test_os_writer_freeze_rejects_helper_with_cwd_and_writable_fd(kanban_home, t
         time.sleep(0.1)
         with kb.connect_closing() as conn:
             task_id = kb.create_task(conn, title="writer", workspace_kind="dir", workspace_path=str(repo))
-            complete_with_evidence(conn, task_id)
+            complete_with_evidence(conn, task_id, repo)
             with pytest.raises(kb.FrozenHeadReviewError, match="active OS writers"):
                 kb.submit_frozen_head_for_review(
                     conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)

--- a/tests/hermes_cli/test_frozen_head_review.py
+++ b/tests/hermes_cli/test_frozen_head_review.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import json
-import os
+import select
 import subprocess
-import time
+import sys
 from pathlib import Path
 
 import pytest
@@ -21,7 +21,7 @@ def kanban_home(tmp_path, monkeypatch, request):
     # The hermetic test runner may expose host processes through a restricted
     # /proc mount. Scanner behavior is exercised by the real helper test below;
     # admission tests isolate that unrelated host state.
-    if "os_writer_freeze" not in request.node.name:
+    if "writer" not in request.node.name:
         monkeypatch.setattr(
             kb, "_worktree_writer_pids",
             lambda _path: kb._WorktreeWriterScan((), True, False, ()),
@@ -75,6 +75,59 @@ def evidence(head: str, repo: Path, *, include_tree: bool = True) -> dict:
     if include_tree:
         result["tree_sha"] = git_tree(repo)
     return result
+
+
+def wait_for_helper_ready(helper: subprocess.Popen[str]) -> None:
+    assert helper.stdout is not None
+    ready, _, _ = select.select([helper.stdout], [], [], 5)
+    assert ready, "writer helper did not signal readiness"
+    assert helper.stdout.readline().strip() == "READY"
+
+
+def start_writer_helper(
+    code: str, *, cwd: Path, args: tuple[str, ...] = (),
+) -> subprocess.Popen[str]:
+    helper = subprocess.Popen(
+        [sys.executable, "-c", code, *args],
+        cwd=cwd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    wait_for_helper_ready(helper)
+    return helper
+
+
+def stop_writer_helper(helper: subprocess.Popen[str]) -> None:
+    try:
+        assert helper.stdin is not None
+        helper.stdin.write("STOP\n")
+        helper.stdin.flush()
+        helper.wait(timeout=5)
+    finally:
+        if helper.poll() is None:
+            helper.kill()
+            helper.wait(timeout=5)
+
+
+def isolate_proc_to_pid(monkeypatch, pid: int) -> None:
+    real_iterdir = Path.iterdir
+
+    def only_helper(path):
+        if path == Path("/proc"):
+            return iter([Path(f"/proc/{pid}")])
+        return real_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", only_helper)
+
+
+def submit_valid_frozen_head(
+    conn, task_id: str, head: str, repo: Path,
+) -> None:
+    assert kb.submit_frozen_head_for_review(
+        conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
+    )
 
 
 def test_db_accepts_completed_clean_exact_head_without_claim(kanban_home, tmp_path):
@@ -265,25 +318,245 @@ def test_missing_task_is_frozen_head_error_without_fk_event_failure(kanban_home,
             )
 
 
-def test_os_writer_freeze_rejects_helper_with_cwd_and_writable_fd(kanban_home, tmp_path):
+def test_os_writer_freeze_rejects_cwd_only_helper(kanban_home, tmp_path):
     repo, head = make_repo(tmp_path)
-    helper = subprocess.Popen(
-        [os.environ.get("HERMES_PYTHON", "python"), "-c",
-         "import time; f=open('implemented.txt','r+'); time.sleep(30)"],
+    helper = start_writer_helper(
+        "import sys; print('READY', flush=True); sys.stdin.readline()",
         cwd=repo,
     )
     try:
-        time.sleep(0.1)
         with kb.connect_closing() as conn:
             task_id = kb.create_task(conn, title="writer", workspace_kind="dir", workspace_path=str(repo))
             complete_with_evidence(conn, task_id, repo)
             with pytest.raises(kb.FrozenHeadReviewError, match="active OS writers"):
-                kb.submit_frozen_head_for_review(
-                    conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
-                )
+                submit_valid_frozen_head(conn, task_id, head, repo)
     finally:
-        helper.terminate()
-        helper.wait(timeout=5)
+        stop_writer_helper(helper)
+
+
+def test_os_writer_freeze_rejects_writable_fd_with_cwd_outside(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    helper = start_writer_helper(
+        "import sys; f=open(sys.argv[1], 'r+b'); print('READY', flush=True); sys.stdin.readline()",
+        cwd=tmp_path,
+        args=(str(repo / "implemented.txt"),),
+    )
+    try:
+        with kb.connect_closing() as conn:
+            task_id = kb.create_task(conn, title="fd writer", workspace_kind="dir", workspace_path=str(repo))
+            complete_with_evidence(conn, task_id, repo)
+            with pytest.raises(kb.FrozenHeadReviewError, match="active OS writers"):
+                submit_valid_frozen_head(conn, task_id, head, repo)
+    finally:
+        stop_writer_helper(helper)
+
+
+def test_os_writer_freeze_rejects_shared_writable_mmap_after_fd_close(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    helper = start_writer_helper(
+        "import mmap, os, sys; fd=os.open(sys.argv[1], os.O_RDWR); mapping=mmap.mmap(fd, 0, access=mmap.ACCESS_WRITE); os.close(fd); print('READY', flush=True); sys.stdin.readline()",
+        cwd=tmp_path,
+        args=(str(repo / "implemented.txt"),),
+    )
+    try:
+        with kb.connect_closing() as conn:
+            task_id = kb.create_task(conn, title="mmap writer", workspace_kind="dir", workspace_path=str(repo))
+            complete_with_evidence(conn, task_id, repo)
+            with pytest.raises(kb.FrozenHeadReviewError, match="active OS writers"):
+                submit_valid_frozen_head(conn, task_id, head, repo)
+    finally:
+        stop_writer_helper(helper)
+
+
+def test_os_writer_freeze_allows_read_only_fd(kanban_home, tmp_path, monkeypatch):
+    repo, head = make_repo(tmp_path)
+    helper = start_writer_helper(
+        "import sys; f=open(sys.argv[1], 'rb'); print('READY', flush=True); sys.stdin.readline()",
+        cwd=tmp_path,
+        args=(str(repo / "implemented.txt"),),
+    )
+    try:
+        isolate_proc_to_pid(monkeypatch, helper.pid)
+        with kb.connect_closing() as conn:
+            task_id = kb.create_task(conn, title="reader", workspace_kind="dir", workspace_path=str(repo))
+            complete_with_evidence(conn, task_id, repo)
+            submit_valid_frozen_head(conn, task_id, head, repo)
+            task = kb.get_task(conn, task_id)
+            assert task is not None and task.status == "review"
+    finally:
+        stop_writer_helper(helper)
+
+
+def test_os_writer_freeze_allows_private_writable_mmap(kanban_home, tmp_path, monkeypatch):
+    repo, head = make_repo(tmp_path)
+    helper = start_writer_helper(
+        "import ctypes, os, sys; fd=os.open(sys.argv[1], os.O_RDWR); size=os.fstat(fd).st_size; libc=ctypes.CDLL(None); mapping=libc.mmap(None, size, 3, 2, fd, 0); os.close(fd); print('READY', flush=True); sys.stdin.readline()",
+        cwd=tmp_path,
+        args=(str(repo / "implemented.txt"),),
+    )
+    try:
+        isolate_proc_to_pid(monkeypatch, helper.pid)
+        with kb.connect_closing() as conn:
+            task_id = kb.create_task(conn, title="private mmap", workspace_kind="dir", workspace_path=str(repo))
+            complete_with_evidence(conn, task_id, repo)
+            submit_valid_frozen_head(conn, task_id, head, repo)
+            task = kb.get_task(conn, task_id)
+            assert task is not None and task.status == "review"
+    finally:
+        stop_writer_helper(helper)
+
+
+def test_writer_scan_rejects_unsupported_platform(tmp_path, monkeypatch):
+    monkeypatch.setattr(kb.sys, "platform", "win32")
+    scan = kb._worktree_writer_pids(tmp_path)
+    assert scan.writers == ()
+    assert scan.complete is False
+    assert scan.unsupported is True
+    assert scan.errors == ("unsupported platform: win32",)
+
+
+def test_writer_scan_rejects_absent_proc(tmp_path, monkeypatch):
+    real_iterdir = Path.iterdir
+
+    def fail_proc_enumeration(path):
+        if path == Path("/proc"):
+            raise FileNotFoundError("/proc disappeared")
+        return real_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", fail_proc_enumeration)
+    scan = kb._worktree_writer_pids(tmp_path)
+    assert scan.writers == ()
+    assert scan.complete is False
+    assert scan.unsupported is False
+    assert scan.errors == ("proc unavailable",)
+
+
+def test_writer_scan_rejects_proc_enumeration_denial(tmp_path, monkeypatch):
+    real_iterdir = Path.iterdir
+
+    def deny_proc_enumeration(path):
+        if path == Path("/proc"):
+            raise PermissionError("hidden by policy")
+        return real_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", deny_proc_enumeration)
+    scan = kb._worktree_writer_pids(tmp_path)
+    assert scan.writers == ()
+    assert scan.complete is False
+    assert scan.unsupported is False
+    assert scan.errors == ("proc enumeration denied",)
+
+
+@pytest.mark.parametrize("process_kind", ["same uid", "root", "unknown"])
+def test_writer_scan_rejects_unreadable_process_without_leaking_error(
+    tmp_path, monkeypatch, process_kind,
+):
+    real_iterdir = Path.iterdir
+    real_resolve = Path.resolve
+    process = Path("/proc/424242")
+
+    def fake_iterdir(path):
+        if path == Path("/proc"):
+            return iter([process])
+        return real_iterdir(path)
+
+    def deny_process(path, *args, **kwargs):
+        if path == process / "cwd":
+            raise PermissionError(f"private {process_kind} details")
+        return real_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+    monkeypatch.setattr(Path, "resolve", deny_process)
+    scan = kb._worktree_writer_pids(tmp_path)
+    assert scan.writers == ()
+    assert scan.complete is False
+    assert scan.unsupported is False
+    assert len(scan.errors) <= 32
+    assert scan.errors == ("pid 424242: permission denied",)
+    assert process_kind not in " ".join(scan.errors)
+
+
+@pytest.mark.parametrize(
+    "changed_snapshot",
+    [
+        ("changed-head", lambda head, tree: ("0" * 40, tree, "")),
+        ("changed-tree", lambda head, tree: (head, "1" * 40, "")),
+        ("changed-dirty-status", lambda head, tree: (head, tree, " M implemented.txt\n")),
+    ],
+)
+def test_git_snapshot_race_rejects_without_transition(
+    kanban_home, tmp_path, monkeypatch, changed_snapshot,
+):
+    repo, head = make_repo(tmp_path)
+    tree = git_tree(repo)
+    label, second = changed_snapshot
+    snapshots = [(head, tree, ""), second(head, tree)]
+    calls = []
+
+    def snapshots_with_race(path):
+        calls.append(path)
+        return snapshots.pop(0)
+
+    monkeypatch.setattr(kb, "_git_worktree_snapshot", snapshots_with_race)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title=label, workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, task_id, repo)
+        with pytest.raises(kb.FrozenHeadReviewError, match="changed during verification"):
+            submit_valid_frozen_head(conn, task_id, head, repo)
+        assert len(calls) == 2
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "done"
+
+
+@pytest.mark.parametrize("race", ["status", "workspace", "current_run", "claim", "pid", "run_id", "metadata"])
+def test_final_transaction_races_reject_atomically(
+    kanban_home, tmp_path, monkeypatch, race,
+):
+    repo, head = make_repo(tmp_path)
+    tree = git_tree(repo)
+    original_write_txn = kb.write_txn
+    injected = False
+
+    def inject_race(conn):
+        nonlocal injected
+        if not injected:
+            injected = True
+            if race == "status":
+                conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (task_id,))
+            elif race == "workspace":
+                conn.execute(
+                    "UPDATE tasks SET workspace_path=? WHERE id=?",
+                    (str(tmp_path / "different-worktree"), task_id),
+                )
+            elif race == "current_run":
+                conn.execute("UPDATE tasks SET current_run_id=999999 WHERE id=?", (task_id,))
+            elif race == "claim":
+                conn.execute("UPDATE tasks SET claim_lock='racer' WHERE id=?", (task_id,))
+            elif race == "pid":
+                conn.execute("UPDATE tasks SET worker_pid=424242 WHERE id=?", (task_id,))
+            elif race == "run_id":
+                kb._synthesize_ended_run(
+                    conn, task_id, outcome="completed", summary="newer run",
+                    metadata={"changed_files": ["implemented.txt"], "tests_run": 4,
+                              "head_sha": head, "tree_sha": tree},
+                )
+            elif race == "metadata":
+                conn.execute(
+                    "UPDATE task_runs SET metadata=? WHERE task_id=? AND outcome='completed'",
+                    (json.dumps({"changed_files": ["implemented.txt"], "tests_run": 4,
+                                 "head_sha": head, "tree_sha": tree}), task_id),
+                )
+            conn.commit()
+        return original_write_txn(conn)
+
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title=f"race {race}", workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, task_id, repo)
+        monkeypatch.setattr(kb, "write_txn", inject_race)
+        with pytest.raises(kb.FrozenHeadReviewError):
+            submit_valid_frozen_head(conn, task_id, head, repo)
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status != "review"
 
 
 def test_legacy_submit_task_for_review_keeps_running_and_blocked_contract(kanban_home):
@@ -299,3 +572,23 @@ def test_legacy_submit_task_for_review_keeps_running_and_blocked_contract(kanban
         assert kb.block_task(conn, blocked_id, reason="review-required: inspect", expected_run_id=run_id)
         reviewed = kb.submit_task_for_review(conn, blocked_id, "reviewer")
         assert reviewed is not None and reviewed.status == "review"
+
+
+def test_frozen_head_rejects_unrelated_blocked_state(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn, title="unrelated blocked", workspace_kind="dir",
+            workspace_path=str(repo), assignee="programmer",
+        )
+        kb.claim_task(conn, task_id, claimer="programmer")
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        run_id = task.current_run_id
+        assert kb.block_task(
+            conn, task_id, reason="waiting for operator input", expected_run_id=run_id,
+        )
+        with pytest.raises(kb.FrozenHeadReviewError, match="unrelated blocked state"):
+            submit_valid_frozen_head(conn, task_id, head, repo)
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "blocked"

--- a/tests/hermes_cli/test_frozen_head_review.py
+++ b/tests/hermes_cli/test_frozen_head_review.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    kb.init_db()
+    return home
+
+
+def git_head(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def make_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "implementation"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    (repo / "implemented.txt").write_text("done\n")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "implementation"],
+        check=True,
+    )
+    return repo, git_head(repo)
+
+
+def complete_with_evidence(conn, task_id: str) -> None:
+    assert kb.complete_task(
+        conn, task_id, summary="implementation complete",
+        metadata={"changed_files": ["implemented.txt"], "tests_run": 3},
+    )
+
+
+def evidence(head: str, repo: Path) -> dict:
+    return {
+        "head_sha": head,
+        "worktree_path": str(repo),
+        "clean": True,
+        "implementation_complete": True,
+        "source": "frozen-head-cli",
+    }
+
+
+def test_db_accepts_completed_clean_exact_head_without_claim(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="frozen", workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, task_id)
+        assert kb.submit_task_for_review(
+            conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
+        )
+        assert kb.get_task(conn, task_id).status == "review"
+        event = kb.list_events(conn, task_id)[-1]
+        assert event.kind == "review_submitted_frozen_head"
+        assert event.payload["head_sha"] == head
+        assert event.payload["implementation_run_id"]
+
+
+def test_scheduled_ready_recovery_can_reach_frozen_review(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="scheduled recovery", workspace_kind="dir", workspace_path=str(repo))
+        assert kb.schedule_task(conn, task_id, reason="today's frozen head")
+        assert kb.unblock_task(conn, task_id)
+        assert kb.get_task(conn, task_id).status == "ready"
+        complete_with_evidence(conn, task_id)
+        assert kb.submit_task_for_review(
+            conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
+        )
+
+
+@pytest.mark.parametrize(
+    "mutator, expected",
+    [
+        (lambda e, r: {**e, "head_sha": "0" * 40}, "evidence head_sha"),
+        (lambda e, r: {**e, "clean": False}, "clean must be true"),
+        (lambda e, r: {**e, "implementation_complete": False}, "implementation_complete"),
+    ],
+)
+def test_db_rejects_malformed_or_mismatched_evidence(kanban_home, tmp_path, mutator, expected):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="reject", workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, task_id)
+        with pytest.raises(kb.FrozenHeadReviewError, match=expected):
+            kb.submit_task_for_review(
+                conn, task_id, head_sha=head, worktree_path=str(repo), evidence=mutator(evidence(head, repo), repo)
+            )
+        assert kb.get_task(conn, task_id).status == "done"
+        assert kb.list_events(conn, task_id)[-1].kind == "review_submission_rejected"
+
+
+def test_db_rejects_missing_or_malformed_head_and_unrelated_state(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="head validation", workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, task_id)
+        valid = evidence(head, repo)
+        with pytest.raises(kb.FrozenHeadReviewError, match="full 40-character"):
+            kb.submit_task_for_review(conn, task_id, head_sha="", worktree_path=str(repo), evidence=valid)
+        with pytest.raises(kb.FrozenHeadReviewError, match="full 40-character"):
+            kb.submit_task_for_review(conn, task_id, head_sha="not-a-sha", worktree_path=str(repo), evidence=valid)
+
+        unrelated_id = kb.create_task(conn, title="not done", workspace_kind="dir", workspace_path=str(repo))
+        with pytest.raises(kb.FrozenHeadReviewError, match="must be done"):
+            kb.submit_task_for_review(conn, unrelated_id, head_sha=head, worktree_path=str(repo), evidence=valid)
+
+
+def test_db_rejects_dirty_head_live_claim_and_missing_implementation_evidence(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        dirty_id = kb.create_task(conn, title="dirty", workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, dirty_id)
+        (repo / "dirty.txt").write_text("uncommitted\n")
+        with pytest.raises(kb.FrozenHeadReviewError, match="dirty"):
+            kb.submit_task_for_review(conn, dirty_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo))
+        (repo / "dirty.txt").unlink()
+
+        live_id = kb.create_task(conn, title="live", workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, live_id)
+        conn.execute("UPDATE tasks SET claim_lock='live', worker_pid=1234 WHERE id=?", (live_id,))
+        conn.commit()
+        with pytest.raises(kb.FrozenHeadReviewError, match="live claim"):
+            kb.submit_task_for_review(conn, live_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo))
+
+        no_evidence_id = kb.create_task(conn, title="no evidence", workspace_kind="dir", workspace_path=str(repo))
+        assert kb.complete_task(conn, no_evidence_id, result="done")
+        with pytest.raises(kb.FrozenHeadReviewError, match="metadata is malformed"):
+            kb.submit_task_for_review(conn, no_evidence_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo))
+
+
+def test_cli_submit_review_uses_same_fail_closed_route(kanban_home, tmp_path, capsys):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="cli", workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, task_id)
+    parser = __import__("argparse").ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args([
+        "kanban", "submit-review", task_id, "--head-sha", head,
+        "--worktree", str(repo), "--evidence", json.dumps(evidence(head, repo)),
+    ])
+    assert kc.kanban_command(args) == 0
+    assert "Submitted" in capsys.readouterr().out
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, task_id).status == "review"

--- a/tests/hermes_cli/test_frozen_head_review.py
+++ b/tests/hermes_cli/test_frozen_head_review.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -61,7 +63,7 @@ def test_db_accepts_completed_clean_exact_head_without_claim(kanban_home, tmp_pa
     with kb.connect_closing() as conn:
         task_id = kb.create_task(conn, title="frozen", workspace_kind="dir", workspace_path=str(repo))
         complete_with_evidence(conn, task_id)
-        assert kb.submit_task_for_review(
+        assert kb.submit_frozen_head_for_review(
             conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
         )
         assert kb.get_task(conn, task_id).status == "review"
@@ -71,15 +73,21 @@ def test_db_accepts_completed_clean_exact_head_without_claim(kanban_home, tmp_pa
         assert event.payload["implementation_run_id"]
 
 
-def test_scheduled_ready_recovery_can_reach_frozen_review(kanban_home, tmp_path):
+@pytest.mark.parametrize("status", ["scheduled", "ready"])
+def test_scheduled_ready_submit_directly_without_transition_dance(kanban_home, tmp_path, status):
     repo, head = make_repo(tmp_path)
     with kb.connect_closing() as conn:
         task_id = kb.create_task(conn, title="scheduled recovery", workspace_kind="dir", workspace_path=str(repo))
         assert kb.schedule_task(conn, task_id, reason="today's frozen head")
-        assert kb.unblock_task(conn, task_id)
-        assert kb.get_task(conn, task_id).status == "ready"
-        complete_with_evidence(conn, task_id)
-        assert kb.submit_task_for_review(
+        if status == "ready":
+            assert kb.unblock_task(conn, task_id)
+        assert kb.get_task(conn, task_id).status == status
+        kb._synthesize_ended_run(
+            conn, task_id, outcome="completed",
+            summary="implementation complete",
+            metadata={"changed_files": ["implemented.txt"], "tests_run": 3},
+        )
+        assert kb.submit_frozen_head_for_review(
             conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
         )
 
@@ -98,7 +106,7 @@ def test_db_rejects_malformed_or_mismatched_evidence(kanban_home, tmp_path, muta
         task_id = kb.create_task(conn, title="reject", workspace_kind="dir", workspace_path=str(repo))
         complete_with_evidence(conn, task_id)
         with pytest.raises(kb.FrozenHeadReviewError, match=expected):
-            kb.submit_task_for_review(
+            kb.submit_frozen_head_for_review(
                 conn, task_id, head_sha=head, worktree_path=str(repo), evidence=mutator(evidence(head, repo), repo)
             )
         assert kb.get_task(conn, task_id).status == "done"
@@ -112,13 +120,13 @@ def test_db_rejects_missing_or_malformed_head_and_unrelated_state(kanban_home, t
         complete_with_evidence(conn, task_id)
         valid = evidence(head, repo)
         with pytest.raises(kb.FrozenHeadReviewError, match="full 40-character"):
-            kb.submit_task_for_review(conn, task_id, head_sha="", worktree_path=str(repo), evidence=valid)
+            kb.submit_frozen_head_for_review(conn, task_id, head_sha="", worktree_path=str(repo), evidence=valid)
         with pytest.raises(kb.FrozenHeadReviewError, match="full 40-character"):
-            kb.submit_task_for_review(conn, task_id, head_sha="not-a-sha", worktree_path=str(repo), evidence=valid)
+            kb.submit_frozen_head_for_review(conn, task_id, head_sha="not-a-sha", worktree_path=str(repo), evidence=valid)
 
         unrelated_id = kb.create_task(conn, title="not done", workspace_kind="dir", workspace_path=str(repo))
-        with pytest.raises(kb.FrozenHeadReviewError, match="must be done"):
-            kb.submit_task_for_review(conn, unrelated_id, head_sha=head, worktree_path=str(repo), evidence=valid)
+        with pytest.raises(kb.FrozenHeadReviewError, match="completed implementation evidence is absent"):
+            kb.submit_frozen_head_for_review(conn, unrelated_id, head_sha=head, worktree_path=str(repo), evidence=valid)
 
 
 def test_db_rejects_dirty_head_live_claim_and_missing_implementation_evidence(kanban_home, tmp_path):
@@ -128,7 +136,7 @@ def test_db_rejects_dirty_head_live_claim_and_missing_implementation_evidence(ka
         complete_with_evidence(conn, dirty_id)
         (repo / "dirty.txt").write_text("uncommitted\n")
         with pytest.raises(kb.FrozenHeadReviewError, match="dirty"):
-            kb.submit_task_for_review(conn, dirty_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo))
+            kb.submit_frozen_head_for_review(conn, dirty_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo))
         (repo / "dirty.txt").unlink()
 
         live_id = kb.create_task(conn, title="live", workspace_kind="dir", workspace_path=str(repo))
@@ -136,12 +144,12 @@ def test_db_rejects_dirty_head_live_claim_and_missing_implementation_evidence(ka
         conn.execute("UPDATE tasks SET claim_lock='live', worker_pid=1234 WHERE id=?", (live_id,))
         conn.commit()
         with pytest.raises(kb.FrozenHeadReviewError, match="live claim"):
-            kb.submit_task_for_review(conn, live_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo))
+            kb.submit_frozen_head_for_review(conn, live_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo))
 
         no_evidence_id = kb.create_task(conn, title="no evidence", workspace_kind="dir", workspace_path=str(repo))
         assert kb.complete_task(conn, no_evidence_id, result="done")
         with pytest.raises(kb.FrozenHeadReviewError, match="metadata is malformed"):
-            kb.submit_task_for_review(conn, no_evidence_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo))
+            kb.submit_frozen_head_for_review(conn, no_evidence_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo))
 
 
 def test_cli_submit_review_uses_same_fail_closed_route(kanban_home, tmp_path, capsys):
@@ -160,3 +168,49 @@ def test_cli_submit_review_uses_same_fail_closed_route(kanban_home, tmp_path, ca
     assert "Submitted" in capsys.readouterr().out
     with kb.connect_closing() as conn:
         assert kb.get_task(conn, task_id).status == "review"
+
+
+def test_missing_task_is_frozen_head_error_without_fk_event_failure(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        with pytest.raises(kb.FrozenHeadReviewError, match="not found"):
+            kb.submit_frozen_head_for_review(
+                conn, "t_missing", head_sha=head, worktree_path=str(repo),
+                evidence=evidence(head, repo),
+            )
+
+
+def test_os_writer_freeze_rejects_helper_with_cwd_and_writable_fd(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    helper = subprocess.Popen(
+        [os.environ.get("HERMES_PYTHON", "python"), "-c",
+         "import time; f=open('implemented.txt','r+'); time.sleep(30)"],
+        cwd=repo,
+    )
+    try:
+        time.sleep(0.1)
+        with kb.connect_closing() as conn:
+            task_id = kb.create_task(conn, title="writer", workspace_kind="dir", workspace_path=str(repo))
+            complete_with_evidence(conn, task_id)
+            with pytest.raises(kb.FrozenHeadReviewError, match="active OS writers"):
+                kb.submit_frozen_head_for_review(
+                    conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
+                )
+    finally:
+        helper.terminate()
+        helper.wait(timeout=5)
+
+
+def test_legacy_submit_task_for_review_keeps_running_and_blocked_contract(kanban_home):
+    with kb.connect_closing() as conn:
+        running_id = kb.create_task(conn, title="legacy running", assignee="programmer")
+        kb.claim_task(conn, running_id, claimer="programmer")
+        reviewed = kb.submit_task_for_review(conn, running_id, "reviewer")
+        assert reviewed is not None and reviewed.status == "review"
+
+        blocked_id = kb.create_task(conn, title="legacy blocked", assignee="programmer")
+        kb.claim_task(conn, blocked_id, claimer="programmer")
+        run_id = kb.get_task(conn, blocked_id).current_run_id
+        assert kb.block_task(conn, blocked_id, reason="review-required: inspect", expected_run_id=run_id)
+        reviewed = kb.submit_task_for_review(conn, blocked_id, "reviewer")
+        assert reviewed is not None and reviewed.status == "review"

--- a/tests/hermes_cli/test_frozen_head_review.py
+++ b/tests/hermes_cli/test_frozen_head_review.py
@@ -4,6 +4,8 @@ import json
 import select
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -144,6 +146,51 @@ def test_db_accepts_completed_clean_exact_head_without_claim(kanban_home, tmp_pa
         assert event.payload["head_sha"] == head
         assert event.payload["tree_sha"] == git_tree(repo)
         assert event.payload["implementation_run_id"]
+
+
+def test_committed_admission_freeze_persists_and_authorized_thaw_restores_modes(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    tracked = repo / "implemented.txt"
+    root_mode = repo.stat().st_mode & 0o7777
+    file_mode = tracked.stat().st_mode & 0o7777
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="durable freeze", workspace_kind="dir", workspace_path=str(repo))
+        with kb._workspace_admission_lock(repo, exclusive=True, task_id=task_id, head_sha=head) as lease:
+            assert not (repo.stat().st_mode & 0o222)
+            assert not (tracked.stat().st_mode & 0o222)
+            lease.commit()
+        assert not (repo.stat().st_mode & 0o222)
+        assert not (tracked.stat().st_mode & 0o222)
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (task_id,))
+        conn.commit()
+        conn.execute("UPDATE tasks SET status='done' WHERE id=?", (task_id,))
+        conn.commit()
+        assert kb.thaw_frozen_workspace(conn, task_id, head_sha=head)
+    assert repo.stat().st_mode & 0o7777 == root_mode
+    assert tracked.stat().st_mode & 0o7777 == file_mode
+
+
+def test_rejected_evidence_is_bounded_and_redacted(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    secret = "SUPER-SECRET-" + ("x" * 10000)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="bounded rejection", workspace_kind="dir", workspace_path=str(repo))
+        with pytest.raises(kb.FrozenHeadReviewError):
+            kb.submit_frozen_head_for_review(
+                conn,
+                task_id,
+                head_sha=secret,
+                worktree_path=secret,
+                evidence={"head_sha": secret, "worktree_path": secret},
+                actor=secret,
+            )
+        event = kb.list_events(conn, task_id)[-1]
+        assert event is not None
+        payload = json.dumps(event.payload)
+        assert len(payload) < 2048
+        assert secret not in payload
+        assert event.payload["code"] == "FROZEN_HEAD_REVIEW_REJECTED"
+        assert "SUPER-SECRET" not in payload
 
 
 @pytest.mark.parametrize("status", ["scheduled", "ready"])
@@ -510,51 +557,78 @@ def test_git_snapshot_race_rejects_without_transition(
 
 @pytest.mark.parametrize("race", ["status", "workspace", "current_run", "claim", "pid", "run_id", "metadata"])
 def test_final_transaction_races_reject_atomically(
-    kanban_home, tmp_path, monkeypatch, race,
+    kanban_home, tmp_path, race,
 ):
     repo, head = make_repo(tmp_path)
     tree = git_tree(repo)
-    original_write_txn = kb.write_txn
-    injected = False
-
-    def inject_race(conn):
-        nonlocal injected
-        if not injected:
-            injected = True
-            if race == "status":
-                conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (task_id,))
-            elif race == "workspace":
-                conn.execute(
-                    "UPDATE tasks SET workspace_path=? WHERE id=?",
-                    (str(tmp_path / "different-worktree"), task_id),
-                )
-            elif race == "current_run":
-                conn.execute("UPDATE tasks SET current_run_id=999999 WHERE id=?", (task_id,))
-            elif race == "claim":
-                conn.execute("UPDATE tasks SET claim_lock='racer' WHERE id=?", (task_id,))
-            elif race == "pid":
-                conn.execute("UPDATE tasks SET worker_pid=424242 WHERE id=?", (task_id,))
-            elif race == "run_id":
-                kb._synthesize_ended_run(
-                    conn, task_id, outcome="completed", summary="newer run",
-                    metadata={"changed_files": ["implemented.txt"], "tests_run": 4,
-                              "head_sha": head, "tree_sha": tree},
-                )
-            elif race == "metadata":
-                conn.execute(
-                    "UPDATE task_runs SET metadata=? WHERE task_id=? AND outcome='completed'",
-                    (json.dumps({"changed_files": ["implemented.txt"], "tests_run": 4,
-                                 "head_sha": head, "tree_sha": tree}), task_id),
-                )
-            conn.commit()
-        return original_write_txn(conn)
-
     with kb.connect_closing() as conn:
         task_id = kb.create_task(conn, title=f"race {race}", workspace_kind="dir", workspace_path=str(repo))
         complete_with_evidence(conn, task_id, repo)
-        monkeypatch.setattr(kb, "write_txn", inject_race)
-        with pytest.raises(kb.FrozenHeadReviewError):
-            submit_valid_frozen_head(conn, task_id, head, repo)
+        run_row = conn.execute(
+            "SELECT id FROM task_runs WHERE task_id=? AND outcome='completed' "
+            "ORDER BY ended_at DESC, id DESC LIMIT 1", (task_id,),
+        ).fetchone()
+        assert run_row is not None
+        run_id = int(run_row["id"])
+        db_path = str(kb.kanban_db_path())
+        racer_code = """
+import json, sqlite3, sys, time
+db, task_id, race, run_id, head, tree, other_workspace = sys.argv[1:]
+conn = sqlite3.connect(db, timeout=30)
+conn.execute("BEGIN IMMEDIATE")
+print("READY", flush=True)
+sys.stdin.readline()
+if race == "status":
+    conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (task_id,))
+elif race == "workspace":
+    conn.execute("UPDATE tasks SET workspace_path=? WHERE id=?", (other_workspace, task_id))
+elif race == "current_run":
+    conn.execute("UPDATE tasks SET current_run_id=999999 WHERE id=?", (task_id,))
+elif race == "claim":
+    conn.execute("UPDATE tasks SET claim_lock='racer' WHERE id=?", (task_id,))
+elif race == "pid":
+    conn.execute("UPDATE tasks SET worker_pid=424242 WHERE id=?", (task_id,))
+elif race == "run_id":
+    conn.execute('''INSERT INTO task_runs
+        (task_id, status, started_at, ended_at, outcome, summary, metadata)
+        SELECT task_id, 'done', started_at, started_at + 1, 'completed',
+               'newer run', metadata FROM task_runs WHERE id=?''', (int(run_id),))
+elif race == "metadata":
+    conn.execute("UPDATE task_runs SET metadata=? WHERE id=?", (json.dumps({
+        "changed_files": ["implemented.txt"], "tests_run": 4,
+        "head_sha": head, "tree_sha": tree}), int(run_id)))
+conn.commit()
+conn.close()
+"""
+        racer = subprocess.Popen(
+            [sys.executable, "-c", racer_code, db_path, task_id, race, str(run_id),
+             head, tree, str(tmp_path / "different-worktree")],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True,
+        )
+        try:
+            wait_for_helper_ready(racer)
+            result: dict[str, BaseException] = {}
+
+            def submit() -> None:
+                try:
+                    with kb.connect_closing() as submit_conn:
+                        submit_valid_frozen_head(submit_conn, task_id, head, repo)
+                except BaseException as exc:  # assertion below checks the exact class
+                    result["error"] = exc
+
+            thread = threading.Thread(target=submit)
+            thread.start()
+            time.sleep(0.1)
+            assert racer.stdin is not None
+            racer.stdin.write("COMMIT\n")
+            racer.stdin.flush()
+            thread.join(timeout=10)
+            assert not thread.is_alive()
+            assert isinstance(result.get("error"), kb.FrozenHeadReviewError)
+        finally:
+            if racer.poll() is None:
+                racer.kill()
+            racer.wait(timeout=5)
         task = kb.get_task(conn, task_id)
         assert task is not None and task.status != "review"
 
@@ -592,3 +666,58 @@ def test_frozen_head_rejects_unrelated_blocked_state(kanban_home, tmp_path):
             submit_valid_frozen_head(conn, task_id, head, repo)
         task = kb.get_task(conn, task_id)
         assert task is not None and task.status == "blocked"
+
+
+def test_reviewer_claim_request_changes_and_next_implementation_claim_lifecycle(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    tracked = repo / "implemented.txt"
+    original_file = tracked.stat().st_mode & 0o7777
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="review lifecycle", workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, task_id, repo)
+        submit_valid_frozen_head(conn, task_id, head, repo)
+        assert kb.claim_review_task(conn, task_id, claimer="reviewer") is not None
+        assert not (repo.stat().st_mode & 0o222)
+        assert not (tracked.stat().st_mode & 0o222)
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        run_id = task.current_run_id
+        assert kb.block_task(conn, task_id, reason="review-required: changes", expected_run_id=run_id)
+        assert kb.unblock_task(conn, task_id)
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "ready"
+        assert not (repo.stat().st_mode & 0o222)
+        assert kb.claim_task(conn, task_id, claimer="programmer") is not None
+        assert tracked.stat().st_mode & 0o7777 == original_file
+
+
+def test_terminal_review_completion_thaws_and_delete_requires_cleanup(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="terminal thaw", workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, task_id, repo)
+        submit_valid_frozen_head(conn, task_id, head, repo)
+        with pytest.raises(kb.FrozenHeadReviewError):
+            kb.delete_task(conn, task_id)
+        assert kb.complete_task(conn, task_id, result="approved")
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "done"
+        assert repo.stat().st_mode & 0o222
+        assert kb.delete_task(conn, task_id)
+
+
+def test_failed_implementation_thaw_blocks_without_spawn(kanban_home, tmp_path):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="thaw failure", workspace_kind="dir", workspace_path=str(repo))
+        complete_with_evidence(conn, task_id, repo)
+        submit_valid_frozen_head(conn, task_id, head, repo)
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+        conn.commit()
+        manifests = kb._admission_state_root() / "manifests"
+        for manifest in manifests.glob("*.json"):
+            manifest.unlink()
+        assert kb.claim_task(conn, task_id, claimer="programmer") is None
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "blocked"
+        assert not (repo.stat().st_mode & 0o222)

--- a/tests/hermes_cli/test_frozen_head_review.py
+++ b/tests/hermes_cli/test_frozen_head_review.py
@@ -28,6 +28,13 @@ def git_head(repo: Path) -> str:
     ).stdout.strip()
 
 
+def git_tree(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD^{tree}"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
 def make_repo(tmp_path: Path) -> tuple[Path, str]:
     repo = tmp_path / "implementation"
     repo.mkdir()
@@ -48,14 +55,17 @@ def complete_with_evidence(conn, task_id: str) -> None:
     )
 
 
-def evidence(head: str, repo: Path) -> dict:
-    return {
+def evidence(head: str, repo: Path, *, include_tree: bool = False) -> dict:
+    result = {
         "head_sha": head,
         "worktree_path": str(repo),
         "clean": True,
         "implementation_complete": True,
         "source": "frozen-head-cli",
     }
+    if include_tree:
+        result["tree_sha"] = git_tree(repo)
+    return result
 
 
 def test_db_accepts_completed_clean_exact_head_without_claim(kanban_home, tmp_path):
@@ -70,6 +80,7 @@ def test_db_accepts_completed_clean_exact_head_without_claim(kanban_home, tmp_pa
         event = kb.list_events(conn, task_id)[-1]
         assert event.kind == "review_submitted_frozen_head"
         assert event.payload["head_sha"] == head
+        assert event.payload["tree_sha"] == git_tree(repo)
         assert event.payload["implementation_run_id"]
 
 
@@ -90,6 +101,38 @@ def test_scheduled_ready_submit_directly_without_transition_dance(kanban_home, t
         assert kb.submit_frozen_head_for_review(
             conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
         )
+
+
+@pytest.mark.parametrize("status", ["scheduled", "ready", "todo", "done"])
+def test_every_accepted_dormant_state_is_explicitly_supported(kanban_home, tmp_path, status):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title=f"accepted {status}", workspace_kind="dir", workspace_path=str(repo))
+        if status == "done":
+            complete_with_evidence(conn, task_id)
+        else:
+            conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, task_id))
+            conn.commit()
+            kb._synthesize_ended_run(
+                conn, task_id, outcome="completed", summary="implementation complete",
+                metadata={"changed_files": ["implemented.txt"], "tests_run": 3},
+            )
+        assert kb.submit_frozen_head_for_review(
+            conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
+        )
+
+
+@pytest.mark.parametrize("status", ["triage", "running", "archived"])
+def test_non_dormant_states_are_rejected(kanban_home, tmp_path, status):
+    repo, head = make_repo(tmp_path)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title=f"reject {status}", workspace_kind="dir", workspace_path=str(repo))
+        conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, task_id))
+        conn.commit()
+        with pytest.raises(kb.FrozenHeadReviewError, match="cannot be submitted"):
+            kb.submit_frozen_head_for_review(
+                conn, task_id, head_sha=head, worktree_path=str(repo), evidence=evidence(head, repo)
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -80,6 +80,41 @@ def test_board_empty(client):
     assert data["latest_event_id"] == 0
 
 
+def test_submit_review_accepts_frozen_head_without_claim(client, kanban_home, tmp_path):
+    repo = tmp_path / "frozen-api"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    (repo / "implementation.txt").write_text("done\n")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run([
+        "git", "-C", str(repo), "-c", "user.name=Test", "-c", "user.email=test@example.com",
+        "commit", "-qm", "implementation",
+    ], check=True)
+    head = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="API frozen", workspace_kind="dir", workspace_path=str(repo))
+        assert kb.complete_task(
+            conn, task_id, summary="implemented",
+            metadata={"changed_files": ["implementation.txt"], "tests_run": 1},
+        )
+    payload = {
+        "head_sha": head,
+        "worktree_path": str(repo),
+        "evidence": {
+            "head_sha": head,
+            "worktree_path": str(repo),
+            "clean": True,
+            "implementation_complete": True,
+        },
+    }
+    response = client.post(f"/api/plugins/kanban/tasks/{task_id}/submit-review", json=payload)
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["status"] == "review"
+
+
 # ---------------------------------------------------------------------------
 # POST /tasks then GET /board sees it
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -49,6 +49,10 @@ def kanban_home(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(
+        kb, "_worktree_writer_pids",
+        lambda _path: kb._WorktreeWriterScan((), True, False, ()),
+    )
     kb.init_db()
     return home
 
@@ -94,17 +98,27 @@ def test_submit_review_accepts_frozen_head_without_claim(client, kanban_home, tm
         ["git", "-C", str(repo), "rev-parse", "HEAD"], check=True,
         capture_output=True, text=True,
     ).stdout.strip()
+    tree_sha = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD^{tree}"], check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
     with kb.connect_closing() as conn:
         task_id = kb.create_task(conn, title="API frozen", workspace_kind="dir", workspace_path=str(repo))
         assert kb.complete_task(
             conn, task_id, summary="implemented",
-            metadata={"changed_files": ["implementation.txt"], "tests_run": 1},
+            metadata={
+                "changed_files": ["implementation.txt"],
+                "tests_run": 1,
+                "head_sha": head,
+                "tree_sha": tree_sha,
+            },
         )
     payload = {
         "head_sha": head,
         "worktree_path": str(repo),
         "evidence": {
             "head_sha": head,
+            "tree_sha": tree_sha,
             "worktree_path": str(repo),
             "clean": True,
             "implementation_complete": True,


### PR DESCRIPTION
## Summary
- add an explicit fail-closed DB route for completed immutable exact implementation heads
- expose the route through `hermes kanban submit-review` and the dashboard API
- record accepted/rejected provenance events and behavior-test scheduled recovery plus rejection paths

## Verification
- `HERMES_PYTHON=/home/fardochebot/.hermes/hermes-agent/venv/bin/python bash scripts/run_tests.sh tests/hermes_cli/test_frozen_head_review.py tests/plugins/test_kanban_dashboard_plugin.py -q` — 29 passed
- focused direct pytest — 29 passed
- relevant Kanban suite — 168 passed, 2 unrelated async-plugin failures in `test_kanban_notify.py` under per-file runner
- `py_compile` and `git diff --check` passed

Do not merge; separate-engine review requested.