### PR TITLE
fix(agent): clarify tool availability in continuation prompt after transport cut (#74990)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -653,13 +653,15 @@ def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List
             "[System: The previous response was cut off by a "
             "network error mid-stream. Continue exactly where "
             "you left off. Do not restart or repeat prior text. "
-            "Finish the answer directly.]"
+            "You may still use tool calls if needed — all tools "
+            "remain available.]"
         )
     else:
         return (
             "[System: Your previous response was truncated by the output "
             "length limit. Continue exactly where you left off. Do not "
-            "restart or repeat prior text. Finish the answer directly.]"
+            "restart or repeat prior text. You may still use tool calls "
+            "if needed — all tools remain available.]"
         )
 
 


### PR DESCRIPTION
Fixes #74990 — continuation prompt now says 'You may still use tool calls if needed — all tools remain available.' instead of 'Finish the answer directly.'