### PR TITLE
fix(agent): detect the Nous proxy's generic 404 as a missing model

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4014,6 +4014,9 @@ def _is_model_not_found_error(exc: Exception) -> bool:
         "the model `",            # OpenAI-style: "The model `X` does not exist"
         "model_not_found",
         "unknown model",
+        # Nous inference proxy generic 404 body — returned when the requested
+        # model has no vision/chat route, with no model-specific phrasing.
+        "couldn't find that",
     ))
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1383,6 +1383,15 @@ class TestIsModelNotFoundError:
         # billing keyword wins — payment owns it
         assert _is_model_not_found_error(exc) is False
 
+    def test_nous_generic_404_body(self):
+        """Nous inference proxy 404s with a generic body when a model has no
+        vision/chat route — must still trigger the stale-model self-heal."""
+        exc = Exception(
+            "Error code: 404 - {'status': 404, 'message': "
+            "\"Couldn't find that, sorry.\"}"
+        )
+        exc.status_code = 404
+        assert _is_model_not_found_error(exc) is True
 
 
 


### PR DESCRIPTION
The Nous inference proxy answers with a generic body — `"Couldn't find that, sorry."` — when the requested model has no route (e.g. a text-only chat SKU handed an image request), with no model-specific phrasing. `_is_model_not_found_error` matched only the model-specific vendor strings, so that 404 fell through and the stale-model self-heal never fired; the caller kept retrying the same dead model.

This matches the proxy's generic body too.

### Scope change on rebase

This PR originally also kept the main chat model out of the Nous strict vision backend in `resolve_vision_provider_client`. That fix **landed upstream independently**, in a stronger form (it also honours an explicit `auxiliary.vision.model` override), with tests that exercise the real resolution chain rather than mocking it. Both that code change and my now-redundant test have been dropped on rebase — only the 404-detection fix remains.
