### PR TITLE
fix(cron): isolate per-profile errors in multiplex ticker (#74878)

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -313,14 +313,23 @@ class InProcessCronScheduler(CronScheduler):
                 reset_hermes_home_override(home_token)
 
         while not stop_event.is_set():
-            ok = False
+            # Track per-profile tick outcomes so one profile's failure does not
+            # skip the remaining profiles in this tick cycle (#74878). Each
+            # profile's tick is independently guarded so a transient error in
+            # one store (locked/corrupt jobs.json, file-permission error) does
+            # NOT cascade and leave other profiles unserved.
+            _all_ok = True
+            _tick_errors: dict[str, str] = {}
+
             try:
                 if can_dispatch is not None and not can_dispatch():
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in profile_homes:
                         home = entry[1] if isinstance(entry, tuple) else entry
+                        profile_name = entry[0] if isinstance(entry, tuple) else str(home)
                         home_token = set_hermes_home_override(str(home))
+                        _profile_ok = False
                         try:
                             with use_cron_store(home):
                                 cron_tick(
@@ -330,28 +339,51 @@ class InProcessCronScheduler(CronScheduler):
                                     sync=False,
                                     can_dispatch=can_dispatch,
                                 )
+                            _profile_ok = True
+                        except BaseException as _pe:
+                            logger.error(
+                                "Cron tick error for profile %s: %s",
+                                profile_name, _pe, exc_info=True,
+                            )
+                            _tick_errors[profile_name] = (
+                                f"{type(_pe).__name__}: {_pe}"
+                            )
                         finally:
                             reset_hermes_home_override(home_token)
-                ok = True
+                        # Record heartbeat and tick-error right after each
+                        # profile's tick (inside the scope where
+                        # hermes_home_override is still active and the cron
+                        # store is open) so there is no ambiguity about which
+                        # profile's files are written (#74878).
+                        _hb_token = set_hermes_home_override(str(home))
+                        try:
+                            with use_cron_store(home):
+                                record_ticker_heartbeat(success=_profile_ok)
+                                if _profile_ok:
+                                    clear_ticker_error()
+                                elif _profile_name := _tick_errors.get(profile_name):
+                                    record_ticker_error(_profile_name)
+                        finally:
+                            reset_hermes_home_override(_hb_token)
+                        if not _profile_ok:
+                            _all_ok = False
             except BaseException as e:
-                logger.error("Cron tick error: %s", e, exc_info=True)
-                _tick_error = f"{type(e).__name__}: {e}"
-            else:
-                _tick_error = None
-            # Record per-profile heartbeat after each tick cycle.
-            for entry in profile_homes:
-                home = entry[1] if isinstance(entry, tuple) else entry
-                home_token = set_hermes_home_override(str(home))
-                try:
-                    with use_cron_store(home):
-                        record_ticker_heartbeat(success=ok)
-                        # Surface the failure reason (or clear it) per profile
-                        # so `hermes cron status` can show WHY ticks fail
-                        # (#68483).
-                        if ok:
-                            clear_ticker_error()
-                        elif _tick_error:
-                            record_ticker_error(_tick_error)
-                finally:
-                    reset_hermes_home_override(home_token)
+                # Outer catch for failures in can_dispatch() itself or
+                # unexpected iteration-level errors (e.g. profile_homes mutated).
+                # This is intentionally broad: the ticker thread MUST survive.
+                logger.error("Cron tick cycle error: %s", e, exc_info=True)
+                # Record a fallback heartbeat on every profile so the status
+                # endpoint can detect the ticker is alive but failing.
+                for entry in profile_homes:
+                    home = entry[1] if isinstance(entry, tuple) else entry
+                    profile_name = entry[0] if isinstance(entry, tuple) else str(home)
+                    _fb_token = set_hermes_home_override(str(home))
+                    try:
+                        with use_cron_store(home):
+                            record_ticker_heartbeat(success=False)
+                            record_ticker_error(f"{type(e).__name__}: {e}")
+                    finally:
+                        reset_hermes_home_override(_fb_token)
+                _all_ok = False
+
             stop_event.wait(interval)


### PR DESCRIPTION
Fixes #74878 — refactored _start_multiplex() to guard each profile's cron_tick() independently so one profile's failure doesn't skip the rest.