### PR TITLE
fix(gateway): rate-limit systemd restarts (Burst=8/300s)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2811,7 +2811,8 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=0
+StartLimitBurst=8
+StartLimitIntervalSec=300
 
 [Service]
 Type={systemd_type}
@@ -2854,7 +2855,8 @@ WantedBy=multi-user.target
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=0
+StartLimitBurst=8
+StartLimitIntervalSec=300
 
 [Service]
 Type={systemd_type}


### PR DESCRIPTION
## Summary
- Replace `StartLimitIntervalSec=0` with `StartLimitBurst=8` / `StartLimitIntervalSec=300` in both generated systemd unit templates (system + user).
- Prevents unbounded `Restart=always` crash-loops (e.g. `status=200/CHDIR` on a rotten WorkingDirectory) while keeping watchdog-driven `reset-failed` recovery.

## Test plan
- [ ] `generate_systemd_unit()` emits Burst=8 / Interval=300 for user and system templates
- [ ] Existing gateway systemd unit tests pass
- [ ] After `refresh_systemd_unit_if_needed()`, `systemctl show` reports non-zero `StartLimitIntervalUSec`

Made with [Cursor](https://cursor.com)