### PR TITLE
fix(honcho): coerce structured message content in sync_turn — turns were silently dropped

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1325,6 +1325,29 @@ class HonchoMemoryProvider(MemoryProvider):
             ),
         }
 
+    @staticmethod
+    def _coerce_turn_text(value: Any) -> str:
+        """Flatten structured message content into plain text.
+
+        The agent core can hand ``sync_turn`` content in the OpenAI
+        content-parts shape (a list of ``{"type": ..., "text": ...}``
+        dicts) rather than a plain string.  ``sanitize_context`` runs
+        regexes over the value, so a list raises ``TypeError: expected
+        string or bytes-like object`` and the turn is silently dropped —
+        Honcho then never receives any conversation data.
+        """
+        if isinstance(value, list):
+            parts = []
+            for item in value:
+                if isinstance(item, dict):
+                    parts.append(str(item.get("text") or item.get("content") or ""))
+                else:
+                    parts.append(str(item))
+            return "\n".join(part for part in parts if part)
+        if isinstance(value, str):
+            return value
+        return "" if value is None else str(value)
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Record the conversation turn in Honcho (non-blocking).
 
@@ -1340,8 +1363,8 @@ class HonchoMemoryProvider(MemoryProvider):
             return
 
         msg_limit = self._config.message_max_chars if self._config else 25000
-        clean_user_content = sanitize_context(user_content or "").strip()
-        clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        clean_user_content = sanitize_context(self._coerce_turn_text(user_content) or "").strip()
+        clean_assistant_content = sanitize_context(self._coerce_turn_text(assistant_content) or "").strip()
 
         def _sync():
             try:

--- a/tests/honcho_plugin/test_sync_turn_content_coercion.py
+++ b/tests/honcho_plugin/test_sync_turn_content_coercion.py
@@ -1,0 +1,31 @@
+"""sync_turn must accept structured (list-of-parts) message content.
+
+The agent core can pass content in the OpenAI content-parts shape.  Before the
+coercion fix, ``sanitize_context`` received the raw list and raised
+``TypeError: expected string or bytes-like object, got 'list'`` — every turn
+sync failed and Honcho silently accumulated nothing.
+"""
+
+from plugins.memory.honcho import HonchoMemoryProvider
+
+
+def test_coerce_turn_text_flattens_content_parts():
+    value = [
+        {"type": "text", "text": "first part"},
+        {"type": "text", "text": "second part"},
+        {"type": "image_url", "image_url": {"url": "ignored"}},
+    ]
+    assert HonchoMemoryProvider._coerce_turn_text(value) == "first part\nsecond part"
+
+
+def test_coerce_turn_text_passes_strings_through():
+    assert HonchoMemoryProvider._coerce_turn_text("plain text") == "plain text"
+
+
+def test_coerce_turn_text_handles_none_and_scalars():
+    assert HonchoMemoryProvider._coerce_turn_text(None) == ""
+    assert HonchoMemoryProvider._coerce_turn_text(42) == "42"
+
+
+def test_coerce_turn_text_handles_plain_string_parts():
+    assert HonchoMemoryProvider._coerce_turn_text(["a", "", "b"]) == "a\nb"


### PR DESCRIPTION
## Symptom

With the Honcho memory provider enabled, **no conversation turns ever reach Honcho**. Every turn logs:

```
WARNING agent.memory_manager: Memory provider 'honcho' sync_turn failed: expected string or bytes-like object, got 'list'
```

Sessions get created (session init works), but they stay empty — the workspace accumulates no messages, MEMORY/USER context still uploads, and nothing else visibly breaks, so the failure is easy to miss entirely.

## Root cause

`HonchoMemoryProvider.sync_turn` type-hints `user_content: str` / `assistant_content: str`, but the agent core can deliver turn content in the OpenAI **content-parts shape** — a list of `{"type": ..., "text": ...}` dicts. The very first thing `sync_turn` does is:

```python
clean_user_content = sanitize_context(user_content or "").strip()
```

`sanitize_context` runs regexes over the value, so a list raises `TypeError: expected string or bytes-like object` before the sync thread ever starts. The exception escapes to the memory manager's wrapper, the turn is dropped, and the provider silently records nothing.

## Why this can stay hidden for weeks

We hit this in a deployment where the Honcho tenant had gone into **cold storage** (hosted-platform inactivity). While cold, every operation fails fast with the cold-storage message — which *masks* the type bug completely. The moment the tenant was resumed, the cold-storage errors disappeared and this `TypeError` surfaced in their place: the tenant then looks "active but empty", and the platform's inactivity emails keep arriving because rejected syncs never count as activity. Deadlocked deployments may be sitting out there believing Honcho is merely idle.

## Fix

Flatten structured content to plain text before sanitizing (`_coerce_turn_text`): join the `text`/`content` fields of dict parts, pass strings through, stringify scalars, map `None` to `""`. This mirrors how the other memory providers tolerate the same caller behavior.

Verified live on the affected deployment: after this change, Telegram DM turns and cron-session conversations sync to the workspace correctly (first successful syncs in that deployment's history).

## Tests

`tests/honcho_plugin/test_sync_turn_content_coercion.py` — content-parts flattening (image parts ignored), string passthrough, `None`/scalar handling, plain-string list parts. All network-free per the package's isolation contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ET9RfzJuDRi1Y9Ejsg55oV
