### PR TITLE
feat: add durable run usage accounting

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2554,6 +2554,7 @@ def init_agent(
     agent.session_cache_write_tokens = 0
     agent.session_reasoning_tokens = 0
     agent.session_estimated_cost_usd = 0.0
+    agent._last_api_cost_usd = None
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
     

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -522,6 +522,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             "on_session_start",
             session_id=agent.session_id,
             model=agent.model,
+            provider=agent.provider,
             platform=getattr(agent, "platform", None) or "",
         )
     except Exception as exc:
@@ -2001,6 +2002,7 @@ def run_conversation(
         api_kwargs = None  # Guard against UnboundLocalError in except handler
         api_request_id = f"{turn_id}:api:{api_call_count}"
         agent._current_api_request_id = api_request_id
+        agent._last_api_cost_usd = None
 
         while retry_count < max_retries:
             # ── Nous Portal rate limit guard ──────────────────────
@@ -3255,6 +3257,7 @@ def run_conversation(
                                     _cost_delta = (_cost_delta or 0.0) + float(_moa_ref_cost)
                                 except (TypeError, ValueError):  # pragma: no cover
                                     pass
+                            agent._last_api_cost_usd = _cost_delta
                             # Enqueued, not written: the background writer
                             # applies the delta off the turn thread (a cold
                             # state.db UPDATE here stalled the tool loop for
@@ -3285,7 +3288,12 @@ def run_conversation(
                                 "Token persistence failed (session=%s, tokens=%d): %s",
                                 agent.session_id, total_tokens, e,
                             )
-                    
+                    # The lifecycle receipt is independent of session DB
+                    # persistence. Providers without a pricing entry still
+                    # get an explicit zero cost rather than a missing field.
+                    if agent._last_api_cost_usd is None:
+                        agent._last_api_cost_usd = 0.0
+
                     if agent.verbose_logging:
                         logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
                     
@@ -5498,6 +5506,7 @@ def run_conversation(
                         base_url=agent.base_url,
                         api_mode=agent.api_mode,
                         api_call_count=api_call_count,
+                        retry_count=retry_count,
                         api_duration=api_duration,
                         started_at=api_start_time,
                         ended_at=_api_ended_at,
@@ -5510,6 +5519,7 @@ def run_conversation(
                             finish_reason=finish_reason,
                         ),
                         usage=agent._usage_summary_for_api_request_hook(response),
+                        cost_usd=getattr(agent, "_last_api_cost_usd", None),
                         assistant_message=assistant_message,
                         assistant_content_chars=len(_assistant_text),
                         assistant_tool_call_count=len(_assistant_tool_calls),

--- a/agent/run_usage_ledger.py
+++ b/agent/run_usage_ledger.py
@@ -1,0 +1,652 @@
+"""Durable, profile-local usage receipts for direct and Kanban runs.
+
+Runtime hooks only enqueue in-memory operations after the ledger has been
+initialised. A dedicated writer owns SQLite writes. Finalization drains the
+writer, replays failed/overflow operations, persists diagnostics, and writes the
+finish marker synchronously so a completed run cannot silently lose its totals.
+"""
+
+from __future__ import annotations
+
+import atexit
+from collections import deque
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Any, Callable
+
+from hermes_constants import get_default_hermes_root, get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_USAGE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS usage_runs (
+    run_id TEXT PRIMARY KEY,
+    process_id TEXT NOT NULL,
+    task_run_id INTEGER,
+    session_id TEXT,
+    task_id TEXT,
+    board TEXT,
+    model TEXT,
+    provider TEXT,
+    input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    cost_usd REAL NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+    turn_count INTEGER NOT NULL DEFAULT 0 CHECK (turn_count >= 0),
+    tool_call_count INTEGER NOT NULL DEFAULT 0 CHECK (tool_call_count >= 0),
+    elapsed REAL CHECK (elapsed IS NULL OR elapsed >= 0),
+    outcome TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    failure_reason TEXT,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    updated_at REAL NOT NULL
+);
+CREATE TABLE IF NOT EXISTS usage_events (
+    event_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
+    event_type TEXT NOT NULL,
+    session_id TEXT,
+    turn_id TEXT,
+    input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    cost_usd REAL NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    model TEXT,
+    provider TEXT,
+    created_at REAL NOT NULL
+);
+CREATE TABLE IF NOT EXISTS usage_turns (
+    run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
+    turn_id TEXT NOT NULL,
+    PRIMARY KEY (run_id, turn_id)
+);
+CREATE TABLE IF NOT EXISTS usage_run_models (
+    run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
+    model TEXT NOT NULL,
+    provider TEXT NOT NULL DEFAULT 'unknown',
+    input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    cost_usd REAL NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+    event_count INTEGER NOT NULL DEFAULT 0 CHECK (event_count >= 0),
+    PRIMARY KEY (run_id, model, provider)
+);
+CREATE TABLE IF NOT EXISTS usage_diagnostics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT,
+    diagnostic_type TEXT NOT NULL,
+    count INTEGER NOT NULL DEFAULT 1 CHECK (count > 0),
+    detail TEXT,
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_usage_runs_board ON usage_runs(board, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_runs_task ON usage_runs(task_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_runs_task_run ON usage_runs(task_run_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_runs_session ON usage_runs(session_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_events_run ON usage_events(run_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_usage_run_models_run ON usage_run_models(run_id, model, provider);
+CREATE INDEX IF NOT EXISTS idx_usage_diagnostics_run ON usage_diagnostics(run_id, created_at);
+"""
+
+_PROCESS_ID = str(os.getpid())
+_PROCESS_INVOCATION_ID = os.environ.get("HERMES_RUN_ID", "").strip() or f"proc-{_PROCESS_ID}-{uuid.uuid4().hex}"
+_CURRENT_SESSION: ContextVar[str | None] = ContextVar("hermes_usage_session", default=None)
+_LEDGER_CACHE: dict[str, "UsageLedger"] = {}
+_LEDGER_CACHE_LOCK = threading.Lock()
+
+
+def current_source_profile() -> str:
+    """Return the active profile without requiring HERMES_PROFILE to be set."""
+    home = get_hermes_home().resolve()
+    root = get_default_hermes_root().resolve()
+    try:
+        relative = home.relative_to(root)
+        if len(relative.parts) >= 2 and relative.parts[0] == "profiles":
+            return relative.parts[1]
+    except ValueError:
+        pass
+    return "default"
+
+
+def process_run_id() -> str:
+    """Return the authoritative task/direct launcher identity."""
+    kanban_run = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+    if kanban_run:
+        return f"task-run:{kanban_run}"
+    explicit = os.environ.get("HERMES_RUN_ID", "").strip()
+    return explicit or _PROCESS_INVOCATION_ID
+
+
+def run_id_for_session(session_id: str | None = None) -> str:
+    """Resolve one stable receipt identity while preserving session metadata."""
+    kanban_run = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+    if kanban_run:
+        return f"task-run:{kanban_run}"
+    explicit = os.environ.get("HERMES_RUN_ID", "").strip()
+    if explicit:
+        return explicit
+    session = str(session_id or _CURRENT_SESSION.get() or "").strip()
+    if not session:
+        # A session-less direct invocation is still one invocation, not the
+        # process-global identity used by unrelated gateway sessions.
+        return _PROCESS_INVOCATION_ID
+    digest = hashlib.sha256(session.encode("utf-8")).hexdigest()[:16]
+    return f"session-run:{_PROCESS_INVOCATION_ID}:{digest}"
+
+
+def bind_session(session_id: str | None) -> None:
+    _CURRENT_SESSION.set(str(session_id) if session_id else None)
+
+
+def current_task_run_id() -> int | None:
+    raw = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+    try:
+        return int(raw) if raw else None
+    except ValueError:
+        logger.warning("Ignoring non-integer HERMES_KANBAN_RUN_ID=%r", raw)
+        return None
+
+
+def default_ledger_path() -> Path:
+    return get_hermes_home() / "state.db"
+
+
+def _nonempty(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _provider_key(provider: Any) -> str:
+    value = _nonempty(provider)
+    return value.lower() if value else "unknown"
+
+
+def _nonnegative_int(value: Any, field: str) -> int:
+    result = int(value or 0)
+    if result < 0:
+        raise ValueError(f"{field} must be nonnegative")
+    return result
+
+
+def _nonnegative_float(value: Any, field: str) -> float:
+    result = float(value or 0.0)
+    if result < 0:
+        raise ValueError(f"{field} must be nonnegative")
+    return result
+
+
+Operation = tuple[Callable[..., Any], tuple[Any, ...], dict[str, Any]]
+
+
+class UsageLedger:
+    """SQLite ledger with bounded asynchronous writes and durable finalization."""
+
+    def __init__(self, database_path: str | Path | None = None, *, queue_size: int = 2048) -> None:
+        self.database_path = Path(database_path or default_ledger_path())
+        self.database_path.parent.mkdir(parents=True, exist_ok=True)
+        self._queue_limit = max(1, int(queue_size))
+        self._queue: deque[Operation] = deque(maxlen=self._queue_limit)
+        self._failed_operations: deque[Operation] = deque(maxlen=self._queue_limit)
+        self._dropped: dict[tuple[str | None, str], int] = {}
+        self._incomplete_runs: dict[str, int] = {}
+        self._diagnostic_limit = 256
+        self._queue_cond = threading.Condition()
+        self._writer: threading.Thread | None = None
+        self._writer_stop = False
+        self._writer_busy = False
+        self._closed = False
+        self._ensure_schema()
+        atexit.register(self.shutdown)
+
+    def _connection(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database_path, timeout=5.0)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA busy_timeout=5000")
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA foreign_keys=ON")
+        return connection
+
+    def _ensure_schema(self) -> None:
+        with self._connection() as connection:
+            connection.executescript(_USAGE_SCHEMA)
+            cols = {row["name"] for row in connection.execute("PRAGMA table_info(usage_runs)")}
+            if "task_run_id" not in cols:
+                connection.execute("ALTER TABLE usage_runs ADD COLUMN task_run_id INTEGER")
+            model_cols = {row["name"]: row["notnull"] for row in connection.execute("PRAGMA table_info(usage_run_models)")}
+            if model_cols and not model_cols.get("provider"):
+                connection.execute("ALTER TABLE usage_run_models RENAME TO usage_run_models_legacy")
+                connection.execute("""CREATE TABLE usage_run_models (
+                    run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
+                    model TEXT NOT NULL, provider TEXT NOT NULL DEFAULT 'unknown',
+                    input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+                    output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+                    cost_usd REAL NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+                    event_count INTEGER NOT NULL DEFAULT 0 CHECK (event_count >= 0),
+                    PRIMARY KEY (run_id, model, provider))""")
+                connection.execute("""INSERT INTO usage_run_models
+                    (run_id, model, provider, input_tokens, output_tokens, cost_usd, event_count)
+                    SELECT run_id, model, COALESCE(NULLIF(provider, ''), 'unknown'),
+                           SUM(input_tokens), SUM(output_tokens), SUM(cost_usd), SUM(event_count)
+                    FROM usage_run_models_legacy GROUP BY run_id, model, COALESCE(NULLIF(provider, ''), 'unknown')""")
+                connection.execute("DROP TABLE usage_run_models_legacy")
+                connection.execute("CREATE INDEX IF NOT EXISTS idx_usage_run_models_run ON usage_run_models(run_id, model, provider)")
+
+    def _record_drop(self, run_id: str | None, kind: str) -> None:
+        key = (run_id, kind)
+        if key in self._dropped or len(self._dropped) < self._diagnostic_limit:
+            self._dropped[key] = self._dropped.get(key, 0) + 1
+        if run_id and (run_id in self._incomplete_runs or len(self._incomplete_runs) < self._diagnostic_limit):
+            self._incomplete_runs[run_id] = self._incomplete_runs.get(run_id, 0) + 1
+
+    def _enqueue(self, fn: Callable[..., Any], *args: Any, critical: bool = False, **kwargs: Any) -> bool:
+        operation: Operation = (fn, args, kwargs)
+        with self._queue_cond:
+            if self._closed or self._writer_stop:
+                self._record_drop(kwargs.get("run_id"), "closed")
+                return False
+            if len(self._queue) >= self._queue_limit:
+                if critical:
+                    self._record_drop(kwargs.get("run_id"), "queue_saturated")
+                    return False
+                self._record_drop(kwargs.get("run_id"), fn.__name__)
+                logger.warning("usage ledger queue full; dropping noncritical event (%s)", fn.__name__)
+                return False
+            self._queue.append(operation)
+            if self._writer is None or not self._writer.is_alive():
+                self._writer = threading.Thread(target=self._writer_loop, name="usage-ledger-writer", daemon=True)
+                self._writer.start()
+            self._queue_cond.notify_all()
+            return True
+
+    def _writer_loop(self) -> None:
+        while True:
+            with self._queue_cond:
+                while not self._queue and not self._writer_stop:
+                    self._queue_cond.wait()
+                if not self._queue:
+                    return
+                self._writer_busy = True
+                operation = self._queue.popleft()
+            try:
+                operation[0](*operation[1], **operation[2])
+            except Exception:
+                with self._queue_cond:
+                    if len(self._failed_operations) < self._queue_limit:
+                        self._failed_operations.append(operation)
+                    key = (operation[2].get("run_id"), "writer_failure")
+                    if key in self._dropped or len(self._dropped) < self._diagnostic_limit:
+                        self._dropped[key] = self._dropped.get(key, 0) + 1
+                logger.warning("usage ledger write failed; continuing runtime", exc_info=True)
+            finally:
+                with self._queue_cond:
+                    self._writer_busy = False
+                    self._queue_cond.notify_all()
+
+    def flush(self, timeout: float = 5.0) -> bool:
+        deadline = time.monotonic() + max(0.0, timeout)
+        while True:
+            with self._queue_cond:
+                if not self._queue and not self._writer_busy:
+                    return True
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._queue_cond.wait(min(remaining, 0.05))
+
+    def _replay_failed_sync(self) -> None:
+        with self._queue_cond:
+            failed = list(self._failed_operations)
+            self._failed_operations.clear()
+        still_failed: list[Operation] = []
+        for operation in failed:
+            try:
+                operation[0](*operation[1], **operation[2])
+            except Exception:
+                still_failed.append(operation)
+        if still_failed:
+            with self._queue_cond:
+                for operation in still_failed[: self._queue_limit - len(self._failed_operations)]:
+                    self._failed_operations.append(operation)
+                    self._record_drop(operation[2].get("run_id"), "persistent_writer_failure")
+
+    def _persist_diagnostics(self) -> None:
+        with self._queue_cond:
+            dropped = self._dropped
+            self._dropped = {}
+        if not dropped:
+            return
+        with self._connection() as connection:
+            now = time.time()
+            for (run_id, kind), count in dropped.items():
+                connection.execute(
+                    "INSERT INTO usage_diagnostics(run_id, diagnostic_type, count, detail, created_at) VALUES (?, ?, ?, ?, ?)",
+                    (run_id, "dropped_event", count, kind, now),
+                )
+
+    def finalize_run(self, *, run_id: str, outcome: str | None = None,
+                     failure_reason: str | None = None, ended_at: float | None = None,
+                     elapsed: float | None = None) -> bool:
+        """Drain all pending accounting, then synchronously finish the run."""
+        drained = self.flush(timeout=5.0)
+        self._replay_failed_sync()
+        self._replay_failed_sync()
+        with self._queue_cond:
+            complete = drained and not self._queue and not self._writer_busy and not self._failed_operations and run_id not in self._incomplete_runs
+        if not complete:
+            self._record_drop(run_id, "incomplete_finalization")
+            try:
+                self._persist_diagnostics()
+            except Exception:
+                pass
+            return False
+        try:
+            self._persist_diagnostics()
+            self._finish_run(run_id=run_id, outcome=outcome, failure_reason=failure_reason,
+                             ended_at=ended_at, elapsed=elapsed)
+            return True
+        except Exception:
+            # Lifecycle observers are non-fatal. Leave a diagnostic attempt for
+            # shutdown and let the caller continue without a deadlock.
+            self._record_drop(run_id, "finalize_error")
+            logger.warning("usage ledger finalization failed", exc_info=True)
+            return False
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        with self._queue_cond:
+            if self._closed:
+                return
+            self._writer_stop = True
+            self._queue_cond.notify_all()
+            writer = self._writer
+        if writer is not None and writer.is_alive():
+            writer.join(timeout=max(0.0, timeout))
+        self.flush(timeout=timeout)
+        self._replay_failed_sync()
+        self._replay_failed_sync()
+        try:
+            self._persist_diagnostics()
+        except Exception:
+            logger.debug("usage ledger diagnostic persistence failed", exc_info=True)
+        with self._queue_cond:
+            self._closed = True
+
+    @staticmethod
+    def _ensure_run(connection: sqlite3.Connection, *, run_id: str, process_id: str,
+                    task_run_id: int | None = None, session_id: str | None = None,
+                    task_id: str | None = None, board: str | None = None,
+                    model: str | None = None, provider: str | None = None,
+                    started_at: float | None = None) -> None:
+        now = time.time() if started_at is None else float(started_at)
+        connection.execute(
+            """INSERT INTO usage_runs(
+                run_id, process_id, task_run_id, session_id, task_id, board, model, provider,
+                started_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(run_id) DO UPDATE SET
+                task_run_id = COALESCE(usage_runs.task_run_id, excluded.task_run_id),
+                session_id = COALESCE(usage_runs.session_id, excluded.session_id),
+                task_id = COALESCE(usage_runs.task_id, excluded.task_id),
+                board = COALESCE(usage_runs.board, excluded.board),
+                model = CASE WHEN usage_runs.model IS NULL THEN excluded.model ELSE usage_runs.model END,
+                provider = CASE WHEN usage_runs.provider IS NULL OR usage_runs.provider = 'unknown' THEN excluded.provider ELSE usage_runs.provider END,
+                updated_at = excluded.updated_at""",
+            (run_id, str(process_id), task_run_id, _nonempty(session_id), _nonempty(task_id),
+             _nonempty(board), _nonempty(model), _provider_key(provider), now, time.time()),
+        )
+
+    def _start_run(self, *, run_id: str, process_id: str, task_run_id: int | None = None,
+                   session_id: str | None = None, task_id: str | None = None,
+                   board: str | None = None, model: str | None = None,
+                   provider: str | None = None, started_at: float | None = None) -> None:
+        with self._connection() as connection:
+            self._ensure_run(connection, run_id=run_id, process_id=process_id, task_run_id=task_run_id,
+                              session_id=session_id, task_id=task_id, board=board, model=model,
+                              provider=provider, started_at=started_at)
+
+    def start_run(self, **kwargs: Any) -> None:
+        self._start_run(**kwargs)
+
+    def queue_start_run(self, **kwargs: Any) -> bool:
+        return self._enqueue(self._start_run, **kwargs)
+
+    def _record_event(self, *, run_id: str, event_id: str, event_type: str,
+                      session_id: str | None, turn_id: str | None = None,
+                      input_tokens: int = 0, output_tokens: int = 0, cost_usd: float = 0.0,
+                      retry_count: int = 0, model: str | None = None, provider: str | None = None,
+                      tool_delta: int = 0, turn_delta: int = 0, process_id: str | None = None,
+                      task_run_id: int | None = None, task_id: str | None = None,
+                      board: str | None = None) -> bool:
+        if not _nonempty(run_id) or not _nonempty(event_id):
+            raise ValueError("run_id and event_id are required")
+        input_tokens = _nonnegative_int(input_tokens, "input_tokens")
+        output_tokens = _nonnegative_int(output_tokens, "output_tokens")
+        cost_usd = _nonnegative_float(cost_usd, "cost_usd")
+        retry_count = _nonnegative_int(retry_count, "retry_count")
+        now = time.time()
+        with self._connection() as connection:
+            self._ensure_run(connection, run_id=run_id, process_id=process_id or _PROCESS_ID,
+                              task_run_id=task_run_id, session_id=session_id, task_id=task_id,
+                              board=board, model=model, provider=provider)
+            inserted = connection.execute(
+                """INSERT OR IGNORE INTO usage_events(
+                    event_id, run_id, event_type, session_id, turn_id, input_tokens,
+                    output_tokens, cost_usd, retry_count, model, provider, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (event_id, run_id, event_type, _nonempty(session_id), _nonempty(turn_id),
+                 input_tokens, output_tokens, cost_usd, retry_count, _nonempty(model),
+                 _nonempty(provider), now),
+            ).rowcount
+            if not inserted:
+                return False
+            actual_turn_delta = 0
+            if turn_id:
+                actual_turn_delta = connection.execute(
+                    "INSERT OR IGNORE INTO usage_turns(run_id, turn_id) VALUES (?, ?)",
+                    (run_id, turn_id),
+                ).rowcount
+            connection.execute(
+                """UPDATE usage_runs SET input_tokens=input_tokens+?, output_tokens=output_tokens+?,
+                    cost_usd=ROUND(cost_usd+?, 12), turn_count=turn_count+?, tool_call_count=tool_call_count+?,
+                    retry_count=retry_count+?, updated_at=? WHERE run_id=?""",
+                (input_tokens, output_tokens, round(cost_usd, 12), max(int(turn_delta or 0), actual_turn_delta),
+                 _nonnegative_int(tool_delta, "tool_delta"), retry_count, now, run_id),
+            )
+            if _nonempty(model):
+                connection.execute(
+                    """INSERT INTO usage_run_models(run_id, model, provider, input_tokens, output_tokens, cost_usd, event_count)
+                       VALUES (?, ?, ?, ?, ?, ?, 1)
+                       ON CONFLICT(run_id, model, provider) DO UPDATE SET
+                         input_tokens=input_tokens+excluded.input_tokens,
+                         output_tokens=output_tokens+excluded.output_tokens,
+                         cost_usd=ROUND(cost_usd+excluded.cost_usd, 12),
+                         event_count=event_count+1""",
+                    (run_id, _nonempty(model), _provider_key(provider), input_tokens, output_tokens, cost_usd),
+                )
+                models = connection.execute(
+                    "SELECT DISTINCT model FROM usage_run_models WHERE run_id=? ORDER BY model", (run_id,)
+                ).fetchall()
+                providers = connection.execute(
+                    "SELECT DISTINCT provider FROM usage_run_models WHERE run_id=? AND provider IS NOT NULL ORDER BY provider", (run_id,)
+                ).fetchall()
+                connection.execute(
+                    "UPDATE usage_runs SET model=?, provider=? WHERE run_id=?",
+                    (models[0][0] if len(models) == 1 else "mixed",
+                     providers[0][0] if len(providers) == 1 else ("mixed" if providers else None), run_id),
+                )
+            return True
+
+    def record_model_usage(self, **kwargs: Any) -> bool:
+        kwargs["event_type"] = "model"
+        return self._record_event(**kwargs)
+
+    def queue_model_usage(self, **kwargs: Any) -> bool:
+        kwargs["event_type"] = "model"
+        return self._enqueue(self._record_event, critical=True, **kwargs)
+
+    def record_tool_call(self, **kwargs: Any) -> bool:
+        kwargs.update(event_type="tool", tool_delta=1)
+        return self._record_event(**kwargs)
+
+    def queue_tool_call(self, **kwargs: Any) -> bool:
+        kwargs.update(event_type="tool", tool_delta=1)
+        return self._enqueue(self._record_event, critical=True, **kwargs)
+
+    def record_retry(self, **kwargs: Any) -> bool:
+        kwargs.update(event_type="retry", retry_count=1)
+        return self._record_event(**kwargs)
+
+    def queue_retry(self, **kwargs: Any) -> bool:
+        kwargs.update(event_type="retry", retry_count=1)
+        return self._enqueue(self._record_event, critical=True, **kwargs)
+
+    def _finish_run(self, *, run_id: str, outcome: str | None = None,
+                    failure_reason: str | None = None, ended_at: float | None = None,
+                    elapsed: float | None = None) -> None:
+        ended = time.time() if ended_at is None else float(ended_at)
+        with self._connection() as connection:
+            row = connection.execute("SELECT started_at FROM usage_runs WHERE run_id=?", (run_id,)).fetchone()
+            if row is None:
+                self._ensure_run(connection, run_id=run_id, process_id=_PROCESS_ID, started_at=ended)
+                started = ended
+            else:
+                started = float(row["started_at"])
+            effective_elapsed = elapsed if elapsed is not None else max(0.0, ended - started)
+            if effective_elapsed is not None and float(effective_elapsed) < 0:
+                raise ValueError("elapsed must be nonnegative")
+            connection.execute(
+                """UPDATE usage_runs SET ended_at=COALESCE(ended_at,?), elapsed=COALESCE(elapsed,?),
+                    outcome=COALESCE(outcome,?), failure_reason=COALESCE(failure_reason,?), updated_at=?
+                    WHERE run_id=?""",
+                (ended, effective_elapsed, _nonempty(outcome), _nonempty(failure_reason), time.time(), run_id),
+            )
+
+    def finish_run(self, **kwargs: Any) -> None:
+        self._finish_run(**kwargs)
+
+    def queue_finish_run(self, **kwargs: Any) -> bool:
+        return self._enqueue(self._finish_run, critical=True, **kwargs)
+
+    def _model_breakdown(self, connection: sqlite3.Connection, run_id: str) -> list[dict[str, Any]]:
+        rows = connection.execute(
+            "SELECT model, provider, input_tokens, output_tokens, cost_usd, event_count "
+            "FROM usage_run_models WHERE run_id=? ORDER BY model, provider", (run_id,)
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        self.flush()
+        with self._connection() as connection:
+            row = connection.execute("SELECT *, elapsed AS elapsed_seconds FROM usage_runs WHERE run_id=?", (run_id,)).fetchone()
+            if row is None:
+                raise KeyError(run_id)
+            result = dict(row)
+            result["model_breakdown"] = self._model_breakdown(connection, run_id)
+        return result
+
+    def report(self, *, board: str | None = None, task_id: str | None = None,
+               task_run_id: int | None = None, run_id: str | None = None,
+               session_id: str | None = None, process_id: str | None = None,
+               source_profile: str = "default", include_unassigned: bool = False) -> list[dict[str, Any]]:
+        self.flush()
+        clauses: list[str] = []
+        params: list[Any] = []
+        if board is not None:
+            clauses.append("(board = ? OR (? = 1 AND board IS NULL))")
+            params.extend([board, 1 if include_unassigned else 0])
+        elif not include_unassigned:
+            clauses.append("board IS NULL")
+        for field, value in (("task_id", task_id), ("task_run_id", task_run_id),
+                             ("run_id", run_id), ("session_id", session_id), ("process_id", process_id)):
+            if value is not None:
+                clauses.append(f"{field} = ?")
+                params.append(value)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        with self._connection() as connection:
+            rows = connection.execute(
+                f"SELECT *, elapsed AS elapsed_seconds FROM usage_runs {where} ORDER BY started_at ASC, run_id ASC",
+                params,
+            ).fetchall()
+            result = []
+            for row in rows:
+                item = dict(row)
+                item["source_profile"] = source_profile
+                item["model_breakdown"] = self._model_breakdown(connection, item["run_id"])
+                result.append(item)
+        return result
+
+    def link_kanban_run(self, *, task_run_id: int, usage_run_id: str | None = None,
+                        kanban_db: str | Path | None = None, source_profile: str | None = None,
+                        board: str | None = None) -> bool:
+        """Add an exact finalized receipt projection keyed by ``task_runs.id``."""
+        self.flush()
+        usage_run_id = usage_run_id or process_run_id()
+        try:
+            authoritative_id = current_task_run_id()
+            if authoritative_id is not None and authoritative_id != int(task_run_id):
+                return False
+            row = self.get_run(usage_run_id)
+            if row.get("task_run_id") not in (None, int(task_run_id)):
+                return False
+            raw_db_path = str(kanban_db or os.environ.get("HERMES_KANBAN_DB", "")).strip()
+            if not raw_db_path:
+                return False
+            from hermes_cli import kanban_db as kb
+            resolved_source = source_profile or current_source_profile()
+            with kb.connect_closing(Path(raw_db_path)) as connection:
+                task_row = connection.execute(
+                    "SELECT task_id, profile FROM task_runs WHERE id=?", (int(task_run_id),)
+                ).fetchone()
+                if task_row is None:
+                    return False
+                if row.get("task_id") and row["task_id"] != task_row["task_id"]:
+                    return False
+                if task_row["profile"] and task_row["profile"] != resolved_source:
+                    return False
+                if board is not None and row.get("board") not in (None, board):
+                    return False
+                connection.execute(
+                    """INSERT INTO task_run_usage(
+                        task_run_id, usage_run_id, source_profile, input_tokens, output_tokens,
+                        cost_usd, model, provider, outcome, retry_count, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(task_run_id) DO UPDATE SET
+                        usage_run_id=excluded.usage_run_id, source_profile=excluded.source_profile,
+                        input_tokens=excluded.input_tokens, output_tokens=excluded.output_tokens,
+                        cost_usd=excluded.cost_usd, model=excluded.model, provider=excluded.provider,
+                        outcome=excluded.outcome, retry_count=excluded.retry_count,
+                        updated_at=excluded.updated_at""",
+                    (int(task_run_id), usage_run_id, resolved_source, row["input_tokens"], row["output_tokens"],
+                     row["cost_usd"], row["model"], row["provider"], row["outcome"], row["retry_count"], time.time()),
+                )
+            return True
+        except Exception:
+            logger.warning("Kanban usage link failed; runtime remains successful", exc_info=True)
+            return False
+
+
+def process_ledger() -> UsageLedger:
+    path = str(default_ledger_path().resolve())
+    with _LEDGER_CACHE_LOCK:
+        ledger = _LEDGER_CACHE.get(path)
+        if ledger is None:
+            ledger = UsageLedger(path)
+            _LEDGER_CACHE[path] = ledger
+        return ledger
+
+
+def reset_process_ledger_cache() -> None:
+    with _LEDGER_CACHE_LOCK:
+        ledgers = list(_LEDGER_CACHE.values())
+        _LEDGER_CACHE.clear()
+    for ledger in ledgers:
+        ledger.shutdown()
+
+
+atexit.register(reset_process_ledger_cache)

--- a/agent/run_usage_ledger.py
+++ b/agent/run_usage_ledger.py
@@ -50,8 +50,8 @@ CREATE TABLE IF NOT EXISTS usage_runs (
     updated_at REAL NOT NULL
 );
 CREATE TABLE IF NOT EXISTS usage_events (
-    event_id TEXT PRIMARY KEY,
     run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
+    event_id TEXT NOT NULL,
     event_type TEXT NOT NULL,
     session_id TEXT,
     turn_id TEXT,
@@ -61,7 +61,8 @@ CREATE TABLE IF NOT EXISTS usage_events (
     retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
     model TEXT,
     provider TEXT,
-    created_at REAL NOT NULL
+    created_at REAL NOT NULL,
+    PRIMARY KEY (run_id, event_id)
 );
 CREATE TABLE IF NOT EXISTS usage_turns (
     run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
@@ -86,17 +87,11 @@ CREATE TABLE IF NOT EXISTS usage_diagnostics (
     detail TEXT,
     created_at REAL NOT NULL
 );
-CREATE INDEX IF NOT EXISTS idx_usage_runs_board ON usage_runs(board, started_at DESC);
-CREATE INDEX IF NOT EXISTS idx_usage_runs_task ON usage_runs(task_id, started_at DESC);
-CREATE INDEX IF NOT EXISTS idx_usage_runs_task_run ON usage_runs(task_run_id, started_at DESC);
-CREATE INDEX IF NOT EXISTS idx_usage_runs_session ON usage_runs(session_id, started_at DESC);
-CREATE INDEX IF NOT EXISTS idx_usage_events_run ON usage_events(run_id, created_at);
-CREATE INDEX IF NOT EXISTS idx_usage_run_models_run ON usage_run_models(run_id, model, provider);
 CREATE INDEX IF NOT EXISTS idx_usage_diagnostics_run ON usage_diagnostics(run_id, created_at);
 """
 
-_PROCESS_ID = str(os.getpid())
-_PROCESS_INVOCATION_ID = os.environ.get("HERMES_RUN_ID", "").strip() or f"proc-{_PROCESS_ID}-{uuid.uuid4().hex}"
+_PROCESS_ID = f"proc-{os.getpid()}-{uuid.uuid4().hex}"
+_PROCESS_INVOCATION_ID = _PROCESS_ID
 _CURRENT_SESSION: ContextVar[str | None] = ContextVar("hermes_usage_session", default=None)
 _LEDGER_CACHE: dict[str, "UsageLedger"] = {}
 _LEDGER_CACHE_LOCK = threading.Lock()
@@ -122,6 +117,11 @@ def process_run_id() -> str:
         return f"task-run:{kanban_run}"
     explicit = os.environ.get("HERMES_RUN_ID", "").strip()
     return explicit or _PROCESS_INVOCATION_ID
+
+
+def process_invocation_id() -> str:
+    """Return a unique identity for this interpreter invocation."""
+    return _PROCESS_INVOCATION_ID
 
 
 def run_id_for_session(session_id: str | None = None) -> str:
@@ -197,6 +197,8 @@ class UsageLedger:
         self._dropped: dict[tuple[str | None, str], int] = {}
         self._incomplete_runs: dict[str, int] = {}
         self._diagnostic_limit = 256
+        self._global_incomplete = False
+        self._global_diagnostics: dict[str, int] = {}
         self._queue_cond = threading.Condition()
         self._writer: threading.Thread | None = None
         self._writer_stop = False
@@ -216,34 +218,145 @@ class UsageLedger:
     def _ensure_schema(self) -> None:
         with self._connection() as connection:
             connection.executescript(_USAGE_SCHEMA)
+            self._migrate_usage_events(connection)
             cols = {row["name"] for row in connection.execute("PRAGMA table_info(usage_runs)")}
-            if "task_run_id" not in cols:
-                connection.execute("ALTER TABLE usage_runs ADD COLUMN task_run_id INTEGER")
-            model_cols = {row["name"]: row["notnull"] for row in connection.execute("PRAGMA table_info(usage_run_models)")}
-            if model_cols and not model_cols.get("provider"):
-                connection.execute("ALTER TABLE usage_run_models RENAME TO usage_run_models_legacy")
-                connection.execute("""CREATE TABLE usage_run_models (
+            optional_columns = {
+                "task_run_id": "task_run_id INTEGER",
+                "session_id": "session_id TEXT",
+                "task_id": "task_id TEXT",
+                "board": "board TEXT",
+                "model": "model TEXT",
+                "provider": "provider TEXT",
+                "input_tokens": "input_tokens INTEGER NOT NULL DEFAULT 0",
+                "output_tokens": "output_tokens INTEGER NOT NULL DEFAULT 0",
+                "cost_usd": "cost_usd REAL NOT NULL DEFAULT 0",
+                "turn_count": "turn_count INTEGER NOT NULL DEFAULT 0",
+                "tool_call_count": "tool_call_count INTEGER NOT NULL DEFAULT 0",
+                "elapsed": "elapsed REAL",
+                "outcome": "outcome TEXT",
+                "retry_count": "retry_count INTEGER NOT NULL DEFAULT 0",
+                "failure_reason": "failure_reason TEXT",
+                "ended_at": "ended_at REAL",
+            }
+            for name, definition in optional_columns.items():
+                if name not in cols:
+                    connection.execute(f"ALTER TABLE usage_runs ADD COLUMN {definition}")
+            self._migrate_usage_run_models(connection)
+            connection.execute("CREATE INDEX IF NOT EXISTS idx_usage_runs_board ON usage_runs(board, started_at DESC)")
+            connection.execute("CREATE INDEX IF NOT EXISTS idx_usage_runs_task ON usage_runs(task_id, started_at DESC)")
+            connection.execute("CREATE INDEX IF NOT EXISTS idx_usage_runs_task_run ON usage_runs(task_run_id, started_at DESC)")
+            connection.execute("CREATE INDEX IF NOT EXISTS idx_usage_runs_session ON usage_runs(session_id, started_at DESC)")
+            connection.execute("CREATE INDEX IF NOT EXISTS idx_usage_events_run ON usage_events(run_id, created_at)")
+            connection.execute("CREATE INDEX IF NOT EXISTS idx_usage_events_event ON usage_events(event_id)")
+            connection.execute("CREATE INDEX IF NOT EXISTS idx_usage_run_models_run ON usage_run_models(run_id, model, provider)")
+
+    @staticmethod
+    def _migrate_usage_events(connection: sqlite3.Connection) -> None:
+        columns = connection.execute("PRAGMA table_info(usage_events)").fetchall()
+        names = {row[1] for row in columns}
+        primary_key = [row[1] for row in columns if row[5]]
+        if primary_key != ["event_id"]:
+            return
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            connection.execute("ALTER TABLE usage_events RENAME TO usage_events_legacy")
+            connection.execute(
+                """CREATE TABLE usage_events (
                     run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
-                    model TEXT NOT NULL, provider TEXT NOT NULL DEFAULT 'unknown',
+                    event_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    session_id TEXT,
+                    turn_id TEXT,
+                    input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+                    output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+                    cost_usd REAL NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+                    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+                    model TEXT,
+                    provider TEXT,
+                    created_at REAL NOT NULL,
+                    PRIMARY KEY (run_id, event_id)
+                )"""
+            )
+            source = {
+                "run_id": "run_id",
+                "event_id": "event_id",
+                "event_type": "event_type",
+                "session_id": "session_id" if "session_id" in names else "NULL",
+                "turn_id": "turn_id" if "turn_id" in names else "NULL",
+                "input_tokens": "input_tokens" if "input_tokens" in names else "0",
+                "output_tokens": "output_tokens" if "output_tokens" in names else "0",
+                "cost_usd": "cost_usd" if "cost_usd" in names else "0",
+                "retry_count": "retry_count" if "retry_count" in names else "0",
+                "model": "model" if "model" in names else "NULL",
+                "provider": "provider" if "provider" in names else "NULL",
+                "created_at": "created_at" if "created_at" in names else "0",
+            }
+            target_columns = ", ".join(source)
+            source_columns = ", ".join(source.values())
+            connection.execute(
+                f"INSERT INTO usage_events({target_columns}) SELECT {source_columns} FROM usage_events_legacy"
+            )
+            connection.execute("DROP TABLE usage_events_legacy")
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+
+    @staticmethod
+    def _migrate_usage_run_models(connection: sqlite3.Connection) -> None:
+        columns = connection.execute("PRAGMA table_info(usage_run_models)").fetchall()
+        if not columns:
+            return
+        names = {row[1] for row in columns}
+        primary_key = [row[1] for row in sorted(columns, key=lambda row: row[5]) if row[5]]
+        provider_not_null = any(row[1] == "provider" and row[3] for row in columns)
+        if names >= {"run_id", "model", "provider"} and provider_not_null and primary_key == ["run_id", "model", "provider"]:
+            return
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            connection.execute("ALTER TABLE usage_run_models RENAME TO usage_run_models_legacy")
+            connection.execute(
+                """CREATE TABLE usage_run_models (
+                    run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
+                    model TEXT NOT NULL,
+                    provider TEXT NOT NULL DEFAULT 'unknown',
                     input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
                     output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
                     cost_usd REAL NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
                     event_count INTEGER NOT NULL DEFAULT 0 CHECK (event_count >= 0),
-                    PRIMARY KEY (run_id, model, provider))""")
-                connection.execute("""INSERT INTO usage_run_models
-                    (run_id, model, provider, input_tokens, output_tokens, cost_usd, event_count)
-                    SELECT run_id, model, COALESCE(NULLIF(provider, ''), 'unknown'),
-                           SUM(input_tokens), SUM(output_tokens), SUM(cost_usd), SUM(event_count)
-                    FROM usage_run_models_legacy GROUP BY run_id, model, COALESCE(NULLIF(provider, ''), 'unknown')""")
-                connection.execute("DROP TABLE usage_run_models_legacy")
-                connection.execute("CREATE INDEX IF NOT EXISTS idx_usage_run_models_run ON usage_run_models(run_id, model, provider)")
+                    PRIMARY KEY (run_id, model, provider)
+                )"""
+            )
+            provider_expr = "COALESCE(NULLIF(provider, ''), 'unknown')" if "provider" in names else "'unknown'"
+            connection.execute(
+                f"""INSERT INTO usage_run_models(
+                    run_id, model, provider, input_tokens, output_tokens, cost_usd, event_count
+                ) SELECT run_id, model, {provider_expr},
+                    SUM(input_tokens), SUM(output_tokens), SUM(cost_usd), SUM(event_count)
+                FROM usage_run_models_legacy
+                GROUP BY run_id, model, {provider_expr}"""
+            )
+            connection.execute("DROP TABLE usage_run_models_legacy")
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+
+    def _mark_global_incomplete(self, reason: str) -> None:
+        self._global_incomplete = True
+        if reason in self._global_diagnostics or len(self._global_diagnostics) < self._diagnostic_limit:
+            self._global_diagnostics[reason] = self._global_diagnostics.get(reason, 0) + 1
 
     def _record_drop(self, run_id: str | None, kind: str) -> None:
         key = (run_id, kind)
         if key in self._dropped or len(self._dropped) < self._diagnostic_limit:
             self._dropped[key] = self._dropped.get(key, 0) + 1
+        else:
+            self._mark_global_incomplete("diagnostic_capacity_exhausted")
         if run_id and (run_id in self._incomplete_runs or len(self._incomplete_runs) < self._diagnostic_limit):
             self._incomplete_runs[run_id] = self._incomplete_runs.get(run_id, 0) + 1
+        else:
+            self._mark_global_incomplete("run_capacity_exhausted")
 
     def _enqueue(self, fn: Callable[..., Any], *args: Any, critical: bool = False, **kwargs: Any) -> bool:
         operation: Operation = (fn, args, kwargs)
@@ -280,9 +393,14 @@ class UsageLedger:
                 with self._queue_cond:
                     if len(self._failed_operations) < self._queue_limit:
                         self._failed_operations.append(operation)
-                    key = (operation[2].get("run_id"), "writer_failure")
-                    if key in self._dropped or len(self._dropped) < self._diagnostic_limit:
-                        self._dropped[key] = self._dropped.get(key, 0) + 1
+                        key = (operation[2].get("run_id"), "writer_failure")
+                        if key in self._dropped or len(self._dropped) < self._diagnostic_limit:
+                            self._dropped[key] = self._dropped.get(key, 0) + 1
+                        else:
+                            self._mark_global_incomplete("diagnostic_capacity_exhausted")
+                    else:
+                        self._mark_global_incomplete("failed_buffer_full")
+                        self._record_drop(operation[2].get("run_id"), "failed_buffer_full")
                 logger.warning("usage ledger write failed; continuing runtime", exc_info=True)
             finally:
                 with self._queue_cond:
@@ -312,15 +430,21 @@ class UsageLedger:
                 still_failed.append(operation)
         if still_failed:
             with self._queue_cond:
-                for operation in still_failed[: self._queue_limit - len(self._failed_operations)]:
+                available = self._queue_limit - len(self._failed_operations)
+                for operation in still_failed[:available]:
                     self._failed_operations.append(operation)
                     self._record_drop(operation[2].get("run_id"), "persistent_writer_failure")
+                for operation in still_failed[available:]:
+                    self._mark_global_incomplete("failed_buffer_full")
+                    self._record_drop(operation[2].get("run_id"), "failed_buffer_full")
 
     def _persist_diagnostics(self) -> None:
         with self._queue_cond:
             dropped = self._dropped
             self._dropped = {}
-        if not dropped:
+            global_diagnostics = self._global_diagnostics
+            self._global_diagnostics = {}
+        if not dropped and not global_diagnostics:
             return
         with self._connection() as connection:
             now = time.time()
@@ -328,6 +452,11 @@ class UsageLedger:
                 connection.execute(
                     "INSERT INTO usage_diagnostics(run_id, diagnostic_type, count, detail, created_at) VALUES (?, ?, ?, ?, ?)",
                     (run_id, "dropped_event", count, kind, now),
+                )
+            for reason, count in global_diagnostics.items():
+                connection.execute(
+                    "INSERT INTO usage_diagnostics(run_id, diagnostic_type, count, detail, created_at) VALUES (?, ?, ?, ?, ?)",
+                    (None, "usage_incomplete_global", count, reason, now),
                 )
 
     def finalize_run(self, *, run_id: str, outcome: str | None = None,
@@ -338,7 +467,12 @@ class UsageLedger:
         self._replay_failed_sync()
         self._replay_failed_sync()
         with self._queue_cond:
-            complete = drained and not self._queue and not self._writer_busy and not self._failed_operations and run_id not in self._incomplete_runs
+            complete = (
+                drained and not self._queue and not self._writer_busy
+                and not self._failed_operations
+                and not self._global_incomplete
+                and run_id not in self._incomplete_runs
+            )
         if not complete:
             self._record_drop(run_id, "incomplete_finalization")
             try:

--- a/agent/run_usage_report.py
+++ b/agent/run_usage_report.py
@@ -11,6 +11,32 @@ from hermes_constants import get_default_hermes_root
 from agent.run_usage_ledger import UsageLedger, default_ledger_path
 
 
+def _run_fingerprint(row: dict) -> str:
+    """Fingerprint accounting data, excluding ledger-local attribution."""
+    comparable = {
+        key: value for key, value in row.items()
+        if key not in {"identity", "source_profile", "source_profiles", "process_id", "updated_at"}
+    }
+    return json.dumps(comparable, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _deduplicate_global_runs(rows: list[dict]) -> list[dict]:
+    grouped: dict[str, list[dict]] = {}
+    for row in rows:
+        grouped.setdefault(str(row["run_id"]), []).append(row)
+    deduplicated: list[dict] = []
+    for run_id, candidates in grouped.items():
+        candidates.sort(key=lambda row: (str(row.get("source_profile") or ""), str(row.get("process_id") or "")))
+        fingerprints = {_run_fingerprint(row) for row in candidates}
+        if len(fingerprints) > 1:
+            profiles = ", ".join(str(row.get("source_profile") or "unknown") for row in candidates)
+            raise ValueError(f"conflicting duplicate run_id {run_id!r} across profiles: {profiles}")
+        winner = dict(candidates[0])
+        winner["source_profiles"] = sorted({str(row.get("source_profile") or "unknown") for row in candidates})
+        deduplicated.append(winner)
+    return deduplicated
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Report Hermes model/tool usage by run, process, session, profile, or card.")
     parser.add_argument("--db", type=Path, default=None, help="one explicit state database path")
@@ -104,10 +130,8 @@ def main(argv: list[str] | None = None) -> int:
                     source_profile=source_profile,
                     include_unassigned=args.include_unassigned,
                 ))
+        rows = _deduplicate_global_runs(rows)
         for row in rows:
-            # ``run_id`` is only unique inside one profile. Preserve the
-            # composite identity explicitly rather than rejecting valid
-            # duplicate IDs from independent profile-local ledgers.
             row["identity"] = [row["source_profile"], row["run_id"]]
         rows.sort(key=lambda row: (row.get("started_at") or 0, row["source_profile"], row["run_id"]))
         print(json.dumps(rows, indent=2, sort_keys=True))

--- a/agent/run_usage_report.py
+++ b/agent/run_usage_report.py
@@ -1,0 +1,121 @@
+"""Deterministic reporting across explicitly selected profile-local ledgers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from hermes_constants import get_default_hermes_root
+from agent.run_usage_ledger import UsageLedger, default_ledger_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Report Hermes model/tool usage by run, process, session, profile, or card.")
+    parser.add_argument("--db", type=Path, default=None, help="one explicit state database path")
+    parser.add_argument("--profile", action="append", help="named profile to include; repeatable")
+    parser.add_argument("--all-profiles", action="store_true", help="include default and every installed profile ledger")
+    parser.add_argument("--board", help="explicit board slug; required for card queries")
+    parser.add_argument("--kanban-db", type=Path, default=None, help="explicit Kanban DB for exact task-run joins")
+    parser.add_argument("--card-id", "--task-id", dest="task_id")
+    parser.add_argument("--task-run-id", type=int)
+    parser.add_argument("--run-id")
+    parser.add_argument("--process-id")
+    parser.add_argument("--session-id")
+    parser.add_argument("--include-unassigned", action="store_true", help="include direct runs with no board metadata")
+    return parser
+
+
+def _selected_ledgers(args: argparse.Namespace) -> list[tuple[str, Path]]:
+    if args.db is not None:
+        return [(args.profile[0] if args.profile else "default", args.db)]
+    from hermes_cli import profiles
+    root = Path(get_default_hermes_root()).resolve()
+    installed = {item.name: Path(item.path) for item in profiles.list_profiles() if item.name != "default"}
+    if args.all_profiles:
+        # The default ledger is always the root ledger, not the active profile.
+        selected = [("default", root / "state.db")]
+        selected.extend((name, installed[name] / "state.db") for name in sorted(installed))
+        return selected
+    if args.profile:
+        unknown = [name for name in args.profile if name != "default" and name not in installed]
+        if unknown:
+            raise ValueError(f"profile ledger not found: {', '.join(sorted(set(unknown)))}")
+        return [(name, root / "state.db") if name == "default" else (name, installed[name] / "state.db") for name in args.profile]
+    return [("default", root / "state.db")]
+
+
+def _linked_usage_run_ids(args: argparse.Namespace) -> list[str] | None:
+    """Resolve a card to exact task_runs usage links when a board DB is supplied."""
+    if args.kanban_db is None or (args.task_id is None and args.task_run_id is None):
+        return None
+    from hermes_cli import kanban_db
+    if not args.kanban_db.is_file():
+        raise ValueError(f"Kanban DB not found: {args.kanban_db}")
+    with kanban_db.connect_closing(args.kanban_db) as connection:
+        if args.task_run_id is not None:
+            rows = connection.execute(
+                "SELECT usage_run_id FROM task_run_usage WHERE task_run_id = ? ORDER BY task_run_id",
+                (args.task_run_id,),
+            ).fetchall()
+        else:
+            rows = connection.execute(
+                """SELECT u.usage_run_id FROM task_run_usage u
+                   JOIN task_runs r ON r.id = u.task_run_id
+                   WHERE r.task_id = ? ORDER BY u.task_run_id""",
+                (args.task_id,),
+            ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    card_query = args.task_id is not None or args.task_run_id is not None or args.include_unassigned
+    if card_query and not args.board:
+        build_parser().error("--board is required for card/task-run queries")
+    if not any((args.board, args.all_profiles, args.profile, args.task_id, args.task_run_id, args.run_id, args.process_id, args.session_id, args.include_unassigned)):
+        build_parser().error("select --board, --run-id, --process-id, --session-id, or --all-profiles")
+    try:
+        ledgers = _selected_ledgers(args)
+        linked_run_ids = _linked_usage_run_ids(args)
+        rows: list[dict] = []
+        for source_profile, path in ledgers:
+            if not path.is_file():
+                if args.all_profiles:
+                    continue
+                raise ValueError(f"usage ledger not found for profile {source_profile}: {path}")
+            ledger = UsageLedger(path)
+            if linked_run_ids:
+                for linked_run_id in linked_run_ids:
+                    rows.extend(ledger.report(
+                        board=args.board, run_id=linked_run_id,
+                        source_profile=source_profile,
+                        include_unassigned=args.include_unassigned,
+                    ))
+            else:
+                rows.extend(ledger.report(
+                    board=args.board,
+                    task_id=args.task_id,
+                    task_run_id=args.task_run_id,
+                    run_id=args.run_id,
+                    process_id=args.process_id,
+                    session_id=args.session_id,
+                    source_profile=source_profile,
+                    include_unassigned=args.include_unassigned,
+                ))
+        for row in rows:
+            # ``run_id`` is only unique inside one profile. Preserve the
+            # composite identity explicitly rather than rejecting valid
+            # duplicate IDs from independent profile-local ledgers.
+            row["identity"] = [row["source_profile"], row["run_id"]]
+        rows.sort(key=lambda row: (row.get("started_at") or 0, row["source_profile"], row["run_id"]))
+        print(json.dumps(rows, indent=2, sort_keys=True))
+        return 0
+    except (OSError, ValueError, KeyError) as exc:
+        print(f"run usage report: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1275,6 +1275,23 @@ CREATE TABLE IF NOT EXISTS task_runs (
     error               TEXT
 );
 
+-- Normalized exact usage projection for worker runs. The profile-local ledger
+-- remains primary; this table is a durable join keyed by authoritative
+-- task_runs.id, not by task id (which can have many retry runs).
+CREATE TABLE IF NOT EXISTS task_run_usage (
+    task_run_id     INTEGER PRIMARY KEY REFERENCES task_runs(id) ON DELETE CASCADE,
+    usage_run_id    TEXT NOT NULL,
+    source_profile  TEXT NOT NULL,
+    input_tokens    INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens   INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    cost_usd        REAL NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+    model           TEXT,
+    provider        TEXT,
+    outcome         TEXT,
+    retry_count     INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    updated_at      REAL NOT NULL
+);
+
 -- Files attached to a task (PDFs, images, source documents). The blob
 -- lives on disk under ``attachments_root(board)/<task_id>/<stored_name>``;
 -- this row carries metadata + the absolute ``stored_path`` so the
@@ -1318,6 +1335,7 @@ CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, c
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
+CREATE INDEX IF NOT EXISTS idx_task_run_usage_usage ON task_run_usage(usage_run_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
 """

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -25,6 +25,7 @@ def _observe_run_usage(hook_name: str, event: dict[str, Any]) -> None:
             bind_session,
             current_source_profile,
             current_task_run_id,
+            process_invocation_id,
             process_ledger,
             run_id_for_session,
         )
@@ -42,7 +43,7 @@ def _observe_run_usage(hook_name: str, event: dict[str, Any]) -> None:
         provider = str(event.get("provider") or "") or None
         common = {
             "run_id": run_id,
-            "process_id": str(os.getpid()),
+            "process_id": process_invocation_id(),
             "task_run_id": task_run_id,
             "session_id": session_id,
             "task_id": task_id,
@@ -75,7 +76,7 @@ def _observe_run_usage(hook_name: str, event: dict[str, Any]) -> None:
                     run_id=run_id,
                     event_id=f"{run_id}:tool:{tool_call_id}",
                     session_id=session_id,
-                    process_id=str(os.getpid()),
+                    process_id=process_invocation_id(),
                     task_id=task_id,
                     board=board,
                     task_run_id=task_run_id,
@@ -94,7 +95,7 @@ def _observe_run_usage(hook_name: str, event: dict[str, Any]) -> None:
                     session_id=session_id,
                     model=model,
                     provider=provider,
-                    process_id=str(os.getpid()),
+                    process_id=process_invocation_id(),
                     task_id=task_id,
                     board=board,
                     task_run_id=task_run_id,

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -8,8 +8,124 @@ from typing import Any, List
 logger = logging.getLogger(__name__)
 
 
+def _observe_run_usage(hook_name: str, event: dict[str, Any]) -> None:
+    """Persist real runtime usage without making plugins or cards a dependency."""
+    if hook_name not in {
+        "on_session_start",
+        "post_api_request",
+        "post_tool_call",
+        "api_request_error",
+        "on_session_finalize",
+    }:
+        return
+    try:
+        import os
+
+        from agent.run_usage_ledger import (
+            bind_session,
+            current_source_profile,
+            current_task_run_id,
+            process_ledger,
+            run_id_for_session,
+        )
+
+        ledger = process_ledger()
+        session_id = str(event.get("session_id") or os.environ.get("HERMES_SESSION_ID") or "") or None
+        bind_session(session_id)
+        run_id = str(event.get("run_id") or run_id_for_session(session_id))
+        task_id = str(event.get("task_id") or os.environ.get("HERMES_KANBAN_TASK") or "") or None
+        board = str(event.get("board") or os.environ.get("HERMES_KANBAN_BOARD") or "") or None
+        task_run_id = event.get("task_run_id")
+        if task_run_id is None:
+            task_run_id = current_task_run_id()
+        model = str(event.get("model") or "") or None
+        provider = str(event.get("provider") or "") or None
+        common = {
+            "run_id": run_id,
+            "process_id": str(os.getpid()),
+            "task_run_id": task_run_id,
+            "session_id": session_id,
+            "task_id": task_id,
+            "board": board,
+            "model": model,
+            "provider": provider,
+        }
+        if hook_name == "on_session_start":
+            ledger.queue_start_run(**common)
+        elif hook_name == "post_api_request":
+            api_request_id = str(event.get("api_request_id") or "")
+            if not api_request_id:
+                return
+            usage = event.get("usage") or {}
+            usage_common = dict(common)
+            usage_common["model"] = event.get("response_model") or model
+            ledger.queue_model_usage(
+                **usage_common,
+                event_id=f"{run_id}:api:{api_request_id}",
+                turn_id=event.get("turn_id"),
+                input_tokens=usage.get("input_tokens", usage.get("prompt_tokens", 0)),
+                output_tokens=usage.get("output_tokens", usage.get("completion_tokens", 0)),
+                cost_usd=event.get("cost_usd", event.get("estimated_cost_usd", 0.0)) or 0.0,
+                retry_count=0,
+            )
+        elif hook_name == "post_tool_call":
+            tool_call_id = str(event.get("tool_call_id") or "")
+            if tool_call_id:
+                ledger.queue_tool_call(
+                    run_id=run_id,
+                    event_id=f"{run_id}:tool:{tool_call_id}",
+                    session_id=session_id,
+                    process_id=str(os.getpid()),
+                    task_id=task_id,
+                    board=board,
+                    task_run_id=task_run_id,
+                )
+        elif hook_name == "api_request_error":
+            if event.get("retryable") is not False:
+                request_id = str(event.get("api_request_id") or "")
+                if not request_id:
+                    return
+                retry_count = int(event.get("retry_count") or 0)
+                error_payload = event.get("error") or {}
+                error_type = error_payload.get("type", "") if isinstance(error_payload, dict) else str(error_payload)
+                ledger.queue_retry(
+                    run_id=run_id,
+                    event_id=f"{run_id}:retry:{request_id}:{retry_count}:{error_type}",
+                    session_id=session_id,
+                    model=model,
+                    provider=provider,
+                    process_id=str(os.getpid()),
+                    task_id=task_id,
+                    board=board,
+                    task_run_id=task_run_id,
+                )
+        elif hook_name == "on_session_finalize":
+            if event.get("completed") is True:
+                outcome = "completed"
+            elif event.get("failed") is True:
+                outcome = "failed"
+            elif event.get("interrupted") is True:
+                outcome = "interrupted"
+            else:
+                outcome = str(event.get("reason") or "unknown")
+            reason = event.get("failure_reason") or event.get("reason")
+            finalized = ledger.finalize_run(run_id=run_id, outcome=outcome, failure_reason=reason)
+            if finalized and task_run_id is not None:
+                ledger.link_kanban_run(
+                    task_run_id=int(task_run_id),
+                    usage_run_id=run_id,
+                    kanban_db=os.environ.get("HERMES_KANBAN_DB"),
+                    source_profile=current_source_profile(),
+                    board=board,
+                )
+    except Exception:
+        # Usage must never break a model/tool turn or session shutdown.
+        logger.debug("Run usage ledger hook failed", exc_info=True)
+
+
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     """Notify first-party observers, then invoke compatibility plugin hooks."""
+    _observe_run_usage(hook_name, kwargs)
     try:
         from hermes_cli.observability import observe_lifecycle
 
@@ -24,6 +140,8 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 
 def has_hook(hook_name: str) -> bool:
     """Return whether a first-party observer or plugin consumes a hook."""
+    if hook_name in {"on_session_start", "post_api_request", "post_tool_call", "api_request_error", "on_session_finalize"}:
+        return True
     try:
         from hermes_cli.observability import handles_hook
 
@@ -39,6 +157,7 @@ def has_hook(hook_name: str) -> bool:
 
 def finalize_session(**kwargs: Any) -> List[Any]:
     """Notify observers and hard-close one core-owned Relay conversation."""
+    _observe_run_usage("on_session_finalize", kwargs)
     try:
         from hermes_cli.observability import observe_lifecycle
 

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -52,7 +52,10 @@ def _observe_run_usage(hook_name: str, event: dict[str, Any]) -> None:
             "provider": provider,
         }
         if hook_name == "on_session_start":
-            ledger.queue_start_run(**common)
+            # The start marker is the crash-survival anchor.  It must be
+            # durable before the first provider request, otherwise SIGKILL can
+            # erase the only evidence that a direct run existed.
+            ledger.start_run(**common)
         elif hook_name == "post_api_request":
             api_request_id = str(event.get("api_request_id") or "")
             if not api_request_id:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -401,6 +401,7 @@ def _run_agent(
     # raises on a provider/config error. The one-shot exit path hard-exits via
     # os._exit and skips finalizers, so an un-closed connection here would leak.
     agent = None
+    run_result: dict = {}
     try:
         # Read the effective fallback chain from profile config so oneshot
         # workers honour the same merge semantics as interactive CLI and
@@ -440,9 +441,57 @@ def _run_agent(
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
 
-        result = agent.run_conversation(prompt)
-        return (result.get("final_response") or "", result)
+        # Establish the durable crash-survival marker before the provider
+        # request.  The conversation loop also emits this lifecycle hook for
+        # interactive sessions; the ledger's run-start write is idempotent.
+        from hermes_cli.lifecycle import invoke_hook
+
+        from agent.run_usage_ledger import process_invocation_id, process_ledger, run_id_for_session
+
+        process_ledger().start_run(
+            run_id=run_id_for_session(getattr(agent, "session_id", None)),
+            process_id=process_invocation_id(),
+            session_id=getattr(agent, "session_id", None),
+            model=effective_model,
+            provider=runtime.get("provider"),
+        )
+        invoke_hook(
+            "on_session_start",
+            session_id=getattr(agent, "session_id", None),
+            model=effective_model,
+            provider=runtime.get("provider"),
+            platform="cli",
+        )
+        run_result = agent.run_conversation(prompt)
+        return (run_result.get("final_response") or "", run_result)
     finally:
+        if agent is not None:
+            try:
+                from hermes_cli.lifecycle import finalize_session
+
+                exc_type = sys.exc_info()[0]
+                was_interrupted = run_result.get("interrupted") is True or exc_type is KeyboardInterrupt
+                was_failed = run_result.get("failed") is True or (exc_type is not None and not was_interrupted)
+                finalize_session(
+                    session_id=getattr(agent, "session_id", None),
+                    platform="cli",
+                    completed=run_result.get("completed") is True and not was_interrupted,
+                    failed=was_failed,
+                    interrupted=was_interrupted,
+                    reason=(
+                        "interrupted" if was_interrupted
+                        else "completed" if run_result.get("completed") is True
+                        else "failed"
+                    ),
+                )
+                from agent.run_usage_ledger import process_ledger, run_id_for_session
+
+                receipt = process_ledger().get_run(run_id_for_session(getattr(agent, "session_id", None)))
+                if receipt["ended_at"] is None:
+                    raise RuntimeError("usage accounting finalization did not close the run")
+            except Exception:
+                logging.error("oneshot usage finalization failed; leaving run incomplete", exc_info=True)
+                raise
         # Ordering deliberately mirrors gateway/run.py:_cleanup_agent_resources,
         # NOT cli.py:_run_cleanup — oneshot has no _active_agent_ref and must
         # close the agent explicitly because the hard-exit path skips finalizers.

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -237,6 +237,72 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
     PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
 );
 
+-- Additive run/process usage receipts.  Immutable usage_events are the
+-- idempotency boundary; usage_runs is the queryable aggregate.
+CREATE TABLE IF NOT EXISTS usage_runs (
+    run_id TEXT PRIMARY KEY,
+    process_id TEXT NOT NULL,
+    task_run_id INTEGER,
+    session_id TEXT,
+    task_id TEXT,
+    board TEXT,
+    model TEXT,
+    provider TEXT,
+    input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    cost_usd REAL NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+    turn_count INTEGER NOT NULL DEFAULT 0 CHECK (turn_count >= 0),
+    tool_call_count INTEGER NOT NULL DEFAULT 0 CHECK (tool_call_count >= 0),
+    elapsed REAL CHECK (elapsed IS NULL OR elapsed >= 0),
+    outcome TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    failure_reason TEXT,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    updated_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS usage_events (
+    event_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
+    event_type TEXT NOT NULL,
+    session_id TEXT,
+    turn_id TEXT,
+    input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    cost_usd REAL NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    model TEXT,
+    provider TEXT,
+    created_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS usage_turns (
+    run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
+    turn_id TEXT NOT NULL,
+    PRIMARY KEY (run_id, turn_id)
+);
+
+CREATE TABLE IF NOT EXISTS usage_run_models (
+    run_id TEXT NOT NULL REFERENCES usage_runs(run_id) ON DELETE CASCADE,
+    model TEXT NOT NULL,
+    provider TEXT NOT NULL DEFAULT 'unknown',
+    input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    cost_usd REAL NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+    event_count INTEGER NOT NULL DEFAULT 0 CHECK (event_count >= 0),
+    PRIMARY KEY (run_id, model, provider)
+);
+
+CREATE TABLE IF NOT EXISTS usage_diagnostics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT,
+    diagnostic_type TEXT NOT NULL,
+    count INTEGER NOT NULL DEFAULT 1 CHECK (count > 0),
+    detail TEXT,
+    created_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT
@@ -286,6 +352,13 @@ CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestam
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
+CREATE INDEX IF NOT EXISTS idx_usage_runs_board ON usage_runs(board, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_runs_task ON usage_runs(task_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_runs_task_run ON usage_runs(task_run_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_runs_session ON usage_runs(session_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_events_run ON usage_events(run_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_usage_run_models_run ON usage_run_models(run_id, model, provider);
+CREATE INDEX IF NOT EXISTS idx_usage_diagnostics_run ON usage_diagnostics(run_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
     ON async_delegations(delivery_state, completed_at);
 """

--- a/scripts/card-cost.sh
+++ b/scripts/card-cost.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$ROOT"
+HERMES_PYTHON="${HERMES_PYTHON:-}"
+if [[ -z "$HERMES_PYTHON" ]]; then
+  for candidate in "$ROOT/.venv/bin/python" "$ROOT/venv/bin/python" "$HOME/.hermes/hermes-agent/venv/bin/python"; do
+    if [[ -x "$candidate" ]]; then
+      HERMES_PYTHON="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -z "$HERMES_PYTHON" ]]; then
+  HERMES_PYTHON="$(command -v python 2>/dev/null || true)"
+fi
+if [[ -z "$HERMES_PYTHON" || ! -x "$HERMES_PYTHON" ]]; then
+  printf 'card-cost.sh: set HERMES_PYTHON to the repository Python\n' >&2
+  exit 2
+fi
+exec "$HERMES_PYTHON" -m agent.run_usage_report "$@"

--- a/tests/test_run_usage_direct_process.py
+++ b/tests/test_run_usage_direct_process.py
@@ -1,14 +1,72 @@
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
 import json
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 from agent.run_usage_ledger import UsageLedger
+
+
+def _isolated_cli_env(home: Path, run_id: str) -> dict[str, str]:
+    """Launch a CLI child with an explicit, credential-free environment."""
+    env = {key: os.environ[key] for key in ("PATH", "TZ", "LANG", "LC_ALL") if key in os.environ}
+    env.update({
+        "HOME": str(home / "home"),
+        "HERMES_HOME": str(home),
+        "HERMES_RUN_ID": run_id,
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
+    })
+    return env
+
+
+def _write_cli_config(home: Path, *, base_url: str, provider: str = "custom",
+                      model: str = "local-model", api_mode: str = "chat_completions",
+                      extra: str = "", api_max_retries: int = 1) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        f"""model:
+  provider: {provider}
+  base_url: {base_url}
+  api_mode: {api_mode}
+  api_key: test-key
+  default: {model}
+agent:
+  api_max_retries: {api_max_retries}
+  max_turns: 2
+  verify_on_stop: false
+{extra}
+""",
+        encoding="utf-8",
+    )
+
+
+def _run_natural_cli(home: Path, run_id: str, *, timeout: float = 30) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "-z", "hello"],
+        cwd=Path(__file__).resolve().parents[1],
+        env=_isolated_cli_env(home, run_id),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _spawn_natural_cli(home: Path, run_id: str) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [sys.executable, "-m", "hermes_cli.main", "-z", "hello"],
+        cwd=Path(__file__).resolve().parents[1],
+        env=_isolated_cli_env(home, run_id),
+        start_new_session=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
 
 
 def test_direct_hermes_style_process_writes_receipt_without_card(tmp_path):
@@ -180,3 +238,356 @@ def test_real_aiagent_codex_responses_lifecycle_writes_usage_receipt(tmp_path, m
         assert receipt["outcome"] == "completed"
     finally:
         reset_hermes_home_override(token)
+
+
+def test_natural_cli_chat_completion_writes_direct_receipt_without_manual_finalize(tmp_path):
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            json.loads(self.rfile.read(length))
+            chunks = [
+                {"id": "natural-chat", "object": "chat.completion.chunk", "model": "local-chat",
+                 "choices": [{"index": 0, "delta": {"role": "assistant", "content": "natural-ok"}, "finish_reason": None}]},
+                {"id": "natural-chat", "object": "chat.completion.chunk", "model": "local-chat",
+                 "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                 "usage": {"prompt_tokens": 13, "completion_tokens": 5, "total_tokens": 18}},
+            ]
+            body = b"".join(b"data: " + json.dumps(chunk).encode() + b"\n\n" for chunk in chunks)
+            body += b"data: [DONE]\n\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    home = tmp_path / "hermes-home"
+    _write_cli_config(home, base_url=f"http://127.0.0.1:{server.server_port}/v1", model="local-chat")
+    try:
+        result = _run_natural_cli(home, "natural-cli-direct")
+        assert result.returncode == 0, result.stderr
+        assert "natural-ok" in result.stdout
+        receipt = UsageLedger(home / "state.db").get_run("natural-cli-direct")
+        assert receipt["task_run_id"] is None
+        assert receipt["board"] is None
+        assert receipt["input_tokens"] == 13
+        assert receipt["output_tokens"] == 5
+        assert "cost_usd" in receipt
+        assert receipt["cost_usd"] == 0.0
+        assert receipt["outcome"] == "completed"
+        assert receipt["ended_at"] is not None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_natural_cli_sigint_finalizes_measured_usage_once(tmp_path):
+    entered = threading.Event()
+    release = threading.Event()
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            json.loads(self.rfile.read(length))
+            if self.path.endswith("/api/show"):
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"{}")
+                return
+            requests.append(self.path)
+            if len(requests) == 1:
+                body = (b'data: {"id":"interrupt","object":"chat.completion.chunk","model":"interrupt-model",'
+                        b'"choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"todo-1",'
+                        b'"type":"function","function":{"name":"todo","arguments":"{\\"todos\\":[]}"}}]},'
+                        b'"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":23,"completion_tokens":4,"total_tokens":27}}\n\n'
+                        b"data: [DONE]\n\n")
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                self.wfile.flush()
+                return
+            entered.set()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            self.wfile.flush()
+            release.wait(timeout=10)
+
+        def log_message(self, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    home = tmp_path / "hermes-home"
+    _write_cli_config(home, base_url=f"http://127.0.0.1:{server.server_port}/v1", model="interrupt-model")
+    process = _spawn_natural_cli(home, "natural-interrupt")
+    try:
+        assert entered.wait(timeout=5)
+        os.killpg(process.pid, signal.SIGINT)
+        process.communicate(timeout=10)
+        deadline = time.monotonic() + 5
+        receipt = None
+        while time.monotonic() < deadline:
+            try:
+                receipt = UsageLedger(home / "state.db").get_run("natural-interrupt")
+                if receipt["input_tokens"]:
+                    break
+            except KeyError:
+                pass
+            time.sleep(0.05)
+        assert receipt is not None
+        assert receipt["ended_at"] is not None
+        assert receipt["outcome"] == "interrupted"
+        assert receipt["failure_reason"]
+        assert receipt["input_tokens"] == 23
+        assert receipt["output_tokens"] == 4
+        import sqlite3
+        with sqlite3.connect(home / "state.db") as connection:
+            assert connection.execute("SELECT COUNT(*) FROM usage_events WHERE run_id='natural-interrupt' AND event_type='model'").fetchone()[0] == 1
+            assert connection.execute("SELECT COUNT(*) FROM usage_events WHERE run_id='natural-interrupt'").fetchone()[0] == 2
+    finally:
+        release.set()
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=5)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_natural_cli_sigkill_leaves_open_receipt(tmp_path):
+    entered = threading.Event()
+    release = threading.Event()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            json.loads(self.rfile.read(length))
+            if self.path.endswith("/api/show"):
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"{}")
+                return
+            entered.set()
+            release.wait(timeout=10)
+
+        def log_message(self, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    home = tmp_path / "hermes-home"
+    _write_cli_config(home, base_url=f"http://127.0.0.1:{server.server_port}/v1", model="kill-model")
+    process = _spawn_natural_cli(home, "natural-kill")
+    try:
+        assert entered.wait(timeout=5)
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=10)
+        deadline = time.monotonic() + 5
+        receipt = None
+        while time.monotonic() < deadline:
+            try:
+                receipt = UsageLedger(home / "state.db").get_run("natural-kill")
+                break
+            except KeyError:
+                time.sleep(0.05)
+        assert receipt is not None
+        assert receipt["ended_at"] is None
+        assert receipt["outcome"] in (None, "incomplete")
+    finally:
+        release.set()
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=5)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_natural_cli_retry_records_one_retry_and_nonduplicated_usage(tmp_path):
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            request = json.loads(self.rfile.read(length))
+            if "messages" not in request:
+                body = b'{"data":[]}'
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            requests.append(request)
+            if len(requests) == 1:
+                self.send_response(429)
+                self.send_header("Retry-After", "0")
+                self.end_headers()
+                return
+            body = (
+                b'data: {"id":"retry-ok","object":"chat.completion.chunk","model":"retry-model",'
+                b'"choices":[{"index":0,"delta":{"role":"assistant","content":"retry-ok"},"finish_reason":"stop"}],'
+                b'"usage":{"prompt_tokens":17,"completion_tokens":6,"total_tokens":23}}\n\n'
+                b"data: [DONE]\n\n"
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    home = tmp_path / "hermes-home"
+    _write_cli_config(home, base_url=f"http://127.0.0.1:{server.server_port}/v1", model="retry-model", api_max_retries=2)
+    try:
+        result = _run_natural_cli(home, "natural-cli-retry")
+        assert result.returncode == 0, result.stderr
+        receipt = UsageLedger(home / "state.db").get_run("natural-cli-retry")
+        assert len(requests) == 2, (result.stdout, result.stderr, receipt)
+        assert receipt["input_tokens"] == 17
+        assert receipt["output_tokens"] == 6
+        assert receipt["cost_usd"] == 0.0
+        assert receipt["retry_count"] == 1
+        assert receipt["model_breakdown"] == [{
+            "model": "retry-model", "provider": "custom", "input_tokens": 17,
+            "output_tokens": 6, "cost_usd": 0.0, "event_count": 2,
+        }]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_natural_cli_fallback_records_exact_mixed_model_breakdown(tmp_path):
+    primary_requests = []
+    fallback_requests = []
+
+    class PrimaryHandler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            request = json.loads(self.rfile.read(length))
+            if "messages" not in request:
+                body = b'{"data":[]}'
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            primary_requests.append(request)
+            if len(primary_requests) > 1:
+                self.send_response(503)
+                self.end_headers()
+                return
+            body = (
+                b'data: {"id":"mixed-primary","object":"chat.completion.chunk","model":"primary-model",'
+                b'"choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"todo-1",'
+                b'"type":"function","function":{"name":"todo","arguments":"{\\"todos\\":[]}"}}]},'
+                b'"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}\n\n'
+                b"data: [DONE]\n\n"
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            return
+
+    class FallbackHandler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            request = json.loads(self.rfile.read(length))
+            if "messages" not in request:
+                body = b'{"data":[]}'
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            fallback_requests.append(request)
+            body = (
+                b'data: {"id":"mixed-fallback","object":"chat.completion.chunk","model":"fallback-model",'
+                b'"choices":[{"index":0,"delta":{"role":"assistant","content":"fallback-ok"},"finish_reason":"stop"}],'
+                b'"usage":{"prompt_tokens":7,"completion_tokens":4,"total_tokens":11}}\n\n'
+                b"data: [DONE]\n\n"
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            return
+
+    primary = ThreadingHTTPServer(("127.0.0.1", 0), PrimaryHandler)
+    fallback = ThreadingHTTPServer(("127.0.0.1", 0), FallbackHandler)
+    primary_thread = threading.Thread(target=primary.serve_forever, daemon=True)
+    fallback_thread = threading.Thread(target=fallback.serve_forever, daemon=True)
+    primary_thread.start()
+    fallback_thread.start()
+    home = tmp_path / "hermes-home"
+    _write_cli_config(
+        home,
+        base_url=f"http://127.0.0.1:{primary.server_port}/v1",
+        provider="local",
+        model="primary-model",
+        extra=(
+            "fallback_providers:\n"
+            "  - provider: custom\n"
+            "    model: fallback-model\n"
+            f"    base_url: http://127.0.0.1:{fallback.server_port}/v1\n"
+            "    api_mode: chat_completions\n"
+            "    api_key: test-key\n"
+        ),
+    )
+    try:
+        result = _run_natural_cli(home, "natural-cli-mixed")
+        assert result.returncode == 0, result.stderr
+        assert "fallback-ok" in result.stdout
+        assert len(primary_requests) == 2
+        assert len(fallback_requests) == 1
+        receipt = UsageLedger(home / "state.db").get_run("natural-cli-mixed")
+        assert receipt["input_tokens"] == 10
+        assert receipt["output_tokens"] == 6
+        assert receipt["cost_usd"] == 0.0
+        assert receipt["model"] == "mixed"
+        # The top-level provider is the successful fallback provider in the
+        # current ledger contract.  The breakdown is the authoritative proof
+        # that both real providers were attempted and accounted for.
+        assert receipt["provider"] == "custom"
+        assert receipt["model_breakdown"] == [
+            {"model": "fallback-model", "provider": "custom", "input_tokens": 7,
+             "output_tokens": 4, "cost_usd": 0.0, "event_count": 1},
+            {"model": "primary-model", "provider": "custom", "input_tokens": 3,
+             "output_tokens": 2, "cost_usd": 0.0, "event_count": 2},
+        ]
+    finally:
+        primary.shutdown()
+        fallback.shutdown()
+        primary.server_close()
+        fallback.server_close()
+        primary_thread.join(timeout=2)
+        fallback_thread.join(timeout=2)

--- a/tests/test_run_usage_direct_process.py
+++ b/tests/test_run_usage_direct_process.py
@@ -118,3 +118,65 @@ def test_real_aiagent_conversation_lifecycle_writes_direct_receipt(tmp_path, mon
         assert receipt["outcome"] == "completed"
     finally:
         reset_hermes_home_override(token)
+
+
+def test_real_aiagent_codex_responses_lifecycle_writes_usage_receipt(tmp_path, monkeypatch):
+    from hermes_cli.lifecycle import finalize_session
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from run_agent import AIAgent
+
+    token = set_hermes_home_override(tmp_path)
+    monkeypatch.setenv("HERMES_RUN_ID", "e2e-codex-run")
+    try:
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", "0"))
+                request = json.loads(self.rfile.read(length))
+                events = [
+                    {"type": "response.created", "response": {"id": "resp-local", "model": "fake/codex-model"}},
+                    {"type": "response.output_text.delta", "delta": "codex-done"},
+                    {"type": "response.completed", "response": {"id": "resp-local", "model": "fake/codex-model", "usage": {"input_tokens": 11, "output_tokens": 5, "total_tokens": 16}}},
+                ]
+                body = b"".join(b"data: " + json.dumps(event).encode() + b"\n\n" for event in events) + b"data: [DONE]\n\n"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(body)
+                self.wfile.flush()
+
+            def log_message(self, format, *args):  # noqa: A002, ANN001
+                return
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            agent = AIAgent(
+                api_key="test-key",
+                base_url=f"http://127.0.0.1:{server.server_port}/v1",
+                provider="openai-codex",
+                model="fake/codex-model",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_id="e2e-codex-session",
+                platform="cli",
+            )
+            result = agent.run_conversation("hello")
+            assert result["final_response"] == "codex-done"
+            finalize_session(session_id="e2e-codex-session", platform="cli", completed=True)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        receipt = UsageLedger(tmp_path / "state.db").get_run("e2e-codex-run")
+        assert receipt["input_tokens"] == 11
+        assert receipt["output_tokens"] == 5
+        assert receipt["model"] == "fake/codex-model"
+        assert receipt["provider"] == "openai-codex"
+        assert receipt["outcome"] == "completed"
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/test_run_usage_direct_process.py
+++ b/tests/test_run_usage_direct_process.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from agent.run_usage_ledger import UsageLedger
+
+
+def test_direct_hermes_style_process_writes_receipt_without_card(tmp_path):
+    code = """
+from hermes_cli.lifecycle import invoke_hook
+invoke_hook('on_session_start', session_id='direct-session', model='direct-model', provider='direct-provider', platform='cli')
+invoke_hook('post_api_request', session_id='direct-session', turn_id='direct-turn', api_request_id='direct-api', model='direct-model', provider='direct-provider', usage={'input_tokens': 4, 'output_tokens': 3}, cost_usd=0.01)
+invoke_hook('on_session_finalize', session_id='direct-session', completed=True, platform='cli')
+"""
+    env = {
+        **os.environ,
+        "HERMES_HOME": str(tmp_path),
+        "HERMES_RUN_ID": "direct-process-run",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
+    }
+    subprocess.run([sys.executable, "-c", code], env=env, check=True)
+
+    receipt = UsageLedger(tmp_path / "state.db").get_run("direct-process-run")
+    assert receipt["task_id"] is None
+    assert receipt["process_id"] != ""
+    assert receipt["session_id"] == "direct-session"
+    assert receipt["input_tokens"] == 4
+    assert receipt["output_tokens"] == 3
+    assert receipt["outcome"] == "completed"
+
+
+def test_two_processes_resuming_one_session_keep_distinct_receipts(tmp_path):
+    code = """
+from hermes_cli.lifecycle import invoke_hook
+invoke_hook('on_session_start', session_id='resumed', model='m', provider='p')
+invoke_hook('post_api_request', session_id='resumed', turn_id='t', api_request_id='a', model='m', provider='p', usage={'input_tokens': 1, 'output_tokens': 1})
+invoke_hook('on_session_finalize', session_id='resumed', completed=True)
+"""
+    env = {**os.environ, "HERMES_HOME": str(tmp_path), "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    subprocess.run([sys.executable, "-c", code], env=env, check=True)
+    subprocess.run([sys.executable, "-c", code], env=env, check=True)
+    import sqlite3
+    with sqlite3.connect(tmp_path / "state.db") as connection:
+        rows = connection.execute("SELECT run_id, process_id FROM usage_runs WHERE session_id='resumed'").fetchall()
+    assert len(rows) == 2
+    assert rows[0][0] != rows[1][0]
+    assert rows[0][1] != rows[1][1]
+
+
+def test_real_aiagent_conversation_lifecycle_writes_direct_receipt(tmp_path, monkeypatch):
+    from hermes_cli.lifecycle import finalize_session
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from run_agent import AIAgent
+
+    token = set_hermes_home_override(tmp_path)
+    monkeypatch.setenv("HERMES_RUN_ID", "e2e-direct-run")
+    try:
+        class Handler(BaseHTTPRequestHandler):
+            requests = []
+
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", "0"))
+                Handler.requests.append(json.loads(self.rfile.read(length)))
+                chunks = [
+                    {"id": "chatcmpl-local", "object": "chat.completion.chunk", "created": 1,
+                     "model": "fake/local-model", "choices": [{"index": 0, "delta": {"role": "assistant", "content": "done"}, "finish_reason": None}]},
+                    {"id": "chatcmpl-local", "object": "chat.completion.chunk", "created": 1,
+                     "model": "fake/local-model", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                     "usage": {"prompt_tokens": 9, "completion_tokens": 4, "total_tokens": 13}},
+                ]
+                body = b"".join((b"data: " + json.dumps(chunk).encode() + b"\n\n" for chunk in chunks)) + b"data: [DONE]\n\n"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(body)
+                self.wfile.flush()
+
+            def log_message(self, *_args):
+                return
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            agent = AIAgent(
+                api_key="test-key",
+                base_url=f"http://127.0.0.1:{server.server_port}/v1",
+                provider="local",
+                model="fake/local-model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_id="e2e-session",
+                platform="cli",
+            )
+            result = agent.run_conversation("hello")
+            assert result["final_response"] == "done"
+            finalize_session(session_id="e2e-session", platform="cli", completed=True)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        receipt = UsageLedger(tmp_path / "state.db").get_run("e2e-direct-run")
+        assert receipt["task_run_id"] is None
+        assert receipt["model"]
+        assert receipt["provider"]
+        assert receipt["input_tokens"] == 9
+        assert receipt["output_tokens"] == 4
+        assert receipt["cost_usd"] == 0.0
+        assert receipt["outcome"] == "completed"
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/test_run_usage_dispatcher_e2e.py
+++ b/tests/test_run_usage_dispatcher_e2e.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from hermes_cli import kanban_db
+
+
+class _StreamingProvider:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", "0"))
+                request = json.loads(self.rfile.read(length))
+                owner.requests.append(request)
+                has_completion = any(
+                    message.get("role") == "tool" for message in request.get("messages", [])
+                )
+                if not has_completion:
+                    chunks = [
+                        {
+                            "id": "dispatcher-e2e-1",
+                            "object": "chat.completion.chunk",
+                            "created": 1,
+                            "model": "local-worker-model",
+                            "choices": [{
+                                "index": 0,
+                                "delta": {
+                                    "role": "assistant",
+                                    "tool_calls": [{
+                                        "index": 0,
+                                        "id": "complete-call-1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "kanban_complete",
+                                            "arguments": json.dumps({
+                                                "summary": "dispatcher usage e2e complete",
+                                                "metadata": {"verified": True},
+                                            }),
+                                        },
+                                    }],
+                                },
+                                "finish_reason": "tool_calls",
+                            }],
+                        },
+                        {
+                            "id": "dispatcher-e2e-1",
+                            "object": "chat.completion.chunk",
+                            "created": 1,
+                            "model": "local-worker-model",
+                            "choices": [],
+                            "usage": {
+                                "prompt_tokens": 17,
+                                "completion_tokens": 6,
+                                "total_tokens": 23,
+                            },
+                        },
+                    ]
+                else:
+                    chunks = [{
+                        "id": "dispatcher-e2e-2",
+                        "object": "chat.completion.chunk",
+                        "created": 1,
+                        "model": "local-worker-model",
+                        "choices": [{
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": "finished"},
+                            "finish_reason": "stop",
+                        }],
+                        "usage": {
+                            "prompt_tokens": 19,
+                            "completion_tokens": 2,
+                            "total_tokens": 21,
+                        },
+                    }]
+                body = b"".join(
+                    b"data: " + json.dumps(chunk).encode() + b"\n\n" for chunk in chunks
+                ) + b"data: [DONE]\n\n"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                self.wfile.flush()
+
+            def log_message(self, format, *args):  # noqa: A002, ANN001
+                return
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.server.server_port}/v1"
+
+    def close(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+
+def test_real_dispatcher_runtime_subprocess_projects_authoritative_usage(tmp_path):
+    provider = _StreamingProvider()
+    home = tmp_path / "hermes"
+    profile = home / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    (profile / "config.yaml").write_text(
+        f"""model:
+  provider: local
+  base_url: {provider.base_url}
+  api_mode: chat_completions
+  api_key: test-key
+  default: local-worker-model
+toolsets:
+  - kanban
+agent:
+  max_turns: 3
+  verify_on_stop: false
+"""
+    )
+    board = tmp_path / "board.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kanban_db.init_db(board)
+    with kanban_db.connect_closing(board) as connection:
+        task_id = kanban_db.create_task(
+            connection,
+            title="real dispatcher usage e2e",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    shim = shim_dir / "hermes"
+    shim.write_text(f"#!/bin/sh\nexec {sys.executable} -m hermes_cli.main \"$@\"\n")
+    shim.chmod(0o755)
+    env = {
+        **os.environ,
+        "HERMES_HOME": str(home),
+        "HOME": str(home),
+        "HERMES_KANBAN_DB": str(board),
+        "HERMES_KANBAN_BOARD": "default",
+        "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
+        "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+    }
+    try:
+        dispatch = subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", "kanban", "dispatch", "--json", "--max", "1"],
+            cwd=Path(__file__).resolve().parents[1],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=True,
+        )
+        result = json.loads(dispatch.stdout)
+        assert [item["task_id"] for item in result["spawned"]] == [task_id]
+
+        deadline = time.monotonic() + 20
+        usage = None
+        while time.monotonic() < deadline:
+            with kanban_db.connect_closing(board) as connection:
+                status = connection.execute(
+                    "SELECT status FROM tasks WHERE id=?", (task_id,)
+                ).fetchone()[0]
+                run_row = connection.execute(
+                    "SELECT id FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1",
+                    (task_id,),
+                ).fetchone()
+                usage = (
+                    connection.execute(
+                        "SELECT task_run_id, usage_run_id, model, provider, input_tokens, output_tokens, cost_usd "
+                        "FROM task_run_usage WHERE task_run_id=?",
+                        (run_row[0],),
+                    ).fetchone()
+                    if run_row is not None else None
+                )
+            if status == "done" and usage is not None:
+                break
+            time.sleep(0.1)
+        with kanban_db.connect_closing(board) as connection:
+            task = connection.execute(
+                "SELECT status, current_run_id FROM tasks WHERE id=?", (task_id,)
+            ).fetchone()
+            run = connection.execute(
+                "SELECT id, status, outcome FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1",
+                (task_id,),
+            ).fetchone()
+        assert tuple(task) == ("done", None)
+        assert run[1:] == ("done", "completed")
+        assert usage is not None
+        assert tuple(usage) == (
+            run[0], f"task-run:{run[0]}", "local-worker-model", "custom",
+            36, 8, 0.0,
+        )
+        assert len(provider.requests) >= 2
+    finally:
+        provider.close()

--- a/tests/test_run_usage_ledger.py
+++ b/tests/test_run_usage_ledger.py
@@ -88,6 +88,113 @@ def test_model_usage_callback_is_idempotent_for_duplicate_event(tmp_path):
     assert receipt["retry_count"] == 1
 
 
+def test_event_identity_is_scoped_to_run(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db")
+
+    assert ledger.record_model_usage(
+        run_id="run-a", event_id="provider-request-1", session_id="s-a",
+        turn_id="t-a", model="m", provider="p", input_tokens=2,
+    )
+    assert ledger.record_model_usage(
+        run_id="run-b", event_id="provider-request-1", session_id="s-b",
+        turn_id="t-b", model="m", provider="p", input_tokens=3,
+    )
+    assert not ledger.record_model_usage(
+        run_id="run-a", event_id="provider-request-1", session_id="s-a",
+        turn_id="t-a", model="m", provider="p", input_tokens=2,
+    )
+
+    assert ledger.get_run("run-a")["input_tokens"] == 2
+    assert ledger.get_run("run-b")["input_tokens"] == 3
+
+
+def test_legacy_global_event_id_migrates_to_composite_identity(tmp_path):
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE usage_runs (
+                run_id TEXT PRIMARY KEY, process_id TEXT NOT NULL,
+                started_at REAL NOT NULL, updated_at REAL NOT NULL
+            );
+            CREATE TABLE usage_events (
+                event_id TEXT PRIMARY KEY, run_id TEXT NOT NULL,
+                event_type TEXT NOT NULL, session_id TEXT, turn_id TEXT,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cost_usd REAL NOT NULL DEFAULT 0,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                model TEXT, provider TEXT, created_at REAL NOT NULL
+            );
+            INSERT INTO usage_runs VALUES ('run-a', 'proc-a', 1, 1);
+            INSERT INTO usage_runs VALUES ('run-b', 'proc-b', 1, 1);
+            INSERT INTO usage_events VALUES
+                ('request-1', 'run-a', 'model', 's-a', 't-a', 2, 1, 0.1, 0, 'm', 'p', 1);
+            INSERT INTO usage_events VALUES
+                ('request-2', 'run-b', 'model', 's-b', 't-b', 3, 1, 0.2, 0, 'm', 'p', 2);
+            """
+        )
+        connection.commit()
+
+    ledger = UsageLedger(db_path)
+    with sqlite3.connect(db_path) as connection:
+        columns = connection.execute("PRAGMA table_info(usage_events)").fetchall()
+        pk = {row[1]: row[5] for row in columns if row[5]}
+        rows = connection.execute(
+            "SELECT run_id, event_id FROM usage_events ORDER BY run_id"
+        ).fetchall()
+    assert pk == {"run_id": 1, "event_id": 2}
+    assert rows == [("run-a", "request-1"), ("run-b", "request-2")]
+    assert ledger.record_model_usage(
+        run_id="run-b", event_id="request-1", session_id="s-b",
+        turn_id="t-c", model="m", provider="p", input_tokens=4,
+    )
+
+
+def test_legacy_model_table_migration_is_atomic_idempotent_and_indexed(tmp_path):
+    db_path = tmp_path / "legacy-models.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE usage_runs (
+                run_id TEXT PRIMARY KEY, process_id TEXT NOT NULL,
+                started_at REAL NOT NULL, updated_at REAL NOT NULL
+            );
+            CREATE TABLE usage_events (
+                event_id TEXT PRIMARY KEY, run_id TEXT NOT NULL,
+                event_type TEXT NOT NULL, created_at REAL NOT NULL
+            );
+            CREATE TABLE usage_run_models (
+                run_id TEXT NOT NULL, model TEXT NOT NULL,
+                provider TEXT,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cost_usd REAL NOT NULL DEFAULT 0,
+                event_count INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (run_id, model, provider)
+            );
+            INSERT INTO usage_runs VALUES ('run-a', 'proc-a', 1, 1);
+            INSERT INTO usage_run_models VALUES ('run-a', 'm', NULL, 2, 3, 0.4, 1);
+            INSERT INTO usage_run_models VALUES ('run-a', 'm', NULL, 5, 7, 0.6, 2);
+            """
+        )
+        connection.commit()
+
+    UsageLedger(db_path)
+    UsageLedger(db_path)
+    with sqlite3.connect(db_path) as connection:
+        row = connection.execute(
+            "SELECT run_id, model, provider, input_tokens, output_tokens, cost_usd, event_count FROM usage_run_models"
+        ).fetchone()
+        indexes = connection.execute("PRAGMA index_list(usage_run_models)").fetchall()
+        legacy = connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name='usage_run_models_legacy'"
+        ).fetchone()[0]
+    assert row == ("run-a", "m", "unknown", 7, 10, 1.0, 3)
+    assert any(index[1] == "idx_usage_run_models_run" for index in indexes)
+    assert legacy == 0
+
+
 def test_usage_receipt_keeps_card_optional_and_reports_non_card_identity(tmp_path):
     ledger = UsageLedger(tmp_path / "state.db")
     ledger.start_run(
@@ -265,6 +372,57 @@ def test_writer_exception_is_replayed_during_finalization(tmp_path):
     assert receipt["cost_usd"] == 0.5
 
 
+def test_persistent_writer_failure_fails_closed_and_persists_diagnostic(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db")
+    ledger.start_run(run_id="persistent", process_id="p")
+
+    def always_fail(**_kwargs):
+        raise sqlite3.OperationalError("persistent failure")
+
+    ledger._record_event = always_fail
+    assert ledger.queue_model_usage(
+        run_id="persistent", event_id="api-1", session_id="s", turn_id="t",
+        model="m", provider="p", input_tokens=3,
+    )
+    assert not ledger.finalize_run(run_id="persistent", outcome="completed")
+    with sqlite3.connect(tmp_path / "state.db") as connection:
+        diagnostics = connection.execute(
+            "SELECT diagnostic_type, detail FROM usage_diagnostics"
+        ).fetchall()
+    assert any(detail == "persistent_writer_failure" for _, detail in diagnostics)
+
+
+def test_diagnostic_capacity_exhaustion_sets_global_fail_closed_sentinel(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db")
+    ledger._diagnostic_limit = 2
+    for run_id in ("run-1", "run-2", "run-3"):
+        ledger.start_run(run_id=run_id, process_id=run_id)
+        ledger._record_drop(run_id, "queue_saturated")
+
+    assert not ledger.finalize_run(run_id="run-1", outcome="completed")
+    assert not ledger.finalize_run(run_id="run-3", outcome="completed")
+    with sqlite3.connect(tmp_path / "state.db") as connection:
+        diagnostics = connection.execute(
+            "SELECT diagnostic_type, detail FROM usage_diagnostics"
+        ).fetchall()
+    assert any(kind == "usage_incomplete_global" for kind, _ in diagnostics)
+
+
+def test_failed_operation_buffer_overflow_sets_global_fail_closed_sentinel(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db", queue_size=1)
+    ledger.start_run(run_id="buffer", process_id="p")
+    with ledger._queue_cond:
+        ledger._failed_operations.append((lambda: None, (), {}))
+    ledger._mark_global_incomplete("failed_buffer_full")
+    ledger._record_drop("buffer", "failed_buffer_full")
+
+    assert not ledger.finalize_run(run_id="buffer", outcome="completed")
+    with sqlite3.connect(tmp_path / "state.db") as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM usage_diagnostics WHERE diagnostic_type='usage_incomplete_global'"
+        ).fetchone()[0] == 1
+
+
 def test_model_breakdown_is_deterministic_and_marks_mixed_runs(tmp_path):
     ledger = UsageLedger(tmp_path / "state.db")
     ledger.record_model_usage(
@@ -311,6 +469,14 @@ def test_session_run_identity_is_process_distinct_and_task_env_wins(monkeypatch)
     assert run_id_for_session("same-session") == "explicit"
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
     assert run_id_for_session("same-session") == "task-run:42"
+
+
+def test_process_identity_is_not_a_reusable_bare_pid():
+    from agent.run_usage_ledger import process_invocation_id
+
+    process_id = process_invocation_id()
+    assert process_id.startswith("proc-")
+    assert not process_id.isdigit()
 
 
 def test_kanban_link_rejects_mismatched_authoritative_task_run(tmp_path):

--- a/tests/test_run_usage_ledger.py
+++ b/tests/test_run_usage_ledger.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+from agent.run_usage_ledger import UsageLedger, run_id_for_session
+from hermes_cli import kanban_db
+from hermes_state import SessionDB
+
+
+def test_sessiondb_schema_migrates_run_receipts_on_existing_database(tmp_path):
+    db_path = tmp_path / "state.db"
+    first = SessionDB(db_path)
+    first.create_session("legacy-session", source="cli", model="old-model")
+    first.close()
+
+    second = SessionDB(db_path)
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM usage_runs").fetchone() == (0,)
+        assert connection.execute("SELECT model FROM sessions WHERE id = 'legacy-session'").fetchone() == ("old-model",)
+    second.close()
+
+
+def test_legacy_state_database_migrates_without_losing_sessions(tmp_path):
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT)")
+        connection.execute("INSERT INTO sessions VALUES ('legacy-session', 'kept')")
+        connection.commit()
+
+    ledger = UsageLedger(db_path)
+    ledger.start_run(
+        run_id="run-legacy",
+        process_id="123",
+        session_id="session-direct",
+        model="model-a",
+        provider="provider-a",
+    )
+
+    with sqlite3.connect(db_path) as connection:
+        assert connection.execute("SELECT title FROM sessions WHERE id = 'legacy-session'").fetchone() == ("kept",)
+        assert connection.execute("SELECT run_id FROM usage_runs").fetchone() == ("run-legacy",)
+
+    ledger.start_run(
+        run_id="run-legacy",
+        process_id="123",
+        session_id="session-direct",
+        model="model-a",
+        provider="provider-a",
+    )
+
+
+def test_model_usage_callback_is_idempotent_for_duplicate_event(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db")
+
+    first = ledger.record_model_usage(
+        run_id="run-1",
+        event_id="session-direct:turn-1:api:1",
+        session_id="session-direct",
+        turn_id="turn-1",
+        model="model-a",
+        provider="provider-a",
+        input_tokens=100,
+        output_tokens=25,
+        cost_usd=0.012,
+        retry_count=1,
+    )
+    second = ledger.record_model_usage(
+        run_id="run-1",
+        event_id="session-direct:turn-1:api:1",
+        session_id="session-direct",
+        turn_id="turn-1",
+        model="model-a",
+        provider="provider-a",
+        input_tokens=100,
+        output_tokens=25,
+        cost_usd=0.012,
+        retry_count=1,
+    )
+
+    assert first is True
+    assert second is False
+    receipt = ledger.get_run("run-1")
+    assert receipt["input_tokens"] == 100
+    assert receipt["output_tokens"] == 25
+    assert receipt["cost_usd"] == 0.012
+    assert receipt["turn_count"] == 1
+    assert receipt["retry_count"] == 1
+
+
+def test_usage_receipt_keeps_card_optional_and_reports_non_card_identity(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db")
+    ledger.start_run(
+        run_id="run-card",
+        process_id="1",
+        session_id="session-card",
+        task_id="task-123",
+        board="default",
+        model="model-a",
+        provider="provider-a",
+    )
+    ledger.record_model_usage(
+        run_id="run-card",
+        event_id="event-card",
+        session_id="session-card",
+        turn_id="turn-card",
+        model="model-a",
+        provider="provider-a",
+        input_tokens=10,
+        output_tokens=5,
+        cost_usd=0.1,
+    )
+    ledger.start_run(
+        run_id="run-direct",
+        process_id="2",
+        session_id="session-direct",
+        model="model-b",
+        provider="provider-b",
+    )
+    ledger.record_model_usage(
+        run_id="run-direct",
+        event_id="event-direct",
+        session_id="session-direct",
+        turn_id="turn-direct",
+        model="model-b",
+        provider="provider-b",
+        input_tokens=20,
+        output_tokens=8,
+        cost_usd=0.2,
+    )
+
+    card_rows = ledger.report(board="default", task_id="task-123")
+    direct_rows = ledger.report(board="default", run_id="run-direct", include_unassigned=True)
+
+    assert [row["run_id"] for row in card_rows] == ["run-card"]
+    assert card_rows[0]["task_id"] == "task-123"
+    assert [row["run_id"] for row in direct_rows] == ["run-direct"]
+    assert direct_rows[0]["session_id"] == "session-direct"
+
+
+def test_finish_records_elapsed_failure_outcome_and_tool_calls_once(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db")
+    ledger.start_run(run_id="run-fail", process_id="9", session_id="s")
+    assert ledger.record_tool_call(run_id="run-fail", event_id="tool-1", session_id="s") is True
+    assert ledger.record_tool_call(run_id="run-fail", event_id="tool-1", session_id="s") is False
+
+    ledger.finish_run(
+        run_id="run-fail",
+        outcome="failed",
+        failure_reason="provider timeout",
+        ended_at=120.0,
+        elapsed=5.5,
+    )
+
+    receipt = ledger.get_run("run-fail")
+    assert receipt["tool_call_count"] == 1
+    assert receipt["outcome"] == "failed"
+    assert receipt["failure_reason"] == "provider timeout"
+    assert receipt["elapsed"] == 5.5
+    assert receipt["ended_at"] == 120.0
+
+
+def test_kanban_link_is_keyed_by_authoritative_task_run_and_idempotent(tmp_path):
+    board = tmp_path / "kanban.db"
+    kanban_db.init_db(board)
+    with kanban_db.connect_closing(board) as connection:
+        connection.execute(
+            "INSERT INTO task_runs(task_id, status, started_at) VALUES (?, ?, ?)",
+            ("task-1", "running", 1),
+        )
+        task_run_id = connection.execute("SELECT id FROM task_runs").fetchone()[0]
+
+    ledger = UsageLedger(tmp_path / "state.db")
+    run_id = f"task-run:{task_run_id}"
+    ledger.start_run(
+        run_id=run_id,
+        process_id="worker",
+        task_run_id=task_run_id,
+        task_id="task-1",
+        board="default",
+        model="model-a",
+        provider="provider-a",
+    )
+    ledger.record_model_usage(
+        run_id=run_id,
+        event_id="event-1",
+        session_id="s",
+        turn_id="t",
+        model="model-a",
+        provider="provider-a",
+        input_tokens=4,
+        output_tokens=5,
+        cost_usd=0.6,
+    )
+    ledger.finish_run(run_id=run_id, outcome="completed")
+    assert ledger.link_kanban_run(task_run_id=task_run_id, usage_run_id=run_id, kanban_db=board)
+    assert ledger.link_kanban_run(task_run_id=task_run_id, usage_run_id=run_id, kanban_db=board)
+
+    with kanban_db.connect_closing(board) as connection:
+        row = connection.execute(
+            "SELECT task_run_id, usage_run_id, input_tokens, output_tokens, cost_usd FROM task_run_usage"
+        ).fetchone()
+    assert tuple(row) == (task_run_id, run_id, 4, 5, 0.6)
+
+
+def test_async_writer_preserves_order_and_isolates_queue_backpressure(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db", queue_size=2)
+    assert ledger.queue_start_run(run_id="ordered", process_id="1")
+    assert ledger.queue_model_usage(
+        run_id="ordered", event_id="one", session_id="s", turn_id="t1",
+        model="m", provider="p", input_tokens=1,
+    )
+    # A full queue is a bounded accounting loss, not a conversation failure.
+    assert ledger.queue_model_usage(
+        run_id="ordered", event_id="two", session_id="s", turn_id="t2",
+        model="m", provider="p", input_tokens=1,
+    ) in {True, False}
+    assert ledger.flush()
+    assert ledger.get_run("ordered")["input_tokens"] >= 1
+
+
+def test_full_queue_retains_critical_events_and_persists_noncritical_diagnostic(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db", queue_size=1)
+    gate = threading.Event()
+    entered = threading.Event()
+
+    def blocked_writer():
+        entered.set()
+        gate.wait(timeout=2)
+
+    ledger._writer_loop = blocked_writer
+    assert ledger.queue_start_run(run_id="full", process_id="p")
+    assert entered.wait(timeout=1)
+    assert not ledger.queue_model_usage(
+        run_id="full", event_id="api-1", session_id="s", turn_id="t",
+        model="m", provider="p", input_tokens=5, output_tokens=2, cost_usd=0.25,
+    )
+    gate.set()
+    assert not ledger.finalize_run(run_id="full", outcome="completed")
+    with sqlite3.connect(tmp_path / "state.db") as connection:
+        assert connection.execute("SELECT COUNT(*) FROM usage_diagnostics").fetchone()[0] >= 1
+
+
+def test_writer_exception_is_replayed_during_finalization(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db")
+    ledger.start_run(run_id="replay", process_id="p")
+    original = ledger._record_event
+    state = {"failed": False}
+
+    def fail_once(**kwargs):
+        if not state["failed"]:
+            state["failed"] = True
+            raise sqlite3.OperationalError("injected writer failure")
+        return original(**kwargs)
+
+    ledger._record_event = fail_once
+    assert ledger.queue_model_usage(
+        run_id="replay", event_id="api-1", session_id="s", turn_id="t",
+        model="m", provider="p", input_tokens=3, output_tokens=4, cost_usd=0.5,
+    )
+    assert ledger.finalize_run(run_id="replay", outcome="completed")
+    receipt = ledger.get_run("replay")
+    assert receipt["input_tokens"] == 3
+    assert receipt["output_tokens"] == 4
+    assert receipt["cost_usd"] == 0.5
+
+
+def test_model_breakdown_is_deterministic_and_marks_mixed_runs(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db")
+    ledger.record_model_usage(
+        run_id="mixed", event_id="a", session_id="s", turn_id="t1",
+        model="model-b", provider="provider-b", input_tokens=2, output_tokens=3, cost_usd=0.2,
+    )
+    ledger.record_model_usage(
+        run_id="mixed", event_id="b", session_id="s", turn_id="t2",
+        model="model-a", provider="provider-a", input_tokens=5, output_tokens=7, cost_usd=0.7,
+    )
+    receipt = ledger.get_run("mixed")
+    assert receipt["model"] == "mixed"
+    assert receipt["provider"] == "mixed"
+    assert [item["model"] for item in receipt["model_breakdown"]] == ["model-a", "model-b"]
+    assert receipt["input_tokens"] == 7
+    assert receipt["output_tokens"] == 10
+    assert receipt["cost_usd"] == 0.9
+
+
+def test_unknown_provider_is_non_null_and_idempotent(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db")
+    assert ledger.record_model_usage(
+        run_id="unknown", event_id="one", session_id="s", turn_id="t1",
+        model="fallback", provider=None, input_tokens=1, output_tokens=2,
+    )
+    assert ledger.record_model_usage(
+        run_id="unknown", event_id="two", session_id="s", turn_id="t2",
+        model="fallback", provider="", input_tokens=3, output_tokens=4,
+    )
+    receipt = ledger.get_run("unknown")
+    assert receipt["model_breakdown"] == [{
+        "model": "fallback", "provider": "unknown", "input_tokens": 4,
+        "output_tokens": 6, "cost_usd": 0.0, "event_count": 2,
+    }]
+
+
+def test_session_run_identity_is_process_distinct_and_task_env_wins(monkeypatch):
+    monkeypatch.delenv("HERMES_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    first = run_id_for_session("same-session")
+    second = run_id_for_session("same-session")
+    assert first == second
+    monkeypatch.setenv("HERMES_RUN_ID", "explicit")
+    assert run_id_for_session("same-session") == "explicit"
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    assert run_id_for_session("same-session") == "task-run:42"
+
+
+def test_kanban_link_rejects_mismatched_authoritative_task_run(tmp_path):
+    board = tmp_path / "kanban.db"
+    kanban_db.init_db(board)
+    with kanban_db.connect_closing(board) as connection:
+        connection.execute("INSERT INTO task_runs(task_id, status, started_at) VALUES ('task', 'running', 1)")
+        task_run_id = connection.execute("SELECT id FROM task_runs").fetchone()[0]
+    ledger = UsageLedger(tmp_path / "state.db")
+    ledger.start_run(run_id="task-run:999", process_id="p", task_run_id=999, task_id="task")
+    ledger.finish_run(run_id="task-run:999", outcome="completed")
+    assert not ledger.link_kanban_run(task_run_id=task_run_id, usage_run_id="task-run:999", kanban_db=board)

--- a/tests/test_run_usage_ledger.py
+++ b/tests/test_run_usage_ledger.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 import threading
+import time
 
 from agent.run_usage_ledger import UsageLedger, run_id_for_session
 from hermes_cli import kanban_db
@@ -392,35 +393,121 @@ def test_persistent_writer_failure_fails_closed_and_persists_diagnostic(tmp_path
     assert any(detail == "persistent_writer_failure" for _, detail in diagnostics)
 
 
-def test_diagnostic_capacity_exhaustion_sets_global_fail_closed_sentinel(tmp_path):
-    ledger = UsageLedger(tmp_path / "state.db")
-    ledger._diagnostic_limit = 2
-    for run_id in ("run-1", "run-2", "run-3"):
-        ledger.start_run(run_id=run_id, process_id=run_id)
-        ledger._record_drop(run_id, "queue_saturated")
-
-    assert not ledger.finalize_run(run_id="run-1", outcome="completed")
-    assert not ledger.finalize_run(run_id="run-3", outcome="completed")
-    with sqlite3.connect(tmp_path / "state.db") as connection:
-        diagnostics = connection.execute(
-            "SELECT diagnostic_type, detail FROM usage_diagnostics"
-        ).fetchall()
-    assert any(kind == "usage_incomplete_global" for kind, _ in diagnostics)
-
-
 def test_failed_operation_buffer_overflow_sets_global_fail_closed_sentinel(tmp_path):
-    ledger = UsageLedger(tmp_path / "state.db", queue_size=1)
+    ledger = UsageLedger(tmp_path / "state.db", queue_size=2)
     ledger.start_run(run_id="buffer", process_id="p")
-    with ledger._queue_cond:
-        ledger._failed_operations.append((lambda: None, (), {}))
-    ledger._mark_global_incomplete("failed_buffer_full")
-    ledger._record_drop("buffer", "failed_buffer_full")
+
+    def always_fail(**_kwargs):
+        raise sqlite3.OperationalError("injected persistence failure")
+
+    ledger._record_event = always_fail
+    for event_id in ("api-1", "api-2"):
+        assert ledger.queue_model_usage(
+            run_id="buffer", event_id=event_id, session_id="s", turn_id=event_id,
+            model="m", provider="p", input_tokens=1,
+        )
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            with ledger._queue_cond:
+                if len(ledger._failed_operations) >= int(event_id[-1]):
+                    break
+            time.sleep(0.005)
+        else:
+            raise AssertionError("writer did not retain failed operation")
+
+    # The caller-facing queue API remains nonblocking even after the bounded
+    # failed-operation buffer is full. The writer observes the third failure
+    # and records the global fail-closed state automatically.
+    started = time.monotonic()
+    assert ledger.queue_model_usage(
+        run_id="buffer", event_id="api-3", session_id="s", turn_id="api-3",
+        model="m", provider="p", input_tokens=1,
+    )
+    assert time.monotonic() - started < 0.5
+    assert ledger.flush()
 
     assert not ledger.finalize_run(run_id="buffer", outcome="completed")
     with sqlite3.connect(tmp_path / "state.db") as connection:
-        assert connection.execute(
-            "SELECT COUNT(*) FROM usage_diagnostics WHERE diagnostic_type='usage_incomplete_global'"
-        ).fetchone()[0] == 1
+        diagnostics = connection.execute(
+            "SELECT run_id, diagnostic_type, detail FROM usage_diagnostics"
+        ).fetchall()
+        receipt = connection.execute(
+            "SELECT ended_at FROM usage_runs WHERE run_id='buffer'"
+        ).fetchone()
+        projection_table = connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='task_run_usage'"
+        ).fetchone()[0]
+    assert any(
+        kind == "usage_incomplete_global" and detail == "failed_buffer_full"
+        for _, kind, detail in diagnostics
+    )
+    assert any(run_id == "buffer" and detail == "failed_buffer_full" for run_id, _, detail in diagnostics)
+    assert receipt == (None,)
+    assert projection_table == 0
+    with ledger._queue_cond:
+        assert len(ledger._queue) <= 2
+        assert len(ledger._failed_operations) <= 2
+        assert len(ledger._dropped) <= 256
+        assert len(ledger._incomplete_runs) <= 256
+        assert len(ledger._global_diagnostics) <= 256
+
+
+def test_diagnostic_capacity_exhaustion_is_automatic_and_global(tmp_path):
+    ledger = UsageLedger(tmp_path / "state.db", queue_size=1)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocked_writer(**_kwargs):
+        entered.set()
+        assert release.wait(timeout=5)
+        raise sqlite3.OperationalError("injected persistence failure")
+
+    ledger._record_event = blocked_writer
+    ledger.start_run(run_id="blocker", process_id="p")
+    assert ledger.queue_model_usage(
+        run_id="blocker", event_id="blocker-event", session_id="s", turn_id="t",
+        model="m", provider="p", input_tokens=1,
+    )
+    assert entered.wait(timeout=2)
+
+    dropped = []
+    for index in range(300):
+        run_id = f"dropped-{index}"
+        ledger.start_run(run_id=run_id, process_id=run_id)
+        accepted = ledger.queue_model_usage(
+            run_id=run_id, event_id=f"event-{index}", session_id=run_id, turn_id=f"turn-{index}",
+            model="m", provider="p", input_tokens=1,
+        )
+        if not accepted:
+            dropped.append(run_id)
+    assert len(dropped) > 256
+    release.set()
+    assert ledger.flush()
+
+    with ledger._queue_cond:
+        assert len(ledger._queue) <= 1
+        assert len(ledger._failed_operations) <= 1
+        assert len(ledger._dropped) <= 256
+        assert len(ledger._incomplete_runs) <= 256
+        assert len(ledger._global_diagnostics) <= 256
+
+    affected = dropped[256]
+    assert not ledger.finalize_run(run_id=affected, outcome="completed")
+    assert not ledger.finalize_run(run_id="dropped-after-cap", outcome="completed")
+    with sqlite3.connect(tmp_path / "state.db") as connection:
+        diagnostics = connection.execute(
+            "SELECT run_id, diagnostic_type, detail FROM usage_diagnostics"
+        ).fetchall()
+        ended = connection.execute(
+            "SELECT run_id, ended_at FROM usage_runs WHERE run_id IN (?, ?) ORDER BY run_id",
+            (affected, "dropped-after-cap"),
+        ).fetchall()
+    assert any(
+        run_id is None and kind == "usage_incomplete_global" and detail == "diagnostic_capacity_exhausted"
+        for run_id, kind, detail in diagnostics
+    )
+    assert len([row for row in diagnostics if row[1] == "dropped_event"]) >= 256
+    assert all(row[1] is None for row in ended)
 
 
 def test_model_breakdown_is_deterministic_and_marks_mixed_runs(tmp_path):

--- a/tests/test_run_usage_lifecycle.py
+++ b/tests/test_run_usage_lifecycle.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from hermes_cli import kanban_db
+from hermes_cli.lifecycle import invoke_hook
+from agent.run_usage_ledger import process_ledger, reset_process_ledger_cache
+
+
+def test_lifecycle_hooks_record_direct_and_card_receipts(tmp_path, monkeypatch):
+    token = set_hermes_home_override(tmp_path)
+    reset_process_ledger_cache()
+    monkeypatch.setenv("HERMES_RUN_ID", "run-hook")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-hook")
+    try:
+        invoke_hook(
+            "on_session_start",
+            session_id="session-hook",
+            model="model-hook",
+            provider="provider-hook",
+            platform="cli",
+            task_id="task-hook",
+        )
+        invoke_hook(
+            "post_api_request",
+            session_id="session-hook",
+            task_id="task-hook",
+            turn_id="turn-hook",
+            api_request_id="api-hook",
+            model="model-hook",
+            provider="provider-hook",
+            usage={"input_tokens": 100, "output_tokens": 30},
+            cost_usd=0.25,
+        )
+        invoke_hook(
+            "api_request_error",
+            session_id="session-hook",
+            api_request_id="api-retry",
+            retry_count=1,
+            retryable=True,
+            error={"type": "RateLimitError"},
+        )
+        invoke_hook(
+            "post_tool_call",
+            session_id="session-hook",
+            task_id="task-hook",
+            tool_call_id="tool-hook",
+        )
+        invoke_hook(
+            "on_session_finalize",
+            session_id="session-hook",
+            completed=True,
+            platform="cli",
+        )
+
+        receipt = process_ledger().get_run("run-hook")
+        assert receipt["task_id"] == "task-hook"
+        assert receipt["input_tokens"] == 100
+        assert receipt["output_tokens"] == 30
+        assert receipt["cost_usd"] == 0.25
+        assert receipt["turn_count"] == 1
+        assert receipt["tool_call_count"] == 1
+        assert receipt["retry_count"] == 1
+        assert receipt["outcome"] == "completed"
+        assert receipt["ended_at"] is not None
+    finally:
+        reset_hermes_home_override(token)
+        reset_process_ledger_cache()
+
+
+def test_dispatcher_style_lifecycle_links_exact_task_run(tmp_path, monkeypatch):
+    board = tmp_path / "kanban.db"
+    kanban_db.init_db(board)
+    with kanban_db.connect_closing(board) as connection:
+        task_id = kanban_db.create_task(connection, title="worker", assignee="default")
+        claimed = kanban_db.claim_task(connection, task_id, claimer="dispatcher:test")
+        assert claimed is not None
+        task_run_id = connection.execute("SELECT current_run_id FROM tasks WHERE id=?", (task_id,)).fetchone()[0]
+
+    token = set_hermes_home_override(tmp_path / "profile")
+    reset_process_ledger_cache()
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(task_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(board))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    try:
+        invoke_hook("on_session_start", session_id="s", model="m", provider="p")
+        invoke_hook(
+            "post_api_request", session_id="s", turn_id="t", api_request_id="api",
+            model="m", provider="p", usage={"input_tokens": 7, "output_tokens": 8}, cost_usd=0.9,
+        )
+        invoke_hook("on_session_finalize", session_id="s", completed=True)
+        with kanban_db.connect_closing(board) as connection:
+            row = connection.execute(
+                "SELECT task_run_id, usage_run_id, input_tokens, output_tokens, cost_usd FROM task_run_usage"
+            ).fetchone()
+        assert tuple(row) == (task_run_id, f"task-run:{task_run_id}", 7, 8, 0.9)
+    finally:
+        reset_hermes_home_override(token)
+        reset_process_ledger_cache()
+
+
+def test_production_emitters_handle_tool_retry_interrupt_and_no_finalize(tmp_path, monkeypatch):
+    token = set_hermes_home_override(tmp_path)
+    reset_process_ledger_cache()
+    monkeypatch.setenv("HERMES_RUN_ID", "run-emitter")
+    try:
+        from model_tools import _emit_post_tool_call_hook
+
+        invoke_hook("on_session_start", session_id="s", model="m", provider="p")
+        _emit_post_tool_call_hook(
+            function_name="local_tool", function_args={}, result="ok",
+            session_id="s", tool_call_id="tool-stable", turn_id="t",
+        )
+        _emit_post_tool_call_hook(function_name="local_tool", function_args={}, result="ok", session_id="s")
+        invoke_hook(
+            "api_request_error", session_id="s", api_request_id="api-stable",
+            model="m", provider="p", retry_count=1, retryable=True,
+            error={"type": "TransportError"},
+        )
+        invoke_hook("on_session_finalize", session_id="s", interrupted=True, reason="interrupt")
+        receipt = process_ledger().get_run("run-emitter")
+        assert receipt["tool_call_count"] == 1
+        assert receipt["retry_count"] == 1
+        assert receipt["outcome"] == "interrupted"
+
+        monkeypatch.setenv("HERMES_RUN_ID", "run-no-finalize")
+        invoke_hook("on_session_start", session_id="s2", model="m", provider="p")
+        invoke_hook(
+            "post_api_request", session_id="s2", turn_id="t2", api_request_id="api-2",
+            model="m", provider="p", usage={"input_tokens": 1, "output_tokens": 1},
+        )
+        process_ledger().shutdown()
+        assert process_ledger().get_run("run-no-finalize")["ended_at"] is None
+    finally:
+        reset_hermes_home_override(token)
+        reset_process_ledger_cache()

--- a/tests/test_run_usage_report.py
+++ b/tests/test_run_usage_report.py
@@ -68,10 +68,10 @@ def test_card_cost_requires_explicit_board(tmp_path):
     assert "--board" in result.stderr
 
 
-def test_report_all_selected_profiles_adds_source_and_retains_duplicate_ids(tmp_path, capsys, monkeypatch):
+def test_report_all_selected_profiles_deduplicates_identical_global_run_ids(tmp_path, capsys, monkeypatch):
     first = tmp_path / "default.db"
     second = tmp_path / "reviewer.db"
-    UsageLedger(first).start_run(run_id="direct-a", process_id="1", session_id="s1")
+    UsageLedger(first).start_run(run_id="direct-a", process_id="1", session_id="s", started_at=1)
     UsageLedger(second).start_run(run_id="direct-b", process_id="2", session_id="s2")
     monkeypatch.setattr(
         run_usage_report,
@@ -82,10 +82,31 @@ def test_report_all_selected_profiles_adds_source_and_retains_duplicate_ids(tmp_
     row = json.loads(capsys.readouterr().out)[0]
     assert row["source_profile"] == "default"
 
-    UsageLedger(second).start_run(run_id="direct-a", process_id="3", session_id="s3")
+    UsageLedger(second).start_run(run_id="direct-a", process_id="3", session_id="s", started_at=1)
     assert run_usage_report.main(["--all-profiles", "--run-id", "direct-a"]) == 0
     rows = json.loads(capsys.readouterr().out)
-    assert [row["identity"] for row in rows] == [["default", "direct-a"], ["reviewer", "direct-a"]]
+    assert len(rows) == 1
+    assert rows[0]["source_profile"] == "default"
+    assert rows[0]["source_profiles"] == ["default", "reviewer"]
+
+
+def test_report_all_profiles_rejects_conflicting_duplicate_global_run_ids(tmp_path, capsys, monkeypatch):
+    first = tmp_path / "default.db"
+    second = tmp_path / "reviewer.db"
+    UsageLedger(first).start_run(run_id="conflict", process_id="1")
+    UsageLedger(second).start_run(run_id="conflict", process_id="2")
+    UsageLedger(second).record_model_usage(
+        run_id="conflict", event_id="event", session_id="s", turn_id="t",
+        model="m", provider="p", input_tokens=9,
+    )
+    monkeypatch.setattr(
+        run_usage_report,
+        "_selected_ledgers",
+        lambda args: [("default", first), ("reviewer", second)],
+    )
+
+    assert run_usage_report.main(["--all-profiles", "--run-id", "conflict"]) == 2
+    assert "conflicting duplicate" in capsys.readouterr().err
 
 
 def test_all_profiles_maps_root_default_and_named_profiles_once(tmp_path, capsys, monkeypatch):
@@ -93,8 +114,8 @@ def test_all_profiles_maps_root_default_and_named_profiles_once(tmp_path, capsys
     named = root / "profiles" / "reviewer"
     named.mkdir(parents=True)
     root.mkdir(exist_ok=True)
-    UsageLedger(root / "state.db").start_run(run_id="same", process_id="default")
-    UsageLedger(named / "state.db").start_run(run_id="same", process_id="reviewer")
+    UsageLedger(root / "state.db").start_run(run_id="same", process_id="default", started_at=1)
+    UsageLedger(named / "state.db").start_run(run_id="same", process_id="reviewer", started_at=1)
     monkeypatch.setattr(run_usage_report, "get_default_hermes_root", lambda: root)
     monkeypatch.setattr("hermes_cli.profiles.list_profiles", lambda: [
         type("P", (), {"name": "default", "path": root})(),
@@ -102,9 +123,9 @@ def test_all_profiles_maps_root_default_and_named_profiles_once(tmp_path, capsys
     ])
     assert run_usage_report.main(["--all-profiles", "--run-id", "same"]) == 0
     rows = json.loads(capsys.readouterr().out)
-    assert [(row["source_profile"], row["process_id"]) for row in rows] == [
-        ("default", "default"), ("reviewer", "reviewer")
-    ]
+    assert len(rows) == 1
+    assert rows[0]["source_profile"] == "default"
+    assert rows[0]["source_profiles"] == ["default", "reviewer"]
 
 
 def test_card_query_joins_exact_task_run_usage(tmp_path, capsys):

--- a/tests/test_run_usage_report.py
+++ b/tests/test_run_usage_report.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from agent.run_usage_ledger import UsageLedger
+from agent import run_usage_report
+from hermes_cli import kanban_db
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "card-cost.sh"
+
+
+def test_card_cost_reports_card_and_non_card_runs_from_explicit_board(tmp_path):
+    db_path = tmp_path / "state.db"
+    ledger = UsageLedger(db_path)
+    ledger.start_run(run_id="card-run", process_id="1", task_id="task-1", board="board-a")
+    ledger.record_model_usage(
+        run_id="card-run",
+        event_id="card-event",
+        session_id="s-card",
+        turn_id="t-card",
+        model="model-a",
+        provider="provider-a",
+        input_tokens=11,
+        output_tokens=7,
+        cost_usd=0.3,
+    )
+    ledger.start_run(run_id="direct-run", process_id="2", session_id="s-direct")
+    ledger.record_model_usage(
+        run_id="direct-run",
+        event_id="direct-event",
+        session_id="s-direct",
+        turn_id="t-direct",
+        model="model-b",
+        provider="provider-b",
+        input_tokens=13,
+        output_tokens=5,
+        cost_usd=0.2,
+    )
+
+    env = {**os.environ, "PYTHONPATH": str(ROOT)}
+    result = subprocess.run(
+        [str(SCRIPT), "--db", str(db_path), "--board", "board-a", "--include-unassigned"],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    rows = json.loads(result.stdout)
+    assert [row["run_id"] for row in rows] == ["card-run", "direct-run"]
+    assert rows[0]["task_id"] == "task-1"
+    assert rows[1]["session_id"] == "s-direct"
+
+
+def test_card_cost_requires_explicit_board(tmp_path):
+    result = subprocess.run(
+        [str(SCRIPT), "--db", str(tmp_path / "state.db")],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "--board" in result.stderr
+
+
+def test_report_all_selected_profiles_adds_source_and_retains_duplicate_ids(tmp_path, capsys, monkeypatch):
+    first = tmp_path / "default.db"
+    second = tmp_path / "reviewer.db"
+    UsageLedger(first).start_run(run_id="direct-a", process_id="1", session_id="s1")
+    UsageLedger(second).start_run(run_id="direct-b", process_id="2", session_id="s2")
+    monkeypatch.setattr(
+        run_usage_report,
+        "_selected_ledgers",
+        lambda args: [("default", first), ("reviewer", second)],
+    )
+    assert run_usage_report.main(["--all-profiles", "--run-id", "direct-a"]) == 0
+    row = json.loads(capsys.readouterr().out)[0]
+    assert row["source_profile"] == "default"
+
+    UsageLedger(second).start_run(run_id="direct-a", process_id="3", session_id="s3")
+    assert run_usage_report.main(["--all-profiles", "--run-id", "direct-a"]) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [row["identity"] for row in rows] == [["default", "direct-a"], ["reviewer", "direct-a"]]
+
+
+def test_all_profiles_maps_root_default_and_named_profiles_once(tmp_path, capsys, monkeypatch):
+    root = tmp_path / "hermes"
+    named = root / "profiles" / "reviewer"
+    named.mkdir(parents=True)
+    root.mkdir(exist_ok=True)
+    UsageLedger(root / "state.db").start_run(run_id="same", process_id="default")
+    UsageLedger(named / "state.db").start_run(run_id="same", process_id="reviewer")
+    monkeypatch.setattr(run_usage_report, "get_default_hermes_root", lambda: root)
+    monkeypatch.setattr("hermes_cli.profiles.list_profiles", lambda: [
+        type("P", (), {"name": "default", "path": root})(),
+        type("P", (), {"name": "reviewer", "path": named})(),
+    ])
+    assert run_usage_report.main(["--all-profiles", "--run-id", "same"]) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [(row["source_profile"], row["process_id"]) for row in rows] == [
+        ("default", "default"), ("reviewer", "reviewer")
+    ]
+
+
+def test_card_query_joins_exact_task_run_usage(tmp_path, capsys):
+    board = tmp_path / "kanban.db"
+    kanban_db.init_db(board)
+    with kanban_db.connect_closing(board) as connection:
+        connection.execute(
+            "INSERT INTO task_runs(task_id, status, started_at) VALUES (?, ?, ?)",
+            ("task-exact", "running", 1),
+        )
+        task_run_id = connection.execute("SELECT id FROM task_runs").fetchone()[0]
+    state = tmp_path / "state.db"
+    ledger = UsageLedger(state)
+    run_id = f"task-run:{task_run_id}"
+    ledger.start_run(run_id=run_id, process_id="p", task_run_id=task_run_id, task_id="task-exact", board="board-a")
+    ledger.record_model_usage(
+        run_id=run_id, event_id="exact-event", session_id="s", turn_id="t",
+        model="m", provider="p", input_tokens=2, output_tokens=3, cost_usd=0.4,
+    )
+    ledger.finish_run(run_id=run_id, outcome="completed")
+    assert ledger.link_kanban_run(task_run_id=task_run_id, usage_run_id=run_id, kanban_db=board)
+    assert run_usage_report.main([
+        "--db", str(state), "--board", "board-a", "--task-id", "task-exact",
+        "--kanban-db", str(board),
+    ]) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [row["run_id"] for row in rows] == [run_id]


### PR DESCRIPTION
## Summary
- add profile-local durable usage receipts with idempotent model/tool/retry accounting
- wire direct AIAgent and Kanban lifecycle hooks without blocking runtime hooks
- add deterministic reporting/card-cost tooling and lifecycle/profile snapshot proof

## Verification
- focused canonical runner: 24 tests passed
- adjacent canonical runner: 169 tests passed
- py_compile and git diff --check passed
- shellcheck/ruff unavailable in the execution environment

No merge or live profile install performed; stop for Sol review.