### PR TITLE
fix(gateway): suppress governed provider failures

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4969,6 +4969,57 @@ class BasePlatformAdapter(ABC):
         except Exception as e:
             logger.warning("[%s] %s hook failed: %s", self.name, hook_name, e)
 
+    async def _handle_governed_error(self, event: Any) -> bool:
+        """Apply a per-event fail-silent policy supplied by a gateway plugin.
+
+        Returns ``True`` when the source-chat error reply must be suppressed.
+        An optional fixed alert may be sent to a different administrative chat;
+        failures in that alert path remain server-side only.
+        """
+        metadata = getattr(event, "metadata", None)
+        policy = metadata.get("gateway_error_policy") if isinstance(metadata, dict) else None
+        source = getattr(event, "source", event)
+        if not isinstance(policy, dict):
+            policy = getattr(source, "_gateway_error_policy", None)
+        if not isinstance(policy, dict) or policy.get("suppress_reply") is not True:
+            return False
+
+        source_chat_id = str(getattr(source, "chat_id", "") or "")
+        alert_chat_id = str(policy.get("alert_chat_id") or "").strip()
+        alert_message = str(policy.get("alert_message") or "").strip()
+        logger.warning(
+            "[%s] Suppressing governed error reply for chat=%s",
+            self.name,
+            source_chat_id or "unknown",
+        )
+        already_alerted = bool(policy.get("alerted")) or bool(
+            getattr(source, "_gateway_error_alerted", False)
+        )
+        policy["alerted"] = True
+        setattr(source, "_gateway_error_alerted", True)
+        if (
+            not already_alerted
+            and alert_chat_id
+            and alert_message
+            and alert_chat_id != source_chat_id
+        ):
+            try:
+                alert_result = await self.send(chat_id=alert_chat_id, content=alert_message)
+                if getattr(alert_result, "success", True) is False:
+                    logger.error(
+                        "[%s] Governed error alert delivery failed: %s",
+                        self.name,
+                        getattr(alert_result, "error", None) or "platform returned success=False",
+                    )
+            except Exception as alert_error:
+                logger.error(
+                    "[%s] Failed to send governed error alert: %s",
+                    self.name,
+                    alert_error,
+                    exc_info=True,
+                )
+        return True
+
     @staticmethod
     def _is_retryable_error(error: Optional[str]) -> bool:
         """Return True if the error string looks like a transient network failure."""
@@ -6352,6 +6403,8 @@ class BasePlatformAdapter(ABC):
         except Exception as e:
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
+            if await self._handle_governed_error(event):
+                return
             # Send the error to the user so they aren't left with radio silence
             try:
                 error_type = type(e).__name__

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -639,22 +639,22 @@ def _format_exec_approval_fallback(
 
 
 def _gateway_provider_error_reply(text: str) -> str:
-    """Map raw provider/API errors to a short user-safe Telegram reply."""
+    """Map raw provider/API errors to a clear, business-safe chat reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return (
-            "⚠️ Provider authentication failed. Check the configured credentials; "
-            "raw provider details are in the gateway logs."
+            "⚠️ I couldn't complete this request because the AI service connection needs attention. "
+            "Nothing was changed. Please retry after the connection is restored."
         )
     if _GATEWAY_PROVIDER_POLICY_RE.search(text):
         return (
-            "⚠️ The model provider rejected the request. I kept the raw provider "
-            "error out of chat; check gateway logs for details or try rephrasing."
+            "⚠️ I couldn't complete this request because the AI service rejected it. "
+            "Nothing was changed. Try rephrasing the request; if it fails again, technical support should review it."
         )
     if _GATEWAY_RATE_LIMIT_RE.search(text):
-        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+        return "⏱️ The AI service is temporarily busy. Nothing was changed. Please try again shortly."
     return (
-        "⚠️ The model provider failed after retries. I kept raw provider details "
-        "out of chat; check gateway logs for diagnostics."
+        "⚠️ I couldn't complete this request because the AI service is temporarily unavailable. "
+        "Nothing was changed. Please try again shortly."
     )
 
 
@@ -676,23 +676,15 @@ _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
 def _looks_like_gateway_provider_error(text: str) -> bool:
     """True when text is infrastructure/provider failure, not normal content.
 
-    Two heuristics combined so the rewrite only fires on actual provider
-    error envelopes, not on assistant prose that happens to mention an
-    HTTP status code:
-
-    1. The text is short — real provider errors are 1–3 lines of envelope
-       text; assistant answers are usually longer.
-    2. AND the error marker appears at the start of the message (optionally
-       behind a punctuation/symbol prefix), not buried mid-paragraph in an
-       explanation like "HTTP 404 means 'not found' — ...".
+    The error marker must appear at the start of the message (optionally behind
+    a punctuation/symbol prefix), not buried in normal assistant prose. Do not
+    impose a length or line-count limit: provider/authentication envelopes can
+    contain verbose diagnostics, and those are the most important responses to
+    sanitize and suppress on governed chat routes.
     """
     if not text:
         return False
     body = str(text).strip()
-    # Provider failure envelopes are short. Assistant answers that happen
-    # to mention HTTP status codes ("HTTP 404 means...") tend to be longer.
-    if len(body) > 400 or body.count("\n") > 4:
-        return False
     return bool(_GATEWAY_PROVIDER_ERROR_SHAPE_RE.search(body))
 
 
@@ -3527,6 +3519,26 @@ def _normalize_empty_agent_response(
     return response
 
 
+def _is_gateway_failure_delivery(
+    agent_result: dict,
+    *,
+    response_was_empty: bool,
+    normalized_response: str,
+) -> bool:
+    """Identify failure/retry text produced by the gateway rather than the agent."""
+    return bool(
+        agent_result.get("failed")
+        or (response_was_empty and normalized_response)
+        or _looks_like_gateway_provider_error(normalized_response)
+        or str(normalized_response or "").startswith(
+            (
+                "⚠️ I couldn't complete this request because the AI service",
+                "⏱️ The AI service is temporarily busy.",
+            )
+        )
+    )
+
+
 def _is_gateway_hidden_reasoning_incomplete_turn(agent_result: dict) -> bool:
     """Detect retry-exhausted turns with hidden reasoning but no visible answer.
 
@@ -4372,6 +4384,22 @@ class TurnRunner:
                 ctx.source.platform.value if ctx.source.platform else "unknown",
                 event_type,
                 _redact_gateway_user_facing_secrets(str(message or ""))[:160],
+            )
+            return
+        error_policy = getattr(ctx.source, "_gateway_error_policy", None)
+        if (
+            isinstance(error_policy, dict)
+            and error_policy.get("suppress_reply") is True
+            and _is_gateway_failure_delivery(
+                {},
+                response_was_empty=False,
+                normalized_response=prepared_message,
+            )
+        ):
+            logger.warning(
+                "governed status failure suppressed for %s/%s",
+                ctx.source.platform.value if ctx.source.platform else "unknown",
+                event_type,
             )
             return
         _fut = safe_schedule_threadsafe(
@@ -5583,6 +5611,7 @@ class TurnRunner:
                 "messages": result.get("messages", []),
                 "api_calls": result.get("api_calls", 0),
                 "failed": result.get("failed", False),
+                "gateway_generated_failure_response": bool(final_response),
                 # Sibling of the non-empty-response return below (#64686):
                 # the classifier's failure_reason must survive the
                 # empty-response normalization path too, or downstream
@@ -14400,6 +14429,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Plugins receive the MessageEvent and may return a dict influencing flow:
         #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
         #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
+        #   {"action": "allow", "error_policy": {...}} -> normal dispatch
+        #       with an optional per-event fail-silent policy
         #   {"action": "allow"}   /   None          -> normal dispatch
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
         # (e.g. customer handover ingest) without triggering the pairing flow.
@@ -14438,6 +14469,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         source = event.source
                     break
                 if _action == "allow":
+                    _error_policy = _result.get("error_policy")
+                    if (
+                        isinstance(_error_policy, dict)
+                        and _error_policy.get("suppress_reply") is True
+                    ):
+                        _event_metadata = dict(getattr(event, "metadata", None) or {})
+                        _event_metadata["gateway_error_policy"] = {
+                            "suppress_reply": True,
+                            "alert_chat_id": str(
+                                _error_policy.get("alert_chat_id") or ""
+                            ).strip(),
+                            "alert_message": str(
+                                _error_policy.get("alert_message") or ""
+                            ).strip()[:1000],
+                        }
+                        event.metadata = _event_metadata
+                        setattr(
+                            event.source,
+                            "_gateway_error_policy",
+                            _event_metadata["gateway_error_policy"],
+                        )
                     break
 
         if is_internal:
@@ -17664,7 +17716,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.
+            _response_was_empty = False
             if not _intentional_silence:
+                _response_was_empty = not bool(response)
                 response = _normalize_empty_agent_response(
                     agent_result, response, history_len=len(history),
                 )
@@ -18124,6 +18178,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 response = ""
 
+            if _is_gateway_failure_delivery(
+                agent_result,
+                response_was_empty=_response_was_empty,
+                normalized_response=response,
+            ):
+                _error_adapter = self._adapter_for_source(source)
+                _handle_governed_error = getattr(
+                    _error_adapter, "_handle_governed_error", None
+                )
+                if callable(_handle_governed_error) and await _handle_governed_error(event):
+                    return None
+
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
             # Skip when streaming TTS already delivered audio for this turn (#60671).
@@ -18240,6 +18306,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
             except Exception:
                 logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
+            _error_adapter = self._adapter_for_source(source)
+            _handle_governed_error = getattr(
+                _error_adapter, "_handle_governed_error", None
+            )
+            if callable(_handle_governed_error) and await _handle_governed_error(event):
+                return None
             # Log full details server-side only; never expose raw exception
             # types or messages to end users (info-leakage risk).
             status_hint = ""
@@ -25610,6 +25682,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _delivery_result = response if isinstance(response, dict) else (result or {})
                     _previewed = bool(_delivery_result.get("response_previewed"))
                     first_response = _delivery_result.get("final_response", "")
+                    _queued_failure_delivery = _is_gateway_failure_delivery(
+                        _delivery_result,
+                        response_was_empty=bool(
+                            _delivery_result.get("gateway_generated_failure_response")
+                        ),
+                        normalized_response=first_response,
+                    )
+                    if _queued_failure_delivery:
+                        _handle_governed_error = getattr(
+                            adapter, "_handle_governed_error", None
+                        )
+                        if callable(_handle_governed_error):
+                            _governed_error_handler = cast(
+                                Callable[[Any], Awaitable[bool]],
+                                _handle_governed_error,
+                            )
+                            if await _governed_error_handler(source):
+                                first_response = ""
                     _already_streamed = _stream_confirmed_final_delivery(
                         _sc,
                         first_response,

--- a/tests/gateway/test_gateway_error_policy.py
+++ b/tests/gateway/test_gateway_error_policy.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.run import TurnRunner, _is_gateway_failure_delivery, _sanitize_gateway_final_response
+from gateway.session import SessionSource, build_session_key
+from gateway.turn_context import TurnContext
+
+
+class ErrorPolicyAdapter(BasePlatformAdapter):
+    def __init__(self, *, alert_success: bool = True):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.WHATSAPP)
+        self.sent: list[dict[str, str]] = []
+        self.alert_success = alert_success
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({"chat_id": chat_id, "content": content})
+        return SendResult(
+            success=self.alert_success,
+            message_id="sent-1" if self.alert_success else None,
+            error=None if self.alert_success else "bridge rejected alert",
+        )
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+def event(*, governed: bool) -> MessageEvent:
+    metadata = {}
+    if governed:
+        metadata["gateway_error_policy"] = {
+            "suppress_reply": True,
+            "alert_chat_id": "control-room@g.us",
+            "alert_message": (
+                "⚠️ Nova could not complete a management request from a job-card group. "
+                "No technical error was posted there. Please retry in this control room."
+            ),
+        }
+    return MessageEvent(
+        text="Nova, push this card to the app",
+        message_id="m1",
+        source=SessionSource(
+            platform=Platform.WHATSAPP,
+            user_id="maff@s.whatsapp.net",
+            chat_id="job-card@g.us",
+            chat_type="group",
+        ),
+        metadata=metadata,
+    )
+
+
+@pytest.mark.parametrize(
+    "provider_status",
+    [
+        "Provider authentication failed. Check the configured credentials.",
+        "❌ Non-retryable error (HTTP 401): token rejected",
+        "❌ Rate limited after 3 retries — too many requests",
+        "❌ API failed after 3 retries — provider unavailable",
+    ],
+)
+def test_governed_provider_status_is_suppressed_before_source_send(monkeypatch, provider_status):
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="maff@s.whatsapp.net",
+        chat_id="job-card@g.us",
+        chat_type="group",
+    )
+    source._gateway_error_policy = {
+        "suppress_reply": True,
+        "alert_chat_id": "control-room@g.us",
+        "alert_message": "Management request incomplete. Check the app before retrying.",
+    }
+    scheduled = []
+
+    def fake_schedule(coro, *_args, **_kwargs):
+        scheduled.append(coro)
+        coro.close()
+        return None
+
+    monkeypatch.setattr(gateway_run, "safe_schedule_threadsafe", fake_schedule)
+    ctx = TurnContext(
+        source=source,
+        _run_still_current=lambda: True,
+        _status_adapter=object(),
+        _status_chat_id=source.chat_id,
+    )
+
+    TurnRunner(None, ctx)._status_callback_sync("provider_error", provider_status)
+
+    assert scheduled == []
+
+
+def test_governed_normal_status_still_schedules(monkeypatch):
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="maff@s.whatsapp.net",
+        chat_id="job-card@g.us",
+        chat_type="group",
+    )
+    source._gateway_error_policy = {"suppress_reply": True}
+    scheduled = []
+
+    def fake_schedule(coro, *_args, **_kwargs):
+        scheduled.append(coro)
+        coro.close()
+        return None
+
+    monkeypatch.setattr(gateway_run, "safe_schedule_threadsafe", fake_schedule)
+    ctx = TurnContext(
+        source=source,
+        _run_still_current=lambda: True,
+        _status_adapter=object(),
+        _status_chat_id=source.chat_id,
+    )
+
+    TurnRunner(None, ctx)._status_callback_sync("working", "Checking the job card")
+
+    assert len(scheduled) == 1
+
+
+async def failing_handler(_event):
+    raise RuntimeError("internal import mismatch")
+
+
+@pytest.mark.asyncio
+async def test_governed_error_is_silent_at_source_and_alerts_control_room():
+    adapter = ErrorPolicyAdapter()
+    adapter.set_message_handler(failing_handler)
+    inbound = event(governed=True)
+
+    await adapter._process_message_background(inbound, build_session_key(inbound.source))
+
+    assert adapter.sent == [{
+        "chat_id": "control-room@g.us",
+        "content": (
+            "⚠️ Nova could not complete a management request from a job-card group. "
+            "No technical error was posted there. Please retry in this control room."
+        ),
+    }]
+
+
+@pytest.mark.asyncio
+async def test_ordinary_error_still_notifies_source_chat():
+    adapter = ErrorPolicyAdapter()
+    adapter.set_message_handler(failing_handler)
+    inbound = event(governed=False)
+
+    await adapter._process_message_background(inbound, build_session_key(inbound.source))
+
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["chat_id"] == "job-card@g.us"
+    assert "internal import mismatch" in adapter.sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_governed_error_policy_can_follow_session_source_into_queued_delivery():
+    adapter = ErrorPolicyAdapter()
+    source = event(governed=False).source
+    setattr(source, "_gateway_error_policy", {
+        "suppress_reply": True,
+        "alert_chat_id": "control-room@g.us",
+        "alert_message": "Nova could not complete a queued management request.",
+    })
+
+    suppressed = await adapter._handle_governed_error(source)
+
+    assert suppressed is True
+    assert adapter.sent == [
+        {
+            "chat_id": "control-room@g.us",
+            "content": "Nova could not complete a queued management request.",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_control_room_delivery_is_logged_without_replying_to_source(caplog):
+    adapter = ErrorPolicyAdapter(alert_success=False)
+    inbound = event(governed=True)
+
+    suppressed = await adapter._handle_governed_error(inbound)
+
+    assert suppressed is True
+    assert [message["chat_id"] for message in adapter.sent] == ["control-room@g.us"]
+    assert "Governed error alert delivery failed: bridge rejected alert" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("agent_result", "response_was_empty", "normalized_response", "expected"),
+    [
+        ({"failed": True}, False, "partial provider text", True),
+        ({"api_calls": 0}, True, "⚠️ Your message wasn't processed. Please retry.", True),
+        ({"api_calls": 1}, False, "⚠️ Provider authentication failed. Check the configured credentials.", True),
+        ({"api_calls": 1}, False, "HTTP 401: invalid provider credentials", True),
+        ({"api_calls": 1}, False, "⚠️ I couldn't complete this request because the AI service connection needs attention. Nothing was changed.", True),
+        ({"api_calls": 1}, False, "Card submitted.", False),
+        ({"partial": True}, True, "", False),
+    ],
+)
+def test_gateway_failure_delivery_covers_all_generated_retry_text(
+    agent_result,
+    response_was_empty,
+    normalized_response,
+    expected,
+):
+    assert _is_gateway_failure_delivery(
+        agent_result,
+        response_was_empty=response_was_empty,
+        normalized_response=normalized_response,
+    ) is expected
+
+
+def test_verbose_provider_envelope_is_still_classified_after_sanitization():
+    raw = (
+        "HTTP 401: invalid provider credentials\n"
+        + "provider diagnostic context that must never reach WhatsApp\n" * 20
+    )
+
+    sanitized = _sanitize_gateway_final_response(Platform.WHATSAPP, raw)
+
+    assert len(raw) > 400
+    assert "provider diagnostic" not in sanitized
+    assert _is_gateway_failure_delivery(
+        {"api_calls": 1},
+        response_was_empty=False,
+        normalized_response=sanitized,
+    ) is True
+
+
+def test_long_normal_answer_that_mentions_http_mid_paragraph_is_not_rewritten():
+    answer = "Here is the explanation. HTTP 404 means not found. " + ("More context. " * 60)
+
+    assert _sanitize_gateway_final_response(Platform.WHATSAPP, answer) == answer
+
+
+@pytest.mark.asyncio
+async def test_governed_error_alert_is_sent_at_most_once_per_event():
+    adapter = ErrorPolicyAdapter()
+    inbound = event(governed=True)
+
+    assert await adapter._handle_governed_error(inbound) is True
+    assert await adapter._handle_governed_error(inbound) is True
+
+    assert adapter.sent == [{
+        "chat_id": "control-room@g.us",
+        "content": (
+            "⚠️ Nova could not complete a management request from a job-card group. "
+            "No technical error was posted there. Please retry in this control room."
+        ),
+    }]

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -118,3 +118,38 @@ async def test_hook_fires_without_session_store_attribute(monkeypatch):
     # Hook actually fired (skip short-circuited before auth) with a None store.
     assert seen == {"session_store": None}
     adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_allow_hook_can_attach_a_fail_silent_error_policy(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+
+    error_policy = {
+        "suppress_reply": True,
+        "alert_chat_id": "control-room@g.us",
+        "alert_message": "Retry this management request in the control room.",
+    }
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "allow", "error_policy": error_policy}]
+        return []
+
+    captured = {}
+
+    async def _capture(event, source, _quick_key, _run_generation):
+        captured["metadata"] = event.metadata
+        return "ok"
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    monkeypatch.setattr(runner, "_handle_message_with_agent", _capture)
+
+    inbound = _make_event("Nova, fix this")
+    result = await runner._handle_message(inbound)
+
+    assert result == "ok"
+    assert captured["metadata"]["gateway_error_policy"] == error_policy
+    assert inbound.metadata["gateway_error_policy"] == error_policy
+    assert getattr(inbound.source, "_gateway_error_policy") == error_policy

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -196,7 +196,7 @@ def test_chat_gateways_redact_secret_in_provider_error(platform):
     assert "sk-ABCDEF" not in sanitized
     assert "HTTP 401" not in sanitized
     # The user gets the safe provider-error category instead of the raw body.
-    assert "provider" in sanitized.lower()
+    assert "ai service" in sanitized.lower()
 
 
 @pytest.mark.parametrize("platform", ["slack", "matrix"])
@@ -265,7 +265,8 @@ def test_telegram_status_sanitizes_raw_provider_security_errors():
     sanitized = _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", raw)
 
     assert sanitized is not None
-    assert "provider rejected" in sanitized.lower()
+    assert "ai service rejected" in sanitized.lower()
+    assert "nothing was changed" in sanitized.lower()
     assert "cybersecurity risk" not in sanitized.lower()
     assert "HTTP 400" not in sanitized
     assert "req_123" not in sanitized
@@ -280,7 +281,8 @@ def test_telegram_final_response_sanitizes_raw_provider_errors():
 
     sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
 
-    assert "provider rejected" in sanitized.lower()
+    assert "ai service rejected" in sanitized.lower()
+    assert "nothing was changed" in sanitized.lower()
     assert "cybersecurity risk" not in sanitized.lower()
     assert "HTTP 400" not in sanitized
     assert "req_abc" not in sanitized
@@ -295,8 +297,8 @@ def test_telegram_final_response_redacts_auth_secrets():
 
     sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
 
-    assert "authentication failed" in sanitized.lower()
-    assert "check the configured credentials" in sanitized.lower()
+    assert "ai service connection needs attention" in sanitized.lower()
+    assert "nothing was changed" in sanitized.lower()
     assert "sk-live" not in sanitized
 
 


### PR DESCRIPTION
## Summary

- add event-scoped gateway error policy propagation from `pre_gateway_dispatch`
- suppress provider/authentication failures and outer/queued exceptions on governed chat routes
- suppress terminal provider/auth/rate-limit status callbacks before they can reach the governed source chat
- send a fixed control-room alert at most once while preserving successful replies and normal progress statuses
- sanitize verbose provider envelopes without rewriting normal long answers

## Production incident

A WhatsApp job-card management request could return raw provider authentication/configuration text into an operative group. The Nova T2B policy now consumes this generic gateway capability from its separate plugin repository.

## Tests

- focused gateway governance tests: 155 passed
- explicit status-callback coverage for HTTP 401, provider auth, rate-limit exhaustion and provider retry exhaustion
- isolated unrelated-failure comparison against current `origin/main`: 8/10 pass on both; the same two macOS-incompatible shutdown/systemd tests fail on both the branch and pristine main
- `git diff --check` passed
