### PR TITLE
feat(dashboard): add HERMES_DASHBOARD_EXTRA_HOSTS for reverse-proxy / tunnel WS Origin acceptance

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -461,6 +461,22 @@ def should_require_auth(host: str, allow_public: bool = False) -> bool:
     return host not in _LOOPBACK_HOST_VALUES
 
 
+def _extra_accepted_hosts() -> frozenset:
+    """Hostnames accepted in addition to the bound host (operator opt-in).
+
+    ``HERMES_DASHBOARD_EXTRA_HOSTS`` is a comma-separated list of hostnames
+    the operator explicitly trusts: the public name of a reverse proxy or
+    tunnel (nginx, Tailscale Serve, Cloudflare Tunnel) in front of a
+    loopback-bound dashboard. The proxy rewrites the ``Host`` header, but a
+    browser sets the WebSocket ``Origin`` header to the public hostname and
+    no proxy can rewrite it — so WS upgrades are refused without this
+    opt-in (see #70059). Read per call so long-lived processes and tests
+    see changes without a restart.
+    """
+    raw = os.environ.get("HERMES_DASHBOARD_EXTRA_HOSTS", "")
+    return frozenset(h.strip().lower() for h in raw.split(",") if h.strip())
+
+
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     """True if the Host header targets the interface we bound to.
 
@@ -489,6 +505,11 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     else:
         host_only = h.rsplit(":", 1)[0] if ":" in h else h
     host_only = host_only.lower()
+
+    # Operator-trusted extra hostnames (reverse proxy / tunnel fronting a
+    # loopback bind) — see _extra_accepted_hosts.
+    if host_only in _extra_accepted_hosts():
+        return True
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -137,3 +137,53 @@ class TestWebSocketHostOriginGuard:
             },
         ):
             pass
+
+class TestExtraAcceptedHosts:
+    """HERMES_DASHBOARD_EXTRA_HOSTS — operator-trusted reverse-proxy /
+    tunnel hostnames in front of a loopback bind (#70059).
+
+    The proxy rewrites the Host header, but the browser-set WebSocket
+    Origin header carries the public hostname and cannot be rewritten by
+    any proxy — without this opt-in every WS upgrade is refused with
+    ``origin_mismatch``."""
+
+    def test_extra_host_accepted_on_loopback_bind(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv("HERMES_DASHBOARD_EXTRA_HOSTS", "atlas.example.com")
+        assert _is_accepted_host("atlas.example.com", "127.0.0.1")
+        assert _is_accepted_host("atlas.example.com:9119", "127.0.0.1")
+        # Case-insensitive, like every other host comparison here
+        assert _is_accepted_host("Atlas.Example.COM", "127.0.0.1")
+
+    def test_other_hosts_still_rejected(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv("HERMES_DASHBOARD_EXTRA_HOSTS", "atlas.example.com")
+        assert not _is_accepted_host("evil.example", "127.0.0.1")
+        # Loopback aliases keep working on a loopback bind
+        assert _is_accepted_host("localhost:9119", "127.0.0.1")
+
+    def test_unset_env_keeps_strict_behaviour(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.delenv("HERMES_DASHBOARD_EXTRA_HOSTS", raising=False)
+        assert not _is_accepted_host("atlas.example.com", "127.0.0.1")
+
+    def test_comma_separated_list_with_whitespace(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_EXTRA_HOSTS",
+            " atlas.example.com , hermes.tail1234.ts.net ",
+        )
+        assert _is_accepted_host("atlas.example.com", "127.0.0.1")
+        assert _is_accepted_host("hermes.tail1234.ts.net", "127.0.0.1")
+        assert not _is_accepted_host("other.example.com", "127.0.0.1")
+
+    def test_empty_entries_ignored(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setenv("HERMES_DASHBOARD_EXTRA_HOSTS", " , ,")
+        assert not _is_accepted_host("", "127.0.0.1")
+        assert not _is_accepted_host("evil.example", "127.0.0.1")


### PR DESCRIPTION
## Summary

Closes #70059. Related: #54072, #50365.

Behind a reverse proxy or tunnel (nginx, Tailscale Serve, Cloudflare Tunnel) fronting a **loopback-bound** dashboard, HTTP works because the proxy rewrites the `Host` header — but the browser-set WebSocket `Origin` header carries the public hostname and **cannot be rewritten by any proxy** (it's a browser security header). `_is_accepted_host()` then refuses every WS upgrade:

```
pty refused: origin_mismatch origin=https://<proxy-hostname> bound=127.0.0.1
```

breaking chat, the events feed and the PTY, while the SPA itself loads fine.

## Change

Adds the operator opt-in proposed in #70059:

```bash
HERMES_DASHBOARD_EXTRA_HOSTS=atlas.example.com,hermes.tail1234.ts.net
```

- Comma-separated hostnames, case-insensitive, port-suffix tolerated — accepted **in addition to** the bound host in `_is_accepted_host()` (covers both the HTTP Host middleware and the WS Host/Origin guard, which share this helper).
- **Unset (default): behaviour is unchanged** — strict loopback/bound-host matching.
- Unlisted origins and DNS-rebinding Hosts are still rejected; this does not touch auth (`_ws_auth_ok`) or the loopback peer gate.
- Read per call, so tests and long-lived processes see changes without a restart.

## Testing

- 5 new unit tests in `tests/hermes_cli/test_web_server_host_header.py` (`TestExtraAcceptedHosts`): accept-on-loopback-bind (incl. port + case), unlisted-host rejection, unset-env strictness, comma-list with whitespace, empty-entry handling.
- `pytest tests/hermes_cli/test_web_server_host_header.py` → **11 passed** (6 pre-existing + 5 new).
- Verified live on a production instance (Hermes v0.19.0, Cloudflare Tunnel + CF Access → `127.0.0.1:9119`, env set via systemd drop-in): dashboard chat / events feed / PTY connect again; foreign origins still refused.