### PR TITLE
fix(credential-pool): reduce TTL for HTTP 402 (Payment Required) from 1h to 2min

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -122,6 +122,7 @@ SUPPORTED_POOL_STRATEGIES = {
 # 429 (rate-limited), 402 (billing/quota), and other failures cool down after 1 hour.
 # Provider-supplied reset_at timestamps override these defaults.
 EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
+EXHAUSTED_TTL_402_SECONDS = 2 * 60           # 2 minutes — 402 Payment Required
 EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
 # When a pool has no other credential to rotate to (the offending key is the
@@ -331,12 +332,18 @@ def _exhausted_ttl(
     """
     if error_code == 401:
         return EXHAUSTED_TTL_401_SECONDS
+    if error_code == 402:
+        # PAYG/prepaid accounts recover as soon as the balance is recharged;
+        # a short TTL lets the pool self-heal within minutes instead of
+        # benching the key for an hour. If still unfunded, the next request
+        # re-marks the credential with a fresh TTL.
+        return EXHAUSTED_TTL_402_SECONDS
     base = EXHAUSTED_TTL_429_SECONDS if error_code == 429 else EXHAUSTED_TTL_DEFAULT_SECONDS
     # Sole credential: shorten only TRANSIENT throttles (429 rate-limit, 403
     # edge-throttle, 5xx server, or unknown). Billing exhaustion — whether
     # classified as such or self-evident from a 402 — is a genuine depletion
     # where a quick retry can't help, so it keeps the full bench.
-    is_billing = error_code == 402 or failure_reason == FAILURE_REASON_BILLING
+    is_billing = failure_reason == FAILURE_REASON_BILLING
     if sole_credential and not is_billing:
         return min(base, EXHAUSTED_TTL_SOLE_CREDENTIAL_SECONDS)
     return base

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -122,6 +122,7 @@ SUPPORTED_POOL_STRATEGIES = {
 # 429 (rate-limited), 402 (billing/quota), and other failures cool down after 1 hour.
 # Provider-supplied reset_at timestamps override these defaults.
 EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
+EXHAUSTED_TTL_402_SECONDS = 2 * 60           # 2 minutes — 402 Payment Required
 EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
 
@@ -293,6 +294,8 @@ def _exhausted_ttl(error_code: Optional[int]) -> int:
     """Return cooldown seconds based on the HTTP status that caused exhaustion."""
     if error_code == 401:
         return EXHAUSTED_TTL_401_SECONDS
+    if error_code == 402:
+        return EXHAUSTED_TTL_402_SECONDS
     if error_code == 429:
         return EXHAUSTED_TTL_429_SECONDS
     return EXHAUSTED_TTL_DEFAULT_SECONDS

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2079,3 +2079,123 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+def test_exhausted_402_without_reset_at_recovers_after_short_ttl(tmp_path, monkeypatch):
+    """A 402-exhausted entry with no provider reset timestamp recovers after its TTL.
+
+    Regression for the status-specific 402 cooldown (2 min, vs 1 h for 429):
+    billing errors carry no provider ``last_error_reset_at``, so
+    ``_exhausted_until`` must fall back to ``last_status_at + _exhausted_ttl(code)``
+    for the entry to ever re-enter rotation.  Verify the entry stays
+    unavailable *before* ``EXHAUSTED_TTL_402_SECONDS`` elapses, becomes
+    selectable again *after* it elapses, and — at the same age — a
+    429-exhausted sibling is still benched (proving the short TTL is 402-only).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    # Prevent auto-seeding from Codex CLI tokens on the host
+    monkeypatch.setattr(
+        "hermes_cli.auth._import_codex_cli_tokens",
+        lambda: None,
+    )
+
+    from agent.credential_pool import EXHAUSTED_TTL_402_SECONDS, load_pool
+
+    def _write_entry(error_code: int, status_at_age: float) -> None:
+        _write_auth_store(
+            tmp_path,
+            {
+                "version": 1,
+                "credential_pool": {
+                    "openai-codex": [
+                        {
+                            "id": "cred-1",
+                            "label": "billing",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "source": "manual:device_code",
+                            "access_token": "tok-1",
+                            "refresh_token": "rt-1",
+                            "last_status": "exhausted",
+                            "last_status_at": time.time() - status_at_age,
+                            "last_error_code": error_code,
+                            "last_error_reason": (
+                                "billing_exhausted"
+                                if error_code == 402
+                                else "rate_limit_exceeded"
+                            ),
+                            # Deliberately NO last_error_reset_at: the pool
+                            # must derive the cooldown from last_status_at
+                            # plus the status-specific TTL.
+                        }
+                    ]
+                },
+            },
+        )
+
+    # --- Before the 402 TTL elapses: the entry stays unavailable. ---
+    _write_entry(402, status_at_age=EXHAUSTED_TTL_402_SECONDS - 30)
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is False
+    assert pool.select() is None
+
+    # --- After the 402 TTL elapses: the entry becomes selectable again. ---
+    _write_entry(402, status_at_age=EXHAUSTED_TTL_402_SECONDS + 30)
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is True
+    selected = pool.select()
+    assert selected is not None
+    assert selected.id == "cred-1"
+    # The cooldown was actually cleared, not just skipped: the entry is
+    # reset to STATUS_OK on disk so it stays usable across pool reloads.
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["openai-codex"][0]
+    assert persisted["last_status"] == "ok"
+    assert persisted.get("last_error_code") is None
+
+    # --- Same age, but exhausted with 429: still benched (1 h TTL). ---
+    # Two entries so the pool is NOT sole-credential: upstream's
+    # sole-credential path shortens transient throttles for a lone key,
+    # which would mask the 429/402 distinction. With a sibling entry the
+    # 429 keeps its full 1-hour bench — proving the short TTL is 402-only.
+    def _write_two_429_entries(status_at_age: float) -> None:
+        _write_auth_store(
+            tmp_path,
+            {
+                "version": 1,
+                "credential_pool": {
+                    "openai-codex": [
+                        {
+                            "id": "cred-1",
+                            "label": "billing",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "source": "manual:device_code",
+                            "access_token": "tok-1",
+                            "refresh_token": "rt-1",
+                            "last_status": "exhausted",
+                            "last_status_at": time.time() - status_at_age,
+                            "last_error_code": 429,
+                            "last_error_reason": "rate_limit_exceeded",
+                        },
+                        {
+                            "id": "cred-2",
+                            "label": "billing-2",
+                            "auth_type": "oauth",
+                            "priority": 1,
+                            "source": "manual:device_code",
+                            "access_token": "tok-2",
+                            "refresh_token": "rt-2",
+                            "last_status": "exhausted",
+                            "last_status_at": time.time() - status_at_age,
+                            "last_error_code": 429,
+                            "last_error_reason": "rate_limit_exceeded",
+                        },
+                    ]
+                },
+            },
+        )
+
+    _write_two_429_entries(status_at_age=EXHAUSTED_TTL_402_SECONDS + 30)
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is False
+    assert pool.select() is None

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -143,6 +143,85 @@ def test_billing_rotation_marks_all_entries_sharing_failed_key(tmp_path, monkeyp
     assert statuses["cred-model-config"] == STATUS_EXHAUSTED
 
 
+def test_exhausted_402_without_reset_at_recovers_after_short_ttl(tmp_path, monkeypatch):
+    """A 402-exhausted entry with no provider reset timestamp recovers after its TTL.
+
+    Regression for the status-specific 402 cooldown (2 min, vs 1 h for 429):
+    billing errors carry no provider ``last_error_reset_at``, so
+    ``_exhausted_until`` must fall back to ``last_status_at + _exhausted_ttl(code)``
+    for the entry to ever re-enter rotation.  Verify the entry stays
+    unavailable *before* ``EXHAUSTED_TTL_402_SECONDS`` elapses, becomes
+    selectable again *after* it elapses, and — at the same age — a
+    429-exhausted sibling is still benched (proving the short TTL is 402-only).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    # Prevent auto-seeding from Codex CLI tokens on the host
+    monkeypatch.setattr(
+        "hermes_cli.auth._import_codex_cli_tokens",
+        lambda: None,
+    )
+
+    from agent.credential_pool import EXHAUSTED_TTL_402_SECONDS, load_pool
+
+    def _write_entry(error_code: int, status_at_age: float) -> None:
+        _write_auth_store(
+            tmp_path,
+            {
+                "version": 1,
+                "credential_pool": {
+                    "openai-codex": [
+                        {
+                            "id": "cred-1",
+                            "label": "billing",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "source": "manual:device_code",
+                            "access_token": "tok-1",
+                            "refresh_token": "rt-1",
+                            "last_status": "exhausted",
+                            "last_status_at": time.time() - status_at_age,
+                            "last_error_code": error_code,
+                            "last_error_reason": (
+                                "billing_exhausted"
+                                if error_code == 402
+                                else "rate_limit_exceeded"
+                            ),
+                            # Deliberately NO last_error_reset_at: the pool
+                            # must derive the cooldown from last_status_at
+                            # plus the status-specific TTL.
+                        }
+                    ]
+                },
+            },
+        )
+
+    # --- Before the 402 TTL elapses: the entry stays unavailable. ---
+    _write_entry(402, status_at_age=EXHAUSTED_TTL_402_SECONDS - 30)
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is False
+    assert pool.select() is None
+
+    # --- After the 402 TTL elapses: the entry becomes selectable again. ---
+    _write_entry(402, status_at_age=EXHAUSTED_TTL_402_SECONDS + 30)
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is True
+    selected = pool.select()
+    assert selected is not None
+    assert selected.id == "cred-1"
+    # The cooldown was actually cleared, not just skipped: the entry is
+    # reset to STATUS_OK on disk so it stays usable across pool reloads.
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["openai-codex"][0]
+    assert persisted["last_status"] == "ok"
+    assert persisted.get("last_error_code") is None
+
+    # --- Same age, but exhausted with 429: still benched (1 h TTL). ---
+    _write_entry(429, status_at_age=EXHAUSTED_TTL_402_SECONDS + 30)
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is False
+    assert pool.select() is None
+
+
 def test_unmatched_api_key_hint_rotates_without_benching_innocent_key(tmp_path, monkeypatch):
     """An api_key_hint matching no entry must not quarantine a healthy key.
 


### PR DESCRIPTION
## Problem

When **any provider** returns HTTP 402 (Payment Required — credits exhausted), the credential pool marks the key as `STATUS_EXHAUSTED` with the default **1-hour TTL**. After the user recharges credits, they must wait the full hour for the credential to become available again — even across gateway restarts, since the status is persisted in `auth.json`.

This affects all API-key providers that use pay-as-you-go billing:
- **deepseek**, **openai-api**, **openrouter**, **anthropic** (API key mode)
- **alibaba**, **zai**, **kimi-for-coding**, **stepfun**, **minimax**, **minimax-cn**
- **nvidia**, **fireworks**, **upstage**, **gmi**, **xiaomi**, **tencent-tokenhub**
- **arcee**, **ollama-cloud**, **novita**, **azure-foundry**, **kilo**, **github-copilot**
- **opencode**, **opencode-go**, **vercel**, **huggingface**

And OAuth providers: **anthropic** (OAuth), **openai-codex**, **nous**, **xai-oauth**, **minimax-oauth**, **qwen-oauth**.

## Root Cause

`_exhausted_ttl()` only had special cases for HTTP 401 (5 min) and 429 (1 hour). HTTP 402 fell through to the default 1-hour TTL, which is appropriate for rate limits but too aggressive for billing/payment errors.

## Fix

- **New constant:** `EXHAUSTED_TTL_402_SECONDS = 120` (2 minutes)
- **_exhausted_ttl():** now checks for `error_code == 402` before the 429/generic fallthrough

HTTP 402 is fundamentally different from 429: when the user recharges, the key works again immediately. A 2-minute window is enough to prevent rapid retry storms while being short enough that the credential auto-recovers shortly after recharging. If credits are still out after 2 min, the next request fails again and re-marks the credential with a fresh TTL.

## Related

Companion PR in Hermes WebUI: nesquena/hermes-webui#6626