### PR TITLE
fix(buzz): deliver local images through native upload

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -678,6 +678,50 @@ class BuzzAdapter(BasePlatformAdapter):
         text = f"{caption}\n{image_url}" if caption else image_url
         return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
 
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        local = Path(image_path).expanduser()
+        if local.is_file():
+            args = [
+                "messages", "send",
+                "--channel", str(chat_id),
+                "--file", str(local),
+                "--content", "-",
+            ]
+            reply_target = reply_to or (metadata or {}).get("thread_id")
+            if reply_target:
+                args += ["--reply-to", str(reply_target)]
+            code, out, err = await self._run_cli(args, input_text=caption or "")
+            if code != 0:
+                return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
+            try:
+                data = json.loads(out or "{}")
+            except ValueError:
+                data = {}
+            event_id = data.get("event_id")
+            if event_id:
+                self._mark_seen(str(chat_id), str(event_id))
+            return SendResult(
+                success=bool(data.get("accepted", True)),
+                message_id=str(event_id) if event_id else None,
+                raw_response=data,
+            )
+        return await super().send_image_file(
+            chat_id=chat_id,
+            image_path=image_path,
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+            **kwargs,
+        )
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         chat_id = str(chat_id)
         state = self._channel_state.get(chat_id)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -421,6 +421,101 @@ class TestBuzzAdapterSend:
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
 
+    @pytest.mark.asyncio
+    async def test_send_image_file_existing_local_path_stays_native_upload_after_probe_flip(
+        self, tmp_path, monkeypatch
+    ):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt126b", "message": ""})
+        adapter._run_cli = cli
+
+        original_is_file = _buzz_mod.Path.is_file
+        probe_results = iter([True, False])
+
+        def sequential_is_file(path):
+            if path == img:
+                return next(probe_results, original_is_file(path))
+            return original_is_file(path)
+
+        monkeypatch.setattr(_buzz_mod.Path, "is_file", sequential_is_file)
+
+        result = await adapter.send_image_file(CHANNEL, str(img), caption="screenshot")
+
+        assert result.success is True
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "send"]
+        assert args[args.index("--channel") + 1] == CHANNEL
+        assert args[args.index("--file") + 1] == str(img)
+        assert args[args.index("--content") + 1] == "-"
+        assert stdin_text == "screenshot"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_uses_metadata_thread_id_when_reply_to_missing(self, tmp_path):
+        img = tmp_path / "reply-shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        thread_id = "b" * 64
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt126c", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send_image_file(
+            CHANNEL,
+            str(img),
+            caption="screenshot",
+            metadata={"thread_id": thread_id},
+        )
+
+        assert result.success is True
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "send"]
+        assert args[args.index("--channel") + 1] == CHANNEL
+        assert args[args.index("--file") + 1] == str(img)
+        assert args[args.index("--content") + 1] == "-"
+        assert args[args.index("--reply-to") + 1] == thread_id
+        assert stdin_text == "screenshot"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_missing_local_path_uses_base_fallback_notice(self, tmp_path):
+        missing = tmp_path / "missing.png"
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt127", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send_image_file(CHANNEL, str(missing), caption="screenshot")
+
+        assert result.success is True
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "send"]
+        assert "--file" not in args
+        assert str(missing) not in args
+        assert stdin_text == "screenshot\n⚠️ Couldn't deliver the image attachment."
+        assert str(missing) not in stdin_text
+
+    @pytest.mark.asyncio
+    async def test_send_multiple_images_file_url_uses_native_file_send(self, tmp_path):
+        img = tmp_path / "shot with spaces.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt127", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send_multiple_images(CHANNEL, [(img.as_uri(), "screenshot")])
+
+        assert len(cli.calls) == 1
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "send"]
+        assert args[args.index("--channel") + 1] == CHANNEL
+        assert args[args.index("--file") + 1] == str(img)
+        assert args[args.index("--content") + 1] == "-"
+        assert stdin_text == "screenshot"
+        assert "Couldn't deliver the image attachment." not in stdin_text
+
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Fixes native delivery of local image attachments through the Buzz adapter.

The gateway's real local-image path calls `BasePlatformAdapter.send_image_file()` (including `file://` items passed through `send_multiple_images()`). Buzz already uploads local files natively in `send_image()`, but it did not override `send_image_file()`, so the Base fallback sent a warning message instead of the attachment.

This adds the missing adapter-local bridge. Existing files use Buzz's current `messages send --file` path directly; missing or non-file paths retain the Base fallback so host filesystem paths are never echoed into chat. The direct path avoids a second file probe that could otherwise race into the text fallback if the file disappeared between checks.

## Related Issue

N/A — small adapter-local regression found during live Buzz testing; no existing Buzz image-delivery issue or PR was found.

Related work:

- #73610 introduced the bundled Buzz adapter this extends.
- #61694 proposes generic media-capability metadata. It is complementary: this PR provides the concrete Buzz `send_image_file` override and does not change registry or routing infrastructure.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/buzz/adapter.py`
  - Add `BuzzAdapter.send_image_file()`.
  - Send existing local files through Buzz's native `messages send --file` path with the same result parsing, retry, and echo-suppression behavior as `send_image()`.
  - Preserve upstream's current `reply_to` then `metadata["thread_id"]` precedence.
  - Preserve the Base no-path-leak fallback for missing/non-file paths.
- `tests/gateway/test_buzz_adapter.py`
  - Prove the real Base `send_multiple_images()` `file://` path reaches Buzz's native `--file` upload with its caption.
  - Prove a missing local path is not exposed in argv or message content.
  - Prove a file-probe race cannot fall through to text and expose the path.
  - Prove metadata-only thread context is forwarded using upstream's current semantics.

## How to Test

1. Run:

   ```bash
   scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py tests/gateway/test_send_multiple_images.py tests/gateway/test_send_image_file.py tests/gateway/test_media_metadata_contract.py -q
   ```

2. Confirm all 49 tests pass.
3. Run:

   ```bash
   ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py
   python -m py_compile plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py
   git diff --check origin/main...HEAD
   ```

4. Confirm Ruff, compilation, and diff checks are clean.

Full-suite baseline note:

- `scripts/run_tests.sh tests/ -q` is not currently clean on this macOS checkout: 23 unrelated test files failed.
- Running those exact 23 files from a detached clean `origin/main` checkout reproduced the same failed-file set.
- One parallel-run count differed by one; a direct rerun of the differing transcription file produced the same single failure on the patch branch and clean upstream.
- Neither touched file failed. The focused and surrounding media suite above is clean.

RED evidence before implementation:

- The Base `file://` path test failed because no `--file` argument was emitted and the Base fallback warning was used.
- The missing-path safety test failed because the path was echoed in message content instead of using the friendly Base fallback.
- The sequential file-probe test failed because a second `is_file()` check could race into the text fallback and expose the path.
- The metadata-only reply test failed because the new direct upload path initially omitted upstream's existing metadata fallback.

Private dogfood confirmed the equivalent adapter behavior on two Hermes installations. No private logs, hostnames, paths, channel IDs, event IDs, screenshots, or credentials are included here.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and closed PRs/issues for overlap
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test wrapper and all affected tests pass
- [ ] `pytest tests/ -q` is fully clean — see the baseline note above; the same 23 unrelated files fail on clean upstream
- [x] I've added behavioral tests for the fix and no-path-leak fallback
- [x] I've tested on macOS 26.5.1

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing configuration or API change
- [x] `cli-config.yaml.example` — N/A; no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no architecture or workflow change
- [x] Cross-platform impact considered; uses existing `pathlib.Path` and adapter/Base contracts
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

N/A. Automated behavioral evidence is included above; private dogfood artifacts are intentionally not published.

## Independent review

Final fail-closed review passed with zero security concerns, logic errors, or scope violations. The reviewer also ran 49 targeted tests and six adversarial image-delivery probes.

## AI assistance

AI assisted with implementation and test drafting. I reviewed the complete diff, ran the affected test suites and static checks, and verified that no credentials or setup-specific data are included.
