### PR TITLE
fix(computer_use): recover window PIDs on wlroots compositors

### DIFF
--- a/tests/tools/test_computer_use_wayland_toplevel_pid.py
+++ b/tests/tools/test_computer_use_wayland_toplevel_pid.py
@@ -1,0 +1,549 @@
+"""Regression for the wlroots/Hyprland "no window ever matched" capture bug.
+
+NousResearch/hermes-agent#74969.
+
+``zwlr_foreign_toplevel_manager_v1`` — the protocol every wlroots compositor
+(Hyprland, Sway, river) uses to enumerate windows — carries an app-id and a
+title and *nothing else*. There is no PID in the protocol, so cua-driver
+reports ``pid: null`` for **every** window on such a session::
+
+    {"app_name": "google-chrome", "pid": null, "window_id": 4278190081,
+     "title": "Pull requests - Google Chrome [google-chrome]", "z_index": null}
+
+``_ingest_windows`` dropped every pid-less row (correct on X11, where only
+panels and popups omit ``_NET_WM_PID``), so the normalized window list came
+back empty and capture() surfaced either a silent ``0x0`` result or
+``<no on-screen window matched app='Google Chrome'>``. The driver itself was
+fine the whole time: ``get_window_state`` returns a full PNG plus AT-SPI tree
+the moment it is handed a real pid, and it hard-rejects the call without one
+(``Missing required integer field: pid``).
+
+The fix recovers the pid out-of-band from the compositor (``hyprctl clients
+-j``) before dropping the window, and refuses to guess when the mapping is
+ambiguous.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# 8x8 transparent PNG — decodes cleanly so capture() can size it.
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+    "NkGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+)
+
+MODULE = "tools.computer_use.cua_backend"
+
+# Shape cua-driver actually emits on Hyprland (captured from a live session).
+_WLROOTS_WINDOWS = [
+    {
+        "app_name": "google-chrome",
+        "bounds": {"height": 0, "width": 0, "x": 0, "y": 0},
+        "height": 0,
+        "is_on_screen": True,
+        "pid": None,
+        "title": "Pull requests - Google Chrome [google-chrome]",
+        "width": 0,
+        "window_id": 4278190081,
+        "x": 0,
+        "y": 0,
+        "z_index": None,
+    },
+    {
+        "app_name": "kitty",
+        "bounds": {"height": 0, "width": 0, "x": 0, "y": 0},
+        "height": 0,
+        "is_on_screen": True,
+        "pid": None,
+        "title": "hermes - kitty [kitty]",
+        "width": 0,
+        "window_id": 4278190080,
+        "x": 0,
+        "y": 0,
+        "z_index": None,
+    },
+]
+
+# Shape `hyprctl clients -j` actually emits, trimmed to the read fields.
+_HYPR_CLIENTS = [
+    {"pid": 57569, "class": "google-chrome", "mapped": True,
+     "title": "Pull requests - Google Chrome"},
+    {"pid": 54645, "class": "kitty", "mapped": True, "title": "hermes - kitty"},
+]
+
+
+# ---------------------------------------------------------------------------
+# _strip_wayland_title_suffix
+# ---------------------------------------------------------------------------
+
+class TestStripTitleSuffix:
+    @pytest.mark.parametrize("raw,expected", [
+        ("Pull requests - Google Chrome [google-chrome]", "Pull requests - Google Chrome"),
+        ("hermes - kitty [kitty]", "hermes - kitty"),
+        ("No suffix here", "No suffix here"),
+        # Only the trailing label is a suffix; brackets mid-title stay put.
+        ("[Draft] PR title [firefox]", "[Draft] PR title"),
+        ("", ""),
+    ])
+    def test_strips_only_the_trailing_app_label(self, raw, expected):
+        from tools.computer_use.cua_backend import _strip_wayland_title_suffix
+
+        assert _strip_wayland_title_suffix(raw) == expected
+
+    def test_non_string_is_empty(self):
+        from tools.computer_use.cua_backend import _strip_wayland_title_suffix
+
+        assert _strip_wayland_title_suffix(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# _resolve_wayland_pid — the matching policy, including its refusals
+# ---------------------------------------------------------------------------
+
+class TestResolveWaylandPid:
+    def _toplevels(self):
+        from tools.computer_use.cua_backend import _hyprland_toplevels
+
+        with patch.dict("os.environ", {"HYPRLAND_INSTANCE_SIGNATURE": "sig"}), \
+             patch(f"{MODULE}.shutil.which", return_value="/usr/bin/hyprctl"), \
+             patch(f"{MODULE}.subprocess.run") as run:
+            run.return_value = MagicMock(
+                returncode=0, stdout=json.dumps(_HYPR_CLIENTS),
+            )
+            return _hyprland_toplevels()
+
+    def test_matches_on_exact_title(self):
+        from tools.computer_use.cua_backend import _resolve_wayland_pid
+
+        pid = _resolve_wayland_pid(
+            "google-chrome",
+            "Pull requests - Google Chrome [google-chrome]",
+            self._toplevels(),
+        )
+        assert pid == 57569
+
+    def test_falls_back_to_app_id_when_title_drifted(self):
+        """Titles change as the user switches tabs between the two probes."""
+        from tools.computer_use.cua_backend import _resolve_wayland_pid
+
+        pid = _resolve_wayland_pid(
+            "kitty", "some other title [kitty]", self._toplevels(),
+        )
+        assert pid == 54645
+
+    def test_app_id_match_allows_multiple_windows_of_one_process(self):
+        """A browser with several windows is one PID — still unambiguous."""
+        from tools.computer_use.cua_backend import _resolve_wayland_pid
+
+        toplevels = [
+            {"pid": 900, "app": "firefox", "title": "window one"},
+            {"pid": 900, "app": "firefox", "title": "window two"},
+        ]
+        assert _resolve_wayland_pid("firefox", "drifted", toplevels) == 900
+
+    def test_refuses_to_guess_between_distinct_processes(self):
+        """Two PIDs behind one app-id must NOT resolve — capturing/clicking
+        the wrong process is worse than reporting no match."""
+        from tools.computer_use.cua_backend import _resolve_wayland_pid
+
+        toplevels = [
+            {"pid": 900, "app": "firefox", "title": "window one"},
+            {"pid": 901, "app": "firefox", "title": "window two"},
+        ]
+        assert _resolve_wayland_pid("firefox", "drifted", toplevels) is None
+
+    def test_ambiguous_title_falls_through_to_app_id(self):
+        from tools.computer_use.cua_backend import _resolve_wayland_pid
+
+        toplevels = [
+            {"pid": 900, "app": "firefox", "title": "same"},
+            {"pid": 901, "app": "chrome", "title": "same"},
+        ]
+        # Title is ambiguous (two PIDs), but the app-id is not.
+        assert _resolve_wayland_pid("chrome", "same", toplevels) == 901
+
+    def test_no_toplevels_resolves_to_none(self):
+        from tools.computer_use.cua_backend import _resolve_wayland_pid
+
+        assert _resolve_wayland_pid("firefox", "title", []) is None
+
+    def test_unknown_app_resolves_to_none(self):
+        from tools.computer_use.cua_backend import _resolve_wayland_pid
+
+        assert _resolve_wayland_pid(
+            "inkscape", "Untitled [inkscape]", self._toplevels(),
+        ) is None
+
+
+# ---------------------------------------------------------------------------
+# _hyprland_toplevels — the probe must be inert off Hyprland and never raise
+# ---------------------------------------------------------------------------
+
+class TestHyprlandToplevels:
+    def test_no_probe_without_hyprland_signature(self):
+        """X11/GNOME sessions must not pay for (or be changed by) the probe."""
+        from tools.computer_use.cua_backend import _hyprland_toplevels
+
+        with patch.dict("os.environ", {}, clear=True), \
+             patch(f"{MODULE}.sys.platform", "linux"), \
+             patch(f"{MODULE}.subprocess.run") as run:
+            assert _hyprland_toplevels() == []
+            run.assert_not_called()
+
+    def test_no_probe_off_linux(self):
+        from tools.computer_use.cua_backend import _hyprland_toplevels
+
+        with patch.dict("os.environ", {"HYPRLAND_INSTANCE_SIGNATURE": "sig"}), \
+             patch(f"{MODULE}.sys.platform", "darwin"), \
+             patch(f"{MODULE}.subprocess.run") as run:
+            assert _hyprland_toplevels() == []
+            run.assert_not_called()
+
+    def test_missing_binary_is_not_fatal(self):
+        from tools.computer_use.cua_backend import _hyprland_toplevels
+
+        with patch.dict("os.environ", {"HYPRLAND_INSTANCE_SIGNATURE": "sig"}), \
+             patch(f"{MODULE}.sys.platform", "linux"), \
+             patch(f"{MODULE}.shutil.which", return_value=None):
+            assert _hyprland_toplevels() == []
+
+    @pytest.mark.parametrize("stdout", ["", "not json", "{}", "null", "[1, 2]"])
+    def test_malformed_payload_is_not_fatal(self, stdout):
+        from tools.computer_use.cua_backend import _hyprland_toplevels
+
+        with patch.dict("os.environ", {"HYPRLAND_INSTANCE_SIGNATURE": "sig"}), \
+             patch(f"{MODULE}.sys.platform", "linux"), \
+             patch(f"{MODULE}.shutil.which", return_value="/usr/bin/hyprctl"), \
+             patch(f"{MODULE}.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout=stdout)
+            assert _hyprland_toplevels() == []
+
+    def test_subprocess_failure_is_not_fatal(self):
+        from tools.computer_use.cua_backend import _hyprland_toplevels
+
+        with patch.dict("os.environ", {"HYPRLAND_INSTANCE_SIGNATURE": "sig"}), \
+             patch(f"{MODULE}.sys.platform", "linux"), \
+             patch(f"{MODULE}.shutil.which", return_value="/usr/bin/hyprctl"), \
+             patch(f"{MODULE}.subprocess.run", side_effect=OSError("boom")):
+            assert _hyprland_toplevels() == []
+
+    def test_skips_unmapped_and_pidless_clients(self):
+        from tools.computer_use.cua_backend import _hyprland_toplevels
+
+        clients = [
+            {"pid": 1, "class": "a", "mapped": False, "title": "hidden"},
+            {"pid": None, "class": "b", "mapped": True, "title": "no pid"},
+            "not a dict",
+            {"pid": 42, "class": "Kitty", "mapped": True, "title": "Real"},
+        ]
+        with patch.dict("os.environ", {"HYPRLAND_INSTANCE_SIGNATURE": "sig"}), \
+             patch(f"{MODULE}.sys.platform", "linux"), \
+             patch(f"{MODULE}.shutil.which", return_value="/usr/bin/hyprctl"), \
+             patch(f"{MODULE}.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout=json.dumps(clients))
+            out = _hyprland_toplevels()
+
+        # Case-folded for comparison against the driver's app_name/title.
+        assert out == [{"pid": 42, "app": "kitty", "title": "real"}]
+
+    def test_invocation_is_argv_not_shell(self):
+        """No shell: compositor-controlled strings never reach a shell."""
+        from tools.computer_use.cua_backend import _hyprland_toplevels
+
+        with patch.dict("os.environ", {"HYPRLAND_INSTANCE_SIGNATURE": "sig"}), \
+             patch(f"{MODULE}.sys.platform", "linux"), \
+             patch(f"{MODULE}.shutil.which", return_value="/usr/bin/hyprctl"), \
+             patch(f"{MODULE}.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout="[]")
+            _hyprland_toplevels()
+
+        args, kwargs = run.call_args
+        assert args[0] == ["/usr/bin/hyprctl", "clients", "-j"]
+        assert kwargs.get("shell") is None or kwargs.get("shell") is False
+        assert kwargs.get("timeout") == 2
+        assert kwargs.get("check") is False
+
+
+# ---------------------------------------------------------------------------
+# _ingest_windows — the bug locus
+# ---------------------------------------------------------------------------
+
+class TestIngestWindowsOnWlroots:
+    def test_wlroots_windows_survive_ingestion(self):
+        """The regression: every window was dropped, so capture saw nothing."""
+        from tools.computer_use.cua_backend import _ingest_windows
+
+        with patch(f"{MODULE}._hyprland_toplevels") as probe:
+            probe.return_value = [
+                {"pid": 57569, "app": "google-chrome",
+                 "title": "pull requests - google chrome"},
+                {"pid": 54645, "app": "kitty", "title": "hermes - kitty"},
+            ]
+            out = _ingest_windows(_WLROOTS_WINDOWS)
+
+        assert [w["app_name"] for w in out] == ["google-chrome", "kitty"]
+        assert [w["pid"] for w in out] == [57569, 54645]
+        assert [w["window_id"] for w in out] == [4278190081, 4278190080]
+        # z_index: null must normalise to 0, not crash the later sort.
+        assert all(w["z_index"] == 0 for w in out)
+        # The compositor is probed once for the whole batch, not per window.
+        assert probe.call_count == 1
+
+    def test_probe_is_skipped_when_every_pid_is_present(self):
+        from tools.computer_use.cua_backend import _ingest_windows
+
+        with patch(f"{MODULE}._hyprland_toplevels") as probe:
+            out = _ingest_windows([
+                {"app_name": "Firefox", "pid": 4321, "window_id": 77, "z_index": 1},
+            ])
+            probe.assert_not_called()
+        assert out[0]["pid"] == 4321
+
+    def test_unresolvable_window_is_still_dropped(self):
+        """X11 behaviour is unchanged: no recovery available => drop it."""
+        from tools.computer_use.cua_backend import _ingest_windows
+
+        with patch(f"{MODULE}._hyprland_toplevels", return_value=[]):
+            out = _ingest_windows([
+                {"app_name": "Desktop", "pid": None, "window_id": 1, "z_index": 0},
+                {"app_name": "Firefox", "pid": 4321, "window_id": 77, "z_index": 1},
+            ])
+
+        assert [w["app_name"] for w in out] == ["Firefox"]
+
+    def test_partially_resolvable_batch_keeps_only_identified_windows(self):
+        from tools.computer_use.cua_backend import _ingest_windows
+
+        with patch(f"{MODULE}._hyprland_toplevels") as probe:
+            probe.return_value = [{"pid": 55, "app": "kitty", "title": "t"}]
+            out = _ingest_windows([
+                {"app_name": "unknown-app", "pid": None, "window_id": 1},
+                {"app_name": "kitty", "pid": None, "window_id": 2},
+            ])
+
+        assert [(w["app_name"], w["pid"]) for w in out] == [("kitty", 55)]
+
+    def test_window_without_window_id_is_always_dropped(self):
+        """No window_id means no screenshot/click target, pid or not."""
+        from tools.computer_use.cua_backend import _ingest_windows
+
+        with patch(f"{MODULE}._hyprland_toplevels") as probe:
+            out = _ingest_windows([
+                {"app_name": "kitty", "pid": 55, "window_id": None},
+            ])
+            probe.assert_not_called()
+        assert out == []
+
+    def test_original_order_is_preserved(self):
+        """Callers sort by z_index with a stable sort; when the compositor
+        reports no stacking order, list order is the only signal left."""
+        from tools.computer_use.cua_backend import _ingest_windows
+
+        with patch(f"{MODULE}._hyprland_toplevels") as probe:
+            probe.return_value = [{"pid": 55, "app": "kitty", "title": "t"}]
+            out = _ingest_windows([
+                {"app_name": "kitty", "pid": None, "window_id": 1},
+                {"app_name": "Firefox", "pid": 4321, "window_id": 2},
+            ])
+
+        assert [w["app_name"] for w in out] == ["kitty", "Firefox"]
+
+
+# ---------------------------------------------------------------------------
+# capture() end-to-end on a simulated Hyprland session
+# ---------------------------------------------------------------------------
+
+def _backend_with_windows(raw_windows):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    session = MagicMock()
+    session.capabilities_discovered = True
+    session._has_tool.return_value = True
+
+    def _call_tool(name, args, *a, **k):
+        if name == "list_windows":
+            return {"structuredContent": {"windows": raw_windows}}
+        if name == "screenshot":
+            return {
+                "structuredContent": {
+                    "screenshot_png_b64": _PNG_B64,
+                    "screenshot_mime_type": "image/png",
+                }
+            }
+        return {}
+
+    session.call_tool.side_effect = _call_tool
+    backend._session = session
+    return backend
+
+
+def test_capture_by_app_finds_the_wlroots_window():
+    """Before the fix this returned `<no on-screen window matched ...>`."""
+    backend = _backend_with_windows(_WLROOTS_WINDOWS)
+
+    with patch(f"{MODULE}._hyprland_toplevels") as probe:
+        probe.return_value = [
+            {"pid": 57569, "app": "google-chrome",
+             "title": "pull requests - google chrome"},
+            {"pid": 54645, "app": "kitty", "title": "hermes - kitty"},
+        ]
+        cap = backend.capture(mode="vision", app="google-chrome")
+
+    assert cap.app == "google-chrome"
+    assert cap.png_b64 == _PNG_B64
+    assert base64.b64decode(cap.png_b64)
+    # The pid recovered from the compositor is what actions will be sent to.
+    assert backend._active_pid == 57569
+    assert backend._active_window_id == 4278190081
+
+
+def test_capture_reports_no_match_when_pid_is_unrecoverable():
+    """Fail closed and say so, rather than capturing an unrelated window."""
+    backend = _backend_with_windows(_WLROOTS_WINDOWS)
+
+    with patch(f"{MODULE}._hyprland_toplevels", return_value=[]):
+        cap = backend.capture(mode="vision", app="google-chrome")
+
+    assert cap.width == 0 and cap.height == 0
+    assert cap.png_b64 is None
+    assert backend._active_pid is None
+
+
+# ---------------------------------------------------------------------------
+# app= matching against a Wayland app id
+# ---------------------------------------------------------------------------
+
+class TestAppIdMatching:
+    """Wayland reports the app *id* (`google-chrome`), never the display name.
+
+    `capture(app="Google Chrome")` therefore matched nothing: not exactly
+    (`google chrome` != `google-chrome`) and not as a substring either, since
+    the separators differ. That produced the reported
+    `<no on-screen window matched app='Google Chrome'>` even once the window
+    list itself was populated.
+    """
+
+    def _match(self, windows, query):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        # list_apps enumerates every process on Linux; keep it out of the way.
+        with patch.object(CuaDriverBackend, "list_apps", return_value=[]):
+            return backend._match_windows_for_app(windows, query)
+
+    def _window(self, app_name):
+        return {
+            "app_name": app_name, "pid": 1, "window_id": 1,
+            "off_screen": False, "title": f"Some page [{app_name}]",
+            "z_index": 0,
+        }
+
+    @pytest.mark.parametrize("query", [
+        "Google Chrome", "google chrome", "google-chrome", "GOOGLE CHROME",
+    ])
+    def test_display_name_matches_hyphenated_app_id(self, query):
+        assert len(self._match([self._window("google-chrome")], query)) == 1
+
+    def test_reverse_dns_app_id_matches_its_tail(self):
+        assert len(self._match([self._window("org.mozilla.firefox")], "Firefox")) == 1
+
+    def test_underscored_app_id_matches_display_name(self):
+        assert len(self._match([self._window("libre_office_writer")],
+                               "LibreOffice Writer")) == 0
+        assert len(self._match([self._window("libre_office_writer")],
+                               "Libre Office Writer")) == 1
+
+    def test_folding_does_not_outrank_the_exact_tier(self):
+        """The pre-existing guarantee: `Code` must not select `Visual Studio
+        Code` merely because it is frontmost. Folding is an *exact* tier, so
+        it must not start matching across distinct names.
+
+        (A lone `Visual Studio Code` still matches `Code` through the
+        substring tier further down — that is long-standing behaviour and is
+        deliberately left alone.)
+        """
+        windows = [
+            self._window("Visual Studio Code"),
+            self._window("Code"),
+        ]
+        out = self._match(windows, "Code")
+        assert [w["app_name"] for w in out] == ["Code"]
+
+    def test_folding_alone_does_not_bridge_distinct_names(self):
+        from tools.computer_use.cua_backend import _app_name_aliases
+
+        assert not (_app_name_aliases("Code") & _app_name_aliases("Visual Studio Code"))
+
+    def test_unrelated_app_still_does_not_match(self):
+        assert self._match([self._window("google-chrome")], "Firefox") == []
+
+    def test_exact_app_name_still_wins_over_folding(self):
+        windows = [
+            self._window("google-chrome"),
+            self._window("Google Chrome"),
+        ]
+        out = self._match(windows, "Google Chrome")
+        assert [w["app_name"] for w in out] == ["Google Chrome"]
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics: an empty window list and a bare timeout must both be legible
+# ---------------------------------------------------------------------------
+
+class TestDiagnostics:
+    def test_raw_window_summary_counts_without_leaking_titles(self):
+        from tools.computer_use.cua_backend import _describe_raw_windows
+
+        summary = _describe_raw_windows(_WLROOTS_WINDOWS)
+
+        assert "2 raw entries" in summary
+        assert "2 missing pid" in summary
+        assert "google-chrome" in summary
+        # Window titles carry private content (chats, documents, URLs) and
+        # must never reach the log.
+        assert "Pull requests" not in summary
+
+    def test_empty_raw_window_summary(self):
+        from tools.computer_use.cua_backend import _describe_raw_windows
+
+        assert _describe_raw_windows([]) == "0 raw entries"
+
+    def test_bridge_timeout_becomes_an_actionable_message(self):
+        """`fut.result(timeout=...)` raises TimeoutError with an EMPTY str(),
+        which reached the model as a bare "capture failed:" (#74969)."""
+        import concurrent.futures
+
+        from tools.computer_use.cua_backend import _CuaDriverSession
+
+        session = _CuaDriverSession.__new__(_CuaDriverSession)
+        session._started = True
+        session._require_started = lambda: None
+        session._call_tool_async = lambda name, args: None
+        session._bridge = MagicMock()
+        session._bridge.run.side_effect = concurrent.futures.TimeoutError()
+
+        with pytest.raises(RuntimeError) as excinfo:
+            session.call_tool("get_window_state", {}, timeout=30.0)
+
+        message = str(excinfo.value)
+        assert message.strip(), "the whole point is that it is not empty"
+        assert "get_window_state" in message
+        assert "30" in message
+
+    def test_tool_layer_never_returns_an_empty_error_string(self):
+        from tools.computer_use import tool as cu_tool
+
+        class _Silent(Exception):
+            pass
+
+        with patch.object(cu_tool, "_get_backend", return_value=MagicMock()), \
+             patch.object(cu_tool, "_dispatch", side_effect=_Silent()):
+            out = json.loads(cu_tool.handle_computer_use({"action": "capture"}))
+
+        assert out["error"] == "capture failed: _Silent"

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1669,6 +1669,19 @@ class _CuaDriverSession:
                 self._call_tool_async(name, args),
                 timeout=timeout,
             )
+        except concurrent.futures.TimeoutError as e:
+            # `fut.result(timeout=...)` raises a TimeoutError whose str() is
+            # the empty string, so this reached the model as a bare
+            # "capture failed:" with no cause at all (#74969). Name the tool,
+            # the budget, and the next step instead. The caller's
+            # `_call_capture_tool` still disarms the active target on the way
+            # out, so this only changes the message, never the state machine.
+            raise RuntimeError(
+                f"cua-driver {name} timed out after {timeout:g}s over the MCP "
+                f"transport (the driver never answered). Check that the daemon "
+                f"is healthy with `cua-driver status`; a large window tree can "
+                f"also exceed the budget — retry, or raise the timeout."
+            ) from e
         except Exception as e:
             if self._is_transient_daemon_error(e):
                 logger.warning(
@@ -1811,6 +1824,165 @@ def _positive_int(value: Any) -> Optional[int]:
     return parsed if parsed > 0 else None
 
 
+# cua-driver labels a wlroots toplevel by appending " [app_id]" to its title,
+# e.g. "Pull requests - Google Chrome [google-chrome]". The compositor's own
+# title carries no such suffix, so strip it before comparing the two.
+_WAYLAND_TITLE_APP_SUFFIX_RE = re.compile(r"\s*\[[^\[\]]*\]\s*$")
+
+
+def _strip_wayland_title_suffix(title: str) -> str:
+    """Drop the ``[app_id]`` label cua-driver appends to wlroots titles."""
+    if not isinstance(title, str):
+        return ""
+    return _WAYLAND_TITLE_APP_SUFFIX_RE.sub("", title).strip()
+
+
+def _hyprland_toplevels() -> List[Dict[str, Any]]:
+    """Best-effort ``hyprctl clients -j`` snapshot. Never raises.
+
+    Returns ``[{"pid": int, "app": str, "title": str}, ...]`` for mapped
+    toplevels, with ``app``/``title`` case-folded for comparison. Returns an
+    empty list off Hyprland, when ``hyprctl`` is absent, or when the payload
+    is unparseable — every caller treats that as "no recovery available".
+
+    The gate on ``HYPRLAND_INSTANCE_SIGNATURE`` keeps this off the X11 and
+    macOS/Windows paths entirely, so the common case pays nothing.
+    """
+    if sys.platform != "linux" or not os.environ.get("HYPRLAND_INSTANCE_SIGNATURE"):
+        return []
+    binary = shutil.which("hyprctl")
+    if not binary:
+        return []
+    try:
+        proc = subprocess.run(
+            [binary, "clients", "-j"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=2,
+            check=False,
+        )
+    except Exception as exc:
+        logger.debug("hyprctl clients probe failed: %s", exc)
+        return []
+    if proc.returncode != 0:
+        return []
+    try:
+        parsed = json.loads(proc.stdout or "")
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    toplevels: List[Dict[str, Any]] = []
+    for client in parsed:
+        # Compositor output is untrusted input: skip malformed records rather
+        # than aborting the whole recovery on one bad entry.
+        if not isinstance(client, dict) or client.get("mapped") is False:
+            continue
+        pid = _positive_int(client.get("pid"))
+        if pid is None:
+            continue
+        app = client.get("class")
+        title = client.get("title")
+        toplevels.append({
+            "pid": pid,
+            "app": app.strip().lower() if isinstance(app, str) else "",
+            "title": title.strip().lower() if isinstance(title, str) else "",
+        })
+    return toplevels
+
+
+def _resolve_wayland_pid(
+    app_name: str, title: str, toplevels: List[Dict[str, Any]]
+) -> Optional[int]:
+    """Recover the PID that wlroots' foreign-toplevel protocol never exposes.
+
+    ``zwlr_foreign_toplevel_manager_v1`` carries an app-id and a title and
+    nothing else — there is no PID in the protocol — so cua-driver reports
+    ``pid: null`` for *every* window on a wlroots compositor (Hyprland, Sway,
+    river). Because ``get_window_state`` requires an integer pid
+    (``Missing required integer field: pid``), those windows were dropped by
+    ``_ingest_windows`` and capture saw an empty window list: a 0x0 capture,
+    or ``<no on-screen window matched app=...>`` (#74969).
+
+    Matching is deliberately conservative — **ambiguity resolves to None** so
+    the caller drops the window instead of capturing, clicking, and typing
+    into the wrong one:
+
+      1. Exact title match, unique. Titles are per-window, so this is the only
+         signal that can separate two windows of the same application.
+      2. Exact app-id match where every candidate resolves to a single PID.
+         This covers the common multi-window/one-process case (a browser with
+         several windows) without ever guessing between distinct processes.
+    """
+    if not toplevels:
+        return None
+    want_title = _strip_wayland_title_suffix(title).lower()
+    if want_title:
+        pids = {t["pid"] for t in toplevels if t["title"] == want_title}
+        if len(pids) == 1:
+            return next(iter(pids))
+    want_app = app_name.strip().lower() if isinstance(app_name, str) else ""
+    if want_app:
+        pids = {t["pid"] for t in toplevels if t["app"] == want_app}
+        if len(pids) == 1:
+            return next(iter(pids))
+    return None
+
+
+def _normalize_app_token(value: Any) -> str:
+    """Fold an app id or app name into a comparable token.
+
+    Wayland reports the *app id* (``google-chrome``, ``org.mozilla.firefox``)
+    while callers naturally type the human name (``Google Chrome``). Folding
+    every run of non-alphanumerics to a single space makes the two comparable
+    without loosening the match into a substring test.
+    """
+    if not isinstance(value, str):
+        return ""
+    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+
+
+def _app_name_aliases(value: Any) -> set:
+    """Comparable aliases for an app id / app name.
+
+    Includes the folded form and, for reverse-DNS app ids, the trailing
+    component (``org.mozilla.firefox`` → ``firefox``) — which is the name a
+    caller actually types.
+    """
+    aliases = set()
+    folded = _normalize_app_token(value)
+    if folded:
+        aliases.add(folded)
+    if isinstance(value, str) and "." in value:
+        tail = _normalize_app_token(value.rsplit(".", 1)[-1])
+        if tail:
+            aliases.add(tail)
+    return aliases
+
+
+def _describe_raw_windows(raw_windows: List[Dict[str, Any]]) -> str:
+    """Summarise a raw ``list_windows`` payload for logs.
+
+    Deliberately counts-only: window *titles* routinely carry private content
+    (message previews, document names, URLs), so they never reach the log.
+    App ids are low-sensitivity and are what a maintainer actually needs to
+    tell "driver returned nothing" from "driver returned rows we rejected".
+    """
+    if not raw_windows:
+        return "0 raw entries"
+    entries = [w for w in raw_windows if isinstance(w, dict)]
+    no_pid = sum(1 for w in entries if _positive_int(w.get("pid")) is None)
+    no_wid = sum(1 for w in entries if _positive_int(w.get("window_id")) is None)
+    apps = sorted({
+        str(w.get("app_name") or "?").strip()[:40]
+        for w in entries
+    })
+    return (
+        f"{len(raw_windows)} raw entries ({no_pid} missing pid, "
+        f"{no_wid} missing window_id); app ids: {apps}"
+    )
+
+
 def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Normalise cua-driver ``list_windows`` entries, dropping unusable ones.
 
@@ -1826,29 +1998,38 @@ def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     targetable windows. We skip the unusable entries instead so capture()
     and focus_app() still find the windows that matter.
 
+    On **wlroots compositors** (Hyprland, Sway, river) a null pid is not the
+    exception but the rule: the foreign-toplevel protocol carries no PID at
+    all, so *every* window arrived unusable and capture enumerated nothing
+    (#74969). Before dropping a pid-less window we therefore try to recover
+    the pid out-of-band from the compositor via ``_resolve_wayland_pid``;
+    only windows that stay unidentified are dropped, which keeps the X11
+    behaviour above byte-for-byte (the probe is inert off Hyprland).
+
     ``z_index`` follows CUA Driver semantics: higher = closer to front.
     Wayland may return ``z_index: null`` (undefined stacking order); we
     treat null as the lowest priority so real windows still sort above
     desktop/root windows, and the backmost never ends up selected as the
     capture target.
     """
-    windows: List[Dict[str, Any]] = []
+    normalized: List[Dict[str, Any]] = []
     for w in raw_windows:
         # Compatibility envelopes are untrusted input: skip non-dict members
         # instead of raising AttributeError on one malformed record.
         if not isinstance(w, dict):
             continue
-        pid_int = _positive_int(w.get("pid"))
         window_id_int = _positive_int(w.get("window_id"))
-        if pid_int is None or window_id_int is None:
+        if window_id_int is None:
             continue
         z_raw = w.get("z_index")
         z_index = z_raw if isinstance(z_raw, (int, float)) and not isinstance(z_raw, bool) else 0
         app_name = w.get("app_name", "")
         title = w.get("title", "")
-        windows.append({
+        normalized.append({
             "app_name": app_name if isinstance(app_name, str) else "",
-            "pid": pid_int,
+            # May be None here; the recovery pass below fills it in where it
+            # can, and the final filter drops whatever stays unidentified.
+            "pid": _positive_int(w.get("pid")),
             "window_id": window_id_int,
             # cua-driver 0.6.x on Linux may return JSON null here.
             # Only explicit False means off-screen; null means unknown.
@@ -1856,7 +2037,20 @@ def _ingest_windows(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             "title": title if isinstance(title, str) else "",
             "z_index": z_index,
         })
-    return windows
+
+    if any(w["pid"] is None for w in normalized):
+        # One compositor probe per ingest, not one per window.
+        toplevels = _hyprland_toplevels()
+        if toplevels:
+            for w in normalized:
+                if w["pid"] is None:
+                    w["pid"] = _resolve_wayland_pid(
+                        w["app_name"], w["title"], toplevels,
+                    )
+
+    # Order is preserved: callers sort by z_index afterwards and rely on a
+    # stable sort when the compositor reports no stacking order at all.
+    return [w for w in normalized if w["pid"] is not None]
 
 
 def _windows_from_tool_result(out: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -2111,14 +2305,19 @@ class CuaDriverBackend(ComputerUseBackend):
             "list_windows",
             {"on_screen_only": True, "session": self._session_id},
         )
-        windows = _ingest_windows(_windows_from_tool_result(out))
+        raw = _windows_from_tool_result(out)
+        windows = _ingest_windows(raw)
         windows.sort(key=lambda w: w["z_index"], reverse=True)
         if windows:
             return windows
 
+        # Distinguish "driver returned nothing" from "driver returned rows we
+        # rejected" — the two have completely different fixes, and without
+        # this the only symptom is a silent 0x0 capture (#74969).
         logger.warning(
-            "cua-driver list_windows returned no windows over MCP; "
-            "re-fetching via CLI transport",
+            "cua-driver list_windows returned no usable windows over MCP "
+            "[%s]; re-fetching via CLI transport",
+            _describe_raw_windows(raw),
         )
         try:
             cli_out = self._session._call_tool_via_cli(
@@ -2146,6 +2345,14 @@ class CuaDriverBackend(ComputerUseBackend):
         name/bundle-ID metadata. Exact direct names and exact metadata aliases
         must win over substring matches: querying ``Code`` must not silently
         select ``Visual Studio Code`` merely because it is frontmost.
+
+        Wayland complicates the *exact* tier: the compositor reports an app id
+        (``google-chrome``, ``org.mozilla.firefox``), never the display name,
+        so the natural ``app="Google Chrome"`` matched nothing — not by exact
+        name, and not by substring either, since the separators differ
+        (#74969). A punctuation-folded comparison bridges the two while
+        staying an exact match, so the ``Code`` / ``Visual Studio Code``
+        distinction above is preserved.
         """
         app_lower = app.strip().lower()
         if not app_lower:
@@ -2157,6 +2364,15 @@ class CuaDriverBackend(ComputerUseBackend):
         ]
         if direct_exact:
             return direct_exact
+
+        app_aliases = _app_name_aliases(app)
+        if app_aliases:
+            folded_exact = [
+                w for w in windows
+                if _app_name_aliases(w.get("app_name")) & app_aliases
+            ]
+            if folded_exact:
+                return folded_exact
 
         try:
             running_apps = self.list_apps()

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -508,7 +508,12 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
             return _dispatch(backend, action, args)
     except Exception as e:
         logger.exception("computer_use %s failed", action)
-        return json.dumps({"error": f"{action} failed: {e}"})
+        # Some failures carry no message at all — most notably the empty-str
+        # TimeoutError from the MCP bridge — which rendered as a bare
+        # "capture failed:" the model could not act on (#74969). Fall back to
+        # the exception class so there is always *something* to react to.
+        detail = str(e).strip() or type(e).__name__
+        return json.dumps({"error": f"{action} failed: {detail}"})
 
 
 def _request_approval(action: str, args: Dict[str, Any],


### PR DESCRIPTION
Fixes #74969.

## The bug

`computer_use` could not capture any window on a Wayland session running a wlroots compositor (Hyprland, Sway, river). Captures came back `0x0`, or `capture(app=...)` reported `<no on-screen window matched app='...'>` — while `hermes computer-use doctor` reported every capability green.

The driver was healthy the whole time. Calling it directly returns a full desktop PNG, and `get_window_state` returns a screenshot plus AT-SPI tree the moment it is handed a real pid. The defect is in window **discovery**, in two independent places.

## 1. wlroots reports no PID at all

`zwlr_foreign_toplevel_manager_v1` carries an app-id and a title and *nothing else* — there is no PID in the protocol. So cua-driver reports `pid: null` for **every** window on such a session:

```json
{"app_name": "google-chrome", "is_on_screen": true, "pid": null,
 "window_id": 4278190081, "z_index": null,
 "title": "Pull requests - Google Chrome [google-chrome]"}
```

`_ingest_windows` dropped every pid-less row. That is correct on X11 — only panels, popups and the desktop root omit the optional `_NET_WM_PID` — but on wlroots it zeroed the entire window list, so capture had nothing to target. And the pid is not optional downstream:

```
$ cua-driver call get_window_state '{"window_id": 4278190081}'
Missing required integer field: pid
```

This PR recovers the pid out-of-band from the compositor (`hyprctl clients -j`) before dropping the window.

Matching is deliberately **fail-closed**: unique exact title first (titles are per-window, the only signal that separates two windows of one app), then app-id where every candidate resolves to a single PID (the common multi-window/one-process browser case), otherwise `None`. A wrong PID would capture, click and type into an unrelated process, so ambiguity never resolves.

The probe is gated on `HYPRLAND_INSTANCE_SIGNATURE`, so X11, macOS and Windows never invoke it and behave exactly as before.

## 2. `app="Google Chrome"` never matched

Wayland reports the app *id* (`google-chrome`), never the display name. So the natural call matched nothing — not exactly (`google chrome` != `google-chrome`), and not by substring either, since the separators differ. This is the reported `<no on-screen window matched app='Google Chrome'>`, and it persisted even once the window list was populated.

Added a punctuation-folded **exact** tier that bridges the two, and resolves reverse-DNS ids (`org.mozilla.firefox` → `Firefox`). It stays an exact match rather than becoming a substring test, so the existing `Code` vs `Visual Studio Code` guarantee still holds (covered by a test).

## Diagnostics

Two things made this much harder to identify than it should have been:

- An empty window list logged only *"returned no windows"*, which cannot distinguish "the driver returned nothing" from "the driver returned rows we rejected" — opposite fixes, identical log line. Now logs counts and app ids. Window **titles are deliberately excluded**: they routinely carry private content (message previews, document names, URLs).
- `fut.result(timeout=...)` raises a `TimeoutError` whose `str()` is the **empty string**, so a timed-out capture reached the model as a bare `capture failed:` with no cause whatsoever. Now names the tool and the budget, and the tool layer never lets an empty message through.

## Verification

End-to-end on Arch Linux + Hyprland, cua-driver 0.14.1, reproducing the exact call from the issue:

| `capture(mode="som", app="Google Chrome")` | before | after |
|---|---|---|
| capture | `0x0` / `<no on-screen window matched>` | `1456x819`, valid 1.8 MB PNG |
| pid | dropped | `57569`, recovered from the compositor |
| elements | 0 | AT-SPI tree returned |

The resulting PNG was inspected visually.

## Tests

46 new tests in `tests/tools/test_computer_use_wayland_toplevel_pid.py`, built on payloads captured from a live Hyprland session — including the refusals (ambiguous pid → no match), the inertness of the probe off Hyprland, malformed/hostile compositor output, and preservation of the existing X11 drop behaviour.

263 existing `computer_use`/`cua` tests pass. `ruff` clean.

## Notes for reviewers

- Deliberately **not** included: a `get_desktop_state` capture fallback (suggested in the issue). Now that discovery works it would be unreachable code, and it returns no clickable elements — which is the whole contract of `som` mode.
- Also not included: having the gateway own the `cua-driver serve` lifecycle. That is its own scope; the MCP path now works without relying on the CLI fallback.
- Only Hyprland is wired up as a pid source. Sway/river expose the same gap and could be added the same way through `swaymsg -t get_tree`; I did not have a session to verify against, and I would rather not ship an unverified path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
