### PR TITLE
fix(agent): stop doubling the profile path in the system-prompt hint (#72894)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -49,7 +49,7 @@ from agent.prompt_builder import (
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -418,11 +418,19 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             "you to."
         )
     else:
+        # A non-default name is only ever returned when get_hermes_home() has
+        # ALREADY resolved to <root>/profiles/<name> — that is exactly how
+        # _resolve_active_profile_name() derives it. So the profile home is
+        # the session home itself; appending /profiles/<name> again doubled
+        # it. The default profile's data sits at the root, which in profile
+        # mode is get_hermes_home()'s grandparent, not get_hermes_home().
+        profile_home = get_hermes_home()
+        default_root = get_default_hermes_root()
         post_workspace_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes {get_hermes_home()}/profiles/{active_profile}/. The default "
-            f"profile's data lives at {get_hermes_home()}/skills/, {get_hermes_home()}/plugins/, "
-            f"{get_hermes_home()}/cron/, {get_hermes_home()}/memories/ — those belong to a "
+            f"and writes {profile_home}/. The default "
+            f"profile's data lives at {default_root}/skills/, {default_root}/plugins/, "
+            f"{default_root}/cron/, {default_root}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -116,72 +116,68 @@ class TestCodingContextBlock:
         assert "coding agent" not in _stable_prompt(agent)
 
 
-class TestNamedProfileHint:
-    """The profile hint must point at real paths (#72894).
+class TestNamedProfileHintIntegration:
+    """The same defect through the REAL resolution chain (#72894).
 
-    ``_resolve_active_profile_name()`` only returns a non-default name when
-    ``get_hermes_home()`` has already resolved to ``<root>/profiles/<name>``,
-    so appending ``/profiles/<name>`` to it doubled the segment, and using it
-    for the *default* profile's data pointed those inside the active profile.
+    ``TestNamedProfileHint`` mocks ``get_hermes_home``,
+    ``get_default_hermes_root`` and ``_resolve_active_profile_name``, so it
+    validates template rendering but not the relationship that causes the bug:
+    ``_resolve_active_profile_name`` returns a named profile *only* when the
+    active home is already ``<root>/profiles/<name>``, which is exactly why
+    appending that suffix again doubled it. Drive it with a real
+    ``HERMES_HOME`` and no resolver mocks.
     """
 
-    @staticmethod
-    def _full_prompt(monkeypatch, agent):
-        # Pin the prompt shape: with the coding posture off there is no
-        # workspace snapshot, so the hint's position doesn't depend on the
-        # cwd the suite happens to run from. Join both parts regardless.
+    def test_real_hermes_home_under_profiles_renders_correct_paths(
+        self, tmp_path, monkeypatch
+    ):
+        root = tmp_path / ".hermes"
+        profile_home = root / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        # Sanity-check the real chain before asserting on the prompt.
+        from agent.file_safety import _resolve_active_profile_name
+        from hermes_constants import get_default_hermes_root, get_hermes_home
+
+        assert _resolve_active_profile_name() == "coder"
+        assert get_hermes_home() == profile_home
+        assert get_default_hermes_root() == root
+
+        agent = _make_agent(valid_tool_names=["read_file"])
         with patch("agent.coding_context._coding_mode", return_value="off"):
-            return "\n\n".join(_prompt_parts(agent).values())
+            prompt = "\n\n".join(_prompt_parts(agent).values())
 
-    @classmethod
-    def _named_profile_prompt(cls, monkeypatch, name="mac"):
-        import agent.system_prompt as system_prompt
+        assert "Active Hermes profile: coder." in prompt
+        assert f"reads and writes {profile_home}/." in prompt
+        # The doubled form must not appear anywhere.
+        assert f"{profile_home}/profiles/coder" not in prompt
+        # Default-profile pointers belong at the root, not inside the profile.
+        assert f"The default profile's data lives at {root}/skills/" in prompt
+        assert f"{profile_home}/skills/" not in prompt
 
-        agent = _make_agent(valid_tool_names=["read_file"])
-        monkeypatch.setattr(
-            system_prompt, "get_hermes_home", lambda: Path(f"/hermes/profiles/{name}")
-        )
-        monkeypatch.setattr(
-            system_prompt, "get_default_hermes_root", lambda: Path("/hermes")
-        )
-        monkeypatch.setattr(
-            "agent.file_safety._resolve_active_profile_name", lambda: name
-        )
-        return cls._full_prompt(monkeypatch, agent)
+    def test_real_default_home_renders_default_branch(self, tmp_path, monkeypatch):
+        """HERMES_HOME at the root resolves to the default profile, unchanged."""
+        root = tmp_path / ".hermes"
+        root.mkdir(parents=True)
 
-    def test_session_home_is_not_doubled(self, monkeypatch):
-        prompt = self._named_profile_prompt(monkeypatch)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
 
-        assert "This session reads and writes /hermes/profiles/mac/." in prompt
-        assert "/hermes/profiles/mac/profiles/mac" not in prompt
+        from agent.file_safety import _resolve_active_profile_name
 
-    def test_default_profile_data_points_at_the_root(self, monkeypatch):
-        prompt = self._named_profile_prompt(monkeypatch)
-
-        assert (
-            "The default profile's data lives at /hermes/skills/, "
-            "/hermes/plugins/, /hermes/cron/, /hermes/memories/"
-        ) in prompt
-        # Never inside the active profile — that's the cross-profile
-        # confusion this hint exists to prevent.
-        assert "/hermes/profiles/mac/skills/" not in prompt
-        assert "/hermes/profiles/mac/memories/" not in prompt
-
-    def test_default_profile_hint_is_unchanged(self, monkeypatch):
-        import agent.system_prompt as system_prompt
+        assert _resolve_active_profile_name() == "default"
 
         agent = _make_agent(valid_tool_names=["read_file"])
-        monkeypatch.setattr(system_prompt, "get_hermes_home", lambda: Path("/hermes"))
-        monkeypatch.setattr(
-            "agent.file_safety._resolve_active_profile_name", lambda: "default"
-        )
-        prompt = self._full_prompt(monkeypatch, agent)
+        with patch("agent.coding_context._coding_mode", return_value="off"):
+            prompt = "\n\n".join(_prompt_parts(agent).values())
 
-        assert (
-            "Active Hermes profile: default. Other profiles (if any) live "
-            "under /hermes/profiles/<name>/."
-        ) in prompt
+        assert "Active Hermes profile: default." in prompt
+        assert f"under {root}/profiles/<name>/." in prompt
 
 
 def test_build_system_prompt_records_stable_prefix():

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -116,6 +116,74 @@ class TestCodingContextBlock:
         assert "coding agent" not in _stable_prompt(agent)
 
 
+class TestNamedProfileHint:
+    """The profile hint must point at real paths (#72894).
+
+    ``_resolve_active_profile_name()`` only returns a non-default name when
+    ``get_hermes_home()`` has already resolved to ``<root>/profiles/<name>``,
+    so appending ``/profiles/<name>`` to it doubled the segment, and using it
+    for the *default* profile's data pointed those inside the active profile.
+    """
+
+    @staticmethod
+    def _full_prompt(monkeypatch, agent):
+        # Pin the prompt shape: with the coding posture off there is no
+        # workspace snapshot, so the hint's position doesn't depend on the
+        # cwd the suite happens to run from. Join both parts regardless.
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        with patch("agent.coding_context._coding_mode", return_value="off"):
+            return "\n\n".join(_prompt_parts(agent).values())
+
+    @classmethod
+    def _named_profile_prompt(cls, monkeypatch, name="mac"):
+        import agent.system_prompt as system_prompt
+
+        agent = _make_agent(valid_tool_names=["read_file"])
+        monkeypatch.setattr(
+            system_prompt, "get_hermes_home", lambda: Path(f"/hermes/profiles/{name}")
+        )
+        monkeypatch.setattr(
+            system_prompt, "get_default_hermes_root", lambda: Path("/hermes")
+        )
+        monkeypatch.setattr(
+            "agent.file_safety._resolve_active_profile_name", lambda: name
+        )
+        return cls._full_prompt(monkeypatch, agent)
+
+    def test_session_home_is_not_doubled(self, monkeypatch):
+        prompt = self._named_profile_prompt(monkeypatch)
+
+        assert "This session reads and writes /hermes/profiles/mac/." in prompt
+        assert "/hermes/profiles/mac/profiles/mac" not in prompt
+
+    def test_default_profile_data_points_at_the_root(self, monkeypatch):
+        prompt = self._named_profile_prompt(monkeypatch)
+
+        assert (
+            "The default profile's data lives at /hermes/skills/, "
+            "/hermes/plugins/, /hermes/cron/, /hermes/memories/"
+        ) in prompt
+        # Never inside the active profile — that's the cross-profile
+        # confusion this hint exists to prevent.
+        assert "/hermes/profiles/mac/skills/" not in prompt
+        assert "/hermes/profiles/mac/memories/" not in prompt
+
+    def test_default_profile_hint_is_unchanged(self, monkeypatch):
+        import agent.system_prompt as system_prompt
+
+        agent = _make_agent(valid_tool_names=["read_file"])
+        monkeypatch.setattr(system_prompt, "get_hermes_home", lambda: Path("/hermes"))
+        monkeypatch.setattr(
+            "agent.file_safety._resolve_active_profile_name", lambda: "default"
+        )
+        prompt = self._full_prompt(monkeypatch, agent)
+
+        assert (
+            "Active Hermes profile: default. Other profiles (if any) live "
+            "under /hermes/profiles/<name>/."
+        ) in prompt
+
+
 def test_build_system_prompt_records_stable_prefix():
     agent = _make_agent()
     with (


### PR DESCRIPTION
## What & why

Fixes #72894.

The named-profile branch of the "Active Hermes profile" hint appended `/profiles/{active_profile}` to `get_hermes_home()`. But `_resolve_active_profile_name()` (`agent/file_safety.py`) returns a non-default name **only** when `get_hermes_home()` has already resolved under `<root>/profiles/` — that's precisely how it derives the name. Both scoping mechanisms satisfy that:

- `HERMES_HOME=<root>/profiles/<name>` in the environment
- the multiplexer's contextvar override (`gateway/run.py` `_profile_runtime_scope` → `set_hermes_home_override`)

So in that branch the home is *always* already profile-scoped and the appended suffix *always* doubles. The same branch then used `get_hermes_home()` for the **default** profile's data pointers, where the root was intended — placing them inside the active profile.

### Verified live

On a real 4-profile install (`upstream/main` @ 8defb9fd6):

```
active profile      : via
get_hermes_home()   : /Users/…/.hermes/profiles/via
get_default_hermes_root() : /Users/…/.hermes

hint says session writes    : /Users/…/.hermes/profiles/via/profiles/via/   ← doubled
hint says default data lives: /Users/…/.hermes/profiles/via/skills/          ← inside the active profile

actual session home         : /Users/…/.hermes/profiles/via/
actual default data         : /Users/…/.hermes/skills/
```

Every named-profile session ships a prompt naming directories that don't exist, and telling the model this profile's own `skills/plugins/cron/memories` belong to the *default* profile — the exact cross-profile confusion the hint and `classify_cross_profile_target` exist to prevent.

## The change

Use `get_hermes_home()` directly as the profile home (it already *is* `<root>/profiles/<name>` whenever this branch runs), and `get_default_hermes_root()` — already import-safe, and documented to return `<root>` in profile mode — for the default-profile pointers.

The default-profile branch is untouched.

## Tests

`TestNamedProfileHint` in `tests/agent/test_system_prompt.py`:

- `test_session_home_is_not_doubled` — asserts `…/profiles/mac/` and explicitly that `…/profiles/mac/profiles/mac` never appears
- `test_default_profile_data_points_at_the_root` — root pointers, and that none land inside the active profile
- `test_default_profile_hint_is_unchanged` — the default branch still renders as before

```
13 passed  tests/agent/test_system_prompt.py
```

### Note on the full-directory run

These three tests pass standalone and for the whole file. In a full `pytest tests/agent/` run they fail — but so do two **pre-existing** tests in this same file on unmodified `main` (`test_build_system_prompt_records_stable_prefix`, `test_coding_prompt_preserves_legacy_workspace_order`), with the same signature: module-level `monkeypatch.setattr` on `agent.system_prompt` stops taking effect once other files in the directory have run, so the real identity/paths leak through.

Measured on this machine, `pytest tests/agent/`:

| | failures |
|---|---|
| unmodified `main` | 87 |
| this branch | 90 (the 3 above) |

I could not isolate the polluting module within a reasonable timebox, and did not want to reshape unrelated tests to chase it. Flagging it rather than papering over it — if CI is green on that directory, the pollution is local to my environment and these will pass there too; if it isn't, the pre-existing pair is the better place to fix the root cause, and I'm happy to follow up separately.

## Platforms

macOS 15 (Darwin 25.5.0), Python 3.11. Path handling goes through the existing `hermes_constants` helpers, which already handle native Windows roots.

## Duplicate check

Related history, none of it landed:

- #68117 — the closest prior attempt; **closed unmerged** after triage first called it a duplicate of #52676 and then retracted that twice ("Current main still has the named-profile nesting defect").
- #52676 — also closed unmerged; corrected configured-root *display*, not the profile-home interpretation.
- #66725 / the #66450 fix (`2bae4df`) — only swapped a hardcoded `~/.hermes` for `get_hermes_home()`, which is what introduced the doubling for named profiles.

The defect is still present on `8defb9fd6`, as the live output above shows.


---
*Authored by an AI agent (Claude Opus 5) operating autonomously on @jeff-mettel's behalf: the defect was traced, the patch written, and the tests run and verified end-to-end before submission.*