### PR TITLE
test(modal): isolate lazy dependency gate

### DIFF
--- a/tests/tools/test_modal_snapshot_isolation.py
+++ b/tests/tools/test_modal_snapshot_isolation.py
@@ -127,6 +127,10 @@ def _install_modal_test_modules(
         iter_skills_files=lambda **kw: [],
         iter_cache_files=lambda **kw: [],
     )
+    lazy_ensure_calls: list[tuple[str, bool]] = []
+    sys.modules["tools.lazy_deps"] = types.SimpleNamespace(
+        ensure=lambda feature, *, prompt=True: lazy_ensure_calls.append((feature, prompt)),
+    )
 
     from_id_calls: list[str] = []
     registry_calls: list[tuple[str, list[str] | None]] = []
@@ -193,6 +197,7 @@ def _install_modal_test_modules(
         "snapshot_store": hermes_home / "modal_snapshots.json",
         "create_calls": create_calls,
         "from_id_calls": from_id_calls,
+        "lazy_ensure_calls": lazy_ensure_calls,
         "registry_calls": registry_calls,
     }
 
@@ -208,6 +213,10 @@ def test_modal_environment_migrates_legacy_snapshot_key_and_uses_snapshot_id(tmp
 
     try:
         assert state["from_id_calls"] == ["im-legacy123"]
+        assert state["lazy_ensure_calls"] == [
+            ("terminal.modal", False),
+            ("terminal.modal", False),
+        ]
         assert state["create_calls"][0]["image"] == {"kind": "snapshot", "image_id": "im-legacy123"}
         assert json.loads(snapshot_store.read_text()) == {"direct:task-legacy": "im-legacy123"}
     finally:
@@ -223,6 +232,10 @@ def test_resolve_modal_image_uses_snapshot_ids_and_registry_images(tmp_path):
 
     assert snapshot_image == {"kind": "snapshot", "image_id": "im-snapshot123"}
     assert registry_image == {"kind": "registry", "image": "python:3.11"}
+    assert state["lazy_ensure_calls"] == [
+        ("terminal.modal", False),
+        ("terminal.modal", False),
+    ]
     assert state["from_id_calls"] == ["im-snapshot123"]
     assert state["registry_calls"][0][0] == "python:3.11"
     assert "ensurepip" in state["registry_calls"][0][1][0]


### PR DESCRIPTION
## What does this PR do?

Fixes the current `tests/tools/test_modal_snapshot_isolation.py` regression introduced when Modal became a lazy dependency. The test already installs a complete fake Modal SDK, but `_ensure_modal_sdk()` still imports the real `tools.lazy_deps.ensure`; on machines with `security.allow_lazy_installs: false`, both isolation tests fail before reaching the behavior they are intended to cover.

The fixture now supplies a fake `tools.lazy_deps` module and records the call, so the tests remain hermetic while still proving production requests `terminal.modal` with `prompt=False`.

## Related Issue

No linked issue; discovered while reconciling a downstream integration against current `main`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/tools/test_modal_snapshot_isolation.py`: stub `tools.lazy_deps.ensure` inside the existing isolated module graph.
- Assert both test paths call the lazy-dependency seam as `ensure("terminal.modal", prompt=False)`.

## How to Test

1. Set `security.allow_lazy_installs: false` and run the current test on `main`; both tests fail with `Feature 'terminal.modal' unavailable`.
2. Check out this branch.
3. Run `scripts/run_tests.sh -j 1 tests/tools/test_modal_snapshot_isolation.py`; both tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1 (Apple Silicon)

### Documentation & Housekeeping

- [x] Documentation update: N/A, test-only isolation repair
- [x] `cli-config.yaml.example`: N/A, no config changes
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no workflow or architecture changes
- [x] Cross-platform impact considered: the fake module removes host-config dependence
- [x] Tool descriptions/schemas: N/A, no tool behavior change

## Screenshots / Logs

Before this patch on current `main`:

```text
2 failed
ImportError: Feature 'terminal.modal' unavailable: lazy installs disabled
```

After this patch:

```text
scripts/run_tests.sh -j 1 tests/tools/test_modal_snapshot_isolation.py
2 passed, 0 failed
```