### PR TITLE
fix(tools): strip PYTHONPATH from subprocess env to prevent leak (#74817)

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -346,7 +346,7 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # to a different Python version overwrites it and breaks the gateway). The
 # Hermes venv stays reachable via PATH (its bin dir is first), so stripping
 # these markers is safe and only prevents the cross-project clobber (#23473).
-_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
+_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX", "PYTHONPATH")
 
 
 def _is_hermes_internal_secret(key: str) -> bool:


### PR DESCRIPTION
Fixes #74817 — added PYTHONPATH to _ACTIVE_VENV_MARKER_VARS in tools/environments/local.py. Covers all 3 spawn paths.