### PR TITLE
feat(voice): provider-neutral streaming TTS playout

### DIFF
--- a/apps/desktop/public/audio-worklet/voice-playout-processor.js
+++ b/apps/desktop/public/audio-worklet/voice-playout-processor.js
@@ -1,0 +1,90 @@
+class HermesVoicePlayoutProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super()
+    this.maxSamples = options?.processorOptions?.maxBufferSamples || 24000
+    this.queue = []
+    this.queuedSamples = 0
+    this.drainRequest = null
+    this.cancelled = false
+    this.started = false
+    this.stableCallbacks = 0
+    this.port.onmessage = event => {
+      const message = event.data || {}
+
+      if (message.type === 'start') {
+        this.started = true
+      } else if (message.type === 'pause') {
+        this.started = false
+      } else if (message.type === 'write' && message.samples) {
+        const samples = new Float32Array(message.samples)
+
+        if (this.queuedSamples + samples.length > this.maxSamples) {
+          this.port.postMessage({ type: 'overflow' })
+          return
+        }
+
+        this.queue.push(samples)
+        this.queuedSamples += samples.length
+      } else if (message.type === 'drain') {
+        this.drainRequest = message.id
+      } else if (message.type === 'cancel') {
+        this.queue = []
+        this.queuedSamples = 0
+        this.cancelled = true
+      }
+    }
+  }
+
+  process(_inputs, outputs) {
+    const output = outputs[0]
+    const channel = output && output[0]
+
+    if (!channel) {
+      return !this.cancelled
+    }
+
+    if (!this.started) {
+      channel.fill(0)
+      return !this.cancelled
+    }
+
+    let written = 0
+
+    while (written < channel.length && this.queue.length > 0) {
+      const current = this.queue[0]
+      const count = Math.min(channel.length - written, current.length)
+      channel.set(current.subarray(0, count), written)
+      written += count
+      this.queuedSamples -= count
+
+      if (count === current.length) {
+        this.queue.shift()
+      } else {
+        this.queue[0] = current.subarray(count)
+      }
+    }
+
+    if (written < channel.length) {
+      channel.fill(0, written)
+      this.stableCallbacks = 0
+      if (!this.cancelled) {
+        this.port.postMessage({ type: 'underrun' })
+      }
+    } else {
+      this.stableCallbacks += 1
+      if (this.stableCallbacks >= 25) {
+        this.stableCallbacks = 0
+        this.port.postMessage({ type: 'stable' })
+      }
+    }
+
+    if (this.drainRequest !== null && this.queuedSamples === 0) {
+      this.port.postMessage({ id: this.drainRequest, type: 'drained' })
+      this.drainRequest = null
+    }
+
+    return !this.cancelled
+  }
+}
+
+registerProcessor('hermes-voice-playout', HermesVoicePlayoutProcessor)

--- a/apps/desktop/public/audio-worklet/voice-playout-processor.js
+++ b/apps/desktop/public/audio-worklet/voice-playout-processor.js
@@ -8,6 +8,8 @@ class HermesVoicePlayoutProcessor extends AudioWorkletProcessor {
     this.cancelled = false
     this.started = false
     this.stableCallbacks = 0
+    this.underrunActive = false
+    this.drainReady = false
     this.port.onmessage = event => {
       const message = event.data || {}
 
@@ -48,6 +50,14 @@ class HermesVoicePlayoutProcessor extends AudioWorkletProcessor {
       return !this.cancelled
     }
 
+    if (this.drainReady) {
+      channel.fill(0)
+      this.port.postMessage({ id: this.drainRequest, type: 'drained' })
+      this.drainRequest = null
+      this.drainReady = false
+      return !this.cancelled
+    }
+
     let written = 0
 
     while (written < channel.length && this.queue.length > 0) {
@@ -67,10 +77,12 @@ class HermesVoicePlayoutProcessor extends AudioWorkletProcessor {
     if (written < channel.length) {
       channel.fill(0, written)
       this.stableCallbacks = 0
-      if (!this.cancelled) {
+      if (!this.cancelled && this.drainRequest === null && !this.underrunActive) {
+        this.underrunActive = true
         this.port.postMessage({ type: 'underrun' })
       }
     } else {
+      this.underrunActive = false
       this.stableCallbacks += 1
       if (this.stableCallbacks >= 25) {
         this.stableCallbacks = 0
@@ -79,8 +91,7 @@ class HermesVoicePlayoutProcessor extends AudioWorkletProcessor {
     }
 
     if (this.drainRequest !== null && this.queuedSamples === 0) {
-      this.port.postMessage({ id: this.drainRequest, type: 'drained' })
-      this.drainRequest = null
+      this.drainReady = true
     }
 
     return !this.cancelled

--- a/apps/desktop/public/audio-worklet/voice-playout-processor.js
+++ b/apps/desktop/public/audio-worklet/voice-playout-processor.js
@@ -45,6 +45,18 @@ class HermesVoicePlayoutProcessor extends AudioWorkletProcessor {
       return !this.cancelled
     }
 
+    // A terminal drain may arrive after an underrun paused the clock.  There
+    // is no audio left to render in that state, so acknowledge the request
+    // even though normal playback is paused; otherwise the client waits for
+    // a `drained` message that can never be produced.
+    if (!this.started && this.drainRequest !== null && this.queuedSamples === 0) {
+      channel.fill(0)
+      this.port.postMessage({ id: this.drainRequest, type: 'drained' })
+      this.drainRequest = null
+      this.drainReady = false
+      return !this.cancelled
+    }
+
     if (!this.started) {
       channel.fill(0)
       return !this.cancelled
@@ -99,3 +111,7 @@ class HermesVoicePlayoutProcessor extends AudioWorkletProcessor {
 }
 
 registerProcessor('hermes-voice-playout', HermesVoicePlayoutProcessor)
+
+// Exporting the processor keeps the worklet's behavior directly testable in
+// the renderer suite; AudioWorklet ignores module exports at runtime.
+export { HermesVoicePlayoutProcessor }

--- a/apps/desktop/src/lib/voice-playback.test.ts
+++ b/apps/desktop/src/lib/voice-playback.test.ts
@@ -1,6 +1,123 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { negotiateVoiceStreamProtocol } from './voice-playback'
+import { negotiateVoiceStreamProtocol, startSpeechStream, stopVoicePlayback } from './voice-playback'
+
+class FakeWebSocket {
+  static readonly OPEN = 1
+  static readonly CONNECTING = 0
+  static readonly CLOSED = 3
+  static latest: FakeWebSocket | null = null
+
+  readonly sent: string[] = []
+  readonly url: string
+  readyState = FakeWebSocket.OPEN
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  onmessage: ((event: { data: ArrayBuffer | string }) => void) | null = null
+  onopen: (() => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.latest = this
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    if (this.readyState === FakeWebSocket.CLOSED) {
+      return
+    }
+
+    this.readyState = FakeWebSocket.CLOSED
+    this.onclose?.()
+  }
+
+  emitJson(frame: object) {
+    this.onmessage?.({ data: JSON.stringify(frame) })
+  }
+
+  emitBinary(data: ArrayBuffer) {
+    this.onmessage?.({ data })
+  }
+}
+
+class FakeAudioWorkletNode {
+  static latest: FakeAudioWorkletNode | null = null
+  readonly port = {
+    onmessage: null as ((event: { data: { id?: number; type?: string } }) => void) | null,
+    postMessage: vi.fn((message: { id?: number; type?: string }) => {
+      if (message.type === 'drain') {
+        this.port.onmessage?.({ data: { id: message.id, type: 'drained' } })
+      }
+    })
+  }
+  readonly connect = vi.fn()
+  readonly disconnect = vi.fn()
+
+  constructor() {
+    FakeAudioWorkletNode.latest = this
+  }
+}
+
+class FakeAudioContext {
+  static latest: FakeAudioContext | null = null
+  readonly audioWorklet = { addModule: vi.fn(async () => undefined) }
+  readonly destination = {}
+  readonly sampleRate: number
+  readonly state = 'running'
+  readonly currentTime = 0
+  readonly close = vi.fn(async () => undefined)
+  readonly resume = vi.fn(async () => undefined)
+  readonly createBuffer = vi.fn((_channels: number, sampleCount: number, sampleRate: number) => ({
+    duration: sampleCount / sampleRate,
+    getChannelData: () => new Float32Array(sampleCount)
+  }))
+  readonly createBufferSource = vi.fn(() => ({
+    buffer: null as unknown,
+    connect: vi.fn(),
+    start: vi.fn()
+  }))
+
+  constructor(options?: { sampleRate?: number }) {
+    this.sampleRate = options?.sampleRate ?? 24_000
+    FakeAudioContext.latest = this
+  }
+}
+
+const desktopWindow = window as unknown as { hermesDesktop?: unknown }
+
+beforeEach(() => {
+  FakeWebSocket.latest = null
+  FakeAudioWorkletNode.latest = null
+  FakeAudioContext.latest = null
+  vi.stubGlobal('WebSocket', FakeWebSocket)
+  vi.stubGlobal('AudioContext', FakeAudioContext)
+  vi.stubGlobal('AudioWorkletNode', FakeAudioWorkletNode)
+  desktopWindow.hermesDesktop = {
+    getConnection: vi.fn(async () => ({ wsUrl: 'ws://gateway/api/ws', authMode: 'token' }))
+  }
+})
+
+afterEach(() => {
+  stopVoicePlayback()
+  FakeWebSocket.latest = null
+  FakeAudioWorkletNode.latest = null
+  FakeAudioContext.latest = null
+  delete desktopWindow.hermesDesktop
+  vi.unstubAllGlobals()
+})
+
+async function waitForWorklet(): Promise<FakeAudioWorkletNode> {
+  await vi.waitFor(() => expect(FakeAudioWorkletNode.latest).not.toBeNull())
+
+  return FakeAudioWorkletNode.latest as FakeAudioWorkletNode
+}
+
+function framePayload(sampleCount = 480): ArrayBuffer {
+  return new Int16Array(sampleCount).buffer
+}
 
 describe('voice stream negotiation', () => {
   it('selects the provider-neutral protocol only from an explicit v1 start frame', () => {
@@ -12,5 +129,89 @@ describe('voice stream negotiation', () => {
     expect(negotiateVoiceStreamProtocol({ sample_rate: 24_000 })).toBe('legacy')
     expect(negotiateVoiceStreamProtocol({ encoding: 'pcm_s16le', version: 1 })).toBe('legacy')
     expect(negotiateVoiceStreamProtocol({ protocol: 'hermes.audio.v0' })).toBe('legacy')
+  })
+})
+
+describe('voice stream WebSocket playback', () => {
+  it('consumes v1 start/metadata/binary/end frames through the AudioWorklet sink', async () => {
+    const session = await startSpeechStream({ source: 'voice-conversation' })
+    expect(session).not.toBeNull()
+    const socket = FakeWebSocket.latest as FakeWebSocket
+    expect(socket.url).toBe('ws://gateway/api/audio/speak-stream')
+
+    socket.emitJson({
+      channels: 1,
+      encoding: 'pcm_s16le',
+      initial_buffer_ms: 0,
+      max_buffer_ms: 1_000,
+      protocol: 'hermes.audio.v1',
+      sample_rate: 24_000,
+      type: 'start'
+    })
+    const node = await waitForWorklet()
+    session?.append('Hello there.')
+    session?.finish()
+
+    socket.emitJson({
+      sample_count: 480,
+      sample_offset: 0,
+      sequence: 0,
+      type: 'audio'
+    })
+    socket.emitBinary(framePayload())
+    socket.emitJson({ type: 'end' })
+
+    await expect(session?.done).resolves.toBe('done')
+    expect(node.port.postMessage).toHaveBeenCalledWith({ type: 'start' })
+    expect(node.port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'write' }), expect.anything())
+    expect(node.port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'drain' }))
+    expect(socket.sent.map(data => JSON.parse(data))).toEqual([
+      { text: 'Hello there.' },
+      { done: true }
+    ])
+  })
+
+  it('falls back when a v1 stream reports an error before producing audio', async () => {
+    const session = await startSpeechStream({ source: 'voice-conversation' })
+    expect(session).not.toBeNull()
+    const socket = FakeWebSocket.latest as FakeWebSocket
+
+    socket.emitJson({
+      channels: 1,
+      encoding: 'pcm_s16le',
+      initial_buffer_ms: 0,
+      max_buffer_ms: 1_000,
+      protocol: 'hermes.audio.v1',
+      sample_rate: 24_000,
+      type: 'start'
+    })
+    await waitForWorklet()
+    socket.emitJson({ code: 'synthesis_failed', type: 'error' })
+
+    await expect(session?.done).resolves.toBe('fallback')
+  })
+
+  it('plays legacy raw PCM received before any v1 start frame', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const session = await startSpeechStream({ source: 'voice-conversation' })
+      expect(session).not.toBeNull()
+      const socket = FakeWebSocket.latest as FakeWebSocket
+
+      socket.emitBinary(framePayload())
+
+      const context = FakeAudioContext.latest as FakeAudioContext
+      expect(context.createBuffer).toHaveBeenCalledWith(1, 480, 24_000)
+      const source = context.createBufferSource.mock.results[0]?.value
+      expect(source?.start).toHaveBeenCalled()
+      expect(FakeAudioWorkletNode.latest).toBeNull()
+
+      socket.close()
+      await vi.runAllTimersAsync()
+      await expect(session?.done).resolves.toBe('done')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/desktop/src/lib/voice-playback.test.ts
+++ b/apps/desktop/src/lib/voice-playback.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { negotiateVoiceStreamProtocol } from './voice-playback'
+
+describe('voice stream negotiation', () => {
+  it('selects the provider-neutral protocol only from an explicit v1 start frame', () => {
+    expect(negotiateVoiceStreamProtocol({ protocol: 'hermes.audio.v1' })).toBe('hermes.audio.v1')
+    expect(negotiateVoiceStreamProtocol({ protocol_version: 'hermes.audio.v1' })).toBe('hermes.audio.v1')
+  })
+
+  it('keeps older raw-PCM gateways on the legacy path', () => {
+    expect(negotiateVoiceStreamProtocol({ sample_rate: 24_000 })).toBe('legacy')
+    expect(negotiateVoiceStreamProtocol({ encoding: 'pcm_s16le', version: 1 })).toBe('legacy')
+    expect(negotiateVoiceStreamProtocol({ protocol: 'hermes.audio.v0' })).toBe('legacy')
+  })
+})

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -9,6 +9,13 @@ import {
 } from '@/store/voice-playback'
 
 import { sanitizeTextForSpeech } from './speech-text'
+import {
+  createVoicePlayoutController,
+  type VoiceAudioFrame,
+  type VoiceAudioSink,
+  type VoicePlayoutController,
+  type VoicePlayoutTelemetry
+} from './voice-playout'
 
 // Free Edge TTS occasionally hands back audio that never fires `playing`/`ended`
 // nor `error` — leaving voice mode stuck "speaking" forever. Reject if playback
@@ -91,9 +98,9 @@ export function stopVoicePlayback() {
 }
 
 // ---------------------------------------------------------------------------
-// Streaming path — /api/audio/speak-stream WebSocket, raw int16 PCM frames
-// scheduled through Web Audio. Speech starts on the provider's first chunk
-// instead of after full synthesis + base64 transfer.
+// Streaming path — /api/audio/speak-stream WebSocket. Versioned streams feed
+// one bounded AudioWorklet ring-buffer clock; legacy raw PCM remains on its
+// compatibility scheduler. Speech starts while synthesis is still running.
 // ---------------------------------------------------------------------------
 
 async function resolveSpeakStreamUrl(): Promise<null | string> {
@@ -140,6 +147,99 @@ export interface SpeechStreamSession {
    *             text through `playSpeechText` instead.
    */
   done: Promise<'done' | 'fallback'>
+  /** Snapshot of provider-neutral playout counters for diagnostics. */
+  getTelemetry?: () => VoicePlayoutTelemetry
+}
+
+export type VoiceStreamProtocol = 'hermes.audio.v1' | 'legacy'
+
+export function negotiateVoiceStreamProtocol(frame: {
+  encoding?: string
+  protocol?: string
+  protocol_version?: string
+  sample_rate?: number
+  version?: number | string
+}): VoiceStreamProtocol {
+  const versioned =
+    frame.protocol === 'hermes.audio.v1' ||
+    frame.protocol_version === 'hermes.audio.v1' ||
+    frame.version === 'hermes.audio.v1'
+
+  return versioned ? 'hermes.audio.v1' : 'legacy'
+}
+
+async function createAudioWorkletSink(context: AudioContext, maxBufferSamples: number): Promise<VoiceAudioSink> {
+  const moduleUrl = new URL('audio-worklet/voice-playout-processor.js', window.location.href)
+  await context.audioWorklet.addModule(moduleUrl.toString())
+
+  const node = new AudioWorkletNode(context, 'hermes-voice-playout', {
+    numberOfInputs: 0,
+    numberOfOutputs: 1,
+    processorOptions: { maxBufferSamples }
+  })
+  node.connect(context.destination)
+  let drainId = 0
+  const pendingDrains = new Map<number, () => void>()
+  let sink: VoiceAudioSink
+
+  node.port.onmessage = event => {
+    const message = event.data as { id?: number; type?: string }
+
+    if (message.type === 'underrun') {
+      sink.onUnderrun?.()
+    } else if (message.type === 'overflow') {
+      sink.onOverflow?.()
+    } else if (message.type === 'stable') {
+      sink.onStablePlayback?.()
+    } else if (message.type === 'drained' && typeof message.id === 'number') {
+      pendingDrains.get(message.id)?.()
+      pendingDrains.delete(message.id)
+    }
+  }
+
+  let stopped = false
+  sink = {
+    drain: () => {
+      if (stopped) {
+        return
+      }
+
+      const id = ++drainId
+
+      return new Promise<void>(resolve => {
+        pendingDrains.set(id, resolve)
+        node.port.postMessage({ id, type: 'drain' })
+      })
+    },
+    pause: () => {
+      if (!stopped) {
+        node.port.postMessage({ type: 'pause' })
+      }
+    },
+    start: () => {
+      if (!stopped) {
+        node.port.postMessage({ type: 'start' })
+      }
+    },
+    stop: () => {
+      if (stopped) {
+        return
+      }
+
+      stopped = true
+      node.port.postMessage({ type: 'cancel' })
+      node.disconnect()
+      pendingDrains.forEach(resolve => resolve())
+      pendingDrains.clear()
+    },
+    write: samples => {
+      if (!stopped) {
+        node.port.postMessage({ samples: samples.buffer, type: 'write' }, [samples.buffer])
+      }
+    }
+  }
+
+  return sink
 }
 
 /**
@@ -156,6 +256,36 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
   let streamRate = 24_000
   let nextStartAt = 0
   let carry: null | Uint8Array = null
+  let versioned = false
+  let controller: VoicePlayoutController | null = null
+  let latestTelemetry: VoicePlayoutTelemetry = {
+    framesReceived: 0,
+    maxBufferedMs: 0,
+    orderingViolations: 0,
+    queueOverflows: 0,
+    samplesReceived: 0,
+    underruns: 0
+  }
+  let pendingAudioMeta: null | {
+    sample_count?: number
+    sample_offset?: number
+    sampleCount?: number
+    sampleOffset?: number
+    sequence?: number
+  } = null
+  const pendingVersionedAudio: Array<{
+    data: ArrayBuffer
+    meta: {
+      sample_count?: number
+      sample_offset?: number
+      sampleCount?: number
+      sampleOffset?: number
+      sequence?: number
+    }
+  }> = []
+  let versionedEnd = false
+  let maxPendingVersionedFrames = 50
+  let versionedInit: Promise<void> | null = null
   let started = false
   let settled = false
   let finished = false
@@ -196,14 +326,43 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
 
   // stopVoicePlayback() → immediate barge-in: kill the socket (the server
   // aborts synthesis on disconnect) and the audio context (cuts sound now).
-  currentStop = () => settle('done')
+  currentStop = () => {
+    controller?.cancel()
+
+    if (ws.readyState === WebSocket.OPEN) {
+      try {
+        ws.send(JSON.stringify({ type: 'stop' }))
+      } catch {
+        // Closing the socket below remains the cancellation fallback.
+      }
+    }
+
+    settle('done')
+  }
 
   const finishWhenDrained = () => {
+    if (controller) {
+      if (controller.getTelemetry().framesReceived === 0) {
+        settle('fallback')
+        return
+      }
+
+      void controller.end().then(() => settle('done'))
+      return
+    }
+
     const remainingMs = context ? Math.max(0, nextStartAt - context.currentTime) * 1_000 : 0
     window.setTimeout(() => settle('done'), remainingMs + 100)
   }
 
-  const schedule = (data: ArrayBuffer) => {
+  const scheduleLegacy = (data: ArrayBuffer) => {
+    if (!context) {
+      context = new AudioContext()
+      if (context.state === 'suspended') {
+        void context.resume().catch(() => undefined)
+      }
+    }
+
     if (!context) {
       return
     }
@@ -251,18 +410,190 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
     }
   }
 
+  const pushVersioned = (
+    data: ArrayBuffer,
+    meta: {
+      sample_count?: number
+      sample_offset?: number
+      sampleCount?: number
+      sampleOffset?: number
+      sequence?: number
+    }
+  ) => {
+    if (!controller) {
+      if (pendingVersionedAudio.length >= maxPendingVersionedFrames) {
+        settle(started ? 'done' : 'fallback')
+        return
+      }
+      pendingVersionedAudio.push({ data, meta })
+      return
+    }
+
+    const bytes = new Uint8Array(data)
+
+    if (bytes.byteLength % 2 !== 0) {
+      controller.push({
+        sampleCount: Number(meta.sample_count ?? meta.sampleCount ?? 0),
+        sampleOffset: Number(meta.sample_offset ?? meta.sampleOffset ?? 0),
+        sequence: Number(meta.sequence ?? 0),
+        samples: new Int16Array()
+      })
+      return
+    }
+
+    const samples = new Int16Array(bytes.byteLength / 2)
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+
+    for (let index = 0; index < samples.length; index += 1) {
+      samples[index] = view.getInt16(index * 2, true)
+    }
+
+    const frame: VoiceAudioFrame = {
+      sampleCount: Number(meta.sample_count ?? meta.sampleCount ?? samples.length),
+      sampleOffset: Number(meta.sample_offset ?? meta.sampleOffset ?? 0),
+      sequence: Number(meta.sequence ?? 0),
+      samples
+    }
+    controller.push(frame)
+    latestTelemetry = controller.getTelemetry()
+
+    if (!started && controller.getState().started) {
+      started = true
+      setVoicePlaybackState(currentState('speaking', options))
+    }
+  }
+
+  const initializeVersioned = (frame: {
+    channels?: number
+    encoding?: string
+    initial_buffer_ms?: number
+    max_buffer_ms?: number
+    initialBufferMs?: number
+    maxBufferMs?: number
+    sample_rate?: number
+    sampleRate?: number
+  }) => {
+    if (versionedInit) {
+      return versionedInit
+    }
+
+    streamRate = frame.sample_rate ?? frame.sampleRate ?? 24_000
+    const channels = frame.channels ?? 1
+    const maxBufferMs = frame.max_buffer_ms ?? frame.maxBufferMs ?? 1_000
+    maxPendingVersionedFrames = Math.max(1, Math.ceil(maxBufferMs / 20))
+
+    if (
+      frame.encoding !== 'pcm_s16le' ||
+      !Number.isInteger(streamRate) ||
+      streamRate < 8_000 ||
+      streamRate > 96_000 ||
+      channels !== 1
+    ) {
+      settle('fallback')
+      versionedInit = Promise.resolve()
+      return versionedInit
+    }
+
+    try {
+      // AudioWorklet samples are consumed on the AudioContext clock. Bind that
+      // clock to the negotiated PCM rate; otherwise 44.1 kHz providers play at
+      // the host's common 48 kHz rate (fast, pitched up, and prone to underrun).
+      context = new AudioContext({ sampleRate: streamRate })
+      if (context.sampleRate !== streamRate) {
+        throw new Error('AudioContext did not honor the negotiated sample rate')
+      }
+    } catch {
+      settle('fallback')
+      versionedInit = Promise.resolve()
+      return versionedInit
+    }
+    if (context.state === 'suspended') {
+      void context.resume().catch(() => undefined)
+    }
+
+    versionedInit = createAudioWorkletSink(context, Math.ceil((maxBufferMs / 1_000) * streamRate))
+      .then(sink => {
+        if (settled) {
+          sink.stop()
+          return
+        }
+
+        controller = createVoicePlayoutController(sink, {
+          channels,
+          initialBufferMs: frame.initial_buffer_ms ?? frame.initialBufferMs,
+          maxBufferMs,
+          onError: () => {
+            latestTelemetry = controller?.getTelemetry() ?? latestTelemetry
+            settle(started ? 'done' : 'fallback')
+          },
+          onState: state => {
+            if (!started && state.started) {
+              started = true
+              setVoicePlaybackState(currentState('speaking', options))
+            }
+          },
+          sampleRate: streamRate
+        })
+
+        pendingVersionedAudio.splice(0).forEach(item => pushVersioned(item.data, item.meta))
+
+        if (versionedEnd) {
+          finishWhenDrained()
+        }
+      })
+      .catch(() => {
+        settle('fallback')
+      })
+
+    return versionedInit
+  }
+
   ws.onopen = () => {
     pendingSends.splice(0).forEach(data => ws.send(data))
   }
 
   ws.onmessage = event => {
     if (typeof event.data !== 'string') {
-      schedule(event.data as ArrayBuffer)
+      if (versioned) {
+        if (versionedEnd) {
+          controller?.cancel()
+          settle(started ? 'done' : 'fallback')
+        } else if (pendingAudioMeta) {
+          pushVersioned(event.data as ArrayBuffer, pendingAudioMeta)
+          pendingAudioMeta = null
+        } else {
+          controller?.cancel()
+          settle(started ? 'done' : 'fallback')
+        }
+      } else {
+        // Older gateways send raw PCM without a versioned start frame.
+        scheduleLegacy(event.data as ArrayBuffer)
+        if (!started) {
+          started = true
+          setVoicePlaybackState(currentState('speaking', options))
+        }
+      }
 
       return
     }
 
-    let frame: { channels?: number; sample_rate?: number; type?: string }
+    let frame: {
+      channels?: number
+      encoding?: string
+      initial_buffer_ms?: number
+      max_buffer_ms?: number
+      protocol?: string
+      protocol_version?: string
+      sample_count?: number
+      sample_offset?: number
+      sampleCount?: number
+      sampleOffset?: number
+      sample_rate?: number
+      sampleRate?: number
+      sequence?: number
+      type?: string
+      version?: number | string
+    }
 
     try {
       frame = JSON.parse(event.data) as typeof frame
@@ -271,21 +602,41 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
     }
 
     if (frame.type === 'start') {
-      streamRate = frame.sample_rate || 24_000
-      context = new AudioContext()
+      versioned = negotiateVoiceStreamProtocol(frame) === 'hermes.audio.v1'
 
-      // Autoplay policy can hand back a suspended context when playback wasn't
-      // started by a user gesture (e.g. a wake-word-started voice turn). Resume
-      // it so the first reply is audible instead of silently buffering. Electron
-      // chat windows also set autoplayPolicy: no-user-gesture-required, but the
-      // dashboard-embedded surface relies on this resume.
-      if (context.state === 'suspended') {
-        void context.resume().catch(() => undefined)
+      if (versioned) {
+        void initializeVersioned(frame)
+      } else {
+        // The old start frame only carries format information. Keep its raw
+        // PCM scheduling path intact until the versioned contract is observed.
+        streamRate = frame.sample_rate || 24_000
+        scheduleLegacy(new ArrayBuffer(0))
       }
-
-      nextStartAt = 0
+    } else if (versioned && frame.type === 'audio') {
+      if (pendingAudioMeta || versionedEnd) {
+        controller?.cancel()
+        settle(started ? 'done' : 'fallback')
+      } else {
+        pendingAudioMeta = frame
+      }
     } else if (frame.type === 'end') {
-      finishWhenDrained()
+      if (versioned) {
+        if (pendingAudioMeta) {
+          controller?.cancel()
+          settle(started ? 'done' : 'fallback')
+          return
+        }
+        versionedEnd = true
+        if (controller) {
+          finishWhenDrained()
+        }
+      } else {
+        finishWhenDrained()
+      }
+    } else if (frame.type === 'error') {
+      latestTelemetry = controller?.getTelemetry() ?? latestTelemetry
+      controller?.cancel()
+      settle(started ? 'done' : 'fallback')
     } else if (frame.type === 'fallback') {
       settle(started ? 'done' : 'fallback')
     }
@@ -295,7 +646,19 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
   // auth, network) → fall back. After audio started, replaying the whole
   // message via POST would stutter — treat what played as the playback.
   ws.onerror = () => settle(started ? 'done' : 'fallback')
-  ws.onclose = () => (started ? finishWhenDrained() : settle('fallback'))
+  ws.onclose = () => {
+    if (versioned && pendingAudioMeta) {
+      controller?.cancel()
+      settle(started ? 'done' : 'fallback')
+      return
+    }
+    if (versioned && versionedEnd && versionedInit) {
+      void versionedInit.then(() => finishWhenDrained())
+      return
+    }
+
+    started ? finishWhenDrained() : settle('fallback')
+  }
 
   return {
     // Raw deltas — the server strips markdown/emoji per *sentence*, which is
@@ -311,7 +674,8 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
         send({ done: true })
       }
     },
-    done
+    done,
+    getTelemetry: () => controller?.getTelemetry() ?? latestTelemetry
   }
 }
 

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -347,7 +347,10 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
         return
       }
 
-      void controller.end().then(() => settle('done'))
+      void controller
+        .end()
+        .then(() => settle('done'))
+        .catch(() => settle(started ? 'done' : 'fallback'))
       return
     }
 
@@ -568,10 +571,6 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
       } else {
         // Older gateways send raw PCM without a versioned start frame.
         scheduleLegacy(event.data as ArrayBuffer)
-        if (!started) {
-          started = true
-          setVoicePlaybackState(currentState('speaking', options))
-        }
       }
 
       return

--- a/apps/desktop/src/lib/voice-playout-processor.test.ts
+++ b/apps/desktop/src/lib/voice-playout-processor.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+interface WorkletPort {
+  onmessage: ((event: MessageEvent) => void) | null
+  postMessage: ReturnType<typeof vi.fn>
+}
+
+class TestAudioWorkletProcessor {
+  port: WorkletPort
+
+  constructor() {
+    this.port = {
+      onmessage: null,
+      postMessage: vi.fn()
+    }
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('HermesVoicePlayoutProcessor', () => {
+  it('acknowledges an empty terminal drain while the clock is paused', async () => {
+    let registered: typeof TestAudioWorkletProcessor | undefined
+
+    vi.stubGlobal('AudioWorkletProcessor', TestAudioWorkletProcessor)
+    vi.stubGlobal('registerProcessor', (_name: string, processor: typeof TestAudioWorkletProcessor) => {
+      registered = processor
+    })
+
+    // @ts-expect-error The worklet is a browser-loaded JavaScript module and
+    // intentionally has no renderer-side declaration file.
+    const { HermesVoicePlayoutProcessor } = await import('../../public/audio-worklet/voice-playout-processor.js')
+    expect(registered).toBe(HermesVoicePlayoutProcessor)
+
+    const processor = new HermesVoicePlayoutProcessor({ processorOptions: {} }) as unknown as {
+      port: WorkletPort
+      process: (inputs: unknown[], outputs: Float32Array[][]) => boolean
+    }
+
+    processor.port.onmessage?.({ data: { id: 17, type: 'drain' } } as MessageEvent)
+
+    expect(processor.process([], [[new Float32Array(128)]])).toBe(true)
+    expect(processor.port.postMessage).toHaveBeenCalledWith({ id: 17, type: 'drained' })
+  })
+})

--- a/apps/desktop/src/lib/voice-playout.test.ts
+++ b/apps/desktop/src/lib/voice-playout.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createVoicePlayoutController, type VoiceAudioFrame, type VoiceAudioSink } from './voice-playout'
+
+function frame(sequence: number, sampleOffset: number, sampleCount = 480): VoiceAudioFrame {
+  return {
+    sampleCount,
+    sampleOffset,
+    sequence,
+    samples: new Int16Array(sampleCount)
+  }
+}
+
+function fakeSink() {
+  const sink: VoiceAudioSink & {
+    writes: Float32Array[]
+    started: boolean
+    stopped: boolean
+    resolveDrain: (() => void) | null
+  } = {
+    drain: vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          sink.resolveDrain = resolve
+        })
+    ),
+    pause: vi.fn(),
+    onUnderrun: undefined,
+    start: vi.fn(() => {
+      sink.started = true
+    }),
+    stop: vi.fn(() => {
+      sink.stopped = true
+    }),
+    writes: [],
+    write: vi.fn((samples: Float32Array) => {
+      sink.writes.push(samples)
+    }),
+    started: false,
+    stopped: false,
+    resolveDrain: null
+  }
+
+  return sink
+}
+
+describe('VoicePlayoutController', () => {
+  it('waits for the adaptive startup target, then writes a continuous sequence', () => {
+    const sink = fakeSink()
+    const controller = createVoicePlayoutController(sink, {
+      initialBufferMs: 40,
+      maxBufferMs: 200,
+      sampleRate: 24_000
+    })
+
+    controller.push(frame(0, 0, 480))
+    expect(sink.start).not.toHaveBeenCalled()
+    controller.push(frame(1, 480, 480))
+
+    expect(sink.start).toHaveBeenCalledWith(24_000, 1)
+    expect(sink.write).toHaveBeenCalledTimes(2)
+    expect(controller.getState().started).toBe(true)
+    expect(controller.getState().bufferedMs).toBe(0)
+
+    controller.push(frame(2, 960, 480))
+    expect(sink.write).toHaveBeenCalledTimes(3)
+  })
+
+  it('starts early when the stream ends and drains queued audio', async () => {
+    const sink = fakeSink()
+    const controller = createVoicePlayoutController(sink, {
+      initialBufferMs: 200,
+      maxBufferMs: 400,
+      sampleRate: 24_000
+    })
+
+    controller.push(frame(0, 0, 480))
+    const done = controller.end()
+
+    expect(sink.start).toHaveBeenCalled()
+    sink.resolveDrain?.()
+    await done
+    expect(sink.drain).toHaveBeenCalled()
+  })
+
+  it('raises the startup target after an underrun and cautiously decays it after stability', () => {
+    const sink = fakeSink()
+    const controller = createVoicePlayoutController(sink, {
+      initialBufferMs: 100,
+      maxBufferMs: 300,
+      sampleRate: 24_000,
+      stableFramesToDecrease: 2
+    })
+
+    expect(controller.getState().targetBufferMs).toBe(100)
+    controller.reportUnderrun()
+    expect(controller.getState().targetBufferMs).toBeGreaterThan(100)
+    const raised = controller.getState().targetBufferMs
+    controller.reportStablePlayback()
+    controller.reportStablePlayback()
+    expect(controller.getState().targetBufferMs).toBeLessThan(raised)
+    expect(controller.getState().targetBufferMs).toBeGreaterThanOrEqual(100)
+  })
+
+  it('records sink underruns as telemetry and adapts the target', () => {
+    const sink = fakeSink()
+    const controller = createVoicePlayoutController(sink, { initialBufferMs: 40, maxBufferMs: 200 })
+
+    sink.onUnderrun?.()
+
+    expect(controller.getTelemetry().underruns).toBe(1)
+    expect(controller.getState().targetBufferMs).toBeGreaterThan(40)
+  })
+
+  it('re-buffers after a post-start underrun before resuming the sink clock', () => {
+    const sink = fakeSink()
+    const controller = createVoicePlayoutController(sink, {
+      initialBufferMs: 20,
+      maxBufferMs: 200,
+      sampleRate: 24_000
+    })
+
+    controller.push(frame(0, 0))
+    sink.onUnderrun?.()
+    expect(sink.pause).toHaveBeenCalledOnce()
+
+    controller.push(frame(1, 480))
+    expect(sink.write).toHaveBeenCalledTimes(1)
+    controller.push(frame(2, 960))
+    controller.push(frame(3, 1440))
+
+    expect(sink.start).toHaveBeenCalledTimes(2)
+    expect(sink.write).toHaveBeenCalledTimes(4)
+  })
+
+  it('bounds queued audio and reports overflow without accumulating latency', () => {
+    const sink = fakeSink()
+    const onError = vi.fn()
+    const controller = createVoicePlayoutController(sink, {
+      initialBufferMs: 1000,
+      maxBufferMs: 10,
+      sampleRate: 24_000,
+      onError
+    })
+
+    controller.push(frame(0, 0, 480))
+    expect(onError).toHaveBeenCalledWith('buffer-overflow')
+    expect(controller.getTelemetry().queueOverflows).toBe(1)
+    expect(controller.getState().bufferedMs).toBe(0)
+  })
+
+  it('rejects sequence and sample-offset violations', () => {
+    const sink = fakeSink()
+    const onError = vi.fn()
+    const controller = createVoicePlayoutController(sink, { onError })
+
+    controller.push(frame(0, 0))
+    controller.push(frame(2, 960))
+
+    expect(onError).toHaveBeenCalledWith('ordering-violation')
+    expect(controller.getTelemetry().orderingViolations).toBe(1)
+    expect(sink.stop).toHaveBeenCalled()
+  })
+
+  it('rejects a stream whose first frame is not the origin', () => {
+    const sink = fakeSink()
+    const onError = vi.fn()
+    const controller = createVoicePlayoutController(sink, { onError })
+
+    controller.push(frame(1, 480))
+
+    expect(onError).toHaveBeenCalledWith('ordering-violation')
+    expect(sink.write).not.toHaveBeenCalled()
+  })
+
+  it('does not start or claim audio for an empty stream', async () => {
+    const sink = fakeSink()
+    const controller = createVoicePlayoutController(sink)
+
+    await controller.end()
+
+    expect(sink.start).not.toHaveBeenCalled()
+    expect(controller.getTelemetry().framesReceived).toBe(0)
+  })
+
+  it('cancels immediately and makes later frames no-ops', () => {
+    const sink = fakeSink()
+    const controller = createVoicePlayoutController(sink)
+
+    controller.push(frame(0, 0))
+    controller.cancel()
+    controller.push(frame(1, 480))
+
+    expect(sink.stop).toHaveBeenCalled()
+    expect(controller.getState().cancelled).toBe(true)
+    expect(sink.write).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/voice-playout.ts
+++ b/apps/desktop/src/lib/voice-playout.ts
@@ -1,0 +1,286 @@
+/**
+ * Provider-neutral PCM playout coordination.  This module deliberately has no
+ * React or Web Audio dependencies so the stream invariants can be tested with
+ * a deterministic sink.
+ */
+
+export interface VoiceAudioFrame {
+  sequence: number
+  sampleOffset: number
+  sampleCount: number
+  samples: Int16Array
+}
+
+export interface VoiceAudioSink {
+  start: (sampleRate: number, channels: number) => void | Promise<void>
+  pause: () => void
+  write: (samples: Float32Array) => void
+  drain: () => void | Promise<void>
+  stop: () => void
+  /** Called by a sink when its audio clock has no samples to render. */
+  onUnderrun?: () => void
+  /** Called by a sink when its own ring reaches the bounded limit. */
+  onOverflow?: () => void
+  /** Called periodically while the audio clock consumes without underrun. */
+  onStablePlayback?: () => void
+}
+
+export interface VoicePlayoutTelemetry {
+  framesReceived: number
+  samplesReceived: number
+  underruns: number
+  orderingViolations: number
+  queueOverflows: number
+  maxBufferedMs: number
+}
+
+export interface VoicePlayoutState {
+  started: boolean
+  ended: boolean
+  cancelled: boolean
+  failed: boolean
+  bufferedMs: number
+  targetBufferMs: number
+  maxBufferMs: number
+}
+
+export interface VoicePlayoutOptions {
+  sampleRate?: number
+  channels?: number
+  initialBufferMs?: number
+  maxBufferMs?: number
+  stableFramesToDecrease?: number
+  onError?: (reason: 'buffer-overflow' | 'ordering-violation') => void
+  onState?: (state: VoicePlayoutState) => void
+}
+
+export interface VoicePlayoutController {
+  push: (frame: VoiceAudioFrame) => void
+  end: () => Promise<void>
+  cancel: () => void
+  reportUnderrun: () => void
+  reportStablePlayback: () => void
+  getState: () => VoicePlayoutState
+  getTelemetry: () => VoicePlayoutTelemetry
+}
+
+const DEFAULT_INITIAL_BUFFER_MS = 120
+const DEFAULT_MAX_BUFFER_MS = 1_000
+
+function toFloat32(samples: Int16Array): Float32Array {
+  const output = new Float32Array(samples.length)
+
+  for (let index = 0; index < samples.length; index += 1) {
+    output[index] = samples[index] / 32_768
+  }
+
+  return output
+}
+
+export function createVoicePlayoutController(
+  sink: VoiceAudioSink,
+  options: VoicePlayoutOptions = {}
+): VoicePlayoutController {
+  const sampleRate = options.sampleRate ?? 24_000
+  const channels = options.channels ?? 1
+  const initialBufferMs = Math.max(0, options.initialBufferMs ?? DEFAULT_INITIAL_BUFFER_MS)
+  const maxBufferMs = Math.max(0, options.maxBufferMs ?? DEFAULT_MAX_BUFFER_MS)
+  const stableFramesToDecrease = Math.max(1, options.stableFramesToDecrease ?? 12)
+
+  let state: VoicePlayoutState = {
+    bufferedMs: 0,
+    cancelled: false,
+    ended: false,
+    failed: false,
+    maxBufferMs,
+    started: false,
+    targetBufferMs: Math.min(initialBufferMs, maxBufferMs)
+  }
+  let telemetry: VoicePlayoutTelemetry = {
+    framesReceived: 0,
+    maxBufferedMs: 0,
+    orderingViolations: 0,
+    queueOverflows: 0,
+    samplesReceived: 0,
+    underruns: 0
+  }
+  let expectedSequence: number | null = null
+  let expectedSampleOffset: number | null = null
+  let stableFrames = 0
+  let rebuffering = false
+  let drainPromise: Promise<void> | null = null
+  const queue: VoiceAudioFrame[] = []
+
+  const publish = () => options.onState?.({ ...state })
+  const fail = (reason: 'buffer-overflow' | 'ordering-violation') => {
+    if (state.failed || state.cancelled) {
+      return
+    }
+
+    state = { ...state, failed: true }
+    options.onError?.(reason)
+    sink.stop()
+    queue.length = 0
+    state = { ...state, bufferedMs: 0 }
+    publish()
+  }
+  const flush = () => {
+    if (!state.started || state.failed || state.cancelled) {
+      return
+    }
+
+    while (queue.length > 0) {
+      const next = queue.shift()
+
+      if (!next) {
+        break
+      }
+
+      sink.write(toFloat32(next.samples))
+      state = {
+        ...state,
+        bufferedMs: Math.max(0, state.bufferedMs - (next.sampleCount / sampleRate) * 1_000)
+      }
+    }
+
+    publish()
+  }
+  const maybeStart = () => {
+    if (state.started || state.failed || state.cancelled) {
+      return
+    }
+
+    if (state.bufferedMs < state.targetBufferMs && !state.ended) {
+      return
+    }
+
+    state = { ...state, started: true }
+    void sink.start(sampleRate, channels)
+    publish()
+    flush()
+  }
+
+  const controller: VoicePlayoutController = {
+    push: frame => {
+      if (state.cancelled || state.failed || state.ended) {
+        return
+      }
+
+      const validSampleCount = frame.sampleCount === frame.samples.length && frame.sampleCount > 0
+      const ordered =
+        expectedSequence === null
+          ? frame.sequence === 0 && frame.sampleOffset === 0
+          : frame.sequence === expectedSequence && frame.sampleOffset === expectedSampleOffset
+
+      if (!validSampleCount || !ordered) {
+        telemetry = { ...telemetry, orderingViolations: telemetry.orderingViolations + 1 }
+        fail('ordering-violation')
+        return
+      }
+
+      const frameMs = (frame.sampleCount / sampleRate) * 1_000
+
+      if (state.bufferedMs + frameMs > state.maxBufferMs) {
+        telemetry = { ...telemetry, queueOverflows: telemetry.queueOverflows + 1 }
+        fail('buffer-overflow')
+        return
+      }
+
+      expectedSequence = frame.sequence + 1
+      expectedSampleOffset = frame.sampleOffset + frame.sampleCount
+      telemetry = {
+        ...telemetry,
+        framesReceived: telemetry.framesReceived + 1,
+        maxBufferedMs: Math.max(telemetry.maxBufferedMs, state.bufferedMs + frameMs),
+        samplesReceived: telemetry.samplesReceived + frame.sampleCount
+      }
+      queue.push(frame)
+      state = { ...state, bufferedMs: state.bufferedMs + frameMs }
+      publish()
+      maybeStart()
+      if (rebuffering && state.bufferedMs >= state.targetBufferMs) {
+        rebuffering = false
+        void sink.start(sampleRate, channels)
+      }
+      if (!rebuffering) {
+        flush()
+      }
+    },
+    end: () => {
+      if (drainPromise) {
+        return drainPromise
+      }
+
+      state = { ...state, ended: true }
+      if (telemetry.framesReceived > 0) {
+        maybeStart()
+      }
+
+      if (state.cancelled || state.failed || telemetry.framesReceived === 0) {
+        drainPromise = Promise.resolve()
+      } else {
+        drainPromise = Promise.resolve(sink.drain()).then(() => undefined)
+      }
+
+      publish()
+
+      return drainPromise
+    },
+    cancel: () => {
+      if (state.cancelled) {
+        return
+      }
+
+      state = { ...state, cancelled: true, bufferedMs: 0 }
+      queue.length = 0
+      sink.stop()
+      publish()
+    },
+    getState: () => ({ ...state }),
+    getTelemetry: () => ({ ...telemetry }),
+    reportStablePlayback: () => {
+      if (state.cancelled || state.failed) {
+        return
+      }
+
+      stableFrames += 1
+
+      if (stableFrames >= stableFramesToDecrease) {
+        stableFrames = 0
+        state = {
+          ...state,
+          targetBufferMs: Math.max(initialBufferMs, state.targetBufferMs - Math.max(5, state.targetBufferMs * 0.1))
+        }
+        publish()
+      }
+    },
+    reportUnderrun: () => {
+      if (state.cancelled || state.failed) {
+        return
+      }
+
+      stableFrames = 0
+      rebuffering = state.started
+      if (rebuffering) {
+        sink.pause()
+      }
+      state = {
+        ...state,
+        targetBufferMs: Math.min(maxBufferMs, Math.max(state.targetBufferMs + 20, state.targetBufferMs * 1.5))
+      }
+      publish()
+    }
+  }
+
+  sink.onUnderrun = () => {
+    telemetry = { ...telemetry, underruns: telemetry.underruns + 1 }
+    controller.reportUnderrun()
+  }
+  sink.onOverflow = () => {
+    telemetry = { ...telemetry, queueOverflows: telemetry.queueOverflows + 1 }
+    fail('buffer-overflow')
+  }
+  sink.onStablePlayback = () => controller.reportStablePlayback()
+
+  return controller
+}

--- a/apps/desktop/src/lib/voice-playout.ts
+++ b/apps/desktop/src/lib/voice-playout.ts
@@ -86,6 +86,7 @@ export function createVoicePlayoutController(
   const initialBufferMs = Math.max(0, options.initialBufferMs ?? DEFAULT_INITIAL_BUFFER_MS)
   const maxBufferMs = Math.max(0, options.maxBufferMs ?? DEFAULT_MAX_BUFFER_MS)
   const stableFramesToDecrease = Math.max(1, options.stableFramesToDecrease ?? 12)
+  const targetCeilingMs = Math.max(0, maxBufferMs - 20)
 
   let state: VoicePlayoutState = {
     bufferedMs: 0,
@@ -94,7 +95,7 @@ export function createVoicePlayoutController(
     failed: false,
     maxBufferMs,
     started: false,
-    targetBufferMs: Math.min(initialBufferMs, maxBufferMs)
+    targetBufferMs: Math.min(initialBufferMs, targetCeilingMs)
   }
   let telemetry: VoicePlayoutTelemetry = {
     framesReceived: 0,
@@ -212,6 +213,11 @@ export function createVoicePlayoutController(
       }
 
       state = { ...state, ended: true }
+      if (rebuffering && queue.length > 0) {
+        rebuffering = false
+        void sink.start(sampleRate, channels)
+        flush()
+      }
       if (telemetry.framesReceived > 0) {
         maybeStart()
       }
@@ -266,7 +272,7 @@ export function createVoicePlayoutController(
       }
       state = {
         ...state,
-        targetBufferMs: Math.min(maxBufferMs, Math.max(state.targetBufferMs + 20, state.targetBufferMs * 1.5))
+        targetBufferMs: Math.min(targetCeilingMs, Math.max(state.targetBufferMs + 20, state.targetBufferMs * 1.5))
       }
       publish()
     }

--- a/docs/plans/provider-neutral-streaming-tts-ledger.md
+++ b/docs/plans/provider-neutral-streaming-tts-ledger.md
@@ -1,0 +1,76 @@
+# Provider-neutral streaming TTS feature-dev ledger
+
+## Run
+
+- Run ID: `2026-07-30-provider-neutral-streaming-tts`
+- Loop: Plebdev Feature Dev
+- Target repo: `NousResearch/hermes-agent`
+- Base branch: `main` (repo has no `staging`; explicit repository exception)
+- Feature branch: `codex/provider-neutral-streaming-tts`
+- Human owner: plebdev
+- Started: 2026-07-30
+- Current status: implementation
+- Skill setup status: GitHub issue tracker inferred from origin; root and Desktop
+  AGENTS guidance loaded; no repo-local Plebdev issue/triage/domain adapter exists.
+
+## Goal
+
+Implement a robust provider-independent streaming TTS path with a stable audio
+contract, adaptive continuous Desktop playback, qualification gates, and Fish
+Audio as the first conforming front-door provider.
+
+## Durable Artifacts
+
+- CONTEXT updates: not required; terms live in the adjacent plan.
+- ADRs: `docs/plans/provider-neutral-streaming-tts.md`
+- Prototype source branch, if any: none; direct cadence evidence answered the
+  design question.
+- Spec issue: pending publication.
+- Tickets: four delivery slices in the spec; delegated approval recorded below.
+- Ticket sessions: pending.
+- Agent briefs: three Luna-high read-only architecture briefs in current task.
+- Review packets: pending.
+- Local CodeRabbit report: pending.
+- PR URL: pending.
+
+## Commands
+
+- Install: reuse root Python venv and existing `node_modules` where available.
+- Typecheck: `npm --prefix apps/desktop run typecheck`
+- Test: targeted pytest and Vitest suites per slice; root full suite at issue end.
+- Build: `npm --prefix apps/desktop run build`
+- Visual verification: Hermes Desktop against authenticated Beelink gateway.
+
+## Ticket Ledger
+
+| Issue | Type | Status | Review thread | Fixes needed | Verified |
+| --- | --- | --- | --- | --- | --- |
+| Frame contract | AFK | in progress | pending | pending | no |
+| Gateway transport | AFK | pending | pending | pending | no |
+| Desktop playout | AFK | pending | pending | pending | no |
+| Fish qualification | AFK + production handoff | pending | pending | pending | no |
+
+## Parked HITL Slices
+
+| Issue | Why parked | Blocks | Required human action | Final PR decision |
+| --- | --- | --- | --- | --- |
+| Live promotion | Feature Dev production boundary | live route only | separate promotion loop | out of feature PR |
+
+## Issue Session Ledger
+
+| Issue | Fixed point | Worker session | Commit | Review result | Checks |
+| --- | --- | --- | --- | --- | --- |
+| Frame contract | `07447bd5d` | pending | pending | pending | pending |
+
+## Open Questions
+
+- None. The user explicitly approved the previously proposed architecture and
+  delegated testing-seam and ticket-boundary decisions on 2026-07-30.
+
+## Escalations
+
+- Hermes has no `staging` branch and no Plebdev repo adapter. This run targets
+  the repository's actual integration branch (`main`) while retaining all other
+  feature-loop gates.
+- Production changes are excluded from Feature Dev and will use the Spark
+  Front-Door Model Promotion Loop after the implementation is reviewable.

--- a/docs/plans/provider-neutral-streaming-tts-ledger.md
+++ b/docs/plans/provider-neutral-streaming-tts-ledger.md
@@ -9,7 +9,7 @@
 - Feature branch: `codex/provider-neutral-streaming-tts`
 - Human owner: plebdev
 - Started: 2026-07-30
-- Current status: implementation
+- Current status: branch review complete; publication pending
 - Skill setup status: GitHub issue tracker inferred from origin; root and Desktop
   AGENTS guidance loaded; no repo-local Plebdev issue/triage/domain adapter exists.
 
@@ -29,8 +29,8 @@ Audio as the first conforming front-door provider.
 - Tickets: four delivery slices in the spec; delegated approval recorded below.
 - Ticket sessions: pending.
 - Agent briefs: three Luna-high read-only architecture briefs in current task.
-- Review packets: pending.
-- Local CodeRabbit report: pending.
+- Review packets: Luna-high standards/spec reviews completed; all P1/P2 findings resolved.
+- Local CodeRabbit report: one round completed; nine findings addressed and reverified.
 - PR URL: pending.
 
 ## Commands
@@ -45,9 +45,9 @@ Audio as the first conforming front-door provider.
 
 | Issue | Type | Status | Review thread | Fixes needed | Verified |
 | --- | --- | --- | --- | --- | --- |
-| Frame contract | AFK | in progress | pending | pending | no |
-| Gateway transport | AFK | pending | pending | pending | no |
-| Desktop playout | AFK | pending | pending | pending | no |
+| Frame contract | AFK | complete | Luna + CodeRabbit | fixed | yes |
+| Gateway transport | AFK | complete | Luna + CodeRabbit | fixed | yes |
+| Desktop playout | AFK | complete | Luna + CodeRabbit | fixed | yes |
 | Fish qualification | AFK + production handoff | pending | pending | pending | no |
 
 ## Parked HITL Slices
@@ -60,7 +60,9 @@ Audio as the first conforming front-door provider.
 
 | Issue | Fixed point | Worker session | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
-| Frame contract | `07447bd5d` | pending | pending | pending | pending |
+| Frame + gateway | `07447bd5d` | Luna worker | `45f895572` | passed after fixes | 39 Python tests |
+| Desktop playout | `45f895572` | Luna worker | `75fdf2acf` | passed after fixes | 12 focused Vitest + typecheck + build |
+| Design record | `75fdf2acf` | orchestrator | `695c2a772` | passed | docs review |
 
 ## Open Questions
 

--- a/docs/plans/provider-neutral-streaming-tts-ledger.md
+++ b/docs/plans/provider-neutral-streaming-tts-ledger.md
@@ -9,7 +9,9 @@
 - Feature branch: `codex/provider-neutral-streaming-tts`
 - Human owner: plebdev
 - Started: 2026-07-30
-- Current status: branch review complete; publication pending
+- Current status: implementation review is complete through committed
+  hardening `97238bf73`; PR #75014 is open; the follow-up is verified and
+  ready for its issue commit.
 - Skill setup status: GitHub issue tracker inferred from origin; root and Desktop
   AGENTS guidance loaded; no repo-local Plebdev issue/triage/domain adapter exists.
 
@@ -25,13 +27,16 @@ Audio as the first conforming front-door provider.
 - ADRs: `docs/plans/provider-neutral-streaming-tts.md`
 - Prototype source branch, if any: none; direct cadence evidence answered the
   design question.
-- Spec issue: pending publication.
-- Tickets: four delivery slices in the spec; delegated approval recorded below.
-- Ticket sessions: pending.
+- Spec issue: https://github.com/NousResearch/hermes-agent/issues/75029.
+- Tickets: four approved delivery slices published in dependency order as
+  #75030, #75031, #75032, and #75033.
+- Ticket sessions: recorded below; final follow-up commit pending.
 - Agent briefs: three Luna-high read-only architecture briefs in current task.
 - Review packets: Luna-high standards/spec reviews completed; all P1/P2 findings resolved.
-- Local CodeRabbit report: one round completed; nine findings addressed and reverified.
-- PR URL: pending.
+- Local CodeRabbit report: initial nine findings and follow-up rounds of zero,
+  three, and one finding were processed; every worthy finding was addressed
+  and the affected checks were rerun.
+- PR URL: https://github.com/NousResearch/hermes-agent/pull/75014 (OPEN).
 
 ## Commands
 
@@ -48,7 +53,7 @@ Audio as the first conforming front-door provider.
 | Frame contract | AFK | complete | Luna + CodeRabbit | fixed | yes |
 | Gateway transport | AFK | complete | Luna + CodeRabbit | fixed | yes |
 | Desktop playout | AFK | complete | Luna + CodeRabbit | fixed | yes |
-| Fish qualification | AFK + production handoff | pending | pending | pending | no |
+| Fish qualification | AFK + production handoff | request-streaming measured; realtime thresholds failed; public admission probe failed | Spark PR #218 + Luna audit | sustained RTF > 1 and max gap > threshold; authenticated public route returned 429 | raw transport only |
 
 ## Parked HITL Slices
 
@@ -56,13 +61,24 @@ Audio as the first conforming front-door provider.
 | --- | --- | --- | --- | --- |
 | Live promotion | Feature Dev production boundary | live route only | separate promotion loop | out of feature PR |
 
+The provider-neutral qualification probe is merged in
+`finitecomputer/spark-cluster` PR #218. Raw Fish produced a valid incremental
+WAV stream, but the thresholded run measured total RTF about 2.02, steady RTF
+about 1.95, and a maximum inter-chunk gap about 2.31 seconds. A fresh
+authenticated public-front-door probe on 2026-07-30 returned HTTP 429. This is
+evidence for request-streaming transport conformance and against a realtime
+claim; it is not Front-Door Model Promotion evidence or admission.
+
 ## Issue Session Ledger
 
 | Issue | Fixed point | Worker session | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
-| Frame + gateway | `07447bd5d` | Luna worker | `45f895572` | passed after fixes | 39 Python tests |
-| Desktop playout | `45f895572` | Luna worker | `75fdf2acf` | passed after fixes | 12 focused Vitest + typecheck + build |
-| Design record | `75fdf2acf` | orchestrator | `695c2a772` | passed | docs review |
+| Frame + gateway | `c9de69c6d` | Luna worker | `4a1cca7b6` | passed after fixes | 39 Python tests |
+| Desktop playout | `4a1cca7b6` | Luna worker | `93b780fd5` | passed after fixes | 12 focused Vitest + typecheck + build |
+| Design record | `93b780fd5` | orchestrator | `e80796df2` | passed | docs review |
+| Playout/cancellation hardening | `e80796df2` | delegated worker | `97238bf73` | passed | focused Desktop/Python tests + typecheck |
+| Integration/docs follow-up | `97238bf73` | Luna worker | pending (uncommitted) | passed pending final review | 15 Desktop + 75 Python tests, typecheck, build |
+| Provider cancellation contract | `97238bf73` | Luna worker | pending (uncommitted) | passed pending final review | included in 75 Python tests |
 
 ## Open Questions
 

--- a/docs/plans/provider-neutral-streaming-tts-ledger.md
+++ b/docs/plans/provider-neutral-streaming-tts-ledger.md
@@ -9,9 +9,8 @@
 - Feature branch: `codex/provider-neutral-streaming-tts`
 - Human owner: plebdev
 - Started: 2026-07-30
-- Current status: implementation review is complete through committed
-  hardening `97238bf73`; PR #75014 is open; the follow-up is verified and
-  ready for its issue commit.
+- Current status: implementation and local review are complete through
+  follow-up commit `47f249aa1`; PR #75014 is open pending upstream review.
 - Skill setup status: GitHub issue tracker inferred from origin; root and Desktop
   AGENTS guidance loaded; no repo-local Plebdev issue/triage/domain adapter exists.
 
@@ -30,7 +29,7 @@ Audio as the first conforming front-door provider.
 - Spec issue: https://github.com/NousResearch/hermes-agent/issues/75029.
 - Tickets: four approved delivery slices published in dependency order as
   #75030, #75031, #75032, and #75033.
-- Ticket sessions: recorded below; final follow-up commit pending.
+- Ticket sessions: recorded below and committed.
 - Agent briefs: three Luna-high read-only architecture briefs in current task.
 - Review packets: Luna-high standards/spec reviews completed; all P1/P2 findings resolved.
 - Local CodeRabbit report: initial nine findings and follow-up rounds of zero,
@@ -73,12 +72,12 @@ claim; it is not Front-Door Model Promotion evidence or admission.
 
 | Issue | Fixed point | Worker session | Commit | Review result | Checks |
 | --- | --- | --- | --- | --- | --- |
-| Frame + gateway | `c9de69c6d` | Luna worker | `4a1cca7b6` | passed after fixes | 39 Python tests |
-| Desktop playout | `4a1cca7b6` | Luna worker | `93b780fd5` | passed after fixes | 12 focused Vitest + typecheck + build |
-| Design record | `93b780fd5` | orchestrator | `e80796df2` | passed | docs review |
-| Playout/cancellation hardening | `e80796df2` | delegated worker | `97238bf73` | passed | focused Desktop/Python tests + typecheck |
-| Integration/docs follow-up | `97238bf73` | Luna worker | pending (uncommitted) | passed pending final review | 15 Desktop + 75 Python tests, typecheck, build |
-| Provider cancellation contract | `97238bf73` | Luna worker | pending (uncommitted) | passed pending final review | included in 75 Python tests |
+| Frame + gateway | `c9de69c6d` | Luna worker | `dd2e84929` | passed after fixes | 39 Python tests |
+| Desktop playout | `dd2e84929` | Luna worker | `70087f6bc` | passed after fixes | 12 focused Vitest + typecheck + build |
+| Design record | `70087f6bc` | orchestrator | `79c74999b` | passed | docs review |
+| Playout/cancellation hardening | `79c74999b` | delegated worker | `a468f23f1` | passed | focused Desktop/Python tests + typecheck |
+| Integration/docs follow-up | `a468f23f1` | Luna worker | `47f249aa1` | passed after standards/spec/CodeRabbit review | 16 Desktop + 77 Python tests, typecheck, build |
+| Provider cancellation contract | `a468f23f1` | Luna worker | `47f249aa1` | passed after fail-closed/send-failure fixes | included in 77 Python tests |
 
 ## Open Questions
 

--- a/docs/plans/provider-neutral-streaming-tts.md
+++ b/docs/plans/provider-neutral-streaming-tts.md
@@ -1,0 +1,99 @@
+# Provider-neutral streaming TTS
+
+## Goal
+
+Make Hermes speech playback smooth and model-independent while preserving the
+existing low-latency text-to-speech experience. A provider adapter may emit
+audio with arbitrary HTTP chunk boundaries, but the Hermes gateway and Desktop
+must exchange a stable, versioned stream and play it from one continuous audio
+clock.
+
+Fish Audio S2 Pro is the first non-built-in provider required to conform to the
+contract. The contract must remain useful when that provider is replaced.
+
+## Terms
+
+- **provider chunk**: arbitrary bytes yielded by a provider SDK or HTTP body.
+- **audio frame**: validated mono signed-16-bit PCM covering a known duration.
+- **playout buffer**: client-owned queued audio measured in milliseconds.
+- **underrun**: the audio clock requests samples while no playable samples are
+  buffered and the stream has not ended.
+- **realtime factor (RTF)**: synthesis wall time divided by emitted audio time.
+
+## Contract
+
+The `/api/audio/speak-stream` WebSocket is versioned as `hermes.audio.v1`.
+
+The server sends a JSON `start` frame before audio with:
+
+- protocol version;
+- encoding (`pcm_s16le`), sample rate, and channel count;
+- monotonically increasing stream identifier;
+- recommended initial and maximum playout-buffer durations.
+
+Audio remains binary PCM for a narrow hot path. Each binary message is a whole,
+sample-aligned audio frame. A JSON `audio` metadata frame precedes it and carries
+the sequence number, starting sample offset, frame sample count, and synthesis
+timing. JSON `end`, `error`, and `fallback` frames terminate explicitly. Client
+`stop` and disconnect cancel production promptly.
+
+The gateway owns normalization from provider chunks to 20 ms audio frames,
+sequence/sample accounting, bounded buffering, and stream telemetry. Provider
+adapters own format decoding and must yield raw PCM plus a declared format;
+they do not own Desktop scheduling.
+
+The Desktop owns playout. It buffers frames in a bounded ring, starts only after
+an adaptive initial target is reached (or the stream ends), and feeds one
+continuous audio clock. It increases the target after underruns and cautiously
+decreases it after stable playback. It never creates one WebAudio source per
+provider chunk.
+
+## Degradation policy
+
+- Short jitter is absorbed by the adaptive buffer.
+- Missing/duplicate/out-of-order frames are detected from sequence/sample
+  metadata and reported as a stream error, never silently reordered.
+- If production is persistently slower than playback (RTF greater than one),
+  buffering is bounded. Hermes may wait for a phrase to complete or use the
+  existing whole-response fallback; it must not accumulate unbounded latency.
+- Barge-in stops the audio clock and cancels upstream synthesis.
+- Older gateways remain supported through the current raw-PCM compatibility
+  path until the versioned `start` frame is observed.
+
+## Testing seams
+
+1. Pure Python framing tests: arbitrary provider chunk boundaries become exact
+   20 ms aligned frames with monotonic sequence and sample offsets.
+2. WebSocket contract tests: start/audio/binary/end ordering, cancellation,
+   bounded queue behavior, fallback, and error termination.
+3. Pure TypeScript playout-controller tests: startup threshold, ordering,
+   underrun adaptation, bounded latency, drain, and cancellation using a fake
+   audio sink and clock.
+4. Desktop integration tests: version negotiation and legacy compatibility.
+5. Qualification probe: exact Hermes-style request reports time-to-first-audio,
+   RTF, p95/max inter-frame gap, underruns predicted at the configured buffer,
+   cancellation latency, and concurrency behavior.
+6. Live acceptance: Fish through the authenticated front door and a Hermes
+   Desktop connected to the Beelink, without changing protected ingress merely
+   to reload configuration.
+
+## Acceptance
+
+- Provider HTTP chunking cannot change the Desktop playback unit.
+- Audio frame sequence and sample offsets are monotonic and loss-detectable.
+- Desktop uses a continuous sink with an adaptive, bounded playout buffer.
+- No audible gap is introduced at phrase boundaries when buffered audio exists.
+- Cancellation cuts local playback immediately and stops server production.
+- Legacy server compatibility and the existing whole-audio fallback remain.
+- Qualification evidence distinguishes TTFA, throughput, jitter, and playout
+  underruns; a provider with sustained RTF above one cannot be labelled realtime.
+- Fish conforms through the same provider-neutral path without Fish-specific
+  scheduling logic in Desktop or the WebSocket protocol.
+
+## Delivery slices
+
+1. Provider-neutral frame model and deterministic framing tests.
+2. Versioned gateway transport, cancellation, telemetry, and WebSocket tests.
+3. Continuous Desktop playout controller and adaptive buffering tests.
+4. Fish adapter conformance, qualification probe, end-to-end evidence, and
+   separately governed production promotion.

--- a/docs/streaming-tts.md
+++ b/docs/streaming-tts.md
@@ -18,8 +18,10 @@ The streaming pipeline has four parts:
 3. **TTS provider** — a registered `StreamingTTSProvider` turns each sentence
    into raw PCM chunks (int16 mono at the provider's declared `sample_rate`)
 4. **Audio sink** — `sounddevice.OutputStream` for local playback
-   (`tools.tts_tool.stream_tts_to_speaker`), or a gateway platform adapter's
-   `write_streaming_tts` seam (`gateway/streaming_tts_consumer.py`)
+   (`tools.tts_tool.stream_tts_to_speaker`), a gateway platform adapter's
+   `write_streaming_tts` seam (`gateway/streaming_tts_consumer.py`), or the
+   Desktop's single bounded AudioWorklet clock behind
+   `/api/audio/speak-stream`.
 
 Providers with no chunked API still get per-*sentence* playback via the proven
 sync `text_to_speech_tool` path, so edge (the default) is conversational too.
@@ -34,8 +36,8 @@ swaps your voice for a different provider just to get streaming.
 
 To override, set `tts.streaming.provider` in your `config.yaml`:
 
-- a provider name (`elevenlabs`, `gemini`, `openai`, `xai`) pins that streamer
-- `auto` walks the priority list `elevenlabs → gemini → openai → xai` and uses
+- a provider name (`elevenlabs`, `gemini`, `openai`, `xai`, `finite_fish`) pins that streamer
+- `auto` walks the priority list `elevenlabs → gemini → openai → xai → finite_fish` and uses
   the first one whose credentials resolve — an explicit opt-in to "best
   chunked voice available"
 
@@ -57,12 +59,43 @@ tts:
 | openai      | chunked HTTP (`with_streaming_response`, `pcm`) | yes | `tts.openai.api_key` → env → managed gateway |
 | gemini      | SSE (`streamGenerateContent?alt=sse`) | yes         | `GEMINI_API_KEY` / `GOOGLE_API_KEY` |
 | xai         | WebSocket (`wss://api.x.ai/v1/tts`)   | yes         | xAI OAuth or `XAI_API_KEY` |
+| finite_fish | streamed HTTP WAV (`/audio/speech`)   | request-streaming | `tts.finite_fish.base_url` + provider secret resolution for the API key |
 | edge, piper, kitten, neutts, mistral, minimax, deepinfra, … | — | no (per-sentence sync fallback) | as usual |
+
+`finite_fish` is wired through the same provider-neutral adapter and framing
+path, but its request-streaming behavior is not realtime-qualified. A usable
+HTTP stream is not an admission decision: realtime claims require separate
+qualification evidence for time-to-first-audio, throughput/RTF, jitter,
+underruns, cancellation, and concurrency.
 
 All credential lookups go through `resolve_provider_secret()`
 (config > env/.env > credential pool) — never bare env reads. Streamed bodies
 are capped at 16 MiB per sentence, mirroring the sync providers' bounded
 upstream-body invariant.
+
+## Desktop WebSocket contract
+
+The Desktop requests `/api/audio/speak-stream` and accepts a stream only after
+an explicit `start` frame with `protocol: "hermes.audio.v1"`. The gateway
+emits that versioned start only for adapters advertising upstream cancellation;
+other adapters fail closed to the existing whole-response `fallback` path. It
+then sends one JSON `audio` metadata frame followed by one binary, little-endian
+16-bit PCM payload for every frame, with monotonic `sequence`, `sample_offset`,
+and `sample_count`; the stream ends with `end`, `error`, or `fallback`. The
+gateway normalizes arbitrary provider chunks into 20 ms frames and applies a
+bounded output queue.
+
+Desktop buffers those frames in one adaptive AudioWorklet ring. It waits for
+the negotiated startup target (or an ended stream), raises the target after an
+underrun, and drains the same clock at end-of-stream. `stop` or WebSocket
+disconnect cuts local playback immediately, closes the accepted provider
+response, and never emits a normal `end`. A provider or transport failure
+before any audio starts uses the existing whole-response playback fallback; an
+explicit stop is a barge-in and does not replay the response. Noncancellable
+adapters remain available to the CLI/local speaker, where they retain the
+legacy per-sentence behavior.
+Older gateways that do not send the versioned `start` frame stay on the legacy
+raw-PCM scheduler.
 
 ## Adding a new streaming provider
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -25,6 +25,7 @@ import hashlib
 import hmac
 import inspect
 import importlib.util
+import itertools
 import json
 import logging
 import math
@@ -134,6 +135,16 @@ except ImportError:
 
 WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
 _log = logging.getLogger(__name__)
+
+# Provider-neutral speak-stream transport defaults.  The queue is deliberately
+# finite: synthesis applies backpressure while the WebSocket writer catches up
+# instead of allowing a slow desktop client to accumulate unbounded PCM.
+_SPEAK_STREAM_FRAME_MS = 20
+_SPEAK_STREAM_INITIAL_BUFFER_MS = 120
+_SPEAK_STREAM_MAX_BUFFER_MS = 1000
+_SPEAK_STREAM_QUEUE_MAX_FRAMES = 64
+_SPEAK_STREAM_QUEUE_WAIT_SECONDS = 1.0
+_SPEAK_STREAM_IDS = itertools.count(1)
 
 # ---------------------------------------------------------------------------
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
@@ -4487,7 +4498,7 @@ def _split_text_for_speak_stream(text: str, cap: int) -> list:
 
 @app.websocket("/api/audio/speak-stream")
 async def speak_stream_ws(ws: "WebSocket") -> None:
-    """Streaming TTS for the desktop: text in, raw int16 PCM frames out.
+    """Streaming TTS for the desktop using the ``hermes.audio.v1`` contract.
 
     The socket is a per-reply speech *session*: the client feeds text
     incrementally as LLM deltas arrive, the server cuts sentences
@@ -4496,14 +4507,10 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
     exactly like the token→sentence→TTS pipelining the realtime-voice
     literature converges on.
 
-    Protocol:
-      client → ``{"text": "..."}`` frames (incremental; may combine with done),
-               ``{"done": true}`` when the reply is complete,
-               ``{"stop": true}`` or disconnect = barge-in
-      server → ``{"type": "start", "sample_rate": N, "channels": 1}``,
-               binary PCM frames, then ``{"type": "end"}``
-      server → ``{"type": "fallback"}`` when the configured provider has no
-               chunked API — the client uses the POST endpoint instead.
+    Every binary message is a complete 20 ms (or final partial) PCM frame and
+    is immediately preceded by a JSON ``audio`` metadata message.  A bounded
+    producer queue provides backpressure; if a client remains unable to drain
+    it, the stream terminates with a structured ``error`` frame.
     """
     if not _ws_auth_ok(ws):
         await ws.close(code=4401)
@@ -4542,13 +4549,79 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
             await ws.close()
         return
 
+    try:
+        from tools.tts_streaming import AudioFormat
+
+        declared_format = getattr(streamer, "audio_format", None)
+        if declared_format is None:
+            declared_format = AudioFormat(
+                sample_rate=int(getattr(streamer, "sample_rate", 24000)),
+                channels=int(getattr(streamer, "channels", 1)),
+                sample_width=int(getattr(streamer, "sample_width", 2)),
+            )
+        sample_rate = declared_format.sample_rate
+        channels = declared_format.channels
+    except Exception as exc:
+        with contextlib.suppress(Exception):
+            await ws.send_json({"type": "error", "code": "invalid_audio_format", "message": str(exc)})
+            await ws.close()
+        return
+
+    stream_id = next(_SPEAK_STREAM_IDS)
     await ws.send_json(
-        {"type": "start", "sample_rate": streamer.sample_rate, "channels": streamer.channels}
+        {
+            "type": "start",
+            "protocol": "hermes.audio.v1",
+            "protocol_version": "hermes.audio.v1",
+            "version": 1,
+            "stream_id": stream_id,
+            "encoding": declared_format.encoding,
+            "sample_rate": sample_rate,
+            "channels": channels,
+            "initial_buffer_ms": _SPEAK_STREAM_INITIAL_BUFFER_MS,
+            "max_buffer_ms": _SPEAK_STREAM_MAX_BUFFER_MS,
+        }
     )
 
     stop = threading.Event()
     text_q: queue.Queue = queue.Queue()  # str deltas; None = end-of-text
-    chunks: asyncio.Queue = asyncio.Queue()  # PCM out; None = synthesis done
+    # ``AudioFrame`` instances are kept in the queue until the writer has sent
+    # both their metadata and binary payload.  The terminal tuple is always
+    # enqueued after the producer has stopped, so end/error ordering is stable.
+    chunks: asyncio.Queue = asyncio.Queue(maxsize=_SPEAK_STREAM_QUEUE_MAX_FRAMES)
+    totals = {"frames": 0, "samples": 0}
+    synthesis_started = time.monotonic()
+    producer_failure: dict[str, str] = {}
+
+    def _elapsed_ms() -> float:
+        return round(max(0.0, time.monotonic() - synthesis_started) * 1000.0, 3)
+
+    def _queue_put(item: tuple[str, Any], *, ignore_stop: bool = False) -> bool:
+        """Put an item into the async queue, applying bounded backpressure."""
+        while ignore_stop or not stop.is_set():
+            future = asyncio.run_coroutine_threadsafe(chunks.put(item), loop)
+            deadline = time.monotonic() + _SPEAK_STREAM_QUEUE_WAIT_SECONDS
+            try:
+                while ignore_stop or not stop.is_set():
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        future.cancel()
+                        producer_failure.update(
+                            code="buffer_overflow",
+                            message="speak-stream output buffer is full",
+                        )
+                        stop.set()
+                        return False
+                    try:
+                        future.result(timeout=min(0.1, remaining))
+                        return True
+                    except concurrent.futures.TimeoutError:
+                        continue
+                future.cancel()
+                return False
+            except Exception:
+                return False
+        return False
 
     def _produce():
         from tools.tts_streaming import SentenceChunker
@@ -4587,6 +4660,9 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
                 yield from chunker.feed(delta)
 
         try:
+            from tools.tts_streaming import AudioFramer
+
+            framer = AudioFramer(declared_format, frame_ms=_SPEAK_STREAM_FRAME_MS)
             for sentence in _sentences():
                 cleaned = _strip_markdown_for_tts(sentence)
                 if not cleaned:
@@ -4595,11 +4671,26 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
                     for chunk in streamer.stream(piece):
                         if stop.is_set():
                             return
-                        loop.call_soon_threadsafe(chunks.put_nowait, chunk)
+                        for frame in framer.feed(chunk):
+                            totals["frames"] += 1
+                            totals["samples"] += frame.sample_count
+                            if not _queue_put(("frame", frame)):
+                                return
+            for frame in framer.flush():
+                if stop.is_set():
+                    return
+                totals["frames"] += 1
+                totals["samples"] += frame.sample_count
+                if not _queue_put(("frame", frame)):
+                    return
         except Exception as exc:
             _log.warning("speak-stream synthesis failed: %s", exc)
+            producer_failure.update(code="synthesis_failed", message=str(exc) or "Speech synthesis failed")
         finally:
-            loop.call_soon_threadsafe(chunks.put_nowait, None)
+            if producer_failure and (not stop.is_set() or producer_failure.get("code") == "buffer_overflow"):
+                _queue_put(("error", dict(producer_failure)), ignore_stop=True)
+            elif not stop.is_set():
+                _queue_put(("done", None), ignore_stop=True)
 
     threading.Thread(target=_produce, daemon=True).start()
 
@@ -4611,24 +4702,72 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
                 frame = json.loads(await ws.receive_text())
                 if frame.get("text"):
                     text_q.put(str(frame["text"]))
-                if frame.get("stop"):
+                if frame.get("stop") or frame.get("type") == "stop":
                     break
                 if frame.get("done"):
                     text_q.put(None)
         except Exception:
             pass
         stop.set()
+        cancel = getattr(streamer, "cancel", None)
+        if callable(cancel):
+            with contextlib.suppress(Exception):
+                cancel()
         text_q.put(None)  # unblock the producer
+        await chunks.put(("cancelled", None))
 
     pump = asyncio.ensure_future(_pump_client())
     try:
         while True:
-            chunk = await chunks.get()
-            if chunk is None:
+            kind, item = await chunks.get()
+            if kind == "frame":
+                frame = item
+                await ws.send_json(
+                    {
+                        "type": "audio",
+                        "stream_id": stream_id,
+                        "seq": frame.seq,
+                        "start_sample": frame.start_sample,
+                        "sequence": frame.seq,
+                        "sample_offset": frame.start_sample,
+                        "sample_count": frame.sample_count,
+                        "synthesis_ms": _elapsed_ms(),
+                    }
+                )
+                await ws.send_bytes(frame.pcm)
+                continue
+            if kind == "error":
+                error = dict(item or {})
+                error.update(
+                    {
+                        "type": "error",
+                        "stream_id": stream_id,
+                        "frame_count": totals["frames"],
+                        "frames": totals["frames"],
+                        "sample_count": totals["samples"],
+                        "samples": totals["samples"],
+                        "synthesis_ms": _elapsed_ms(),
+                    }
+                )
+                await ws.send_json(error)
                 break
-            await ws.send_bytes(chunk)
-        if not stop.is_set():
-            await ws.send_json({"type": "end"})
+            if kind == "done":
+                if not stop.is_set():
+                    await ws.send_json(
+                        {
+                        "type": "end",
+                        "stream_id": stream_id,
+                        "frame_count": totals["frames"],
+                        "frames": totals["frames"],
+                        "sample_count": totals["samples"],
+                        "samples": totals["samples"],
+                        "duration_ms": round(totals["samples"] * 1000 / sample_rate, 3),
+                        "synthesis_ms": _elapsed_ms(),
+                        }
+                    )
+                break
+            if kind == "cancelled":
+                break
     except (WebSocketDisconnect, RuntimeError):
         pass
     finally:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4714,7 +4714,12 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
             with contextlib.suppress(Exception):
                 cancel()
         text_q.put(None)  # unblock the producer
-        await chunks.put(("cancelled", None))
+        while True:
+            try:
+                chunks.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        chunks.put_nowait(("cancelled", None))
 
     pump = asyncio.ensure_future(_pump_client())
     try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -146,6 +146,38 @@ _SPEAK_STREAM_QUEUE_MAX_FRAMES = 64
 _SPEAK_STREAM_QUEUE_WAIT_SECONDS = 1.0
 _SPEAK_STREAM_IDS = itertools.count(1)
 
+
+async def _next_speak_stream_item(
+    chunks: "asyncio.Queue[tuple[str, Any]]", cancelled: "asyncio.Event"
+) -> Optional[tuple[str, Any]]:
+    """Wait for output or cancellation without using the output queue as a signal.
+
+    Producer refill runs from a worker thread via ``run_coroutine_threadsafe``.
+    A cancellation sentinel inserted with ``put_nowait`` can therefore race a
+    refill and raise ``QueueFull`` after the consumer drained the queue.  Keep
+    cancellation out-of-band so a full output queue cannot strand the writer.
+    """
+    if cancelled.is_set():
+        return None
+
+    item_task = asyncio.create_task(chunks.get())
+    cancel_task = asyncio.create_task(cancelled.wait())
+    done, _ = await asyncio.wait(
+        {item_task, cancel_task}, return_when=asyncio.FIRST_COMPLETED
+    )
+
+    if cancel_task in done:
+        item_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await item_task
+        return None
+
+    cancel_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await cancel_task
+    return item_task.result()
+
+
 # ---------------------------------------------------------------------------
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
 # and /api/events (dashboard → browser sidebar).  Keyed by an opaque channel id
@@ -4549,6 +4581,17 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
             await ws.close()
         return
 
+    # Versioned speak-stream sessions promise fail-closed upstream stop. A
+    # legacy adapter may still be useful to the CLI/local speaker, but it
+    # cannot safely participate in this route because its remote request may
+    # outlive a client barge-in. Fall back before emitting a v1 ``start``.
+    upstream_cancellable = bool(getattr(streamer, "upstream_cancellable", False))
+    if not upstream_cancellable:
+        with contextlib.suppress(Exception):
+            await ws.send_json({"type": "fallback"})
+            await ws.close()
+        return
+
     try:
         from tools.tts_streaming import AudioFormat
 
@@ -4580,21 +4623,46 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
             "channels": channels,
             "initial_buffer_ms": _SPEAK_STREAM_INITIAL_BUFFER_MS,
             "max_buffer_ms": _SPEAK_STREAM_MAX_BUFFER_MS,
+            # Reaching v1 start means the fail-closed gate above has already
+            # admitted an adapter with an active upstream-close contract.
+            "upstream_cancellable": upstream_cancellable,
+            "capabilities": {"upstream_cancellable": upstream_cancellable},
         }
     )
 
     stop = threading.Event()
     text_q: queue.Queue = queue.Queue()  # str deltas; None = end-of-text
     # ``AudioFrame`` instances are kept in the queue until the writer has sent
-    # both their metadata and binary payload.  The terminal tuple is always
-    # enqueued after the producer has stopped, so end/error ordering is stable.
+    # both their metadata and binary payload.  Normal end/error tuples are
+    # enqueued after the producer has stopped, so ordering is stable; client
+    # cancellation uses the separate event below and never competes for space.
     chunks: asyncio.Queue = asyncio.Queue(maxsize=_SPEAK_STREAM_QUEUE_MAX_FRAMES)
+    cancelled = asyncio.Event()
+    cancel_lock = threading.Lock()
+    cancel_invoked = False
     totals = {"frames": 0, "samples": 0}
     synthesis_started = time.monotonic()
     producer_failure: dict[str, str] = {}
 
     def _elapsed_ms() -> float:
         return round(max(0.0, time.monotonic() - synthesis_started) * 1000.0, 3)
+
+    def _cancel_stream() -> None:
+        """Stop local work and close the accepted upstream response once."""
+        nonlocal cancel_invoked
+        stop.set()
+        cancelled.set()
+        text_q.put(None)  # unblock a producer waiting for more text
+        with cancel_lock:
+            if cancel_invoked:
+                return
+            cancel_invoked = True
+        cancel = getattr(streamer, "cancel", None)
+        if callable(cancel):
+            try:
+                cancel()
+            except Exception:
+                _log.warning("speak-stream provider cancellation failed", exc_info=True)
 
     def _queue_put(item: tuple[str, Any], *, ignore_stop: bool = False) -> bool:
         """Put an item into the async queue, applying bounded backpressure."""
@@ -4668,6 +4736,8 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
                 if not cleaned:
                     continue
                 for piece in _split_text_for_speak_stream(cleaned, cap):
+                    if stop.is_set():
+                        return
                     for chunk in streamer.stream(piece):
                         if stop.is_set():
                             return
@@ -4708,23 +4778,15 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
                     text_q.put(None)
         except Exception:
             pass
-        stop.set()
-        cancel = getattr(streamer, "cancel", None)
-        if callable(cancel):
-            with contextlib.suppress(Exception):
-                cancel()
-        text_q.put(None)  # unblock the producer
-        while True:
-            try:
-                chunks.get_nowait()
-            except asyncio.QueueEmpty:
-                break
-        chunks.put_nowait(("cancelled", None))
+        _cancel_stream()
 
     pump = asyncio.ensure_future(_pump_client())
     try:
         while True:
-            kind, item = await chunks.get()
+            next_item = await _next_speak_stream_item(chunks, cancelled)
+            if next_item is None:
+                break
+            kind, item = next_item
             if kind == "frame":
                 frame = item
                 await ws.send_json(
@@ -4776,9 +4838,10 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
     except (WebSocketDisconnect, RuntimeError):
         pass
     finally:
-        stop.set()
-        text_q.put(None)
+        _cancel_stream()
         pump.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await pump
         with contextlib.suppress(Exception):
             await ws.close()
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1947,3 +1947,91 @@ class TestStreamTtsTempfileFallback:
         )
         # And the temp file is cleaned up afterwards.
         assert not os.path.exists(played[0]), "temp WAV was not unlinked"
+
+    def test_barge_in_during_buffering_does_not_play_partial_wav(self, monkeypatch):
+        import tools.tts_tool as tts_mod
+        import tools.voice_mode as vm
+        from tools.tts_tool import stream_tts_to_speaker
+
+        stop_evt = threading.Event()
+
+        class _BargingStreamer:
+            sample_rate = 24000
+            channels = 1
+
+            def stream(self, text):
+                yield b"\x00\x00" * 240
+                stop_evt.set()  # barge-in while the temp file is still filling
+                yield b"\x00\x00" * 240
+
+        monkeypatch.setattr(
+            "tools.tts_streaming.resolve_streaming_provider",
+            lambda tts_config, preferred=None: _BargingStreamer(),
+        )
+
+        def _no_sounddevice():
+            raise ImportError("sounddevice unavailable in test")
+
+        monkeypatch.setattr(tts_mod, "_import_sounddevice", _no_sounddevice)
+        played = []
+        monkeypatch.setattr(vm, "play_audio_file", lambda path: played.append(path))
+
+        text_q = queue.Queue()
+        done_evt = threading.Event()
+        text_q.put("This sentence is interrupted while buffering audio. ")
+        text_q.put(None)
+
+        stream_tts_to_speaker(text_q, stop_evt, done_evt)
+
+        assert done_evt.is_set()
+        assert played == []
+
+    def test_stop_invokes_streamer_cancel_from_another_thread(self, monkeypatch):
+        import tools.tts_tool as tts_mod
+        from tools.tts_tool import stream_tts_to_speaker
+
+        stream_started = threading.Event()
+        release_stream = threading.Event()
+        cancel_called = threading.Event()
+
+        class _BlockingStreamer:
+            sample_rate = 24000
+            channels = 1
+
+            def stream(self, text):
+                stream_started.set()
+                yield b"\x00\x00" * 240
+                release_stream.wait(timeout=2)
+
+            def cancel(self):
+                cancel_called.set()
+                release_stream.set()
+
+        streamer = _BlockingStreamer()
+        monkeypatch.setattr(
+            "tools.tts_streaming.resolve_streaming_provider",
+            lambda tts_config, preferred=None: streamer,
+        )
+
+        def _no_sounddevice():
+            raise ImportError("sounddevice unavailable in test")
+
+        monkeypatch.setattr(tts_mod, "_import_sounddevice", _no_sounddevice)
+
+        text_q = queue.Queue()
+        stop_evt = threading.Event()
+        done_evt = threading.Event()
+        text_q.put("This sentence blocks until cancellation arrives. ")
+
+        worker = threading.Thread(
+            target=stream_tts_to_speaker,
+            args=(text_q, stop_evt, done_evt),
+        )
+        worker.start()
+        assert stream_started.wait(timeout=2)
+        stop_evt.set()
+        worker.join(timeout=2)
+
+        assert not worker.is_alive()
+        assert done_evt.is_set()
+        assert cancel_called.is_set()

--- a/tests/hermes_cli/test_web_server_speak_stream.py
+++ b/tests/hermes_cli/test_web_server_speak_stream.py
@@ -8,7 +8,6 @@ from urllib.parse import urlencode
 
 import pytest
 from starlette.testclient import TestClient
-from starlette.websockets import WebSocketDisconnect
 
 from hermes_cli import web_server
 
@@ -49,6 +48,13 @@ class _FakeStreamer:
         yield from self.chunks
 
 
+class _FailingStreamer(_FakeStreamer):
+    def stream(self, text):
+        self.requests.append(text)
+        raise RuntimeError("provider unavailable")
+        yield b""  # pragma: no cover
+
+
 def _patch_provider(monkeypatch, streamer, cap=4000):
     monkeypatch.setattr("tools.tts_streaming.resolve_streaming_provider", lambda cfg: streamer)
     monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: {})
@@ -61,17 +67,35 @@ def _patch_provider(monkeypatch, streamer, cap=4000):
 
 
 def test_streams_pcm_frames_then_end(stream_client, monkeypatch):
-    streamer = _FakeStreamer([b"\x01\x02\x03\x04", b"\x05\x06"])
+    streamer = _FakeStreamer([b"\x01\x02" * 480, b"\x05\x06" * 480])
     _patch_provider(monkeypatch, streamer)
 
     with stream_client.websocket_connect(_url()) as conn:
         start = conn.receive_json()
-        assert start == {"type": "start", "sample_rate": 24000, "channels": 1}
+        assert start["type"] == "start"
+        assert start["protocol"] == "hermes.audio.v1"
+        assert start["encoding"] == "pcm_s16le"
+        assert start["sample_rate"] == 24000
+        assert start["channels"] == 1
+        assert start["stream_id"] > 0
+        assert start["initial_buffer_ms"] < start["max_buffer_ms"]
 
         conn.send_text(json.dumps({"text": "Hello there.", "done": True}))
-        assert conn.receive_bytes() == b"\x01\x02\x03\x04"
-        assert conn.receive_bytes() == b"\x05\x06"
-        assert conn.receive_json() == {"type": "end"}
+        metadata = conn.receive_json()
+        assert metadata["type"] == "audio"
+        assert metadata["seq"] == metadata["sequence"] == 0
+        assert metadata["start_sample"] == metadata["sample_offset"] == 0
+        assert metadata["sample_count"] == 480
+        assert conn.receive_bytes() == b"\x01\x02" * 480
+        metadata = conn.receive_json()
+        assert metadata["seq"] == metadata["sequence"] == 1
+        assert metadata["start_sample"] == metadata["sample_offset"] == 480
+        assert metadata["sample_count"] == 480
+        assert conn.receive_bytes() == b"\x05\x06" * 480
+        end = conn.receive_json()
+        assert end["type"] == "end"
+        assert end["frames"] == end["frame_count"] == 2
+        assert end["samples"] == end["sample_count"] == 960
 
     assert streamer.requests == ["Hello there."]
 
@@ -83,7 +107,7 @@ def test_streams_pcm_frames_then_end(stream_client, monkeypatch):
 
 
 def test_long_text_is_split_across_provider_requests(stream_client, monkeypatch):
-    streamer = _FakeStreamer([b"\x00\x00"])
+    streamer = _FakeStreamer([b"\x00\x00" * 480])
     _patch_provider(monkeypatch, streamer, cap=24)
 
     with stream_client.websocket_connect(_url()) as conn:
@@ -98,10 +122,13 @@ def test_long_text_is_split_across_provider_requests(stream_client, monkeypatch)
         while True:
             message = conn.receive()
             if message.get("bytes") is not None:
-                frames += 1
-            else:
-                assert json.loads(message["text"]) == {"type": "end"}
+                pytest.fail("binary payload was not preceded by metadata")
+            frame = json.loads(message["text"])
+            if frame["type"] == "end":
                 break
+            assert frame["type"] == "audio"
+            assert conn.receive_bytes()
+            frames += 1
 
     assert len(streamer.requests) > 1
     assert frames == len(streamer.requests)
@@ -109,6 +136,42 @@ def test_long_text_is_split_across_provider_requests(stream_client, monkeypatch)
     joined = " ".join(streamer.requests)
     for fragment in ("First sentence here.", "Second sentence here.", "Third one."):
         assert fragment in joined
+
+
+def test_synthesis_failure_is_structured_and_terminal(stream_client, monkeypatch):
+    streamer = _FailingStreamer([])
+    _patch_provider(monkeypatch, streamer)
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": "This will fail.", "done": True}))
+        error = conn.receive_json()
+        assert error["type"] == "error"
+        assert error["code"] == "synthesis_failed"
+        assert "provider unavailable" in error["message"]
+
+
+def test_type_stop_frame_cancels_without_end(stream_client, monkeypatch):
+    release = __import__("threading").Event()
+
+    class _BlockingStreamer(_FakeStreamer):
+        def stream(self, text):
+            self.requests.append(text)
+            yield b"\x00\x00" * 480
+            release.wait(timeout=1)
+
+    streamer = _BlockingStreamer([])
+    _patch_provider(monkeypatch, streamer)
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": "Please stop this sentence."}))
+        assert conn.receive_json()["type"] == "audio"
+        assert conn.receive_bytes()
+        conn.send_text(json.dumps({"type": "stop"}))
+        assert conn.receive()["type"] == "websocket.close"
+
+    release.set()
 
 
 def test_split_text_respects_cap_and_preserves_content():
@@ -119,5 +182,3 @@ def test_split_text_respects_cap_and_preserves_content():
     joined = " ".join(pieces)
     for word in text.replace(".", "").split():
         assert word in joined
-
-

--- a/tests/hermes_cli/test_web_server_speak_stream.py
+++ b/tests/hermes_cli/test_web_server_speak_stream.py
@@ -123,7 +123,9 @@ def test_long_text_is_split_across_provider_requests(stream_client, monkeypatch)
             message = conn.receive()
             if message.get("bytes") is not None:
                 pytest.fail("binary payload was not preceded by metadata")
+            assert message.get("text") is not None, f"unexpected message: {message}"
             frame = json.loads(message["text"])
+            assert frame["type"] != "error", frame
             if frame["type"] == "end":
                 break
             assert frame["type"] == "audio"

--- a/tests/hermes_cli/test_web_server_speak_stream.py
+++ b/tests/hermes_cli/test_web_server_speak_stream.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import threading
 import time
 from urllib.parse import urlencode
 
@@ -38,6 +40,7 @@ def _url(token: str | None = None) -> str:
 class _FakeStreamer:
     sample_rate = 24000
     channels = 1
+    upstream_cancellable = True
 
     def __init__(self, chunks):
         self.chunks = chunks
@@ -62,6 +65,20 @@ def _patch_provider(monkeypatch, streamer, cap=4000):
     monkeypatch.setattr("tools.tts_tool._resolve_max_text_length", lambda provider, cfg: cap)
 
 
+def test_cancellation_signal_does_not_compete_with_a_full_output_queue():
+    chunks: asyncio.Queue[tuple[str, object]] = asyncio.Queue(maxsize=1)
+    frame_item = ("frame", object())
+    chunks.put_nowait(frame_item)
+    cancelled = asyncio.Event()
+    cancelled.set()
+
+    assert asyncio.run(web_server._next_speak_stream_item(chunks, cancelled)) is None
+    # Cancellation itself never attempts a racy put_nowait sentinel or raises
+    # QueueFull, even if a producer has already filled the output queue.
+    assert chunks.qsize() == 1
+    assert chunks.get_nowait() == frame_item
+
+
 
 
 
@@ -79,6 +96,8 @@ def test_streams_pcm_frames_then_end(stream_client, monkeypatch):
         assert start["channels"] == 1
         assert start["stream_id"] > 0
         assert start["initial_buffer_ms"] < start["max_buffer_ms"]
+        assert start["upstream_cancellable"] is True
+        assert start["capabilities"]["upstream_cancellable"] is True
 
         conn.send_text(json.dumps({"text": "Hello there.", "done": True}))
         metadata = conn.receive_json()
@@ -98,6 +117,20 @@ def test_streams_pcm_frames_then_end(stream_client, monkeypatch):
         assert end["samples"] == end["sample_count"] == 960
 
     assert streamer.requests == ["Hello there."]
+
+
+def test_non_cancellable_provider_falls_back_before_v1_start(stream_client, monkeypatch):
+    class _LegacyStreamer(_FakeStreamer):
+        upstream_cancellable = False
+
+    streamer = _LegacyStreamer([b"\x00\x00" * 480])
+    _patch_provider(monkeypatch, streamer)
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json() == {"type": "fallback"}
+        assert conn.receive()["type"] == "websocket.close"
+
+    assert streamer.requests == []
 
 
 
@@ -174,6 +207,40 @@ def test_type_stop_frame_cancels_without_end(stream_client, monkeypatch):
         assert conn.receive()["type"] == "websocket.close"
 
     release.set()
+
+
+def test_server_send_failure_cancels_blocked_provider(stream_client, monkeypatch):
+    release = threading.Event()
+    cancel_called = threading.Event()
+
+    class _BlockingCancellableStreamer(_FakeStreamer):
+        def stream(self, text):
+            self.requests.append(text)
+            yield b"\x00\x00" * 480
+            release.wait(timeout=2)
+
+        def cancel(self):
+            cancel_called.set()
+            release.set()
+
+    streamer = _BlockingCancellableStreamer([])
+    _patch_provider(monkeypatch, streamer)
+    original_send_json = web_server.WebSocket.send_json
+
+    async def _fail_audio_send(ws, data, *args, **kwargs):
+        if data.get("type") == "audio":
+            raise RuntimeError("simulated client send failure")
+        return await original_send_json(ws, data, *args, **kwargs)
+
+    monkeypatch.setattr(web_server.WebSocket, "send_json", _fail_audio_send)
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": "Cancel when the writer fails."}))
+        assert conn.receive()["type"] == "websocket.close"
+
+    assert cancel_called.wait(timeout=1)
+    assert release.is_set()
 
 
 def test_split_text_respects_cap_and_preserves_content():

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -7,6 +7,7 @@ the chunked-streamer playback path, and the universal per-sentence sync fallback
 """
 
 import queue
+import struct
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -15,6 +16,97 @@ import pytest
 import tools.tts_streaming as ts
 
 pytest.importorskip("numpy")
+
+
+# ── Provider-neutral PCM framing ────────────────────────────────────────
+
+
+def test_audio_framer_handles_arbitrary_chunk_boundaries_and_monotonic_timing():
+    audio_format = ts.AudioFormat(sample_rate=1000)
+    framer = ts.AudioFramer(audio_format)
+    pcm = b"".join(struct.pack("<h", sample) for sample in range(47))
+
+    frames = []
+    for chunk in (pcm[:1], pcm[1:7], pcm[7:17], pcm[17:58], pcm[58:]):
+        frames.extend(framer.feed(chunk))
+    frames.extend(framer.flush())
+
+    assert [frame.seq for frame in frames] == [0, 1, 2]
+    assert [frame.start_sample for frame in frames] == [0, 20, 40]
+    assert [frame.sample_count for frame in frames] == [20, 20, 7]
+    assert b"".join(frame.pcm for frame in frames) == pcm
+    assert all(frame.format == audio_format for frame in frames)
+
+
+def test_audio_framer_rejects_invalid_encoding_and_sample_alignment():
+    with pytest.raises(ValueError, match="pcm_s16le"):
+        ts.AudioFormat(sample_rate=24000, encoding="audio/wav")
+    with pytest.raises(ValueError, match="mono"):
+        ts.AudioFormat(sample_rate=24000, channels=2)
+
+    framer = ts.AudioFramer(ts.AudioFormat(sample_rate=1000))
+    assert framer.feed(b"\x00") == []
+    with pytest.raises(ValueError, match="partial sample"):
+        framer.flush()
+
+
+def test_provider_stream_frames_preserves_legacy_stream_and_flushes_partial():
+    class _Provider(ts.StreamingTTSProvider):
+        sample_rate = 1000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            yield b"\x01\x00" * 20
+            yield b"\x02\x00" * 3
+
+    provider = _Provider({}, {})
+    assert list(provider.stream("hello")) == [b"\x01\x00" * 20, b"\x02\x00" * 3]
+    frames = list(provider.stream_frames("hello"))
+    assert [(frame.seq, frame.start_sample, frame.sample_count) for frame in frames] == [
+        (0, 0, 20),
+        (1, 20, 3),
+    ]
+
+
+def test_finite_fish_wav_header_can_arrive_split_across_http_chunks():
+    header = bytearray(44)
+    header[:4] = b"RIFF"
+    header[8:12] = b"WAVE"
+    header[12:16] = b"fmt "
+    struct.pack_into("<I", header, 16, 16)
+    struct.pack_into("<HHIIHH", header, 20, 1, 1, 44100, 88200, 2, 16)
+    header[36:40] = b"data"
+    struct.pack_into("<I", header, 40, 6)
+    pcm = b"\x01\x00\x02\x00\x03\x00"
+
+    chunks = [bytes(header[:3]), bytes(header[3:17]), bytes(header[17:44]) + pcm[:1], pcm[1:]]
+    assert b"".join(ts._streaming_wav_pcm(iter(chunks))) == pcm
+
+
+def test_finite_fish_rejects_incompatible_wav_format():
+    header = bytearray(44)
+    header[:4] = b"RIFF"
+    header[8:12] = b"WAVE"
+    header[12:16] = b"fmt "
+    struct.pack_into("<I", header, 16, 16)
+    struct.pack_into("<HHIIHH", header, 20, 1, 2, 44100, 176400, 4, 16)
+    header[36:40] = b"data"
+    struct.pack_into("<I", header, 40, 0)
+    with pytest.raises(RuntimeError, match="incompatible"):
+        list(ts._streaming_wav_pcm(iter([bytes(header)])))
+
+
+def test_finite_fish_cancel_closes_the_active_http_response():
+    response = MagicMock()
+    streamer = ts.FiniteFishStreamer({}, {})
+    streamer._active_response = response
+
+    streamer.cancel()
+
+    response.close.assert_called_once_with()
 
 
 # ── SentenceChunker ──────────────────────────────────────────────────────

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -77,7 +77,7 @@ def test_finite_fish_wav_header_can_arrive_split_across_http_chunks():
     header[8:12] = b"WAVE"
     header[12:16] = b"fmt "
     struct.pack_into("<I", header, 16, 16)
-    struct.pack_into("<HHIIHH", header, 20, 1, 1, 44100, 88200, 2, 16)
+    struct.pack_into("<HHIIHH", header, 20, 1, 1, 24000, 48000, 2, 16)
     header[36:40] = b"data"
     struct.pack_into("<I", header, 40, 6)
     pcm = b"\x01\x00\x02\x00\x03\x00"
@@ -92,7 +92,7 @@ def test_finite_fish_rejects_incompatible_wav_format():
     header[8:12] = b"WAVE"
     header[12:16] = b"fmt "
     struct.pack_into("<I", header, 16, 16)
-    struct.pack_into("<HHIIHH", header, 20, 1, 2, 44100, 176400, 4, 16)
+    struct.pack_into("<HHIIHH", header, 20, 1, 2, 24000, 96000, 4, 16)
     header[36:40] = b"data"
     struct.pack_into("<I", header, 40, 0)
     with pytest.raises(RuntimeError, match="incompatible"):

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -109,6 +109,167 @@ def test_finite_fish_cancel_closes_the_active_http_response():
     response.close.assert_called_once_with()
 
 
+def test_streaming_provider_cancellation_capability_is_explicit():
+    for provider_name, provider_class in ts._REGISTRY.items():
+        capability = provider_class.upstream_cancellable
+        assert isinstance(capability, bool), provider_name
+
+
+def test_openai_cancel_latch_closes_response_assigned_after_cancel(monkeypatch):
+    import openai
+
+    create_started = threading.Event()
+    release_create = threading.Event()
+    response_closed = threading.Event()
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def close(self):
+            response_closed.set()
+
+        def iter_bytes(self):
+            yield b"\x00\x00"
+
+    response = _Response()
+
+    class _Create:
+        def create(self, **_kwargs):
+            create_started.set()
+            release_create.wait(timeout=2)
+            return response
+
+    class _OpenAI:
+        def __init__(self, **_kwargs):
+            self.audio = MagicMock()
+            self.audio.speech.with_streaming_response = _Create()
+
+    monkeypatch.setattr(openai, "OpenAI", _OpenAI)
+    streamer = ts.OpenAIStreamer({}, {})
+    errors = []
+
+    def _consume():
+        try:
+            list(streamer.stream("cancel race"))
+        except Exception as exc:  # pragma: no cover - defensive
+            errors.append(exc)
+
+    worker = threading.Thread(target=_consume)
+    worker.start()
+    assert create_started.wait(timeout=2)
+    streamer.cancel()
+    release_create.set()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert not errors
+    response_closed.wait(timeout=1)
+    assert response_closed.is_set()
+    # The latch is idempotent and does not close the already-detached handle twice.
+    streamer.cancel()
+
+
+def test_openai_cancel_closes_active_response_cross_thread(monkeypatch):
+    import openai
+
+    response_started = threading.Event()
+    release_iter = threading.Event()
+    response_closed = threading.Event()
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def close(self):
+            response_closed.set()
+            release_iter.set()
+
+        def iter_bytes(self):
+            response_started.set()
+            release_iter.wait(timeout=2)
+            return iter(())
+
+    class _Create:
+        @staticmethod
+        def create(**_kwargs):
+            return _Response()
+
+    class _OpenAI:
+        def __init__(self, **_kwargs):
+            self.audio = MagicMock()
+            self.audio.speech.with_streaming_response = _Create()
+
+    monkeypatch.setattr(openai, "OpenAI", _OpenAI)
+    streamer = ts.OpenAIStreamer({}, {})
+    worker = threading.Thread(target=lambda: list(streamer.stream("active cancel")))
+    worker.start()
+    assert response_started.wait(timeout=2)
+    streamer.cancel()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert response_closed.is_set()
+
+
+def test_gemini_cancel_closes_active_response_cross_thread(monkeypatch):
+    import requests
+
+    response_started = threading.Event()
+    release_iter = threading.Event()
+    response_closed = threading.Event()
+
+    class _Response:
+        headers = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def close(self):
+            response_closed.set()
+            release_iter.set()
+
+        def iter_lines(self, **_kwargs):
+            response_started.set()
+            release_iter.wait(timeout=2)
+            return iter(())
+
+    response = _Response()
+    monkeypatch.setattr(requests, "post", lambda *_args, **_kwargs: response)
+    monkeypatch.setattr(ts, "_resolve_key", lambda *_args: "gemini-key")
+
+    streamer = ts.GeminiStreamer({}, {})
+    errors = []
+
+    def _consume():
+        try:
+            list(streamer.stream("cancel active"))
+        except Exception as exc:  # pragma: no cover - defensive
+            errors.append(exc)
+
+    worker = threading.Thread(target=_consume)
+    worker.start()
+    assert response_started.wait(timeout=2)
+    streamer.cancel()
+    worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert not errors
+    assert response_closed.is_set()
+
+
 # ── SentenceChunker ──────────────────────────────────────────────────────
 
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -323,6 +323,10 @@ class StreamingTTSProvider(ABC):
     sample_rate: int = 24000
     channels: int = 1
     sample_width: int = 2  # bytes/sample (int16)
+    # ``True`` means ``cancel()`` can actively close an in-flight upstream
+    # response.  False is honest local cancellation only: the transport stops
+    # forwarding audio, but the provider request is allowed to finish.
+    upstream_cancellable: bool = False
 
     def __init__(self, tts_config: Dict, section: Dict):
         self.tts_config = tts_config
@@ -357,7 +361,67 @@ class StreamingTTSProvider(ABC):
         )
 
     def cancel(self) -> None:
-        """Best-effort interruption of an active provider stream."""
+        """Idempotent, thread-safe best-effort cancellation contract.
+
+        Non-cancellable adapters intentionally keep this as a no-op.  The
+        transport and caller still stop locally; they must not claim that the
+        remote request was interrupted.
+        """
+
+
+class _ResponseCancellationMixin:
+    """Close a public response handle safely across a streaming worker race."""
+
+    upstream_cancellable = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._response_lock = threading.Lock()
+        self._active_response = None
+        self._cancel_requested = False
+
+    def _begin_response(self) -> bool:
+        """Start one operation, preserving a cancellation that won a race."""
+        with self._response_lock:
+            # A cancelled provider instance is not reused for another request.
+            # This is intentional: callers cancel the whole speech session,
+            # and retaining the latch covers cancel-before-handle assignment.
+            return not self._cancel_requested
+
+    def _attach_response(self, response) -> bool:
+        """Publish *response* unless cancellation already won the race."""
+        with self._response_lock:
+            if self._cancel_requested:
+                close = True
+            else:
+                self._active_response = response
+                close = False
+        if close:
+            try:
+                response.close()
+            except Exception:
+                # SDK response types do not share a narrower close-error
+                # hierarchy; retain the unexpected adapter failure while
+                # cancellation itself remains non-raising.
+                logger.warning("Streaming provider response close failed", exc_info=True)
+            return False
+        return True
+
+    def _detach_response(self, response) -> None:
+        with self._response_lock:
+            if self._active_response is response:
+                self._active_response = None
+
+    def cancel(self) -> None:
+        """Set the latch and close the active public response at most once."""
+        with self._response_lock:
+            self._cancel_requested = True
+            response, self._active_response = self._active_response, None
+        if response is not None:
+            try:
+                response.close()
+            except Exception:
+                logger.warning("Streaming provider response close failed", exc_info=True)
 
 
 _REGISTRY: Dict[str, type[StreamingTTSProvider]] = {}
@@ -401,13 +465,21 @@ def resolve_streaming_provider(
     1. ``tts.streaming.provider`` (config knob) when set:
        * a provider name pins that exact streamer (or ``None`` if unusable);
        * ``auto`` walks the priority list (``elevenlabs → gemini → openai
-         → xai``) and returns the first usable streamer — an explicit
-         opt-in to "give me the best chunked voice available".
+         → xai → finite_fish``) and returns the first usable streamer — an
+         explicit opt-in to "give me the best chunked voice available".
+         ``finite_fish`` is a request-streaming S2 Pro adapter (streamed WAV
+         decoded to canonical PCM); its presence here does not claim that
+         Fish has passed Hermes' realtime qualification gates.
     2. Otherwise the *configured* TTS provider (or ``preferred`` override).
        ``None`` means "no chunked API for this provider" — the dispatcher
        then speaks per-sentence via the sync path, preserving the user's
        chosen voice. We never silently swap to a different provider just
-       to get streaming.
+       to get streaming. The gateway's ``hermes.audio.v1`` transport frames
+       every usable stream into 20 ms metadata-plus-binary PCM pairs; Desktop
+       plays those frames from one bounded, adaptive AudioWorklet clock. A
+       client stop/disconnect invokes the provider's best-effort ``cancel``
+       hook; provider/transport failure before audio starts degrades to the
+       existing whole-response fallback.
     """
     streaming_cfg = tts_config.get("streaming") or {}
     pinned = str(streaming_cfg.get("provider") or "").lower().strip()
@@ -433,6 +505,7 @@ class ElevenLabsStreamer(StreamingTTSProvider):
     """ElevenLabs chunked HTTP → pcm_24000 (the original reference path)."""
 
     sample_rate = 24000
+    upstream_cancellable = False
 
     @staticmethod
     def available() -> bool:
@@ -492,10 +565,11 @@ def _finite_fish_config_base_url() -> str:
 
 
 @register("openai")
-class OpenAIStreamer(StreamingTTSProvider):
+class OpenAIStreamer(_ResponseCancellationMixin, StreamingTTSProvider):
     """OpenAI speech with ``response_format=pcm`` (24 kHz mono int16)."""
 
     sample_rate = 24000
+    upstream_cancellable = True
 
     @staticmethod
     def available() -> bool:
@@ -503,6 +577,9 @@ class OpenAIStreamer(StreamingTTSProvider):
 
     def stream(self, text: str) -> Iterator[bytes]:
         from openai import OpenAI
+
+        if not self._begin_response():
+            return
 
         client = OpenAI(
             api_key=(self.section.get("api_key") or resolve_openai_audio_api_key()),
@@ -520,19 +597,20 @@ class OpenAIStreamer(StreamingTTSProvider):
             input=text,
             response_format="pcm",
         ) as response:
-            yield from _capped(response.iter_bytes(), "OpenAI streaming TTS")
+            if not self._attach_response(response):
+                return
+            try:
+                yield from _capped(response.iter_bytes(), "OpenAI streaming TTS")
+            finally:
+                self._detach_response(response)
 
 
 @register("finite_fish")
-class FiniteFishStreamer(StreamingTTSProvider):
+class FiniteFishStreamer(_ResponseCancellationMixin, StreamingTTSProvider):
     """Finite Fish S2 Pro streaming WAV, exposed as canonical raw PCM."""
 
     sample_rate = 44100
-
-    def __init__(self, tts_config: Dict, section: Dict):
-        super().__init__(tts_config, section)
-        self._response_lock = threading.Lock()
-        self._active_response = None
+    upstream_cancellable = True
 
     @staticmethod
     def available() -> bool:
@@ -540,6 +618,9 @@ class FiniteFishStreamer(StreamingTTSProvider):
 
     def stream(self, text: str) -> Iterator[bytes]:
         import requests
+
+        if not self._begin_response():
+            return
 
         api_key = str(
             self.section.get("api_key")
@@ -574,8 +655,8 @@ class FiniteFishStreamer(StreamingTTSProvider):
             stream=True,
             timeout=(10, 600),
         ) as response:
-            with self._response_lock:
-                self._active_response = response
+            if not self._attach_response(response):
+                return
             try:
                 response.raise_for_status()
                 content_type = response.headers.get("Content-Type", "").split(";", 1)[0]
@@ -592,15 +673,7 @@ class FiniteFishStreamer(StreamingTTSProvider):
                     _streaming_wav_pcm(chunks), "Finite Fish streaming TTS"
                 )
             finally:
-                with self._response_lock:
-                    if self._active_response is response:
-                        self._active_response = None
-
-    def cancel(self) -> None:
-        with self._response_lock:
-            response = self._active_response
-        if response is not None:
-            response.close()
+                self._detach_response(response)
 
 
 def _streaming_wav_pcm(chunks: Iterator[bytes]) -> Iterator[bytes]:
@@ -672,7 +745,7 @@ def _capped(chunks: Iterator[bytes], label: str) -> Iterator[bytes]:
 
 
 @register("gemini")
-class GeminiStreamer(StreamingTTSProvider):
+class GeminiStreamer(_ResponseCancellationMixin, StreamingTTSProvider):
     """Gemini ``streamGenerateContent?alt=sse`` → base64 PCM chunks (24 kHz).
 
     Salvaged from PR #47588 (@Cdddo) and rebased onto the post-campaign
@@ -681,6 +754,7 @@ class GeminiStreamer(StreamingTTSProvider):
     """
 
     sample_rate = 24000
+    upstream_cancellable = True
 
     @staticmethod
     def available() -> bool:
@@ -694,6 +768,9 @@ class GeminiStreamer(StreamingTTSProvider):
         import json as _json
 
         import requests
+
+        if not self._begin_response():
+            return
 
         from tools.tts_tool import (
             DEFAULT_GEMINI_TTS_BASE_URL,
@@ -736,24 +813,29 @@ class GeminiStreamer(StreamingTTSProvider):
                 timeout=60,
                 stream=True,
             ) as response:
-                response.raise_for_status()
-                for line in response.iter_lines(decode_unicode=True):
-                    if not line or not line.startswith("data: "):
-                        continue
-                    try:
-                        event = _json.loads(line[len("data: "):])
-                        parts = event["candidates"][0]["content"]["parts"]
-                    except (ValueError, KeyError, IndexError, TypeError):
-                        continue
-                    for part in parts:
-                        inline = part.get("inlineData") or part.get("inline_data") or {}
-                        b64 = inline.get("data", "")
-                        if not b64:
+                if not self._attach_response(response):
+                    return
+                try:
+                    response.raise_for_status()
+                    for line in response.iter_lines(decode_unicode=True):
+                        if not line or not line.startswith("data: "):
                             continue
                         try:
-                            yield base64.b64decode(b64)
-                        except (ValueError, TypeError) as exc:
-                            logger.warning("Gemini SSE: bad base64 audio: %s", exc)
+                            event = _json.loads(line[len("data: "):])
+                            parts = event["candidates"][0]["content"]["parts"]
+                        except (ValueError, KeyError, IndexError, TypeError):
+                            continue
+                        for part in parts:
+                            inline = part.get("inlineData") or part.get("inline_data") or {}
+                            b64 = inline.get("data", "")
+                            if not b64:
+                                continue
+                            try:
+                                yield base64.b64decode(b64)
+                            except (ValueError, TypeError) as exc:
+                                logger.warning("Gemini SSE: bad base64 audio: %s", exc)
+                finally:
+                    self._detach_response(response)
 
         yield from _capped(_sse_chunks(), "Gemini streaming TTS")
 
@@ -771,6 +853,7 @@ class XAIStreamer(StreamingTTSProvider):
     """
 
     sample_rate = 24000
+    upstream_cancellable = False
 
     @staticmethod
     def available() -> bool:

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -23,9 +23,12 @@ from __future__ import annotations
 
 import logging
 import re
+import struct
+import threading
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, Iterator, List, Optional
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, Iterator, List, Optional
 
 from tools.tool_backend_helpers import resolve_openai_audio_api_key
 from tools.tts_tool import _get_provider, _load_tts_config, get_env_value
@@ -37,6 +40,191 @@ logger = logging.getLogger(__name__)
 # providers (``_read_tts_response_bytes`` in tools.tts_tool): a buggy or
 # hostile endpoint must not be able to feed us unbounded audio.
 _STREAM_SENTENCE_BYTE_CAP = 16 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Provider-neutral PCM framing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AudioFormat:
+    """The only audio representation exchanged by streaming TTS providers.
+
+    Provider SDKs are allowed to chunk their response however they like, but
+    the gateway's hot path is deliberately narrower: mono, signed little
+    endian 16-bit PCM at a declared sample rate.  Keeping this as a value
+    object makes the validation explicit at the provider boundary and gives
+    frames a format to carry without relying on provider class attributes.
+    """
+
+    sample_rate: int = 24000
+    encoding: str = "pcm_s16le"
+    channels: int = 1
+    sample_width: int = 2
+
+    def __post_init__(self) -> None:
+        if self.encoding != "pcm_s16le":
+            raise ValueError("audio encoding must be pcm_s16le")
+        if self.channels != 1:
+            raise ValueError("canonical streaming audio must be mono")
+        if self.sample_width != 2:
+            raise ValueError("canonical streaming audio must use 16-bit samples")
+        if isinstance(self.sample_rate, bool) or self.sample_rate <= 0:
+            raise ValueError("sample_rate must be a positive integer")
+        if int(self.sample_rate) != self.sample_rate:
+            raise ValueError("sample_rate must be an integer")
+
+    @property
+    def bytes_per_sample(self) -> int:
+        return self.channels * self.sample_width
+
+    def validate_chunk(self, chunk: bytes) -> bytes:
+        """Return *chunk* as bytes, rejecting non-sample-aligned payloads."""
+        if not isinstance(chunk, (bytes, bytearray, memoryview)):
+            raise TypeError("audio chunks must be bytes-like")
+        payload = bytes(chunk)
+        if len(payload) % self.bytes_per_sample:
+            raise ValueError("audio chunk is not sample-aligned")
+        return payload
+
+
+@dataclass(frozen=True)
+class AudioFrame:
+    """A contiguous, loss-detectable unit of canonical PCM audio."""
+
+    seq: int
+    start_sample: int
+    pcm: bytes
+    format: AudioFormat
+
+    def __post_init__(self) -> None:
+        if self.seq < 0 or self.start_sample < 0:
+            raise ValueError("frame sequence and start_sample must be non-negative")
+        payload = self.format.validate_chunk(self.pcm)
+        object.__setattr__(self, "pcm", payload)
+
+    @property
+    def data(self) -> bytes:
+        """Alias used by transports that call binary frame data ``data``."""
+        return self.pcm
+
+    @property
+    def payload(self) -> bytes:
+        return self.pcm
+
+    @property
+    def samples(self) -> bytes:
+        return self.pcm
+
+    @property
+    def sample_count(self) -> int:
+        return len(self.pcm) // self.format.bytes_per_sample
+
+    @property
+    def sequence(self) -> int:
+        return self.seq
+
+    @property
+    def encoding(self) -> str:
+        return self.format.encoding
+
+    @property
+    def sample_rate(self) -> int:
+        return self.format.sample_rate
+
+    @property
+    def audio_format(self) -> AudioFormat:
+        return self.format
+
+    @property
+    def duration_ms(self) -> float:
+        return self.sample_count * 1000 / self.format.sample_rate
+
+
+class AudioFramer:
+    """Turn arbitrary sample-aligned PCM chunks into fixed-duration frames."""
+
+    def __init__(self, audio_format: AudioFormat, frame_ms: int = 20):
+        if isinstance(frame_ms, bool) or frame_ms <= 0:
+            raise ValueError("frame_ms must be a positive integer")
+        if int(frame_ms) != frame_ms:
+            raise ValueError("frame_ms must be an integer")
+        frame_samples, remainder = divmod(
+            audio_format.sample_rate * int(frame_ms), 1000
+        )
+        if remainder:
+            raise ValueError("frame_ms does not map to whole samples at this rate")
+        self.audio_format = audio_format
+        self.frame_ms = int(frame_ms)
+        self.frame_samples = frame_samples
+        self._buffer = bytearray()
+        self._next_seq = 0
+        self._next_start_sample = 0
+        self._closed = False
+
+    @property
+    def next_seq(self) -> int:
+        return self._next_seq
+
+    @property
+    def next_start_sample(self) -> int:
+        return self._next_start_sample
+
+    def feed(self, chunk: bytes) -> List[AudioFrame]:
+        """Consume one provider chunk and return every complete frame ready."""
+        if self._closed:
+            raise RuntimeError("audio framer is already flushed")
+        if not isinstance(chunk, (bytes, bytearray, memoryview)):
+            raise TypeError("audio chunks must be bytes-like")
+        # HTTP/SDK chunk boundaries are transport details and may split an
+        # int16 sample. Preserve that byte until the next chunk; only the
+        # completed stream is required to be sample-aligned.
+        payload = bytes(chunk)
+        self._buffer.extend(payload)
+        frame_bytes = self.frame_samples * self.audio_format.bytes_per_sample
+        out: List[AudioFrame] = []
+        while len(self._buffer) >= frame_bytes:
+            pcm = bytes(self._buffer[:frame_bytes])
+            del self._buffer[:frame_bytes]
+            out.append(self._make_frame(pcm))
+        return out
+
+    # ``push`` is intentionally an alias: provider adapters often use that
+    # spelling while the gateway tests/readme use ``feed``.
+    push = feed
+
+    def flush(self) -> List[AudioFrame]:
+        """Emit one final partial frame, if any, and close the framer."""
+        if self._closed:
+            return []
+        self._closed = True
+        if not self._buffer:
+            return []
+        if len(self._buffer) % self.audio_format.bytes_per_sample:
+            raise ValueError("audio stream ended with a partial sample")
+        pcm = bytes(self._buffer)
+        self._buffer.clear()
+        return [self._make_frame(pcm)]
+
+    finish = flush
+
+    def frames(self, chunks: Iterable[bytes]) -> Iterator[AudioFrame]:
+        """Yield framed audio for *chunks*, including the final partial frame."""
+        for chunk in chunks:
+            yield from self.feed(chunk)
+        yield from self.flush()
+
+    def _make_frame(self, pcm: bytes) -> AudioFrame:
+        frame = AudioFrame(
+            seq=self._next_seq,
+            start_sample=self._next_start_sample,
+            pcm=pcm,
+            format=self.audio_format,
+        )
+        self._next_seq += 1
+        self._next_start_sample += frame.sample_count
+        return frame
 
 
 def _resolve_key(env_var: str, provider_id: str) -> str:
@@ -139,6 +327,19 @@ class StreamingTTSProvider(ABC):
         self.tts_config = tts_config
         self.section = section
 
+    @property
+    def audio_format(self) -> AudioFormat:
+        """Declared canonical format for this provider's raw stream."""
+        return AudioFormat(
+            sample_rate=self.sample_rate,
+            channels=self.channels,
+            sample_width=self.sample_width,
+        )
+
+    @property
+    def canonical_format(self) -> AudioFormat:
+        return self.audio_format
+
     @staticmethod
     @abstractmethod
     def available() -> bool:
@@ -147,6 +348,15 @@ class StreamingTTSProvider(ABC):
     @abstractmethod
     def stream(self, text: str) -> Iterator[bytes]:
         """Yield PCM chunks for ``text``. Raise on failure (caller logs)."""
+
+    def stream_frames(self, text: str, frame_ms: int = 20) -> Iterator[AudioFrame]:
+        """Adapt the legacy byte iterator to the provider-neutral frame stream."""
+        yield from AudioFramer(self.audio_format, frame_ms=frame_ms).frames(
+            self.stream(text)
+        )
+
+    def cancel(self) -> None:
+        """Best-effort interruption of an active provider stream."""
 
 
 _REGISTRY: Dict[str, type[StreamingTTSProvider]] = {}
@@ -176,7 +386,7 @@ def _try_instantiate(name: str, tts_config: Dict) -> Optional[StreamingTTSProvid
 # latency/quality first. Deliberately hard-coded (a UX decision, not a
 # config knob); edge is absent because it has no chunked-PCM API — the
 # dispatcher's per-sentence sync path keeps it conversational instead.
-_PROVIDER_PRIORITY: List[str] = ["elevenlabs", "gemini", "openai", "xai"]
+_PROVIDER_PRIORITY: List[str] = ["elevenlabs", "gemini", "openai", "xai", "finite_fish"]
 
 
 def resolve_streaming_provider(
@@ -261,6 +471,25 @@ def _openai_config_api_key() -> str:
     return openai_cfg.get("api_key") or ""
 
 
+def _finite_fish_config_api_key() -> str:
+    """Return the explicitly configured Finite Fish streaming credential."""
+    try:
+        section = (_load_tts_config().get("finite_fish") or {})
+    except Exception:
+        return ""
+    return str(
+        section.get("api_key") or _resolve_key("FINITE_TTS_API_KEY", "finite_fish") or ""
+    ).strip()
+
+
+def _finite_fish_config_base_url() -> str:
+    try:
+        section = (_load_tts_config().get("finite_fish") or {})
+    except Exception:
+        return ""
+    return str(section.get("base_url") or get_env_value("FINITE_TTS_BASE_URL") or "").strip()
+
+
 @register("openai")
 class OpenAIStreamer(StreamingTTSProvider):
     """OpenAI speech with ``response_format=pcm`` (24 kHz mono int16)."""
@@ -291,6 +520,137 @@ class OpenAIStreamer(StreamingTTSProvider):
             response_format="pcm",
         ) as response:
             yield from _capped(response.iter_bytes(), "OpenAI streaming TTS")
+
+
+@register("finite_fish")
+class FiniteFishStreamer(StreamingTTSProvider):
+    """Finite Fish S2 Pro streaming WAV, exposed as canonical raw PCM."""
+
+    sample_rate = 44100
+
+    def __init__(self, tts_config: Dict, section: Dict):
+        super().__init__(tts_config, section)
+        self._response_lock = threading.Lock()
+        self._active_response = None
+
+    @staticmethod
+    def available() -> bool:
+        return bool(_finite_fish_config_api_key() and _finite_fish_config_base_url())
+
+    def stream(self, text: str) -> Iterator[bytes]:
+        import requests
+
+        api_key = str(
+            self.section.get("api_key")
+            or _finite_fish_config_api_key()
+            or _resolve_key("FINITE_TTS_API_KEY", "finite_fish")
+            or ""
+        ).strip()
+        base_url = str(
+            self.section.get("base_url") or _finite_fish_config_base_url()
+        ).strip().rstrip("/")
+        if not api_key or not base_url:
+            raise RuntimeError(
+                "Finite Fish streaming TTS requires api_key and base_url"
+            )
+        if not re.match(r"^https?://[^/\s]+", base_url, flags=re.IGNORECASE):
+            raise RuntimeError("Finite Fish streaming TTS base_url must be http(s)")
+        payload = {
+            "model": str(self.section.get("model") or "fishaudio-s2-pro-tts"),
+            "voice": str(self.section.get("voice") or "default"),
+            "input": text,
+            "response_format": "wav",
+            "stream": True,
+            "stream_format": "audio",
+        }
+        with requests.post(
+            f"{base_url}/audio/speech",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Accept": "audio/wav",
+            },
+            json=payload,
+            stream=True,
+            timeout=(10, 600),
+        ) as response:
+            with self._response_lock:
+                self._active_response = response
+            try:
+                response.raise_for_status()
+                content_type = response.headers.get("Content-Type", "").split(";", 1)[0]
+                if content_type.lower() != "audio/wav":
+                    raise RuntimeError(
+                        f"Finite Fish returned {content_type or 'no content type'}"
+                    )
+                chunks = (
+                    chunk
+                    for chunk in response.iter_content(chunk_size=8192)
+                    if chunk
+                )
+                yield from _capped(
+                    _streaming_wav_pcm(chunks), "Finite Fish streaming TTS"
+                )
+            finally:
+                with self._response_lock:
+                    if self._active_response is response:
+                        self._active_response = None
+
+    def cancel(self) -> None:
+        with self._response_lock:
+            response = self._active_response
+        if response is not None:
+            response.close()
+
+
+def _streaming_wav_pcm(chunks: Iterator[bytes]) -> Iterator[bytes]:
+    """Validate Fish's streamed WAV header, then yield aligned PCM payload."""
+
+    def payloads() -> Iterator[bytes]:
+        prefix = b""
+        for chunk in chunks:
+            prefix += chunk
+            if len(prefix) > 64 * 1024:
+                raise RuntimeError("Finite Fish WAV header exceeded 64 KiB")
+            if len(prefix) < 44:
+                continue
+            if (
+                prefix[:4] != b"RIFF"
+                or prefix[8:12] != b"WAVE"
+                or prefix[12:16] != b"fmt "
+            ):
+                raise RuntimeError("Finite Fish returned an invalid WAV stream")
+            audio_format, channels, sample_rate, byte_rate, block_align, bits = (
+                struct.unpack_from("<HHIIHH", prefix, 20)
+            )
+            data_at = prefix.find(b"data", 36)
+            if data_at < 0 or data_at + 8 > len(prefix):
+                continue
+            if (
+                audio_format != 1
+                or channels != 1
+                or sample_rate != 44100
+                or bits != 16
+                or byte_rate != sample_rate * 2
+                or block_align != 2
+            ):
+                raise RuntimeError("Finite Fish returned an incompatible WAV stream")
+            pcm = prefix[data_at + 8 :]
+            if pcm:
+                yield pcm
+            break
+        else:
+            raise RuntimeError("Finite Fish returned a truncated WAV stream")
+        yield from chunks
+
+    carry = b""
+    for payload in payloads():
+        payload = carry + payload
+        aligned = len(payload) - len(payload) % 2
+        if aligned:
+            yield payload[:aligned]
+        carry = payload[aligned:]
+    if carry:
+        raise RuntimeError("Finite Fish returned a partial PCM sample")
 
 
 def _capped(chunks: Iterator[bytes], label: str) -> Iterator[bytes]:

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -74,6 +74,7 @@ class AudioFormat:
             raise ValueError("sample_rate must be a positive integer")
         if int(self.sample_rate) != self.sample_rate:
             raise ValueError("sample_rate must be an integer")
+        object.__setattr__(self, "sample_rate", int(self.sample_rate))
 
     @property
     def bytes_per_sample(self) -> int:

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -609,7 +609,7 @@ class OpenAIStreamer(_ResponseCancellationMixin, StreamingTTSProvider):
 class FiniteFishStreamer(_ResponseCancellationMixin, StreamingTTSProvider):
     """Finite Fish S2 Pro streaming WAV, exposed as canonical raw PCM."""
 
-    sample_rate = 44100
+    sample_rate = 24000
     upstream_cancellable = True
 
     @staticmethod
@@ -638,11 +638,14 @@ class FiniteFishStreamer(_ResponseCancellationMixin, StreamingTTSProvider):
         if not re.match(r"^https?://[^/\s]+", base_url, flags=re.IGNORECASE):
             raise RuntimeError("Finite Fish streaming TTS base_url must be http(s)")
         payload = {
-            "model": str(self.section.get("model") or "fishaudio-s2-pro-tts"),
+            "model": str(self.section.get("model") or "kokoro-82m-tts"),
             "voice": str(self.section.get("voice") or "default"),
             "input": text,
             "response_format": "wav",
-            "stream": True,
+            # The provider still relays the HTTP body incrementally. Keeping the
+            # OpenAI payload non-streaming selects the artifact-capacity lane at
+            # front doors that distinguish model streams from chunked audio.
+            "stream": bool(self.section.get("request_stream", False)),
             "stream_format": "audio",
         }
         with requests.post(
@@ -702,7 +705,7 @@ def _streaming_wav_pcm(chunks: Iterator[bytes]) -> Iterator[bytes]:
             if (
                 audio_format != 1
                 or channels != 1
-                or sample_rate != 44100
+                or sample_rate != 24000
                 or bits != 16
                 or byte_rate != sample_rate * 2
                 or block_align != 2

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3373,6 +3373,30 @@ def stream_tts_to_speaker(
     """
     tts_done_event.clear()
 
+    streamer = None
+    cancel_watcher_stop = None
+    cancel_invoked = threading.Event()
+    cancel_lock = threading.Lock()
+
+    def _invoke_streamer_cancel() -> None:
+        """Invoke an adapter's idempotent cancel hook once per speaker run."""
+        nonlocal streamer
+        if streamer is None:
+            return
+        with cancel_lock:
+            if cancel_invoked.is_set():
+                return
+            cancel_invoked.set()
+        cancel = getattr(streamer, "cancel", None)
+        if callable(cancel):
+            try:
+                cancel()
+            except Exception:
+                # Adapter cancellation is contractually non-raising, so an
+                # exception here is an unexpected provider bug worth retaining
+                # in operational logs even though barge-in must still proceed.
+                logger.warning("Streaming TTS cancellation failed", exc_info=True)
+
     try:
         output_stream = None
         tts_config = _load_tts_config()
@@ -3381,6 +3405,21 @@ def stream_tts_to_speaker(
         # per-sentence sync synthesis (universal — edge + every non-streamer).
         from tools.tts_streaming import SentenceChunker, resolve_streaming_provider
         streamer = resolve_streaming_provider(tts_config, preferred=provider)
+
+        # Stop can arrive from another thread while a provider is blocked in
+        # its network iterator. Bridge that event to the adapter's
+        # cross-thread cancellation hook; non-cancellable adapters still stop
+        # locally and simply leave the upstream request running.
+        if streamer is not None:
+            cancel_watcher_stop = threading.Event()
+
+            def _cancel_on_stop() -> None:
+                while not cancel_watcher_stop.wait(0.05):
+                    if stop_event.is_set():
+                        _invoke_streamer_cancel()
+                        return
+
+            threading.Thread(target=_cancel_on_stop, daemon=True).start()
 
         stream_max_len = 0
         if streamer is not None:
@@ -3515,6 +3554,10 @@ def stream_tts_to_speaker(
                 # os.unlink() below (WinError 32, swallowed → temp .wav files
                 # pile up).  Release the handle before playback and cleanup.
                 tmp.close()
+                # Barge-in while buffering must never turn a partial WAV into
+                # audible output. Cleanup still runs in the finally block.
+                if stop_evt.is_set():
+                    return
                 from tools.voice_mode import play_audio_file
                 play_audio_file(tmp_path)
             except Exception as exc:
@@ -3563,6 +3606,10 @@ def stream_tts_to_speaker(
     except Exception as exc:
         logger.warning("Streaming TTS pipeline error: %s", exc)
     finally:
+        if cancel_watcher_stop is not None:
+            cancel_watcher_stop.set()
+        if stop_event.is_set():
+            _invoke_streamer_cancel()
         # Always close the audio output stream to avoid locking the device
         if output_stream is not None:
             try:


### PR DESCRIPTION
Closes #75029
Tracks #75030, #75031, #75032, and #75033.

## Summary
- add the versioned provider-neutral `hermes.audio.v1` PCM frame contract
- normalize arbitrary provider chunks into loss-detectable 20 ms frames
- replace per-network-chunk scheduling with bounded adaptive AudioWorklet playout
- cover v1 and legacy WebSocket playback, terminal drain, underrun recovery, and ordering
- make upstream cancellation an explicit adapter capability and fail v1 closed before start for non-cancellable adapters
- close OpenAI, Gemini, and Fish response handles on barge-in; stop partial tempfile replay
- add Fish S2 Pro as a request-streaming adapter without claiming realtime admission

## Verification
- 77 focused Python tests passed
- 16 focused Desktop Vitest tests passed
- Desktop TypeScript typecheck passed
- packaged Desktop build passed; AudioWorklet staged under `dist/audio-worklet`
- independent Luna-high standards review: clean
- independent Luna-high spec review: Hermes transport/playout implementation clean
- local CodeRabbit: all worthy findings across initial and follow-up rounds addressed

## Qualification and release boundary
The generic measurement probe landed separately in finitecomputer/spark-cluster#218. Raw Fish transport returned a valid incremental WAV stream, but measured total RTF was about 2.02, steady RTF about 1.95, and max inter-chunk gap about 2.31 seconds. A fresh authenticated public-front-door probe returned HTTP 429.

Accordingly this PR claims provider-neutral request streaming and smooth continuous playout infrastructure only. Fish is not realtime-qualified or canonically promoted; #75033 remains the qualification/live-release tracking slice.