### PR TITLE
fix(gateway): isolate PID check and credentials per profile (#74872)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -580,6 +580,30 @@ def _build_pid_record() -> dict:
     }
 
 
+def _pid_record_belongs_to_current_profile(
+    record: Optional[dict[str, Any]],
+) -> bool:
+    """Return True when the PID record's ``hermes_home`` matches the current process.
+
+    PID records written by ``_build_pid_record()`` include the gateway's
+    ``hermes_home`` at write time. If a profile gateway was started (or recorded)
+    under a different HERMES_HOME, the record belongs to a different profile
+    and must be ignored — otherwise the default-profile gateway can mistakenly
+    assume the identity of another profile (issue #74872).
+
+    Records that predate the ``hermes_home`` field (pre-#74872 gateways) are
+    accepted conservatively (no field → assume current profile).
+    """
+    if not isinstance(record, dict):
+        return False
+    record_home = record.get("hermes_home")
+    if not record_home:
+        # Records without hermes_home belong to a pre-#74872 gateway;
+        # accept them conservatively.
+        return True
+    return _same_hermes_home(record_home, _get_process_hermes_home())
+
+
 def _build_runtime_status_record() -> dict[str, Any]:
     payload = _build_pid_record()
     payload.update({
@@ -1327,6 +1351,13 @@ def get_runtime_status_running_pid(
         and current_start is not None
         and current_start != recorded_start
     ):
+        return None
+
+    # When no explicit expected_home is given (active profile context),
+    # verify the persisted record's hermes_home matches the current process.
+    # This prevents the default-profile gateway from assuming another
+    # profile's identity via a stale runtime status record (#74872).
+    if expected_home is None and not _pid_record_belongs_to_current_profile(payload):
         return None
 
     if _record_matches_live_gateway_pid(payload, pid, expected_home=expected_home):
@@ -2190,6 +2221,9 @@ def get_running_pid(
         recorded_start = record.get("start_time")
         current_start = _get_process_start_time(pid)
         if recorded_start is not None and current_start is not None and current_start != recorded_start:
+            continue
+
+        if not _pid_record_belongs_to_current_profile(record):
             continue
 
         if _record_matches_live_gateway_pid(record, pid):

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4778,6 +4778,24 @@ def _guard_existing_gateway_process_conflict(replace: bool = False) -> None:
         logger.debug("Existing-gateway process probe failed", exc_info=True)
         return
     if pid is None:
+        # get_running_pid() now filters records by the current profile's
+        # HERMES_HOME (via _pid_record_belongs_to_current_profile). When no
+        # match was found, check whether a stale PID file from a different
+        # profile exists — the user may have switched profiles while the old
+        # gateway is still running.
+        try:
+            from gateway.status import _read_pid_record, _pid_record_belongs_to_current_profile
+
+            stale = _read_pid_record()
+            if stale is not None and not _pid_record_belongs_to_current_profile(stale):
+                stale_home = stale.get("hermes_home", "<unknown>")
+                logger.warning(
+                    "PID file belongs to another profile (hermes_home=%s). "
+                    "The old gateway may still be running under that profile.",
+                    stale_home,
+                )
+        except Exception:
+            pass
         return
 
     print_error(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -626,7 +626,14 @@ def _apply_profile_override() -> None:
     hermes_home_env = os.environ.get("HERMES_HOME", "")
     if profile_name is None and hermes_home_env:
         if Path(hermes_home_env).parent.name == "profiles":
-            return
+            # The existing HERMES_HOME points to a specific profile directory,
+            # but no explicit --profile flag was given. Previously this returned
+            # early, trusting the pre-set HERMES_HOME — but if it was set for a
+            # different profile (e.g. by a previous gateway invocation), the
+            # default-profile gateway would incorrectly assume that identity.
+            # Clear HERMES_HOME and fall through to the active_profile sticky
+            # logic below so the correct profile is resolved. See issue #74872.
+            del os.environ["HERMES_HOME"]
 
     # 2. If no flag, check active_profile in the hermes root.
     #


### PR DESCRIPTION
Fixes #74872 — gateway profile identity isolation.

## Changes
- **gateway/status.py** (+34): `_pid_record_belongs_to_current_profile()` helper; used in `get_running_pid()` and `get_runtime_status_running_pid()` to skip PID records from other profiles
- **hermes_cli/main.py** (+9/-1): `_apply_profile_override()` clears stale HERMES_HOME instead of early-returning
- **hermes_cli/gateway.py** (+18): `_guard_existing_gateway_process_conflict()` warns about stale PID files from other profiles