### PR TITLE
fix(desktop): pin a session opened as a tile instead of silently doing nothing

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-pin.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-pin.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $pinnedSessionIds, unpinSession } from '@/store/layout'
+import { $sessions } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { toggleTilePin } from './session-tile'
+
+const STORED = 'stored-tile'
+const LINEAGE = 'lineage-root'
+
+function row(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    cwd: null,
+    ended_at: null,
+    id: STORED,
+    input_tokens: 0,
+    is_active: true,
+    last_active: 1,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    parent_session_id: null,
+    preview: null,
+    source: 'desktop',
+    started_at: 1,
+    title: null,
+    tool_call_count: 0,
+    ...overrides
+  }
+}
+
+describe('toggleTilePin', () => {
+  beforeEach(() => {
+    $sessions.set([])
+    $pinnedSessionIds.set([])
+  })
+  afterEach(() => {
+    $sessions.set([])
+    $pinnedSessionIds.set([])
+  })
+
+  it('pins a tile whose session is loaded, on its lineage root', () => {
+    $sessions.set([row({ _lineage_root_id: LINEAGE })])
+
+    toggleTilePin(STORED)
+
+    expect($pinnedSessionIds.get()).toEqual([LINEAGE])
+  })
+
+  it('unpins on a second toggle', () => {
+    $sessions.set([row()])
+
+    toggleTilePin(STORED)
+    expect($pinnedSessionIds.get()).toEqual([STORED])
+
+    toggleTilePin(STORED)
+    expect($pinnedSessionIds.get()).toEqual([])
+  })
+
+  it('still pins when the session row has not loaded yet', () => {
+    toggleTilePin(STORED)
+
+    expect($pinnedSessionIds.get()).toEqual([STORED])
+    unpinSession(STORED)
+  })
+
+  it('leaves other pins alone', () => {
+    $pinnedSessionIds.set(['other'])
+    $sessions.set([row()])
+
+    toggleTilePin(STORED)
+
+    expect($pinnedSessionIds.get()).toEqual(['other', STORED])
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -184,7 +184,7 @@ function TileChat({
           onSteer={actions.steerPrompt}
           onSubmit={actions.submitText}
           onThreadMessagesChange={actions.handleThreadMessagesChange}
-          onToggleSelectedPin={() => undefined}
+          onToggleSelectedPin={() => toggleTilePin(storedSessionId)}
           onTranscribeAudio={async audio => (await transcribeAudio(await blobToDataUrl(audio), audio.type)).transcript}
         />
       </ComposerScopeProvider>
@@ -332,6 +332,26 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
  *  the paginated recents page, so it has no `$sessions` row at all until new
  *  activity lands it there — resolving through the tree keeps its tab titled
  *  and tinted instead of a grey "Session" placeholder. */
+/**
+ * Pin/unpin a tile's session, keyed on the durable lineage-root id so the pin
+ * survives auto-compression — the same id `useTileMenuRow` gives the tab menu.
+ *
+ * Exported so the title menu and the tab menu cannot drift apart: the tile's
+ * ChatView passed `() => undefined` here, and because the Pin item's
+ * availability is `disabled: !onPin`, a stub function left the item ENABLED and
+ * silently did nothing when clicked.
+ */
+export function toggleTilePin(storedSessionId: string): void {
+  const stored = tileStoredRow(storedSessionId)
+  const pinId = stored ? sessionPinId(stored) : storedSessionId
+
+  if ($pinnedSessionIds.get().includes(pinId)) {
+    unpinSession(pinId)
+  } else {
+    pinSession(pinId)
+  }
+}
+
 export function tileStoredRow(storedSessionId: string): SessionInfo | undefined {
   const match = (s: SessionInfo) => sessionMatchesStoredId(s, storedSessionId)
 


### PR DESCRIPTION
## What and why

Clicking **Pin** on a session opened as a tile does nothing. The control renders, it is not greyed out, and it silently no-ops.

`apps/desktop/src/app/chat/session-tile.tsx` passes a stub to the tile's `ChatView`:

```tsx
onToggleSelectedPin={() => undefined}
```

The Pin item's availability is decided in `session-tile.tsx`'s sibling, `sidebar/session-actions-menu.tsx`:

```tsx
disabled: !onPin,
```

A stub function is truthy, so the item renders **enabled** and the click calls a function whose whole body is `undefined`. The primary chat view is wired correctly — `onPin={selectedSessionId ? onToggleSelectedPin : undefined}` in `chat/index.tsx` — so with no selected session the item correctly greys out. The tile had no such path, so the affordance looked available and was not.

The tile's own tab menu already pins correctly via `useTileMenuRow`, so the two menus **on the same tile** disagreed about whether pinning was possible.

## The change

Extract that toggle as an exported `toggleTilePin(storedSessionId)` next to `tileStoredRow` (which it uses) and call it from the `ChatView` prop, so the title menu and the tab menu share one implementation and cannot drift apart again. It is keyed on the durable lineage-root id, matching the tab menu, so a pin survives auto-compression.

No behaviour change to the tab menu or to the primary chat view.

## How to test

1. Open a session as a tile (open a second session into its own tab/pane).
2. Open the tile's **title** menu and click **Pin**.
   - Before: nothing happens; the session never appears in the sidebar's Pinned section.
   - After: the session is pinned, and clicking again unpins it.
3. Confirm the tile's **tab** context menu still pins/unpins as before, and that both menus agree on the pinned state.
4. Confirm the primary (non-tile) chat view is unchanged, including that Pin stays greyed out with no session selected.

## Tests

Adds `apps/desktop/src/app/chat/session-tile-pin.test.ts` — 4 cases: pins on the lineage root when the row is loaded, toggles back off, falls back to the stored id when the row has not loaded yet, and leaves unrelated pins untouched.

```
npx vitest run src/app/chat/session-tile-pin.test.ts   ->  4 passed
npx vitest run src/app/chat/                            ->  60 files, 424 passed
npx tsc --noEmit                                        ->  clean
npx eslint <changed files>                              ->  clean
npx prettier --check <changed files>                    ->  clean
```

Verified the test is meaningful: neutering `toggleTilePin`'s body fails all 4, restoring it passes all 4.

## Platforms

Reproduced and fixed against a Windows 11 x64 desktop build (MSI, packaged from this tree). Test suite, typecheck and lint run on Linux x64 (Node 22).

## Related

- #73207 — *Desktop `/branch` in a session tile branches the foreground chat*. Same class: a tile handing the tile's control a handler that does not act on the tile's own session. Different control, not fixed here.

I searched open and closed PRs and the issue tracker for the tile pin no-op and did not find a duplicate; the existing pin issues (#74745, #51685, #66762, #49667) are about pinned-session rendering, capacity and lifecycle, not about the tile's Pin control being inert.
