### PR TITLE
fix(cron): persist delivery outcomes accurately

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1044,6 +1044,8 @@ def load_jobs() -> List[Dict[str, Any]]:
     # down the whole cron subsystem.
     if isinstance(data, dict):
         jobs = data.get("jobs", [])
+        for job in jobs:
+            job.setdefault("last_delivery_status", "not_requested")
         if _strict_retry and jobs:
             # Hit control-character corruption — rewrite with proper escaping.
             save_jobs(jobs)
@@ -1052,6 +1054,8 @@ def load_jobs() -> List[Dict[str, Any]]:
     if isinstance(data, list):
         # Bare array — likely saved/edited outside save_jobs(). Wrap it back
         # into the expected {"jobs": [...]} structure.
+        for job in data:
+            job.setdefault("last_delivery_status", "not_requested")
         if data:
             save_jobs(data)
             logger.warning("Auto-repaired jobs.json (bare list wrapped as dict)")
@@ -1421,6 +1425,7 @@ def create_job(
         "last_status": None,
         "last_error": None,
         "last_delivery_error": None,
+        "last_delivery_status": "not_requested",
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
@@ -1686,8 +1691,27 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
-def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+def mark_job_delivery_pending(job_id: str) -> None:
+    """Persist delivery intent before the external send begins."""
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] == job_id:
+                job["last_delivery_status"] = "pending"
+                job["last_delivery_error"] = None
+                save_jobs(jobs)
+                return
+
+
+def mark_job_run(
+    job_id: str,
+    success: bool,
+    error: Optional[str] = None,
+    delivery_error: Optional[str] = None,
+    *,
+    delivery_attempted: Optional[bool] = None,
+    delivery_status: Optional[str] = None,
+):
     """
     Mark a job as having been run.
     
@@ -1707,6 +1731,20 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                if delivery_status is not None:
+                    job["last_delivery_status"] = delivery_status
+                elif delivery_attempted is None and delivery_error:
+                    # Backward compatibility for callers predating explicit
+                    # delivery-attempt bookkeeping.
+                    job["last_delivery_status"] = "failed"
+                elif delivery_attempted is not None:
+                    job["last_delivery_status"] = (
+                        "failed"
+                        if delivery_attempted and delivery_error
+                        else "sent"
+                        if delivery_attempted
+                        else "not_requested"
+                    )
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -101,6 +101,70 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     job_name = job.get("name") or job.get("id") or "cron job"
     text = (error or "unknown error").strip()
     lower = text.lower()
+    fallback_evidenced = (
+        "fallback chain exhausted" in lower
+        or "fallbacks exhausted" in lower
+        or "all providers failed" in lower
+    )
+
+    def _fallback_note() -> str:
+        return "Fallback chain was exhausted or unavailable. " if fallback_evidenced else ""
+
+    if (
+        "pending_approval" in lower
+        or "approval_pending" in lower
+        or "timed out without user response" in lower
+        or "approval timed out" in lower
+    ):
+        return (
+            f"⚠️ Cron '{job_name}' failed: unattended tool approval timed out. "
+            "Full details saved in cron output."
+        )
+
+    inactivity_tool = re.search(
+        r"idle for .*?last activity:\s*executing tool:\s*([^.;,\s]+)", lower
+    )
+    if inactivity_tool:
+        tool_name = inactivity_tool.group(1).strip("'\"")
+        return (
+            f"⚠️ Cron '{job_name}' failed: job inactivity timeout while executing "
+            f"{tool_name}. Full details saved in cron output."
+        )
+    if "idle for" in lower and "last activity:" in lower:
+        if any(
+            marker in lower
+            for marker in (
+                "api response",
+                "provider response",
+                "stream response",
+                "sse event",
+            )
+        ):
+            return (
+                f"⚠️ Cron '{job_name}' failed: provider inactivity timeout. "
+                f"{_fallback_note()}Full details saved in cron output."
+            )
+        return (
+            f"⚠️ Cron '{job_name}' failed: job inactivity timeout. "
+            "Full details saved in cron output."
+        )
+
+    tool_timeout = re.search(
+        r"(?:executing tool|tool)\s+['\"]?([a-z0-9_.:-]+)['\"]?.{0,120}?timed out",
+        lower,
+    )
+    if tool_timeout:
+        tool_name = tool_timeout.group(1)
+        return (
+            f"⚠️ Cron '{job_name}' failed: tool '{tool_name}' timed out. "
+            "Full details saved in cron output."
+        )
+
+    if "delivery" in lower and ("timeout" in lower or "timed out" in lower):
+        return (
+            f"⚠️ Cron '{job_name}' failed: delivery timeout. "
+            "Full details saved in cron output."
+        )
 
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
@@ -111,15 +175,32 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             reason = "quota limit"
         return (
             f"⚠️ Cron '{job_name}' failed: provider {reason}. "
-            "Fallback chain was exhausted or unavailable. "
-            "Full details saved in cron output."
+            f"{_fallback_note()}Full details saved in cron output."
         )
 
     if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
+        provider_evidenced = any(
+            marker in lower
+            for marker in (
+                "apitimeouterror",
+                "provider timeout",
+                "codex stream",
+                "sse events",
+                "openai",
+                "anthropic",
+                "openrouter",
+                "gemini",
+                "inference-api",
+            )
+        )
+        if not provider_evidenced:
+            return (
+                f"⚠️ Cron '{job_name}' failed: operation timed out. "
+                "Full details saved in cron output."
+            )
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "
-            "Fallback chain was exhausted or unavailable. "
-            "Full details saved in cron output."
+            f"{_fallback_note()}Full details saved in cron output."
         )
 
     # Match authentication/authorization wording at a word boundary and the
@@ -281,7 +362,15 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    advance_next_run,
+    claim_dispatch,
+    get_due_jobs,
+    heartbeat_run_claim,
+    mark_job_delivery_pending,
+    mark_job_run,
+    save_job_output,
+)
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -4002,11 +4091,18 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
 
+            normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
+            unresolved_origin = (
+                should_deliver
+                and normalized_deliver == "origin"
+                and not _resolve_delivery_targets(job)
+            )
+            delivery_attempted = (
+                should_deliver and normalized_deliver != "local" and not unresolved_origin
+            )
             if should_deliver:
-                unresolved_origin = (
-                    _normalize_deliver_value(job.get("deliver", "local")) == "origin"
-                    and not _resolve_delivery_targets(job)
-                )
+                if delivery_attempted:
+                    mark_job_delivery_pending(job["id"])
                 try:
                     delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
                 except Exception as de:
@@ -4027,8 +4123,18 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
         if not _consume_interrupted_flag(job["id"]):
-            mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-        normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
+            mark_job_run(
+                job["id"],
+                success,
+                error,
+                delivery_error=delivery_error,
+                delivery_attempted=delivery_attempted,
+                delivery_status=(
+                    "not_configured"
+                    if should_deliver and unresolved_origin and not delivery_error
+                    else None
+                ),
+            )
         if delivery_error:
             delivery_outcome = "failed"
         elif should_deliver and unresolved_origin:

--- a/tests/cron/test_delivery_state.py
+++ b/tests/cron/test_delivery_state.py
@@ -1,0 +1,137 @@
+from unittest.mock import patch
+
+import pytest
+
+from cron.jobs import (
+    create_job,
+    get_job,
+    mark_job_delivery_pending,
+    mark_job_run,
+)
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def test_delivery_state_is_pending_until_success_is_recorded(tmp_cron_dir) -> None:
+    job = create_job(prompt="Report", schedule="every 1h")
+
+    mark_job_delivery_pending(job["id"])
+    assert get_job(job["id"])["last_delivery_status"] == "pending"
+
+    mark_job_run(job["id"], success=True, delivery_attempted=True)
+    assert get_job(job["id"])["last_delivery_status"] == "sent"
+
+
+def test_delivery_failure_is_not_recorded_as_sent(tmp_cron_dir) -> None:
+    job = create_job(prompt="Report", schedule="every 1h")
+
+    mark_job_delivery_pending(job["id"])
+    mark_job_run(
+        job["id"],
+        success=True,
+        delivery_error="Telegram send failed: timed out",
+        delivery_attempted=True,
+    )
+    updated = get_job(job["id"])
+
+    assert updated["last_delivery_status"] == "failed"
+    assert updated["last_delivery_error"] == "Telegram send failed: timed out"
+
+
+def test_silent_run_records_not_requested(tmp_cron_dir) -> None:
+    job = create_job(prompt="Report", schedule="every 1h")
+
+    mark_job_run(job["id"], success=True, delivery_attempted=False)
+
+    assert get_job(job["id"])["last_delivery_status"] == "not_requested"
+
+
+def test_interruption_does_not_erase_pending_delivery_state(tmp_cron_dir) -> None:
+    job = create_job(prompt="Report", schedule="every 1h")
+
+    mark_job_delivery_pending(job["id"])
+    mark_job_run(job["id"], success=False, error="gateway shutdown")
+
+    assert get_job(job["id"])["last_delivery_status"] == "pending"
+
+
+def test_unconfigured_target_is_not_recorded_as_sent(tmp_cron_dir) -> None:
+    job = create_job(prompt="Report", schedule="every 1h")
+
+    mark_job_delivery_pending(job["id"])
+    mark_job_run(
+        job["id"],
+        success=True,
+        delivery_attempted=True,
+        delivery_status="not_configured",
+    )
+
+    assert get_job(job["id"])["last_delivery_status"] == "not_configured"
+
+
+def test_local_only_run_does_not_claim_external_delivery() -> None:
+    from cron.scheduler import run_one_job
+
+    job = {
+        "id": "local-job",
+        "name": "local job",
+        "prompt": "report",
+        "deliver": "local",
+    }
+    with (
+        patch("cron.scheduler.claim_dispatch", return_value=True),
+        patch("agent.secret_scope.set_secret_scope", return_value=None),
+        patch("agent.secret_scope.build_profile_secret_scope", return_value=None),
+        patch("agent.secret_scope.reset_secret_scope"),
+        patch(
+            "cron.scheduler.run_job",
+            return_value=(True, "full output", "final response", None),
+        ),
+        patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"),
+        patch("cron.scheduler._is_cron_silence_response", return_value=False),
+        patch("cron.scheduler._deliver_result", return_value=None),
+        patch("cron.scheduler.mark_job_delivery_pending") as pending,
+        patch("cron.scheduler.mark_job_run") as completed,
+    ):
+        assert run_one_job(job) is True
+
+    pending.assert_not_called()
+    assert completed.call_args.kwargs["delivery_attempted"] is False
+
+
+def test_unresolved_origin_never_enters_pending_state() -> None:
+    from cron.scheduler import run_one_job
+
+    job = {
+        "id": "origin-job",
+        "name": "origin job",
+        "prompt": "report",
+        "deliver": "origin",
+    }
+    with (
+        patch("cron.scheduler.claim_dispatch", return_value=True),
+        patch("agent.secret_scope.set_secret_scope", return_value=None),
+        patch("agent.secret_scope.build_profile_secret_scope", return_value=None),
+        patch("agent.secret_scope.reset_secret_scope"),
+        patch(
+            "cron.scheduler.run_job",
+            return_value=(True, "full output", "final response", None),
+        ),
+        patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"),
+        patch("cron.scheduler._is_cron_silence_response", return_value=False),
+        patch("cron.scheduler._resolve_delivery_targets", return_value=[]),
+        patch("cron.scheduler._deliver_result", return_value=None),
+        patch("cron.scheduler.mark_job_delivery_pending") as pending,
+        patch("cron.scheduler.mark_job_run") as completed,
+    ):
+        assert run_one_job(job) is True
+
+    pending.assert_not_called()
+    assert completed.call_args.kwargs["delivery_attempted"] is False
+    assert completed.call_args.kwargs["delivery_status"] == "not_configured"

--- a/tests/cron/test_failure_summary_semantics.py
+++ b/tests/cron/test_failure_summary_semantics.py
@@ -1,0 +1,131 @@
+from cron.scheduler import _summarize_cron_failure_for_delivery
+
+
+def _job() -> dict[str, str]:
+    return {"id": "job-1", "name": "Weekly report"}
+
+
+def test_inactivity_timeout_names_terminal_tool_instead_of_provider() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(),
+        "TimeoutError: Cron job 'Weekly report' idle for 3618s (limit 600s) — "
+        "last activity: executing tool: terminal",
+    )
+
+    assert message == (
+        "⚠️ Cron 'Weekly report' failed: job inactivity timeout while executing terminal. "
+        "Full details saved in cron output."
+    )
+    assert "provider" not in message
+    assert "Fallback chain" not in message
+
+
+def test_api_wait_inactivity_is_provider_not_fake_tool() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(),
+        "TimeoutError: Cron job idle for 601s — last activity: "
+        "waiting for non-streaming API response",
+    )
+
+    assert "provider inactivity timeout" in message
+    assert "executing waiting" not in message
+
+
+def test_concurrent_activity_inactivity_does_not_invent_tool_name() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(),
+        "TimeoutError: Cron job idle for 601s — last activity: concurrent tools pending",
+    )
+
+    assert "job inactivity timeout" in message
+    assert "executing concurrent" not in message
+
+
+def test_pending_approval_timeout_names_unattended_approval_block() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(),
+        "Tool terminal returned error: status=pending_approval approval_pending=true timeout",
+    )
+
+    assert message == (
+        "⚠️ Cron 'Weekly report' failed: unattended tool approval timed out. "
+        "Full details saved in cron output."
+    )
+
+
+def test_provider_timeout_only_claims_fallback_exhaustion_when_evidenced() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(),
+        "TimeoutError: Codex stream produced no SSE events for 60s",
+    )
+    exhausted = _summarize_cron_failure_for_delivery(
+        _job(),
+        "Provider timeout; fallback chain exhausted",
+    )
+
+    assert message == (
+        "⚠️ Cron 'Weekly report' failed: provider timeout. "
+        "Full details saved in cron output."
+    )
+    assert exhausted == (
+        "⚠️ Cron 'Weekly report' failed: provider timeout. "
+        "Fallback chain was exhausted or unavailable. "
+        "Full details saved in cron output."
+    )
+
+
+def test_generic_timeout_does_not_guess_provider() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(), "TimeoutError: operation timed out"
+    )
+
+    assert message == (
+        "⚠️ Cron 'Weekly report' failed: operation timed out. "
+        "Full details saved in cron output."
+    )
+
+
+def test_rate_limit_does_not_claim_unobserved_fallback_exhaustion() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(), "HTTP 429 rate limit exceeded"
+    )
+
+    assert "provider rate limit" in message
+    assert "Fallback chain" not in message
+
+
+def test_real_approval_timeout_wording_is_classified() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(), "BLOCKED: Action timed out without user response after 600 seconds"
+    )
+
+    assert "unattended tool approval timed out" in message
+    assert "provider" not in message
+
+
+def test_tool_timeout_names_tool() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(), "Error executing tool 'terminal': timed out after 300.0s"
+    )
+
+    assert "tool 'terminal' timed out" in message
+    assert "provider" not in message
+
+
+def test_delivery_timeout_is_not_provider_timeout() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(), "delivery to telegram:123 failed: TimeoutError"
+    )
+
+    assert "delivery timeout" in message
+    assert "provider" not in message
+    assert "Fallback chain" not in message
+
+
+def test_api_timeout_exception_is_provider_timeout() -> None:
+    message = _summarize_cron_failure_for_delivery(
+        _job(), "APITimeoutError: Request timed out"
+    )
+
+    assert "provider timeout" in message
+    assert "Fallback chain" not in message

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -345,6 +345,7 @@ class TestMarkJobRun:
         assert updated["last_status"] == "ok"
         assert updated["last_error"] is None
         assert updated["last_delivery_error"] == "platform 'telegram' not configured"
+        assert updated["last_delivery_status"] == "failed"
 
 
     def test_recurring_cron_not_disabled_when_croniter_missing(self, tmp_cron_dir, monkeypatch):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -31,7 +31,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("deliver", job["id"]))
         return None
 
-    def fake_mark(jid, ok, err=None, delivery_error=None):
+    def fake_mark(jid, ok, err=None, delivery_error=None, **delivery_state):
         calls.append(("mark", jid, ok))
 
     monkeypatch.setattr(s, "run_job", fake_run_job)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -964,6 +964,8 @@ class TestSilentDelivery:
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
+            delivery_attempted=False,
+            delivery_status=None,
         )
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -549,6 +549,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "last_run_at": job.get("last_run_at"),
         "last_status": job.get("last_status"),
         "last_delivery_error": job.get("last_delivery_error"),
+        "last_delivery_status": job.get("last_delivery_status", "not_requested"),
         "enabled": job.get("enabled", True),
         "state": job.get("state", "scheduled" if job.get("enabled", True) else "paused"),
         "paused_at": job.get("paused_at"),


### PR DESCRIPTION
## What does this PR do?

Cron failure notifications currently collapse distinct failure domains into provider/fallback language, and job-level delivery state can report no durable uncertainty window between intent and completion. This PR classifies timeout origins conservatively and records delivery intent before calling an adapter.

## Related Issue

No existing issue or PR matched this behavior in repository search.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`: distinguish provider, tool, approval, inactivity, generic operation, and delivery timeouts; claim fallback exhaustion only when evidenced.
- `cron/jobs.py`: persist delivery as `pending`, then close it as `sent`, `failed`, `not_configured`, or `not_requested`; preserve pending state across interruption bookkeeping.
- `tests/cron/`: cover classification and transactional state transitions.

## How to Test

1. Run `python3 -m pytest -o addopts='' tests/cron/test_failure_summary_semantics.py tests/cron/test_delivery_state.py tests/cron/test_jobs.py -q`.
2. Run `python3 -m ruff check cron/scheduler.py cron/jobs.py tests/cron/test_failure_summary_semantics.py tests/cron/test_delivery_state.py`.
3. Verify a local-only cron run records `last_delivery_status=not_requested`; adapter failures record `failed`, not `sent`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the complete `tests/cron` suite (`391 passed`); the repository-wide suite cannot collect in this checkout because optional dev dependencies are not installed
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.1

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md`/`AGENTS.md` update is N/A; no workflow architecture changed
- [x] Cross-platform impact considered: code uses existing platform-neutral JSON persistence and scheduler paths
- [x] Tool schema update is N/A

## Screenshots / Logs

Focused result: `391 passed` across the complete `tests/cron` suite; Ruff check passed.
