### PR TITLE
fix(gateway): emit silent lifecycle activity without progress bubbles

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5302,6 +5302,15 @@ class BasePlatformAdapter(ABC):
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Hook called when background processing begins."""
 
+    async def on_processing_activity(
+        self,
+        source: SessionSource,
+        message_id: str,
+        event_type: str,
+        tool_name: Optional[str] = None,
+    ) -> None:
+        """Hook called when the active reasoning/tool state changes."""
+
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3839,6 +3839,24 @@ class TurnRunner:
                     ctx._live_status_adapter.set_status_text(ctx.source.chat_id, None)
             except Exception as _ls_err:
                 logger.debug("live status update failed: %s", _ls_err)
+
+        # Platform lifecycle reactions/status are independent of visible
+        # progress messages. Adapters can reflect state without creating a
+        # second chat surface or notification.
+        if ctx._activity_enabled and ctx._run_still_current():
+            safe_schedule_threadsafe(
+                ctx._activity_adapter._run_processing_hook(
+                    "on_processing_activity",
+                    ctx.source,
+                    ctx.event_message_id,
+                    event_type,
+                    tool_name,
+                ),
+                ctx._activity_loop,
+                logger=logger,
+                log_message="processing activity hook scheduling error",
+            )
+
         # "log" mode: append tool.started lines to the log queue and stay
         # silent in chat. Handled before the progress_queue guard because
         # log mode runs without a chat progress queue.
@@ -5042,6 +5060,7 @@ class TurnRunner:
                 ctx.needs_progress_queue
                 or ctx.log_mode_enabled
                 or ctx._live_status_adapter is not None
+                or ctx._activity_enabled
             )
             else None
         )
@@ -25577,6 +25596,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _cleanup_progress = False
             _cleanup_adapter = None
         _cleanup_msg_ids: List[str] = []
+        _activity_adapter = self._adapter_for_source(source)
+        # Activity hooks target the original inbound message. A turn without
+        # that platform reference has no safe status surface and remains a no-op.
+        _activity_enabled = bool(
+            _activity_adapter is not None
+            and event_message_id
+            and type(_activity_adapter).on_processing_activity
+            is not BasePlatformAdapter.on_processing_activity
+        )
+        _activity_loop = asyncio.get_running_loop()
         # First-touch onboarding latch: fires at most once per run, even if
         # several tools exceed the threshold.
         long_tool_hint_fired = [False]
@@ -25587,6 +25616,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _run_still_current=_run_still_current,
             _live_status_adapter=_live_status_adapter,
             _live_status_mode=_live_status_mode,
+            _activity_adapter=_activity_adapter,
+            _activity_enabled=_activity_enabled,
+            _activity_loop=_activity_loop,
             _thinking_enabled=_thinking_enabled,
             progress_mode=progress_mode,
             progress_grouping=progress_grouping,

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -38,6 +38,9 @@ class TurnContext:
     _run_still_current: Callable[[], bool] = None  # type: ignore[assignment]
     _live_status_adapter: Any = None
     _live_status_mode: str = "off"
+    _activity_adapter: Any = None
+    _activity_enabled: bool = False
+    _activity_loop: Any = None
     _thinking_enabled: bool = False
     progress_mode: str = "off"
     progress_grouping: str = "grouped"

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9934,28 +9934,41 @@ class TelegramAdapter(BasePlatformAdapter):
             lock = self._processing_reactions_lock = asyncio.Lock()
         return lock
 
-    async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
+    async def _set_reaction(
+        self,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+        *,
+        retain_state: bool = True,
+    ) -> bool:
         """Set one reaction, skipping duplicate state updates."""
-        if not self._bot:
-            return False
         key = (str(chat_id), str(message_id))
         async with self._reaction_update_lock():
             states = getattr(self, "_processing_reactions", None)
             if states is None:
                 states = self._processing_reactions = {}
             if states.get(key) == emoji:
+                if not retain_state:
+                    states.pop(key, None)
                 return True
             try:
+                if not self._bot:
+                    return False
                 await self._bot.set_message_reaction(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     reaction=emoji,
                 )
-                states[key] = emoji
+                if retain_state:
+                    states[key] = emoji
                 return True
             except Exception as e:
                 logger.debug("[%s] set_message_reaction failed (%s): %s", self.name, emoji, _redact_telegram_error_text(e))
                 return False
+            finally:
+                if not retain_state:
+                    states.pop(key, None)
 
     async def _clear_reactions(self, chat_id: str, message_id: str) -> bool:
         """Clear all reactions from a Telegram message.
@@ -9965,22 +9978,24 @@ class TelegramAdapter(BasePlatformAdapter):
         reactions on a message — equivalent to Bot API 10.0's
         ``deleteMessageReaction`` but supported in PTB 22.6 already.
         """
-        if not self._bot:
-            return False
+        key = (str(chat_id), str(message_id))
         async with self._reaction_update_lock():
             try:
+                if not self._bot:
+                    return False
                 await self._bot.set_message_reaction(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     reaction=None,
                 )
-                states = getattr(self, "_processing_reactions", None)
-                if states is not None:
-                    states.pop((str(chat_id), str(message_id)), None)
                 return True
             except Exception as e:
                 logger.debug("[%s] clear reactions failed: %s", self.name, _redact_telegram_error_text(e))
                 return False
+            finally:
+                states = getattr(self, "_processing_reactions", None)
+                if states is not None:
+                    states.pop(key, None)
 
     async def on_processing_activity(
         self,
@@ -10046,6 +10061,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 chat_id,
                 message_id,
                 "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
+                retain_state=False,
             )
 
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9927,20 +9927,35 @@ class TelegramAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
 
+    def _reaction_update_lock(self) -> asyncio.Lock:
+        """Serialize reaction updates so cache and Telegram stay in sync."""
+        lock = getattr(self, "_processing_reactions_lock", None)
+        if lock is None:
+            lock = self._processing_reactions_lock = asyncio.Lock()
+        return lock
+
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
-        """Set a single emoji reaction on a Telegram message."""
+        """Set one reaction, skipping duplicate state updates."""
         if not self._bot:
             return False
-        try:
-            await self._bot.set_message_reaction(
-                chat_id=normalize_telegram_chat_id(chat_id),
-                message_id=int(message_id),
-                reaction=emoji,
-            )
-            return True
-        except Exception as e:
-            logger.debug("[%s] set_message_reaction failed (%s): %s", self.name, emoji, _redact_telegram_error_text(e))
-            return False
+        key = (str(chat_id), str(message_id))
+        async with self._reaction_update_lock():
+            states = getattr(self, "_processing_reactions", None)
+            if states is None:
+                states = self._processing_reactions = {}
+            if states.get(key) == emoji:
+                return True
+            try:
+                await self._bot.set_message_reaction(
+                    chat_id=normalize_telegram_chat_id(chat_id),
+                    message_id=int(message_id),
+                    reaction=emoji,
+                )
+                states[key] = emoji
+                return True
+            except Exception as e:
+                logger.debug("[%s] set_message_reaction failed (%s): %s", self.name, emoji, _redact_telegram_error_text(e))
+                return False
 
     async def _clear_reactions(self, chat_id: str, message_id: str) -> bool:
         """Clear all reactions from a Telegram message.
@@ -9952,16 +9967,49 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return False
-        try:
-            await self._bot.set_message_reaction(
-                chat_id=normalize_telegram_chat_id(chat_id),
-                message_id=int(message_id),
-                reaction=None,
-            )
-            return True
-        except Exception as e:
-            logger.debug("[%s] clear reactions failed: %s", self.name, _redact_telegram_error_text(e))
-            return False
+        async with self._reaction_update_lock():
+            try:
+                await self._bot.set_message_reaction(
+                    chat_id=normalize_telegram_chat_id(chat_id),
+                    message_id=int(message_id),
+                    reaction=None,
+                )
+                states = getattr(self, "_processing_reactions", None)
+                if states is not None:
+                    states.pop((str(chat_id), str(message_id)), None)
+                return True
+            except Exception as e:
+                logger.debug("[%s] clear reactions failed: %s", self.name, _redact_telegram_error_text(e))
+                return False
+
+    async def on_processing_activity(
+        self,
+        source: "SessionSource",
+        message_id: str,
+        event_type: str,
+        tool_name: str | None = None,
+    ) -> None:
+        """Reflect thinking/tool state with Telegram-supported reactions."""
+        chat_id = source.chat_id
+        if not self._reactions_enabled() or not (chat_id and message_id):
+            return
+        if event_type in {"reasoning.available", "_thinking", "tool.completed", "tool.failed"}:
+            emoji = "🤔"
+        elif event_type == "tool.started":
+            name = (tool_name or "").lower()
+            if any(part in name for part in ("terminal", "browser", "computer", "code", "process")):
+                emoji = "👨‍💻"
+            elif any(part in name for part in ("file", "patch", "todo", "memory")):
+                emoji = "✍"
+            elif any(part in name for part in ("web", "search", "vision")):
+                emoji = "🤓"
+            elif any(part in name for part in ("delegate", "advisor", "clarify", "message")):
+                emoji = "🤝"
+            else:
+                emoji = "⚡"
+        else:
+            return
+        await self._set_reaction(chat_id, message_id, emoji)
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9934,6 +9934,16 @@ class TelegramAdapter(BasePlatformAdapter):
             lock = self._processing_reactions_lock = asyncio.Lock()
         return lock
 
+    def _settle_reaction_key(self, key: tuple[str, str]) -> None:
+        """Remember a terminal message briefly so late activity cannot overwrite it."""
+        settled = getattr(self, "_settled_processing_reactions", None)
+        if settled is None:
+            settled = self._settled_processing_reactions = {}
+        settled.pop(key, None)
+        settled[key] = None
+        if len(settled) > 1024:
+            settled.pop(next(iter(settled)))
+
     async def _set_reaction(
         self,
         chat_id: str,
@@ -9941,6 +9951,9 @@ class TelegramAdapter(BasePlatformAdapter):
         emoji: str,
         *,
         retain_state: bool = True,
+        begin_state: bool = False,
+        activity_state: bool = False,
+        terminal_state: bool = False,
     ) -> bool:
         """Set one reaction, skipping duplicate state updates."""
         key = (str(chat_id), str(message_id))
@@ -9948,8 +9961,15 @@ class TelegramAdapter(BasePlatformAdapter):
             states = getattr(self, "_processing_reactions", None)
             if states is None:
                 states = self._processing_reactions = {}
+            settled = getattr(self, "_settled_processing_reactions", None)
+            if begin_state and settled is not None:
+                settled.pop(key, None)
+            elif activity_state and settled is not None and key in settled:
+                return False
             if states.get(key) == emoji:
-                if not retain_state:
+                if terminal_state:
+                    self._settle_reaction_key(key)
+                if not retain_state or terminal_state:
                     states.pop(key, None)
                 return True
             try:
@@ -9967,10 +9987,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.debug("[%s] set_message_reaction failed (%s): %s", self.name, emoji, _redact_telegram_error_text(e))
                 return False
             finally:
-                if not retain_state:
+                if terminal_state:
+                    self._settle_reaction_key(key)
+                if not retain_state or terminal_state:
                     states.pop(key, None)
 
-    async def _clear_reactions(self, chat_id: str, message_id: str) -> bool:
+    async def _clear_reactions(
+        self, chat_id: str, message_id: str, *, terminal_state: bool = False
+    ) -> bool:
         """Clear all reactions from a Telegram message.
 
         Calling ``set_message_reaction`` with ``reaction=None`` (or an empty
@@ -9996,6 +10020,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 states = getattr(self, "_processing_reactions", None)
                 if states is not None:
                     states.pop(key, None)
+                if terminal_state:
+                    self._settle_reaction_key(key)
 
     async def on_processing_activity(
         self,
@@ -10024,7 +10050,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 emoji = "⚡"
         else:
             return
-        await self._set_reaction(chat_id, message_id, emoji)
+        await self._set_reaction(chat_id, message_id, emoji, activity_state=True)
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""
@@ -10033,7 +10059,12 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
-            await self._set_reaction(chat_id, message_id, "\U0001f440")
+            await self._set_reaction(
+                chat_id,
+                message_id,
+                "\U0001f440",
+                begin_state=True,
+            )
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Swap the in-progress reaction for a final success/failure reaction.
@@ -10055,13 +10086,14 @@ class TelegramAdapter(BasePlatformAdapter):
         if not (chat_id and message_id):
             return
         if outcome == ProcessingOutcome.CANCELLED:
-            await self._clear_reactions(chat_id, message_id)
+            await self._clear_reactions(chat_id, message_id, terminal_state=True)
         else:
             await self._set_reaction(
                 chat_id,
                 message_id,
                 "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
                 retain_state=False,
+                terminal_state=True,
             )
 
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -90,6 +90,17 @@ class MediaCaptureProgressAdapter(ProgressCaptureAdapter):
         )
 
 
+class ActivityCaptureAdapter(ProgressCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.activities = []
+
+    async def on_processing_activity(
+        self, source, message_id, event_type, tool_name=None
+    ) -> None:
+        self.activities.append((message_id, event_type, tool_name))
+
+
 class SmallLimitProgressAdapter(ProgressCaptureAdapter):
     """Adapter with a tiny platform limit to exercise progress rollover."""
 
@@ -399,6 +410,60 @@ def _make_runner(adapter):
         stt_enabled=False,
     )
     return runner
+
+
+@pytest.mark.asyncio
+async def test_activity_hook_receives_tool_events_when_visible_progress_is_off(
+    monkeypatch, tmp_path
+):
+    """Silent lifecycle status still receives tool events without progress bubbles."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    (tmp_path / "config.yaml").write_text(
+        "display:\n"
+        "  platforms:\n"
+        "    telegram:\n"
+        "      tool_progress: false\n"
+        "      thinking_progress: false\n",
+        encoding="utf-8",
+    )
+
+    adapter = ActivityCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="private",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-activity-only",
+        session_key="agent:main:telegram:private:123",
+        event_message_id="incoming-42",
+    )
+    await asyncio.sleep(0.1)
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+    assert adapter.activities == [
+        ("incoming-42", "tool.started", "terminal"),
+        ("incoming-42", "tool.started", "browser_navigate"),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_dynamic_reactions.py
+++ b/tests/gateway/test_telegram_dynamic_reactions.py
@@ -1,9 +1,12 @@
 """Focused tests for Telegram dynamic processing-state reactions."""
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+
+from gateway.platforms.base import ProcessingOutcome
 
 
 @pytest.mark.asyncio
@@ -83,6 +86,42 @@ async def test_processing_activity_deduplicates_concurrent_same_reaction(monkeyp
     )
 
     adapter._bot.set_message_reaction.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("outcome", "expected"),
+    [
+        (ProcessingOutcome.SUCCESS, "👍"),
+        (ProcessingOutcome.FAILURE, "👎"),
+    ],
+)
+async def test_processing_complete_forgets_terminal_reaction_state(
+    monkeypatch, outcome, expected
+):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = AsyncMock()
+    adapter._bot.set_message_reaction = AsyncMock()
+
+    from gateway.session import SessionSource
+
+    source = SessionSource(
+        platform="telegram", chat_id="123", chat_type="private", user_id="42"
+    )
+    event = SimpleNamespace(source=source, message_id="456")
+
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, outcome)
+
+    assert adapter._processing_reactions == {}
+    assert adapter._bot.set_message_reaction.await_args_list[-1].kwargs == {
+        "chat_id": 123,
+        "message_id": 456,
+        "reaction": expected,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_dynamic_reactions.py
+++ b/tests/gateway/test_telegram_dynamic_reactions.py
@@ -1,0 +1,101 @@
+"""Focused tests for Telegram dynamic processing-state reactions."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "tool_name", "expected"),
+    [
+        ("reasoning.available", "_thinking", "🤔"),
+        ("tool.completed", "terminal", "🤔"),
+        ("tool.failed", "terminal", "🤔"),
+        ("tool.started", "terminal", "👨‍💻"),
+        ("tool.started", "browser_click", "👨‍💻"),
+        ("tool.started", "write_file", "✍"),
+        ("tool.started", "web_search", "🤓"),
+        ("tool.started", "delegate_task", "🤝"),
+        ("tool.started", "unknown_tool", "⚡"),
+    ],
+)
+async def test_processing_activity_maps_state_to_standard_reaction(
+    monkeypatch, event_type, tool_name, expected
+):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = AsyncMock()
+    adapter._bot.set_message_reaction = AsyncMock()
+
+    from gateway.session import SessionSource
+    source = SessionSource(platform="telegram", chat_id="123", chat_type="private", user_id="42")
+    await adapter.on_processing_activity(source, "456", event_type, tool_name)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction=expected,
+    )
+
+
+@pytest.mark.asyncio
+async def test_processing_activity_deduplicates_same_reaction(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = AsyncMock()
+    adapter._bot.set_message_reaction = AsyncMock()
+
+    from gateway.session import SessionSource
+    source = SessionSource(platform="telegram", chat_id="123", chat_type="private", user_id="42")
+    await adapter.on_processing_activity(source, "456", "tool.started", "terminal")
+    await adapter.on_processing_activity(source, "456", "tool.started", "browser_click")
+
+    adapter._bot.set_message_reaction.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_processing_activity_deduplicates_concurrent_same_reaction(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = AsyncMock()
+
+    async def delayed_reaction(**kwargs):
+        await asyncio.sleep(0)
+
+    adapter._bot.set_message_reaction = AsyncMock(side_effect=delayed_reaction)
+
+    from gateway.session import SessionSource
+
+    source = SessionSource(
+        platform="telegram", chat_id="123", chat_type="private", user_id="42"
+    )
+    await asyncio.gather(
+        adapter.on_processing_activity(source, "456", "tool.started", "terminal"),
+        adapter.on_processing_activity(source, "456", "tool.started", "browser_click"),
+    )
+
+    adapter._bot.set_message_reaction.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_processing_activity_is_gated_by_existing_reactions_setting(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = AsyncMock()
+    adapter._bot.set_message_reaction = AsyncMock()
+
+    from gateway.session import SessionSource
+    source = SessionSource(platform="telegram", chat_id="123", chat_type="private", user_id="42")
+    await adapter.on_processing_activity(source, "456", "tool.started", "terminal")
+
+    adapter._bot.set_message_reaction.assert_not_awaited()

--- a/tests/gateway/test_telegram_dynamic_reactions.py
+++ b/tests/gateway/test_telegram_dynamic_reactions.py
@@ -125,6 +125,90 @@ async def test_processing_complete_forgets_terminal_reaction_state(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("outcome", "terminal_reaction"),
+    [
+        (ProcessingOutcome.SUCCESS, "👍"),
+        (ProcessingOutcome.FAILURE, "👎"),
+        (ProcessingOutcome.CANCELLED, None),
+    ],
+)
+async def test_late_activity_cannot_overwrite_terminal_reaction(
+    monkeypatch, outcome, terminal_reaction
+):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = AsyncMock()
+    adapter._bot.set_message_reaction = AsyncMock()
+
+    from gateway.session import SessionSource
+
+    source = SessionSource(
+        platform="telegram", chat_id="123", chat_type="private", user_id="42"
+    )
+    event = SimpleNamespace(source=source, message_id="456")
+
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, outcome)
+    calls_after_completion = adapter._bot.set_message_reaction.await_count
+
+    await adapter.on_processing_activity(source, "456", "tool.started", "terminal")
+
+    assert adapter._bot.set_message_reaction.await_count == calls_after_completion
+    assert (
+        adapter._bot.set_message_reaction.await_args_list[-1].kwargs["reaction"]
+        == terminal_reaction
+    )
+
+
+@pytest.mark.asyncio
+async def test_terminal_reaction_guard_is_bounded(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = AsyncMock()
+    adapter._bot.set_message_reaction = AsyncMock()
+
+    from gateway.session import SessionSource
+
+    source = SessionSource(
+        platform="telegram", chat_id="123", chat_type="private", user_id="42"
+    )
+    for message_id in range(1025):
+        event = SimpleNamespace(source=source, message_id=str(message_id))
+        await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert len(adapter._settled_processing_reactions) == 1024
+    assert ("123", "0") not in adapter._settled_processing_reactions
+
+
+@pytest.mark.asyncio
+async def test_new_start_reopens_reaction_state_for_same_message(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = AsyncMock()
+    adapter._bot.set_message_reaction = AsyncMock()
+
+    from gateway.session import SessionSource
+
+    source = SessionSource(
+        platform="telegram", chat_id="123", chat_type="private", user_id="42"
+    )
+    event = SimpleNamespace(source=source, message_id="456")
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_activity(source, "456", "tool.started", "terminal")
+
+    assert adapter._bot.set_message_reaction.await_args_list[-1].kwargs["reaction"] == "👨‍💻"
+
+
+@pytest.mark.asyncio
 async def test_processing_activity_is_gated_by_existing_reactions_setting(monkeypatch):
     monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
     from plugins.platforms.telegram.adapter import TelegramAdapter

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -124,10 +124,13 @@ async def test_clear_reactions_handles_api_error_gracefully(monkeypatch):
     """API errors during clear should not propagate."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
+    adapter._processing_reactions = {("123", "456"): "👀"}
     adapter._bot.set_message_reaction = AsyncMock(side_effect=RuntimeError("no perms"))
 
     result = await adapter._clear_reactions("123", "456")
+
     assert result is False
+    assert adapter._processing_reactions == {}
 
 
 # ── config.py bridging ───────────────────────────────────────────────

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1196,11 +1196,16 @@ This covers the custom fallback transport layer that Hermes uses for Telegram co
 
 ## Message Reactions
 
-The bot can add emoji reactions to messages as visual processing feedback:
+The bot can replace its reaction on the original user message as quiet processing feedback:
 
-- 👀 when the bot starts processing your message
-- ✅ when the response is delivered successfully
-- ❌ if an error occurs during processing
+- 👀 when processing starts
+- 🤔 while reasoning or between tool calls
+- 👨‍💻, ✍, 🤓, 🤝, or ⚡ while using different tool categories
+- 👍 when the response is delivered successfully
+- 👎 if processing fails
+- no reaction after cancellation
+
+These lifecycle updates do not send progress messages. Reaction calls are best-effort and never block the final response. Hermes forgets its per-message reaction state after completion or cancellation while leaving the final 👍/👎 visible on Telegram.
 
 Reactions are **disabled by default**. Enable them in `config.yaml`:
 


### PR DESCRIPTION
1|## Summary
2|
3|- add an optional platform hook for quiet processing activity
4|- dispatch lifecycle/tool events even when visible progress messages are disabled
5|- use Telegram reactions as a best-effort implementation of that hook
6|- deduplicate and serialize reaction updates so concurrent events cannot race
7|- make terminal reaction state monotonic so late activity cannot overwrite success, failure, or cancellation
8|- bound settled-reaction state and reopen it when a new run starts for the same message
9|
10|## Problem
11|
12|The gateway currently ties tool-event delivery to the visible progress-message path. When both `tool_progress` and `thinking_progress` are disabled, a platform adapter cannot provide a quieter status surface even if it supports one.
13|
14|This keeps lifecycle activity separate from progress messages. Platforms that do not implement the optional hook retain the existing behavior.
15|
16|An activity update also requires the original inbound message reference. Turns without that reference remain a no-op because there is no safe message-scoped status surface to update.
17|
18|## Failure and ordering behavior
19|
20|Reaction updates are best-effort. API failures are logged at debug level and do not affect agent execution or final-answer delivery. Repeated identical states are skipped, and reaction writes are serialized.
21|
22|Terminal outcomes are monotonic for a message run: delayed fire-and-forget activity cannot replace `completed`, `failed`, or `cancelled`. The guard is bounded to 1024 message keys and a new processing start reopens lifecycle state for reused message identifiers.
23|
24|## Tests
25|
26|Validated on final head `3f7bdfa8c683ee4f0ecf3dbfe6bade8f696a6d28`, rebased onto `origin/main`:
27|
28|```text
29|52 passed in 23.69s (clean detached worktree)
30|ruff: PASS
31|git diff --check: PASS
32|added-lines privacy/security scan: PASS
33|independent blocker-focused review: MERGE-READY
34|```
35|
36|The exact-head repository-wide runner completed with 68 failures across 13 files plus one collection/import-error file. A canonical sequential rerun reproduced 64 failures across 10 files plus the same collection error; four timing-sensitive failures (`fuzzy_match`, transcription, and delegation cleanup) did not reproduce. The only reproduced gateway failure, `test_profile_route_and_nonmultiplexed_resolution_preserve_boundaries`, also fails unchanged on base `c0106e50e7`; most other reproductions are optional-integration/lazy-dependency or environment failures. None touches the focused lifecycle/reaction files. This PR does not claim a clean full-suite result; the focused exact-head evidence above remains green, and upstream CI remains authoritative.
37|
38|Coverage includes:
39|
40|- tool lifecycle delivery with `tool_progress=false`
41|- tool lifecycle delivery with `thinking_progress=false`
42|- Telegram state mapping and fallback behavior
43|- reaction feature gating
44|- non-fatal API failures
45|- duplicate-state suppression
46|- concurrent duplicate suppression
47|- terminal success, failure, and cancellation cleanup
48|- late activity after terminal completion
49|- bounded terminal-state tracking
50|- reopening state for a new run reusing the same message ID
51|- missing message-reference safety
52|