### PR TITLE
fix(gateway): start idle /goal kickoffs immediately

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17285,15 +17285,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # already completed platform delivery, so a post-delivery
                 # callback registered now would never fire.
                 if response.strip():
-                    try:
-                        await self._post_turn_goal_continuation(
-                            session_entry=session_entry,
-                            source=source,
-                            final_response=response,
-                            response_already_delivered=True,
-                        )
-                    except Exception as _goal_exc:
-                        logger.debug("goal continuation hook after streamed response failed: %s", _goal_exc)
+                    await self._post_streamed_goal_turn(
+                        session_entry=session_entry,
+                        source=source,
+                        final_response=response,
+                    )
                 return None
 
             return response
@@ -17994,6 +17990,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._enqueue_fifo(_quick_key, cont_event, adapter)
         except Exception as exc:
             logger.debug("goal continuation: enqueue failed: %s", exc)
+
+    async def _post_streamed_goal_turn(
+        self,
+        *,
+        session_entry: Any,
+        source: Any,
+        final_response: str,
+    ) -> None:
+        """Judge a response whose streaming delivery already completed.
+
+        ``_handle_message_with_agent`` returns ``None`` for an already-sent
+        response, so the ordinary outer turn hook cannot see its final text.
+        Keep this boundary explicit and tested; status delivery must be direct
+        because the adapter's post-delivery callback has already fired.
+        """
+        try:
+            await self._post_turn_goal_continuation(
+                session_entry=session_entry,
+                source=source,
+                final_response=final_response,
+                response_already_delivered=True,
+            )
+        except Exception as exc:
+            logger.debug("goal continuation hook after streamed response failed: %s", exc)
 
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17277,6 +17277,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
+                # The outer turn boundary normally runs the goal judge from
+                # this method's returned text. Streaming returns None to avoid
+                # sending the already-delivered response twice, so run the
+                # judge here while the actual final response is still present.
+                # Its status message must be sent directly: streaming has
+                # already completed platform delivery, so a post-delivery
+                # callback registered now would never fire.
+                if response.strip():
+                    try:
+                        await self._post_turn_goal_continuation(
+                            session_entry=session_entry,
+                            source=source,
+                            final_response=response,
+                            response_already_delivered=True,
+                        )
+                    except Exception as _goal_exc:
+                        logger.debug("goal continuation hook after streamed response failed: %s", _goal_exc)
                 return None
 
             return response
@@ -17901,6 +17918,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_entry: Any,
         source: Any,
         final_response: str,
+        response_already_delivered: bool = False,
     ) -> None:
         """Run the goal judge after a gateway turn and, if still active,
         enqueue a continuation prompt for the same session.
@@ -17948,7 +17966,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # an awaited post-delivery callback preserves delivery reliability
         # without reversing the user-visible ordering.
         if msg and source is not None:
-            await self._defer_goal_status_notice_after_delivery(source, msg)
+            if response_already_delivered:
+                await self._send_goal_status_notice(source, msg)
+            else:
+                await self._defer_goal_status_notice_after_delivery(source, msg)
 
         if not decision.get("should_continue"):
             return

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2720,7 +2720,20 @@ class GatewaySlashCommandsMixin:
                     message_id=event.message_id,
                     channel_prompt=event.channel_prompt,
                 )
-                self._enqueue_fifo(_quick_key, kickoff_event, adapter)
+                # Most adapters are still processing the slash-command event
+                # here, and their normal post-command drain will consume a
+                # FIFO entry.  Some command paths (notably Telegram's pending
+                # slash-input flow) dispatch directly to the gateway runner,
+                # however, so there is no adapter frame left to wake a queue.
+                # In that idle case, start the normal adapter pipeline directly
+                # rather than queuing a duplicate that its own drain would run
+                # a second time. Without this, /goal reports success but its
+                # first turn never runs.
+                active = getattr(adapter, "_active_sessions", {})
+                if _quick_key in active:
+                    self._enqueue_fifo(_quick_key, kickoff_event, adapter)
+                else:
+                    await adapter.handle_message(kickoff_event)
             except Exception as exc:
                 logger.debug("goal kickoff enqueue failed: %s", exc)
 

--- a/tests/gateway/test_goal_max_turns_config.py
+++ b/tests/gateway/test_goal_max_turns_config.py
@@ -22,6 +22,18 @@ class _FakeSessionStore:
         return "agent:main:discord:channel:goal-config"
 
 
+class _IdleAdapter:
+    """Command-path adapter probe: no active adapter frame to drain FIFO."""
+
+    def __init__(self):
+        self._pending_messages = {}
+        self._active_sessions = {}
+        self.handled = []
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
 @pytest.mark.asyncio
 async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monkeypatch):
     """Gateway /goal should honor top-level goals.max_turns from config.yaml."""
@@ -58,5 +70,46 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
         state = goals.GoalManager("sid-gateway-goal-config").state
         assert state is not None
         assert state.max_turns == 7
+    finally:
+        goals._DB_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_gateway_goal_starts_kickoff_when_command_has_no_adapter_frame(tmp_path, monkeypatch):
+    """A gateway command path without BasePlatformAdapter's in-band drain
+    must actively wake the queued /goal kickoff instead of leaving turns_used
+    at zero until the user sends another message."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chat-goal-kickoff",
+        chat_type="channel",
+        user_id="user-goal-kickoff",
+    )
+    adapter = _IdleAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+    )
+    runner.session_store = _FakeSessionStore()
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._queued_events = {}
+
+    event = MessageEvent(
+        text="/goal ship the benchmark",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg-goal-kickoff",
+    )
+
+    try:
+        response = await GatewayRunner._handle_goal_command(runner, event)
+        assert "Goal set" in response
+        assert [item.text for item in adapter.handled] == ["ship the benchmark"]
+        assert adapter.handled[0].message_id == "msg-goal-kickoff"
     finally:
         goals._DB_CACHE.clear()

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -61,6 +61,18 @@ class _RecordingAdapter:
         return _R()
 
 
+class _PostDeliveryRecordingAdapter(_RecordingAdapter):
+    """Adapter probe for a response that streaming has already delivered."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.callbacks: list[object] = []
+        self._active_sessions = {}
+
+    def register_post_delivery_callback(self, session_key, callback, *, generation=None):
+        self.callbacks.append(callback)
+
+
 def _make_runner_with_adapter(session_id: str = None):
     from gateway.run import GatewayRunner
     import uuid
@@ -94,6 +106,59 @@ def _make_runner_with_adapter(session_id: str = None):
     adapter = _RecordingAdapter()
     runner.adapters[Platform.TELEGRAM] = adapter
     return runner, adapter, session_entry, src
+
+
+@pytest.mark.asyncio
+async def test_goal_verdict_done_sent_via_adapter_send(hermes_home):
+    """When the judge says done, the '✓ Goal achieved' message must reach
+    the user through the adapter's ``send()`` method."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+
+    from hermes_cli.goals import GoalManager
+
+    mgr = GoalManager(session_entry.session_id)
+    mgr.set("ship the feature")
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "the feature shipped", False, None, False)):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="I shipped the feature.",
+        )
+        # fire-and-forget create_task — give the loop a tick
+        await asyncio.sleep(0.05)
+
+    assert len(adapter.sends) == 1, f"expected 1 send, got {len(adapter.sends)}: {adapter.sends}"
+    msg = adapter.sends[0]
+    assert msg["chat_id"] == "c1"
+    assert "Goal achieved" in msg["content"]
+    assert "the feature shipped" in msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_streamed_goal_response_judges_and_sends_status_immediately(hermes_home):
+    """A streamed response returns None to the outer handler, so its goal
+    judge runs inside the streaming branch after the body has been delivered.
+    It must not register a callback which has already missed its delivery edge.
+    """
+    runner, _, session_entry, src = _make_runner_with_adapter()
+    adapter = _PostDeliveryRecordingAdapter()
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    from hermes_cli.goals import GoalManager
+
+    GoalManager(session_entry.session_id).set("ship the feature")
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "the feature shipped", False, None, False)):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="I shipped the feature.",
+            response_already_delivered=True,
+        )
+
+    assert len(adapter.sends) == 1
+    assert "Goal achieved" in adapter.sends[0]["content"]
+    assert adapter.callbacks == []
 
 
 @pytest.mark.asyncio
@@ -153,3 +218,42 @@ async def test_goal_verdict_budget_exhausted_sends_pause(hermes_home):
     assert not adapter._pending_messages
 
 
+@pytest.mark.asyncio
+async def test_goal_verdict_skipped_when_no_active_goal(hermes_home):
+    """No goal set → the hook is a no-op. Nothing is sent, nothing enqueued."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+
+    await runner._post_turn_goal_continuation(
+        session_entry=session_entry,
+        source=src,
+        final_response="anything",
+    )
+    await asyncio.sleep(0.05)
+
+    assert adapter.sends == []
+    assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_goal_verdict_survives_adapter_without_send(hermes_home):
+    """Bad adapter (no ``send`` attribute) must not crash the judge hook."""
+    runner, _adapter, session_entry, src = _make_runner_with_adapter()
+
+    from hermes_cli.goals import GoalManager
+
+    GoalManager(session_entry.session_id).set("survive missing send")
+
+    class _NoSendAdapter:
+        def __init__(self):
+            self._pending_messages: dict = {}
+
+    runner.adapters[Platform.TELEGRAM] = _NoSendAdapter()
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "ok", False, None, False)):
+        # must not raise
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="whatever",
+        )
+        await asyncio.sleep(0.05)

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -149,11 +149,10 @@ async def test_streamed_goal_response_judges_and_sends_status_immediately(hermes
 
     GoalManager(session_entry.session_id).set("ship the feature")
     with patch("hermes_cli.goals.judge_goal", return_value=("done", "the feature shipped", False, None, False)):
-        await runner._post_turn_goal_continuation(
+        await runner._post_streamed_goal_turn(
             session_entry=session_entry,
             source=src,
             final_response="I shipped the feature.",
-            response_already_delivered=True,
         )
 
     assert len(adapter.sends) == 1


### PR DESCRIPTION
## Summary
- Start a `/goal` kickoff via the adapter when no adapter processing frame is active.
- Preserve the normal FIFO path when a live adapter frame will drain it.
- Fixes gateway command paths where `/goal` is accepted but remains active at `0` turns until another user message arrives.

## Verification
- `uv run --extra dev pytest -q tests/gateway/test_goal_max_turns_config.py tests/gateway/test_goal_continuation_drain.py tests/gateway/test_goal_verdict_send.py tests/gateway/test_goal_status_notice.py`
- Result: `12 passed`.
- Added a regression test for the idle command-path kickoff.