### PR TITLE
feat(cron): add native usage delivery footer

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5517,6 +5517,26 @@ def run_conversation(
             except Exception:
                 pass
 
+            # Native cron accounting is context-scoped by the scheduler.  This
+            # sits beside the post-request hook so it observes every completed
+            # model request (including tool-follow-up turns) without asking a
+            # plugin or model to reconstruct usage.  It is a no-op outside an
+            # active cron execution and failures must never affect a response.
+            try:
+                from cron.usage_footer import record_native_usage
+                record_native_usage(
+                    normalize_usage(
+                        getattr(response, "usage", None),
+                        provider=agent.provider,
+                        api_mode=agent.api_mode,
+                    ) if getattr(response, "usage", None) else None,
+                    agent.provider or "",
+                    getattr(response, "model", None) or agent.model or "",
+                    agent.base_url or "",
+                )
+            except Exception:
+                logger.debug("Native cron usage collection failed", exc_info=True)
+
             # Handle assistant response
             if assistant_message.content and not agent.quiet_mode:
                 if agent.verbose_logging:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1447,7 +1447,14 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    *,
+    usage_footer: str = "",
+) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -1506,6 +1513,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         )
     else:
         delivery_content = content
+
+    # Application-generated usage belongs after the existing cron wrapper, so
+    # platform splitters retain exactly one footer on the final outbound chunk.
+    if usage_footer:
+        delivery_content = f"{delivery_content.rstrip()}\n\n{usage_footer}"
 
     # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter
@@ -3941,21 +3953,26 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # below once delivery is done. Defense-in-depth alongside the
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
-        try:
-            success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents
-            )
-        except BaseException:
-            # run_job's finally still hands back the agent when it raises; tear
-            # it down here so a failed run never leaks its async resources
-            # (#10200), then re-raise into the outer handler. BaseException
-            # (not just Exception) so a KeyboardInterrupt/SystemExit mid-run
-            # still triggers teardown before propagating.
-            for _deferred_agent in _deferred_agents:
-                _teardown_cron_agent(_deferred_agent, job["id"])
-            raise
-        finally:
-            reset_secret_scope(_scope_token)
+        # A fresh ContextVar-backed bucket confines request accounting to this
+        # exact run even when tick() executes other jobs concurrently.
+        from cron.usage_footer import activate_cron_usage
+        with activate_cron_usage() as _run_usage:
+            try:
+                success, output, final_response, error = run_job(
+                    job, defer_agent_teardown=_deferred_agents
+                )
+            except BaseException:
+                # run_job's finally still hands back the agent when it raises; tear
+                # it down here so a failed run never leaks its async resources
+                # (#10200), then re-raise into the outer handler. BaseException
+                # (not just Exception) so a KeyboardInterrupt/SystemExit mid-run
+                # still triggers teardown before propagating.
+                for _deferred_agent in _deferred_agents:
+                    _teardown_cron_agent(_deferred_agent, job["id"])
+                raise
+            finally:
+                reset_secret_scope(_scope_token)
+        usage_footer = _run_usage.footer()
 
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step
@@ -4008,7 +4025,19 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     and not _resolve_delivery_targets(job)
                 )
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    # Preserve the established call shape when no native usage
+                    # was observed; it keeps alternate delivery implementations
+                    # and tests compatible. A non-empty footer is appended only
+                    # by the generic delivery path.
+                    if usage_footer:
+                        delivery_error = _deliver_result(
+                            job, deliver_content, adapters=adapters, loop=loop,
+                            usage_footer=usage_footer,
+                        )
+                    else:
+                        delivery_error = _deliver_result(
+                            job, deliver_content, adapters=adapters, loop=loop,
+                        )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)

--- a/cron/usage_footer.py
+++ b/cron/usage_footer.py
@@ -1,0 +1,140 @@
+"""Per-execution native LLM usage accounting for cron delivery.
+
+The accumulator is held in a ContextVar, never in module-global mutable state.
+A scheduler run activates it around its agent work; the core request path records
+provider-normalized usage into that exact context.  Interactive calls have no
+active scope and are deliberately ignored.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Iterator
+
+from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+
+_ACTIVE_CRON_USAGE: ContextVar["CronRunUsage | None"] = ContextVar(
+    "active_cron_usage", default=None
+)
+
+
+def _tokens(value: int) -> str:
+    """Compact, deterministic token formatting used only for the delivery footer."""
+    value = int(value)
+    if abs(value) < 1_000:
+        return str(value)
+    return f"{value / 1_000:.1f}k"
+
+
+def _usd(value: Decimal) -> str:
+    """Retain useful precision for cheap requests without implying provider cost."""
+    text = f"{value:.6f}".rstrip("0").rstrip(".")
+    return text if "." in text else f"{text}.0"
+
+
+@dataclass
+class CronRunUsage:
+    """One cron execution's native request usage and local pricing state."""
+
+    usage: CanonicalUsage = field(
+        default_factory=lambda: CanonicalUsage(request_count=0)
+    )
+    routes: set[tuple[str, str]] = field(default_factory=set)
+    known_cost: Decimal = Decimal("0")
+    estimated_calls: int = 0
+    unavailable_calls: int = 0
+
+    def record(
+        self,
+        usage: CanonicalUsage | None,
+        provider: str,
+        model: str,
+        base_url: str = "",
+    ) -> None:
+        """Record exactly one post-request observation without raising into a run."""
+        self.usage += usage or CanonicalUsage()
+        self.routes.add(((provider or "").strip(), (model or "").strip()))
+        if usage is None:
+            self.unavailable_calls += 1
+            return
+        try:
+            estimated = estimate_usage_cost(
+                model, usage, provider=provider, base_url=base_url,
+            )
+        except Exception:
+            self.unavailable_calls += 1
+            return
+        if estimated.amount_usd is None:
+            self.unavailable_calls += 1
+            return
+        self.known_cost += estimated.amount_usd
+        self.estimated_calls += 1
+
+    @property
+    def call_count(self) -> int:
+        return self.usage.request_count
+
+    def footer(self) -> str:
+        """Format a footer only when at least one actual LLM request was observed.
+
+        Total is intentionally ``input + output``.  Canonical reasoning is
+        commonly a subset of output, while cache buckets are provider input
+        sub-buckets, so neither is added again.
+        """
+        if not self.call_count:
+            return ""
+        parts = [
+            f"{_tokens(self.usage.input_tokens)} input",
+            f"{_tokens(self.usage.output_tokens)} output",
+        ]
+        if self.usage.reasoning_tokens:
+            parts.append(f"{_tokens(self.usage.reasoning_tokens)} reasoning")
+        parts.append(f"{_tokens(self.usage.input_tokens + self.usage.output_tokens)} total")
+        lines = ["──", "Usage: " + " · ".join(parts)]
+        cache_parts = []
+        if self.usage.cache_read_tokens:
+            cache_parts.append(f"{_tokens(self.usage.cache_read_tokens)} read")
+        if self.usage.cache_write_tokens:
+            cache_parts.append(f"{_tokens(self.usage.cache_write_tokens)} write")
+        if cache_parts:
+            lines.append("Cache: " + " · ".join(cache_parts))
+        calls = f"{self.call_count} LLM call" + ("" if self.call_count == 1 else "s")
+        if self.estimated_calls == self.call_count:
+            cost = f"Estimated cost: ${_usd(self.known_cost)}"
+        elif self.estimated_calls:
+            cost = f"Estimated cost incomplete: ${_usd(self.known_cost)}"
+        else:
+            cost = "Estimated cost unavailable"
+        suffix = [calls]
+        if len(self.routes) > 1:
+            suffix.append(f"Routes: {len(self.routes)}")
+        lines.append(cost + " · " + " · ".join(suffix))
+        return "\n".join(lines)
+
+
+@contextmanager
+def activate_cron_usage() -> Iterator[CronRunUsage]:
+    """Activate a fresh usage bucket for the current cron execution context."""
+    usage = CronRunUsage()
+    token = _ACTIVE_CRON_USAGE.set(usage)
+    try:
+        yield usage
+    finally:
+        _ACTIVE_CRON_USAGE.reset(token)
+
+
+def record_native_usage(
+    usage: CanonicalUsage | None,
+    provider: str,
+    model: str,
+    base_url: str,
+) -> bool:
+    """Record a request iff it belongs to the active cron execution."""
+    active = _ACTIVE_CRON_USAGE.get()
+    if active is None:
+        return False
+    active.record(usage, provider, model, base_url)
+    return True

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -29,6 +29,7 @@ import re
 import threading
 import time
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -72,8 +73,8 @@ _READ_FILE_TAIL_LINES = 15
 # narrow: a cron-like interactive session must retain ordinary trace behavior.
 _CRON_SESSION_ID_RE = re.compile(
     r"^cron_([0-9a-f]{12})_"
-    r"(?:[12]\d{3})(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])_"
-    r"(?:[01]\d|2[0-3])[0-5]\d[0-5]\d$"
+    r"([12]\d{3}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])_"
+    r"(?:[01]\d|2[0-3])[0-5]\d[0-5]\d)$"
 )
 
 # Langfuse-issued keys always carry these prefixes (cloud or self-hosted —
@@ -119,7 +120,13 @@ def _parse_cron_session_id(session_id: str) -> Optional[str]:
     if not isinstance(session_id, str):
         return None
     match = _CRON_SESSION_ID_RE.fullmatch(session_id)
-    return match.group(1) if match else None
+    if not match:
+        return None
+    try:
+        datetime.strptime(match.group(2), "%Y%m%d_%H%M%S")
+    except ValueError:
+        return None
+    return match.group(1)
 
 
 # Sentinel: "_get_langfuse() has tried and failed". Lets us short-circuit

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -67,6 +67,14 @@ _LANGFUSE_CLIENT = None
 _READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
 _READ_FILE_HEAD_LINES = 25
 _READ_FILE_TAIL_LINES = 15
+# Cron jobs are created with ``uuid.uuid4().hex[:12]`` and scheduler.py emits
+# sessions as ``cron_<job-id>_<YYYYMMDD_HHMMSS>``. Keep this deliberately
+# narrow: a cron-like interactive session must retain ordinary trace behavior.
+_CRON_SESSION_ID_RE = re.compile(
+    r"^cron_([0-9a-f]{12})_"
+    r"(?:[12]\d{3})(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])_"
+    r"(?:[01]\d|2[0-3])[0-5]\d[0-5]\d$"
+)
 
 # Langfuse-issued keys always carry these prefixes (cloud or self-hosted —
 # the prefix is baked into the server-side issuance flow, not a UI hint).
@@ -99,6 +107,19 @@ def _debug_enabled() -> bool:
 def _debug(message: str) -> None:
     if _debug_enabled():
         logger.info("Langfuse tracing: %s", message)
+
+
+def _parse_cron_session_id(session_id: str) -> Optional[str]:
+    """Return the stable job ID from a supported scheduler cron session.
+
+    The scheduler owns the session format. Invalid, legacy, or merely
+    cron-looking values intentionally return ``None`` so observability falls
+    back to the ordinary trace shape without affecting the Hermes runtime.
+    """
+    if not isinstance(session_id, str):
+        return None
+    match = _CRON_SESSION_ID_RE.fullmatch(session_id)
+    return match.group(1) if match else None
 
 
 # Sentinel: "_get_langfuse() has tried and failed". Lets us short-circuit
@@ -605,6 +626,11 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
                       turn_id: str = "", api_request_id: str = "") -> TraceState:
     trace_id = client.create_trace_id(seed=f"{session_id or 'sessionless'}::{task_id or task_key}")
     trace_input = _extract_last_user_message(messages)
+    cron_job_id = _parse_cron_session_id(session_id)
+    trace_name = f"cron:{cron_job_id}" if cron_job_id else "Hermes turn"
+    tags = ["hermes", "langfuse"]
+    if cron_job_id:
+        tags.extend(["cron", f"cron-job:{cron_job_id}"])
     metadata = {
         "source": "hermes",
         "task_id": task_id,
@@ -615,6 +641,12 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         "model": model,
         "api_mode": api_mode,
     }
+    if cron_job_id:
+        metadata.update({
+            "workload_type": "cron",
+            "cron_job_id": cron_job_id,
+            "cron_run_session": session_id,
+        })
 
     # session_id must be passed in trace_context for Langfuse session grouping.
     trace_ctx: Dict[str, Any] = {"trace_id": trace_id}
@@ -625,12 +657,12 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         try:
             with propagate_attributes(
                 session_id=session_id or task_key,
-                trace_name="Hermes turn",
-                tags=["hermes", "langfuse"],
+                trace_name=trace_name,
+                tags=tags,
             ):
                 root_ctx = client.start_as_current_observation(
                     trace_context=trace_ctx,
-                    name="Hermes turn",
+                    name=trace_name,
                     as_type="chain",
                     input=trace_input,
                     metadata=metadata,
@@ -640,7 +672,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         except Exception:
             root_ctx = client.start_as_current_observation(
                 trace_context=trace_ctx,
-                name="Hermes turn",
+                name=trace_name,
                 as_type="chain",
                 input=trace_input,
                 metadata=metadata,
@@ -650,7 +682,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
     else:
         root_ctx = client.start_as_current_observation(
             trace_context=trace_ctx,
-            name="Hermes turn",
+            name=trace_name,
             as_type="chain",
             input=trace_input,
             metadata=metadata,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -285,6 +285,26 @@ class TestDeliverResultWrapping:
         assert "Here is today's summary." in sent_content
         assert "To stop or manage this job" in sent_content
 
+    def test_delivery_keeps_prepared_usage_footer_once_at_end(self):
+        """The generic transport sees one footer after the unchanged result."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        footer = "──\nUsage: 842 input · 91 output · 933 total\nEstimated cost: $0.0003 · 1 LLM call"
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            _deliver_result(
+                {"id": "usage-job", "deliver": "origin", "origin": {"platform": "telegram", "chat_id": "123"}},
+                "Report body",
+                usage_footer=footer,
+            )
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content.count("Usage:") == 1
+        assert sent_content.endswith(footer)
 
     def test_relay_fronted_home_uses_relay_config_and_live_adapter(self, monkeypatch, tmp_path):
         """Persisted Slack home survives restart without native Slack config."""

--- a/tests/cron/test_usage_footer.py
+++ b/tests/cron/test_usage_footer.py
@@ -1,0 +1,84 @@
+"""Behavior tests for native, per-cron-run usage footer aggregation."""
+
+from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
+
+from agent.usage_pricing import CanonicalUsage, CostResult
+
+
+def _cost(amount):
+    return CostResult(amount_usd=Decimal(amount), status="estimated", source="official_docs_snapshot", label="")
+
+
+def test_footer_aggregates_native_usage_without_double_counting(monkeypatch):
+    from cron.usage_footer import CronRunUsage
+
+    monkeypatch.setattr("cron.usage_footer.estimate_usage_cost", lambda *a, **kw: _cost("0.0054"))
+    usage = CronRunUsage()
+    usage.record(
+        CanonicalUsage(input_tokens=17700, output_tokens=312, reasoning_tokens=2400,
+                       cache_read_tokens=8100, cache_write_tokens=20),
+        provider="openai", model="gpt-5.6-terra", base_url="https://api.openai.com/v1",
+    )
+    usage.record(CanonicalUsage(input_tokens=0, output_tokens=0), provider="openai", model="gpt-5.6-terra")
+
+    footer = usage.footer()
+
+    assert "Usage: 17.7k input · 312 output · 2.4k reasoning · 18.0k total" in footer
+    assert "Cache: 8.1k read · 20 write" in footer
+    assert "Estimated cost: $0.0108 · 2 LLM calls" in footer
+    # Reasoning/cache are provider sub-buckets: displayed total is input + output only.
+    assert "28.5k total" not in footer
+
+
+def test_footer_marks_partially_known_cost_incomplete(monkeypatch):
+    from cron.usage_footer import CronRunUsage
+
+    estimates = iter([_cost("0.0003"), CostResult(None, "unknown", "none", "n/a")])
+    monkeypatch.setattr("cron.usage_footer.estimate_usage_cost", lambda *a, **kw: next(estimates))
+    usage = CronRunUsage()
+    usage.record(CanonicalUsage(input_tokens=842, output_tokens=91), provider="openai", model="known")
+    usage.record(CanonicalUsage(input_tokens=10, output_tokens=2), provider="unknown", model="unknown")
+
+    assert "Estimated cost incomplete: $0.0003 · 2 LLM calls" in usage.footer()
+
+
+def test_footer_handles_unavailable_cost_and_multiple_routes(monkeypatch):
+    from cron.usage_footer import CronRunUsage
+
+    monkeypatch.setattr(
+        "cron.usage_footer.estimate_usage_cost",
+        lambda *a, **kw: CostResult(None, "unknown", "none", "n/a"),
+    )
+    usage = CronRunUsage()
+    usage.record(CanonicalUsage(input_tokens=21_300, output_tokens=608), provider="openai", model="a")
+    usage.record(CanonicalUsage(), provider="anthropic", model="b")
+
+    footer = usage.footer()
+    assert "Usage: 21.3k input · 608 output · 21.9k total" in footer
+    assert "Estimated cost unavailable · 2 LLM calls · Routes: 2" in footer
+
+
+def test_context_scopes_concurrent_runs_and_ignores_interactive_calls(monkeypatch):
+    from cron.usage_footer import activate_cron_usage, record_native_usage
+
+    monkeypatch.setattr("cron.usage_footer.estimate_usage_cost", lambda *a, **kw: _cost("0"))
+    # No active cron scope: interactive usage remains unaffected.
+    assert record_native_usage(CanonicalUsage(input_tokens=999, output_tokens=1), "p", "interactive", "") is False
+
+    def one_run(tokens):
+        with activate_cron_usage() as usage:
+            assert record_native_usage(CanonicalUsage(input_tokens=tokens, output_tokens=1), "p", "m", "") is True
+            return usage.footer()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first, second = list(executor.map(one_run, (100, 200)))
+
+    assert "100 input · 1 output · 101 total" in first
+    assert "200 input · 1 output · 201 total" in second
+
+
+def test_footer_is_empty_when_no_native_usage():
+    from cron.usage_footer import CronRunUsage
+
+    assert CronRunUsage().footer() == ""

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -196,6 +197,148 @@ class TestTraceScopeKey:
         assert key_a != key_b
         assert "turn:turn-a" in key_a
         assert "turn:turn-b" in key_b
+
+
+class TestCronTraceTagging:
+    """Stable cron-job aggregation must not replace run-specific sessions."""
+
+    @staticmethod
+    def _fresh_plugin():
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    @staticmethod
+    def _recording_client(started):
+        class _Span:
+            def set_trace_io(self, **kwargs):
+                pass
+
+        class _RootCM:
+            def __enter__(self):
+                return _Span()
+
+            def __exit__(self, *exc):
+                return False
+
+        class _Client:
+            def create_trace_id(self, seed=None):
+                return f"trace::{seed}"
+
+            def start_as_current_observation(self, **kwargs):
+                started.append(kwargs)
+                return _RootCM()
+
+        return _Client()
+
+    @pytest.mark.parametrize(
+        ("session_id", "job_id"),
+        [
+            ("cron_a21a08cee82d_20260730_183452", "a21a08cee82d"),
+            ("cron_0123456789ab_20260101_000000", "0123456789ab"),
+        ],
+    )
+    def test_parse_supported_cron_session_id(self, session_id, job_id):
+        assert self._fresh_plugin()._parse_cron_session_id(session_id) == job_id
+
+    @pytest.mark.parametrize("session_id", [
+        "",
+        "cron_a21a08cee82d_20260730_18345",
+        "cron_a21a08cee82d_20261330_183452",
+        "cron_A21A08CEE82D_20260730_183452",
+        "cron_a21a08cee82d_extra_20260730_183452",
+        "cron_job-name_20260730_183452",
+        "cron_a21a08cee82d_20260730_246000",
+        "cron_a21a08cee82d_20260730_183452_suffix",
+    ])
+    def test_malformed_cron_like_session_fails_open(self, session_id):
+        assert self._fresh_plugin()._parse_cron_session_id(session_id) is None
+
+    def test_cron_root_trace_has_stable_aggregation_attributes(self, monkeypatch):
+        mod = self._fresh_plugin()
+        propagation = []
+
+        @contextmanager
+        def record_propagation(**kwargs):
+            propagation.append(kwargs)
+            yield
+
+        started = []
+        monkeypatch.setattr(mod, "propagate_attributes", record_propagation)
+        session_id = "cron_a21a08cee82d_20260730_183452"
+        mod._start_root_trace(
+            "task", task_id="task", session_id=session_id, platform="cron",
+            provider="provider", model="model", api_mode="chat",
+            messages=[{"role": "user", "content": "run"}],
+            client=self._recording_client(started),
+        )
+
+        assert propagation == [{
+            "session_id": session_id,
+            "trace_name": "cron:a21a08cee82d",
+            "tags": ["hermes", "langfuse", "cron", "cron-job:a21a08cee82d"],
+        }]
+        assert started[0]["name"] == "cron:a21a08cee82d"
+        assert started[0]["trace_context"]["session_id"] == session_id
+        assert started[0]["metadata"] == {
+            "source": "hermes", "task_id": "task", "turn_id": "",
+            "api_request_id": "", "platform": "cron", "provider": "provider",
+            "model": "model", "api_mode": "chat", "workload_type": "cron",
+            "cron_job_id": "a21a08cee82d", "cron_run_session": session_id,
+        }
+
+    def test_runs_keep_unique_sessions_and_share_only_their_stable_job_tag(self, monkeypatch):
+        mod = self._fresh_plugin()
+        propagation, started = [], []
+
+        @contextmanager
+        def record_propagation(**kwargs):
+            propagation.append(kwargs)
+            yield
+
+        monkeypatch.setattr(mod, "propagate_attributes", record_propagation)
+        client = self._recording_client(started)
+        for session_id in (
+            "cron_a21a08cee82d_20260730_183452",
+            "cron_a21a08cee82d_20260731_183452",
+            "cron_b21a08cee82d_20260730_183452",
+        ):
+            mod._start_root_trace(
+                session_id, task_id=session_id, session_id=session_id, platform="",
+                provider="", model="", api_mode="", messages=[], client=client,
+            )
+
+        assert [item["session_id"] for item in propagation] == [
+            "cron_a21a08cee82d_20260730_183452",
+            "cron_a21a08cee82d_20260731_183452",
+            "cron_b21a08cee82d_20260730_183452",
+        ]
+        assert propagation[0]["tags"][-1] == propagation[1]["tags"][-1] == "cron-job:a21a08cee82d"
+        assert propagation[2]["tags"][-1] == "cron-job:b21a08cee82d"
+        assert [item["name"] for item in started] == [
+            "cron:a21a08cee82d", "cron:a21a08cee82d", "cron:b21a08cee82d",
+        ]
+
+    @pytest.mark.parametrize("session_id", ["interactive-session", ""])
+    def test_non_cron_or_absent_session_preserves_trace_shape(self, monkeypatch, session_id):
+        mod = self._fresh_plugin()
+        propagation, started = [], []
+
+        @contextmanager
+        def record_propagation(**kwargs):
+            propagation.append(kwargs)
+            yield
+
+        monkeypatch.setattr(mod, "propagate_attributes", record_propagation)
+        mod._start_root_trace(
+            "task", task_id="task", session_id=session_id, platform="telegram",
+            provider="provider", model="model", api_mode="chat", messages=[],
+            client=self._recording_client(started),
+        )
+
+        assert propagation[0]["trace_name"] == "Hermes turn"
+        assert propagation[0]["tags"] == ["hermes", "langfuse"]
+        assert started[0]["name"] == "Hermes turn"
+        assert not {"workload_type", "cron_job_id", "cron_run_session"} & set(started[0]["metadata"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -244,6 +244,7 @@ class TestCronTraceTagging:
         "",
         "cron_a21a08cee82d_20260730_18345",
         "cron_a21a08cee82d_20261330_183452",
+        "cron_a21a08cee82d_20260231_183452",
         "cron_A21A08CEE82D_20260730_183452",
         "cron_a21a08cee82d_extra_20260730_183452",
         "cron_job-name_20260730_183452",


### PR DESCRIPTION
## Summary
- aggregate canonical per-request LLM usage in an execution-scoped cron ContextVar
- append deterministic usage/cost footer only to externally delivered cron payloads
- preserve silent and local-only behavior

## Validation
- `scripts/run_tests.sh tests/cron -q` (379 passed)
- `scripts/run_tests.sh tests/agent/test_usage_pricing.py tests/plugins/test_langfuse_plugin.py -q` (50 passed)
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py -q` (220 passed)
- full suite running locally