### PR TITLE
fix: validate persisted disk-cleanup entries before deletion

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -70,12 +70,16 @@ def is_safe_path(path: Path) -> bool:
     """
     hermes_home = get_hermes_home()
     try:
-        path.resolve().relative_to(hermes_home)
+        resolved = path.resolve()
+    except OSError:
+        return False
+    try:
+        resolved.relative_to(hermes_home)
         return True
-    except (ValueError, OSError):
+    except ValueError:
         pass
-    # Allow /tmp/hermes-* explicitly
-    parts = path.parts
+    # Allow /tmp/hermes-* explicitly, but only after canonical resolution.
+    parts = resolved.parts
     if len(parts) >= 3 and parts[1] == "tmp" and parts[2].startswith("hermes-"):
         return True
     return False
@@ -311,14 +315,47 @@ def quick() -> Dict[str, Any]:
     errors: List[str] = []
 
     for item in tracked:
+        if not isinstance(item, dict) or not {
+            "path", "category", "timestamp", "size"
+        }.issubset(item):
+            _log("SKIP malformed tracked entry: missing required fields")
+            continue
+
+        if not (
+            isinstance(item["path"], str) and item["path"].strip()
+            and isinstance(item["category"], str)
+            and isinstance(item["timestamp"], str)
+            and isinstance(item["size"], int)
+            and not isinstance(item["size"], bool)
+            and item["size"] >= 0
+        ):
+            _log("SKIP malformed tracked entry: invalid field types")
+            continue
+
         p = Path(item["path"])
         cat = item["category"]
+
+        if cat not in ALLOWED_CATEGORIES:
+            _log(f"SKIP malformed tracked entry: unknown category {cat!r}")
+            continue
+
+        if ".." in p.parts:
+            _log(f"SKIP unsafe tracked path traversal: {p}")
+            continue
+
+        if not is_safe_path(p):
+            _log(f"SKIP unsafe tracked path: {p}")
+            continue
 
         if not p.exists():
             _log(f"STALE: {p} (removed from tracking)")
             continue
 
-        age = (now - datetime.fromisoformat(item["timestamp"])).days
+        try:
+            age = (now - datetime.fromisoformat(item["timestamp"])).days
+        except (TypeError, ValueError):
+            _log("SKIP malformed tracked entry: invalid timestamp")
+            continue
 
         # ---- stale-state migration (fixes #37721) ----
         # Old tracked.json entries may carry a "cron-output" category for
@@ -561,7 +598,7 @@ def guess_category(path: Path) -> Optional[str]:
         top = rel.parts[0] if rel.parts else ""
         if top in {
             "disk-cleanup", "logs", "memories", "sessions", "config.yaml",
-            "skills", "plugins", ".env", "USER.md", "MEMORY.md", "SOUL.md",
+            "skills", "plugins", "ops", ".env", "USER.md", "MEMORY.md", "SOUL.md",
             "auth.json", "hermes-agent",
         }:
             return None

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -149,7 +149,7 @@ ALLOWED_CATEGORIES = {
 }
 
 _EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
-    "logs", "memories", "sessions", "cron", "cronjobs",
+    "logs", "memories", "sessions", "cron", "cronjobs", "ops",
     "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
     "hermes-agent", "backups", "profiles", ".worktrees",
 })

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -86,6 +86,19 @@ class TestIsSafePath:
         dg = _load_lib()
         assert dg.is_safe_path(Path("/etc/passwd")) is False
 
+    def test_accepts_tmp_hermes_prefix(self, _isolate_env):
+        dg = _load_lib()
+        assert dg.is_safe_path(Path("/tmp/hermes-abc/x.log")) is True
+
+    def test_rejects_tmp_hermes_path_traversal(self, _isolate_env):
+        dg = _load_lib()
+        escaped = Path("/tmp/hermes-abc/../../tmp/outside/test_victim.py")
+        assert dg.is_safe_path(escaped) is False
+
+    def test_rejects_plain_tmp(self, _isolate_env):
+        dg = _load_lib()
+        assert dg.is_safe_path(Path("/tmp/other.log")) is False
+
 
 class TestGuessCategory:
     def test_test_prefix(self, _isolate_env):
@@ -113,6 +126,14 @@ class TestGuessCategory:
         p = logs_dir / "test_log.txt"
         p.write_text("x")
         # Even though it matches test_* pattern, logs/ is excluded.
+        assert dg.guess_category(p) is None
+
+    def test_skips_durable_ops_workspaces(self, _isolate_env):
+        dg = _load_lib()
+        tests_dir = _isolate_env / "ops" / "model-routing" / "tests"
+        tests_dir.mkdir(parents=True)
+        p = tests_dir / "test_usage_collection.py"
+        p.write_text("def test_durable(): pass")
         assert dg.guess_category(p) is None
 
     def test_cron_subtree_categorised(self, _isolate_env):
@@ -226,6 +247,114 @@ class TestStaleCronEntryMigration:
 
 
 class TestTrackForgetQuick:
+    def test_quick_rejects_forged_outside_home_entry(self, _isolate_env, tmp_path):
+        dg = _load_lib()
+        victim = tmp_path / "outside" / "test_victim.py"
+        victim.parent.mkdir()
+        victim.write_text("durable")
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(victim),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": victim.stat().st_size,
+        }]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert victim.read_text() == "durable"
+        assert json.loads(tracked_file.read_text()) == []
+
+    def test_quick_rejects_lexical_traversal_inside_home(self, _isolate_env):
+        dg = _load_lib()
+        victim = _isolate_env / "test_victim.py"
+        victim.write_text("durable")
+        forged = _isolate_env / "disk-cleanup" / ".." / "test_victim.py"
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(forged), "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00", "size": 7,
+        }]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert victim.read_text() == "durable"
+        assert json.loads(tracked_file.read_text()) == []
+
+    def test_quick_rejects_malformed_entry_without_deleting(self, _isolate_env):
+        dg = _load_lib()
+        victim = _isolate_env / "test_victim.py"
+        victim.write_text("durable")
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        tracked_file.write_text(json.dumps([{"path": str(victim)}]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert victim.read_text() == "durable"
+        assert json.loads(tracked_file.read_text()) == []
+
+    def test_quick_rejects_unknown_category(self, _isolate_env):
+        dg = _load_lib()
+        victim = _isolate_env / "test_victim.py"
+        victim.write_text("durable")
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(victim), "category": "unknown-danger",
+            "timestamp": "2025-01-01T00:00:00+00:00", "size": 7,
+        }]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert victim.read_text() == "durable"
+        assert json.loads(tracked_file.read_text()) == []
+
+    def test_quick_rejects_invalid_timestamp(self, _isolate_env):
+        dg = _load_lib()
+        victim = _isolate_env / "test_victim.py"
+        victim.write_text("durable")
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(victim), "category": "test",
+            "timestamp": "not-a-timestamp", "size": 7,
+        }]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert victim.read_text() == "durable"
+        assert json.loads(tracked_file.read_text()) == []
+
+    @pytest.mark.parametrize("field,value", [("path", None), ("size", "seven")])
+    def test_quick_rejects_invalid_field_types(
+        self, _isolate_env, field, value
+    ):
+        dg = _load_lib()
+        victim = _isolate_env / "test_victim.py"
+        victim.write_text("durable")
+        item = {
+            "path": str(victim), "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00", "size": 7,
+        }
+        item[field] = value
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        tracked_file.write_text(json.dumps([item]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert victim.read_text() == "durable"
+        assert json.loads(tracked_file.read_text()) == []
+
     def test_track_then_quick_deletes_test(self, _isolate_env):
         dg = _load_lib()
         p = _isolate_env / "test_a.py"

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -364,6 +364,15 @@ class TestTrackForgetQuick:
         assert summary["deleted"] == 1
         assert not p.exists()
 
+    def test_quick_preserves_empty_ops_tree(self, _isolate_env):
+        dg = _load_lib()
+        durable_empty = _isolate_env / "ops" / "model-routing" / "reports"
+        durable_empty.mkdir(parents=True)
+
+        dg.quick()
+
+        assert durable_empty.exists()
+
 
     def test_forget_removes_entry(self, _isolate_env):
         dg = _load_lib()


### PR DESCRIPTION
## Summary
- canonicalize approved roots before validating persisted cleanup paths
- reject traversal, malformed records, unknown categories, and invalid timestamps/types before filesystem deletion
- protect durable `ops/` workspaces from auto-tracking
- preserve empty directory structure under `ops/` during quick cleanup

## Evidence
- focused safety tests passed on current upstream main
- disk-cleanup suite on Windows: 38 passed, 1 pre-existing terminal-path parser test deselected
- Python compilation and `git diff --check` passed
- independent read-only Codex review: PASS, no unresolved P0/P1/P2 findings for persisted-entry validation
- empty `ops/model-routing/reports` regression observed RED before the protection-set fix and GREEN afterward

## Safety
The approved `/tmp/hermes-*` feature remains supported; canonical resolution prevents traversal from escaping that root. `ops/` is durable operator state and is protected from both auto-tracking and empty-directory sweeping.