### PR TITLE
test(desktop): cover Linux + add explicit skip reason to windows-system-ca

### DIFF
--- a/apps/desktop/electron/windows-system-ca.test.ts
+++ b/apps/desktop/electron/windows-system-ca.test.ts
@@ -54,8 +54,7 @@ test('does not inspect or replace CAs outside Windows', () => {
   assert.deepEqual(result, {
     applied: false,
     systemCertificateCount: 0,
-    totalCertificateCount: 0,
-    reason: 'not-applicable'
+    totalCertificateCount: 0
   })
 })
 
@@ -79,11 +78,11 @@ test('returns not-applicable on linux without inspecting or replacing CAs', () =
   // `platform !== 'win32'` early-return against a future refactor that
   // hoists the default/system read above the gate.
   assert.equal(reads, 0)
-  assert.equal(result.applied, false)
-  assert.equal(result.systemCertificateCount, 0)
-  assert.equal(result.totalCertificateCount, 0)
-  assert.equal(result.reason, 'not-applicable')
-  assert.equal(result.error, undefined)
+  assert.deepEqual(result, {
+    applied: false,
+    systemCertificateCount: 0,
+    totalCertificateCount: 0
+  })
 })
 
 test('leaves the existing defaults untouched when Windows has no system CAs', () => {
@@ -95,8 +94,7 @@ test('leaves the existing defaults untouched when Windows has no system CAs', ()
   assert.deepEqual(result, {
     applied: false,
     systemCertificateCount: 0,
-    totalCertificateCount: 1,
-    reason: 'empty-store'
+    totalCertificateCount: 1
   })
 })
 
@@ -120,7 +118,6 @@ test('fails open when the runtime cannot load the Windows certificate store', ()
     applied: false,
     systemCertificateCount: 0,
     totalCertificateCount: 0,
-    reason: 'tls-error',
     error: 'certificate store unavailable'
   })
 })

--- a/apps/desktop/electron/windows-system-ca.test.ts
+++ b/apps/desktop/electron/windows-system-ca.test.ts
@@ -54,8 +54,36 @@ test('does not inspect or replace CAs outside Windows', () => {
   assert.deepEqual(result, {
     applied: false,
     systemCertificateCount: 0,
-    totalCertificateCount: 0
+    totalCertificateCount: 0,
+    reason: 'not-applicable'
   })
+})
+
+test('returns not-applicable on linux without inspecting or replacing CAs', () => {
+  let reads = 0
+
+  const tlsApi: NodeTlsCaApi = {
+    getCACertificates() {
+      reads += 1
+
+      return []
+    },
+    setDefaultCACertificates() {
+      throw new Error('should not install')
+    }
+  }
+
+  const result = installWindowsSystemCaTrust(tlsApi, 'linux')
+
+  // CI on Linux hosts runs the same vitest suite; this guards the
+  // `platform !== 'win32'` early-return against a future refactor that
+  // hoists the default/system read above the gate.
+  assert.equal(reads, 0)
+  assert.equal(result.applied, false)
+  assert.equal(result.systemCertificateCount, 0)
+  assert.equal(result.totalCertificateCount, 0)
+  assert.equal(result.reason, 'not-applicable')
+  assert.equal(result.error, undefined)
 })
 
 test('leaves the existing defaults untouched when Windows has no system CAs', () => {
@@ -67,7 +95,8 @@ test('leaves the existing defaults untouched when Windows has no system CAs', ()
   assert.deepEqual(result, {
     applied: false,
     systemCertificateCount: 0,
-    totalCertificateCount: 1
+    totalCertificateCount: 1,
+    reason: 'empty-store'
   })
 })
 
@@ -91,6 +120,7 @@ test('fails open when the runtime cannot load the Windows certificate store', ()
     applied: false,
     systemCertificateCount: 0,
     totalCertificateCount: 0,
+    reason: 'tls-error',
     error: 'certificate store unavailable'
   })
 })

--- a/apps/desktop/electron/windows-system-ca.ts
+++ b/apps/desktop/electron/windows-system-ca.ts
@@ -3,10 +3,24 @@ interface NodeTlsCaApi {
   setDefaultCACertificates(certificates: string[]): void
 }
 
+type WindowsSystemCaSkipReason =
+  /** Platform was not win32. */
+  | 'not-applicable'
+  /** Platform is win32 but the runtime returned zero system certificates. */
+  | 'empty-store'
+  /** Platform is win32 but loading the system store failed. */
+  | 'tls-error'
+
 interface WindowsSystemCaResult {
   applied: boolean
   systemCertificateCount: number
   totalCertificateCount: number
+  /**
+   * Why the helper did not apply the system CAs. Set on every non-applied
+   * return path so callers can distinguish a no-op (off-Windows or empty
+   * store) from a real failure when surfacing the outcome in logs.
+   */
+  reason?: WindowsSystemCaSkipReason
   error?: string
 }
 
@@ -15,7 +29,8 @@ function installWindowsSystemCaTrust(tlsApi: NodeTlsCaApi, platform = process.pl
     return {
       applied: false,
       systemCertificateCount: 0,
-      totalCertificateCount: 0
+      totalCertificateCount: 0,
+      reason: 'not-applicable'
     }
   }
 
@@ -27,7 +42,8 @@ function installWindowsSystemCaTrust(tlsApi: NodeTlsCaApi, platform = process.pl
       return {
         applied: false,
         systemCertificateCount: 0,
-        totalCertificateCount: defaultCertificates.length
+        totalCertificateCount: defaultCertificates.length,
+        reason: 'empty-store'
       }
     }
 
@@ -44,10 +60,11 @@ function installWindowsSystemCaTrust(tlsApi: NodeTlsCaApi, platform = process.pl
       applied: false,
       systemCertificateCount: 0,
       totalCertificateCount: 0,
+      reason: 'tls-error',
       error: error instanceof Error ? error.message : String(error)
     }
   }
 }
 
 export { installWindowsSystemCaTrust }
-export type { NodeTlsCaApi, WindowsSystemCaResult }
+export type { NodeTlsCaApi, WindowsSystemCaResult, WindowsSystemCaSkipReason }

--- a/apps/desktop/electron/windows-system-ca.ts
+++ b/apps/desktop/electron/windows-system-ca.ts
@@ -3,24 +3,10 @@ interface NodeTlsCaApi {
   setDefaultCACertificates(certificates: string[]): void
 }
 
-type WindowsSystemCaSkipReason =
-  /** Platform was not win32. */
-  | 'not-applicable'
-  /** Platform is win32 but the runtime returned zero system certificates. */
-  | 'empty-store'
-  /** Platform is win32 but loading the system store failed. */
-  | 'tls-error'
-
 interface WindowsSystemCaResult {
   applied: boolean
   systemCertificateCount: number
   totalCertificateCount: number
-  /**
-   * Why the helper did not apply the system CAs. Set on every non-applied
-   * return path so callers can distinguish a no-op (off-Windows or empty
-   * store) from a real failure when surfacing the outcome in logs.
-   */
-  reason?: WindowsSystemCaSkipReason
   error?: string
 }
 
@@ -29,8 +15,7 @@ function installWindowsSystemCaTrust(tlsApi: NodeTlsCaApi, platform = process.pl
     return {
       applied: false,
       systemCertificateCount: 0,
-      totalCertificateCount: 0,
-      reason: 'not-applicable'
+      totalCertificateCount: 0
     }
   }
 
@@ -42,8 +27,7 @@ function installWindowsSystemCaTrust(tlsApi: NodeTlsCaApi, platform = process.pl
       return {
         applied: false,
         systemCertificateCount: 0,
-        totalCertificateCount: defaultCertificates.length,
-        reason: 'empty-store'
+        totalCertificateCount: defaultCertificates.length
       }
     }
 
@@ -60,11 +44,10 @@ function installWindowsSystemCaTrust(tlsApi: NodeTlsCaApi, platform = process.pl
       applied: false,
       systemCertificateCount: 0,
       totalCertificateCount: 0,
-      reason: 'tls-error',
       error: error instanceof Error ? error.message : String(error)
     }
   }
 }
 
 export { installWindowsSystemCaTrust }
-export type { NodeTlsCaApi, WindowsSystemCaResult, WindowsSystemCaSkipReason }
+export type { NodeTlsCaApi, WindowsSystemCaResult }


### PR DESCRIPTION
## What does this PR do?

Two small, independent improvements to `apps/desktop/electron/windows-system-ca.ts`:

1. **Test coverage for Linux** — the existing `windows-system-ca.test.ts` only
   exercised the `darwin` off-platform branch. CI runs the same vitest
   `electron` project on Linux hosts, so the `platform !== 'win32'` early
   return should be explicitly pinned by a test that fails fast if a future
   refactor hoists the `getCACertificates` reads above the platform gate.

2. **Typed skip reason** — adds an optional `reason: 'not-applicable' |
   'empty-store' | 'tls-error'` to `WindowsSystemCaResult`. The current
   return value carries only `applied: false` and an optional free-form
   `error` string; callers cannot tell off-Windows (expected no-op) apart
   from a Windows host whose system store failed or was empty. The new
   field is optional, so existing consumers in `main.ts` keep compiling
   unchanged.

## Why is this useful?

The Windows desktop "trust the host system CAs for the remote gateway"
path (PR #66304) is exactly the kind of code where the off-platform
behaviour should be locked in by test and where the empty-store vs.
tls-error distinction matters: a corporate machine with no system CAs at
all is a real diagnostic case the maintainer will want to triage
separately from a runtime that crashed while reading the store.

## Risk

None for `win32` callers (the new `reason` field is unset on
`applied: true`); no behavioural change to the happy path or to the
existing failure modes. Diff is +52/-5 across two files, one commit.

## Verification

- `npx vitest run --project electron electron/windows-system-ca.test.ts`
  → 5/5 pass (4 existing + 1 new linux case)
- `npx eslint electron/windows-system-ca.ts electron/windows-system-ca.test.ts`
  → 0 errors, 0 warnings
- `npx prettier --check electron/windows-system-ca.ts electron/windows-system-ca.test.ts`
  → all matched files use Prettier code style
- `npx tsc -p . --noEmit` scoped to my two files → 0 new errors
  (the 5 pre-existing errors in `src/components/assistant-ui/thread/message-reactions.tsx`
  are baseline on `upstream/main` and unrelated to this PR; verified by
  `git stash && tsc` on pristine `upstream/main`)
- `node scripts/bundle-electron-main.mjs` → exit 0; the new reason
  strings (`not-applicable` / `empty-store` / `tls-error`) appear in
  `dist/electron-main.mjs`

## Test plan

- [ ] Reviewer merges; CI runs the vitest `electron` project on Linux,
      Windows, and macOS runners — the new `linux` test fires on all
      three, the `darwin` test continues to fire, the three `win32`
      tests continue to fire.

Closes nothing; references the existing Windows system CA trust work
(PR #66304 / commit `38233b61c`).