### PR TITLE
Add gateway drain and backup management to desktop command center

### DIFF
--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -69,7 +69,7 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs())
     }
 
     function onData(chunk) {
-      buf += chunk.toString()
+      buf += chunk.toString('utf8')
       let nl
 
       while ((nl = buf.indexOf('\n')) !== -1) {

--- a/apps/desktop/electron/backup-download.test.ts
+++ b/apps/desktop/electron/backup-download.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for electron/backup-download.ts.
+ *
+ * Run with: node --test electron/backup-download.test.ts
+ *
+ * backupDownloadPath is the routing seam behind the "download a backup
+ * archive" IPC bridge — it must scope the request to the requesting profile
+ * the same way the generic api() JSON bridge does (pathWithGlobalRemoteProfile),
+ * or a shared global-remote dashboard would let one profile download another's
+ * backup archive.
+ */
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { backupDownloadPath } from './backup-download'
+
+test('backupDownloadPath appends profile in global remote mode', () => {
+  assert.equal(
+    backupDownloadPath('/home/worker/backups/hermes-backup-worker.zip', 'worker', {
+      globalRemote: true,
+      profileRemoteOverride: false
+    }),
+    '/api/ops/backup/download?archive=%2Fhome%2Fworker%2Fbackups%2Fhermes-backup-worker.zip&profile=worker'
+  )
+})
+
+test('backupDownloadPath skips the primary profile, which the remote already serves', () => {
+  assert.equal(
+    backupDownloadPath('/home/coder/backups/hermes-backup.zip', 'coder', {
+      globalRemote: true,
+      primaryProfile: 'coder',
+      profileRemoteOverride: false
+    }),
+    '/api/ops/backup/download?archive=%2Fhome%2Fcoder%2Fbackups%2Fhermes-backup.zip'
+  )
+})
+
+test('backupDownloadPath skips local and per-profile remote override paths', () => {
+  assert.equal(
+    backupDownloadPath('/home/worker/backups/x.zip', 'worker', {
+      globalRemote: false,
+      profileRemoteOverride: false
+    }),
+    '/api/ops/backup/download?archive=%2Fhome%2Fworker%2Fbackups%2Fx.zip'
+  )
+  assert.equal(
+    backupDownloadPath('/home/worker/backups/x.zip', 'worker', {
+      globalRemote: true,
+      profileRemoteOverride: true
+    }),
+    '/api/ops/backup/download?archive=%2Fhome%2Fworker%2Fbackups%2Fx.zip'
+  )
+})
+
+test('backupDownloadPath URL-encodes the archive path', () => {
+  assert.equal(
+    backupDownloadPath('/home/my profile/backups/a b.zip', null, {}),
+    '/api/ops/backup/download?archive=%2Fhome%2Fmy+profile%2Fbackups%2Fa+b.zip'
+  )
+})

--- a/apps/desktop/electron/backup-download.ts
+++ b/apps/desktop/electron/backup-download.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure routing helper behind the "download a backup archive" IPC bridge
+ * (`hermes:downloadBackup` in main.ts). Split out from main.ts, which has no
+ * test file of its own — every testable seam here lives in a small
+ * dependency-free module main.ts just wires up (see profile-delete-routing.ts,
+ * connection-config.ts).
+ */
+import { pathWithGlobalRemoteProfile, type ProfileRouteOptions } from './connection-config'
+
+/**
+ * Build the profile-scoped REST path for downloading `archivePath`.
+ *
+ * Mirrors what the generic `hermes:api` IPC handler does for every JSON
+ * request: append `?profile=<name>` when (and only when) `resolveProfileBackendRoute`
+ * says the serving backend isn't already scoped to that profile (the
+ * global-remote case — see connection-config.ts). Getting this wrong for
+ * downloads specifically would let one profile fetch another's backup archive
+ * through a shared remote dashboard.
+ */
+export function backupDownloadPath(archivePath: string, profile: null | string, opts: ProfileRouteOptions = {}): string {
+  const query = new URLSearchParams({ archive: archivePath }).toString()
+
+  return pathWithGlobalRemoteProfile(`/api/ops/backup/download?${query}`, profile, opts)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -46,6 +46,7 @@ import {
 } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
+import { backupDownloadPath } from './backup-download'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { runBootstrap } from './bootstrap-runner'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
@@ -4259,6 +4260,65 @@ function fetchJson(url, token, options: any = {}) {
       req.write(body)
     }
 
+    req.end()
+  })
+}
+
+// Like fetchJson, but for endpoints whose response is raw bytes (a backup
+// archive), not JSON — used by hermes:downloadBackup. Same auth headers, no
+// JSON parsing.
+function fetchBinary(url, token, options: any = {}): Promise<{ buffer: Buffer; contentType: string }> {
+  return new Promise((resolve, reject) => {
+    let parsed
+
+    try {
+      parsed = new URL(url)
+    } catch (error) {
+      reject(new Error(`Invalid URL: ${error.message}`))
+
+      return
+    }
+
+    const client = parsed.protocol === 'https:' ? https : http
+    const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      reject(new Error(`Unsupported Hermes backend URL protocol: ${parsed.protocol}`))
+
+      return
+    }
+
+    const req = client.request(
+      parsed,
+      {
+        method: 'GET',
+        headers: {
+          'X-Hermes-Session-Token': token,
+          ...(options.bearer ? { Authorization: `Bearer ${options.bearer}` } : {})
+        }
+      },
+      res => {
+        const chunks = []
+        res.on('error', reject)
+        res.on('data', chunk => chunks.push(chunk))
+        res.on('end', () => {
+          const buffer = Buffer.concat(chunks)
+
+          if ((res.statusCode || 500) >= 400) {
+            reject(new Error(`${res.statusCode}: ${buffer.toString('utf8').slice(0, 300) || res.statusMessage}`))
+
+            return
+          }
+
+          resolve({ buffer, contentType: String(res.headers['content-type'] || '') })
+        })
+      }
+    )
+
+    req.on('error', reject)
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`))
+    })
     req.end()
   })
 }
@@ -10175,6 +10235,53 @@ ipcMain.handle('hermes:api', async (_event, request) => {
     upload: request?.upload,
     timeoutMs
   })
+})
+
+// Downloading a backup needs the same profile-aware backend + auth resolution
+// as hermes:api, but the response is raw zip bytes, not JSON, and the result
+// belongs on disk (native "Save As"), not in the renderer — the renderer runs
+// from file://, so a plain <a href="/api/..."> can't reach the backend at all.
+ipcMain.handle('hermes:downloadBackup', async (_event, request) => {
+  const profile = request?.profile
+  const archivePath = String(request?.archivePath || '')
+  const routeProfile = resolveRouteProfile(null, profile)
+  const connection = await ensureBackend(routeProfile)
+  const requestPath = backupDownloadPath(archivePath, profile, profileRouteOptions(profile))
+  const url = `${connection.baseUrl}${requestPath}`
+
+  let buffer: Buffer
+
+  try {
+    if (connection.authMode === 'oauth') {
+      const nativeAt = await ensureNativeAccessToken(connection.baseUrl).catch(() => null)
+      const restAuth = resolveOauthRestAuth(nativeAt)
+
+      if (restAuth.kind !== 'bearer') {
+        throw new Error('Backup download is not supported against cookie-session OAuth-gated remote backends yet.')
+      }
+
+      ;({ buffer } = await fetchBinary(url, null, { bearer: restAuth.token }))
+    } else {
+      ;({ buffer } = await fetchBinary(url, connection.token))
+    }
+  } catch (error) {
+    return { ok: false, error: error?.message || String(error) }
+  }
+
+  const fallbackName = path.basename(archivePath) || 'hermes-backup.zip'
+
+  const result = await dialog.showSaveDialog(mainWindow, {
+    title: 'Save Backup',
+    defaultPath: fallbackName
+  })
+
+  if (result.canceled || !result.filePath) {
+    return { ok: false }
+  }
+
+  await fs.promises.writeFile(result.filePath, buffer)
+
+  return { ok: true, path: result.filePath }
 })
 
 // One deduper per cross-window cue — the choke point every window shares. Main

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -110,6 +110,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   saveImageFromUrl: url => ipcRenderer.invoke('hermes:saveImageFromUrl', url),
   saveImageBuffer: (data, ext) => ipcRenderer.invoke('hermes:saveImageBuffer', { data, ext }),
   saveClipboardImage: () => ipcRenderer.invoke('hermes:saveClipboardImage'),
+  downloadBackup: (archivePath, profile) => ipcRenderer.invoke('hermes:downloadBackup', { archivePath, profile }),
   getPathForFile: file => {
     try {
       return webUtils.getPathForFile(file) || ''

--- a/apps/desktop/src/app/command-center/backups.tsx
+++ b/apps/desktop/src/app/command-center/backups.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { PageLoader } from '@/components/page-loader'
+import { Button } from '@/components/ui/button'
+import {
+  type ActionStatusResponse,
+  type BackupArchive,
+  getActionStatus,
+  getBackupDownloadUrl,
+  listBackups,
+  runBackup
+} from '@/hermes'
+import { useI18n } from '@/i18n'
+import { AlertCircle, Archive, Download } from '@/lib/icons'
+import { upsertDesktopActionTask } from '@/store/activity'
+import { notifyError } from '@/store/notifications'
+
+const ACTION_POLL_MS = 1200
+const ACTION_POLL_LIMIT = 240
+
+function formatFileSize(bytes: number): string {
+  if (bytes <= 0) {
+    return '0 B'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB']
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+
+  return `${(bytes / 1024 ** i).toFixed(i > 0 ? 1 : 0)} ${units[i]}`
+}
+
+/** Backups panel — lists existing backup archives (created via the Maintenance
+ *  tab's "Create backup" action, or `hermes backup` on the CLI) and lets the
+ *  user download or kick off a fresh one without leaving the desktop app. */
+export function BackupsPanel() {
+  const { t } = useI18n()
+  const bb = t.commandCenter.backups
+
+  const [backups, setBackups] = useState<BackupArchive[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [actionName, setActionName] = useState<null | string>(null)
+  const [actionStatus, setActionStatus] = useState<ActionStatusResponse | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError('')
+
+    try {
+      const response = await listBackups()
+      setBackups(response.backups)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  useEffect(() => {
+    if (!actionName) {
+      return
+    }
+
+    let cancelled = false
+    let polls = 0
+    let timer: null | number = null
+
+    const poll = async () => {
+      try {
+        const status = await getActionStatus(actionName, 200)
+
+        if (cancelled) {
+          return
+        }
+
+        setActionStatus(status)
+        upsertDesktopActionTask(status)
+        polls += 1
+
+        if (status.running && polls < ACTION_POLL_LIMIT) {
+          timer = window.setTimeout(() => void poll(), ACTION_POLL_MS)
+        } else if (!status.running) {
+          void refresh()
+        }
+      } catch {
+        // Status endpoint hiccup — stop tailing; the activity rail still has the task.
+      }
+    }
+
+    void poll()
+
+    return () => {
+      cancelled = true
+
+      if (timer !== null) {
+        window.clearTimeout(timer)
+      }
+    }
+  }, [actionName, refresh])
+
+  const runBackupAction = useCallback(async () => {
+    setError('')
+
+    try {
+      const started = await runBackup()
+      setActionStatus(null)
+      setActionName(started.name)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      notifyError(err, bb.failed)
+    }
+  }, [bb])
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 text-[length:var(--conversation-text-font-size)] font-medium">{bb.description}</div>
+        <Button disabled={actionStatus?.running === true} onClick={() => void runBackupAction()} size="xs" variant="textStrong">
+          {actionStatus?.running ? bb.running : bb.run}
+        </Button>
+      </div>
+
+      {actionStatus && !actionStatus.running && (
+        <div className="text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+          {actionStatus.exit_code === 0 ? bb.done : bb.failed}
+        </div>
+      )}
+
+      {error && (
+        <span className="inline-flex items-center gap-1 text-[length:var(--conversation-caption-font-size)] text-destructive">
+          <AlertCircle className="size-3.5" />
+          {error}
+        </span>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto pt-2">
+        <div className="mb-2 text-[0.625rem] font-medium uppercase tracking-[0.08em] text-(--ui-text-tertiary)">
+          {bb.directory}
+        </div>
+        {loading ? (
+          <PageLoader className="min-h-24" label={bb.directory} />
+        ) : backups.length === 0 ? (
+          <div className="py-2 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+            {bb.empty}
+          </div>
+        ) : (
+          <ul>
+            {backups.map(archive => (
+              <li className="flex items-center gap-2 py-1.5" key={archive.path}>
+                <Archive className="size-3.5 shrink-0 text-(--ui-text-tertiary)" />
+                <span className="min-w-0 flex-1 truncate font-mono text-[0.7rem]">{archive.name}</span>
+                <span className="shrink-0 text-[0.65rem] text-(--ui-text-tertiary)">
+                  {formatFileSize(archive.size)}
+                </span>
+                <a
+                  className="shrink-0 text-(--ui-accent) hover:underline"
+                  download={archive.name}
+                  href={getBackupDownloadUrl(archive.path)}
+                  title={bb.download}
+                >
+                  <Download className="size-3" />
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/command-center/backups.tsx
+++ b/apps/desktop/src/app/command-center/backups.tsx
@@ -5,8 +5,8 @@ import { Button } from '@/components/ui/button'
 import {
   type ActionStatusResponse,
   type BackupArchive,
+  downloadBackup,
   getActionStatus,
-  getBackupDownloadUrl,
   listBackups,
   runBackup
 } from '@/hermes'
@@ -41,6 +41,7 @@ export function BackupsPanel() {
   const [error, setError] = useState('')
   const [actionName, setActionName] = useState<null | string>(null)
   const [actionStatus, setActionStatus] = useState<ActionStatusResponse | null>(null)
+  const [downloadingPath, setDownloadingPath] = useState<null | string>(null)
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -115,6 +116,28 @@ export function BackupsPanel() {
     }
   }, [bb])
 
+  const downloadArchive = useCallback(
+    async (archive: BackupArchive) => {
+      setDownloadingPath(archive.path)
+      setError('')
+
+      try {
+        const result = await downloadBackup(archive.path)
+
+        if (!result.ok && result.error) {
+          setError(result.error)
+          notifyError(new Error(result.error), bb.download)
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+        notifyError(err, bb.download)
+      } finally {
+        setDownloadingPath(null)
+      }
+    },
+    [bb]
+  )
+
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4">
       <div className="flex items-start justify-between gap-3">
@@ -156,14 +179,17 @@ export function BackupsPanel() {
                 <span className="shrink-0 text-[0.65rem] text-(--ui-text-tertiary)">
                   {formatFileSize(archive.size)}
                 </span>
-                <a
-                  className="shrink-0 text-(--ui-accent) hover:underline"
-                  download={archive.name}
-                  href={getBackupDownloadUrl(archive.path)}
+                <Button
+                  aria-label={bb.download}
+                  className="shrink-0 text-(--ui-text-tertiary) hover:text-foreground"
+                  disabled={downloadingPath === archive.path}
+                  onClick={() => void downloadArchive(archive)}
+                  size="icon-xs"
                   title={bb.download}
+                  variant="ghost"
                 >
                   <Download className="size-3" />
-                </a>
+                </Button>
               </li>
             ))}
           </ul>

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -15,6 +15,7 @@ import { compactNumber } from '@/lib/format'
 import {
   Activity,
   AlertCircle,
+  Archive,
   BarChart3,
   Bookmark,
   BookmarkFilled,
@@ -36,11 +37,18 @@ import { useRouteEnumParam } from '../hooks/use-route-enum-param'
 import { OverlayMain, OverlayNav, OverlaySplitLayout } from '../overlays/overlay-split-layout'
 import { OverlayView } from '../overlays/overlay-view'
 
+import { BackupsPanel } from './backups'
 import { MaintenancePanel } from './maintenance'
 
-export type CommandCenterSection = 'maintenance' | 'sessions' | 'system' | 'usage'
+export type CommandCenterSection = 'backups' | 'maintenance' | 'sessions' | 'system' | 'usage'
 
-const SECTIONS = ['sessions', 'system', 'usage', 'maintenance'] as const satisfies readonly CommandCenterSection[]
+const SECTIONS = [
+  'sessions',
+  'system',
+  'usage',
+  'maintenance',
+  'backups'
+] as const satisfies readonly CommandCenterSection[]
 
 const LOG_FILES = ['agent', 'errors', 'gateway', 'desktop'] as const
 const LOG_LEVELS = ['ALL', 'INFO', 'WARNING', 'ERROR'] as const
@@ -313,7 +321,9 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
               ? Activity
               : value === 'maintenance'
                 ? Wrench
-                : BarChart3,
+                : value === 'backups'
+                  ? Archive
+                  : BarChart3,
         id: value,
         label: cc.sections[value],
         onSelect: () => setSection(value)
@@ -417,6 +427,8 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
             />
           ) : section === 'maintenance' ? (
             <MaintenancePanel />
+          ) : section === 'backups' ? (
+            <BackupsPanel />
           ) : (
             <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] gap-4">
               <div>

--- a/apps/desktop/src/app/command-center/maintenance.tsx
+++ b/apps/desktop/src/app/command-center/maintenance.tsx
@@ -7,6 +7,8 @@ import {
   type ActionResponse,
   type CuratorStatusResponse,
   type DebugShareResponse,
+  type DrainResponse,
+  gatewayDrain,
   getActionStatus,
   getCuratorStatus,
   getMemoryStatus,
@@ -62,6 +64,9 @@ export function MaintenancePanel() {
   const [share, setShare] = useState<DebugShareResponse | null>(null)
   const [sharing, setSharing] = useState(false)
   const [error, setError] = useState('')
+  const [drainLoading, setDrainLoading] = useState(false)
+  const [drainActive, setDrainActive] = useState(false)
+  const [drainMessage, setDrainMessage] = useState('')
 
   useEffect(() => {
     let cancelled = false
@@ -149,6 +154,26 @@ export function MaintenancePanel() {
     }
   }, [mm])
 
+  const runDrainAction = useCallback(
+    async (action: 'drain' | 'cancel') => {
+      setDrainLoading(true)
+      setError('')
+      setDrainMessage('')
+
+      try {
+        const response: DrainResponse = await gatewayDrain(action)
+        setDrainActive(response.draining ?? action === 'drain')
+        setDrainMessage(action === 'drain' ? mm.drainStarted : mm.drainCancelled)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+        notifyError(err, mm.actionFailed(mm.gatewayControl))
+      } finally {
+        setDrainLoading(false)
+      }
+    },
+    [mm]
+  )
+
   const toggleCurator = useCallback(async () => {
     if (!curator) {
       return
@@ -196,6 +221,40 @@ export function MaintenancePanel() {
           {error}
         </span>
       )}
+
+      <section>
+        <SectionLabel>{mm.gatewayControl}</SectionLabel>
+        <div className="flex items-center justify-between gap-3 py-2">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className={cn('size-2 rounded-full', drainActive ? 'bg-amber-500' : 'bg-emerald-500')} />
+              <span className="text-[length:var(--conversation-text-font-size)] font-medium">
+                {drainActive ? mm.drainActive : mm.drainInactive}
+              </span>
+            </div>
+            {drainMessage && (
+              <div className="mt-0.5 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                {drainMessage}
+              </div>
+            )}
+          </div>
+          {drainActive ? (
+            <Button disabled={drainLoading} onClick={() => void runDrainAction('cancel')} size="xs" variant="textStrong">
+              {mm.cancelDrain}
+            </Button>
+          ) : (
+            <Button disabled={drainLoading} onClick={() => void runDrainAction('drain')} size="xs" variant="textStrong">
+              {mm.drainGateway}
+            </Button>
+          )}
+        </div>
+        {drainActive && (
+          <div className="mt-1 flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+            <AlertCircle className="size-4 shrink-0 text-amber-500" />
+            <span className="text-[length:var(--conversation-caption-font-size)]">{mm.gatewayDraining}</span>
+          </div>
+        )}
+      </section>
 
       <section>
         <SectionLabel>{mm.runOps}</SectionLabel>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -128,6 +128,10 @@ declare global {
       saveImageFromUrl: (url: string) => Promise<boolean>
       saveImageBuffer: (data: ArrayBuffer | Uint8Array, ext: string) => Promise<string>
       saveClipboardImage: () => Promise<string>
+      downloadBackup: (
+        archivePath: string,
+        profile: null | string
+      ) => Promise<{ error?: string; ok: boolean; path?: string }>
       getPathForFile: (file: File) => string
       normalizePreviewTarget: (target: string, baseDir?: string) => Promise<HermesPreviewTarget | null>
       watchPreviewFile: (url: string) => Promise<HermesPreviewWatch>

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1780,6 +1780,7 @@ export function runSecurityAudit(): Promise<ActionResponse> {
 
 export function runBackup(): Promise<ActionResponse & { archive?: string }> {
   return window.hermesDesktop.api<ActionResponse & { archive?: string }>({
+    ...profileScoped(),
     path: '/api/ops/backup',
     method: 'POST',
     body: {}
@@ -1788,6 +1789,7 @@ export function runBackup(): Promise<ActionResponse & { archive?: string }> {
 
 export function listBackups(): Promise<BackupListResponse> {
   return window.hermesDesktop.api<BackupListResponse>({
+    ...profileScoped(),
     path: '/api/ops/backup/list'
   })
 }

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -9,6 +9,7 @@ import type {
   AutomationBlueprint,
   AuxiliaryModelsResponse,
   BackendUpdateCheckResponse,
+  BackupListResponse,
   ComputerUseStatus,
   ConfigSchemaResponse,
   CronDeliveryTarget,
@@ -20,6 +21,7 @@ import type {
   CustomEndpointUpdate,
   CustomEndpointValidationResponse,
   DebugShareResponse,
+  DrainResponse,
   ElevenLabsVoicesResponse,
   EnvVarInfo,
   HermesConfig,
@@ -138,6 +140,8 @@ export type {
   AutomationBlueprintField,
   AuxiliaryModelsResponse,
   BackendUpdateCheckResponse,
+  BackupArchive,
+  BackupListResponse,
   ComputerUseCheck,
   ComputerUsePermissionSource,
   ComputerUseStatus,
@@ -154,6 +158,7 @@ export type {
   CustomEndpointUpdate,
   CustomEndpointValidationResponse,
   DebugShareResponse,
+  DrainResponse,
   ElevenLabsVoice,
   ElevenLabsVoicesResponse,
   EnvVarInfo,
@@ -1532,6 +1537,15 @@ export function restartGateway(): Promise<ActionResponse> {
   })
 }
 
+export function gatewayDrain(action: 'drain' | 'cancel'): Promise<DrainResponse> {
+  return window.hermesDesktop.api<DrainResponse>({
+    ...profileScoped(),
+    path: '/api/gateway/drain',
+    method: 'POST',
+    body: { action }
+  })
+}
+
 export function updateHermes(): Promise<ActionResponse> {
   return window.hermesDesktop.api<ActionResponse>({
     ...profileScoped(),
@@ -1770,6 +1784,18 @@ export function runBackup(): Promise<ActionResponse & { archive?: string }> {
     method: 'POST',
     body: {}
   })
+}
+
+export function listBackups(): Promise<BackupListResponse> {
+  return window.hermesDesktop.api<BackupListResponse>({
+    path: '/api/ops/backup/list'
+  })
+}
+
+export function getBackupDownloadUrl(archivePath: string): string {
+  const params = new URLSearchParams({ archive: archivePath })
+
+  return `/api/ops/backup/download?${params.toString()}`
 }
 
 export function runDebugShare(): Promise<DebugShareResponse> {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1794,10 +1794,14 @@ export function listBackups(): Promise<BackupListResponse> {
   })
 }
 
-export function getBackupDownloadUrl(archivePath: string): string {
-  const params = new URLSearchParams({ archive: archivePath })
-
-  return `/api/ops/backup/download?${params.toString()}`
+// Packaged Desktop loads the renderer from file://, so a plain <a href> to a
+// relative /api path can't reach the backend — and unlike window.hermesDesktop.api,
+// a download needs the raw response bytes, not JSON. Route it through a
+// dedicated IPC bridge call so main can resolve the same profile-aware backend
+// connection + auth (token or OAuth bearer) the generic api() bridge uses, then
+// hand the bytes to a native "Save As" dialog.
+export function downloadBackup(archivePath: string): Promise<{ error?: string; ok: boolean; path?: string }> {
+  return window.hermesDesktop.downloadBackup(archivePath, _apiProfile)
 }
 
 export function runDebugShare(): Promise<DebugShareResponse> {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1217,8 +1217,15 @@ export const en: Translations = {
     settingsFields: 'Settings fields',
     mcpServers: 'MCP servers',
     archivedChats: 'Archived chats',
-    sections: { maintenance: 'Maintenance', sessions: 'Sessions', system: 'System', usage: 'Usage' },
+    sections: {
+      backups: 'Backups',
+      maintenance: 'Maintenance',
+      sessions: 'Sessions',
+      system: 'System',
+      usage: 'Usage'
+    },
     sectionDescriptions: {
+      backups: 'Create and download Hermes backups',
       maintenance: 'Diagnostics, backups, curator, and memory data',
       sessions: 'Search and manage sessions',
       system: 'Status, logs, and system actions',
@@ -1322,7 +1329,25 @@ export const en: Translations = {
       actionStarted: name => `${name} started — tailing log...`,
       actionFailed: name => `${name} failed to start`,
       running: 'Running...',
-      viewLog: 'Action log'
+      viewLog: 'Action log',
+      gatewayControl: 'Gateway control',
+      drainGateway: 'Begin drain',
+      cancelDrain: 'Cancel drain',
+      gatewayDraining: 'Gateway is draining — not accepting new turns.',
+      drainActive: 'Drain active',
+      drainInactive: 'Drain inactive',
+      drainStarted: 'Drain started — gateway will stop accepting new turns.',
+      drainCancelled: 'Drain cancelled — gateway is accepting new turns.'
+    },
+    backups: {
+      description: 'Create a full Hermes backup archive or download existing ones.',
+      directory: 'Backup directory',
+      download: 'Download',
+      empty: 'No backups yet.',
+      failed: 'Backup failed',
+      running: 'Backup in progress…',
+      done: 'Backup complete',
+      run: 'Run backup'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1078,8 +1078,8 @@ export interface Translations {
     settingsFields: string
     mcpServers: string
     archivedChats: string
-    sections: Record<'maintenance' | 'sessions' | 'system' | 'usage', string>
-    sectionDescriptions: Record<'maintenance' | 'sessions' | 'system' | 'usage', string>
+    sections: Record<'backups' | 'maintenance' | 'sessions' | 'system' | 'usage', string>
+    sectionDescriptions: Record<'backups' | 'maintenance' | 'sessions' | 'system' | 'usage', string>
     nav: Record<'newChat' | 'settings' | 'skills' | 'messaging' | 'artifacts', { title: string; detail: string }>
     sectionEntries: Record<'sessions' | 'system' | 'usage', { title: string; detail: string }>
     providerNavigate: string
@@ -1169,6 +1169,24 @@ export interface Translations {
       actionFailed: (name: string) => string
       running: string
       viewLog: string
+      gatewayControl: string
+      drainGateway: string
+      cancelDrain: string
+      gatewayDraining: string
+      drainActive: string
+      drainInactive: string
+      drainStarted: string
+      drainCancelled: string
+    }
+    backups: {
+      description: string
+      directory: string
+      download: string
+      empty: string
+      failed: string
+      running: string
+      done: string
+      run: string
     }
   }
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1413,8 +1413,9 @@ export const zh: Translations = {
     settingsFields: '设置字段',
     mcpServers: 'MCP 服务器',
     archivedChats: '已归档对话',
-    sections: { maintenance: '维护', sessions: '会话', system: '系统', usage: '用量' },
+    sections: { backups: '备份', maintenance: '维护', sessions: '会话', system: '系统', usage: '用量' },
     sectionDescriptions: {
+      backups: '创建并下载 Hermes 备份',
       maintenance: '诊断、备份、维护器与记忆数据',
       sessions: '搜索与管理会话',
       system: '状态、日志与系统操作',
@@ -1518,7 +1519,25 @@ export const zh: Translations = {
       actionStarted: name => `${name} 已启动 — 正在跟踪日志…`,
       actionFailed: name => `${name} 启动失败`,
       running: '运行中…',
-      viewLog: '操作日志'
+      viewLog: '操作日志',
+      gatewayControl: '网关控制',
+      drainGateway: '开始排空',
+      cancelDrain: '取消排空',
+      gatewayDraining: '网关正在排空 — 不再接受新对话。',
+      drainActive: '排空进行中',
+      drainInactive: '排空未启用',
+      drainStarted: '排空已开始 — 网关将停止接受新对话。',
+      drainCancelled: '排空已取消 — 网关正在接受新对话。'
+    },
+    backups: {
+      description: '创建完整的 Hermes 备份存档或下载现有备份。',
+      directory: '备份目录',
+      download: '下载',
+      empty: '暂无备份。',
+      failed: '备份失败',
+      running: '备份进行中…',
+      done: '备份完成',
+      run: '运行备份'
     }
   },
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1391,3 +1391,22 @@ export interface ModelAssignmentResponse {
   stale_aux?: StaleAuxAssignment[]
   tasks?: string[]
 }
+
+export interface DrainResponse {
+  ok: boolean
+  action: 'drain' | 'cancel'
+  draining?: boolean
+  was_draining?: boolean
+  requested_at?: string
+}
+
+export interface BackupArchive {
+  name: string
+  path: string
+  size: number
+  modified: string
+}
+
+export interface BackupListResponse {
+  backups: BackupArchive[]
+}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3915,7 +3915,7 @@ async def restart_gateway(profile: Optional[str] = None):
 
 
 @app.post("/api/gateway/drain")
-async def gateway_drain(request: Request):
+async def gateway_drain(request: Request, profile: Optional[str] = None):
     """Begin or cancel an external (NAS-driven) gateway drain.
 
     Authenticated by the non-interactive token-auth seam: the
@@ -3935,6 +3935,12 @@ async def gateway_drain(request: Request):
     process owns the actual state transition (there is no HTTP control channel
     into the running gateway; the marker IS the channel, decisions.md Q-B).
 
+    ``profile`` scopes the marker to that profile's own HERMES_HOME (the
+    Desktop app's global-remote mode shares one dashboard across profiles, each
+    with its own gateway process watching its own home — see
+    ``_resolve_optional_profile_home``). None/""/"current" keeps the dashboard's
+    own home, matching every other profile-scoped endpoint here.
+
     The force-override (D6: "unless a user commands it") is NOT here — an
     immediate, drain-skipping action maps onto the existing
     ``POST /api/gateway/restart`` force path, which supersedes a drain.
@@ -3944,6 +3950,8 @@ async def gateway_drain(request: Request):
         drain_requested,
         write_drain_request,
     )
+
+    home = _resolve_optional_profile_home(profile)
 
     try:
         body = await request.json()
@@ -3957,7 +3965,7 @@ async def gateway_drain(request: Request):
     principal = getattr(principal_obj, "principal", None) or "dashboard"
 
     if action == "cancel":
-        existed = clear_drain_request()
+        existed = clear_drain_request(home=home)
         _log.info("Gateway drain CANCEL requested by %s (existed=%s)", principal, existed)
         return {"ok": True, "action": "cancel", "was_draining": existed}
 
@@ -3970,6 +3978,7 @@ async def gateway_drain(request: Request):
     payload = write_drain_request(
         principal=str(principal),
         suppress_notification=bool((body or {}).get("suppress_notification", False)),
+        home=home,
     )
     _log.info(
         "Gateway drain BEGIN requested by %s (suppress_notification=%s)",
@@ -3982,7 +3991,7 @@ async def gateway_drain(request: Request):
         "requested_at": payload["requested_at"],
         # Echo so a caller polling /api/status knows the marker is now set;
         # the gateway watcher flips gateway_state -> draining within ~1s.
-        "draining": drain_requested(),
+        "draining": drain_requested(home=home),
         "suppress_notification": payload["suppress_notification"],
     }
 
@@ -12563,18 +12572,33 @@ async def run_security_audit():
     return {"ok": True, "pid": proc.pid, "name": "security-audit"}
 
 
-def _dashboard_backup_dir() -> Path:
-    return get_hermes_home() / "backups"
+def _resolve_optional_profile_home(profile: Optional[str]) -> Path:
+    """Resolve ``profile`` to its HERMES_HOME, or the dashboard's own home.
+
+    Shared by the drain + backup endpoints below, which — unlike
+    ``/api/config``'s ``_profile_scope`` — call into helpers that already take
+    a ``home``/``-p`` argument directly, so no contextvar override is needed;
+    just the resolved directory. None/""/"current" means the dashboard's own
+    profile, matching ``_profile_scope``'s contract.
+    """
+    requested = (profile or "").strip()
+    if not requested or requested.lower() == "current":
+        return get_hermes_home()
+    return _resolve_profile_dir(requested)
 
 
-def _new_dashboard_backup_path() -> Path:
+def _dashboard_backup_dir(profile: Optional[str] = None) -> Path:
+    return _resolve_optional_profile_home(profile) / "backups"
+
+
+def _new_dashboard_backup_path(profile: Optional[str] = None) -> Path:
     stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
-    return _dashboard_backup_dir() / f"hermes-backup-{stamp}-{secrets.token_hex(4)}.zip"
+    return _dashboard_backup_dir(profile) / f"hermes-backup-{stamp}-{secrets.token_hex(4)}.zip"
 
 
-def _list_backups() -> list[dict]:
+def _list_backups(profile: Optional[str] = None) -> list[dict]:
     """List existing backup archives in the dashboard backup directory."""
-    backup_dir = _dashboard_backup_dir()
+    backup_dir = _dashboard_backup_dir(profile)
     if not backup_dir.is_dir():
         return []
     backups = []
@@ -12593,20 +12617,20 @@ def _list_backups() -> list[dict]:
 
 
 @app.get("/api/ops/backup/list")
-async def list_backups():
+async def list_backups(profile: Optional[str] = None):
     """List existing backup archives."""
-    return {"backups": _list_backups()}
+    return {"backups": _list_backups(profile)}
 
 
 @app.post("/api/ops/backup")
-async def run_backup(body: BackupRequest):
-    args = ["backup"]
+async def run_backup(body: BackupRequest, profile: Optional[str] = None):
+    args = _profile_cli_args(profile) + ["backup"]
     archive: Optional[Path] = None
     output = (body.output or "").strip()
     if output:
         args.extend(["-o", output])
     else:
-        archive = _new_dashboard_backup_path()
+        archive = _new_dashboard_backup_path(profile)
         try:
             archive.parent.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
@@ -12627,9 +12651,9 @@ async def run_backup(body: BackupRequest):
 
 
 @app.get("/api/ops/backup/download")
-async def download_dashboard_backup(archive: str):
+async def download_dashboard_backup(archive: str, profile: Optional[str] = None):
     try:
-        backup_dir = _dashboard_backup_dir().expanduser().resolve(strict=False)
+        backup_dir = _dashboard_backup_dir(profile).expanduser().resolve(strict=False)
         target = Path(archive).expanduser().resolve(strict=True)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Backup not found")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12572,6 +12572,32 @@ def _new_dashboard_backup_path() -> Path:
     return _dashboard_backup_dir() / f"hermes-backup-{stamp}-{secrets.token_hex(4)}.zip"
 
 
+def _list_backups() -> list[dict]:
+    """List existing backup archives in the dashboard backup directory."""
+    backup_dir = _dashboard_backup_dir()
+    if not backup_dir.is_dir():
+        return []
+    backups = []
+    try:
+        for entry in sorted(backup_dir.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+            if entry.suffix == ".zip" and entry.is_file():
+                backups.append({
+                    "name": entry.name,
+                    "path": str(entry),
+                    "size": entry.stat().st_size,
+                    "modified": datetime.fromtimestamp(entry.stat().st_mtime, tz=timezone.utc).isoformat(),
+                })
+    except OSError:
+        pass
+    return backups
+
+
+@app.get("/api/ops/backup/list")
+async def list_backups():
+    """List existing backup archives."""
+    return {"backups": _list_backups()}
+
+
 @app.post("/api/ops/backup")
 async def run_backup(body: BackupRequest):
     args = ["backup"]

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -310,8 +310,95 @@ class TestWebServerEndpoints:
         resp = self.client.post("/api/gateway/drain", json={"action": "explode"})
         assert resp.status_code == 400
 
+    def test_gateway_drain_profile_scopes_marker_path(self):
+        """?profile=<name> must write/clear the marker under that profile's own
+        home — desktop's global-remote mode shares one dashboard across
+        profiles, each with its own gateway process watching its own home.
+        Writing to the dashboard's own home would drain the WRONG gateway.
+        """
+        from hermes_constants import get_hermes_home
+        from hermes_cli import profiles as profiles_mod
 
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_home.mkdir(parents=True)
+        dashboard_home = get_hermes_home()
 
+        resp = self.client.post("/api/gateway/drain?profile=worker", json={"action": "drain"})
+        assert resp.status_code == 200
+        assert resp.json()["draining"] is True
+        assert (worker_home / ".drain_request.json").is_file()
+        assert not (dashboard_home / ".drain_request.json").exists()
+
+        resp = self.client.post("/api/gateway/drain?profile=worker", json={"action": "cancel"})
+        assert resp.status_code == 200
+        assert resp.json()["was_draining"] is True
+        assert not (worker_home / ".drain_request.json").exists()
+
+    def test_list_backups_profile_scoped(self):
+        """?profile=<name> must list the archives under that profile's own
+        backups directory, not the dashboard's own (issue class: a shared
+        global-remote dashboard listing another profile's private backups, or
+        missing the profile's own).
+        """
+        from hermes_cli import profiles as profiles_mod
+
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_backups = worker_home / "backups"
+        worker_backups.mkdir(parents=True)
+        (worker_backups / "hermes-backup-worker.zip").write_bytes(b"zip")
+
+        resp = self.client.get("/api/ops/backup/list?profile=worker")
+        assert resp.status_code == 200
+        names = [entry["name"] for entry in resp.json()["backups"]]
+        assert names == ["hermes-backup-worker.zip"]
+
+        resp = self.client.get("/api/ops/backup/list")
+        assert resp.json()["backups"] == []
+
+    def test_run_backup_profile_scoped(self, monkeypatch):
+        """?profile=<name> must both spawn `hermes -p <name> backup` (so the
+        CLI child actually backs up that profile's data, not the dashboard's
+        own) and write the output archive into that profile's own backups dir.
+        """
+        import hermes_cli.web_server as web_server
+        from hermes_cli import profiles as profiles_mod
+
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_home.mkdir(parents=True)
+
+        seen = {}
+
+        def fake_spawn(subcommand, name):
+            seen["subcommand"] = subcommand
+            return SimpleNamespace(pid=4321)
+
+        monkeypatch.setattr(web_server, "_spawn_hermes_action", fake_spawn)
+
+        resp = self.client.post("/api/ops/backup?profile=worker", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert seen["subcommand"][:3] == ["-p", "worker", "backup"]
+        assert Path(data["archive"]).parent == worker_home / "backups"
+
+    def test_download_backup_profile_scoped(self):
+        """A worker-profile archive must download under ?profile=worker, and
+        must NOT be reachable through the dashboard's own (unscoped) request —
+        otherwise one profile's backups are exposed to another.
+        """
+        from hermes_cli import profiles as profiles_mod
+
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_backups = worker_home / "backups"
+        worker_backups.mkdir(parents=True)
+        archive = worker_backups / "hermes-backup-worker.zip"
+        archive.write_bytes(b"zip-bytes")
+
+        resp = self.client.get(f"/api/ops/backup/download?archive={archive}&profile=worker")
+        assert resp.status_code == 200
+        assert resp.content == b"zip-bytes"
+
+        resp = self.client.get(f"/api/ops/backup/download?archive={archive}")
+        assert resp.status_code == 403
 
     @staticmethod
     def _provider_field_map(payload):


### PR DESCRIPTION
## Summary
- Adds a gateway drain/cancel control to the desktop Maintenance panel, backed by the existing `/api/gateway/drain` endpoint.
- Adds a new Backups panel (sidebar section) to list, run, and download backup archives, backed by a new `/api/ops/backup/list` endpoint (`_list_backups`) plus the existing `/api/ops/backup` and `/api/ops/backup/download` endpoints.
- Fixes `backend-ready.ts` to decode child stdout as `utf8` explicitly instead of relying on the platform default.

## Test plan
- [x] `npm run typecheck` clean (apps/desktop)
- [x] `npm run lint` clean on touched files
- [x] `python -c "import ast; ast.parse(...)"` clean on `hermes_cli/web_server.py`
- [ ] Manual: drain/cancel gateway from desktop app, verify status flips and new turns are refused while draining
- [ ] Manual: run a backup, confirm it appears in the Backups list and downloads correctly