### PR TITLE
fix(desktop): front the workspace on ⌘N when the selection is already null

### DIFF
--- a/apps/desktop/e2e/worktree-new-session-tabs.spec.ts
+++ b/apps/desktop/e2e/worktree-new-session-tabs.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * Worktree A's "+" and worktree B's "+" must each open their OWN new session.
+ *
+ * Motivated by a report that, with a session open per worktree in separate
+ * tabs, "+" on lane A opens a new session but "+" on lane B then does nothing.
+ *
+ * SCOPE — this drives the real two-lane scenario end to end, but it is
+ * COVERAGE, not a regression test: it passes both with and without the
+ * `homeFreshDraftToWorkspace` fix in store/session-states.ts (verified by
+ * neutering that function and re-running). In other words the per-lane "+"
+ * path is healthy on this build — two clicks reliably yield two distinct
+ * stacked sessions. Keep it so a future change that collapses them is caught,
+ * and so the (fiddly) worktree-lane fixture below stays exercised.
+ *
+ * Fixture notes (these were the hard part, don't regress them):
+ *  - A desktop session deliberately does NOT adopt its launch directory as a
+ *    workspace (`_LAUNCH_CWD_NOT_A_WORKSPACE` in tui_gateway/server.py), so
+ *    `terminal.cwd` alone never stamps a session cwd and no lane can derive.
+ *    The worktrees are registered as real projects via the folder-open flow
+ *    (⌘O / Ctrl+O) with Electron's dialog stubbed.
+ *  - Worktree lanes are session-derived: a lane appears once a PERSISTED turn
+ *    has a cwd inside it, so each seed waits for the assistant reply.
+ *  - `repo_scan_roots` is pinned to the sandbox so the host's real repos can't
+ *    leak into the sidebar.
+ *  - The `__HERMES_*` window hooks are DEV-only and absent from the packaged
+ *    build these tests launch; use the `data-tree-tab` DOM hook instead.
+ */
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { test, expect } from './test'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  writeEnvFile,
+  writeMockProviderConfig,
+  waitForAppReady,
+  type MockBackendFixture,
+} from './fixtures'
+import { startMockServer } from './mock-server'
+
+const WORKTREE_A = 'e2e-tree-a'
+const WORKTREE_B = 'e2e-tree-b'
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' })
+}
+
+function createRepoWithWorktrees(root: string): { repo: string; treeA: string; treeB: string } {
+  const repo = path.join(root, 'repo')
+
+  fs.mkdirSync(repo, { recursive: true })
+  git(repo, 'init', '--initial-branch=main')
+  git(repo, 'config', 'user.email', 'e2e@example.com')
+  git(repo, 'config', 'user.name', 'Hermes E2E')
+  fs.writeFileSync(path.join(repo, 'README.md'), '# E2E repo\n', 'utf8')
+  git(repo, 'add', 'README.md')
+  git(repo, 'commit', '-m', 'initial')
+
+  const treeA = path.join(root, WORKTREE_A)
+  const treeB = path.join(root, WORKTREE_B)
+
+  git(repo, 'worktree', 'add', '-b', WORKTREE_A, treeA)
+  git(repo, 'worktree', 'add', '-b', WORKTREE_B, treeB)
+
+  return { repo, treeA, treeB }
+}
+
+let fixture: MockBackendFixture | null = null
+let trees: { repo: string; treeA: string; treeB: string } | null = null
+
+test.beforeAll(async () => {
+  const sandbox = createSandbox('worktree-new-session-tabs')
+  trees = createRepoWithWorktrees(sandbox.root)
+  const mock = await startMockServer()
+
+  writeMockProviderConfig(sandbox.hermesHome, mock.url)
+  fs.appendFileSync(
+    path.join(sandbox.hermesHome, 'config.yaml'),
+    `\nterminal:\n  cwd: ${trees.treeA}\n` +
+      `desktop:\n  repo_scan_enabled: true\n  repo_scan_roots:\n    - ${sandbox.root}\n`,
+    'utf8',
+  )
+  writeEnvFile(sandbox.hermesHome)
+
+  const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+
+  fixture = {
+    app,
+    page,
+    mock,
+    mockUrl: mock.url,
+    sandbox,
+    cleanup: async () => {
+      await app.close().catch(() => undefined)
+      await mock.close()
+      sandbox.cleanup()
+    },
+  }
+
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+  trees = null
+})
+
+test('"+" on each worktree lane opens its own distinct new session', async ({}, testInfo) => {
+  const { app, page } = fixture!
+  const { treeA, treeB } = trees!
+
+  /** Session-tile tabs in the strip (production DOM hook). */
+  const tabIds = () =>
+    page.evaluate(() =>
+      [...document.querySelectorAll('[data-tree-tab]')]
+        .map(el => el.getAttribute('data-tree-tab') ?? '')
+        .filter(id => id.startsWith('session-tile:')),
+    )
+
+  // The VISIBLE composer — a hidden tab's composer is still in the DOM.
+  const composer = () => page.locator('[contenteditable="true"]:visible').first()
+
+  /** Send a prompt and wait for the reply, so the turn PERSISTS (which is what
+   *  gives the session a cwd and makes its worktree lane appear). */
+  const seedSession = async (prompt: string) => {
+    const input = composer()
+    await input.click()
+    await input.type(prompt, { delay: 2 })
+    await page.keyboard.press('Enter')
+    await page.waitForFunction(
+      text =>
+        [...document.querySelectorAll('[data-slot="aui_thread-viewport"]')].some(
+          el => (el as HTMLElement).offsetParent !== null && (el.textContent ?? '').includes(text),
+        ),
+      prompt,
+      { timeout: 20_000 },
+    )
+    await page.waitForFunction(
+      () =>
+        [...document.querySelectorAll('[data-slot="aui_assistant-message-root"]')].some(
+          el => (el.textContent ?? '').includes('mock inference server'),
+        ),
+      undefined,
+      { timeout: 30_000 },
+    )
+  }
+
+  // ── Register both worktrees as projects via the real folder-open flow ────
+  await app.evaluate(async ({ dialog }, paths) => {
+    let i = 0
+    ;(dialog as any).showOpenDialog = async () => ({ canceled: false, filePaths: [paths[i++]] })
+  }, [treeA, treeB])
+
+  // Ctrl+O = workspace.openFolder → open folder as a project + fresh session.
+  await page.keyboard.press('Control+O')
+  await page.waitForTimeout(4000)
+  await seedSession('worktree A seed session')
+
+  await page.keyboard.press('Control+O')
+  await page.waitForTimeout(4000)
+  await seedSession('worktree B seed session')
+
+  // ── Both lanes must now be present in the projects view ─────────────────
+  const showProjects = page.getByRole('button', { name: 'Show projects' }).first()
+
+  if (await showProjects.isVisible().catch(() => false)) {
+    await showProjects.click()
+  }
+
+  const plusA = page.locator(`[aria-label="New session in ${WORKTREE_A}"]`).first()
+  const plusB = page.locator(`[aria-label="New session in ${WORKTREE_B}"]`).first()
+
+  await expect(plusA).toBeAttached({ timeout: 30_000 })
+  await expect(plusB).toBeAttached({ timeout: 30_000 })
+
+  const before = await tabIds()
+  await page.screenshot({ path: testInfo.outputPath('01-two-worktree-sessions.png') })
+
+  // ── "+" on lane A ────────────────────────────────────────────────────────
+  await plusA.click({ force: true })
+  await expect.poll(async () => (await tabIds()).length, { timeout: 20_000 }).toBeGreaterThan(before.length)
+
+  const afterA = await tabIds()
+  await page.screenshot({ path: testInfo.outputPath('02-after-plus-worktree-a.png') })
+
+  // ── "+" on lane B: MUST open ANOTHER new session, not reuse A's draft ────
+  await plusB.click({ force: true })
+  await expect.poll(async () => (await tabIds()).length, { timeout: 20_000 }).toBeGreaterThan(afterA.length)
+
+  const afterB = await tabIds()
+  await page.screenshot({ path: testInfo.outputPath('03-after-plus-worktree-b.png') })
+
+  // Every open session must be distinct — no id appearing twice.
+  expect(new Set(afterB).size).toBe(afterB.length)
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -60,6 +60,7 @@ import {
   $sessionTiles,
   closeSessionTile,
   dropSessionState,
+  homeFreshDraftToWorkspace,
   openSessionTile,
   patchSessionTile,
   publishSessionState,
@@ -343,6 +344,12 @@ export function useSessionActions({
       setCurrentBranch('')
       // Never clear the composer here — ChatBar's per-thread draft swap owns it.
       setFreshDraftReady(true)
+      // A fresh draft is a PRIMARY navigation, so it must front the workspace
+      // even when the selection did not change value. Setting null over an
+      // already-null selection notifies no listener, which left ⌘N / the New
+      // session row / the worktree button silently dead while a session tile
+      // was fronted. Homing is idempotent, so the listener firing too is fine.
+      homeFreshDraftToWorkspace()
     },
     [activeSessionIdRef, busyRef, navigate, onFreshDraftRouteIntent, resetViewSync, selectedStoredSessionIdRef]
   )

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -8,6 +8,7 @@ import type { SessionTile } from '@/store/session-states'
 import {
   blankDraftTile,
   focusedSessionNeedsRoute,
+  homeFreshDraftToWorkspace,
   markSelectionRestore,
   orderTilesByTree,
   selectionHomesToWorkspace
@@ -81,6 +82,35 @@ describe('boot-restore selection homing (⌘R tab persistence)', () => {
     // One-shot consumed: the next selection change is a real navigation.
     $selectedStoredSessionId.set('nav-2')
     expect(activePane()).toBe('workspace')
+  })
+
+  // A fresh draft over an ALREADY-null selection notifies no listener (nanostores
+  // only fires on a value change), so ⌘N / the New session row / the worktree
+  // button all looked dead while a session tile was fronted.
+  it('a fresh draft fronts the workspace even when the selection does not change', () => {
+    $selectedStoredSessionId.set(null)
+    $layoutTree.set(mainGroup())
+
+    // Setting null over null notifies nothing — the tile stays fronted.
+    $selectedStoredSessionId.set(null)
+    expect(activePane()).toBe(tilePane('t'))
+
+    // The explicit new-chat homing call is what actually reveals the draft.
+    homeFreshDraftToWorkspace()
+    expect(activePane()).toBe('workspace')
+  })
+
+  it('a fresh draft does NOT consume the boot-restore one-shot', () => {
+    $layoutTree.set(mainGroup())
+    markSelectionRestore()
+
+    // An explicit fresh-draft home must leave the armed flag for the boot
+    // resume it belongs to, or a cold start clobbers the persisted active tab.
+    homeFreshDraftToWorkspace()
+    expect(activePane()).toBe(tilePane('t'))
+
+    $selectedStoredSessionId.set('boot-2')
+    expect(activePane()).toBe(tilePane('t'))
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -786,7 +786,15 @@ export function markSelectionRestore() {
 
 // Homing also FRONTS the workspace tab: the resumed chat loads in the workspace
 // pane, so a zone parked on a tile tab must switch back or the click looks dead.
-$selectedStoredSessionId.listen(selected => {
+//
+// Exported so an explicit primary navigation can apply the SAME policy without
+// depending on a selection CHANGE. `.listen` only notifies when the value
+// actually differs, so starting a fresh draft while the selection is already
+// null — main is on a blank new chat and the user is looking at a session tile —
+// never fired this, and ⌘N / the New session row / the worktree button all
+// looked completely dead. Idempotent, so the listener and an explicit call can
+// both run for one navigation.
+export function homeSelectionToWorkspace(selected: null | string): void {
   const restoring = selectionRestoreInFlight
   selectionRestoreInFlight = false
 
@@ -796,7 +804,21 @@ $selectedStoredSessionId.listen(selected => {
 
   noteActiveTreeGroup(null)
   revealTreePane('workspace')
-})
+}
+
+/** Front the workspace for an explicit primary navigation whose selection may
+ *  not have CHANGED (a fresh draft over an already-null selection). Unlike the
+ *  listener path this never consumes the boot-restore one-shot: that flag is
+ *  armed for a specific upcoming resume, and swallowing it here would let a
+ *  cold start clobber the persisted active tab (the ⌘R bug the flag prevents). */
+export function homeFreshDraftToWorkspace(): void {
+  if (!selectionRestoreInFlight && selectionHomesToWorkspace(null, $sessionTiles.get())) {
+    noteActiveTreeGroup(null)
+    revealTreePane('workspace')
+  }
+}
+
+$selectedStoredSessionId.listen(selected => homeSelectionToWorkspace(selected))
 
 // Dev hook for automation (mirrors __HERMES_LAYOUT_TREE__).
 if (import.meta.env.DEV && typeof window !== 'undefined') {


### PR DESCRIPTION
## What does this PR do?

⌘N, the sidebar **New session** row, and the per-worktree **"+"** frequently do nothing — no new chat appears. Reported as happening "almost every single time." It isn't flaky, it's exactly-conditional.

All three affordances funnel into `startFreshSessionDraft`, which sets `$selectedStoredSessionId` to `null`. Fronting the workspace pane was never done by that action — it happened as a **side effect** of `$selectedStoredSessionId.listen(...)` in `store/session-states.ts`.

Nanostores `.listen` only notifies on an actual value **change**:

```
selected = <real id>  ->  set null  ->  CHANGED    ->  listener runs   ->  workspace fronted  ✅
selected = null       ->  set null  ->  NO CHANGE  ->  listener silent ->  nothing revealed   ❌
```

So once main is parked on a blank draft and you're looking at a session tile, every subsequent new-session gesture **creates the session but never reveals it**. The pane you were on stays fronted, so it reads as a dead button. That's the "almost every time" — after your first ⌘N, main is already a blank draft, so every one after it is silent until you open a real session again.

**Why this approach:** the reveal is moved to where the intent lives. A fresh draft is a *primary navigation*, so it applies the homing policy directly instead of depending on a change notification to fire it. This is the same shape as `openNewSessionTile`, which already calls `revealTreePane` explicitly rather than hoping a store change does it. Reveal-by-accident is the actual defect; making the listener "fire on same value" would instead spray redundant homing across every unrelated no-op write.

## Related Issue

No existing issue for this one — found while reproducing locally.

Related but **not** fixed here: #74948 (Ctrl+Shift+N / New *Window* replicates the current session). That is a separate boot-restore/window-provisioning path. Notably, this PR's fix deliberately avoids making it worse — see the boot-restore note below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/session-states.ts` — extract the listener body as `homeSelectionToWorkspace(selected)`; add `homeFreshDraftToWorkspace()` for an explicit primary navigation whose selection may not have changed. The listener now delegates to the shared function, so one policy has one home.
- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts` — call `homeFreshDraftToWorkspace()` from `startFreshSessionDraft`, alongside `setFreshDraftReady(true)`. Homing is idempotent, so the listener also firing on a real transition is harmless.
- `apps/desktop/src/store/session-states.test.ts` — 2 new tests: the `null → null` reveal, and a guard proving the explicit path does **not** consume the boot-restore one-shot.
- `apps/desktop/e2e/worktree-new-session-tabs.spec.ts` — new E2E driving the reported two-worktree "+" scenario (scope caveat below).

**Boot-restore safety:** the explicit path deliberately does *not* consume the boot-restore one-shot. That flag is armed for a specific pending resume; swallowing it here would let a cold start clobber the persisted active tab — the ⌘R bug the flag exists to prevent (cf. #74948's neighbourhood). There's a dedicated test pinning this.

## How to Test

**Reproduce the bug (on `main`):**

1. Open the desktop app and take a turn so you have a real session.
2. Open it as a session tile/tab, so a tile is fronted in the main slot.
3. Press ⌘N once — the new chat appears correctly (selection went `<id> → null`).
4. Front the session tile again and press ⌘N a second time — **nothing happens.** Repeat: still nothing. Same for the sidebar New session row and the per-worktree "+".

**Verify the fix:** repeat step 4 on this branch — the workspace fronts and the blank draft is revealed every time.

**Automated:**

```bash
cd apps/desktop
npm run check                                    # lint + typecheck + 3127 UI tests + build + package
npx vitest run src/store/session-states.test.ts  # the 2 new tests
```

**Proof the regression test actually bites:** neuter the body of `homeFreshDraftToWorkspace()` in `store/session-states.ts` and re-run — the `null → null` test goes RED and the boot-restore guard stays GREEN. Verified; a test that can't fail is worthless.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — 4 files, `+261/-2`
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, TypeScript-only change (CI's Python jobs correctly skipped); ran `npm run check` instead, exit 0
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS 26.11 (Zokor), Linux x64 — plus CI's Playwright E2E on Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, internal store behavior; the reasoning is captured in comments at both call sites
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture change (this consolidates one existing policy into one function)
- [x] I've considered cross-platform impact (Windows, macOS) — no platform-specific code; pure renderer store logic. The keybind layer is untouched, so the fix applies identically wherever ⌘N/Ctrl+N is bound.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool changes

## Screenshots / Logs

**Deterministic repro against the running app** (sandboxed instance, isolated `HERMES_HOME`, mock provider, driven over CDP):

```
CASE 1 — main holds a REAL session, tile fronted, then ⌘N
  handler ran: true    main fronting AFTER: workspace               => shown ✅

CASE 2 — main is ALREADY a blank draft, tile fronted, then ⌘N
  handler ran: true    main fronting AFTER: session-tile:...b0e17c  => silent no-op ❌
  repeat 1: no-op   repeat 2: no-op   repeat 3: no-op
```

`handler ran = true` in every case — the keybind, the click handler and `startFreshSessionDraft` all fire correctly. Only the reveal was missing.

**Why no existing test caught it:** every case in `session-states.test.ts` sets a *distinct* id (`nav-1`, `boot-1`, `nav-2`), so all of them ride the change-notify path. `selectionHomesToWorkspace(null, tiles)` was tested as a pure function and returns `true` correctly — but nothing checked whether the listener consuming it actually fires. The predicate was right; the delivery was change-gated.

<details>
<summary><b>E2E scope — honest caveat (please read before trusting the new spec)</b></summary>

`worktree-new-session-tabs.spec.ts` drives the reported two-worktree scenario end to end, but it is **coverage, not a regression test**: it passes *with and without* the fix (verified by neutering the function and re-running). The per-lane "+" path is healthy on this build — two clicks reliably yield two distinct stacked sessions. My initial `mainChatOccupied` theory for a second, distinct bug there was **wrong** and is disproved: `openNewSessionTile` never nulls the selection, so the second "+" does still stack. This is stated in the spec header too, so nobody trusts it more than it deserves.

It's kept because it pins a genuinely fiddly fixture and would catch a future change that collapses the two lanes into one session. Fixture notes worth preserving:

- A desktop session deliberately does **not** adopt its launch directory as a workspace (`_LAUNCH_CWD_NOT_A_WORKSPACE` in `tui_gateway/server.py`), so `terminal.cwd` alone never stamps a session cwd and no lane can derive. The worktrees are registered as real projects via the folder-open flow (⌘O) with Electron's dialog stubbed.
- Worktree lanes are **session-derived**: a lane appears only once a *persisted* turn has a cwd inside it, so each seed waits for the assistant reply.
- `repo_scan_roots` is pinned to the sandbox so the host's real repos can't leak into the sidebar.
- The `__HERMES_*` window hooks are DEV-only and absent from the packaged build E2E launches — use the `data-tree-tab` DOM hook instead.

My read is that the reported worktree symptom was the *same* `null → null` bug (the session was created, just never revealed while a tile was fronted) rather than a separate one, and this fix should cover it — but that's a hypothesis, worth confirming on a real build.

</details>

<details>
<summary><b>CI visual-diff note</b></summary>

The review bot flagged 1 visual diff (`onboarding-overlay`). I pulled the artifact rather than waving it off, since this change touches pane *reveal*. It's a boot→onboarding **timing race in that spec**, not a layout regression: the diff shows the heading ghosted at two y-positions ~70px apart, with two mutually-exclusive states overlaid (boot splash `Starting Hermes…` + 100% progress bar vs. the provider picker cards). It cannot originate here — this diff touches no onboarding or boot code. The Desktop E2E job itself passed; the evidence-upload failure in the bot comment is a separate token/SAML issue, not a test failure.

</details>
