### PR TITLE
fix(openviking): don't spawn a second server onto a live port (#74846)

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -33,6 +33,7 @@ import mimetypes
 import os
 import re
 import shutil
+import socket
 import stat
 import subprocess
 import tempfile
@@ -126,6 +127,10 @@ _GENERATED_MEMORY_SUMMARY_FILENAMES = {
 }
 _LOCAL_OPENVIKING_HOSTS = {"localhost", "127.0.0.1", "::1"}
 _LOCAL_OPENVIKING_AUTOSTART_TIMEOUT = 60.0
+# Pre-spawn liveness probe budget. A loopback TCP connect either completes or
+# is refused in well under this; it exists only so a wedged listener cannot
+# block the autostart path.
+_LOCAL_OPENVIKING_PROBE_TIMEOUT = 2.0
 # After a refresh attempt fails for a given (unchanged) config, skip re-probing
 # for this long. Keeps "unavailable endpoints reconnect on a later access"
 # true while preventing every provider access from paying a 3s health probe
@@ -1214,14 +1219,36 @@ def _openviking_server_log_path() -> Path:
     return home / _OPENVIKING_SERVER_LOG_RELATIVE_PATH
 
 
+def _local_openviking_port_is_open(host: str, port: int) -> bool:
+    """Return True when something already accepts TCP connections on host:port.
+
+    Used as a pre-spawn guard only. A successful connect proves a listener owns
+    the port, which is enough to know a second ``openviking-server`` would lose
+    the data-directory lock — it deliberately says nothing about whether that
+    listener is healthy.
+    """
+    try:
+        with socket.create_connection((host, port), timeout=_LOCAL_OPENVIKING_PROBE_TIMEOUT):
+            return True
+    except OSError:
+        return False
+
+
 def _start_local_openviking_server(endpoint: str) -> tuple[bool, str]:
-    server_cmd = shutil.which("openviking-server")
-    if not server_cmd:
-        return False, "openviking-server was not found on PATH. Start it manually, then retry."
     try:
         host, port = _local_openviking_bind(endpoint)
     except ValueError as e:
         return False, f"Could not parse local OpenViking URL: {e}"
+    # Health probes can time out client-side while the server is up and well.
+    # Spawning on that signal alone produces a process that immediately dies on
+    # DataDirectoryLocked, and — because the probe keeps timing out — repeats
+    # every cooldown window. Treat an occupied port as "already started": both
+    # callers only need the server running, not started by us.
+    if _local_openviking_port_is_open(host, port):
+        return True, f"openviking-server is already running on {host}:{port}."
+    server_cmd = shutil.which("openviking-server")
+    if not server_cmd:
+        return False, "openviking-server was not found on PATH. Start it manually, then retry."
     log_path = _openviking_server_log_path()
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,5 +1,6 @@
 import json
 import os
+import socket
 import stat
 import threading
 import time
@@ -268,6 +269,7 @@ def test_start_local_openviking_server_uses_endpoint_host_and_port(monkeypatch):
         popen_calls.append((args, kwargs))
         return object()
 
+    monkeypatch.setattr(openviking_module, "_local_openviking_port_is_open", lambda host, port: False)
     monkeypatch.setattr(openviking_module.shutil, "which", lambda name: "/usr/local/bin/openviking-server")
     monkeypatch.setattr(openviking_module.subprocess, "Popen", fake_popen)
 
@@ -278,6 +280,69 @@ def test_start_local_openviking_server_uses_endpoint_host_and_port(monkeypatch):
     args, kwargs = popen_calls[0]
     assert args == ["/usr/local/bin/openviking-server", "--host", "127.0.0.1", "--port", "1934"]
     assert kwargs["start_new_session"] is True
+
+
+def test_start_local_openviking_server_does_not_spawn_when_port_already_open(monkeypatch):
+    """A live listener means a second server would just die on DataDirectoryLocked."""
+    probed = []
+
+    def fake_probe(host, port):
+        probed.append((host, port))
+        return True
+
+    monkeypatch.setattr(openviking_module, "_local_openviking_port_is_open", fake_probe)
+    monkeypatch.setattr(openviking_module.shutil, "which", lambda name: "/usr/local/bin/openviking-server")
+    monkeypatch.setattr(
+        openviking_module.subprocess,
+        "Popen",
+        MagicMock(side_effect=AssertionError("must not spawn while a server is already listening")),
+    )
+
+    started, message = openviking_module._start_local_openviking_server("http://127.0.0.1:1934")
+
+    assert started is True
+    assert "already running" in message
+    assert probed == [("127.0.0.1", 1934)]
+
+
+def test_start_local_openviking_server_reports_running_server_without_cli_on_path(monkeypatch):
+    """The port probe outranks PATH: a reachable server is started, whoever launched it."""
+    monkeypatch.setattr(openviking_module, "_local_openviking_port_is_open", lambda host, port: True)
+    monkeypatch.setattr(openviking_module.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        openviking_module.subprocess,
+        "Popen",
+        MagicMock(side_effect=AssertionError("must not spawn")),
+    )
+
+    started, message = openviking_module._start_local_openviking_server("http://127.0.0.1:1934")
+
+    assert started is True
+    assert "already running" in message
+
+
+def test_start_local_openviking_server_rejects_unparseable_url_before_probing(monkeypatch):
+    monkeypatch.setattr(
+        openviking_module,
+        "_local_openviking_port_is_open",
+        MagicMock(side_effect=AssertionError("must not probe an unparseable endpoint")),
+    )
+
+    started, message = openviking_module._start_local_openviking_server("http://127.0.0.1:not-a-port")
+
+    assert started is False
+    assert "Could not parse local OpenViking URL" in message
+
+
+def test_local_openviking_port_is_open_detects_listener_and_closed_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        _host, port = listener.getsockname()
+        assert openviking_module._local_openviking_port_is_open("127.0.0.1", port) is True
+
+    # Socket closed: the same port no longer accepts connections.
+    assert openviking_module._local_openviking_port_is_open("127.0.0.1", port) is False
 
 
 def test_https_local_endpoint_is_not_runtime_autostart_eligible(monkeypatch):


### PR DESCRIPTION
## What & why

Fixes #74846.

`_start_local_openviking_server()` spawns `openviking-server` unconditionally. Both call sites reach it from a health probe:

| Call site | When |
|---|---|
| `initialize()` | gateway startup |
| `_handle_runtime_openviking_unreachable()` | every health-check cycle that classifies `unreachable` |

`_VikingClient.health()` can time out client-side while the server is genuinely up (`curl /health` returns 200). That produces `unreachable`, which spawns a second server; the new process loses the data-directory lock and exits immediately with `DataDirectoryLocked`. Since the probe keeps timing out, this repeats every cooldown window — the reporter measured a spawn roughly every 5 minutes, ~18 `DataDirectoryLocked` per day.

The existing 30s `_failed_refresh` cooldown paces the loop but can't stop it: it expires while the underlying condition persists. A longer cooldown would only slow the bleeding, so this fixes the spawn decision itself.

## The change

Probe the target `host:port` before spawning; an occupied port means "already started". Both call sites converge on this function, so one guard covers every path.

Two deliberate details:

- **The probe tests liveness, not health.** A successful TCP connect proves a listener owns the port, which is all that's needed to know a second server would lose the lock. Whether that listener is *healthy* is a different question, already handled by the existing waiter/cooldown machinery — this change doesn't touch it.
- **Parse + probe now precede the `shutil.which()` lookup.** A reachable server is reported as running even when `openviking-server` isn't on `PATH` (e.g. started by systemd or another venv). Previously that returned "not found on PATH" despite a perfectly good server listening.

No change to the fallback-to-disabled behavior when nothing is listening and no binary exists.

## Tests

`tests/plugins/memory/test_openviking_provider.py`:

- `..._does_not_spawn_when_port_already_open` — `Popen` raises if called
- `..._reports_running_server_without_cli_on_path` — probe outranks `PATH`
- `..._rejects_unparseable_url_before_probing` — no probe on a bad endpoint
- `_local_openviking_port_is_open` against a real bound loopback socket, then against the same port after close (true/false without mocking the syscall)

The pre-existing `..._uses_endpoint_host_and_port` test now stubs the probe explicitly rather than depending on nothing happening to listen on port 1934 in CI.

```
51 passed  # tests/plugins/memory/test_openviking_provider.py + tests/openviking_plugin/
```

## Platforms

Tested on macOS 15 (Darwin 25.5.0), Python 3.11. `socket.create_connection` + `OSError` handling is platform-neutral; the 2s budget only bounds a wedged listener, since a loopback connect resolves or refuses far below it.

## Duplicate check

`gh search prs` for `DataDirectoryLocked` returns no open or closed PRs, and no open PR references #74846.


---
*Authored by an AI agent (Claude Opus 5) operating autonomously on @jeff-mettel's behalf: the defect was traced, the patch written, and the tests run and verified end-to-end before submission.*