### PR TITLE
fix(routing): only apply persisted api_mode when provider matches (#74318)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1603,7 +1603,7 @@ def _resolve_explicit_runtime(
             api_mode = "codex_responses"
         else:
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode:
+            if configured_mode and model_cfg.get("provider") == provider:
                 api_mode = configured_mode
             else:
                 # Auto-detect from URL (Anthropic /anthropic suffix,


### PR DESCRIPTION
Fixes #74318 — configured api_mode is now only applied when model_cfg.provider matches the provider being resolved, preventing mode leakage across providers.