### PR TITLE
feat(langfuse): tag cron traces by stable job id

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -29,6 +29,7 @@ import re
 import threading
 import time
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -72,8 +73,8 @@ _READ_FILE_TAIL_LINES = 15
 # narrow: a cron-like interactive session must retain ordinary trace behavior.
 _CRON_SESSION_ID_RE = re.compile(
     r"^cron_([0-9a-f]{12})_"
-    r"(?:[12]\d{3})(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])_"
-    r"(?:[01]\d|2[0-3])[0-5]\d[0-5]\d$"
+    r"([12]\d{3}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])_"
+    r"(?:[01]\d|2[0-3])[0-5]\d[0-5]\d)$"
 )
 
 # Langfuse-issued keys always carry these prefixes (cloud or self-hosted —
@@ -119,7 +120,13 @@ def _parse_cron_session_id(session_id: str) -> Optional[str]:
     if not isinstance(session_id, str):
         return None
     match = _CRON_SESSION_ID_RE.fullmatch(session_id)
-    return match.group(1) if match else None
+    if not match:
+        return None
+    try:
+        datetime.strptime(match.group(2), "%Y%m%d_%H%M%S")
+    except ValueError:
+        return None
+    return match.group(1)
 
 
 # Sentinel: "_get_langfuse() has tried and failed". Lets us short-circuit

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -67,6 +67,14 @@ _LANGFUSE_CLIENT = None
 _READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
 _READ_FILE_HEAD_LINES = 25
 _READ_FILE_TAIL_LINES = 15
+# Cron jobs are created with ``uuid.uuid4().hex[:12]`` and scheduler.py emits
+# sessions as ``cron_<job-id>_<YYYYMMDD_HHMMSS>``. Keep this deliberately
+# narrow: a cron-like interactive session must retain ordinary trace behavior.
+_CRON_SESSION_ID_RE = re.compile(
+    r"^cron_([0-9a-f]{12})_"
+    r"(?:[12]\d{3})(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])_"
+    r"(?:[01]\d|2[0-3])[0-5]\d[0-5]\d$"
+)
 
 # Langfuse-issued keys always carry these prefixes (cloud or self-hosted —
 # the prefix is baked into the server-side issuance flow, not a UI hint).
@@ -99,6 +107,19 @@ def _debug_enabled() -> bool:
 def _debug(message: str) -> None:
     if _debug_enabled():
         logger.info("Langfuse tracing: %s", message)
+
+
+def _parse_cron_session_id(session_id: str) -> Optional[str]:
+    """Return the stable job ID from a supported scheduler cron session.
+
+    The scheduler owns the session format. Invalid, legacy, or merely
+    cron-looking values intentionally return ``None`` so observability falls
+    back to the ordinary trace shape without affecting the Hermes runtime.
+    """
+    if not isinstance(session_id, str):
+        return None
+    match = _CRON_SESSION_ID_RE.fullmatch(session_id)
+    return match.group(1) if match else None
 
 
 # Sentinel: "_get_langfuse() has tried and failed". Lets us short-circuit
@@ -605,6 +626,11 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
                       turn_id: str = "", api_request_id: str = "") -> TraceState:
     trace_id = client.create_trace_id(seed=f"{session_id or 'sessionless'}::{task_id or task_key}")
     trace_input = _extract_last_user_message(messages)
+    cron_job_id = _parse_cron_session_id(session_id)
+    trace_name = f"cron:{cron_job_id}" if cron_job_id else "Hermes turn"
+    tags = ["hermes", "langfuse"]
+    if cron_job_id:
+        tags.extend(["cron", f"cron-job:{cron_job_id}"])
     metadata = {
         "source": "hermes",
         "task_id": task_id,
@@ -615,6 +641,12 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         "model": model,
         "api_mode": api_mode,
     }
+    if cron_job_id:
+        metadata.update({
+            "workload_type": "cron",
+            "cron_job_id": cron_job_id,
+            "cron_run_session": session_id,
+        })
 
     # session_id must be passed in trace_context for Langfuse session grouping.
     trace_ctx: Dict[str, Any] = {"trace_id": trace_id}
@@ -625,12 +657,12 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         try:
             with propagate_attributes(
                 session_id=session_id or task_key,
-                trace_name="Hermes turn",
-                tags=["hermes", "langfuse"],
+                trace_name=trace_name,
+                tags=tags,
             ):
                 root_ctx = client.start_as_current_observation(
                     trace_context=trace_ctx,
-                    name="Hermes turn",
+                    name=trace_name,
                     as_type="chain",
                     input=trace_input,
                     metadata=metadata,
@@ -640,7 +672,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         except Exception:
             root_ctx = client.start_as_current_observation(
                 trace_context=trace_ctx,
-                name="Hermes turn",
+                name=trace_name,
                 as_type="chain",
                 input=trace_input,
                 metadata=metadata,
@@ -650,7 +682,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
     else:
         root_ctx = client.start_as_current_observation(
             trace_context=trace_ctx,
-            name="Hermes turn",
+            name=trace_name,
             as_type="chain",
             input=trace_input,
             metadata=metadata,

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -196,6 +197,148 @@ class TestTraceScopeKey:
         assert key_a != key_b
         assert "turn:turn-a" in key_a
         assert "turn:turn-b" in key_b
+
+
+class TestCronTraceTagging:
+    """Stable cron-job aggregation must not replace run-specific sessions."""
+
+    @staticmethod
+    def _fresh_plugin():
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    @staticmethod
+    def _recording_client(started):
+        class _Span:
+            def set_trace_io(self, **kwargs):
+                pass
+
+        class _RootCM:
+            def __enter__(self):
+                return _Span()
+
+            def __exit__(self, *exc):
+                return False
+
+        class _Client:
+            def create_trace_id(self, seed=None):
+                return f"trace::{seed}"
+
+            def start_as_current_observation(self, **kwargs):
+                started.append(kwargs)
+                return _RootCM()
+
+        return _Client()
+
+    @pytest.mark.parametrize(
+        ("session_id", "job_id"),
+        [
+            ("cron_a21a08cee82d_20260730_183452", "a21a08cee82d"),
+            ("cron_0123456789ab_20260101_000000", "0123456789ab"),
+        ],
+    )
+    def test_parse_supported_cron_session_id(self, session_id, job_id):
+        assert self._fresh_plugin()._parse_cron_session_id(session_id) == job_id
+
+    @pytest.mark.parametrize("session_id", [
+        "",
+        "cron_a21a08cee82d_20260730_18345",
+        "cron_a21a08cee82d_20261330_183452",
+        "cron_A21A08CEE82D_20260730_183452",
+        "cron_a21a08cee82d_extra_20260730_183452",
+        "cron_job-name_20260730_183452",
+        "cron_a21a08cee82d_20260730_246000",
+        "cron_a21a08cee82d_20260730_183452_suffix",
+    ])
+    def test_malformed_cron_like_session_fails_open(self, session_id):
+        assert self._fresh_plugin()._parse_cron_session_id(session_id) is None
+
+    def test_cron_root_trace_has_stable_aggregation_attributes(self, monkeypatch):
+        mod = self._fresh_plugin()
+        propagation = []
+
+        @contextmanager
+        def record_propagation(**kwargs):
+            propagation.append(kwargs)
+            yield
+
+        started = []
+        monkeypatch.setattr(mod, "propagate_attributes", record_propagation)
+        session_id = "cron_a21a08cee82d_20260730_183452"
+        mod._start_root_trace(
+            "task", task_id="task", session_id=session_id, platform="cron",
+            provider="provider", model="model", api_mode="chat",
+            messages=[{"role": "user", "content": "run"}],
+            client=self._recording_client(started),
+        )
+
+        assert propagation == [{
+            "session_id": session_id,
+            "trace_name": "cron:a21a08cee82d",
+            "tags": ["hermes", "langfuse", "cron", "cron-job:a21a08cee82d"],
+        }]
+        assert started[0]["name"] == "cron:a21a08cee82d"
+        assert started[0]["trace_context"]["session_id"] == session_id
+        assert started[0]["metadata"] == {
+            "source": "hermes", "task_id": "task", "turn_id": "",
+            "api_request_id": "", "platform": "cron", "provider": "provider",
+            "model": "model", "api_mode": "chat", "workload_type": "cron",
+            "cron_job_id": "a21a08cee82d", "cron_run_session": session_id,
+        }
+
+    def test_runs_keep_unique_sessions_and_share_only_their_stable_job_tag(self, monkeypatch):
+        mod = self._fresh_plugin()
+        propagation, started = [], []
+
+        @contextmanager
+        def record_propagation(**kwargs):
+            propagation.append(kwargs)
+            yield
+
+        monkeypatch.setattr(mod, "propagate_attributes", record_propagation)
+        client = self._recording_client(started)
+        for session_id in (
+            "cron_a21a08cee82d_20260730_183452",
+            "cron_a21a08cee82d_20260731_183452",
+            "cron_b21a08cee82d_20260730_183452",
+        ):
+            mod._start_root_trace(
+                session_id, task_id=session_id, session_id=session_id, platform="",
+                provider="", model="", api_mode="", messages=[], client=client,
+            )
+
+        assert [item["session_id"] for item in propagation] == [
+            "cron_a21a08cee82d_20260730_183452",
+            "cron_a21a08cee82d_20260731_183452",
+            "cron_b21a08cee82d_20260730_183452",
+        ]
+        assert propagation[0]["tags"][-1] == propagation[1]["tags"][-1] == "cron-job:a21a08cee82d"
+        assert propagation[2]["tags"][-1] == "cron-job:b21a08cee82d"
+        assert [item["name"] for item in started] == [
+            "cron:a21a08cee82d", "cron:a21a08cee82d", "cron:b21a08cee82d",
+        ]
+
+    @pytest.mark.parametrize("session_id", ["interactive-session", ""])
+    def test_non_cron_or_absent_session_preserves_trace_shape(self, monkeypatch, session_id):
+        mod = self._fresh_plugin()
+        propagation, started = [], []
+
+        @contextmanager
+        def record_propagation(**kwargs):
+            propagation.append(kwargs)
+            yield
+
+        monkeypatch.setattr(mod, "propagate_attributes", record_propagation)
+        mod._start_root_trace(
+            "task", task_id="task", session_id=session_id, platform="telegram",
+            provider="provider", model="model", api_mode="chat", messages=[],
+            client=self._recording_client(started),
+        )
+
+        assert propagation[0]["trace_name"] == "Hermes turn"
+        assert propagation[0]["tags"] == ["hermes", "langfuse"]
+        assert started[0]["name"] == "Hermes turn"
+        assert not {"workload_type", "cron_job_id", "cron_run_session"} & set(started[0]["metadata"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -244,6 +244,7 @@ class TestCronTraceTagging:
         "",
         "cron_a21a08cee82d_20260730_18345",
         "cron_a21a08cee82d_20261330_183452",
+        "cron_a21a08cee82d_20260231_183452",
         "cron_A21A08CEE82D_20260730_183452",
         "cron_a21a08cee82d_extra_20260730_183452",
         "cron_job-name_20260730_183452",


### PR DESCRIPTION
## Summary
- Derive the immutable cron job ID only from supported scheduler session IDs.
- Name cron traces `cron:<job-id>` and add stable `cron` / `cron-job:<job-id>` tags plus cron metadata.
- Preserve run-specific Langfuse session IDs, non-cron behavior, and existing generation usage export.

## Validation
- `scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py -q`
- `scripts/run_tests.sh tests/plugins -q`
- `python3 -m py_compile plugins/observability/langfuse/__init__.py tests/plugins/test_langfuse_plugin.py`

No cron definitions, runtime configuration, or token/cost accounting logic is changed.