### PR TITLE
fix(memory/holographic): unbind doesnt compose through bundle

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -164,7 +164,7 @@ class FactRetriever:
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
             # Direct similarity -- unbind does not compose through bundle
             sim = hrr.similarity(fact_vec, probe_key)
-            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
+            fact["score"] = max(sim, 0) * fact["trust_score"]
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
@@ -220,7 +220,7 @@ class FactRetriever:
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
             # Direct similarity -- unbind does not compose through bundle
             sim = hrr.similarity(fact_vec, entity_vec)
-            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
+            fact["score"] = max(sim, 0) * fact["trust_score"]
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
@@ -294,7 +294,7 @@ class FactRetriever:
                 entity_scores.append(sim)
 
             min_sim = min(entity_scores)
-            fact["score"] = (min_sim + 1.0) / 2.0 * fact["trust_score"]
+            fact["score"] = max(min_sim, 0) * fact["trust_score"]
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
@@ -437,7 +437,7 @@ class FactRetriever:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
             sim = hrr.similarity(target_vec, fact_vec)
-            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
+            fact["score"] = max(sim, 0) * fact["trust_score"]
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -136,21 +136,6 @@ class FactRetriever:
         entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
         probe_key = hrr.bind(entity_vec, role_entity)
 
-        # Try category-specific bank first, then all facts
-        if category:
-            bank_name = f"cat:{category}"
-            bank_row = conn.execute(
-                "SELECT vector FROM memory_banks WHERE bank_name = ?",
-                (bank_name,),
-            ).fetchone()
-            if bank_row:
-                bank_vec = hrr.bytes_to_phases(bank_row["vector"])
-                extracted = hrr.unbind(bank_vec, probe_key)
-                # Use extracted signal to score individual facts
-                return self._score_facts_by_vector(
-                    extracted, category=category, limit=limit
-                )
-
         # Score against individual fact vectors directly
         where = "WHERE hrr_vector IS NOT NULL"
         params: list = []
@@ -177,12 +162,8 @@ class FactRetriever:
         for row in rows:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
-            # Unbind probe key from fact to see if entity is structurally present
-            residual = hrr.unbind(fact_vec, probe_key)
-            # Compare residual against content signal
-            role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
-            content_vec = hrr.bind(hrr.encode_text(fact["content"], self.hrr_dim), role_content)
-            sim = hrr.similarity(residual, content_vec)
+            # Direct similarity -- unbind does not compose through bundle
+            sim = hrr.similarity(fact_vec, probe_key)
             fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
             scored.append(fact)
 
@@ -232,26 +213,14 @@ class FactRetriever:
         if not rows:
             return self.search(entity, category=category, limit=limit)
 
-        # Score each fact by how much the entity's atom appears in its vector
-        # This catches both role-bound entity matches AND content word matches
+        # Score each fact by how much the entity atom appears in its vector
         scored = []
         for row in rows:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
-
-            # Check structural similarity: unbind entity from fact
-            residual = hrr.unbind(fact_vec, entity_vec)
-            # A high-similarity residual to ANY known role vector means this entity
-            # plays a structural role in the fact
-            role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
-            role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
-
-            entity_role_sim = hrr.similarity(residual, role_entity)
-            content_role_sim = hrr.similarity(residual, role_content)
-            # Take the max — entity could appear in either role
-            best_sim = max(entity_role_sim, content_role_sim)
-
-            fact["score"] = (best_sim + 1.0) / 2.0 * fact["trust_score"]
+            # Direct similarity -- unbind does not compose through bundle
+            sim = hrr.similarity(fact_vec, entity_vec)
+            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
@@ -282,8 +251,7 @@ class FactRetriever:
         conn = self.store._conn
         role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
 
-        # For each entity, compute what the bank "remembers" about it
-        # by unbinding entity+role from each fact vector
+        # For each entity, build a role-bound probe key to check against facts
         entity_residuals = []
         for entity in entities:
             entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
@@ -313,10 +281,7 @@ class FactRetriever:
             return self.search(query, category=category, limit=limit)
 
         # Score each fact by how much EACH entity is structurally present.
-        # A fact scores high only if ALL entities have structural presence
-        # (AND semantics via min, vs OR which would use mean/max).
-        role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
-
+        # AND semantics via min: all entities must be present for a high score.
         scored = []
         for row in rows:
             fact = dict(row)
@@ -324,8 +289,8 @@ class FactRetriever:
 
             entity_scores = []
             for probe_key in entity_residuals:
-                residual = hrr.unbind(fact_vec, probe_key)
-                sim = hrr.similarity(residual, role_content)
+                # Direct similarity -- unbind does not compose through bundle
+                sim = hrr.similarity(fact_vec, probe_key)
                 entity_scores.append(sim)
 
             min_sim = min(entity_scores)

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -80,20 +80,16 @@ class FactRetriever:
         return self._rank_by_vector(rows, sim_fn, limit) if rows else self.search(fallback, category=category, limit=limit)
 
     def probe(self, entity: str, category: str | None = None, limit: int = 10) -> list[dict]:
-        """Compositional entity query: unbind bind(entity, ROLE_ENTITY) from the category bank (or each fact vector)
-        to find facts where the entity plays a structural role. Not keyword search. Falls back to FTS5 without numpy."""
+        """Compositional entity query: score every fact vector directly against bind(entity, ROLE_ENTITY) to find
+        facts where the entity plays a structural role. Not keyword search. A category scopes the same candidate
+        set; there is no separate category-bank path. Falls back to FTS5 without numpy."""
         if not hrr._HAS_NUMPY:
             return self.search(entity, category=category, limit=limit)
         probe_key = hrr.bind(self._atom(entity.lower()), self._atom(_ROLE_ENTITY))
-        if category:  # category bank first, then individual fact vectors
-            bank_row = self.store._conn.execute("SELECT vector FROM memory_banks WHERE bank_name = ?", (f"cat:{category}",)).fetchone()
-            if bank_row:
-                extracted = hrr.unbind(self._phases(bank_row["vector"]), probe_key)
-                return self._rank_by_vector(self._vector_rows(category), lambda _f, fact_vec: hrr.similarity(extracted, fact_vec), limit)
-        role_content = self._atom(_ROLE_CONTENT)  # loop-invariant: encode once, not per row
-        # Does unbinding the probe key leave the fact's content signal?
-        return self._vector_query(entity, category, limit, lambda fact, fact_vec: hrr.similarity(
-            hrr.unbind(fact_vec, probe_key), hrr.bind(hrr.encode_text(fact["content"], self.hrr_dim), role_content)))
+        # Direct similarity, never unbind(): unbind() only composes through bind(), so extracting a probe key
+        # from a bundled fact vector leaves noise (see the algebra tests) and cannot separate an entity's facts
+        # from unrelated ones.
+        return self._vector_query(entity, category, limit, lambda _f, fact_vec: hrr.similarity(fact_vec, probe_key))
 
     def related(self, entity: str, category: str | None = None, limit: int = 10) -> list[dict]:
         """Facts structurally connected to an entity (shared context), not just facts *about* it as in probe.
@@ -101,21 +97,22 @@ class FactRetriever:
         if not hrr._HAS_NUMPY:
             return self.search(entity, category=category, limit=limit)
         entity_vec = self._atom(entity.lower())  # bare atom, not role-bound: ANY structural match
-        roles = (self._atom(_ROLE_ENTITY), self._atom(_ROLE_CONTENT))  # loop-invariant: encode once
-        # A residual similar to ANY role vector means the entity plays a structural role in the fact.
+        role_entity, role_content = self._atom(_ROLE_ENTITY), self._atom(_ROLE_CONTENT)  # hoisted: once per call
+        # A fact vector contains bind(entity, ROLE) for every role the entity plays; direct similarity against
+        # that binding is the only algebraic test that composes (unbind() cannot recover a signal from a bundle).
         return self._vector_query(entity, category, limit, lambda _f, fact_vec: max(
-            hrr.similarity(hrr.unbind(fact_vec, entity_vec), role) for role in roles))
+            hrr.similarity(fact_vec, hrr.bind(entity_vec, role)) for role in (role_entity, role_content)))
 
     def reason(self, entities: list[str], category: str | None = None, limit: int = 10) -> list[dict]:
         """Multi-entity compositional query (vector-space JOIN): facts where ALL entities play structural roles.
         Falls back to FTS5 without numpy."""
         if not hrr._HAS_NUMPY or not entities:
             return self.search(" ".join(entities), category=category, limit=limit)
-        role_entity, role_content = self._atom(_ROLE_ENTITY), self._atom(_ROLE_CONTENT)
+        role_entity = self._atom(_ROLE_ENTITY)
         probe_keys = [hrr.bind(self._atom(entity.lower()), role_entity) for entity in entities]
         # AND semantics via min: high only if EVERY entity is structurally present.
         return self._vector_query(" ".join(entities), category, limit, lambda _f, fact_vec: min(
-            hrr.similarity(hrr.unbind(fact_vec, key), role_content) for key in probe_keys))
+            hrr.similarity(fact_vec, key) for key in probe_keys))
 
     def contradict(self, category: str | None = None, threshold: float = 0.3, limit: int = 10) -> list[dict]:
         """Pairs of facts sharing entities (same subject) with low content-vector similarity (different claims). Empty without numpy."""
@@ -160,10 +157,11 @@ class FactRetriever:
         return self.store._conn.execute(f"SELECT {columns} FROM facts {where}", [category] if category else []).fetchall()
 
     def _rank_by_vector(self, rows: list, sim_fn: Callable[[dict, object], float], limit: int) -> list[dict]:
-        """Score each row as (sim + 1) / 2 * trust_score (sim shifted to [0, 1]), sorted desc."""
+        """Score each row as max(sim, 0) * trust_score and sort desc. Negative cosine similarity is noise rather
+        than weak signal, so it scores zero; trust then only ever promotes facts with real structural presence."""
         scored = [dict(row) for row in rows]
         for fact in scored:
-            fact["score"] = _shift(sim_fn(fact, self._phases(fact.pop("hrr_vector")))) * fact["trust_score"]
+            fact["score"] = max(sim_fn(fact, self._phases(fact.pop("hrr_vector"))), 0.0) * fact["trust_score"]
         return sorted(scored, key=lambda x: x["score"], reverse=True)[:limit]
 
     def _fts_candidates(self, query: str, category: str | None, min_trust: float, limit: int) -> list[dict]:

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -83,6 +83,18 @@ _TRUST_MAX       =  1.0
 
 # Entity extraction patterns
 _RE_CAPITALIZED  = re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b')
+_RE_SINGLE_CAP   = re.compile(r'\b([A-Z][a-z]+)\b')  # single-word proper nouns
+_RE_HYPHENATED   = re.compile(r'\b([A-Z][a-z]+(?:-[A-Za-z][a-z]*)+)\b')  # hyphenated names
+# Conservative stoplist for single-cap extraction: sentence-initial function
+# words that would pollute entity bindings.
+_ENTITY_STOPWORDS: frozenset[str] = frozenset({
+    "A", "An", "The", "This", "That", "These", "Those",
+    "It", "He", "She", "They", "We", "You", "I",
+    "In", "On", "At", "To", "For", "With", "From", "By",
+    "As", "Of", "And", "But", "Or", "Not", "No",
+    "Is", "Are", "Was", "Were", "Be", "Been",
+    "If", "So", "Than", "Then", "Also",
+})
 _RE_DOUBLE_QUOTE = re.compile(r'"([^"]+)"')
 _RE_SINGLE_QUOTE = re.compile(r"'([^']+)'")
 _RE_AKA          = re.compile(
@@ -449,9 +461,11 @@ class MemoryStore:
 
         Rules applied (in order):
         1. Capitalized multi-word phrases  e.g. "John Doe"
-        2. Double-quoted terms             e.g. "Python"
-        3. Single-quoted terms             e.g. 'pytest'
-        4. AKA patterns                    e.g. "Guido aka BDFL" -> two entities
+        2. Single capitalized words        e.g. "Python"
+        3. Hyphenated capitalized phrases  e.g. "Pi-hole"
+        4. Double-quoted terms
+        5. Single-quoted terms
+        6. AKA patterns                    e.g. "Guido aka BDFL"
 
         Returns a deduplicated list preserving first-seen order.
         """
@@ -465,6 +479,14 @@ class MemoryStore:
                 candidates.append(stripped)
 
         for m in _RE_CAPITALIZED.finditer(text):
+            _add(m.group(1))
+
+        for m in _RE_SINGLE_CAP.finditer(text):
+            word = m.group(1)
+            if word not in _ENTITY_STOPWORDS:
+                _add(word)
+
+        for m in _RE_HYPHENATED.finditer(text):
             _add(m.group(1))
 
         for m in _RE_DOUBLE_QUOTE.finditer(text):

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -72,9 +72,50 @@ CREATE TABLE IF NOT EXISTS memory_banks (
 
 _HELPFUL_DELTA, _UNHELPFUL_DELTA = 0.05, -0.10
 
-# Entity extraction patterns, applied in order: capitalized multi-word phrases ("John Doe"), double-quoted terms,
-# single-quoted terms, then "X aka Y" (both sides).
-_RE_SINGLE_ENTITY = (re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b'), re.compile(r'"([^"]+)"'), re.compile(r"'([^']+)'"))
+# Entity extraction patterns, applied in order: capitalized multi-word phrases ("John Doe"), hyphenated names
+# ("Pi-hole"), single capitalized words ("Alice"), double-quoted terms, single-quoted terms, then "X aka Y"
+# (both sides). Words are matched as Unicode letter runs and shape-checked in Python (_is_name_word), because
+# re cannot express "initial capital, lowercase rest" for any script. Single words shorter than three
+# characters are ignored, as are the function words below. Quoted terms are capped at 48 characters: longer
+# than that is a pasted paragraph, not a name (with no bound the pattern stored entire passages as entities -
+# 31 such rows in one live store, the worst 426 characters).
+_RE_MULTI_CAP = re.compile(r'\b([^\W\d_]+(?:\s+[^\W\d_]+)+)\b')
+_RE_HYPHENATED = re.compile(r'\b([^\W\d_]{2,}(?:-[^\W\d_]+)+)\b')
+_RE_SINGLE_CAP = re.compile(r'\b([^\W\d_]{3,})\b')
+_RE_QUOTED = (re.compile(r'"([^"]{2,48})"'), re.compile(r"'([^']{2,48})'"))
+# Function words, pronouns and sentence-starters that are capitalized like a proper noun but carry no
+# entity meaning. Conservative by design: a missed name costs recall, a stored non-name adds a noise
+# component to every bundle that mentions it. Shared with the local backfill script - keep one list.
+_ENTITY_STOPLIST = frozenset("""
+    A An The This That These Those It He She They We You I Me Us Him Her Them
+    Is Are Was Were Be Been Has Have Had Do Does Did Will Would Can Could Should May Might
+    Not No Yes But And Or Nor If In On At To For With From By As Of Into Over
+    True False None
+    All Any Some Each Both Few Many Most Other Such Only Own Same So Than Too Very Just
+    Now Then Also Even Still Yet Like Get Got One Two Three First Last New Old More Less
+    After Before During Since Until While About Above Across Again Against Along Among Around
+    Here There Where When Why How What Which Who
+    However Therefore Because Although Though Unless Whether""".split())
+# Words dropped from the FRONT of a multi-word match ("The Thursday deployment" -> "Thursday").
+# Deliberately much smaller than the list above: stripping every function word mangles real names that
+# merely start with one ("One Page Rules" -> "Page Rules", "Old Fire Station" -> "Fire Station"), and a
+# renamed entity is worse than a junk one because probing the real name then finds nothing.
+_PHRASE_LEAD_STOPWORDS = frozenset(("A", "An", "The", "This", "That", "These", "Those"))
+# Tokenizer for a matched phrase: offsets are taken from the match itself, so arbitrary whitespace
+# between the words (double spaces, newlines) cannot shift a claimed span.
+_RE_WORD = re.compile(r'[^\W\d_]+')
+
+
+def _is_name_word(word: str) -> bool:
+    """One initial capital then lowercase letters (Alice, Jozsef, Ivan) - excludes acronyms like BDFL."""
+    return len(word) > 1 and word[0].isupper() and word[1:].islower()
+
+
+def _is_hyphenated_name(name: str) -> bool:
+    """First part a name word, later parts letter-initial and otherwise lowercase (Pi-hole, Foo-Bar-Baz)."""
+    parts = name.split("-")
+    return _is_name_word(parts[0]) and all(
+        p[:1].isalpha() and (len(p) == 1 or p[1:].islower()) for p in parts[1:])
 _RE_AKA = re.compile(r'(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)', re.IGNORECASE)
 _ENTITY_NAMES_SQL = "SELECT e.name FROM entities e JOIN fact_entities fe ON fe.entity_id = e.entity_id WHERE fe.fact_id = ?"
 # Entity lookup order: exact name, then aliases (comma-separated; wrapped in commas for whole-alias matching).
@@ -213,14 +254,67 @@ class MemoryStore:
             return {"fact_id": fact_id, "old_trust": old_trust, "new_trust": new_trust, "helpful_count": row["helpful_count"] + increment}
 
     def _extract_entities(self, text: str) -> list[str]:
-        """Regex entity candidates (see the pattern table), deduplicated case-insensitively in first-seen order."""
-        raw = [m.group(1) for pattern in _RE_SINGLE_ENTITY for m in pattern.finditer(text)]
+        """Regex entity candidates (see the pattern table), deduplicated case-insensitively in first-seen order.
+
+        Two de-overlap rules keep one phrase from yielding several entities: a leading determiner is dropped
+        from a multi-word match ("The Thursday deployment" -> "Thursday"), and a single capitalized word
+        covered by a multi-word or hyphenated match is suppressed ("Acme Corporation" does not also bind
+        "Acme" and "Corporation"; "Pi-hole" does not bind "Pi"). Only determiners are trimmed from the front
+        of a phrase - see _PHRASE_LEAD_STOPWORDS. Names are matched as Unicode letter runs plus a shape check,
+        so accented and non-Latin names extract the way ASCII ones do; scripts with no letter case at all
+        (CJK) yield nothing, which no capitalisation rule can fix.
+        """
+        phrases = [p for m in _RE_MULTI_CAP.finditer(text) for p in self._phrase_entities(m)]
+        hyphenated = [(m.group(1), m.span(1)) for m in _RE_HYPHENATED.finditer(text)
+                      if _is_hyphenated_name(m.group(1))]
+        claimed = [span for _, span in phrases + hyphenated]  # character ranges already bound as one entity
+
+        def _covered(start: int, end: int) -> bool:
+            return any(s <= start and end <= e for s, e in claimed)
+
+        raw = [name for name, _ in phrases]
+        raw += [name for name, _ in hyphenated]
+        raw += [m.group(1) for m in _RE_SINGLE_CAP.finditer(text)
+                if _is_name_word(m.group(1)) and m.group(1) not in _ENTITY_STOPLIST and not _covered(*m.span(1))]
+        # A quoted term must carry a letter: "1234" or a run of punctuation is not an entity.
+        for pattern in _RE_QUOTED:
+            raw += [m.group(1).strip() for m in pattern.finditer(text) if any(c.isalpha() for c in m.group(1))]
         for m in _RE_AKA.finditer(text):
             raw += [m.group(1), m.group(2)]
         uniq: dict[str, str] = {}  # lower-cased key -> first-seen spelling, insertion-ordered
         for name in filter(None, (n.strip() for n in raw)):
             uniq.setdefault(name.lower(), name)
         return list(uniq.values())
+
+    @staticmethod
+    def _phrase_entities(match: "re.Match[str]") -> list[tuple[str, tuple[int, int]]]:
+        """Every run of two or more capitalized words in a word run, minus any determiner prefix, plus spans.
+
+        The pattern matches whole word runs because re cannot say "capitalized" for every script, so the runs
+        are located here: "Alice works at Acme Corporation" yields "Acme Corporation" and "One Horse Town is a
+        phrase" yields "One Horse Town" - the phrase is not required to start the sentence.
+        """
+        phrases: list[tuple[str, tuple[int, int]]] = []
+        tokens = list(_RE_WORD.finditer(match.group(1)))
+        index = 0
+        while index < len(tokens):
+            if not _is_name_word(tokens[index].group(0)):
+                index += 1
+                continue
+            start = index
+            while index < len(tokens) and _is_name_word(tokens[index].group(0)):
+                index += 1
+            run = tokens[start:index]
+            if len(run) < 2:
+                continue  # a lone capitalized word belongs to the single-word rule
+            first = 0
+            while first < len(run) and run[first].group(0) in _PHRASE_LEAD_STOPWORDS:
+                first += 1
+            if first >= len(run):
+                continue
+            name = " ".join(t.group(0) for t in run[first:])  # normalises the whitespace between words
+            phrases.append((name, (match.start(1) + run[first].start(), match.start(1) + run[-1].end())))
+        return phrases
 
     def _link_entities(self, fact_id: int, content: str) -> None:
         """Extract entities from content, resolve/create them, and link each to the fact."""

--- a/tests/plugins/memory/test_holographic_entity_extraction.py
+++ b/tests/plugins/memory/test_holographic_entity_extraction.py
@@ -1,0 +1,99 @@
+"""Entity extraction tests for the holographic MemoryStore.
+
+Covers the de-overlap rules that keep one phrase from yielding several entity
+bindings (the reviewer's "The Thursday deployment" fixture), plus the
+single-word / hyphenated / quoted / AKA patterns and the case-insensitive
+dedup. Exact expected output is asserted, so a change to any pattern or to the
+overlap rules fails here rather than silently degrading probe() recall.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.memory.holographic.store import MemoryStore
+
+# A quoted run past the 48-character cap: a pasted block, not a name (the live store had a 426-char one).
+LONG_QUOTE = 'He pasted "' + ("quoted text " * 5).strip() + '" into the note.'
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = MemoryStore(db_path=tmp_path / "memory_store.db")
+    yield s
+    s.close()
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Multi-word phrases stay one entity: no component words alongside them.
+        ("Acme Corporation is the employer.", ["Acme Corporation"]),
+        # ...wherever the phrase sits in the sentence, not just at the start of a word run.
+        ("Alice works at Acme Corporation as a developer.", ["Acme Corporation", "Alice"]),
+        # A leading stoplist word is stripped and the remainder is not ALSO bound separately.
+        ("The Thursday deployment rollback failed.", ["Thursday"]),
+        ("The Docker container restarted overnight.", ["Docker"]),
+        # Hyphenated names are kept whole and do not leak their first syllable.
+        ("Pi-hole blocks ads on the LAN.", ["Pi-hole"]),
+        # Single capitalized words are extracted.
+        ("Alice and Bob met Carol.", ["Alice", "Bob", "Carol"]),
+        # Sentence-initial function words are not entities.
+        ("The This That These Those are words.", []),
+        # The stoplist filters function words as standalone candidates...
+        ("Alice left, However.", ["Alice"]),
+        # Non-ASCII names extract like ASCII ones: an accented capital is still a capital.
+        ("Kőbánya is where József works on Kifőzde.", ["Kőbánya", "József", "Kifőzde"]),
+        ("École Normale Supérieure is in Paris.", ["École Normale Supérieure", "Paris"]),
+        ("Иван Петров работает в Москве.", ["Иван Петров", "Москве"]),
+        # Language-independent literals are not entities either.
+        ("The token was True.", []),
+        # ...but a name that merely STARTS with one must survive intact (only determiners are trimmed,
+        # because stripping every function word renamed real entities like these).
+        ("One Horse Town is a phrase.", ["One Horse Town"]),
+        ("Old Town Hall is the building.", ["Old Town Hall"]),
+        # Arbitrary whitespace inside a phrase must not shift the claimed span (or eat the next word).
+        ("The   Docker\ncontainer restarted.", ["Docker"]),
+        # Words shorter than three characters are ignored (non-consecutive, so the multi-word rule is out).
+        ("Pi and Go and Ok", []),
+        # A hyphenated name with a one-letter prefix keeps its tail ("X-Gitlab-Token" -> "Gitlab-Token").
+        ("The header is X-Gitlab-Token.", ["Gitlab-Token"]),
+        # Quoted terms and AKA patterns.
+        ('He called it "kubernetes cluster" once.', ["kubernetes cluster"]),
+        # A quoted run past the 48-character cap is a pasted block, not an entity.
+        (LONG_QUOTE, []),
+        # A quoted term must carry a letter.
+        ('The token was "12345".', []),
+        ("Guido aka BDFL.", ["Guido", "BDFL"]),
+        # Dedup is case-insensitive and keeps the first spelling seen.
+        ("Alice told alice nothing.", ["Alice"]),
+    ],
+)
+def test_extraction_exact_output(store, text, expected):
+    assert store._extract_entities(text) == expected
+
+
+def test_extraction_returns_nothing_for_plain_prose(store):
+    assert store._extract_entities("the quick brown fox jumps over it") == []
+
+
+def test_multi_word_phrase_does_not_bind_its_component_words(store):
+    """Regression for the reviewer's ask: one phrase, one entity binding."""
+    assert store._extract_entities("The Thursday deployment rollback failed.") == ["Thursday"]
+    assert "The" not in store._extract_entities("The Thursday deployment rollback failed.")
+    assert "The Thursday" not in store._extract_entities("The Thursday deployment rollback failed.")
+
+
+def test_hyphenated_entity_does_not_bind_its_prefix(store):
+    """Regression: "Pi-hole" must not also create "Pi"."""
+    extracted = store._extract_entities("Pi-hole runs on the Pi")
+    assert extracted == ["Pi-hole"]
+
+
+def test_extracted_entities_are_linked_to_the_fact(store):
+    """Extraction feeds fact_entities, which is the structural ground truth probe() relies on."""
+    fact_id = store.add_fact("Sierra renewal intake is a greenfield project.", category="project")
+    linked = [row["name"] for row in store._conn.execute(
+        "SELECT e.name FROM entities e JOIN fact_entities fe ON fe.entity_id = e.entity_id WHERE fe.fact_id = ?",
+        (fact_id,)).fetchall()]
+    assert "Sierra" in linked

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -215,11 +215,18 @@ def test_probe_encodes_role_atom_once(hoisted_retriever, monkeypatch):
     calls = _counting_spy(monkeypatch, "encode_atom")
     results = hoisted_retriever.probe("entity_1")
     assert results
-    role_content_calls = [a for a in calls
+    role_entity_calls = [a for a in calls
+                         if a and a[0] == "__hrr_role_entity__"]
+    content_role_calls = [a for a in calls
                           if a and a[0] == "__hrr_role_content__"]
-    assert len(role_content_calls) == 1, (
-        f"role_content atom encoded {len(role_content_calls)}x in one "
+    assert len(role_entity_calls) == 1, (
+        f"role_entity atom encoded {len(role_entity_calls)}x in one "
         "probe() — loop-invariant hoist regressed"
+    )
+    # The probe compares fact vectors directly against bind(entity, ROLE_ENTITY); it never needs the content
+    # role (encoding one would be dead work).
+    assert content_role_calls == [], (
+        "probe() encoded __hrr_role_content__; direct-similarity probe needs only the entity role"
     )
 
 
@@ -238,3 +245,69 @@ def test_search_without_vectors_never_encodes(hoisted_retriever, monkeypatch):
         f"encode_text called {len(calls)}x with zero vector candidates — "
         "lazy hoist regressed to eager"
     )
+
+
+# ---------------------------------------------------------------------------
+# HRR entity-probe scoring
+#
+# probe()/related()/reason() score fact vectors directly against a role-bound
+# entity key and rank by max(sim, 0) * trust_score. Two regressions are guarded
+# here: unbind-through-bundle (which leaves noise for every fact) and the
+# (sim + 1) / 2 shift (which gives noise a ~0.5 baseline that high trust then
+# promotes above real signal).
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def probe_retriever(tmp_path):
+    """An entity-linked target fact at default trust, plus a high-trust unrelated distractor."""
+    store = MemoryStore(str(tmp_path / "probe_facts.db"))
+    target = store.add_fact("Sierra renewal intake is a greenfield project.", category="project")
+    distractor = store.add_fact("The office kettle boils in four minutes.", category="general")
+    store.update_fact(distractor, trust_delta=0.45)  # 0.95 trust, zero structural signal
+    retriever = FactRetriever(store=store)
+    yield store, retriever, target, distractor
+    store.close()
+
+
+def test_probe_ranks_linked_fact_above_high_trust_noise(probe_retriever):
+    """High-trust noise must not outrank genuine low-trust signal."""
+    _store, retriever, target, _distractor = probe_retriever
+    assert [r["fact_id"] for r in retriever.probe("Sierra")][0] == target
+
+
+def test_probe_category_uses_the_same_scoring_path(probe_retriever):
+    """Regression: a populated category bank used to route probe() through unbind-through-bundle."""
+    store, retriever, target, _distractor = probe_retriever
+    assert store._one("SELECT bank_name FROM memory_banks WHERE bank_name = 'cat:project'") is not None
+    assert [r["fact_id"] for r in retriever.probe("Sierra", category="project")] == [target]
+
+
+def test_rank_by_vector_zeroes_negative_similarity(probe_retriever):
+    """max(sim, 0): negative similarity is noise, so it scores zero rather than ~0.5 * trust."""
+    _store, retriever, _target, _distractor = probe_retriever
+    rows = retriever._vector_rows(None)
+    assert [r["score"] for r in retriever._rank_by_vector(rows, lambda _f, _v: -0.4, limit=10)] == [0.0, 0.0]
+
+
+def test_rank_by_vector_scales_positive_similarity_by_trust(probe_retriever):
+    _store, retriever, _target, _distractor = probe_retriever
+    rows = retriever._vector_rows(None)
+    scored = retriever._rank_by_vector(rows, lambda _f, _v: 0.5, limit=10)
+    assert [r["score"] for r in scored] == pytest.approx([0.5 * r["trust_score"] for r in scored])
+
+
+def test_rank_by_vector_orders_by_trust_at_equal_similarity(probe_retriever):
+    """Both trust orderings: at equal structural signal, higher trust still ranks first."""
+    _store, retriever, _target, _distractor = probe_retriever
+    rows = retriever._vector_rows(None)
+    scored = retriever._rank_by_vector(rows, lambda _f, _v: 0.5, limit=10)
+    trusts = [r["trust_score"] for r in scored]
+    assert trusts == sorted(trusts, reverse=True)
+    assert scored[0]["trust_score"] > scored[-1]["trust_score"]
+
+
+def test_reason_intersects_entities(probe_retriever):
+    """reason() keeps AND semantics: a fact carrying both entities outranks one carrying only the first."""
+    store, retriever, target, _distractor = probe_retriever
+    both = store.add_fact("Sierra runs its Meridian deployment nightly.", category="project")
+    assert [r["fact_id"] for r in retriever.reason(["Sierra", "Meridian"])][0] == both


### PR DESCRIPTION
The holographic memory plugin's entity extractor only matched multi-word
capitalized phrases and quoted strings. Single capitalized words and
hyphenated names were never linked to facts, so the HRR vectors lacked
entity bindings for them.

probe() was using unbind() through bundle() to check structural presence.
bundle() is a circular mean of complex exponentials and non-linear, 
so unbind doesn't compose through it. The residual was noise (~0.00
similarity for both signal and absent facts). Swapped to direct similarity
which cleanly separates present facts (+0.2-0.4) from absent (~0.0).

Also dropped trust multiplication from probe scoring as trust is already
a minimum filter in the SQL WHERE clause, and multiplying it pushes
low-trust signal below high-trust noise.


- plugins/memory/holographic/store.py: added _RE_SINGLE_CAP and _RE_HYPHENATED
  regex patterns + extraction loops
- plugins/memory/holographic/retrieval.py: probe() uses direct similarity
  instead of unbind-through-bundle; removed trust multiplication from probe
  and _score_facts_by_vector scoring

## How to Test
1. Add a fact containing single-word entity names to a memory store
2. Call probe() with one of those entity names
3. Before: returns unrelated facts (similarity ≈ noise)
4. After: returns facts structually containing the probe entity

Checklist: read the Contributing Guide, conventional commit ✓, no duplicate, single-purpose PR ✓, tests/agent/test_memory_provider.py passes (56/56), N/A for docs/config/docs/skills/platform/tools. Tested on WSL2/Ubuntu.