### PR TITLE
fix(auxiliary): preserve raw base_url for anthropic_messages in anonymous custom branch

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5427,7 +5427,10 @@ def resolve_provider_client(
         custom_base = ""
         custom_key = ""
         if explicit_base_url:
-            custom_base = _to_openai_base_url(explicit_base_url).strip()
+            if api_mode == "anthropic_messages":
+                custom_base = explicit_base_url.strip().rstrip("/")
+            else:
+                custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()


### PR DESCRIPTION
## Summary

When `api_mode: anthropic_messages` is set and the custom provider's `base_url` ends in `/anthropic` (e.g. `https://ai.hatz.ai/v1/anthropic`), the anonymous custom provider branch in `resolve_provider_client()` unconditionally calls `_to_openai_base_url()` which strips the `/anthropic` suffix and appends `/v1`, producing a mangled URL like `https://ai.hatz.ai/v1/v1`. The Anthropic SDK then appends its own `/v1/messages`, resulting in `https://ai.hatz.ai/v1/v1/v1/messages` → **404**.

## Root cause

`agent/auxiliary_client.py:` `resolve_provider_client()`, anonymous custom branch (line `~5430`):

```python
# Before (buggy — unconditionally rewrites /anthropic → /v1):
custom_base = _to_openai_base_url(explicit_base_url).strip()
```

The named custom provider branch (line `~5554`) already has the correct guard:

```python
if entry_api_mode == "anthropic_messages":
    openai_base = custom_base
    raw_base_for_wrap = custom_base
else:
    openai_base = _to_openai_base_url(custom_base)
    raw_base_for_wrap = custom_base
```

This patch applies the identical guard to the anonymous branch.

## Fix

```python
# After (preserves raw URL for anthropic_messages):
if api_mode == "anthropic_messages":
    custom_base = explicit_base_url.strip().rstrip("/")
else:
    custom_base = _to_openai_base_url(explicit_base_url).strip()
```

## Affected

- MoA reference slots using an `anthropic_messages` custom provider
- Auxiliary tasks (`title_generation`, `compression`, `vision`, `web_extract`, `session_search`) when routed through a custom provider with `anthropic_messages` wire format
- Any custom endpoint whose `base_url` ends in `/anthropic` with `api_mode: anthropic_messages`

## Verification

Both paths tested against a live Hatz.AI Anthropic-compatible gateway:

| Mode | Before | After |
|------|--------|-------|
| `anthropic_messages` | `AnthropicAuxiliaryClient(base=https://ai.hatz.ai/v1/v1)` ❌ | `AnthropicAuxiliaryClient(base=https://ai.hatz.ai/v1/anthropic)` ✅ |
| `chat_completions` | `OpenAI(base=https://ai.hatz.ai/v1/v1)` (correct — will never hit /anthropic) | `OpenAI(base=https://ai.hatz.ai/v1/v1)` (unchanged) ✅ |

## References

- Closes #19753
- References #17086 (duplicate)
- References #41211 (same root cause, double-/v1 URL path)
- Previous partial fixes: #17467, #19772