### PR TITLE
feat(gateway): add sessionless plugin command dispatch

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -118,6 +118,80 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
         server._sessions.pop(sid, None)
 
 
+def test_plugin_command_dispatch_is_sessionless_and_plugin_only(monkeypatch):
+    import hermes_cli.plugins as plugins
+
+    calls = []
+    monkeypatch.setattr(
+        plugins,
+        "get_plugin_command_handler",
+        lambda name: (lambda arg: calls.append((name, arg)) or "bounded output"),
+    )
+    monkeypatch.setattr(plugins, "resolve_plugin_command_result", lambda result: result)
+    server._sessions.clear()
+
+    response = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": "plugin-command",
+            "method": "plugin.command.dispatch",
+            "params": {"name": "plugin-command", "arg": "fixed input"},
+        }
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "plugin-command",
+        "result": {"type": "plugin", "output": "bounded output"},
+    }
+    assert calls == [("plugin-command", "fixed input")]
+    assert server._sessions == {}
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {},
+        {"name": "plugin-command", "arg": "fixed input", "session_id": "forbidden"},
+        {"name": "Plugin-command", "arg": "fixed input"},
+        {"name": "/plugin-command", "arg": "fixed input"},
+        {"name": "plugin-command", "arg": None},
+    ],
+)
+def test_plugin_command_dispatch_rejects_any_non_contract_parameter(params):
+    response = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": "invalid-plugin-command",
+            "method": "plugin.command.dispatch",
+            "params": params,
+        }
+    )
+
+    assert response["error"]["code"] == -32602
+
+
+def test_plugin_command_dispatch_redacts_handler_failure(monkeypatch):
+    import hermes_cli.plugins as plugins
+
+    def failing_handler(_arg):
+        raise RuntimeError("provider-token=not-for-rpc-output")
+
+    monkeypatch.setattr(plugins, "get_plugin_command_handler", lambda _name: failing_handler)
+    monkeypatch.setattr(plugins, "resolve_plugin_command_result", lambda result: result)
+
+    response = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": "failed-plugin-command",
+            "method": "plugin.command.dispatch",
+            "params": {"name": "plugin-command", "arg": "fixed input"},
+        }
+    )
+
+    assert response["error"] == {"code": 5000, "message": "plugin command failed"}
+
+
 def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
     class DbContext:
         def __init__(self, db):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -171,6 +171,33 @@ def test_plugin_command_dispatch_rejects_any_non_contract_parameter(params):
     assert response["error"]["code"] == -32602
 
 
+def test_plugin_command_dispatch_rejects_unknown_plugin_without_fallback(monkeypatch):
+    import hermes_cli.plugins as plugins
+
+    looked_up = []
+    monkeypatch.setattr(
+        plugins,
+        "get_plugin_command_handler",
+        lambda name: looked_up.append(name) or None,
+    )
+
+    response = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": "unknown-plugin-command",
+            "method": "plugin.command.dispatch",
+            "params": {"name": "missing-plugin-command", "arg": "fixed input"},
+        }
+    )
+
+    assert response["error"] == {
+        "code": 4011,
+        "message": "unknown plugin command: missing-plugin-command",
+    }
+    assert looked_up == ["missing-plugin-command"]
+    assert server._sessions == {}
+
+
 def test_plugin_command_dispatch_redacts_handler_failure(monkeypatch):
     import hermes_cli.plugins as plugins
 

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -153,6 +153,54 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
     assert events == ["accept", "ready_after_0"]
 
 
+def test_ws_plugin_command_dispatch_is_sessionless(monkeypatch):
+    """The public WebSocket path must reach only the plugin-command handler."""
+    import hermes_cli.plugins as plugins
+
+    monkeypatch.setattr(
+        plugins,
+        "get_plugin_command_handler",
+        lambda name: (lambda arg: f"{name}:{arg}"),
+    )
+    monkeypatch.setattr(plugins, "resolve_plugin_command_result", lambda result: result)
+    server._sessions.clear()
+    sent = []
+
+    class FakeWS:
+        reads = 0
+
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            self.reads += 1
+            if self.reads == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "plugin-command",
+                        "method": "plugin.command.dispatch",
+                        "params": {"name": "plugin-command", "arg": "fixed input"},
+                    }
+                )
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
+
+    assert {
+        "jsonrpc": "2.0",
+        "id": "plugin-command",
+        "result": {"type": "plugin", "output": "plugin-command:fixed input"},
+    } in sent
+    assert server._sessions == {}
+
+
 def test_ws_transport_serializes_concurrent_sends():
     active_sends = 0
     max_active_sends = 0
@@ -226,5 +274,4 @@ def test_ws_transport_preserves_cross_batch_order():
         assert entered == ["A1", "A2", "B1", "B2"]
 
     asyncio.run(scenario())
-
 

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -201,6 +201,52 @@ def test_ws_plugin_command_dispatch_is_sessionless(monkeypatch):
     assert server._sessions == {}
 
 
+def test_ws_plugin_command_dispatch_rejects_unknown_plugin_without_fallback(monkeypatch):
+    """Unknown plugin commands stay on the bounded sessionless RPC path."""
+    import hermes_cli.plugins as plugins
+
+    monkeypatch.setattr(plugins, "get_plugin_command_handler", lambda _name: None)
+    server._sessions.clear()
+    sent = []
+
+    class FakeWS:
+        reads = 0
+
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            self.reads += 1
+            if self.reads == 1:
+                return json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "unknown-plugin-command",
+                        "method": "plugin.command.dispatch",
+                        "params": {"name": "missing-plugin-command", "arg": "fixed input"},
+                    }
+                )
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
+
+    assert {
+        "jsonrpc": "2.0",
+        "id": "unknown-plugin-command",
+        "error": {
+            "code": 4011,
+            "message": "unknown plugin command: missing-plugin-command",
+        },
+    } in sent
+    assert server._sessions == {}
+
+
 def test_ws_transport_serializes_concurrent_sends():
     active_sends = 0
     max_active_sends = 0
@@ -274,4 +320,3 @@ def test_ws_transport_preserves_cross_batch_order():
         assert entered == ["A1", "A2", "B1", "B2"]
 
     asyncio.run(scenario())
-

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -429,6 +429,45 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5012, str(e))
 
 
+@method("plugin.command.dispatch")
+def _(rid, params: dict) -> dict:
+    """Run one registered plugin command without creating an Agent session.
+
+    This deliberately has a smaller surface than ``command.dispatch``: it does
+    not resolve quick commands, bundles, skills, shell commands, or prompts.
+    The authenticated gateway transport remains responsible for caller access;
+    this handler only narrows what that caller can dispatch.
+    """
+    if frozenset(params) != frozenset({"name", "arg"}):
+        return _err(rid, -32602, "plugin.command.dispatch requires name and arg")
+    name, arg = params.get("name"), params.get("arg")
+    if (
+        not isinstance(name, str)
+        or not isinstance(arg, str)
+        or not (clean_name := name.strip().lstrip("/"))
+        or name != clean_name
+        or clean_name != clean_name.lower()
+    ):
+        return _err(rid, -32602, "plugin.command.dispatch requires a lowercase name and string arg")
+
+    try:
+        from hermes_cli.plugins import (
+            get_plugin_command_handler,
+            resolve_plugin_command_result,
+        )
+
+        handler = get_plugin_command_handler(clean_name)
+    except Exception:
+        return _err(rid, 5000, "plugin command registry unavailable")
+    if handler is None:
+        return _err(rid, 4011, f"unknown plugin command: {clean_name}")
+    try:
+        result = resolve_plugin_command_result(handler(arg))
+    except Exception:
+        return _err(rid, 5000, "plugin command failed")
+    return _ok(rid, {"type": "plugin", "output": str(result or "")})
+
+
 @method("command.dispatch")
 def _(rid, params: dict) -> dict:
     name, arg = params.get("name", "").lstrip("/"), params.get("arg", "")

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -49,12 +49,23 @@ session.title           session.usage           session.status
 clarify.respond         sudo.respond            secret.respond
 approval.respond        config.set / config.get commands.catalog
 command.resolve         command.dispatch        cli.exec
+plugin.command.dispatch
 reload.mcp              reload.env              process.stop
 delegation.status       subagent.interrupt      spawn_tree.save / list / load
 terminal.resize         clipboard.paste         image.attach
 ```
 
 `session.active_list`, `session.activate`, and `session.close` are the process-local live-session controls used by the TUI session switcher. Use `session.list` / `/resume` for saved transcript discovery; use the active-session methods only for sessions that are currently open in the TUI gateway process.
+
+### Sessionless plugin command dispatch
+
+`plugin.command.dispatch` is a deliberately narrow RPC for a host that needs
+to invoke one already-registered plugin command without creating an Agent
+session. Its params must be exactly `{ "name": "lowercase-command", "arg":
+"string input" }`. It looks up only the named plugin command; it does not
+resolve quick commands, bundles, skills, shell commands, prompts, or any other
+gateway command surface. Unknown commands return the fixed `4011` error and
+registry or handler failures return a fixed redacted `5000` error.
 
 ### Events streamed back
 


### PR DESCRIPTION
Closes #75026

## Summary

Adds `plugin.command.dispatch` for an exact, sessionless `{name, arg}` invocation of an already-registered plugin command. It deliberately has no quick-command, bundle, skill, shell, prompt, or generic tool fallback.

The handler returns a fixed redacted error surface for invalid/unknown commands and handler failures, and never creates or resolves a normal Agent session.

## Verification

- `pytest tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py` — 510 passed
- `ruff check tui_gateway/methods_tools.py tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py`
- `git diff --check`

This is generic gateway support; it contains no Chiefstaff-specific behavior.