### PR TITLE
feat(gateway): forward Hermes session identity to LiteLLM

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1586,6 +1586,17 @@ def init_agent(
     except Exception:
         _agent_cfg = {}
 
+    # Privacy opt-in: platform/chat identifiers are never forwarded by default.
+    agent._share_session_identity = False
+    try:
+        _privacy_cfg = _agent_cfg.get("privacy", {})
+        if isinstance(_privacy_cfg, dict):
+            agent._share_session_identity = bool(
+                _privacy_cfg.get("share_session_identity", False)
+            )
+    except Exception:
+        agent._share_session_identity = False
+
     # Codex commentary visibility (display.show_commentary, default true).
     # When true, completed Codex phase=commentary messages are delivered as
     # visible mid-turn updates through the interim message path. When false,

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1818,6 +1818,17 @@ def init_agent(
     except Exception:
         _agent_cfg = {}
 
+    # Privacy opt-in: platform/chat identifiers are never forwarded by default.
+    agent._share_session_identity = False
+    try:
+        _privacy_cfg = _agent_cfg.get("privacy", {})
+        if isinstance(_privacy_cfg, dict):
+            agent._share_session_identity = bool(
+                _privacy_cfg.get("share_session_identity", False)
+            )
+    except Exception:
+        agent._share_session_identity = False
+
     # Codex commentary visibility (display.show_commentary, default true).
     # When true, completed Codex phase=commentary messages are delivered as
     # visible mid-turn updates through the interim message path. When false,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1125,6 +1125,35 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     if tools_for_api is None:
         tools_for_api = agent.tools
 
+    # Forward Hermes identity only after an explicit privacy opt-in and only
+    # for a user-selected custom OpenAI-compatible route (for example LiteLLM).
+    # Built-in providers must never receive platform identifiers implicitly.
+    # Keep this separate from inbound gateway headers and do not mutate the
+    # request_overrides mapping because it is reused across turns.
+    upstream_overrides = dict(agent.request_overrides or {})
+    _provider_norm = str(getattr(agent, "provider", "") or "").strip().lower()
+    _share_session_identity = bool(
+        getattr(agent, "_share_session_identity", False)
+        and (_provider_norm == "custom" or _provider_norm.startswith("custom:"))
+    )
+    if _share_session_identity:
+        upstream_user = getattr(agent, "_user_id", None) or getattr(
+            agent, "_gateway_session_key", None
+        )
+        if upstream_user and "user" not in upstream_overrides:
+            upstream_overrides["user"] = str(upstream_user)
+
+        upstream_metadata = dict(upstream_overrides.get("metadata") or {})
+        if getattr(agent, "session_id", None):
+            # LiteLLM uses metadata.session_id for Session-ID affinity.
+            upstream_metadata.setdefault("session_id", str(agent.session_id))
+        if getattr(agent, "_gateway_session_key", None):
+            upstream_metadata.setdefault(
+                "hermes_session_key", str(agent._gateway_session_key)
+            )
+        if upstream_metadata:
+            upstream_overrides["metadata"] = upstream_metadata
+
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
         anthropic_messages = agent._prepare_anthropic_messages_for_api(api_messages)
@@ -1225,7 +1254,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             base_url=agent.base_url,
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
-            request_overrides=agent.request_overrides,
+            request_overrides=upstream_overrides,
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
@@ -1327,7 +1356,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=agent._max_tokens_param,
             reasoning_config=agent.reasoning_config,
-            request_overrides=agent.request_overrides,
+            request_overrides=upstream_overrides,
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
             ollama_num_ctx=agent._ollama_num_ctx,
@@ -1359,7 +1388,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         ephemeral_max_output_tokens=_ephemeral_out,
         max_tokens_param_fn=agent._max_tokens_param,
         reasoning_config=agent.reasoning_config,
-        request_overrides=agent.request_overrides,
+        request_overrides=upstream_overrides,
         session_id=getattr(agent, "session_id", None),
         model_lower=(agent.model or "").lower(),
         is_openrouter=_is_or,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2025,6 +2025,33 @@ def _build_api_kwargs_for_mode(agent, api_messages: list, tools_for_api: list | 
     # fast override here, per request, only while the window is open.
     _request_overrides = effective_request_overrides(agent)
 
+    # Forward Hermes identity only after an explicit privacy opt-in and only
+    # for a user-selected custom OpenAI-compatible route (for example LiteLLM).
+    # Built-in providers must never receive platform identifiers implicitly.
+    # Keep this separate from inbound gateway headers and do not mutate the
+    # request_overrides mapping because it is reused across turns.
+    _provider_norm = str(getattr(agent, "provider", "") or "").strip().lower()
+    _share_session_identity = bool(
+        getattr(agent, "_share_session_identity", False)
+        and (_provider_norm == "custom" or _provider_norm.startswith("custom:"))
+    )
+    if _share_session_identity:
+        upstream_user = getattr(agent, "_user_id", None) or getattr(
+            agent, "_gateway_session_key", None
+        )
+        if upstream_user and "user" not in _request_overrides:
+            _request_overrides["user"] = str(upstream_user)
+
+        upstream_metadata = dict(_request_overrides.get("metadata") or {})
+        if getattr(agent, "session_id", None):
+            # LiteLLM uses metadata.session_id for Session-ID affinity.
+            upstream_metadata.setdefault("session_id", str(agent.session_id))
+        if getattr(agent, "_gateway_session_key", None):
+            upstream_metadata.setdefault(
+                "hermes_session_key", str(agent._gateway_session_key)
+            )
+        if upstream_metadata:
+            _request_overrides["metadata"] = upstream_metadata
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
         anthropic_messages = agent._prepare_anthropic_messages_for_api(api_messages)

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1030,7 +1030,7 @@ def _preflight_codex_api_kwargs(
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
         "tool_choice", "parallel_tool_calls", "prompt_cache_key",
-        "prompt_cache_retention", "service_tier",
+        "prompt_cache_retention", "service_tier", "user", "metadata",
         "extra_headers", "extra_body", "timeout",
     }
     normalized: Dict[str, Any] = {
@@ -1067,6 +1067,17 @@ def _preflight_codex_api_kwargs(
     temperature = api_kwargs.get("temperature")
     if isinstance(temperature, (int, float)):
         normalized["temperature"] = float(temperature)
+    user = api_kwargs.get("user")
+    if user is not None:
+        if not isinstance(user, str) or not user.strip():
+            raise ValueError("Codex Responses request 'user' must be a non-empty string.")
+        normalized["user"] = user
+    metadata = api_kwargs.get("metadata")
+    if metadata is not None:
+        if not isinstance(metadata, dict):
+            raise ValueError("Codex Responses request 'metadata' must be an object.")
+        normalized["metadata"] = dict(metadata)
+
 
     # Pass through cache routing/retention and tool-dispatch hints.
     for passthrough_key in (

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1312,7 +1312,7 @@ def _preflight_codex_api_kwargs(
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
         "tool_choice", "parallel_tool_calls", "prompt_cache_key",
-        "prompt_cache_retention", "service_tier", "context_management",
+        "prompt_cache_retention", "service_tier", "context_management", "user", "metadata",
         "extra_headers", "extra_body", "timeout",
     }
     normalized: Dict[str, Any] = {
@@ -1349,6 +1349,17 @@ def _preflight_codex_api_kwargs(
     temperature = api_kwargs.get("temperature")
     if isinstance(temperature, (int, float)):
         normalized["temperature"] = float(temperature)
+    user = api_kwargs.get("user")
+    if user is not None:
+        if not isinstance(user, str) or not user.strip():
+            raise ValueError("Codex Responses request 'user' must be a non-empty string.")
+        normalized["user"] = user
+    metadata = api_kwargs.get("metadata")
+    if metadata is not None:
+        if not isinstance(metadata, dict):
+            raise ValueError("Codex Responses request 'metadata' must be an object.")
+        normalized["metadata"] = dict(metadata)
+
 
     # Pass through cache routing/retention and tool-dispatch hints.
     for passthrough_key in (

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1381,6 +1381,8 @@ DEFAULT_CONFIG = {
     # Privacy settings
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
+        # Explicitly allow platform/chat identifiers on custom OpenAI-compatible upstreams.
+        "share_session_identity": False,
     },
 
     # Text-to-speech configuration

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1867,6 +1867,8 @@ DEFAULT_CONFIG = {
     # Privacy settings
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
+        # Explicitly allow platform/chat identifiers on custom OpenAI-compatible upstreams.
+        "share_session_identity": False,
     },
 
     # Text-to-speech configuration

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -162,6 +162,7 @@ _DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin",
 # per-platform enable/disable checklist; configured via the "Reconfigure an
 # existing tool" flow and the GUI provider matrix instead.
 _CONFIG_ONLY_TOOLSETS = {"stt"}
+_SESSION_IDENTITY_TOOL_NAME = "session_identity"
 
 
 def _xai_credentials_present() -> bool:
@@ -2664,6 +2665,33 @@ def _prompt_choice(question: str, choices: list, default: int = 0) -> int:
     return curses_radiolist(question, choices, selected=default, cancel_returns=default)
 
 
+def _configure_session_identity(config: dict) -> None:
+    """Configure consent for forwarding platform identity to custom upstreams."""
+    privacy = config.setdefault("privacy", {})
+    if not isinstance(privacy, dict):
+        privacy = {}
+        config["privacy"] = privacy
+    enabled = privacy.get("share_session_identity") is True
+    print()
+    print(color("  Upstream session identity (privacy setting)", Colors.CYAN, Colors.BOLD))
+    print(color("  When enabled, Hermes sends the platform user ID and stable chat session ID", Colors.DIM))
+    print(color("  to explicitly configured custom OpenAI-compatible providers such as LiteLLM.", Colors.DIM))
+    print(color("  Built-in providers are never sent these identifiers by this setting.", Colors.DIM))
+    choices = [
+        "Disabled (recommended)",
+        "Enabled for custom OpenAI-compatible providers",
+        "Cancel",
+    ]
+    default = 1 if enabled else 0
+    choice = _prompt_choice("Share session identity with custom upstreams?", choices, default)
+    if choice == 0:
+        privacy["share_session_identity"] = False
+        _print_success("  Session identity forwarding disabled")
+    elif choice == 1:
+        privacy["share_session_identity"] = True
+        _print_success("  Session identity forwarding enabled for custom providers")
+
+
 # ─── Token Estimation ────────────────────────────────────────────────────────
 
 # Module-level cache so discovery + tokenization runs at most once per process.
@@ -4941,6 +4969,8 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
             print(color(f"  ✓ Saved {pinfo['label']} tool configuration", Colors.GREEN))
             print()
 
+        _configure_session_identity(config)
+        save_config(config)
         return
 
     # ── Returning user: platform menu loop ──
@@ -4964,17 +4994,25 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     if _has_mcp:
         platform_choices.append("Configure MCP server tools")
 
+    _privacy_idx = len(platform_choices)
+    platform_choices.append("Configure privacy / upstream session identity")
+    _done_idx = _privacy_idx + 1
     platform_choices.append("Done")
 
     # Index offsets for the extra options after per-platform entries
     _global_idx = len(platform_keys) if len(platform_keys) > 1 else -1
     _reconfig_idx = len(platform_keys) + (1 if len(platform_keys) > 1 else 0)
     _mcp_idx = (_reconfig_idx + 1) if _has_mcp else -1
-    _done_idx = _reconfig_idx + (2 if _has_mcp else 1)
 
     while True:
         idx = _prompt_choice("Select an option:", platform_choices, default=0)
 
+        # Privacy / upstream identity selected
+        if idx == _privacy_idx:
+            _configure_session_identity(config)
+            save_config(config)
+            print()
+            continue
         # "Done" selected
         if idx == _done_idx:
             break
@@ -5394,7 +5432,11 @@ def tools_disable_enable_command(args):
         return
 
     targets: List[str] = args.names
-    toolset_targets = [t for t in targets if ":" not in t]
+    if _SESSION_IDENTITY_TOOL_NAME in targets:
+        config.setdefault("privacy", {})["share_session_identity"] = action == "enable"
+        state = "enabled" if action == "enable" else "disabled"
+        _print_success(f"Session identity forwarding {state} for custom providers")
+    toolset_targets = [t for t in targets if ":" not in t and t != _SESSION_IDENTITY_TOOL_NAME]
     mcp_targets = [t for t in targets if ":" in t]
 
     valid_toolsets = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS} | _get_plugin_toolset_keys()

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -166,6 +166,7 @@ _DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin",
 # per-platform enable/disable checklist; configured via the "Reconfigure an
 # existing tool" flow and the GUI provider matrix instead.
 _CONFIG_ONLY_TOOLSETS = {"stt"}
+_SESSION_IDENTITY_TOOL_NAME = "session_identity"
 
 
 def _xai_credentials_present() -> bool:
@@ -3109,6 +3110,32 @@ def _prompt_choice(question: str, choices: list, default: int = 0) -> int:
     return curses_radiolist(question, choices, selected=default, cancel_returns=default)
 
 
+def _configure_session_identity(config: dict) -> None:
+    """Configure consent for forwarding platform identity to custom upstreams."""
+    privacy = config.setdefault("privacy", {})
+    if not isinstance(privacy, dict):
+        privacy = {}
+        config["privacy"] = privacy
+    enabled = privacy.get("share_session_identity") is True
+    print()
+    print(color("  Upstream session identity (privacy setting)", Colors.CYAN, Colors.BOLD))
+    print(color("  When enabled, Hermes sends the platform user ID and stable chat session ID", Colors.DIM))
+    print(color("  to explicitly configured custom OpenAI-compatible providers such as LiteLLM.", Colors.DIM))
+    print(color("  Built-in providers are never sent these identifiers by this setting.", Colors.DIM))
+    choices = [
+        "Disabled (recommended)",
+        "Enabled for custom OpenAI-compatible providers",
+        "Cancel",
+    ]
+    default = 1 if enabled else 0
+    choice = _prompt_choice("Share session identity with custom upstreams?", choices, default)
+    if choice == 0:
+        privacy["share_session_identity"] = False
+        _print_success("  Session identity forwarding disabled")
+    elif choice == 1:
+        privacy["share_session_identity"] = True
+        _print_success("  Session identity forwarding enabled for custom providers")
+
 # ─── Token Estimation ────────────────────────────────────────────────────────
 
 # Profile-keyed cache so one process can serve distinct plugin tool catalogs.
@@ -5790,6 +5817,9 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     if _has_mcp:
         platform_choices.append("Configure MCP server tools")
 
+    _privacy_idx = len(platform_choices)
+    platform_choices.append("Configure privacy / upstream session identity")
+    _done_idx = _privacy_idx + 1
     platform_choices.append("Done")
 
     # Index offsets for the extra options after per-platform entries
@@ -5797,10 +5827,16 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     _reconfig_idx = len(platform_keys) + (1 if len(platform_keys) > 1 else 0)
     _metrics_idx = _reconfig_idx + 1
     _mcp_idx = (_metrics_idx + 1) if _has_mcp else -1
-    _done_idx = _metrics_idx + (2 if _has_mcp else 1)
 
     while True:
         idx = _prompt_choice("Select an option:", platform_choices, default=0)
+
+        # Privacy / upstream identity selected
+        if idx == _privacy_idx:
+            _configure_session_identity(config)
+            save_config(config)
+            print()
+            continue
 
         # "Done" selected
         if idx == _done_idx:
@@ -6296,7 +6332,11 @@ def tools_disable_enable_command(args):
         return
 
     targets: List[str] = args.names
-    toolset_targets = [t for t in targets if ":" not in t]
+    if _SESSION_IDENTITY_TOOL_NAME in targets:
+        config.setdefault("privacy", {})["share_session_identity"] = action == "enable"
+        state = "enabled" if action == "enable" else "disabled"
+        _print_success(f"Session identity forwarding {state} for custom providers")
+    toolset_targets = [t for t in targets if ":" not in t and t != _SESSION_IDENTITY_TOOL_NAME]
     mcp_targets = [t for t in targets if ":" in t]
 
     valid_toolsets = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS} | _get_plugin_toolset_keys()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -859,6 +859,12 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Modal sandbox mode",
         "options": ["sandbox", "function"],
     },
+    "privacy.share_session_identity": {
+        "type": "boolean",
+        "description": ("Allow Hermes to send platform user and stable chat session identifiers "
+                         "to explicitly configured custom OpenAI-compatible upstreams."),
+        "category": "security",
+    },
     "proxy.enabled": {
         "type": "boolean",
         "description": (

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1352,6 +1352,12 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Modal sandbox mode",
         "options": ["sandbox", "function"],
     },
+    "privacy.share_session_identity": {
+        "type": "boolean",
+        "description": ("Allow Hermes to send platform user and stable chat session identifiers "
+                         "to explicitly configured custom OpenAI-compatible upstreams."),
+        "category": "security",
+    },
     "proxy.enabled": {
         "type": "boolean",
         "description": (

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -390,6 +390,22 @@ def test_preflight_codex_api_kwargs_drops_oversized_message_id_end_to_end():
 # ---------------------------------------------------------------------------
 
 
+
+def test_preflight_preserves_user_and_metadata():
+    kwargs = {
+        "model": "gpt-oss-120b",
+        "instructions": "You are Hermes.",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "store": False,
+        "user": "hermes-user",
+        "metadata": {"session_id": "session-123", "source": "hermes"},
+    }
+
+    out = _preflight_codex_api_kwargs(kwargs)
+
+    assert out["user"] == "hermes-user"
+    assert out["metadata"] == {"session_id": "session-123", "source": "hermes"}
+
 def test_preflight_passes_native_web_search_tool_through():
     kwargs = {
         "model": "grok-composer-2.5-fast",

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -546,6 +546,22 @@ def test_preflight_codex_api_kwargs_drops_oversized_message_id_end_to_end():
 # ---------------------------------------------------------------------------
 
 
+
+def test_preflight_preserves_user_and_metadata():
+    kwargs = {
+        "model": "gpt-oss-120b",
+        "instructions": "You are Hermes.",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "store": False,
+        "user": "hermes-user",
+        "metadata": {"session_id": "session-123", "source": "hermes"},
+    }
+
+    out = _preflight_codex_api_kwargs(kwargs)
+
+    assert out["user"] == "hermes-user"
+    assert out["metadata"] == {"session_id": "session-123", "source": "hermes"}
+
 def test_preflight_passes_native_web_search_tool_through():
     kwargs = {
         "model": "grok-composer-2.5-fast",

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -10,6 +10,7 @@ from hermes_cli.nous_account import NousPortalAccountInfo
 from hermes_cli.tools_config import (
     _DEFAULT_OFF_TOOLSETS,
     _RECENTLY_SHIPPED_TOOLSETS,
+    _configure_session_identity,
     _apply_toolset_change,
     _checklist_toolset_keys,
     _configure_provider,

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -13,6 +13,7 @@ from hermes_cli.nous_subscription import NousSubscriptionFeatures
 from hermes_cli.tools_config import (
     _DEFAULT_OFF_TOOLSETS,
     _RECENTLY_SHIPPED_TOOLSETS,
+    _configure_session_identity,
     _apply_toolset_change,
     _checklist_toolset_keys,
     _configure_provider,

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -5,6 +5,7 @@ Ensures changes to one provider path don't silently break another.
 """
 
 import base64
+from copy import deepcopy
 import json
 import sys
 import types
@@ -90,6 +91,63 @@ def _make_agent(monkeypatch, provider, api_mode="chat_completions", base_url="ht
 
 
 # ── _build_api_kwargs tests ─────────────────────────────────────────────────
+
+class TestSessionIdentityForwarding:
+    @staticmethod
+    def _prepare(agent):
+        agent._share_session_identity = True
+        agent._user_id = "platform-user-42"
+        agent._gateway_session_key = "agent:main:telegram:dm:42"
+        agent.session_id = "session-123"
+        agent.request_overrides = {
+            "metadata": {"existing": {"nested": True}},
+        }
+
+    def test_chat_completions_forwards_identity_only_for_opted_in_custom_route(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "custom",
+            base_url="https://litellm.example/v1",
+        )
+        self._prepare(agent)
+        original = deepcopy(agent.request_overrides)
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert kwargs["user"] == "platform-user-42"
+        assert kwargs["metadata"]["session_id"] == "session-123"
+        assert kwargs["metadata"]["hermes_session_key"] == "agent:main:telegram:dm:42"
+        assert kwargs["metadata"]["existing"] == {"nested": True}
+        assert agent.request_overrides == original
+
+    def test_responses_forwards_identity_only_for_opted_in_custom_route(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "custom",
+            api_mode="codex_responses",
+            base_url="https://litellm.example/v1",
+        )
+        self._prepare(agent)
+        original = deepcopy(agent.request_overrides)
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert kwargs["user"] == "platform-user-42"
+        assert kwargs["metadata"]["session_id"] == "session-123"
+        assert kwargs["metadata"]["existing"] == {"nested": True}
+        assert agent.request_overrides == original
+
+    def test_builtin_provider_does_not_receive_identity_even_when_flag_is_set(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openrouter")
+        self._prepare(agent)
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert "user" not in kwargs
+        assert kwargs["metadata"] == {"existing": {"nested": True}}
+        assert "session_id" not in kwargs["metadata"]
+        assert "hermes_session_key" not in kwargs["metadata"]
+
 
 class TestBuildApiKwargsOpenRouter:
     def test_uses_chat_completions_format(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes missing Hermes session identity in requests sent to OpenAI-compatible upstreams such as LiteLLM.

Hermes already has a stable session identity, but the model request builder did not forward it in the upstream request. As a result, LiteLLM could not associate requests with the same Hermes session in its Session ID view or use the identity for session affinity.

This change:

- forwards the Hermes user identity as `user`,
- forwards the stable Hermes session as `metadata.session_id`,
- preserves existing request metadata,
- avoids mutating request overrides reused across turns,
- allows `user` and `metadata` through the Codex Responses preflight adapter.

## Related Issue

Not applicable — no issue currently exists.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`
  - Build per-request upstream overrides.
  - Forward `user`, `metadata.session_id`, and `hermes_session_key`.
  - Preserve existing metadata without mutating shared request overrides.

- `agent/codex_responses_adapter.py`
  - Accept and validate `user` and `metadata` fields.
  - Preserve both fields in normalized Codex Responses requests.

- `tests/agent/test_codex_responses_adapter.py`
  - Add regression coverage for `user` and `metadata` preservation.

## How to Test

1. Run the targeted adapter tests:

   ```bash
   python -m pytest tests/agent/test_codex_responses_adapter.py -q
   ```

## Screenshots (from LiteLLM)
<img width="627" height="510" alt="image" src="https://github.com/user-attachments/assets/6650f786-469e-4e77-9c39-694dc6f8bca5" />

Requests/reponses session grouping...
<img width="1649" height="273" alt="image" src="https://github.com/user-attachments/assets/e37b917f-10e8-4cb5-8402-9b3ac2b6d40b" />
<img width="445" height="257" alt="image" src="https://github.com/user-attachments/assets/1a2e1bab-af5d-46d0-9a81-8b578fba21fa" />
