### PR TITLE
fix(buzz): don't drop a reply when its thread parent is unknown to the relay

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -76,6 +76,9 @@ _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
 
+# Relay rejection when --reply-to names an event it does not have.
+_PARENT_NOT_FOUND_RE = re.compile(r"parent event \S+ not found", re.I)
+
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
 _WS_AUTH_TIMEOUT = 20.0
@@ -589,6 +592,19 @@ class BuzzAdapter(BasePlatformAdapter):
         if reply_target:
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
+        if code != 0 and reply_target and _PARENT_NOT_FOUND_RE.search(err or ""):
+            # The reply target does not exist on this relay. ``metadata["thread_id"]``
+            # is populated by generic gateway machinery — this adapter never sets
+            # thread metadata on inbound — so it can carry an id the relay has
+            # never seen. Threading is a presentation detail; losing the message
+            # over it is not, and the caller's plain-text fallback re-sends with
+            # the same reply target and fails identically. Retry flat once.
+            logger.warning(
+                "Buzz: reply target %s not found on relay; resending unthreaded",
+                str(reply_target)[:12],
+            )
+            args = [a for a in args if a not in ("--reply-to", str(reply_target))]
+            code, out, err = await self._run_cli(args, input_text=content)
         if code != 0:
             return SendResult(
                 success=False,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -46,7 +46,7 @@ import time
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
@@ -294,6 +294,39 @@ async def _exec_buzz(
         stdout.decode("utf-8", errors="replace"),
         stderr.decode("utf-8", errors="replace"),
     )
+
+
+async def _send_retrying_unthreaded(
+    runner: Callable[[List[str]], Awaitable[Tuple[int, str, str]]],
+    args: List[str],
+    reply_target: Optional[str],
+) -> Tuple[int, str, str]:
+    """Run a buzz send, retrying once without ``--reply-to`` if the relay
+    rejects the parent event.
+
+    The reply anchor can name an event this relay has never seen: this adapter
+    never sets thread metadata on inbound, so ``metadata["thread_id"]`` arrives
+    from generic gateway machinery. buzz-cli then rejects the whole send, and
+    the caller's plain-text fallback re-sends with the same anchor and fails
+    identically — so the message is lost outright.
+
+    Threading is a presentation detail; losing the message over it is not.
+    The retry is bounded to a single attempt and to this one error, so every
+    other failure surfaces unchanged.
+
+    ``runner`` takes an argv list and returns ``(code, stdout, stderr)``,
+    which lets the adapter's ``_run_cli`` and the module-level ``_exec_buzz``
+    share this path.
+    """
+    code, out, err = await runner(args)
+    if code == 0 or not reply_target or not _PARENT_NOT_FOUND_RE.search(err or ""):
+        return code, out, err
+    logger.warning(
+        "Buzz: reply target %s not found on relay; resending unthreaded",
+        str(reply_target)[:12],
+    )
+    flat = [a for a in args if a not in ("--reply-to", str(reply_target))]
+    return await runner(flat)
 
 
 def _cli_error_message(stderr: str, returncode: int) -> str:
@@ -591,20 +624,9 @@ class BuzzAdapter(BasePlatformAdapter):
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_cli(args, input_text=content)
-        if code != 0 and reply_target and _PARENT_NOT_FOUND_RE.search(err or ""):
-            # The reply target does not exist on this relay. ``metadata["thread_id"]``
-            # is populated by generic gateway machinery — this adapter never sets
-            # thread metadata on inbound — so it can carry an id the relay has
-            # never seen. Threading is a presentation detail; losing the message
-            # over it is not, and the caller's plain-text fallback re-sends with
-            # the same reply target and fails identically. Retry flat once.
-            logger.warning(
-                "Buzz: reply target %s not found on relay; resending unthreaded",
-                str(reply_target)[:12],
-            )
-            args = [a for a in args if a not in ("--reply-to", str(reply_target))]
-            code, out, err = await self._run_cli(args, input_text=content)
+        code, out, err = await _send_retrying_unthreaded(
+            lambda a: self._run_cli(a, input_text=content), args, reply_target
+        )
         if code != 0:
             return SendResult(
                 success=False,
@@ -675,7 +697,9 @@ class BuzzAdapter(BasePlatformAdapter):
             ]
             if reply_to:
                 args += ["--reply-to", str(reply_to)]
-            code, out, err = await self._run_cli(args, input_text=caption or "")
+            code, out, err = await _send_retrying_unthreaded(
+                lambda a: self._run_cli(a, input_text=caption or ""), args, reply_to
+            )
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
             try:
@@ -1383,8 +1407,12 @@ async def _standalone_send(
     for path in media_files or []:
         args += ["--file", str(path)]
     try:
-        code, out, err = await _exec_buzz(
-            cli_path, args, relay_url=relay, private_key=private_key, input_text=message
+        code, out, err = await _send_retrying_unthreaded(
+            lambda a: _exec_buzz(
+                cli_path, a, relay_url=relay, private_key=private_key, input_text=message
+            ),
+            args,
+            thread_id,
         )
     except asyncio.CancelledError:
         raise

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -421,6 +421,45 @@ class TestBuzzAdapterSend:
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
 
+    @pytest.mark.asyncio
+    async def test_send_retries_unthreaded_when_parent_missing(self):
+        """A reply target this relay does not have must not lose the message."""
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages", "send", "", code=4,
+            stderr='{"error":"other","message":"error: parent event abc123 not found"}',
+        )
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt203", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "hello", reply_to="abc123")
+        assert result.success is True
+        assert result.message_id == "evt203"
+
+        assert len(cli.calls) == 2
+        first_args, _ = cli.calls[0]
+        retry_args, retry_stdin = cli.calls[1]
+        assert first_args[first_args.index("--reply-to") + 1] == "abc123"
+        assert "--reply-to" not in retry_args
+        assert "abc123" not in retry_args
+        assert retry_stdin == "hello"
+
+    @pytest.mark.asyncio
+    async def test_send_does_not_retry_on_unrelated_error(self):
+        """Only the missing-parent case is retried; everything else still fails."""
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages", "send", "", code=1,
+            stderr='{"error":"user_error","message":"something else entirely"}',
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "hello", reply_to="abc123")
+        assert result.success is False
+        assert len(cli.calls) == 1
+
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -460,6 +460,30 @@ class TestBuzzAdapterSend:
         assert result.success is False
         assert len(cli.calls) == 1
 
+    @pytest.mark.asyncio
+    async def test_send_image_retries_unthreaded_when_parent_missing(self, tmp_path):
+        """Native local-file uploads take the same recovery as text sends."""
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages", "send", "", code=4,
+            stderr='{"error":"other","message":"error: parent event abc123 not found"}',
+        )
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt204", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send_image(CHANNEL, str(img), caption="shot", reply_to="abc123")
+        assert result.success is True
+        assert result.message_id == "evt204"
+
+        assert len(cli.calls) == 2
+        retry_args, _ = cli.calls[1]
+        assert "--reply-to" not in retry_args
+        # The upload itself must survive the retry
+        assert retry_args[retry_args.index("--file") + 1] == str(img)
+
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -575,5 +599,34 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_retries_unthreaded_when_parent_missing(self, monkeypatch, tmp_path):
+        """Out-of-process cron delivery takes the same recovery as the adapter."""
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+
+        calls = []
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
+            calls.append(list(args))
+            if len(calls) == 1:
+                return 4, "", '{"error":"other","message":"error: parent event abc123 not found"}'
+            return 0, json.dumps({"accepted": True, "event_id": "evt-cron2", "message": ""}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}), CHANNEL, "cron says hi", thread_id="abc123"
+        )
+        assert result == {"success": True, "message_id": "evt-cron2"}
+        assert len(calls) == 2
+        assert calls[0][calls[0].index("--reply-to") + 1] == "abc123"
+        assert "--reply-to" not in calls[1]
 
 


### PR DESCRIPTION
## What does this PR do?

`BuzzAdapter.send()` forwards `metadata["thread_id"]` as `--reply-to`:

```python
reply_target = reply_to or (metadata or {}).get("thread_id")
```

But this adapter never sets thread metadata on inbound — it has no `reply_to_id`
handling at all, and every inbound event logs `reply_to_id=None`. That value
therefore arrives from generic gateway machinery and can name an event this
relay has never seen, so `buzz-cli` rejects the **entire send**:

```text
error: parent event 503d0e37e4abc3818b7200c3581524fe5df8939f417503e1b2b3f3cc1e074b4a not found (exit 4)
```

The reply is then lost, because the plain-text fallback in
`gateway/platforms/base.py` re-sends with the same `reply_to` and `metadata`,
varying only the text:

```
[Buzz] Send failed: error: parent event 503d0e37…4b4a not found (exit 4) — trying plain-text fallback
[Buzz] Fallback send also failed: error: parent event 503d0e37…4b4a not found (exit 4)
```

It is a fallback for formatting problems, not for argument-level rejections, so
it fails identically and the user sees nothing at all.

This happened twice within ten minutes of ordinary use against a hosted relay,
in a channel where the triggering messages were plain top-level posts, not
replies.

**Fix:** threading is a presentation detail; losing the message over it is not.
On that specific error, strip `--reply-to` and retry once. Unrelated failures
are untouched and still surface exactly as before.

## Related Issue

No existing issue found. Related in-flight work, for reviewer context:

- #74830 fixes the sibling symptom (unresolved `@Name` text killing the same
  send path). This PR deliberately does **not** touch that — it is the other
  argument on the same call, and the two would conflict.
- #74516 / #74084 propose thread-scoped sessions. Those change how thread state
  is produced; this only stops a bad value from destroying messages, so it
  should be compatible either way.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/buzz/adapter.py`
  - added `_PARENT_NOT_FOUND_RE`
  - in `send()`, on that error only, drop `--reply-to` and retry once
- `tests/gateway/test_buzz_adapter.py`
  - `test_send_retries_unthreaded_when_parent_missing` — asserts the retry has
    no `--reply-to`, keeps the original content, and reports success
  - `test_send_does_not_retry_on_unrelated_error` — asserts a single call and a
    failed result for anything else

## How to Test

1. Configure the Buzz platform per `docs/user-guide/messaging/buzz.md` and start
   the gateway against a live relay.
2. Trigger any reply where `metadata["thread_id"]` names an event the relay does
   not have. In practice this happens on its own during normal channel use.
3. Before: `gateway.log` shows `Send failed` immediately followed by
   `Fallback send also failed` with an identical error, and nothing reaches the
   channel. After: one `Buzz: reply target … not found on relay; resending
   unthreaded` warning, and the message arrives unthreaded.

Unit coverage:

```bash
pytest tests/gateway/test_buzz_adapter.py -q
```

Verified the new test genuinely covers the bug: with the fix reverted it fails,
with the fix applied it passes.

### Test run, stated precisely

`pytest tests/gateway/ -q` on this branch: **4433 passed, 7 failed, 23 skipped**.

None of the 7 are caused by this change, and I checked rather than assumed:

- `test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output`
  and `test_systemd_notify.py::test_notify_supports_systemd_abstract_socket`
  fail identically on clean `upstream/main` — macOS environment, no
  `systemd`/abstract sockets.
- `test_discord_send.py`, `test_send_multiple_images.py` and
  `test_session_store_prune.py` failures all **pass in isolation** on this
  branch, so they look like full-run ordering effects rather than real
  breakage. They touch Discord and session-store paths this PR does not go
  near.

Buzz suites specifically: `test_buzz_adapter.py` + `test_buzz_websocket.py`
→ **29 passed**.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the gateway suite — see the note below on pre-existing failures
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Hermes v0.19.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-visible config or
      behaviour change beyond a message being delivered instead of dropped
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys added
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A, pure string/list handling
- [x] I've updated tool descriptions/schemas — N/A

## Notes for the maintainer

The underlying cause is that this adapter does not model Buzz threads at all: it
only ever reports `chat_type` as `"group"` or `"dm"`, never `"thread"`, so
gateway thread state and Buzz thread state are never reconciled. Fixing that
properly is a design change and belongs in its own issue — quite possibly
folded into #74516. This PR only stops the mismatch from destroying messages in
the meantime.

Separately, a docs nit spotted while configuring this:
`docs/user-guide/messaging/buzz.md` shows `tool_progress: off` unquoted, but
bare `off` parses as boolean `false` in YAML while the setting is a string enum
(`off|new|all|verbose|log`). Happy to send that as its own PR if useful.
