### PR TITLE
fix(desktop): preserve UI scale across hash-route navigation

### DIFF
--- a/apps/desktop/e2e/zoom-preservation.spec.ts
+++ b/apps/desktop/e2e/zoom-preservation.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * E2E regression: hash-route navigation must preserve the chosen UI scale.
+ *
+ * Electron resets file:// zoom to level 0 during in-page hash navigation on
+ * macOS. Cmd+N moves Hermes from the current route to a fresh chat route, so
+ * this exercises the exact user path rather than calling the zoom helper.
+ *
+ * Prerequisite: `npm run build` must have been run so dist/ exists.
+ */
+
+import { expect, test } from './test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+
+let fixture: MockBackendFixture | null = null
+
+async function readZoomPercent(): Promise<number> {
+  return fixture!.page.evaluate(async () => {
+    const desktop = window as unknown as {
+      hermesDesktop: { zoom: { get: () => Promise<{ percent: number }> } }
+    }
+
+    return (await desktop.hermesDesktop.zoom.get()).percent
+  })
+}
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('Cmd+N preserves a non-default UI scale', async () => {
+  const page = fixture!.page
+
+  await page.evaluate(() => {
+    window.location.hash = '/settings'
+  })
+  await page.waitForFunction(() => window.location.hash === '#/settings')
+
+  await page.evaluate(() => {
+    const desktop = window as unknown as {
+      hermesDesktop: { zoom: { setPercent: (percent: number) => void } }
+    }
+
+    desktop.hermesDesktop.zoom.setPercent(110)
+  })
+  await expect.poll(readZoomPercent).toBe(110)
+
+  await page.evaluate(() => {
+    ;(document.activeElement as HTMLElement | null)?.blur()
+  })
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+N' : 'Control+N')
+  await page.waitForFunction(() => window.location.hash === '#/')
+
+  await expect.poll(readZoomPercent).toBe(110)
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5426,6 +5426,7 @@ function installPreviewShortcut(window) {
 import {
   applyZoomLevel,
   DEFAULT_ZOOM_LEVEL,
+  installZoomReassertOnNavigation,
   installZoomReassertOnWindowEvents,
   percentToZoomLevel,
   ZOOM_STEP,
@@ -8610,13 +8611,14 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
   if (zoom) {
     installZoomShortcuts(win)
     // Re-apply persisted zoom on show/restore/resize/cross-display move
-    // (Chromium can drop webContents zoom after these window transitions) and
-    // on EVERY full load — not once. The crash-recovery path calls
-    // webContents.reload(), which fires did-finish-load again after a `once`
-    // listener is spent, so zoom was silently lost on renderer crash
-    // recovery and any in-place reload/navigation (#46429).
-    installZoomReassertOnWindowEvents(win, () => restorePersistedZoomLevel(win))
-    win.webContents.on('did-finish-load', () => restorePersistedZoomLevel(win))
+    // (Chromium can drop webContents zoom after these window transitions), on
+    // EVERY full load, and after hash-route navigation. Packaged Desktop uses
+    // file:// hash routes; Chromium resets those to zoom level 0 on macOS, so
+    // actions such as Cmd+N otherwise snap the UI back to 100%.
+    const reassertZoom = () => restorePersistedZoomLevel(win)
+
+    installZoomReassertOnWindowEvents(win, reassertZoom)
+    installZoomReassertOnNavigation(win.webContents, reassertZoom)
   }
 
   installContextMenu(win)

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -12,6 +12,7 @@ import {
   applyZoomLevel,
   clampZoomLevel,
   DEFAULT_ZOOM_LEVEL,
+  installZoomReassertOnNavigation,
   installZoomReassertOnWindowEvents,
   percentToZoomLevel,
   ZOOM_RESIZE_REASSERT_DELAY_MS,
@@ -160,6 +161,34 @@ test('installZoomReassertOnWindowEvents skips destroyed windows', () => {
   destroyed = true
   handlers.get('show')()
   assert.equal(calls, 0)
+})
+
+test('installZoomReassertOnNavigation covers full loads and main-frame in-page routes', () => {
+  const handlers = new Map()
+  let destroyed = false
+  let calls = 0
+
+  const webContents = {
+    isDestroyed: () => destroyed,
+    on(event, listener) {
+      handlers.set(event, listener)
+    }
+  }
+
+  installZoomReassertOnNavigation(webContents, () => {
+    calls += 1
+  })
+
+  assert.deepEqual([...handlers.keys()], ['did-finish-load', 'did-navigate-in-page'])
+
+  handlers.get('did-finish-load')()
+  handlers.get('did-navigate-in-page')({}, 'file:///app/index.html#/new', true)
+  handlers.get('did-navigate-in-page')({}, 'file:///app/frame.html#anchor', false)
+  assert.equal(calls, 2)
+
+  destroyed = true
+  handlers.get('did-navigate-in-page')({}, 'file:///app/index.html#/session/next', true)
+  assert.equal(calls, 2)
 })
 
 // Zoom-wiring contract: chat windows keep global UI zoom, the pet overlay

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -98,6 +98,31 @@ export function installZoomReassertOnWindowEvents(win, reassert, platform = proc
 }
 
 /**
+ * Chromium resets file:// zoom to level 0 on hash-route navigation on macOS.
+ * Hermes Desktop uses hash routes, so ordinary actions such as Cmd+N emit
+ * `did-navigate-in-page` without a full load. Re-assert after both navigation
+ * shapes; subframe hash changes must not touch the chat window's UI scale.
+ */
+export function installZoomReassertOnNavigation(webContents, reassert) {
+  if (!webContents?.on) {
+    return
+  }
+
+  const reassertIfAlive = () => {
+    if (!webContents.isDestroyed?.()) {
+      reassert()
+    }
+  }
+
+  webContents.on('did-finish-load', reassertIfAlive)
+  webContents.on('did-navigate-in-page', (_event, _url, isMainFrame) => {
+    if (isMainFrame) {
+      reassertIfAlive()
+    }
+  })
+}
+
+/**
  * Zoom-wiring decision per window kind. Chat windows (main + session) keep
  * global UI zoom; the pet overlay and the Quick Entry composer opt out because
  * they size their own OS window and inheriting zoom would crop/overflow them.


### PR DESCRIPTION
## Bug Description

Desktop UI scale can reset to 100% when an action changes the in-page hash route. One visible path is Cmd/Ctrl+N from Settings after selecting a non-default scale.

Fixes #38854
Fixes #48658

Related: #38908, #43517, #66989

## Root Cause

Packaged Desktop loads the renderer from a `file://` URL and uses hash routing. Electron can reset `webContents` zoom to level 0 during main-frame hash navigation. The existing `did-finish-load` restoration does not run for these in-page navigations.

## Fix

- Reapply the persisted zoom level after main-frame `did-navigate-in-page` events.
- Retain the existing full-load and window-lifecycle restoration paths.
- Ignore subframe navigation and destroyed `webContents`.
- Add unit coverage for the navigation lifecycle and an Electron E2E for the Cmd/Ctrl+N path.

## Scope

This change addresses resets caused by main-frame hash navigation. Startup persistence and renderer-state synchronization remain separate zoom paths and are unchanged by this PR.

## How to Verify

1. Open Settings → Appearance and choose 110% UI Scale.
2. Press Cmd+N on macOS or Ctrl+N on Windows/Linux.
3. Confirm the fresh chat opens and UI Scale remains 110%.

## Test Plan

- [x] Regression test fails on the parent commit: expected 110%, received 100%.
- [x] Regression test passes on the candidate commit.
- [x] Desktop Electron suite: 868 passed, 2 skipped.
- [x] TypeScript typecheck passes.
- [x] ESLint reports 0 errors.
- [x] Clean macOS arm64 package build from Electron 40.10.2.
- [x] Credential-free sandbox tests across 90%, 110%, and 125%; repeated hash routes, Cmd+N, reload, resize, hide/show, and app relaunch.
- [x] Live configuration and session state remain unchanged by sandbox tests.

## Risk Assessment

Low — the production change only reasserts the already-persisted zoom level after a main-frame navigation event. Existing clamping, persistence, renderer notification, and window-specific wiring remain unchanged.
