### PR TITLE
feat(buzz): honor reply_in_thread so replies can land flat in the channel

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -368,6 +368,21 @@ class BuzzAdapter(BasePlatformAdapter):
             _rm_cfg = _rm_raw
         self.require_mention = str(_rm_cfg).strip().lower() not in ("false", "0", "no", "off")
 
+        # Whether a reply is threaded onto the message that triggered it.
+        # Buzz renders a threaded reply as a collapsed "Thread" pane, so with
+        # this on every answer lands in a sidebar instead of in the channel.
+        # The gateway anchors every reply to the incoming message
+        # (gateway/run.py: initial_reply_to_id=ctx.event_message_id, with no
+        # platform condition), so suppressing it has to happen here. Defaults
+        # to True (behavior unchanged). Env (BUZZ_REPLY_IN_THREAD) overrides
+        # config.yaml, mirroring require_mention above.
+        _rit_raw = os.getenv("BUZZ_REPLY_IN_THREAD")
+        if _rit_raw is None:
+            _rit_cfg = extra.get("reply_in_thread", True)
+        else:
+            _rit_cfg = _rit_raw
+        self.reply_in_thread = str(_rit_cfg).strip().lower() not in ("false", "0", "no", "off")
+
         # Inbound transport: "auto" (WebSocket with poll fallback, default),
         # "websocket" (require WS; fail connect when it can't authenticate),
         # or "poll" (CLI polling only). Env (BUZZ_TRANSPORT) overrides
@@ -586,6 +601,8 @@ class BuzzAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
         reply_target = reply_to or (metadata or {}).get("thread_id")
+        if not self.reply_in_thread:
+            reply_target = None
         if reply_target:
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
@@ -657,7 +674,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            if reply_to:
+            if reply_to and self.reply_in_thread:
                 args += ["--reply-to", str(reply_to)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:


### PR DESCRIPTION
## Problem

Every Hermes reply on Buzz lands in a collapsed **Thread** pane instead of in the channel, which breaks the flow of the conversation for the human reading it.

The cause isn't Buzz's UI — it's that we always ask for a thread. `gateway/run.py` builds the stream consumer with

```python
initial_reply_to_id=ctx.event_message_id,
```

with no platform condition, so every reply is anchored to the message that triggered it. The Buzz adapter turns that anchor into `--reply-to`, and Buzz correctly renders a threaded reply as a thread. On platforms where a reply-anchor is just a quote this is invisible; on Buzz it means the answer is one click away, every single time.

There is a `reply_in_thread` key already accepted per-platform in `gateway/config.py` (bridged into the platform config alongside `reply_prefix`, `require_mention`, etc.), but only the relay/Slack lane reads it — `gateway/relay/adapter.py::_effective_reply_in_thread`. Setting `reply_in_thread: false` under `platforms.buzz` today is a **silent no-op**: the config validates, nothing changes.

## Change

Wire the existing key up in the Buzz adapter, following the same pattern `require_mention` already uses in this file (env var > `extra` > default):

```yaml
platforms:
  buzz:
    extra:
      reply_in_thread: false   # answer flat in the channel
```

`BUZZ_REPLY_IN_THREAD` overrides config.yaml, same as `BUZZ_REQUIRE_MENTION`.

Honored in both outbound paths — `send()` and `send_image()`.

**Default stays `True`, so existing behavior is unchanged for everyone who doesn't set it.**

## Verification

Tested against a hosted community relay (`*.communities.buzz.xyz`), Hermes 0.19.0:

- With `reply_in_thread: false`, the CLI invocation is `['messages', 'send', '--channel', '<id>', '--content', '-']` — no `--reply-to`, and replies appear in the channel.
- With the key absent (default), `--reply-to` is still passed, so threading is preserved.

## Notes

- 17 lines added, 1 changed; no behavior change without opt-in.
- Only the adapter is touched — the unconditional anchor in `gateway/run.py` is left alone, since other platforms rely on it.
- Happy to add a note to `website/docs/user-guide/messaging/buzz.md` if you'd like the key documented in the same PR.
