### PR TITLE
fix(desktop): Windows update race — retry scanVenvBlockers, skip startHermes on remnants, clean stale marker (#74805)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2732,10 +2732,11 @@ async function releaseBackendLockForUpdate(updateRoot) {
 // locks — the before-quit SIGTERM + the cleanup script's own PID-wait suffice).
 async function releaseBackendLock(updateRoot, tag) {
   if (!IS_WINDOWS) {
-    return { unlocked: true }
+    return { unlocked: true, killedPids: [] }
   }
 
   // Collect every backend PID the desktop owns: primary window backend + pool.
+  const killedPids = new Set()
   const pids = []
   const hermesProcess = backendConnectionState.getProcess()
 
@@ -2761,6 +2762,7 @@ async function releaseBackendLock(updateRoot, tag) {
   stopAllPoolBackends()
 
   for (const pid of pids) {
+    killedPids.add(pid)
     forceKillProcessTree(pid)
   }
 
@@ -2771,7 +2773,7 @@ async function releaseBackendLock(updateRoot, tag) {
     if (!isShimLocked(shim)) {
       rememberLog(`[${tag}] venv shim unlocked; safe to proceed`)
 
-      return { unlocked: true }
+      return { unlocked: true, killedPids: Array.from(killedPids) }
     }
 
     // A supervised backend can respawn between kill and check (grandchildren,
@@ -2792,6 +2794,7 @@ async function releaseBackendLock(updateRoot, tag) {
     }
 
     for (const pid of stragglers) {
+      killedPids.add(pid)
       forceKillProcessTree(pid)
     }
 
@@ -2809,7 +2812,7 @@ async function releaseBackendLock(updateRoot, tag) {
     `[${tag}] venv shim still locked after 15s; aborting hand-off (something outside this app holds the venv)`
   )
 
-  return { unlocked: false }
+  return { unlocked: false, killedPids: Array.from(killedPids) }
 }
 
 // applyUpdates — hand off to the installer's --update flow, then exit.
@@ -2933,16 +2936,30 @@ async function applyUpdates(opts = {}) {
     // malformed output, missing psutil) abort the handoff — never proceed
     // to the detached updater when the venv state is unknown.
     if (IS_WINDOWS) {
-      const scanOutcome = await scanVenvBlockers(updateRoot)
+      const scanOutcome = await scanVenvBlockers(updateRoot, undefined, undefined, HERMES_HOME)
 
       if (scanOutcome.kind === 'blocked') {
-        const message = formatBlockerMessage(scanOutcome.result)
+        const blockerPids = scanOutcome.result.processes.map(p => p.pid)
+        const killedPids = lock.killedPids ?? []
+        const allAreRemnants = blockerPids.length > 0 &&
+          blockerPids.every(pid => killedPids.includes(pid))
 
-        rememberLog(`[updates] venv-blocked: ${scanOutcome.result.processes.length} process(es) hold the install`)
-        emitUpdateProgress({ stage: 'error', message, percent: null })
-        startHermes().catch(() => {})
+        if (allAreRemnants) {
+          // All blockers are remnants of our own tree-kill (processes still
+          // winding down).  They'll exit momentarily — no need to restart
+          // the backend or abort the update.  Just log and proceed.
+          rememberLog(
+            `[updates] blocker PIDs ${blockerPids.join(',')} are remnants of our own kill; proceeding`
+          )
+        } else {
+          const message = formatBlockerMessage(scanOutcome.result)
 
-        return { ok: false, error: 'venv-blocked', message }
+          rememberLog(`[updates] venv-blocked: ${scanOutcome.result.processes.length} process(es) hold the install`)
+          emitUpdateProgress({ stage: 'error', message, percent: null })
+          startHermes().catch(() => {})
+
+          return { ok: false, error: 'venv-blocked', message }
+        }
       }
 
       if (scanOutcome.kind === 'probe-failure') {

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -109,18 +109,16 @@ export function parseVenvBlockerScanOutput(raw: string): ScanOutcome {
 }
 
 /**
- * Run the venv-blocker scan subprocess.  Async so the Electron main-process
- * event loop is never blocked by the psutil process scan (up to 15s on a
- * loaded Windows box).  Accepts optional overrides for testing (dependency
- * injection).
+ * Run a single venv-blocker scan subprocess.  Extracted as a helper so
+ * scanVenvBlockers can retry transient failures.  Async so the Electron
+ * main-process event loop is never blocked by the psutil process scan
+ * (up to 15s on a loaded Windows box).
  */
-export async function scanVenvBlockers(
+async function runSingleScan(
   updateRoot: string,
-  execOverride?: typeof execFileAsync,
-  resolveOverride?: typeof resolveVenvPython
+  execFn: typeof execFileAsync,
+  resolveFn: typeof resolveVenvPython
 ): Promise<ScanOutcome> {
-  const execFn = execOverride || execFileAsync
-  const resolveFn = resolveOverride || resolveVenvPython
   const venvPython = resolveFn(updateRoot)
 
   if (!venvPython) {
@@ -149,6 +147,61 @@ export async function scanVenvBlockers(
   }
 
   return parseVenvBlockerScanOutput(stdout)
+}
+
+/**
+ * Run the venv-blocker scan subprocess with a retry loop.  Transient
+ * subprocess failures (e.g. race with the backend being mid-shutdown on
+ * Windows) are retried up to 3 times with 500ms settling delays, so a
+ * momentary probe failure does not abort the update preflight.  Accepts
+ * optional overrides for testing (dependency injection).
+ *
+ * @param updateRoot   Root of the hermetic Hermes install to scan.
+ * @param execOverride  Optional execFile override for tests.
+ * @param resolveOverride  Optional venv-python resolver override for tests.
+ * @param hermesHome   Optional HERMES_HOME path.  When provided, cleans
+ *                     any stale update-in-progress marker before scanning,
+ *                     preventing false positives from orphaned markers
+ *                     (#74805).
+ */
+export async function scanVenvBlockers(
+  updateRoot: string,
+  execOverride?: typeof execFileAsync,
+  resolveOverride?: typeof resolveVenvPython,
+  hermesHome?: string
+): Promise<ScanOutcome> {
+  const execFn = execOverride || execFileAsync
+  const resolveFn = resolveOverride || resolveVenvPython
+
+  // Clean stale update marker before scanning, so an orphaned
+  // .hermes-update-in-progress from a prior crashed update does not
+  // cause false positives (#74805).
+  if (hermesHome) {
+    try {
+      const { readLiveUpdateMarker } = await import('./update-marker')
+      readLiveUpdateMarker(hermesHome)
+    } catch {
+      // Best-effort: if the import or cleanup fails, proceed anyway.
+    }
+  }
+
+  // Retry loop: transient probe failures (race with backend shutdown,
+  // module-not-found during parallel pip install, etc.) settle after
+  // a short delay.  True 'blocked' or 'clear' outcomes are final.
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    const outcome = await runSingleScan(updateRoot, execFn, resolveFn)
+
+    if (outcome.kind !== 'probe-failure') {
+      return outcome
+    }
+
+    if (attempt < 3) {
+      await new Promise(r => setTimeout(r, 500))
+    }
+  }
+
+  // All 3 attempts failed — surface the last probe-failure.
+  return runSingleScan(updateRoot, execFn, resolveFn)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #74805 — Windows update race condition where `scanVenvBlockers` runs while the backend is mid-shutdown, detects remnants as blockers, and aborts the update unnecessarily.

## Changes

### `venv-blocker-scan.ts`
- **Extract `runSingleScan()` helper**: The subprocess invocation logic moves into a private helper, making `scanVenvBlockers` the retry orchestrator.
- **Add retry loop**: 3 attempts with 500ms settling delay between each. Only retries on `probe-failure` — `blocked`/`clear` outcomes are immediate and final.
- **Add optional `hermesHome` param**: When provided, cleans any stale `.hermes-update-in-progress` marker before scanning, preventing false positives from orphaned markers left by crashed updates.

### `main.ts` — `releaseBackendLock`
- **Return `killedPids`**: The function now tracks every PID it tree-kills (initial sweep + stragglers in the polling loop) and returns them as `killedPids: number[]` alongside `unlocked: boolean`. All return sites updated, including the no-op POSIX path (`{ unlocked: true, killedPids: [] }`).

### `main.ts` — `applyUpdates`
- **Remnants check**: After `releaseBackendLockForUpdate` kills our own backends, `scanVenvBlockers` may still find them alive (processes take a moment to fully exit). If all blocker PIDs are a subset of the PIDs we just killed, the update proceeds without aborting or calling `startHermes()`.
- **Updated `scanVenvBlockers` call**: Passes `HERMES_HOME` so stale markers are cleaned before scanning.

## Testing

- Existing unit tests for `venv-blocker-scan.ts` continue to pass (the `runSingleScan` refactor preserves the same logic).
- The retry loop only activates on `probe-failure`, so existing `blocked`/`clear` test cases are unaffected.
- The remnants check is a pure PID-set comparison — testable at the unit level if needed.

Fixes #74805