### PR TITLE
fix(gateway): deliver approval prompts for profiles without their own platform adapter (#74787)

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -125,6 +125,41 @@ class GatewayAuthorizationMixin:
             getattr(source, "profile", None),
         )
 
+    def _delivery_adapter_for_source(self, source: Optional[SessionSource]):
+        """Resolve an adapter for delivery (status, typing, approval, reply).
+
+        Unlike ``_adapter_for_source``, which returns ``None`` in multiplex
+        mode when a secondary profile owns no adapter for the source's platform
+        (correct for authorization — fail closed), this method falls back to the
+        default profile's adapter for the same platform so that approval prompts,
+        typing indicators, status messages, and replies are still delivered.
+
+        Returns the transport adapter, the profile-scoped adapter, the default
+        profile's same-platform adapter, or ``None`` if no adapter is registered
+        for the platform at all.
+        """
+        if source is None:
+            return None
+        # 1. Prefer the transport adapter that owns the source's connection.
+        adapter = self._registered_transport_adapter(source)
+        if adapter is not None:
+            return adapter
+        # 2. Try the authorization-aware lookup (profile-scoped adapter).
+        platform = getattr(source, "platform", None)
+        profile = getattr(source, "profile", None)
+        adapter = self._authorization_adapter(platform, profile)
+        if adapter is not None:
+            return adapter
+        # 3. Fallback: use the default profile's same-platform adapter so
+        #    delivery still reaches the user even when a secondary profile
+        #    has no dedicated adapter for this platform (multiplex mode).
+        if platform is not None:
+            adapters = getattr(self, "adapters", None) or {}
+            adapter = adapters.get(platform)
+            if adapter is not None:
+                return adapter
+        return None
+
     def _registered_transport_adapter(self, source: SessionSource):
         """Return the registered adapter that created *source*, if retained.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4804,6 +4804,13 @@ class TurnRunner:
                 UX.  Otherwise fall back to a plain text message with
                 ``/approve`` instructions.
                 """
+            if not ctx._status_adapter:
+                logger.warning(
+                    "Approval prompt skipped: no delivery adapter available for %s/%s",
+                    ctx.source.platform,
+                    ctx.session_key,
+                )
+                return
             # Pause the typing indicator while the agent waits for
             # user approval.  Critical for Slack's Assistant API where
             # assistant_threads_setStatus disables the compose box — the
@@ -23575,7 +23582,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         turn_ctx._event_callback_sync = turn_runner._event_callback_sync
 
         # Bridge sync status_callback → async adapter.send for context pressure
-        _status_adapter = self._adapter_for_source(source)
+        _status_adapter = self._delivery_adapter_for_source(source)
         _status_chat_id = source.chat_id
         if source.platform == Platform.FEISHU and source.thread_id and event_message_id:
             # Feishu topics only keep messages inside the topic when they are


### PR DESCRIPTION
Fixes #74787

## Problem
In multiplex_profiles mode, `_adapter_for_source()` returns `None` for secondary profiles that don't own a platform adapter. This is correct for authorization (fail-closed), but the same resolver was used to set `ctx._status_adapter` — causing `AttributeError` on all outbound delivery paths (approval, typing, status, clarify).

## Fix
- **gateway/authz_mixin.py** (+41): New `_delivery_adapter_for_source()` with 3-tier fallback: transport adapter → profile-scoped adapter → default profile's same-platform adapter
- **gateway/run.py** (+2): Switched `_adapter_for_source` → `_delivery_adapter_for_source` when setting `ctx._status_adapter`; added explicit `None` guard in approval path