### PR TITLE
fix(mattermost): report a missing local file as a failed send (#65858)

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -583,10 +583,17 @@ class MattermostAdapter(BasePlatformAdapter):
 
         p = Path(file_path)
         if not p.exists():
+            # Report the failure. Returning success here told every caller the
+            # attachment had been delivered when nothing was posted at all,
+            # silently swallowing failed generated images, documents, audio
+            # and video. Matches the Slack adapter's contract for a missing
+            # local file.
             logger.warning(
-                "Mattermost: local file not found, skipping: %s", file_path
+                "Mattermost: local file not found, not sent: %s", file_path
             )
-            return SendResult(success=True, message_id=None)
+            return SendResult(
+                success=False, error=f"Local file not found: {file_path}"
+            )
 
         fname = file_name or p.name
         ct = mimetypes.guess_type(fname)[0] or "application/octet-stream"

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -454,6 +454,63 @@ class TestMattermostFileUpload:
         assert result.message_id == "post_with_file"
 
 
+class TestMattermostMissingLocalFile:
+    """A missing local file must be reported as a failure (#65858).
+
+    ``_send_local_file`` returned ``success=True, message_id=None`` when the
+    path did not exist, so callers recorded a delivered attachment for a post
+    that was never created — hiding failed generated images, documents, audio
+    and video. Matches the Slack adapter, which returns ``success=False``.
+    """
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        # Any network use would mean we got past the existence check.
+        self.adapter._session = MagicMock(
+            post=MagicMock(side_effect=AssertionError("must not post")),
+            get=MagicMock(side_effect=AssertionError("must not fetch")),
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method,kwarg",
+        [
+            ("send_image_file", "image_path"),
+            ("send_document", "file_path"),
+            ("send_voice", "audio_path"),
+            ("send_video", "video_path"),
+        ],
+    )
+    async def test_missing_file_reports_failure(self, tmp_path, method, kwarg):
+        missing = tmp_path / "never-generated.png"
+        assert not missing.exists()
+
+        result = await getattr(self.adapter, method)(
+            "channel_1", **{kwarg: str(missing)}
+        )
+
+        assert result.success is False
+        assert result.message_id is None
+        assert str(missing) in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_existing_file_still_uploads(self, tmp_path):
+        """The guard must not swallow a file that is actually present."""
+        real = tmp_path / "real.png"
+        real.write_bytes(b"\x89PNG\x00fake")
+
+        self.adapter._upload_file = AsyncMock(return_value="file_abc123")
+        self.adapter._thread_root_for_send = AsyncMock(return_value=None)
+        self.adapter._post_preserving_thread = AsyncMock(
+            return_value={"id": "post_with_file"}
+        )
+
+        result = await self.adapter.send_document("channel_1", str(real))
+
+        assert result.success is True
+        assert result.message_id == "post_with_file"
+
+
 # ---------------------------------------------------------------------------
 # Dedup cache
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Fixes #65858.

`_send_local_file()` in `plugins/platforms/mattermost/adapter.py` returned success when the file wasn't there:

```python
p = Path(file_path)
if not p.exists():
    logger.warning("Mattermost: local file not found, skipping: %s", file_path)
    return SendResult(success=True, message_id=None)   # nothing was posted
```

It logs, posts nothing, and reports success. Callers record a delivered attachment for a post that was never created.

All four public entry points delegate straight to it —

| method | |
|---|---|
| `send_image_file` | `_send_local_file(chat_id, image_path, …)` |
| `send_document` | `_send_local_file(chat_id, file_path, …)` |
| `send_voice` | `_send_local_file(chat_id, audio_path, …)` |
| `send_video` | `_send_local_file(chat_id, video_path, …)` |

— which is why the issue describes this as hiding generated images, documents, audio *and* video: it's one guard, not four separate bugs.

## The change

Return `success=False` with the offending path in `error`. This follows the Slack adapter, which already treats the same condition as a failure:

```python
except FileNotFoundError:
    return SendResult(success=False, error=f"Image file not found: {image_path}")
```

The warning is retained (reworded from "skipping" to "not sent", since the send no longer silently continues). A file that does exist uploads and posts exactly as before.

## Tests

`TestMattermostMissingLocalFile` in `tests/gateway/test_mattermost.py`:

- `test_missing_file_reports_failure` — parametrized across all four public methods; asserts `success is False`, `message_id is None`, and that the path appears in `error`. The session mock raises on any `post`/`get`, so reaching the network would fail the test outright.
- `test_existing_file_still_uploads` — the control: a real file on disk still yields `success=True` with the post id, so the guard can't regress into rejecting valid sends.

On unmodified `main` the four parametrized cases fail and the control passes:

```
4 failed, 1 passed   # before
28 passed            # after (test_mattermost.py + test_mattermost_plugin_setup.py)
```

No other test in the tree references `_send_local_file`, so nothing depended on the old success-on-missing contract.

## Platforms

macOS 15 (Darwin 25.5.0), Python 3.11. Pure `Path.exists()` control flow — no platform-specific behavior.

## Duplicate check

`gh search prs` for `mattermost` returns 10 open and 10 closed PRs; none touch `_send_local_file` or attachment failure reporting. No open PR references #65858.


---
*Authored by an AI agent (Claude Opus 5) operating autonomously on @jeff-mettel's behalf: the defect was traced, the patch written, and the tests run and verified end-to-end before submission.*