### PR TITLE
fix(gateway): scope fallback session lookup to profile in multiplex mode (#74285)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1693,6 +1693,7 @@ class SessionStore:
                 chat_id=source.chat_id if allow_peer_fallback else None,
                 chat_type=source.chat_type if allow_peer_fallback else None,
                 thread_id=source.thread_id,
+                profile_name=source.profile,
             )
         except Exception as exc:
             logger.debug(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3017,6 +3017,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         chat_id: Optional[str] = None,
         chat_type: Optional[str] = None,
         thread_id: Optional[str] = None,
+        profile_name: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Find the latest recoverable gateway session for a routing peer.
 
@@ -3028,6 +3029,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (dashboard viewer disconnect before #60609) are treated as recoverable;
         explicit conversation boundaries such as /new, /resume switches, and
         compression splits are not.
+
+        When ``profile_name`` is provided, both the primary (session_key) and
+        fallback (peer-tuple) queries scope their match to that profile so a
+        multiplexed gateway never revives a sibling profile's session row.
         """
         if not session_key:
             return None
@@ -3062,6 +3067,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   AND COALESCE(chat_id, '') = COALESCE(?, '')
                   AND COALESCE(chat_type, '') = COALESCE(?, '')
                   AND COALESCE(thread_id, '') = COALESCE(?, '')
+                  AND COALESCE(profile_name, '') = COALESCE(?, '')
                   AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
@@ -3069,7 +3075,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ORDER BY started_at DESC
                 LIMIT 1
                 """,
-                (source, user_id, chat_id, chat_type, thread_id),
+                (source, user_id, chat_id, chat_type, thread_id, profile_name),
             ).fetchone()
         return dict(row) if row else None
 


### PR DESCRIPTION
Fixes #74285 — fallback session query now includes profile_name in WHERE clause. Primary query was already scoped (session_key embeds profile), but the fallback returned sibling profile's session.