### PR TITLE
fix(gateway): skip MEDIA: scanning in tool results to prevent TTS false-positive dedup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1536,10 +1536,12 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
             continue
         if role not in {"tool", "function"}:
             continue
+        # Skip MEDIA: text scanning for tool/function results — they
+        # contain paths from tool output BEFORE delivery, so including
+        # them causes false-positive dedup that prevents the current
+        # turn's media from ever being sent (#74928).
+        # image_generate JSON payload path below is unaffected.
         content = str(msg.get("content", "") or "")
-        if "MEDIA:" in content:
-            _add_text_media_paths(content)
-            continue
         cid = str(msg.get("tool_call_id") or msg.get("call_id") or "")
         if tool_name_by_call_id.get(cid) == "image_generate":
             try:


### PR DESCRIPTION
## Summary

Fixes #74928.

Voice messages generated by `text_to_speech` are never delivered to Telegram (and likely other platforms) because `_collect_history_media_paths()` treats tool-result MEDIA paths as "already delivered", causing the dedup filter to silently drop them.

## Root Cause

`_collect_history_media_paths()` at `gateway/run.py:1537-1541` unconditionally scans tool/function results for `MEDIA:` text tags and adds them to the dedup set. The TTS tool returns `media_tag` with `MEDIA:/path` in its JSON result content.

The transcript is persisted **before** delivery, so by the time `extract_media()` runs on the assistant response, the current turn's tool result is already in `agent_history`. The dedup set already contains the path → `media_files_after_dedup` is empty → `send_voice` never fires.

## Fix

Skip `MEDIA:` text scanning for tool/function results in `_collect_history_media_paths()`. Tool results contain tool **output metadata** (before delivery), not actually-delivered content. Only assistant messages represent content that was *sent* or is about to be sent.

The `image_generate` JSON payload path (separate codepath at lines 1543-1554) is unaffected — those paths are delivered directly by the tool, not via MEDIA: tag.

## Edge Cases

- Each TTS call generates unique paths via `tempfile.mkstemp`, so duplicate delivery across turns is not a concern
- The `image_generate` codepath (JSON payload extraction) is preserved unchanged
- Previous-turn tool results with MEDIA: are correctly excluded from dedup since they represent pending delivery, not already-delivered content