### PR TITLE
fix(auth): use secret-scoped get_secret instead of raw os.getenv in fallback (#74311)

### DIFF
--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+from agent.secret_scope import get_secret as _get_secret
 from typing import Any
 
 
@@ -27,7 +27,7 @@ def resolve_entry_api_key(entry: dict[str, Any] | None) -> str | None:
         return inline
     key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
     if key_env:
-        return os.getenv(key_env, "").strip() or None
+        return _get_secret(key_env, "").strip() or None
     return None
 
 


### PR DESCRIPTION
Fixes #74311 — resolve_entry_api_key() now uses get_secret() instead of os.getenv(), respecting per-profile secret scope in multiplex mode.