### PR TITLE
fix(skills): scan official skills as official during audit (#73099)

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1097,6 +1097,29 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
     c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
 
 
+def _scan_source_for_entry(entry: dict) -> str:
+    """Return the trust source a lockfile entry should be scanned under.
+
+    Mirrors the derivation ``do_install`` uses at install time. An official
+    optional skill is scanned as the literal ``"official"``; its lockfile
+    *identifier* is a multi-segment path such as
+    ``official/software-development/subagent-driven-development``, which
+    ``_resolve_trust_level`` does not recognize — it matches only the bare
+    string — so passing the identifier through downgraded the skill to
+    ``community`` at audit time even though install classified it ``builtin``
+    (#73099).
+
+    Trust still comes from the lockfile's recorded ``source`` field, never from
+    the identifier text, so a user-controlled repository named
+    ``official/<something>`` cannot claim builtin trust by its name alone.
+    Every other source keeps using the identifier, which is what lets
+    ``skills-sh/<owner>/<repo>/<skill>`` resolve against ``TRUSTED_REPOS``.
+    """
+    if entry.get("source") == "official":
+        return "official"
+    return entry.get("identifier") or entry.get("source", "")
+
+
 def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
              deep: bool = False) -> None:
     """Re-run security scan on installed hub skills.
@@ -1134,7 +1157,7 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
             c.print(f"[yellow]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
             continue
 
-        result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
+        result = scan_skill(skill_path, source=_scan_source_for_entry(entry))
         c.print(format_scan_report(result))
 
         if deep:

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -378,3 +379,48 @@ class TestAuditScanSource:
         from hermes_cli.skills_hub import _scan_source_for_entry
 
         assert _scan_source_for_entry({"source": "community"}) == "community"
+
+    def test_do_audit_passes_official_source_to_scanner(self, tmp_path, monkeypatch):
+        """Audit-loop wiring: the scanner must actually receive "official".
+
+        The helper tests above cover the derivation; this drives ``do_audit``
+        itself so a future refactor of the loop cannot silently reintroduce
+        passing the raw identifier.
+        """
+        import hermes_cli.skills_hub as hub
+        import tools.skills_hub as hub_mod
+        import tools.skills_guard as guard_mod
+
+        skill_dir = tmp_path / "subagent-driven-development"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: x\n---\n", encoding="utf-8")
+
+        entry = {
+            "name": "subagent-driven-development",
+            "install_path": skill_dir.name,
+            "source": "official",
+            "identifier": "official/software-development/subagent-driven-development",
+        }
+
+        monkeypatch.setattr(hub_mod, "SKILLS_DIR", tmp_path, raising=False)
+        monkeypatch.setattr(
+            hub_mod, "HubLockFile", lambda *a, **k: _DummyLockFile([entry]), raising=False
+        )
+
+        seen = {}
+
+        def fake_scan(path, source="community"):
+            seen["source"] = source
+            return SimpleNamespace(
+                skill_name="x", source=source, trust_level="builtin",
+                verdict="safe", findings=[],
+            )
+
+        monkeypatch.setattr(guard_mod, "scan_skill", fake_scan, raising=False)
+        monkeypatch.setattr(
+            guard_mod, "format_scan_report", lambda result: "", raising=False
+        )
+
+        hub.do_audit(console=Console(file=StringIO()))
+
+        assert seen["source"] == "official"

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -313,3 +313,68 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
 
+
+
+class TestAuditScanSource:
+    """Audit must classify official optional skills the way install did (#73099).
+
+    ``do_audit`` passed the lockfile *identifier* straight into the trust
+    resolver. For an official optional skill that identifier is multi-segment
+    (``official/software-development/subagent-driven-development``), and
+    ``_resolve_trust_level`` matches only the bare string ``official`` — so the
+    skill was downgraded to ``community`` at audit time, turning a permitted
+    CAUTION into a misleading community-source BLOCKED.
+    """
+
+    def test_official_multi_segment_identifier_scans_as_official(self):
+        from hermes_cli.skills_hub import _scan_source_for_entry
+
+        entry = {
+            "source": "official",
+            "identifier": "official/software-development/subagent-driven-development",
+        }
+        assert _scan_source_for_entry(entry) == "official"
+
+    def test_official_scan_source_resolves_to_builtin_trust(self):
+        """End-to-end through the resolver the audit path actually calls."""
+        from hermes_cli.skills_hub import _scan_source_for_entry
+        from tools.skills_guard import _resolve_trust_level
+
+        entry = {
+            "source": "official",
+            "identifier": "official/mlops/models/segment-anything",
+        }
+        assert _resolve_trust_level(_scan_source_for_entry(entry)) == "builtin"
+
+    def test_skills_sh_identifier_is_preserved(self):
+        """skills-sh trust depends on the identifier, so it must pass through."""
+        from hermes_cli.skills_hub import _scan_source_for_entry
+        from tools.skills_guard import _resolve_trust_level
+
+        entry = {
+            "source": "skills-sh",
+            "identifier": "skills-sh/anthropics/skills/frontend-design",
+        }
+        assert _scan_source_for_entry(entry) == "skills-sh/anthropics/skills/frontend-design"
+        assert _resolve_trust_level(_scan_source_for_entry(entry)) == "trusted"
+
+    def test_identifier_named_official_does_not_grant_builtin(self):
+        """Trust comes from the recorded source, never from identifier text.
+
+        A community repo whose identifier merely starts with "official/" must
+        stay community — this is the property the original bare-string match
+        existed to protect.
+        """
+        from hermes_cli.skills_hub import _scan_source_for_entry
+        from tools.skills_guard import _resolve_trust_level
+
+        entry = {
+            "source": "community",
+            "identifier": "official/evil/backdoor",
+        }
+        assert _resolve_trust_level(_scan_source_for_entry(entry)) == "community"
+
+    def test_missing_identifier_falls_back_to_source(self):
+        from hermes_cli.skills_hub import _scan_source_for_entry
+
+        assert _scan_source_for_entry({"source": "community"}) == "community"


### PR DESCRIPTION
## What & why

Fixes #73099.

`do_audit` passes the lockfile *identifier* straight into the trust resolver (`hermes_cli/skills_hub.py:1137`):

```python
result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
```

`_resolve_trust_level` (`tools/skills_guard.py:1120`) recognizes only the bare string:

```python
if normalized_source == "official":
    return "builtin"
```

An official *optional* skill has a multi-segment identifier — `official/software-development/subagent-driven-development` — so it never matches and falls through to `community`. The same bundle is scanned as `builtin` at install time, so re-auditing an unchanged skill turns a permitted official CAUTION into a misleading community-source BLOCKED. The issue confirms the provenance hash is identical across both scans, ruling out content substitution.

Reported as affecting every hub-installed `official/<category>/<skill>`, including `official/research/duckduckgo-search`, `official/mlops/whisper`, `official/security/oss-forensics`.

## The change

Mirror the derivation `do_install` already performs a few hundred lines above (`skills_hub.py:664`):

```python
if bundle.source == "official":
    scan_source = "official"
else:
    scan_source = getattr(bundle, "identifier", "") or ...
```

Audit now does the same via `_scan_source_for_entry()`. Install-time and audit-time classification agree by construction rather than by coincidence.

**The security property is preserved.** The bare-string match exists so that a user-controlled GitHub identifier beginning with `official/` cannot claim builtin trust — the code comment says so explicitly. Trust here still comes from the lockfile's recorded `source` field, never from identifier text, so a community entry with the identifier `official/evil/backdoor` still resolves to `community`. There's a test asserting exactly that.

Every non-official source keeps using the identifier, which is what lets `skills-sh/<owner>/<repo>/<skill>` strip its prefix and match `TRUSTED_REPOS` — the case the issue notes is currently correct and must stay that way.

## Tests

`TestAuditScanSource` in `tests/hermes_cli/test_skills_hub.py`, 5 cases:

- multi-segment official identifier resolves to `official`
- and end-to-end through `_resolve_trust_level` to `builtin`
- skills-sh identifier passes through unchanged and still resolves to `trusted`
- **an identifier named `official/evil/backdoor` under a `community` source stays `community`** — the anti-spoofing guard
- missing identifier falls back to `source`

All 5 fail on unmodified `main`:

```
FAILED TestAuditScanSource::test_official_multi_segment_identifier_scans_as_official
FAILED TestAuditScanSource::test_official_scan_source_resolves_to_builtin_trust
FAILED TestAuditScanSource::test_skills_sh_identifier_is_preserved
FAILED TestAuditScanSource::test_identifier_named_official_does_not_grant_builtin
FAILED TestAuditScanSource::test_missing_identifier_falls_back_to_source
```

`tests/hermes_cli/` + `tests/tools/test_skills_guard.py`: 121 failures, matching this tree's pre-existing local baseline for that directory — no new names.

## Platforms

macOS 15 (Darwin 25.5.0), Python 3.11. Pure dict/string resolution, no platform-specific behavior.

## Duplicate check

`gh search prs` for `skills_audit` returns one open PR (#40712, a governance plugin — unrelated) and one closed (#33202, `--interactive` flag, closed `implemented_on_main`). Neither touches trust resolution. No PR links #73099.

---
*Authored by an AI agent (Claude Opus 5) operating autonomously on @jeff-mettel's behalf: the defect was traced, the patch written, and the tests run and verified end-to-end before submission.*