### PR TITLE
fix(goal): pause standing goals on gateway /stop and provider failure

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9074,6 +9074,259 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("goal continuation: active-state recheck failed: %s", exc)
             return False
 
+    @staticmethod
+    def _looks_like_goal_blocking_provider_failure(text: str) -> bool:
+        """True when text looks like a short model/provider failure envelope.
+
+        Secondary signal only — prefer structured ``failed`` /
+        ``failure_reason`` from the agent result when available.
+        """
+        body = str(text or "").strip()
+        if not body:
+            return False
+        # Prefer the gateway's existing short-envelope detector first.
+        if _looks_like_gateway_provider_error(body):
+            return True
+        # Only apply broader markers to short failure envelopes — long
+        # assistant prose that mentions HTTP status codes in passing must
+        # not pause the goal.
+        if len(body) > 400 or body.count("\n") > 4:
+            return False
+        lowered = body.lower()
+        markers = (
+            "the model provider failed after retries",
+            "model provider failed after retries",
+            "provider authentication failed",
+            "model provider is rate-limiting",
+            "model provider rejected the request",
+            "model not found",
+            "no longer in our configuration",
+            "no longer in nous catalog",
+            "non-retryable client error",
+            "non-retryable error",
+            "the request failed:",
+        )
+        if any(m in lowered for m in markers):
+            return True
+        # Model-id 404s: Model 'foo' not found
+        if "not found" in lowered and ("model '" in lowered or 'model "' in lowered):
+            return True
+        return False
+
+    # Failure reasons that are provider/infra problems where re-running the
+    # standing goal will not make progress until the operator fixes config.
+    # Context/payload overflow is intentionally excluded — recovery is
+    # /compact, not goal pause.
+    _GOAL_BLOCKING_FAILURE_REASONS = frozenset({
+        "auth",
+        "auth_permanent",
+        "billing",
+        "rate_limit",
+        "upstream_rate_limit",
+        "overloaded",
+        "server_error",
+        "timeout",
+        "ssl_cert_verification",
+        "model_not_found",
+        "provider_policy_blocked",
+    })
+
+    @classmethod
+    def _is_goal_blocking_agent_failure(
+        cls,
+        *,
+        failed: bool = False,
+        failure_reason: Optional[str] = None,
+        error: Optional[str] = None,
+        final_response: str = "",
+    ) -> bool:
+        """Decide whether a standing goal should auto-pause after this turn.
+
+        Prefer structured agent-result fields (``failed`` / ``failure_reason``)
+        over free-text matching so normal short assistant replies are never
+        mistaken for infra failures.
+        """
+        reason = str(failure_reason or "").strip().lower()
+        if failed:
+            if reason in {"context_overflow", "payload_too_large", "image_too_large"}:
+                return False
+            if reason in cls._GOAL_BLOCKING_FAILURE_REASONS:
+                return True
+            # failed=True without a known reason (or unknown): fall back to
+            # error/final_response envelope detection.
+            blob = "\n".join(
+                part for part in (str(error or ""), str(final_response or "")) if part
+            )
+            return cls._looks_like_goal_blocking_provider_failure(blob)
+
+        # Not structurally failed — only pause on explicit short provider
+        # envelopes (sanitized gateway replies, etc.).
+        return cls._looks_like_goal_blocking_provider_failure(final_response)
+
+    def _session_id_for_session_key(self, session_key: str) -> str:
+        """Best-effort map gateway session_key → durable conversation session_id."""
+        if not session_key:
+            return ""
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return ""
+        try:
+            # Production SessionStore path.
+            entries = getattr(store, "_entries", None)
+            if isinstance(entries, dict):
+                entry = entries.get(session_key)
+                if entry is not None:
+                    return str(getattr(entry, "session_id", None) or "")
+        except Exception:
+            pass
+        try:
+            # Locked helper used elsewhere in the runner.
+            sid = self._lookup_session_id_under_store_lock(store, session_key)
+            return str(sid or "")
+        except Exception:
+            return ""
+
+    def _snapshot_pending_non_goal(
+        self, session_key: str, adapter: Any
+    ) -> Optional[Any]:
+        """Peek the adapter pending slot if it is a real user follow-up."""
+        if not session_key or adapter is None:
+            return None
+        pending_slot = getattr(adapter, "_pending_messages", None)
+        if not isinstance(pending_slot, dict):
+            return None
+        pending = pending_slot.get(session_key)
+        if pending is None:
+            return None
+        if self._is_goal_continuation_event(pending):
+            return None
+        return pending
+
+    def _restore_pending_non_goal(
+        self, session_key: str, adapter: Any, pending: Any
+    ) -> None:
+        """Put back a non-goal pending event after interrupt discarded the slot."""
+        if pending is None or not session_key or adapter is None:
+            return
+        pending_slot = getattr(adapter, "_pending_messages", None)
+        if not isinstance(pending_slot, dict):
+            return
+        # Don't overwrite a newer pending event that landed after interrupt.
+        if session_key in pending_slot:
+            return
+        pending_slot[session_key] = pending
+
+    def _pause_active_goal_for_session(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+        source: Any = None,
+        reason: str = "user-interrupted",
+        adapter: Any = None,
+        preserve_non_goal_pending: bool = True,
+    ) -> bool:
+        """Pause an active standing goal and drain its queued continuations.
+
+        Mirrors CLI Ctrl+C auto-pause so gateway ``/stop`` (and provider-dead
+        turns) cannot leave a Ralph loop re-queuing synthetic user messages.
+        Returns True when a goal was active and got paused.
+
+        When ``preserve_non_goal_pending`` is True (default), a real user
+        follow-up sitting in the adapter pending slot is not removed — only
+        synthetic goal continuations are drained from pending + overflow.
+        """
+        paused = False
+        sid = (session_id or "").strip()
+        if not sid and session_key:
+            sid = self._session_id_for_session_key(session_key)
+
+        key = session_key
+        if not key and source is not None:
+            try:
+                key = self._session_key_for_source(source)
+            except Exception:
+                key = None
+
+        ad = adapter
+        if ad is None and source is not None:
+            try:
+                ad = self._adapter_for_source(source)
+            except Exception:
+                ad = None
+
+        saved_pending = None
+        if preserve_non_goal_pending and key:
+            saved_pending = self._snapshot_pending_non_goal(key, ad)
+
+        if sid:
+            try:
+                from hermes_cli.goals import GoalManager
+
+                max_turns = self._goal_max_turns_from_config()
+                mgr = GoalManager(session_id=sid, default_max_turns=max_turns)
+                if mgr.is_active():
+                    mgr.pause(reason=reason)
+                    paused = True
+            except Exception as exc:
+                logger.debug("goal pause-on-stop failed: %s", exc)
+
+        # Drain synthetic goal FIFO (pending slot + overflow). Real user
+        # queue items are preserved by _clear_goal_pending_continuations.
+        try:
+            if key:
+                self._clear_goal_pending_continuations(key, ad)
+        except Exception as exc:
+            logger.debug("goal continuation drain on pause failed: %s", exc)
+
+        if preserve_non_goal_pending and key:
+            self._restore_pending_non_goal(key, ad, saved_pending)
+
+        return paused
+
+    async def _interrupt_stop_and_pause_goal(
+        self,
+        session_key: str,
+        source: Any,
+        *,
+        interrupt_reason: str,
+        invalidation_reason: str,
+        session_id: Optional[str] = None,
+        reason: str = "user-interrupted (/stop)",
+    ) -> bool:
+        """Interrupt a run, preserve non-goal pending follow-ups, pause goal.
+
+        ``_interrupt_and_clear_session`` discards the adapter pending slot
+        wholesale. Goal continuations should die; ordinary user follow-ups
+        queued while the agent was busy must survive.
+        """
+        adapter = None
+        try:
+            adapter = self._adapter_for_source(source) if source is not None else None
+        except Exception:
+            adapter = None
+
+        saved_pending = self._snapshot_pending_non_goal(session_key, adapter)
+        await self._interrupt_and_clear_session(
+            session_key,
+            source,
+            interrupt_reason=interrupt_reason,
+            invalidation_reason=invalidation_reason,
+        )
+        # Restore real user pending before goal drain so clear only removes
+        # synthetic goal continuations from overflow/pending.
+        self._restore_pending_non_goal(session_key, adapter, saved_pending)
+
+        sid = (session_id or "").strip() or self._session_id_for_session_key(session_key)
+        return self._pause_active_goal_for_session(
+            session_id=sid,
+            session_key=session_key,
+            source=source,
+            reason=reason,
+            adapter=adapter,
+            preserve_non_goal_pending=True,
+        )
+
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         try:
             from gateway.status import write_runtime_status
@@ -16311,11 +16564,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # is truly hung — the executor thread is blocked and never checks
         # _interrupt_requested.  Force-clean _running_agents so the session
         # is unlocked and subsequent messages are processed normally.
-        await self._interrupt_and_clear_session(
+        #
+        # Also pause standing /goal (CLI Ctrl+C parity) while preserving any
+        # real user follow-up that was sitting in the pending slot.
+        try:
+            session_entry = await self.async_session_store.get_or_create_session(source)
+            sid = getattr(session_entry, "session_id", None) or ""
+        except Exception:
+            sid = ""
+        await self._interrupt_stop_and_pause_goal(
             quick_key,
             source,
             interrupt_reason=_INTERRUPT_REASON_STOP,
             invalidation_reason="stop_command",
+            session_id=sid,
+            reason="user-interrupted (/stop)",
         )
         logger.info("STOP for session %s — agent interrupted, session lock released", quick_key)
         return EphemeralReply(t("gateway.stop.stopped"))
@@ -21477,6 +21740,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_entry: Any,
         source: Any,
         final_response: str,
+        failed: bool = False,
+        failure_reason: Optional[str] = None,
+        error: Optional[str] = None,
     ) -> None:
         """Run the goal judge after a gateway turn and, if still active,
         enqueue a continuation prompt for the same session.
@@ -21508,6 +21774,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         mgr = GoalManager(session_id=sid, default_max_turns=max_turns)
         if not mgr.is_active():
+            return
+
+        # Provider/infra failure short-circuit: do NOT call the judge.
+        # Prefer structured agent_result.failed / failure_reason; fall back
+        # to short provider envelopes. Judge fail-open returns "continue"
+        # on "no evidence of progress", which turns a dead model into a
+        # tight self-continuation loop that burns the full turn budget.
+        if self._is_goal_blocking_agent_failure(
+            failed=failed,
+            failure_reason=failure_reason,
+            error=error,
+            final_response=final_response or "",
+        ):
+            try:
+                _quick_key = self._session_key_for_source(source) if source is not None else None
+            except Exception:
+                _quick_key = None
+            self._pause_active_goal_for_session(
+                session_id=sid,
+                session_key=_quick_key,
+                source=source,
+                reason="provider/model failure (auto-paused to prevent goal spin)",
+            )
+            notice = (
+                "⏸ Goal paused — the model provider failed this turn "
+                "(e.g. missing model, auth, or rate limit). "
+                "Fix the model/provider, then `/goal resume` or `/goal clear`."
+            )
+            if source is not None:
+                await self._defer_goal_status_notice_after_delivery(source, notice)
+            logger.info(
+                "goal auto-paused after provider failure for session %s "
+                "(failed=%s failure_reason=%s)",
+                sid,
+                failed,
+                failure_reason,
+            )
+            return
+
+        # Empty successful responses: nothing to judge.
+        if not str(final_response or "").strip():
             return
 
         try:
@@ -21577,6 +21884,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> None:
         """Run goal and loop bookkeeping after an agent turn returns."""
         final_text = self._final_text_for_post_turn_hooks(agent_result, event)
+        agent_failed = False
+        failure_reason = None
+        agent_error = None
+        interrupted = False
+        if isinstance(agent_result, dict):
+            agent_failed = bool(agent_result.get("failed"))
+            failure_reason = agent_result.get("failure_reason")
+            agent_error = agent_result.get("error")
+            interrupted = bool(agent_result.get("interrupted"))
 
         try:
             session_entry = await self.async_session_store.get_or_create_session(
@@ -21589,12 +21905,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Empty interrupted/errored responses must not drive /goal, but an
         # in-flight /loop tick still needs to be released and rescheduled.
-        if final_text.strip():
+        # Exception: structured failed=True still runs the goal short-circuit
+        # so provider deaths pause the standing goal. Interrupted turns must
+        # not re-arm the Ralph loop via judge fail-open on partial text.
+        if not interrupted and (final_text.strip() or agent_failed):
             try:
                 await self._post_turn_goal_continuation(
                     session_entry=session_entry,
                     source=source,
                     final_response=final_text,
+                    failed=agent_failed,
+                    failure_reason=failure_reason,
+                    error=agent_error,
                 )
             except Exception as exc:
                 logger.debug("goal continuation hook failed: %s", exc)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7423,11 +7423,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @staticmethod
     def _looks_like_goal_blocking_provider_failure(text: str) -> bool:
-        """True when the turn failed due to model/provider infrastructure.
+        """True when text looks like a short model/provider failure envelope.
 
-        Standing goals must not self-continue on these responses: the judge
-        fail-opens to ``continue`` (no evidence of progress), which re-queues
-        synthetic goal turns and burns the full turn budget on a dead model.
+        Secondary signal only — prefer structured ``failed`` /
+        ``failure_reason`` from the agent result when available.
         """
         body = str(text or "").strip()
         if not body:
@@ -7452,13 +7451,117 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "no longer in nous catalog",
             "non-retryable client error",
             "non-retryable error",
+            "the request failed:",
         )
         if any(m in lowered for m in markers):
             return True
         # Model-id 404s: Model 'foo' not found
-        if "not found" in lowered and ("model '" in lowered or "model \"" in lowered):
+        if "not found" in lowered and ("model '" in lowered or 'model "' in lowered):
             return True
         return False
+
+    # Failure reasons that are provider/infra problems where re-running the
+    # standing goal will not make progress until the operator fixes config.
+    # Context/payload overflow is intentionally excluded — recovery is
+    # /compact, not goal pause.
+    _GOAL_BLOCKING_FAILURE_REASONS = frozenset({
+        "auth",
+        "auth_permanent",
+        "billing",
+        "rate_limit",
+        "upstream_rate_limit",
+        "overloaded",
+        "server_error",
+        "timeout",
+        "ssl_cert_verification",
+        "model_not_found",
+        "provider_policy_blocked",
+    })
+
+    @classmethod
+    def _is_goal_blocking_agent_failure(
+        cls,
+        *,
+        failed: bool = False,
+        failure_reason: Optional[str] = None,
+        error: Optional[str] = None,
+        final_response: str = "",
+    ) -> bool:
+        """Decide whether a standing goal should auto-pause after this turn.
+
+        Prefer structured agent-result fields (``failed`` / ``failure_reason``)
+        over free-text matching so normal short assistant replies are never
+        mistaken for infra failures.
+        """
+        reason = str(failure_reason or "").strip().lower()
+        if failed:
+            if reason in {"context_overflow", "payload_too_large", "image_too_large"}:
+                return False
+            if reason in cls._GOAL_BLOCKING_FAILURE_REASONS:
+                return True
+            # failed=True without a known reason (or unknown): fall back to
+            # error/final_response envelope detection.
+            blob = "\n".join(
+                part for part in (str(error or ""), str(final_response or "")) if part
+            )
+            return cls._looks_like_goal_blocking_provider_failure(blob)
+
+        # Not structurally failed — only pause on explicit short provider
+        # envelopes (sanitized gateway replies, etc.).
+        return cls._looks_like_goal_blocking_provider_failure(final_response)
+
+    def _session_id_for_session_key(self, session_key: str) -> str:
+        """Best-effort map gateway session_key → durable conversation session_id."""
+        if not session_key:
+            return ""
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return ""
+        try:
+            # Production SessionStore path.
+            entries = getattr(store, "_entries", None)
+            if isinstance(entries, dict):
+                entry = entries.get(session_key)
+                if entry is not None:
+                    return str(getattr(entry, "session_id", None) or "")
+        except Exception:
+            pass
+        try:
+            # Locked helper used elsewhere in the runner.
+            sid = self._lookup_session_id_under_store_lock(store, session_key)
+            return str(sid or "")
+        except Exception:
+            return ""
+
+    def _snapshot_pending_non_goal(
+        self, session_key: str, adapter: Any
+    ) -> Optional[Any]:
+        """Peek the adapter pending slot if it is a real user follow-up."""
+        if not session_key or adapter is None:
+            return None
+        pending_slot = getattr(adapter, "_pending_messages", None)
+        if not isinstance(pending_slot, dict):
+            return None
+        pending = pending_slot.get(session_key)
+        if pending is None:
+            return None
+        if self._is_goal_continuation_event(pending):
+            return None
+        return pending
+
+    def _restore_pending_non_goal(
+        self, session_key: str, adapter: Any, pending: Any
+    ) -> None:
+        """Put back a non-goal pending event after interrupt discarded the slot."""
+        if pending is None or not session_key or adapter is None:
+            return
+        pending_slot = getattr(adapter, "_pending_messages", None)
+        if not isinstance(pending_slot, dict):
+            return
+        # Don't overwrite a newer pending event that landed after interrupt.
+        if session_key in pending_slot:
+            return
+        pending_slot[session_key] = pending
 
     def _pause_active_goal_for_session(
         self,
@@ -7468,15 +7571,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: Any = None,
         reason: str = "user-interrupted",
         adapter: Any = None,
+        preserve_non_goal_pending: bool = True,
     ) -> bool:
         """Pause an active standing goal and drain its queued continuations.
 
         Mirrors CLI Ctrl+C auto-pause so gateway ``/stop`` (and provider-dead
         turns) cannot leave a Ralph loop re-queuing synthetic user messages.
         Returns True when a goal was active and got paused.
+
+        When ``preserve_non_goal_pending`` is True (default), a real user
+        follow-up sitting in the adapter pending slot is not removed — only
+        synthetic goal continuations are drained from pending + overflow.
         """
         paused = False
         sid = (session_id or "").strip()
+        if not sid and session_key:
+            sid = self._session_id_for_session_key(session_key)
+
+        key = session_key
+        if not key and source is not None:
+            try:
+                key = self._session_key_for_source(source)
+            except Exception:
+                key = None
+
+        ad = adapter
+        if ad is None and source is not None:
+            try:
+                ad = self._adapter_for_source(source)
+            except Exception:
+                ad = None
+
+        saved_pending = None
+        if preserve_non_goal_pending and key:
+            saved_pending = self._snapshot_pending_non_goal(key, ad)
 
         if sid:
             try:
@@ -7490,21 +7618,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as exc:
                 logger.debug("goal pause-on-stop failed: %s", exc)
 
-        # Always attempt to drain synthetic goal FIFO even if pause failed
-        # (e.g. goal already paused but continuations still queued).
+        # Drain synthetic goal FIFO (pending slot + overflow). Real user
+        # queue items are preserved by _clear_goal_pending_continuations.
         try:
-            key = session_key
-            if not key and source is not None:
-                key = self._session_key_for_source(source)
-            ad = adapter
-            if ad is None and source is not None:
-                ad = self._adapter_for_source(source)
             if key:
                 self._clear_goal_pending_continuations(key, ad)
         except Exception as exc:
             logger.debug("goal continuation drain on pause failed: %s", exc)
 
+        if preserve_non_goal_pending and key:
+            self._restore_pending_non_goal(key, ad, saved_pending)
+
         return paused
+
+    async def _interrupt_stop_and_pause_goal(
+        self,
+        session_key: str,
+        source: Any,
+        *,
+        interrupt_reason: str,
+        invalidation_reason: str,
+        session_id: Optional[str] = None,
+        reason: str = "user-interrupted (/stop)",
+    ) -> bool:
+        """Interrupt a run, preserve non-goal pending follow-ups, pause goal.
+
+        ``_interrupt_and_clear_session`` discards the adapter pending slot
+        wholesale. Goal continuations should die; ordinary user follow-ups
+        queued while the agent was busy must survive.
+        """
+        adapter = None
+        try:
+            adapter = self._adapter_for_source(source) if source is not None else None
+        except Exception:
+            adapter = None
+
+        saved_pending = self._snapshot_pending_non_goal(session_key, adapter)
+        await self._interrupt_and_clear_session(
+            session_key,
+            source,
+            interrupt_reason=interrupt_reason,
+            invalidation_reason=invalidation_reason,
+        )
+        # Restore real user pending before goal drain so clear only removes
+        # synthetic goal continuations from overflow/pending.
+        self._restore_pending_non_goal(session_key, adapter, saved_pending)
+
+        sid = (session_id or "").strip() or self._session_id_for_session_key(session_key)
+        return self._pause_active_goal_for_session(
+            session_id=sid,
+            session_key=session_key,
+            source=source,
+            reason=reason,
+            adapter=adapter,
+            preserve_non_goal_pending=True,
+        )
 
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         try:
@@ -13501,25 +13669,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # is truly hung — the executor thread is blocked and never checks
         # _interrupt_requested.  Force-clean _running_agents so the session
         # is unlocked and subsequent messages are processed normally.
-        await self._interrupt_and_clear_session(
+        #
+        # Also pause standing /goal (CLI Ctrl+C parity) while preserving any
+        # real user follow-up that was sitting in the pending slot.
+        try:
+            session_entry = await self.async_session_store.get_or_create_session(source)
+            sid = getattr(session_entry, "session_id", None) or ""
+        except Exception:
+            sid = ""
+        await self._interrupt_stop_and_pause_goal(
             quick_key,
             source,
             interrupt_reason=_INTERRUPT_REASON_STOP,
             invalidation_reason="stop_command",
+            session_id=sid,
+            reason="user-interrupted (/stop)",
         )
-        # Parity with CLI Ctrl+C: pause standing /goal so the Ralph loop
-        # cannot re-queue synthetic continuations after the interrupt.
-        try:
-            session_entry = await self.async_session_store.get_or_create_session(source)
-            sid = getattr(session_entry, "session_id", None) or ""
-            self._pause_active_goal_for_session(
-                session_id=sid,
-                session_key=quick_key,
-                source=source,
-                reason="user-interrupted (/stop)",
-            )
-        except Exception as exc:
-            logger.debug("busy /stop goal pause failed: %s", exc)
         logger.info("STOP for session %s — agent interrupted, session lock released", quick_key)
         return EphemeralReply(t("gateway.stop.stopped"))
 
@@ -15017,14 +15182,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # broken judge never breaks normal message handling.
             try:
                 _final_text = ""
+                _agent_failed = False
+                _failure_reason = None
+                _agent_error = None
                 if isinstance(_agent_result, dict):
                     _final_text = str(_agent_result.get("final_response") or "")
+                    _agent_failed = bool(_agent_result.get("failed"))
+                    _failure_reason = _agent_result.get("failure_reason")
+                    _agent_error = _agent_result.get("error")
+                    # Interrupted turns must not re-arm the Ralph loop via
+                    # judge fail-open on partial text.
+                    if _agent_result.get("interrupted"):
+                        _final_text = ""
                 elif isinstance(_agent_result, str):
                     _final_text = _agent_result
                 # Skip for empty responses (interrupted / errored) — the
                 # judge would almost always say "continue" and we'd loop
                 # on error. Let the user drive the next turn.
-                if _final_text.strip():
+                # Exception: structured failed=True still runs the goal
+                # short-circuit so provider deaths pause the standing goal.
+                if _final_text.strip() or _agent_failed:
                     try:
                         session_entry = await self.async_session_store.get_or_create_session(source)
                     except Exception:
@@ -15034,6 +15211,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_entry=session_entry,
                             source=source,
                             final_response=_final_text,
+                            failed=_agent_failed,
+                            failure_reason=_failure_reason,
+                            error=_agent_error,
                         )
             except Exception as _goal_exc:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
@@ -17999,6 +18179,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_entry: Any,
         source: Any,
         final_response: str,
+        failed: bool = False,
+        failure_reason: Optional[str] = None,
+        error: Optional[str] = None,
     ) -> None:
         """Run the goal judge after a gateway turn and, if still active,
         enqueue a continuation prompt for the same session.
@@ -18027,10 +18210,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         # Provider/infra failure short-circuit: do NOT call the judge.
-        # Judge fail-open returns "continue" on "no evidence of progress",
-        # which turns a dead model (404 / auth / rate-limit) into a tight
-        # self-continuation loop that burns the full turn budget.
-        if self._looks_like_goal_blocking_provider_failure(final_response or ""):
+        # Prefer structured agent_result.failed / failure_reason; fall back
+        # to short provider envelopes. Judge fail-open returns "continue"
+        # on "no evidence of progress", which turns a dead model into a
+        # tight self-continuation loop that burns the full turn budget.
+        if self._is_goal_blocking_agent_failure(
+            failed=failed,
+            failure_reason=failure_reason,
+            error=error,
+            final_response=final_response or "",
+        ):
             try:
                 _quick_key = self._session_key_for_source(source) if source is not None else None
             except Exception:
@@ -18049,9 +18238,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if source is not None:
                 await self._defer_goal_status_notice_after_delivery(source, notice)
             logger.info(
-                "goal auto-paused after provider failure for session %s",
+                "goal auto-paused after provider failure for session %s "
+                "(failed=%s failure_reason=%s)",
                 sid,
+                failed,
+                failure_reason,
             )
+            return
+
+        # Empty successful responses: nothing to judge.
+        if not str(final_response or "").strip():
             return
 
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7421,6 +7421,91 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("goal continuation: active-state recheck failed: %s", exc)
             return False
 
+    @staticmethod
+    def _looks_like_goal_blocking_provider_failure(text: str) -> bool:
+        """True when the turn failed due to model/provider infrastructure.
+
+        Standing goals must not self-continue on these responses: the judge
+        fail-opens to ``continue`` (no evidence of progress), which re-queues
+        synthetic goal turns and burns the full turn budget on a dead model.
+        """
+        body = str(text or "").strip()
+        if not body:
+            return False
+        # Prefer the gateway's existing short-envelope detector first.
+        if _looks_like_gateway_provider_error(body):
+            return True
+        # Only apply broader markers to short failure envelopes — long
+        # assistant prose that mentions HTTP status codes in passing must
+        # not pause the goal.
+        if len(body) > 400 or body.count("\n") > 4:
+            return False
+        lowered = body.lower()
+        markers = (
+            "the model provider failed after retries",
+            "model provider failed after retries",
+            "provider authentication failed",
+            "model provider is rate-limiting",
+            "model provider rejected the request",
+            "model not found",
+            "no longer in our configuration",
+            "no longer in nous catalog",
+            "non-retryable client error",
+            "non-retryable error",
+        )
+        if any(m in lowered for m in markers):
+            return True
+        # Model-id 404s: Model 'foo' not found
+        if "not found" in lowered and ("model '" in lowered or "model \"" in lowered):
+            return True
+        return False
+
+    def _pause_active_goal_for_session(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+        source: Any = None,
+        reason: str = "user-interrupted",
+        adapter: Any = None,
+    ) -> bool:
+        """Pause an active standing goal and drain its queued continuations.
+
+        Mirrors CLI Ctrl+C auto-pause so gateway ``/stop`` (and provider-dead
+        turns) cannot leave a Ralph loop re-queuing synthetic user messages.
+        Returns True when a goal was active and got paused.
+        """
+        paused = False
+        sid = (session_id or "").strip()
+
+        if sid:
+            try:
+                from hermes_cli.goals import GoalManager
+
+                max_turns = self._goal_max_turns_from_config()
+                mgr = GoalManager(session_id=sid, default_max_turns=max_turns)
+                if mgr.is_active():
+                    mgr.pause(reason=reason)
+                    paused = True
+            except Exception as exc:
+                logger.debug("goal pause-on-stop failed: %s", exc)
+
+        # Always attempt to drain synthetic goal FIFO even if pause failed
+        # (e.g. goal already paused but continuations still queued).
+        try:
+            key = session_key
+            if not key and source is not None:
+                key = self._session_key_for_source(source)
+            ad = adapter
+            if ad is None and source is not None:
+                ad = self._adapter_for_source(source)
+            if key:
+                self._clear_goal_pending_continuations(key, ad)
+        except Exception as exc:
+            logger.debug("goal continuation drain on pause failed: %s", exc)
+
+        return paused
+
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         try:
             from gateway.status import write_runtime_status
@@ -13422,6 +13507,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             interrupt_reason=_INTERRUPT_REASON_STOP,
             invalidation_reason="stop_command",
         )
+        # Parity with CLI Ctrl+C: pause standing /goal so the Ralph loop
+        # cannot re-queue synthetic continuations after the interrupt.
+        try:
+            session_entry = await self.async_session_store.get_or_create_session(source)
+            sid = getattr(session_entry, "session_id", None) or ""
+            self._pause_active_goal_for_session(
+                session_id=sid,
+                session_key=quick_key,
+                source=source,
+                reason="user-interrupted (/stop)",
+            )
+        except Exception as exc:
+            logger.debug("busy /stop goal pause failed: %s", exc)
         logger.info("STOP for session %s — agent interrupted, session lock released", quick_key)
         return EphemeralReply(t("gateway.stop.stopped"))
 
@@ -17926,6 +18024,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         mgr = GoalManager(session_id=sid, default_max_turns=max_turns)
         if not mgr.is_active():
+            return
+
+        # Provider/infra failure short-circuit: do NOT call the judge.
+        # Judge fail-open returns "continue" on "no evidence of progress",
+        # which turns a dead model (404 / auth / rate-limit) into a tight
+        # self-continuation loop that burns the full turn budget.
+        if self._looks_like_goal_blocking_provider_failure(final_response or ""):
+            try:
+                _quick_key = self._session_key_for_source(source) if source is not None else None
+            except Exception:
+                _quick_key = None
+            self._pause_active_goal_for_session(
+                session_id=sid,
+                session_key=_quick_key,
+                source=source,
+                reason="provider/model failure (auto-paused to prevent goal spin)",
+            )
+            notice = (
+                "⏸ Goal paused — the model provider failed this turn "
+                "(e.g. missing model, auth, or rate limit). "
+                "Fix the model/provider, then `/goal resume` or `/goal clear`."
+            )
+            if source is not None:
+                await self._defer_goal_status_notice_after_delivery(source, notice)
+            logger.info(
+                "goal auto-paused after provider failure for session %s",
+                sid,
+            )
             return
 
         try:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1433,33 +1433,70 @@ class GatewaySlashCommandsMixin:
         fallback.  Force-clean the session lock in all cases for safety.
 
         The session is preserved so the user can continue the conversation.
+
+        Standing ``/goal`` loops are also paused (CLI Ctrl+C parity) and any
+        queued synthetic goal continuations are drained — otherwise ``/stop``
+        only kills the current turn and the Ralph loop immediately re-queues.
+        Real user follow-ups in the pending slot survive interrupt.
         """
         from gateway.run import _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_STOP
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        session_id = getattr(session_entry, "session_id", None) or ""
+        adapter = getattr(self, "adapters", {}).get(source.platform) if source else None
+
+        async def _stop_one(key: str, *, sid: str = "", inv_reason: str) -> bool:
+            try:
+                return bool(
+                    await self._interrupt_stop_and_pause_goal(
+                        key,
+                        source,
+                        interrupt_reason=_INTERRUPT_REASON_STOP,
+                        invalidation_reason=inv_reason,
+                        session_id=sid,
+                        reason="user-interrupted (/stop)",
+                    )
+                )
+            except Exception as exc:
+                logger.debug("/stop goal pause failed for %s: %s", key, exc)
+                return False
+
+        def _pause_only() -> bool:
+            # No running agent: still pause caller's goal + drain continuations.
+            try:
+                return bool(
+                    self._pause_active_goal_for_session(
+                        session_id=session_id,
+                        session_key=session_key,
+                        source=source,
+                        reason="user-interrupted (/stop)",
+                        adapter=adapter,
+                        preserve_non_goal_pending=True,
+                    )
+                )
+            except Exception as exc:
+                logger.debug("/stop goal pause failed: %s", exc)
+                return False
 
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:
-            # Force-clean the sentinel so the session is unlocked.
-            await self._interrupt_and_clear_session(
-                session_key,
-                source,
-                interrupt_reason=_INTERRUPT_REASON_STOP,
-                invalidation_reason="stop_command_pending",
+            goal_paused = await _stop_one(
+                session_key, sid=session_id, inv_reason="stop_command_pending"
             )
             logger.info("STOP (pending) for session %s — sentinel cleared", session_key)
-            return EphemeralReply(t("gateway.stop.stopped_pending"))
+            msg = t("gateway.stop.stopped_pending")
+            if goal_paused:
+                msg = f"{msg}\n⏸ Goal paused — use /goal resume to continue, or /goal clear to stop."
+            return EphemeralReply(msg)
         if agent:
-            # Force-clean the session lock so a truly hung agent doesn't
-            # keep it locked forever.
-            await self._interrupt_and_clear_session(
-                session_key,
-                source,
-                interrupt_reason=_INTERRUPT_REASON_STOP,
-                invalidation_reason="stop_command_handler",
+            goal_paused = await _stop_one(
+                session_key, sid=session_id, inv_reason="stop_command_handler"
             )
-            return EphemeralReply(t("gateway.stop.stopped"))
+            msg = t("gateway.stop.stopped")
+            if goal_paused:
+                msg = f"{msg}\n⏸ Goal paused — use /goal resume to continue, or /goal clear to stop."
+            return EphemeralReply(msg)
 
         # No run under the caller's own session key.  In a per-user thread
         # (thread_sessions_per_user=True) each participant is isolated even
@@ -1467,29 +1504,47 @@ class GatewaySlashCommandsMixin:
         # a different key.  Authorized users should still be able to /stop it
         # (#bernard-thread-stop).  Fall back to interrupting any running
         # agent(s) that share this thread, gated on authorization.
+        #
+        # Pause goals on EACH interrupted sibling session (not just the
+        # caller's), since the standing goal lives on the session that was
+        # actually running.
         sibling_keys = self._sibling_thread_run_keys(source, session_key)
         if sibling_keys and self._is_user_authorized(source):
+            any_paused = False
             for sibling_key in sibling_keys:
-                await self._interrupt_and_clear_session(
+                sibling_sid = ""
+                try:
+                    sibling_sid = self._session_id_for_session_key(sibling_key)
+                except Exception:
+                    sibling_sid = ""
+                if await _stop_one(
                     sibling_key,
-                    source,
-                    interrupt_reason=_INTERRUPT_REASON_STOP,
-                    invalidation_reason="stop_command_thread_sibling",
-                )
+                    sid=sibling_sid,
+                    inv_reason="stop_command_thread_sibling",
+                ):
+                    any_paused = True
+            # Also pause the caller's own goal if they have one active.
+            if _pause_only():
+                any_paused = True
             logger.info(
                 "STOP (thread sibling) by %s — interrupted %d run(s) in thread: %s",
                 session_key,
                 len(sibling_keys),
                 ", ".join(sibling_keys),
             )
-            return EphemeralReply(t("gateway.stop.stopped"))
+            msg = t("gateway.stop.stopped")
+            if any_paused:
+                msg = f"{msg}\n⏸ Goal paused — use /goal resume to continue, or /goal clear to stop."
+            return EphemeralReply(msg)
 
         # No running agent anywhere for this scope. A platform status
         # indicator can still be stuck — e.g. Slack's persistent
         # assistant.threads.setStatus survives a gateway restart or a turn
         # that died without a final send (#32295). Best-effort clear so
         # /stop always dismisses a phantom "is thinking...".
-        adapter = getattr(self, "adapters", {}).get(source.platform)
+        # Also pause standing goals here: between Ralph-loop turns there is
+        # often no active agent, but synthetic continuations keep firing.
+        goal_paused = _pause_only()
         if adapter and hasattr(adapter, "_stop_typing_with_metadata"):
             try:
                 await adapter._stop_typing_with_metadata(
@@ -1504,6 +1559,12 @@ class GatewaySlashCommandsMixin:
                     exc_info=True,
                 )
 
+        if goal_paused:
+            return (
+                "⏸ No active agent task, but the standing goal was paused "
+                "and queued goal continuations were cleared. "
+                "Use /goal resume to continue, or /goal clear to stop."
+            )
         return t("gateway.stop.no_active")
 
     async def _handle_platform_command(self, event: MessageEvent) -> str:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1355,11 +1355,32 @@ class GatewaySlashCommandsMixin:
         fallback.  Force-clean the session lock in all cases for safety.
 
         The session is preserved so the user can continue the conversation.
+
+        Standing ``/goal`` loops are also paused (CLI Ctrl+C parity) and any
+        queued synthetic goal continuations are drained — otherwise ``/stop``
+        only kills the current turn and the Ralph loop immediately re-queues.
         """
         from gateway.run import _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_STOP
         source = event.source
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        session_id = getattr(session_entry, "session_id", None) or ""
+        adapter = getattr(self, "adapters", {}).get(source.platform) if source else None
+
+        def _pause_goal() -> bool:
+            try:
+                return bool(
+                    self._pause_active_goal_for_session(
+                        session_id=session_id,
+                        session_key=session_key,
+                        source=source,
+                        reason="user-interrupted (/stop)",
+                        adapter=adapter,
+                    )
+                )
+            except Exception as exc:
+                logger.debug("/stop goal pause failed: %s", exc)
+                return False
 
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:
@@ -1370,8 +1391,12 @@ class GatewaySlashCommandsMixin:
                 interrupt_reason=_INTERRUPT_REASON_STOP,
                 invalidation_reason="stop_command_pending",
             )
+            goal_paused = _pause_goal()
             logger.info("STOP (pending) for session %s — sentinel cleared", session_key)
-            return EphemeralReply(t("gateway.stop.stopped_pending"))
+            msg = t("gateway.stop.stopped_pending")
+            if goal_paused:
+                msg = f"{msg}\n⏸ Goal paused — use /goal resume to continue, or /goal clear to stop."
+            return EphemeralReply(msg)
         if agent:
             # Force-clean the session lock so a truly hung agent doesn't
             # keep it locked forever.
@@ -1381,7 +1406,11 @@ class GatewaySlashCommandsMixin:
                 interrupt_reason=_INTERRUPT_REASON_STOP,
                 invalidation_reason="stop_command_handler",
             )
-            return EphemeralReply(t("gateway.stop.stopped"))
+            goal_paused = _pause_goal()
+            msg = t("gateway.stop.stopped")
+            if goal_paused:
+                msg = f"{msg}\n⏸ Goal paused — use /goal resume to continue, or /goal clear to stop."
+            return EphemeralReply(msg)
 
         # No run under the caller's own session key.  In a per-user thread
         # (thread_sessions_per_user=True) each participant is isolated even
@@ -1398,20 +1427,26 @@ class GatewaySlashCommandsMixin:
                     interrupt_reason=_INTERRUPT_REASON_STOP,
                     invalidation_reason="stop_command_thread_sibling",
                 )
+            goal_paused = _pause_goal()
             logger.info(
                 "STOP (thread sibling) by %s — interrupted %d run(s) in thread: %s",
                 session_key,
                 len(sibling_keys),
                 ", ".join(sibling_keys),
             )
-            return EphemeralReply(t("gateway.stop.stopped"))
+            msg = t("gateway.stop.stopped")
+            if goal_paused:
+                msg = f"{msg}\n⏸ Goal paused — use /goal resume to continue, or /goal clear to stop."
+            return EphemeralReply(msg)
 
         # No running agent anywhere for this scope. A platform status
         # indicator can still be stuck — e.g. Slack's persistent
         # assistant.threads.setStatus survives a gateway restart or a turn
         # that died without a final send (#32295). Best-effort clear so
         # /stop always dismisses a phantom "is thinking...".
-        adapter = getattr(self, "adapters", {}).get(source.platform)
+        # Also pause standing goals here: between Ralph-loop turns there is
+        # often no active agent, but synthetic continuations keep firing.
+        goal_paused = _pause_goal()
         if adapter and hasattr(adapter, "_stop_typing_with_metadata"):
             try:
                 await adapter._stop_typing_with_metadata(
@@ -1426,6 +1461,12 @@ class GatewaySlashCommandsMixin:
                     exc_info=True,
                 )
 
+        if goal_paused:
+            return (
+                "⏸ No active agent task, but the standing goal was paused "
+                "and queued goal continuations were cleared. "
+                "Use /goal resume to continue, or /goal clear to stop."
+            )
         return t("gateway.stop.no_active")
 
     async def _handle_platform_command(self, event: MessageEvent) -> str:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1359,6 +1359,7 @@ class GatewaySlashCommandsMixin:
         Standing ``/goal`` loops are also paused (CLI Ctrl+C parity) and any
         queued synthetic goal continuations are drained — otherwise ``/stop``
         only kills the current turn and the Ralph loop immediately re-queues.
+        Real user follow-ups in the pending slot survive interrupt.
         """
         from gateway.run import _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_STOP
         source = event.source
@@ -1367,7 +1368,24 @@ class GatewaySlashCommandsMixin:
         session_id = getattr(session_entry, "session_id", None) or ""
         adapter = getattr(self, "adapters", {}).get(source.platform) if source else None
 
-        def _pause_goal() -> bool:
+        async def _stop_one(key: str, *, sid: str = "", inv_reason: str) -> bool:
+            try:
+                return bool(
+                    await self._interrupt_stop_and_pause_goal(
+                        key,
+                        source,
+                        interrupt_reason=_INTERRUPT_REASON_STOP,
+                        invalidation_reason=inv_reason,
+                        session_id=sid,
+                        reason="user-interrupted (/stop)",
+                    )
+                )
+            except Exception as exc:
+                logger.debug("/stop goal pause failed for %s: %s", key, exc)
+                return False
+
+        def _pause_only() -> bool:
+            # No running agent: still pause caller's goal + drain continuations.
             try:
                 return bool(
                     self._pause_active_goal_for_session(
@@ -1376,6 +1394,7 @@ class GatewaySlashCommandsMixin:
                         source=source,
                         reason="user-interrupted (/stop)",
                         adapter=adapter,
+                        preserve_non_goal_pending=True,
                     )
                 )
             except Exception as exc:
@@ -1384,29 +1403,18 @@ class GatewaySlashCommandsMixin:
 
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:
-            # Force-clean the sentinel so the session is unlocked.
-            await self._interrupt_and_clear_session(
-                session_key,
-                source,
-                interrupt_reason=_INTERRUPT_REASON_STOP,
-                invalidation_reason="stop_command_pending",
+            goal_paused = await _stop_one(
+                session_key, sid=session_id, inv_reason="stop_command_pending"
             )
-            goal_paused = _pause_goal()
             logger.info("STOP (pending) for session %s — sentinel cleared", session_key)
             msg = t("gateway.stop.stopped_pending")
             if goal_paused:
                 msg = f"{msg}\n⏸ Goal paused — use /goal resume to continue, or /goal clear to stop."
             return EphemeralReply(msg)
         if agent:
-            # Force-clean the session lock so a truly hung agent doesn't
-            # keep it locked forever.
-            await self._interrupt_and_clear_session(
-                session_key,
-                source,
-                interrupt_reason=_INTERRUPT_REASON_STOP,
-                invalidation_reason="stop_command_handler",
+            goal_paused = await _stop_one(
+                session_key, sid=session_id, inv_reason="stop_command_handler"
             )
-            goal_paused = _pause_goal()
             msg = t("gateway.stop.stopped")
             if goal_paused:
                 msg = f"{msg}\n⏸ Goal paused — use /goal resume to continue, or /goal clear to stop."
@@ -1418,16 +1426,28 @@ class GatewaySlashCommandsMixin:
         # a different key.  Authorized users should still be able to /stop it
         # (#bernard-thread-stop).  Fall back to interrupting any running
         # agent(s) that share this thread, gated on authorization.
+        #
+        # Pause goals on EACH interrupted sibling session (not just the
+        # caller's), since the standing goal lives on the session that was
+        # actually running.
         sibling_keys = self._sibling_thread_run_keys(source, session_key)
         if sibling_keys and self._is_user_authorized(source):
+            any_paused = False
             for sibling_key in sibling_keys:
-                await self._interrupt_and_clear_session(
+                sibling_sid = ""
+                try:
+                    sibling_sid = self._session_id_for_session_key(sibling_key)
+                except Exception:
+                    sibling_sid = ""
+                if await _stop_one(
                     sibling_key,
-                    source,
-                    interrupt_reason=_INTERRUPT_REASON_STOP,
-                    invalidation_reason="stop_command_thread_sibling",
-                )
-            goal_paused = _pause_goal()
+                    sid=sibling_sid,
+                    inv_reason="stop_command_thread_sibling",
+                ):
+                    any_paused = True
+            # Also pause the caller's own goal if they have one active.
+            if _pause_only():
+                any_paused = True
             logger.info(
                 "STOP (thread sibling) by %s — interrupted %d run(s) in thread: %s",
                 session_key,
@@ -1435,7 +1455,7 @@ class GatewaySlashCommandsMixin:
                 ", ".join(sibling_keys),
             )
             msg = t("gateway.stop.stopped")
-            if goal_paused:
+            if any_paused:
                 msg = f"{msg}\n⏸ Goal paused — use /goal resume to continue, or /goal clear to stop."
             return EphemeralReply(msg)
 
@@ -1446,7 +1466,7 @@ class GatewaySlashCommandsMixin:
         # /stop always dismisses a phantom "is thinking...".
         # Also pause standing goals here: between Ralph-loop turns there is
         # often no active agent, but synthetic continuations keep firing.
-        goal_paused = _pause_goal()
+        goal_paused = _pause_only()
         if adapter and hasattr(adapter, "_stop_typing_with_metadata"):
             try:
                 await adapter._stop_typing_with_metadata(

--- a/tests/gateway/test_goal_stop_and_provider_failure.py
+++ b/tests/gateway/test_goal_stop_and_provider_failure.py
@@ -1,0 +1,455 @@
+"""Regression: standing /goal must not spin on provider failure or survive /stop.
+
+Observed failure mode (gateway messaging platforms):
+1. A session has an active standing /goal (Ralph loop).
+2. The configured model starts returning non-retryable provider failures
+   (e.g. HTTP 404 model-not-found after a catalog removal).
+3. Each failed turn still yields a short final_response / failed=True.
+4. The goal judge fail-opens to ``continue`` ("no evidence of progress").
+5. Gateway enqueues another synthetic ``[Continuing toward your standing goal]``
+   user message → tight loop until turn budget (default 20) is exhausted.
+6. Gateway ``/stop`` only interrupted the agent and did NOT pause the goal,
+   so the loop resumed between turns / after restart. CLI Ctrl+C already
+   auto-pauses goals; gateway did not.
+
+Follow-ups from PR review:
+- Sibling-thread /stop must pause goals on EACH interrupted sibling session.
+- Interrupt must preserve non-goal pending follow-ups (only drain goal conts).
+- Prefer structured failed/failure_reason over free-text markers alone.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_cli.goals import CONTINUATION_PROMPT_TEMPLATE, GoalManager
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+def _source(uid="user-1", chat_id="chat-1", thread_id=None):
+    return SessionSource(
+        platform=Platform.TELEGRAM if thread_id is None else Platform.DISCORD,
+        chat_id=chat_id,
+        user_id=uid,
+        thread_id=thread_id,
+        chat_type="forum" if thread_id else "dm",
+    )
+
+
+def _reload(sid: str) -> GoalManager:
+    return GoalManager(session_id=sid, default_max_turns=20)
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self._pending_messages = {}
+        self.callbacks = {}
+        self._active_sessions = {}
+        self.sent = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(content)
+        return SimpleNamespace(success=True)
+
+    def register_post_delivery_callback(self, session_key, callback, *, generation=None):
+        self.callbacks[session_key] = (generation, callback)
+
+    def get_pending_message(self, session_key):
+        return self._pending_messages.pop(session_key, None)
+
+    async def interrupt_session_activity(self, session_key, chat_id, metadata=None):
+        return None
+
+
+class _StoreEntry:
+    def __init__(self, session_key, session_id):
+        self.session_key = session_key
+        self.session_id = session_id
+
+
+class _FakeStore:
+    """SessionStore-shaped stub with optional multi-key entries map."""
+
+    def __init__(self, session_key=None, session_id=None, entries=None):
+        if entries is not None:
+            self._entries = dict(entries)
+        elif session_key is not None:
+            self._entries = {session_key: _StoreEntry(session_key, session_id)}
+        else:
+            self._entries = {}
+        self._key = session_key
+        self._sid = session_id
+
+    def get_or_create_session(self, source):
+        # Prefer exact key if known; otherwise first entry / stored default.
+        if self._key and self._key in self._entries:
+            return self._entries[self._key]
+        if self._entries:
+            return next(iter(self._entries.values()))
+        return _StoreEntry(self._key or "unknown", self._sid or "")
+
+
+async def _inline_exec(func, *args):
+    return func(*args)
+
+
+def _wire_post_turn(runner, adapter, *, session_key="telegram:chat-1", max_turns=20):
+    runner.adapters = {Platform.TELEGRAM: adapter, Platform.DISCORD: adapter}
+    runner.config = SimpleNamespace()
+    runner._goal_max_turns_from_config = lambda: max_turns
+    runner._session_key_for_source = lambda source: session_key
+    runner._adapter_for_source = lambda source: adapter
+    runner._enqueue_fifo = MagicMock()
+    runner._peek_session_state = lambda key: SimpleNamespace(
+        conversation=SimpleNamespace(queued_events=[])
+    )
+    runner._defer_goal_status_notice_after_delivery = AsyncMock()
+    runner._warm_goals_session_db = AsyncMock()
+    runner._run_in_executor_with_context = _inline_exec
+
+
+# ---------------------------------------------------------------------------
+# Structured + text failure detectors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"failed": True, "failure_reason": "model_not_found"},
+        {"failed": True, "failure_reason": "auth"},
+        {"failed": True, "failure_reason": "billing"},
+        {"failed": True, "failure_reason": "rate_limit"},
+        {
+            "failed": True,
+            "failure_reason": None,
+            "error": "HTTP 404: Model 'x' not found",
+        },
+        {
+            "failed": False,
+            "final_response": (
+                "⚠️ The model provider failed after retries. "
+                "I kept raw provider details out of chat."
+            ),
+        },
+    ],
+)
+def test_structured_provider_failure_detector_positive(kwargs):
+    assert GatewayRunner._is_goal_blocking_agent_failure(**kwargs) is True
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"failed": False, "final_response": "All checks passed; goal done."},
+        {"failed": True, "failure_reason": "context_overflow"},
+        {"failed": True, "failure_reason": "payload_too_large"},
+        {
+            "failed": False,
+            "final_response": (
+                "When debugging APIs, remember that clients often treat missing routes "
+                "similarly to missing objects. For example, some docs say that "
+                "receiving a not-found status simply means try another path. "
+                "Here is a longer explanation of DNS resolution and caching layers "
+                "so the body is clearly ordinary assistant prose rather than a "
+                "provider failure envelope returned to chat."
+            ),
+        },
+        {"failed": False, "final_response": "The model 'priya' voice sounded good."},
+    ],
+)
+def test_structured_provider_failure_detector_negative(kwargs):
+    assert GatewayRunner._is_goal_blocking_agent_failure(**kwargs) is False
+
+
+# ---------------------------------------------------------------------------
+# Post-turn continuation short-circuit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_structured_model_not_found_pauses_goal_and_skips_judge(hermes_home):
+    sid = f"sid-provider-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=20).set(
+        "Ship a working integration end-to-end"
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = _FakeAdapter()
+    _wire_post_turn(runner, adapter)
+
+    with patch("hermes_cli.goals.judge_goal") as judge_mock:
+        judge_mock.side_effect = AssertionError("judge must not run on provider failure")
+        await runner._post_turn_goal_continuation(
+            session_entry=SimpleNamespace(session_id=sid),
+            source=_source(),
+            final_response="The request failed: Model 'x' not found",
+            failed=True,
+            failure_reason="model_not_found",
+            error="Model 'x' not found",
+        )
+
+    state = _reload(sid).state
+    assert state.status == "paused"
+    assert "provider" in (state.paused_reason or "").lower()
+    runner._enqueue_fifo.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_text_envelope_still_pauses_when_failed_flag_missing(hermes_home):
+    sid = f"sid-env-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=20).set("Do the thing")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = _FakeAdapter()
+    _wire_post_turn(runner, adapter)
+
+    failure = (
+        "⚠️ The model provider failed after retries. I kept raw provider details "
+        "out of chat; check gateway logs for diagnostics."
+    )
+    with patch("hermes_cli.goals.judge_goal") as judge_mock:
+        judge_mock.side_effect = AssertionError("judge must not run")
+        await runner._post_turn_goal_continuation(
+            session_entry=SimpleNamespace(session_id=sid),
+            source=_source(),
+            final_response=failure,
+            failed=False,
+        )
+
+    assert _reload(sid).state.status == "paused"
+    runner._enqueue_fifo.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_does_not_auto_pause_goal(hermes_home):
+    sid = f"sid-ctx-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=5).set("Finish the task")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = _FakeAdapter()
+    _wire_post_turn(runner, adapter, max_turns=5)
+
+    with patch(
+        "hermes_cli.goals.judge_goal",
+        return_value=("continue", "not done yet", False, None, False),
+    ):
+        await runner._post_turn_goal_continuation(
+            session_entry=SimpleNamespace(session_id=sid),
+            source=_source(),
+            final_response="⚠️ Session too large for the model's context window.",
+            failed=True,
+            failure_reason="context_overflow",
+        )
+
+    # Not auto-paused by provider short-circuit; judge may continue.
+    assert _reload(sid).state.status == "active"
+    runner._enqueue_fifo.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_normal_response_still_evaluates_goal(hermes_home):
+    sid = f"sid-ok-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=5).set("Finish the task")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = _FakeAdapter()
+    _wire_post_turn(runner, adapter, max_turns=5)
+
+    with patch(
+        "hermes_cli.goals.judge_goal",
+        return_value=("done", "verified", False, None, False),
+    ):
+        await runner._post_turn_goal_continuation(
+            session_entry=SimpleNamespace(session_id=sid),
+            source=_source(),
+            final_response="Done. Verification: all checks passed with concrete output.",
+            failed=False,
+        )
+
+    assert _reload(sid).state.status == "done"
+    runner._enqueue_fifo.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# /stop: pause + pending preservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_preserves_non_goal_pending_followup(hermes_home):
+    sid = f"sid-pend-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=10).set("Do the thing")
+
+    session_key = "agent:main:telegram:dm:chat-1"
+    adapter = _FakeAdapter()
+    user_followup = MessageEvent(
+        text="please also summarize costs",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+    adapter._pending_messages[session_key] = user_followup
+
+    class _Agent:
+        def interrupt(self, reason=None):
+            return None
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running_agents = {session_key: _Agent()}
+    runner.session_store = _FakeStore(session_key, sid)
+    runner._is_user_authorized = lambda source: True
+    runner._sibling_thread_run_keys = lambda source, key: []
+    runner._goal_max_turns_from_config = lambda: 10
+    runner._session_key_for_source = lambda source: session_key
+    runner._adapter_for_source = lambda source: adapter
+    runner._thread_metadata_for_source = lambda source, reply_to_message_id=None: None
+    runner._invalidate_session_run_generation = lambda *a, **k: None
+    runner._release_running_agent_state = lambda *a, **k: None
+    runner._evict_cached_agent = lambda *a, **k: None
+    runner._peek_session_state = lambda key: SimpleNamespace(
+        turn=SimpleNamespace(agent=_Agent()),
+        persistent=SimpleNamespace(pending_command_text=None),
+        conversation=SimpleNamespace(queued_events=[]),
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    event = MessageEvent(text="/stop", message_type=MessageType.TEXT, source=_source())
+    await runner._handle_stop_command(event)
+
+    assert _reload(sid).state.status == "paused"
+    # Real user follow-up must survive interrupt+goal drain.
+    restored = adapter._pending_messages.get(session_key)
+    assert restored is not None
+    assert restored.text == "please also summarize costs"
+
+
+@pytest.mark.asyncio
+async def test_stop_with_no_agent_pauses_active_goal_and_drains_queue(hermes_home):
+    sid = f"sid-stop-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=20).set(
+        "Keep working until integration is complete"
+    )
+
+    session_key = "agent:main:telegram:dm:chat-1"
+    adapter = _FakeAdapter()
+    adapter._pending_messages[session_key] = MessageEvent(
+        text=CONTINUATION_PROMPT_TEMPLATE.format(goal="keep going"),
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+
+    q_state = SimpleNamespace(
+        conversation=SimpleNamespace(
+            queued_events=[
+                MessageEvent(
+                    text=CONTINUATION_PROMPT_TEMPLATE.format(goal="keep going"),
+                    message_type=MessageType.TEXT,
+                    source=_source(),
+                ),
+                MessageEvent(
+                    text="real user queued follow-up",
+                    message_type=MessageType.TEXT,
+                    source=_source(),
+                ),
+            ]
+        )
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner.session_store = _FakeStore(session_key, sid)
+    runner._is_user_authorized = lambda source: True
+    runner._sibling_thread_run_keys = lambda source, key: []
+    runner._goal_max_turns_from_config = lambda: 20
+    runner._session_key_for_source = lambda source: session_key
+    runner._adapter_for_source = lambda source: adapter
+    runner._thread_metadata_for_source = lambda source, reply_to_message_id=None: None
+    runner._reply_anchor_for_event = lambda event: None
+    runner._peek_session_state = lambda key: q_state
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    event = MessageEvent(text="/stop", message_type=MessageType.TEXT, source=_source())
+    result = await runner._handle_stop_command(event)
+
+    state = _reload(sid).state
+    assert state.status == "paused"
+    assert adapter._pending_messages.get(session_key) is None
+    remaining = q_state.conversation.queued_events
+    assert len(remaining) == 1
+    assert remaining[0].text == "real user queued follow-up"
+    text = str(getattr(result, "text", result)).lower()
+    assert "goal" in text and "paused" in text
+
+
+@pytest.mark.asyncio
+async def test_stop_pauses_goal_on_each_sibling_session(hermes_home):
+    """Sibling-thread /stop must pause goals on interrupted siblings."""
+    sid_caller = f"sid-caller-{uuid.uuid4().hex}"
+    sid_sibling = f"sid-sib-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid_sibling, default_max_turns=10).set("Sibling goal work")
+    # Caller has no goal; sibling does.
+
+    key_caller = "agent:main:discord:forum:chan:thr:userA"
+    key_sibling = "agent:main:discord:forum:chan:thr:userB"
+
+    class _Agent:
+        def interrupt(self, reason=None):
+            return None
+
+    adapter = _FakeAdapter()
+    entries = {
+        key_caller: _StoreEntry(key_caller, sid_caller),
+        key_sibling: _StoreEntry(key_sibling, sid_sibling),
+    }
+    store = _FakeStore(entries=entries)
+    store._key = key_caller
+    store._sid = sid_caller
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running_agents = {key_sibling: _Agent()}  # only sibling is running
+    runner.session_store = store
+    runner._is_user_authorized = lambda source: True
+    runner._sibling_thread_run_keys = lambda source, key: [key_sibling]
+    runner._goal_max_turns_from_config = lambda: 10
+    runner._session_key_for_source = lambda source: key_caller
+    runner._adapter_for_source = lambda source: adapter
+    runner._thread_metadata_for_source = lambda source, reply_to_message_id=None: None
+    runner._invalidate_session_run_generation = lambda *a, **k: None
+    runner._release_running_agent_state = lambda *a, **k: None
+    runner._evict_cached_agent = lambda *a, **k: None
+    runner._peek_session_state = lambda key: SimpleNamespace(
+        turn=SimpleNamespace(agent=_Agent() if key == key_sibling else None),
+        persistent=SimpleNamespace(pending_command_text=None),
+        conversation=SimpleNamespace(queued_events=[]),
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+
+    source = _source(uid="userA", chat_id="chan", thread_id="thr")
+    event = MessageEvent(text="/stop", message_type=MessageType.TEXT, source=source)
+    result = await runner._handle_stop_command(event)
+
+    # Sibling goal paused even though caller issued /stop.
+    assert _reload(sid_sibling).state.status == "paused"
+    text = str(getattr(result, "text", result)).lower()
+    assert "paused" in text

--- a/tests/gateway/test_goal_stop_and_provider_failure.py
+++ b/tests/gateway/test_goal_stop_and_provider_failure.py
@@ -1,0 +1,312 @@
+"""Regression: standing /goal must not spin on provider failure or survive /stop.
+
+Observed failure mode (gateway messaging platforms):
+1. A session has an active standing /goal (Ralph loop).
+2. The configured model starts returning non-retryable provider errors
+   (e.g. HTTP 404 model-not-found after a catalog removal).
+3. Each failed turn still produces a short final_response.
+4. The goal judge fail-opens to ``continue`` ("no evidence of progress").
+5. Gateway enqueues another synthetic ``[Continuing toward your standing goal]``
+   user message → tight loop until turn budget (default 20) is exhausted.
+6. Gateway ``/stop`` only interrupted the agent and did NOT pause the goal,
+   so the loop resumed between turns / after restart. CLI Ctrl+C already
+   auto-pauses goals; gateway did not.
+
+These tests cover the two escape hatches:
+- auto-pause on provider-looking final responses (skip judge + no enqueue)
+- gateway /stop pauses the goal and drains queued goal continuations
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_cli.goals import CONTINUATION_PROMPT_TEMPLATE, GoalManager
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        user_id="user-1",
+    )
+
+
+def _reload(sid: str) -> GoalManager:
+    return GoalManager(session_id=sid, default_max_turns=20)
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self._pending_messages = {}
+        self.callbacks = {}
+        self._active_sessions = {}
+        self.sent = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(content)
+        return SimpleNamespace(success=True)
+
+    def register_post_delivery_callback(self, session_key, callback, *, generation=None):
+        self.callbacks[session_key] = (generation, callback)
+
+
+class _StoreEntry:
+    def __init__(self, session_key, session_id):
+        self.session_key = session_key
+        self.session_id = session_id
+
+
+class _FakeStore:
+    """Sync SessionStore-shaped stub used via GatewayRunner.async_session_store."""
+
+    def __init__(self, session_key, session_id):
+        self._key = session_key
+        self._sid = session_id
+
+    def get_or_create_session(self, source):
+        return _StoreEntry(self._key, self._sid)
+
+
+# ---------------------------------------------------------------------------
+# Provider-failure detector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "⚠️ The model provider failed after retries. I kept raw provider details out of chat.",
+        "HTTP 404: Model 'example-model:free' not found. The requested model does not exist.",
+        "Error code: 404 - {'status': 404, 'message': \"Model 'x' not found.\"}",
+        "Non-retryable client error: model not found",
+        "API call failed: provider authentication failed",
+    ],
+)
+def test_provider_failure_detector_positive(text):
+    assert GatewayRunner._looks_like_goal_blocking_provider_failure(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "Goal completed successfully. Outbound call placed and audio played back.",
+        # long prose that mentions HTTP 404 mid-sentence, not an error envelope
+        (
+            "When debugging APIs, remember that clients often treat missing routes "
+            "similarly to missing objects. For example, some docs say that "
+            "receiving a not-found status simply means try another path. "
+            "Here is a longer explanation of DNS resolution and caching layers "
+            "so the body is clearly ordinary assistant prose rather than a "
+            "provider failure envelope returned to chat."
+        ),
+        "The model 'priya' voice sounded good on the call.",
+    ],
+)
+def test_provider_failure_detector_negative(text):
+    assert GatewayRunner._looks_like_goal_blocking_provider_failure(text) is False
+
+
+# ---------------------------------------------------------------------------
+# Post-turn continuation short-circuit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_auto_pauses_goal_and_skips_judge(hermes_home):
+    sid = f"sid-provider-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=20).set(
+        "Ship a working integration end-to-end"
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = _FakeAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config = SimpleNamespace()
+    runner._goal_max_turns_from_config = lambda: 20
+    runner._session_key_for_source = lambda source: "telegram:chat-1"
+    runner._adapter_for_source = lambda source: adapter
+    runner._enqueue_fifo = MagicMock()
+    runner._peek_session_state = lambda key: SimpleNamespace(
+        conversation=SimpleNamespace(queued_events=[])
+    )
+    runner._defer_goal_status_notice_after_delivery = AsyncMock()
+
+    session_entry = SimpleNamespace(session_id=sid)
+    source = _source()
+    failure = (
+        "⚠️ The model provider failed after retries. I kept raw provider details "
+        "out of chat; check gateway logs for diagnostics."
+    )
+
+    with patch("hermes_cli.goals.judge_goal") as judge_mock:
+        judge_mock.side_effect = AssertionError("judge must not run on provider failure")
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=source,
+            final_response=failure,
+        )
+
+    state = _reload(sid).state
+    assert state is not None
+    assert state.status == "paused"
+    assert "provider" in (state.paused_reason or "").lower()
+    runner._enqueue_fifo.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_normal_response_still_evaluates_goal(hermes_home):
+    sid = f"sid-ok-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=5).set("Finish the task")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = _FakeAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config = SimpleNamespace()
+    runner._goal_max_turns_from_config = lambda: 5
+    runner._session_key_for_source = lambda source: "telegram:chat-1"
+    runner._adapter_for_source = lambda source: adapter
+    runner._enqueue_fifo = MagicMock()
+    runner._peek_session_state = lambda key: SimpleNamespace(
+        conversation=SimpleNamespace(queued_events=[])
+    )
+    runner._defer_goal_status_notice_after_delivery = AsyncMock()
+
+    session_entry = SimpleNamespace(session_id=sid)
+    source = _source()
+
+    with patch(
+        "hermes_cli.goals.judge_goal",
+        return_value=("done", "verified", False, None, False),
+    ):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=source,
+            final_response="Done. Verification: all checks passed with concrete output.",
+        )
+
+    assert _reload(sid).state.status == "done"
+    runner._enqueue_fifo.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# /stop pauses goal when no agent is running (between Ralph turns)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_with_no_agent_pauses_active_goal_and_drains_queue(hermes_home):
+    sid = f"sid-stop-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=20).set(
+        "Keep working until integration is complete"
+    )
+
+    session_key = "agent:main:telegram:dm:chat-1"
+    adapter = _FakeAdapter()
+    cont = MessageEvent(
+        text=CONTINUATION_PROMPT_TEMPLATE.format(goal="keep going"),
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+    adapter._pending_messages[session_key] = cont
+
+    q_state = SimpleNamespace(
+        conversation=SimpleNamespace(
+            queued_events=[
+                MessageEvent(
+                    text=CONTINUATION_PROMPT_TEMPLATE.format(goal="keep going"),
+                    message_type=MessageType.TEXT,
+                    source=_source(),
+                ),
+                MessageEvent(
+                    text="real user queued follow-up",
+                    message_type=MessageType.TEXT,
+                    source=_source(),
+                ),
+            ]
+        )
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner.session_store = _FakeStore(session_key, sid)
+    runner._is_user_authorized = lambda source: True
+    runner._sibling_thread_run_keys = lambda source, key: []
+    runner._goal_max_turns_from_config = lambda: 20
+    runner._session_key_for_source = lambda source: session_key
+    runner._adapter_for_source = lambda source: adapter
+    runner._thread_metadata_for_source = lambda source, reply_to_message_id=None: None
+    runner._reply_anchor_for_event = lambda event: None
+    runner._peek_session_state = lambda key: q_state
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    event = MessageEvent(text="/stop", message_type=MessageType.TEXT, source=_source())
+    result = await runner._handle_stop_command(event)
+
+    state = _reload(sid).state
+    assert state.status == "paused"
+    assert "stop" in (state.paused_reason or "").lower()
+    assert adapter._pending_messages.get(session_key) is None
+    remaining = q_state.conversation.queued_events
+    assert len(remaining) == 1
+    assert remaining[0].text == "real user queued follow-up"
+    text = str(getattr(result, "text", result)).lower()
+    assert "goal" in text and "paused" in text
+
+
+@pytest.mark.asyncio
+async def test_stop_with_running_agent_also_pauses_goal(hermes_home):
+    sid = f"sid-stop-run-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=10).set("Do the thing")
+
+    session_key = "agent:main:telegram:dm:chat-1"
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running_agents = {session_key: object()}
+    runner.session_store = _FakeStore(session_key, sid)
+    runner._is_user_authorized = lambda source: True
+    runner._sibling_thread_run_keys = lambda source, key: []
+    runner._goal_max_turns_from_config = lambda: 10
+    runner._session_key_for_source = lambda source: session_key
+    runner._peek_session_state = lambda key: SimpleNamespace(
+        conversation=SimpleNamespace(queued_events=[])
+    )
+    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+
+    interrupted = []
+
+    async def _fake_interrupt(session_key, source, *, interrupt_reason, invalidation_reason):
+        interrupted.append((session_key, invalidation_reason))
+
+    runner._interrupt_and_clear_session = _fake_interrupt
+
+    event = MessageEvent(text="/stop", message_type=MessageType.TEXT, source=_source())
+    result = await runner._handle_stop_command(event)
+
+    assert interrupted
+    state = _reload(sid).state
+    assert state.status == "paused"
+    text = str(getattr(result, "text", result)).lower()
+    assert "paused" in text

--- a/tests/gateway/test_goal_stop_and_provider_failure.py
+++ b/tests/gateway/test_goal_stop_and_provider_failure.py
@@ -2,9 +2,9 @@
 
 Observed failure mode (gateway messaging platforms):
 1. A session has an active standing /goal (Ralph loop).
-2. The configured model starts returning non-retryable provider errors
+2. The configured model starts returning non-retryable provider failures
    (e.g. HTTP 404 model-not-found after a catalog removal).
-3. Each failed turn still produces a short final_response.
+3. Each failed turn still yields a short final_response / failed=True.
 4. The goal judge fail-opens to ``continue`` ("no evidence of progress").
 5. Gateway enqueues another synthetic ``[Continuing toward your standing goal]``
    user message → tight loop until turn budget (default 20) is exhausted.
@@ -12,9 +12,10 @@ Observed failure mode (gateway messaging platforms):
    so the loop resumed between turns / after restart. CLI Ctrl+C already
    auto-pauses goals; gateway did not.
 
-These tests cover the two escape hatches:
-- auto-pause on provider-looking final responses (skip judge + no enqueue)
-- gateway /stop pauses the goal and drains queued goal continuations
+Follow-ups from PR review:
+- Sibling-thread /stop must pause goals on EACH interrupted sibling session.
+- Interrupt must preserve non-goal pending follow-ups (only drain goal conts).
+- Prefer structured failed/failure_reason over free-text markers alone.
 """
 
 from __future__ import annotations
@@ -46,11 +47,13 @@ def hermes_home(tmp_path, monkeypatch):
     goals._DB_CACHE.clear()
 
 
-def _source():
+def _source(uid="user-1", chat_id="chat-1", thread_id=None):
     return SessionSource(
-        platform=Platform.TELEGRAM,
-        chat_id="chat-1",
-        user_id="user-1",
+        platform=Platform.TELEGRAM if thread_id is None else Platform.DISCORD,
+        chat_id=chat_id,
+        user_id=uid,
+        thread_id=thread_id,
+        chat_type="forum" if thread_id else "dm",
     )
 
 
@@ -72,6 +75,12 @@ class _FakeAdapter:
     def register_post_delivery_callback(self, session_key, callback, *, generation=None):
         self.callbacks[session_key] = (generation, callback)
 
+    def get_pending_message(self, session_key):
+        return self._pending_messages.pop(session_key, None)
+
+    async def interrupt_session_activity(self, session_key, chat_id, metadata=None):
+        return None
+
 
 class _StoreEntry:
     def __init__(self, session_key, session_id):
@@ -80,54 +89,79 @@ class _StoreEntry:
 
 
 class _FakeStore:
-    """Sync SessionStore-shaped stub used via GatewayRunner.async_session_store."""
+    """SessionStore-shaped stub with optional multi-key entries map."""
 
-    def __init__(self, session_key, session_id):
+    def __init__(self, session_key=None, session_id=None, entries=None):
+        if entries is not None:
+            self._entries = dict(entries)
+        elif session_key is not None:
+            self._entries = {session_key: _StoreEntry(session_key, session_id)}
+        else:
+            self._entries = {}
         self._key = session_key
         self._sid = session_id
 
     def get_or_create_session(self, source):
-        return _StoreEntry(self._key, self._sid)
+        # Prefer exact key if known; otherwise first entry / stored default.
+        if self._key and self._key in self._entries:
+            return self._entries[self._key]
+        if self._entries:
+            return next(iter(self._entries.values()))
+        return _StoreEntry(self._key or "unknown", self._sid or "")
 
 
 # ---------------------------------------------------------------------------
-# Provider-failure detector
+# Structured + text failure detectors
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "text",
+    "kwargs",
     [
-        "⚠️ The model provider failed after retries. I kept raw provider details out of chat.",
-        "HTTP 404: Model 'example-model:free' not found. The requested model does not exist.",
-        "Error code: 404 - {'status': 404, 'message': \"Model 'x' not found.\"}",
-        "Non-retryable client error: model not found",
-        "API call failed: provider authentication failed",
+        {"failed": True, "failure_reason": "model_not_found"},
+        {"failed": True, "failure_reason": "auth"},
+        {"failed": True, "failure_reason": "billing"},
+        {"failed": True, "failure_reason": "rate_limit"},
+        {
+            "failed": True,
+            "failure_reason": None,
+            "error": "HTTP 404: Model 'x' not found",
+        },
+        {
+            "failed": False,
+            "final_response": (
+                "⚠️ The model provider failed after retries. "
+                "I kept raw provider details out of chat."
+            ),
+        },
     ],
 )
-def test_provider_failure_detector_positive(text):
-    assert GatewayRunner._looks_like_goal_blocking_provider_failure(text) is True
+def test_structured_provider_failure_detector_positive(kwargs):
+    assert GatewayRunner._is_goal_blocking_agent_failure(**kwargs) is True
 
 
 @pytest.mark.parametrize(
-    "text",
+    "kwargs",
     [
-        "",
-        "Goal completed successfully. Outbound call placed and audio played back.",
-        # long prose that mentions HTTP 404 mid-sentence, not an error envelope
-        (
-            "When debugging APIs, remember that clients often treat missing routes "
-            "similarly to missing objects. For example, some docs say that "
-            "receiving a not-found status simply means try another path. "
-            "Here is a longer explanation of DNS resolution and caching layers "
-            "so the body is clearly ordinary assistant prose rather than a "
-            "provider failure envelope returned to chat."
-        ),
-        "The model 'priya' voice sounded good on the call.",
+        {"failed": False, "final_response": "All checks passed; goal done."},
+        {"failed": True, "failure_reason": "context_overflow"},
+        {"failed": True, "failure_reason": "payload_too_large"},
+        {
+            "failed": False,
+            "final_response": (
+                "When debugging APIs, remember that clients often treat missing routes "
+                "similarly to missing objects. For example, some docs say that "
+                "receiving a not-found status simply means try another path. "
+                "Here is a longer explanation of DNS resolution and caching layers "
+                "so the body is clearly ordinary assistant prose rather than a "
+                "provider failure envelope returned to chat."
+            ),
+        },
+        {"failed": False, "final_response": "The model 'priya' voice sounded good."},
     ],
 )
-def test_provider_failure_detector_negative(text):
-    assert GatewayRunner._looks_like_goal_blocking_provider_failure(text) is False
+def test_structured_provider_failure_detector_negative(kwargs):
+    assert GatewayRunner._is_goal_blocking_agent_failure(**kwargs) is False
 
 
 # ---------------------------------------------------------------------------
@@ -136,7 +170,7 @@ def test_provider_failure_detector_negative(text):
 
 
 @pytest.mark.asyncio
-async def test_provider_failure_auto_pauses_goal_and_skips_judge(hermes_home):
+async def test_structured_model_not_found_pauses_goal_and_skips_judge(hermes_home):
     sid = f"sid-provider-{uuid.uuid4().hex}"
     GoalManager(session_id=sid, default_max_turns=20).set(
         "Ship a working integration end-to-end"
@@ -155,26 +189,91 @@ async def test_provider_failure_auto_pauses_goal_and_skips_judge(hermes_home):
     )
     runner._defer_goal_status_notice_after_delivery = AsyncMock()
 
-    session_entry = SimpleNamespace(session_id=sid)
-    source = _source()
+    with patch("hermes_cli.goals.judge_goal") as judge_mock:
+        judge_mock.side_effect = AssertionError("judge must not run on provider failure")
+        await runner._post_turn_goal_continuation(
+            session_entry=SimpleNamespace(session_id=sid),
+            source=_source(),
+            final_response="The request failed: Model 'x' not found",
+            failed=True,
+            failure_reason="model_not_found",
+            error="Model 'x' not found",
+        )
+
+    state = _reload(sid).state
+    assert state.status == "paused"
+    assert "provider" in (state.paused_reason or "").lower()
+    runner._enqueue_fifo.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_text_envelope_still_pauses_when_failed_flag_missing(hermes_home):
+    sid = f"sid-env-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=20).set("Do the thing")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = _FakeAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config = SimpleNamespace()
+    runner._goal_max_turns_from_config = lambda: 20
+    runner._session_key_for_source = lambda source: "telegram:chat-1"
+    runner._adapter_for_source = lambda source: adapter
+    runner._enqueue_fifo = MagicMock()
+    runner._peek_session_state = lambda key: SimpleNamespace(
+        conversation=SimpleNamespace(queued_events=[])
+    )
+    runner._defer_goal_status_notice_after_delivery = AsyncMock()
+
     failure = (
         "⚠️ The model provider failed after retries. I kept raw provider details "
         "out of chat; check gateway logs for diagnostics."
     )
-
     with patch("hermes_cli.goals.judge_goal") as judge_mock:
-        judge_mock.side_effect = AssertionError("judge must not run on provider failure")
+        judge_mock.side_effect = AssertionError("judge must not run")
         await runner._post_turn_goal_continuation(
-            session_entry=session_entry,
-            source=source,
+            session_entry=SimpleNamespace(session_id=sid),
+            source=_source(),
             final_response=failure,
+            failed=False,
         )
 
-    state = _reload(sid).state
-    assert state is not None
-    assert state.status == "paused"
-    assert "provider" in (state.paused_reason or "").lower()
+    assert _reload(sid).state.status == "paused"
     runner._enqueue_fifo.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_does_not_auto_pause_goal(hermes_home):
+    sid = f"sid-ctx-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=5).set("Finish the task")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = _FakeAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config = SimpleNamespace()
+    runner._goal_max_turns_from_config = lambda: 5
+    runner._session_key_for_source = lambda source: "telegram:chat-1"
+    runner._adapter_for_source = lambda source: adapter
+    runner._enqueue_fifo = MagicMock()
+    runner._peek_session_state = lambda key: SimpleNamespace(
+        conversation=SimpleNamespace(queued_events=[])
+    )
+    runner._defer_goal_status_notice_after_delivery = AsyncMock()
+
+    with patch(
+        "hermes_cli.goals.judge_goal",
+        return_value=("continue", "not done yet", False, None, False),
+    ):
+        await runner._post_turn_goal_continuation(
+            session_entry=SimpleNamespace(session_id=sid),
+            source=_source(),
+            final_response="⚠️ Session too large for the model's context window.",
+            failed=True,
+            failure_reason="context_overflow",
+        )
+
+    # Not auto-paused by provider short-circuit; judge may continue.
+    assert _reload(sid).state.status == "active"
+    runner._enqueue_fifo.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -195,17 +294,15 @@ async def test_normal_response_still_evaluates_goal(hermes_home):
     )
     runner._defer_goal_status_notice_after_delivery = AsyncMock()
 
-    session_entry = SimpleNamespace(session_id=sid)
-    source = _source()
-
     with patch(
         "hermes_cli.goals.judge_goal",
         return_value=("done", "verified", False, None, False),
     ):
         await runner._post_turn_goal_continuation(
-            session_entry=session_entry,
-            source=source,
+            session_entry=SimpleNamespace(session_id=sid),
+            source=_source(),
             final_response="Done. Verification: all checks passed with concrete output.",
+            failed=False,
         )
 
     assert _reload(sid).state.status == "done"
@@ -213,8 +310,55 @@ async def test_normal_response_still_evaluates_goal(hermes_home):
 
 
 # ---------------------------------------------------------------------------
-# /stop pauses goal when no agent is running (between Ralph turns)
+# /stop: pause + pending preservation
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_preserves_non_goal_pending_followup(hermes_home):
+    sid = f"sid-pend-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid, default_max_turns=10).set("Do the thing")
+
+    session_key = "agent:main:telegram:dm:chat-1"
+    adapter = _FakeAdapter()
+    user_followup = MessageEvent(
+        text="please also summarize costs",
+        message_type=MessageType.TEXT,
+        source=_source(),
+    )
+    adapter._pending_messages[session_key] = user_followup
+
+    class _Agent:
+        def interrupt(self, reason=None):
+            return None
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running_agents = {session_key: _Agent()}
+    runner.session_store = _FakeStore(session_key, sid)
+    runner._is_user_authorized = lambda source: True
+    runner._sibling_thread_run_keys = lambda source, key: []
+    runner._goal_max_turns_from_config = lambda: 10
+    runner._session_key_for_source = lambda source: session_key
+    runner._adapter_for_source = lambda source: adapter
+    runner._thread_metadata_for_source = lambda source, reply_to_message_id=None: None
+    runner._invalidate_session_run_generation = lambda *a, **k: None
+    runner._release_running_agent_state = lambda *a, **k: None
+    runner._evict_cached_agent = lambda *a, **k: None
+    runner._peek_session_state = lambda key: SimpleNamespace(
+        turn=SimpleNamespace(agent=_Agent()),
+        persistent=SimpleNamespace(pending_command_text=None),
+        conversation=SimpleNamespace(queued_events=[]),
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    event = MessageEvent(text="/stop", message_type=MessageType.TEXT, source=_source())
+    await runner._handle_stop_command(event)
+
+    assert _reload(sid).state.status == "paused"
+    # Real user follow-up must survive interrupt+goal drain.
+    restored = adapter._pending_messages.get(session_key)
+    assert restored is not None
+    assert restored.text == "please also summarize costs"
 
 
 @pytest.mark.asyncio
@@ -226,12 +370,11 @@ async def test_stop_with_no_agent_pauses_active_goal_and_drains_queue(hermes_hom
 
     session_key = "agent:main:telegram:dm:chat-1"
     adapter = _FakeAdapter()
-    cont = MessageEvent(
+    adapter._pending_messages[session_key] = MessageEvent(
         text=CONTINUATION_PROMPT_TEMPLATE.format(goal="keep going"),
         message_type=MessageType.TEXT,
         source=_source(),
     )
-    adapter._pending_messages[session_key] = cont
 
     q_state = SimpleNamespace(
         conversation=SimpleNamespace(
@@ -268,7 +411,6 @@ async def test_stop_with_no_agent_pauses_active_goal_and_drains_queue(hermes_hom
 
     state = _reload(sid).state
     assert state.status == "paused"
-    assert "stop" in (state.paused_reason or "").lower()
     assert adapter._pending_messages.get(session_key) is None
     remaining = q_state.conversation.queued_events
     assert len(remaining) == 1
@@ -278,35 +420,53 @@ async def test_stop_with_no_agent_pauses_active_goal_and_drains_queue(hermes_hom
 
 
 @pytest.mark.asyncio
-async def test_stop_with_running_agent_also_pauses_goal(hermes_home):
-    sid = f"sid-stop-run-{uuid.uuid4().hex}"
-    GoalManager(session_id=sid, default_max_turns=10).set("Do the thing")
+async def test_stop_pauses_goal_on_each_sibling_session(hermes_home):
+    """Sibling-thread /stop must pause goals on interrupted siblings."""
+    sid_caller = f"sid-caller-{uuid.uuid4().hex}"
+    sid_sibling = f"sid-sib-{uuid.uuid4().hex}"
+    GoalManager(session_id=sid_sibling, default_max_turns=10).set("Sibling goal work")
+    # Caller has no goal; sibling does.
 
-    session_key = "agent:main:telegram:dm:chat-1"
+    key_caller = "agent:main:discord:forum:chan:thr:userA"
+    key_sibling = "agent:main:discord:forum:chan:thr:userB"
+
+    class _Agent:
+        def interrupt(self, reason=None):
+            return None
+
+    adapter = _FakeAdapter()
+    entries = {
+        key_caller: _StoreEntry(key_caller, sid_caller),
+        key_sibling: _StoreEntry(key_sibling, sid_sibling),
+    }
+    store = _FakeStore(entries=entries)
+    store._key = key_caller
+    store._sid = sid_caller
+
     runner = GatewayRunner.__new__(GatewayRunner)
-    runner._running_agents = {session_key: object()}
-    runner.session_store = _FakeStore(session_key, sid)
+    runner._running_agents = {key_sibling: _Agent()}  # only sibling is running
+    runner.session_store = store
     runner._is_user_authorized = lambda source: True
-    runner._sibling_thread_run_keys = lambda source, key: []
+    runner._sibling_thread_run_keys = lambda source, key: [key_sibling]
     runner._goal_max_turns_from_config = lambda: 10
-    runner._session_key_for_source = lambda source: session_key
+    runner._session_key_for_source = lambda source: key_caller
+    runner._adapter_for_source = lambda source: adapter
+    runner._thread_metadata_for_source = lambda source, reply_to_message_id=None: None
+    runner._invalidate_session_run_generation = lambda *a, **k: None
+    runner._release_running_agent_state = lambda *a, **k: None
+    runner._evict_cached_agent = lambda *a, **k: None
     runner._peek_session_state = lambda key: SimpleNamespace(
-        conversation=SimpleNamespace(queued_events=[])
+        turn=SimpleNamespace(agent=_Agent() if key == key_sibling else None),
+        persistent=SimpleNamespace(pending_command_text=None),
+        conversation=SimpleNamespace(queued_events=[]),
     )
-    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+    runner.adapters = {Platform.DISCORD: adapter}
 
-    interrupted = []
-
-    async def _fake_interrupt(session_key, source, *, interrupt_reason, invalidation_reason):
-        interrupted.append((session_key, invalidation_reason))
-
-    runner._interrupt_and_clear_session = _fake_interrupt
-
-    event = MessageEvent(text="/stop", message_type=MessageType.TEXT, source=_source())
+    source = _source(uid="userA", chat_id="chan", thread_id="thr")
+    event = MessageEvent(text="/stop", message_type=MessageType.TEXT, source=source)
     result = await runner._handle_stop_command(event)
 
-    assert interrupted
-    state = _reload(sid).state
-    assert state.status == "paused"
+    # Sibling goal paused even though caller issued /stop.
+    assert _reload(sid_sibling).state.status == "paused"
     text = str(getattr(result, "text", result)).lower()
     assert "paused" in text


### PR DESCRIPTION
## Bug Description

On messaging gateways (Telegram/Discord/etc.), an active standing `/goal` (Ralph loop) can enter a **tight self-continuation spin** that is hard to stop:

1. Configured model starts returning **non-retryable provider failures** (e.g. HTTP 404 after a model is removed from the provider catalog).
2. Each failed turn still yields a short final response and/or `failed=True` with a structured `failure_reason`.
3. The goal judge **fail-opens to `continue`** (“no evidence of progress toward the goal”).
4. Gateway enqueues another synthetic user message:
   `[Continuing toward your standing goal]\nGoal: …`
5. Loop repeats every few seconds until `goals.max_turns` is exhausted (default 20).
6. Gateway **`/stop` only interrupts the agent** and does **not** pause the standing goal or drain queued goal continuations — so the loop resumes between turns / after restart. CLI Ctrl+C already auto-pauses goals; gateway did not.

Users experience this as “Hermes won’t stop even after /stop or gateway restart.”

## Root Cause

| Surface | Behavior before this PR |
|---------|-------------------------|
| CLI Ctrl+C | Auto-pauses goal + skips judge (tested) |
| Gateway `/stop` | Interrupts agent only; goal stays `active`; FIFO continuations remain |
| Sibling-thread `/stop` | Interrupts sibling keys but would only pause the *caller’s* goal if paused at all |
| Active `/stop` pending slot | `_interrupt_and_clear_session()` discards adapter pending wholesale |
| Post-turn goal hook | Runs judge on provider-error final text → fail-open `continue` → re-queue |

Judge fail-open is correct for flaky *judge* transport, but applying it to a **main-model provider failure** turns a dead model into a budget-burning goal spin.

## Fix

### Original (commit `f3aa5941c`)
1. **Gateway `/stop`** pauses standing goals + drains synthetic goal continuations (CLI Ctrl+C parity), including between Ralph turns when no agent is running.
2. **Post-turn goal continuation** short-circuits on provider/infra failure instead of calling the judge.

### Review follow-ups (commit `01084b751`) — hermes-sweeper / teknium1
1. **Sibling-thread `/stop`:** resolve each interrupted sibling’s `session_id` and pause **that** session’s goal (not only the caller’s).
2. **Pending preservation:** snapshot/restore non-goal adapter pending follow-ups around interrupt; only synthetic goal continuations are removed.
3. **Structured failures:** prefer agent-result `failed` + `failure_reason`; free-text envelopes are secondary only. Context/payload overflow does **not** auto-pause.

## Evidence (redacted)

Reproduced on a long-lived gateway DM session with an active standing `/goal`. After the configured free model returned **HTTP 404 model-not-found**, logs showed the repeating pattern:

```text
agent.conversation_loop: Non-retryable client error: ... Model '…' not found ...
gateway.run: Transient agent failure in session <id> — persisting user message ...
hermes_cli.goals: goal judge: verdict=continue reason=... model provider failure ... no evidence ...
gateway.run: inbound message: ... '[Continuing toward your standing goal] Goal: ...'
```

Goal state ended as `paused` at turn budget (`20/20`) with last verdict `continue`. No user PII, phone numbers, chat IDs, or message content are included here.

## How to Verify

1. Start gateway chat; set `/goal <something multi-turn>`.
2. Point the session model at a deliberately invalid model id so the main agent returns a provider failure (`failed=True` / envelope).
3. **Before:** synthetic goal continuations keep arriving until turn budget.  
   **After:** one failure → goal auto-pauses; no further synthetic continuations.
4. With an active goal and no running agent, send `/stop`.  
   **After:** goal paused + goal continuations cleared; normal queued user messages kept.
5. With a busy agent and a real user follow-up pending, `/stop` should keep the follow-up and pause the goal.
6. In a per-user forum/thread, `/stop` from user A while user B’s agent is running should pause **B’s** standing goal if present.
7. `/goal resume` still works after fixing the model.

## Test Plan

- [x] `tests/gateway/test_goal_stop_and_provider_failure.py`
  - structured `failed` / `failure_reason` positives + false-positive guards
  - model_not_found auto-pause skips judge
  - context_overflow does **not** auto-pause
  - text envelope fallback when structured fields missing
  - `/stop` pauses goal with no agent + drains goal FIFO only
  - `/stop` preserves non-goal pending follow-up
  - sibling-thread `/stop` pauses each sibling’s goal
- [x] Existing related tests still pass:
  - `tests/gateway/test_stop_thread_sibling.py`
  - `tests/cli/test_cli_goal_interrupt.py`
  - `tests/gateway/test_goal_status_notice.py`

```bash
scripts/run_tests.sh \
  tests/gateway/test_goal_stop_and_provider_failure.py \
  tests/gateway/test_stop_thread_sibling.py \
  tests/cli/test_cli_goal_interrupt.py \
  tests/gateway/test_goal_status_notice.py
# → 26 passed
```

## Risk Assessment

**Low–Medium**

- Blast radius limited to gateway `/stop` + post-turn goal continuation.
- Structured failure reasons are the primary signal; text matching is secondary and limited to short envelopes.
- Context overflow intentionally excluded from auto-pause.
- Does not change CLI goal semantics beyond existing Ctrl+C parity.

## Privacy

This PR contains **no** personal data, phone numbers, emails, chat IDs, session transcripts, or credentials. Evidence is generalized from production logs with identifiers removed.