### PR TITLE
feat(dashboard): dashboard.extra_hosts (config.yaml) for reverse-proxy / tunnel WS Origin acceptance

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1594,6 +1594,24 @@ updates:
 #   #
 #   #   public_url: "https://example.com/hermes"
 #
+#   # Extra hostnames accepted by the dashboard's Host/Origin validation, in
+#   # addition to the bound interface. For a reverse proxy or tunnel (nginx,
+#   # Tailscale Serve, Cloudflare Tunnel) in front of a loopback-bound
+#   # dashboard: the proxy rewrites the HTTP Host header, but a browser's
+#   # WebSocket Origin header carries the public hostname and no proxy can
+#   # rewrite it — list that hostname here or every WS upgrade (chat, events,
+#   # PTY) is refused with origin_mismatch.
+#   #
+#   # Exact matches only: bare hostnames, compared case-insensitively, ports
+#   # ignored. No wildcards, schemes, or paths — malformed entries are ignored
+#   # with a warning. This is NOT a public-exposure switch: it only widens
+#   # Host/Origin validation for hostnames you explicitly trust; it changes no
+#   # bind address and adds no auth. Keep access control at the proxy (or use
+#   # the OAuth gate above). Unset = current strict behaviour.
+#   #
+#   #   extra_hosts:
+#   #     - hermes.example.com
+#
 # -----------------------------------------------------------------------------
 # Self-hosted OIDC dashboard auth (generic OpenID Connect — Authentik,
 # Keycloak, Zitadel, Authelia, Auth0, Okta, Google, …). Use this INSTEAD of the

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1801,6 +1801,24 @@ updates:
 #   #
 #   #   public_url: "https://example.com/hermes"
 #
+#   # Extra hostnames accepted by the dashboard's Host/Origin validation, in
+#   # addition to the bound interface. For a reverse proxy or tunnel (nginx,
+#   # Tailscale Serve, Cloudflare Tunnel) in front of a loopback-bound
+#   # dashboard: the proxy rewrites the HTTP Host header, but a browser's
+#   # WebSocket Origin header carries the public hostname and no proxy can
+#   # rewrite it — list that hostname here or every WS upgrade (chat, events,
+#   # PTY) is refused with origin_mismatch.
+#   #
+#   # Exact matches only: bare hostnames, compared case-insensitively, ports
+#   # ignored. No wildcards, schemes, or paths — malformed entries are ignored
+#   # with a warning. This is NOT a public-exposure switch: it only widens
+#   # Host/Origin validation for hostnames you explicitly trust; it changes no
+#   # bind address and adds no auth. Keep access control at the proxy (or use
+#   # the OAuth gate above). Unset = current strict behaviour.
+#   #
+#   #   extra_hosts:
+#   #     - hermes.example.com
+#
 # -----------------------------------------------------------------------------
 # Self-hosted OIDC dashboard auth (generic OpenID Connect — Authentik,
 # Keycloak, Zitadel, Authelia, Auth0, Okta, Google, …). Use this INSTEAD of the

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -67,6 +67,7 @@ from hermes_cli.config import (
     get_hermes_home,
     get_process_hermes_home,
     load_config,
+    load_config_readonly,
     load_env,
     read_raw_config,
     save_config,
@@ -461,6 +462,87 @@ def should_require_auth(host: str, allow_public: bool = False) -> bool:
     return host not in _LOOPBACK_HOST_VALUES
 
 
+# Malformed dashboard.extra_hosts entries already warned about, so the
+# per-request read below doesn't repeat the same warning on every request.
+_EXTRA_HOSTS_WARNED: set = set()
+
+
+def _extra_accepted_hosts() -> frozenset:
+    """Hostnames accepted in addition to the bound host (operator opt-in).
+
+    ``dashboard.extra_hosts`` in ``config.yaml`` is a list of hostnames the
+    operator explicitly trusts: the public name of a reverse proxy or
+    tunnel (nginx, Tailscale Serve, Cloudflare Tunnel) in front of a
+    loopback-bound dashboard. The proxy rewrites the ``Host`` header, but a
+    browser sets the WebSocket ``Origin`` header to the public hostname and
+    no proxy can rewrite it — so WS upgrades are refused without this
+    opt-in (see #70059).
+
+    Exact-match only: each entry is a single bare hostname, compared
+    case-insensitively against the request's host with any port stripped.
+    No wildcards, schemes, or paths — a malformed entry is ignored (with
+    one warning), never partially honoured, so a config mistake fails
+    closed instead of widening the accept set.
+
+    Read per call via the mtime-cached :func:`load_config_readonly` (no
+    disk I/O on the hot path) so a running dashboard picks up config
+    edits without a restart — the same live-edit behaviour tests rely on.
+    """
+    dashboard_cfg = load_config_readonly().get("dashboard") or {}
+    raw = dashboard_cfg.get("extra_hosts")
+    if raw is None:
+        return frozenset()
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        if "__type__" not in _EXTRA_HOSTS_WARNED:
+            _EXTRA_HOSTS_WARNED.add("__type__")
+            _log.warning(
+                "dashboard.extra_hosts must be a list of hostnames; "
+                "ignoring %s value",
+                type(raw).__name__,
+            )
+        return frozenset()
+
+    hosts = set()
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        h = entry.strip().lower()
+        if any(ch in h for ch in ("*", "/", "@", " ")):
+            if entry not in _EXTRA_HOSTS_WARNED:
+                _EXTRA_HOSTS_WARNED.add(entry)
+                _log.warning(
+                    "dashboard.extra_hosts: ignoring %r — entries must be "
+                    "bare hostnames (no wildcards, schemes, or paths)",
+                    entry,
+                )
+            continue
+        # Tolerate an accidental :port suffix — comparison is host-only,
+        # mirroring _is_accepted_host's own port stripping.
+        if h.startswith("["):
+            close = h.find("]")
+            h = h[1:close] if close != -1 else h.strip("[]")
+        elif ":" in h:
+            head, _, tail = h.rpartition(":")
+            if tail.isdigit():
+                h = head
+            else:
+                # Ambiguous (e.g. unbracketed IPv6) — refuse rather than
+                # guess which part is the host.
+                if entry not in _EXTRA_HOSTS_WARNED:
+                    _EXTRA_HOSTS_WARNED.add(entry)
+                    _log.warning(
+                        "dashboard.extra_hosts: ignoring %r — bracket IPv6 "
+                        "addresses ([::1]) and keep ports numeric",
+                        entry,
+                    )
+                continue
+        if h:
+            hosts.add(h)
+    return frozenset(hosts)
+
+
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     """True if the Host header targets the interface we bound to.
 
@@ -489,6 +571,11 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     else:
         host_only = h.rsplit(":", 1)[0] if ":" in h else h
     host_only = host_only.lower()
+
+    # Operator-trusted extra hostnames (reverse proxy / tunnel fronting a
+    # loopback bind) — see _extra_accepted_hosts.
+    if host_only in _extra_accepted_hosts():
+        return True
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -68,6 +68,7 @@ from hermes_cli.config import (
     get_hermes_home,
     get_process_hermes_home,
     load_config,
+    load_config_readonly,
     load_env,
     read_raw_config,
     resolve_cron_model_drift_defaults,
@@ -659,6 +660,87 @@ def should_require_auth(host: str, allow_public: bool = False) -> bool:
     return host not in _LOOPBACK_HOST_VALUES
 
 
+# Malformed dashboard.extra_hosts entries already warned about, so the
+# per-request read below doesn't repeat the same warning on every request.
+_EXTRA_HOSTS_WARNED: set = set()
+
+
+def _extra_accepted_hosts() -> frozenset:
+    """Hostnames accepted in addition to the bound host (operator opt-in).
+
+    ``dashboard.extra_hosts`` in ``config.yaml`` is a list of hostnames the
+    operator explicitly trusts: the public name of a reverse proxy or
+    tunnel (nginx, Tailscale Serve, Cloudflare Tunnel) in front of a
+    loopback-bound dashboard. The proxy rewrites the ``Host`` header, but a
+    browser sets the WebSocket ``Origin`` header to the public hostname and
+    no proxy can rewrite it — so WS upgrades are refused without this
+    opt-in (see #70059).
+
+    Exact-match only: each entry is a single bare hostname, compared
+    case-insensitively against the request's host with any port stripped.
+    No wildcards, schemes, or paths — a malformed entry is ignored (with
+    one warning), never partially honoured, so a config mistake fails
+    closed instead of widening the accept set.
+
+    Read per call via the mtime-cached :func:`load_config_readonly` (no
+    disk I/O on the hot path) so a running dashboard picks up config
+    edits without a restart — the same live-edit behaviour tests rely on.
+    """
+    dashboard_cfg = load_config_readonly().get("dashboard") or {}
+    raw = dashboard_cfg.get("extra_hosts")
+    if raw is None:
+        return frozenset()
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        if "__type__" not in _EXTRA_HOSTS_WARNED:
+            _EXTRA_HOSTS_WARNED.add("__type__")
+            _log.warning(
+                "dashboard.extra_hosts must be a list of hostnames; "
+                "ignoring %s value",
+                type(raw).__name__,
+            )
+        return frozenset()
+
+    hosts = set()
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        h = entry.strip().lower()
+        if any(ch in h for ch in ("*", "/", "@", " ")):
+            if entry not in _EXTRA_HOSTS_WARNED:
+                _EXTRA_HOSTS_WARNED.add(entry)
+                _log.warning(
+                    "dashboard.extra_hosts: ignoring %r — entries must be "
+                    "bare hostnames (no wildcards, schemes, or paths)",
+                    entry,
+                )
+            continue
+        # Tolerate an accidental :port suffix — comparison is host-only,
+        # mirroring _is_accepted_host's own port stripping.
+        if h.startswith("["):
+            close = h.find("]")
+            h = h[1:close] if close != -1 else h.strip("[]")
+        elif ":" in h:
+            head, _, tail = h.rpartition(":")
+            if tail.isdigit():
+                h = head
+            else:
+                # Ambiguous (e.g. unbracketed IPv6) — refuse rather than
+                # guess which part is the host.
+                if entry not in _EXTRA_HOSTS_WARNED:
+                    _EXTRA_HOSTS_WARNED.add(entry)
+                    _log.warning(
+                        "dashboard.extra_hosts: ignoring %r — bracket IPv6 "
+                        "addresses ([::1]) and keep ports numeric",
+                        entry,
+                    )
+                continue
+        if h:
+            hosts.add(h)
+    return frozenset(hosts)
+
+
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     """True if the Host header targets the interface we bound to.
 
@@ -687,6 +769,11 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     else:
         host_only = h.rsplit(":", 1)[0] if ":" in h else h
     host_only = host_only.lower()
+
+    # Operator-trusted extra hostnames (reverse proxy / tunnel fronting a
+    # loopback bind) — see _extra_accepted_hosts.
+    if host_only in _extra_accepted_hosts():
+        return True
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -137,3 +137,177 @@ class TestWebSocketHostOriginGuard:
             },
         ):
             pass
+
+class TestExtraAcceptedHosts:
+    """``dashboard.extra_hosts`` (config.yaml) — operator-trusted
+    reverse-proxy / tunnel hostnames in front of a loopback bind (#70059).
+
+    The proxy rewrites the Host header, but the browser-set WebSocket
+    Origin header carries the public hostname and cannot be rewritten by
+    any proxy — without this opt-in every WS upgrade is refused with
+    ``origin_mismatch``."""
+
+    @staticmethod
+    def _set_extra_hosts(monkeypatch, value):
+        """Point the mtime-cached config read at an in-memory config."""
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(
+            ws,
+            "load_config_readonly",
+            lambda: {"dashboard": {"extra_hosts": value}},
+        )
+
+    def test_extra_host_accepted_on_loopback_bind(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        self._set_extra_hosts(monkeypatch, ["atlas.example.com"])
+        assert _is_accepted_host("atlas.example.com", "127.0.0.1")
+        assert _is_accepted_host("atlas.example.com:9119", "127.0.0.1")
+        # Case-insensitive, like every other host comparison here
+        assert _is_accepted_host("Atlas.Example.COM", "127.0.0.1")
+
+    def test_other_hosts_still_rejected(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        self._set_extra_hosts(monkeypatch, ["atlas.example.com"])
+        assert not _is_accepted_host("evil.example", "127.0.0.1")
+        # Loopback aliases keep working on a loopback bind
+        assert _is_accepted_host("localhost:9119", "127.0.0.1")
+
+    def test_unset_config_keeps_strict_behaviour(self, monkeypatch):
+        import hermes_cli.web_server as ws
+        from hermes_cli.web_server import _is_accepted_host
+
+        monkeypatch.setattr(ws, "load_config_readonly", lambda: {})
+        assert not _is_accepted_host("atlas.example.com", "127.0.0.1")
+
+    def test_multiple_entries_and_whitespace(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        self._set_extra_hosts(
+            monkeypatch, [" atlas.example.com ", "hermes.tail1234.ts.net"]
+        )
+        assert _is_accepted_host("atlas.example.com", "127.0.0.1")
+        assert _is_accepted_host("hermes.tail1234.ts.net", "127.0.0.1")
+        assert not _is_accepted_host("other.example.com", "127.0.0.1")
+
+    def test_single_string_tolerated(self, monkeypatch):
+        """A bare string instead of a one-element list is a natural YAML
+        mistake — accept it rather than silently disabling the opt-in."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        self._set_extra_hosts(monkeypatch, "atlas.example.com")
+        assert _is_accepted_host("atlas.example.com", "127.0.0.1")
+
+    def test_entry_port_suffix_stripped(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        self._set_extra_hosts(monkeypatch, ["atlas.example.com:9119"])
+        assert _is_accepted_host("atlas.example.com", "127.0.0.1")
+        assert _is_accepted_host("atlas.example.com:8443", "127.0.0.1")
+
+    def test_malformed_entries_fail_closed(self, monkeypatch):
+        """Exact-match only: wildcards, schemes/paths, and non-string
+        entries are ignored — never partially honoured."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        self._set_extra_hosts(
+            monkeypatch,
+            ["*.example.com", "https://x.example", "a b.example", 42, None,
+             "", "atlas.example.com"],
+        )
+        assert _is_accepted_host("atlas.example.com", "127.0.0.1")
+        assert not _is_accepted_host("x.example", "127.0.0.1")
+        assert not _is_accepted_host("sub.example.com", "127.0.0.1")
+
+    def test_empty_entries_ignored(self, monkeypatch):
+        from hermes_cli.web_server import _is_accepted_host
+
+        self._set_extra_hosts(monkeypatch, [" ", ""])
+        assert not _is_accepted_host("", "127.0.0.1")
+        assert not _is_accepted_host("evil.example", "127.0.0.1")
+
+    # -- positive regression coverage through the real request paths --
+
+    def test_http_middleware_accepts_extra_host(self, monkeypatch):
+        """The HTTP middleware (host_header_middleware) must accept a
+        configured extra host — not just the unit-level helper."""
+        from fastapi.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        self._set_extra_hosts(monkeypatch, ["atlas.example.com"])
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+
+        client = TestClient(ws.app)
+        resp = client.get(
+            "/api/status",
+            headers={"Host": "atlas.example.com"},
+        )
+        assert resp.status_code != 400
+
+    def test_http_middleware_still_rejects_unlisted_host(self, monkeypatch):
+        """The opt-in must not widen the accept set beyond its entries."""
+        from fastapi.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        self._set_extra_hosts(monkeypatch, ["atlas.example.com"])
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+
+        client = TestClient(ws.app)
+        resp = client.get(
+            "/api/status",
+            headers={"Host": "evil.example"},
+        )
+        assert resp.status_code == 400
+
+    def test_websocket_accepts_extra_host_and_origin(self, monkeypatch):
+        """The WS Host/Origin guard (_ws_host_origin_reason) must accept a
+        configured extra host on both the Host and Origin headers — the
+        exact reverse-proxy failure this opt-in exists for (#70059)."""
+        from fastapi.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        self._set_extra_hosts(monkeypatch, ["atlas.example.com"])
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with client.websocket_connect(
+            url,
+            headers={
+                "Host": "atlas.example.com",
+                "Origin": "https://atlas.example.com",
+            },
+        ):
+            pass
+
+    def test_websocket_still_rejects_unlisted_origin(self, monkeypatch):
+        """With the opt-in configured, an unlisted Origin keeps failing
+        with the same 4403 as before — the DNS-rebinding defence stays."""
+        from fastapi.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        import hermes_cli.web_server as ws
+
+        self._set_extra_hosts(monkeypatch, ["atlas.example.com"])
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect(
+                url,
+                headers={
+                    "Host": "atlas.example.com",
+                    "Origin": "http://evil.example",
+                },
+            ):
+                pass
+
+        assert exc.value.code == 4403

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -1097,6 +1097,41 @@ Instead of the in-app setting, you can point the desktop at a backend with an en
 - **Signed out on every restart** — set `HERMES_DASHBOARD_BASIC_AUTH_SECRET` to a stable value; otherwise the signing key is regenerated per boot.
 - **Connection refused / times out** — the backend bound to `127.0.0.1` (the default) instead of a reachable address, or a firewall/VPN is blocking the port. Bind to `0.0.0.0` or the tailscale IP and open the port to your trusted network.
 
+## Reverse proxies and tunnels (`dashboard.extra_hosts`)
+
+The dashboard validates the `Host` header of every HTTP request and the
+`Host`/`Origin` headers of every WebSocket upgrade against the interface it was
+bound to (DNS-rebinding defence, see [Authentication](#authentication-gated-mode)).
+Behind a reverse proxy or tunnel (nginx, Tailscale Serve, Cloudflare Tunnel)
+fronting a loopback-bound dashboard this fails asymmetrically: the proxy
+rewrites the HTTP `Host` header, so pages load — but a browser sets the
+WebSocket `Origin` header to the public hostname and **no proxy can rewrite
+it**, so every WS upgrade (chat, events feed, PTY) is refused with
+`origin_mismatch`.
+
+Declare the hostnames you explicitly trust in `config.yaml`:
+
+```yaml
+dashboard:
+  extra_hosts:
+    - hermes.example.com
+```
+
+Rules:
+
+- **Exact matches only.** Each entry is a single bare hostname, compared
+  case-insensitively with any port stripped. Wildcards, schemes, and paths are
+  not supported — a malformed entry is ignored with a warning, never partially
+  honoured.
+- **Not a public-exposure switch.** `extra_hosts` only widens Host/Origin
+  validation for hostnames you already trust; it does not change the bind
+  address and adds no authentication. Keep the dashboard loopback-bound and put
+  access control at the proxy (or use the OAuth gate above) for anything
+  reachable beyond the machine.
+- **Unset (the default) changes nothing:** only the bound interface (plus
+  loopback aliases on a loopback bind) is accepted, exactly as before.
+- The list is re-read when `config.yaml` changes — no dashboard restart needed.
+
 ## CORS
 
 The web server restricts CORS to localhost origins only:

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -1054,6 +1054,41 @@ Instead of the in-app setting, you can point the desktop at a backend with an en
 - **Signed out on every restart** — set `HERMES_DASHBOARD_BASIC_AUTH_SECRET` to a stable value; otherwise the signing key is regenerated per boot.
 - **Connection refused / times out** — the backend bound to `127.0.0.1` (the default) instead of a reachable address, or a firewall/VPN is blocking the port. Bind to `0.0.0.0` or the tailscale IP and open the port to your trusted network.
 
+## Reverse proxies and tunnels (`dashboard.extra_hosts`)
+
+The dashboard validates the `Host` header of every HTTP request and the
+`Host`/`Origin` headers of every WebSocket upgrade against the interface it was
+bound to (DNS-rebinding defence, see [Authentication](#authentication-gated-mode)).
+Behind a reverse proxy or tunnel (nginx, Tailscale Serve, Cloudflare Tunnel)
+fronting a loopback-bound dashboard this fails asymmetrically: the proxy
+rewrites the HTTP `Host` header, so pages load — but a browser sets the
+WebSocket `Origin` header to the public hostname and **no proxy can rewrite
+it**, so every WS upgrade (chat, events feed, PTY) is refused with
+`origin_mismatch`.
+
+Declare the hostnames you explicitly trust in `config.yaml`:
+
+```yaml
+dashboard:
+  extra_hosts:
+    - hermes.example.com
+```
+
+Rules:
+
+- **Exact matches only.** Each entry is a single bare hostname, compared
+  case-insensitively with any port stripped. Wildcards, schemes, and paths are
+  not supported — a malformed entry is ignored with a warning, never partially
+  honoured.
+- **Not a public-exposure switch.** `extra_hosts` only widens Host/Origin
+  validation for hostnames you already trust; it does not change the bind
+  address and adds no authentication. Keep the dashboard loopback-bound and put
+  access control at the proxy (or use the OAuth gate above) for anything
+  reachable beyond the machine.
+- **Unset (the default) changes nothing:** only the bound interface (plus
+  loopback aliases on a loopback bind) is accepted, exactly as before.
+- The list is re-read when `config.yaml` changes — no dashboard restart needed.
+
 ## CORS
 
 The web server restricts CORS to localhost origins only:


### PR DESCRIPTION
Re-scope of #75019, which was closed under the standing `env-var-for-config` policy — this version puts the setting on the established `dashboard` config surface in `config.yaml` instead of a new `HERMES_*` env var, as requested in the closing review (and in the same direction required by the #70064 review).

## Problem (unchanged from #75019, reproduced live)

Behind a reverse proxy or tunnel (nginx, Tailscale Serve, Cloudflare Tunnel) fronting a loopback-bound dashboard, HTTP works because the proxy rewrites the `Host` header — but the browser-set WebSocket `Origin` header carries the public hostname and **cannot be rewritten by any proxy**. `_is_accepted_host()` then refuses every WS upgrade (`origin_mismatch`), breaking chat, the events feed, and PTY. Closes #70059.

## Mechanism

```yaml
dashboard:
  extra_hosts:
    - atlas.example.com
```

- **Exact-match validation:** each entry is a single bare hostname, compared case-insensitively against the request host with the port stripped. Wildcards, schemes, paths, and non-string entries are ignored with a single warning — a config mistake fails closed, it never partially widens the accept set.
- **No new env vars:** the value is read per request via the mtime-cached `load_config_readonly()` (no disk I/O on the hot path, ~µs cache hit), so a running dashboard picks up config edits without a restart.
- **Default unchanged:** with `extra_hosts` unset, behaviour is byte-for-byte the current strict behaviour; unlisted hosts and DNS-rebinding Hosts are still rejected (GHSA-ppp5-vxwm-4cf7 defence intact).

## Coverage (both request paths, positive + negative)

As asked for in the #75019 closing review:

- **HTTP middleware** (`host_header_middleware`): configured extra host passes (`!= 400`), unlisted host still rejected with 400.
- **WebSocket Host/Origin guard**: WS upgrade with the extra host on `Host` + `Origin` succeeds end-to-end via `TestClient.websocket_connect`; an unlisted `Origin` still closes with 4403.
- **Unit coverage** of the validation rules: case-insensitivity, port stripping (header and entry side), single-string tolerance, malformed-entry fail-closed, empty/unset strictness.

`tests/hermes_cli/test_web_server_host_header.py`: 18 passed.