### PR TITLE
fix(tools): scope 2-part SKILL.md exception to own skill + route to root

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -143,6 +143,21 @@ class TestValidateFilePath:
         err = _validate_file_path("README.md")
         assert "File must be under one of:" in err
 
+    def test_two_part_skill_md_must_name_the_skill(self):
+        # '<skill-name>/SKILL.md' is accepted only when the first part is the
+        # skill being edited — anything else plants a nested SKILL.md that
+        # skill discovery picks up as a hidden shadow skill.
+        assert _validate_file_path("foo/SKILL.md", "foo") is None
+        assert _validate_file_path("SKILL.md", "foo") is None
+
+        err = _validate_file_path("evil/SKILL.md", "foo")
+        assert "does not refer to skill 'foo'" in err
+
+    def test_two_part_skill_md_rejected_without_skill_name(self):
+        # Callers that don't pass the skill name get no 2-part exception.
+        err = _validate_file_path("foo/SKILL.md")
+        assert err is not None
+
 
 # ---------------------------------------------------------------------------
 # CRUD operations
@@ -217,6 +232,34 @@ class TestPatchSkill:
         content = (tmp_path / "my-skill" / "SKILL.md").read_text()
         assert "Do the new thing." in content
 
+    def test_patch_two_part_skill_md_routes_to_root(self, tmp_path):
+        # '<skill-name>/SKILL.md' patches the skill's main file, not a
+        # nested 'my-skill/my-skill/SKILL.md' shadow file.
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill(
+                "my-skill", "Do the thing.", "Do the new thing.",
+                file_path="my-skill/SKILL.md",
+            )
+        assert result["success"] is True
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        assert "Do the new thing." in content
+        assert not (tmp_path / "my-skill" / "my-skill").exists()
+
+    def test_patch_skill_md_spelling_frontmatter_guard(self, tmp_path):
+        # Patching via an explicit main-file spelling must hit the same
+        # frontmatter guard as the default SKILL.md patch.
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            original = (tmp_path / "my-skill" / "SKILL.md").read_text()
+            result = _patch_skill(
+                "my-skill", "---\nname:", "name:",
+                file_path="my-skill/SKILL.md",
+            )
+        assert result["success"] is False
+        assert "break SKILL.md structure" in result["error"]
+        assert (tmp_path / "my-skill" / "SKILL.md").read_text() == original
+
 
     def test_patch_ambiguous_match_rejected(self, tmp_path):
         content = """\
@@ -284,6 +327,34 @@ class TestWriteFile:
         assert result["success"] is True
         assert (tmp_path / "my-skill" / "references" / "api.md").exists()
 
+    def test_two_part_skill_md_routes_to_root(self, tmp_path):
+        # '<skill-name>/SKILL.md' addresses the skill's main file, not a
+        # nested 'my-skill/my-skill/SKILL.md' shadow file.
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _write_file("my-skill", "my-skill/SKILL.md", VALID_SKILL_CONTENT)
+        assert result["success"] is True
+        assert not (tmp_path / "my-skill" / "my-skill").exists()
+
+    def test_write_skill_md_spelling_validates_frontmatter(self, tmp_path):
+        # Main-file spellings route through edit: a full rewrite with broken
+        # frontmatter must be rejected and leave the root file untouched.
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            original = (tmp_path / "my-skill" / "SKILL.md").read_text()
+            for spelling in ("SKILL.md", "my-skill/SKILL.md"):
+                result = _write_file("my-skill", spelling, "# no frontmatter here")
+                assert result["success"] is False
+        assert (tmp_path / "my-skill" / "SKILL.md").read_text() == original
+
+    def test_two_part_skill_md_wrong_name_rejected(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _write_file("my-skill", "evil/SKILL.md", VALID_SKILL_CONTENT)
+        assert result["success"] is False
+        assert "does not refer to skill 'my-skill'" in result["error"]
+        assert not (tmp_path / "my-skill" / "evil").exists()
+
     def test_write_symlink_escape_blocked(self, tmp_path):
         outside_dir = tmp_path / "outside"
         outside_dir.mkdir()
@@ -312,6 +383,17 @@ class TestRemoveFile:
             result = _remove_file("my-skill", "references/api.md")
         assert result["success"] is True
         assert not (tmp_path / "my-skill" / "references" / "api.md").exists()
+
+    def test_remove_skill_md_spelling_rejected(self, tmp_path):
+        # SKILL.md *is* the skill — remove_file must refuse both main-file
+        # spellings and point at action='delete' instead.
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            for spelling in ("SKILL.md", "my-skill/SKILL.md"):
+                result = _remove_file("my-skill", spelling)
+                assert result["success"] is False
+                assert "action='delete'" in result["error"]
+        assert (tmp_path / "my-skill" / "SKILL.md").exists()
 
     def test_remove_symlink_escape_blocked(self, tmp_path):
         outside_dir = tmp_path / "outside"

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -841,7 +841,7 @@ def _skill_not_found_error(name: str, suffix: str = "") -> str:
     return base
 
 
-def _validate_file_path(file_path: str) -> Optional[str]:
+def _validate_file_path(file_path: str, skill_name: str = "") -> Optional[str]:
     """
     Validate a file path for write_file/remove_file.
     Must be under an allowed subdirectory and not escape the skill dir.
@@ -862,9 +862,18 @@ def _validate_file_path(file_path: str) -> Optional[str]:
     # under an allowed subdirectory. Accept its two natural spellings —
     # 'SKILL.md' and '<skill-name>/SKILL.md' — so callers can target the main
     # file. The traversal guard above still applies, so this can't escape.
+    # The 2-part form must name THIS skill: anything else plants a nested
+    # skill directory whose SKILL.md is discovered as a separate shadow skill.
     if normalized.parts and normalized.name == "SKILL.md":
-        if len(normalized.parts) == 1 or len(normalized.parts) == 2:
+        if len(normalized.parts) == 1:
             return None
+        if len(normalized.parts) == 2 and normalized.parts[0] == skill_name:
+            return None
+        if len(normalized.parts) == 2:
+            return (
+                f"'{file_path}' does not refer to skill '{skill_name}'. "
+                f"Use 'SKILL.md' or '{skill_name}/SKILL.md'."
+            )
 
     # Must be under an allowed subdirectory
     if not normalized.parts or normalized.parts[0] not in ALLOWED_SUBDIRS:
@@ -876,6 +885,21 @@ def _validate_file_path(file_path: str) -> Optional[str]:
         return f"Provide a file path, not just a directory. Example: '{normalized.parts[0]}/myfile.md'"
 
     return None
+
+
+def _is_skill_md_spelling(file_path: str, skill_name: str) -> bool:
+    """True if *file_path* is a canonical spelling of the skill's main file.
+
+    Accepts 'SKILL.md' and '<skill-name>/SKILL.md'. The 2-part form must
+    name THIS skill — anything else plants a nested skill directory whose
+    SKILL.md is discovered as a separate shadow skill.
+    """
+    normalized = Path(file_path)
+    if normalized.name != "SKILL.md":
+        return False
+    if len(normalized.parts) == 1:
+        return True
+    return len(normalized.parts) == 2 and normalized.parts[0] == skill_name
 
 
 def _resolve_skill_target(skill_dir: Path, file_path: str) -> Tuple[Optional[Path], Optional[str]]:
@@ -1067,10 +1091,16 @@ def _patch_skill(
 
     if file_path:
         # Patching a supporting file
-        err = _validate_file_path(file_path)
+        err = _validate_file_path(file_path, name)
         if err:
             return {"success": False, "error": err}
-        target, err = _resolve_skill_target(skill_dir, file_path)
+        if _is_skill_md_spelling(file_path, name):
+            # The main-file spellings address the root SKILL.md: route to
+            # the default path so the frontmatter guard below applies.
+            file_path = None
+            target = skill_dir / "SKILL.md"
+        else:
+            target, err = _resolve_skill_target(skill_dir, file_path)
         if err:
             return {"success": False, "error": err}
         assert target is not None
@@ -1266,9 +1296,15 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
 
 def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     """Add or overwrite a supporting file within any skill directory."""
-    err = _validate_file_path(file_path)
+    err = _validate_file_path(file_path, name)
     if err:
         return {"success": False, "error": err}
+    if _is_skill_md_spelling(file_path, name):
+        # The main-file spellings are full-rewrite requests for the root
+        # SKILL.md: route to edit so frontmatter validation and
+        # scan-rollback apply (bypassing them lets a write corrupt the
+        # skill's frontmatter).
+        return _edit_skill(name, file_content)
 
     if not file_content and file_content != "":
         return {"success": False, "error": "file_content is required."}
@@ -1336,9 +1372,19 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
 
 def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     """Remove a supporting file from any skill directory."""
-    err = _validate_file_path(file_path)
+    err = _validate_file_path(file_path, name)
     if err:
         return {"success": False, "error": err}
+    if _is_skill_md_spelling(file_path, name):
+        # SKILL.md *is* the skill — removing it would leave a broken skill
+        # directory. Deleting the skill itself is a separate action.
+        return {
+            "success": False,
+            "error": (
+                "SKILL.md is the skill's main file and cannot be removed "
+                "with remove_file. Use action='delete' to delete the skill."
+            ),
+        }
 
     existing = _find_skill(name)
     if not existing:


### PR DESCRIPTION
## What does this PR do?

Fixes a path-validation gap in `skill_manage` that lets a caller plant a hidden "shadow skill" inside another skill's directory — and restores the routing the feature was originally designed with.

`_validate_file_path` (`tools/skill_manager_tool.py`) has an exception for the canonical `SKILL.md` file, accepting its "two natural spellings" — `SKILL.md` and `<skill-name>/SKILL.md` (added in `5a36f76a0`, #40568). Two problems:

1. **The 2-part form never checked the first path part.** `skill_manage(action="write_file", name="foo", file_path="evil/SKILL.md", ...)` was accepted, bypassing the allow-listed supporting-file subdirs (`references/ templates/ scripts/ assets/`). The write lands at `skills/foo/evil/SKILL.md` — and `iter_skill_index_files` discovers nested SKILL.md files as standalone skills. The planted content shows up in `skills_list` as a skill named `evil`, invisible inside another skill's directory, able to collide with or shadow a real skill of that name. Same hole in `patch` and `remove_file`.
2. **Even the matching spelling didn't do what it says.** The original design (#40453) had `<skill-name>/SKILL.md` *address the skill's own main file*, routed to the existing SKILL.md handlers. The merged salvage kept the spelling but resolves `skill_dir / file_path` verbatim — so `write_file(name="foo", file_path="foo/SKILL.md")` wrote a nested `foo/foo/SKILL.md` (another shadow skill, duplicating the skill itself) instead of editing the root SKILL.md.

The fix restores the original design in full — main-file spellings go through the same guards as their default equivalents:

- **Validation**: the 2-part form is accepted only when the first path part equals the name of the skill being edited; all three call sites pass the name through. Anything else is rejected with a targeted error.
- **patch**: main-file spellings route to the default SKILL.md path, so the root-file frontmatter guard applies to explicit spellings too.
- **write_file**: main-file spellings route to `_edit_skill`, so frontmatter validation and scan-rollback apply (a generic-path write could corrupt the frontmatter).
- **remove_file**: main-file spellings are rejected with a pointer to `action='delete'` — SKILL.md *is* the skill; removing it would leave a broken directory.

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py`:
  - `_validate_file_path` gains a `skill_name` parameter; the 2-part `SKILL.md` spelling requires `parts[0] == skill_name`, with a targeted error otherwise.
  - New `_is_skill_md_spelling` predicate; used in all three actions to route main-file spellings: patch → default root path (frontmatter guard), write_file → `_edit_skill` (frontmatter validation + scan-rollback), remove_file → rejected with `action='delete'` pointer.
- `tests/tools/test_skill_manager_tool.py`: eight regression tests — 2-part form accepted only for the matching skill name; rejected with no skill name; wrong-name `write_file` rejected without planting a nested dir; matching spelling writes/patches the root with no nested dir created; explicit-spelling writes with broken frontmatter rejected (root untouched); explicit-spelling patch that would break frontmatter rejected; both main-file spellings rejected in `remove_file` with the `action='delete'` pointer.

## How to Test

Reproduction of the bypass (against pre-fix code):

```python
from tools.skill_manager_tool import _validate_file_path
_validate_file_path("evil/SKILL.md")   # pre-fix: None (accepted!)
                                      # post-fix: rejected with a targeted error
```

The shadow-skill consequence (verified live): after the bypassed write lands `foo/evil/SKILL.md`, `iter_skill_index_files(skills_dir, "SKILL.md")` yields `['foo/SKILL.md', 'foo/evil/SKILL.md']` — the planted skill is discovered as a standalone skill.

Focused validation completed:

1. `bash scripts/run_tests.sh tests/tools/test_skill_manager_tool.py` — 53/53 pass.
2. Sabotage checks: pre-fix code → the validator tests fail. Validation+routing reverted to the naive canonicalize-to-string variant → all 3 routing-semantics tests fail (frontmatter write guard, patch guard, remove rejection) — each half of the fix is pinned by its own tests.
3. Wider skill-system suites: `tests/tools/test_skills_tool.py tests/agent/test_skill_utils.py test_skill_bundles.py test_skill_commands.py test_external_skills.py test_ghost_skill_pruning.py` + the manager file — 165/165 pass.
4. `uvx --from ruff==0.15.10 ruff check tools/skill_manager_tool.py tests/tools/test_skill_manager_tool.py` — clean.
5. `git diff --check` — clean.
6. Adversarial cases executed: `evil/SKILL.md` rejected; both spellings of the matching name accepted and routed to root; 3-part `a/b/SKILL.md` still rejected by the subdir rule; traversal `evil/../SKILL.md` still blocked before the exception; allowed-subdir files (`references/notes.md`) unaffected; case-sensitive (`evil/skill.md` rejected); root SKILL.md content verified byte-identical after rejected writes/patches/removals.

The full repo-wide suite was not run for this change; the skill-system suites above cover the changed functions' surface, and GitHub CI owns full-suite validation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite not run locally (see How to Test; all skill-system suites pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (validator/routing comments updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure `pathlib` comparison, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no schema change; behavior now matches the spelling's documented meaning)

## Logs

Sabotage verification output:

```
# pre-fix code:
=== Summary: 1 files, 45 tests passed, 2 failed ===   (validator tests)
# naive canonicalize-to-string variant (review feedback):
=== Summary: 1 files, 50 tests passed, 3 failed ===   (routing-semantics tests)
# full fix:
=== Summary: 1 files, 53 tests passed, 0 failed ===
```
