### PR TITLE
fix(memory/holographic): unbind doesnt compose through bundle

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -177,13 +177,13 @@ class FactRetriever:
         for row in rows:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
-            # Unbind probe key from fact to see if entity is structurally present
-            residual = hrr.unbind(fact_vec, probe_key)
-            # Compare residual against content signal
-            role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
-            content_vec = hrr.bind(hrr.encode_text(fact["content"], self.hrr_dim), role_content)
-            sim = hrr.similarity(residual, content_vec)
-            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
+            # Direct similarity check — unbind does not compose through
+            # the non-linear bundle (circular mean of complex exponentials),
+            # so the previous unbind-through-bundle approach collapsed to noise.
+            sim = hrr.similarity(fact_vec, probe_key)
+            # Score by raw similarity only; trust is already a minimum filter
+            # in the SQL WHERE clause and multiplying it drowns signal below noise.
+            fact["score"] = (sim + 1.0) / 2.0
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
@@ -472,7 +472,7 @@ class FactRetriever:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
             sim = hrr.similarity(target_vec, fact_vec)
-            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
+            fact["score"] = (sim + 1.0) / 2.0
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -83,12 +83,36 @@ _TRUST_MAX       =  1.0
 
 # Entity extraction patterns
 _RE_CAPITALIZED  = re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b')
+_RE_SINGLE_CAP   = re.compile(r'\b([A-Z][a-z]{2,})\b')  # Single-word proper nouns e.g. "Nevaeh", "Jake"
+_RE_HYPHENATED   = re.compile(r'\b([A-Z][a-z]+(?:-[A-Za-z][a-z]*)+)\b')  # Hyphenated e.g. "Pi-hole"
 _RE_DOUBLE_QUOTE = re.compile(r'"([^"]+)"')
 _RE_SINGLE_QUOTE = re.compile(r"'([^']+)'")
 _RE_AKA          = re.compile(
     r'(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)',
     re.IGNORECASE,
 )
+
+# Stoplist: common English words that happen to be capitalized but aren't entities.
+# Excludes function words, pronouns, conjunctions, prepositions, quantifiers, and
+# sentence-starters that would pollute entity extraction. Deliberately kept small —
+# false positives (missing a real entity) are worse than false negatives (storing a
+# common word as an entity, which just adds noise to the HRR bundle).
+_ENTITY_STOPLIST: frozenset[str] = frozenset({
+    "The", "A", "An", "This", "That", "These", "Those",
+    "It", "He", "She", "They", "We", "You", "I", "Me", "Us", "Him", "Her", "Them",
+    "Is", "Are", "Was", "Were", "Be", "Been", "Has", "Have", "Had",
+    "Do", "Does", "Did", "Will", "Would", "Can", "Could", "Should", "May", "Might",
+    "Not", "No", "Yes", "But", "And", "Or", "Nor",
+    "If", "In", "On", "At", "To", "For", "With", "From", "By", "As", "Of", "Into", "Over",
+    "All", "Any", "Some", "Each", "Both", "Few", "Many", "Most", "Other", "Such",
+    "Only", "Own", "Same", "So", "Than", "Too", "Very", "Just",
+    "Now", "Then", "Also", "Even", "Still", "Yet", "Like", "Get", "Got",
+    "One", "Two", "Three", "First", "Last", "New", "Old", "More", "Less",
+    "After", "Before", "During", "Since", "Until", "While",
+    "About", "Above", "Across", "Again", "Against", "Along", "Among", "Around",
+    "Here", "There", "Where", "When", "Why", "How", "What", "Which", "Who",
+    "However", "Therefore", "Because", "Although", "Though", "Unless", "Whether",
+})
 
 
 def _clamp_trust(value: float) -> float:
@@ -449,9 +473,11 @@ class MemoryStore:
 
         Rules applied (in order):
         1. Capitalized multi-word phrases  e.g. "John Doe"
-        2. Double-quoted terms             e.g. "Python"
-        3. Single-quoted terms             e.g. 'pytest'
-        4. AKA patterns                    e.g. "Guido aka BDFL" -> two entities
+        2. Single capitalized words (≥3 chars, not in stoplist)  e.g. "Nevaeh"
+        3. Hyphenated capitalized phrases  e.g. "Pi-hole"
+        4. Double-quoted terms             e.g. "Python"
+        5. Single-quoted terms             e.g. 'pytest'
+        6. AKA patterns                    e.g. "Guido aka BDFL" -> two entities
 
         Returns a deduplicated list preserving first-seen order.
         """
@@ -465,6 +491,14 @@ class MemoryStore:
                 candidates.append(stripped)
 
         for m in _RE_CAPITALIZED.finditer(text):
+            _add(m.group(1))
+
+        for m in _RE_SINGLE_CAP.finditer(text):
+            word = m.group(1)
+            if word not in _ENTITY_STOPLIST:
+                _add(word)
+
+        for m in _RE_HYPHENATED.finditer(text):
             _add(m.group(1))
 
         for m in _RE_DOUBLE_QUOTE.finditer(text):


### PR DESCRIPTION
Noticed the holographic probe was returning nonsense for single-word entity
names when i was debugging why my fact store wasnt surfacing obvious facts.

Two things going on:

The entity extractor only matched multi-word capitalized phrases, so names
like "Jake" or "Pi-hole" never got linked to facts. Added single-cap and
hyphenated patterns with a stoplist.  

The probe method was doing unbind() through bundle(), but bundle is a
circular mean of complex exponentials — non-linear — so it doesnt compose.
Swapped to direct similarity(fact, probe_key) which actually separates
signal from noise (~0.2-0.4 vs ~0.0). Also dropped trust multiplication
from the score since its already filtered in the WHERE clause and it just
pushes low-trust hits below random noise anyways.

Tested against my store — probe went from returning 1/10 relevant results
to 10/10.