### PR TITLE
fix(security): include colon in Bearer token redaction regex (#74967)

### DIFF
--- a/agent/monitoring/redaction.py
+++ b/agent/monitoring/redaction.py
@@ -21,7 +21,7 @@ import re
 from typing import Optional
 
 # ── secret shapes (belt-and-suspenders on top of agent/redact.py) ───────────
-_BEARER_RE = re.compile(r"\bBearer\s+[A-Za-z0-9._~+\-/]+=*", re.IGNORECASE)
+_BEARER_RE = re.compile(r"\bBearer\s+[A-Za-z0-9._~+\-/:]+=*", re.IGNORECASE)
 _TOKEN_RE = re.compile(
     r"\b(xox[baprs]-[A-Za-z0-9-]+|sk-[A-Za-z0-9_-]{8,}|gh[pousr]_[A-Za-z0-9_]{8,})\b"
 )

--- a/tests/monitoring/test_export_redaction.py
+++ b/tests/monitoring/test_export_redaction.py
@@ -28,6 +28,15 @@ def test_bearer_header_stripped():
     assert "abc.def-ghi_jkl" not in out
 
 
+def test_bearer_token_with_colon_stripped():
+    """Regression test for #74967 — Bearer token containing colon leaked suffix."""
+    out = R.redact_for_export("Authorization: Bearer abc:def:ghi")
+    assert out is not None
+    assert "abc:def:ghi" not in out
+    # Ensure the colon didn't cause a partial match
+    assert ":def:ghi" not in out
+
+
 
 
 


### PR DESCRIPTION
Fixes #74967 — added ':' to _BEARER_RE character class so tokens with colons (e.g. LM Studio API keys) are fully redacted.