### PR TITLE
fix(desktop): keep message age labels fresh

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -80,7 +80,23 @@ function Harness({
 }
 
 describe('MessageAge', () => {
-  it('advances relative age on the shared clock without an unrelated render', async () => {
+  it('advances second-level relative ages on the shared clock without an unrelated render', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-01T00:00:05.000Z'))
+
+    render(<Harness assistantCreatedAt={new Date('2026-05-01T00:00:00.000Z')} />)
+    await act(async () => {})
+
+    expect(screen.getByText('5s ago')).toBeTruthy()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+
+    expect(screen.getByText('6s ago')).toBeTruthy()
+  })
+
+  it('advances minute and hour relative ages on the shared clock without an unrelated render', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-01T00:08:00.000Z'))
 

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -5,12 +5,12 @@
 // AssistantMessage's action bar hide the button entirely when no handler is
 // supplied, matching how onDismissError/onRestoreToMessage already behave.
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { Thread } from '.'
 
-const createdAt = new Date('2026-05-01T00:00:00.000Z')
+const defaultCreatedAt = new Date('2026-05-01T00:00:00.000Z')
 
 class TestResizeObserver {
   observe() {}
@@ -28,6 +28,7 @@ Element.prototype.scrollTo = function scrollTo() {}
 
 afterEach(() => {
   cleanup()
+  vi.useRealTimers()
 })
 
 function userMessage(): ThreadMessage {
@@ -36,12 +37,12 @@ function userMessage(): ThreadMessage {
     role: 'user',
     content: [{ type: 'text', text: 'question one' }],
     attachments: [],
-    createdAt,
+    createdAt: defaultCreatedAt,
     metadata: { custom: {} }
   } as ThreadMessage
 }
 
-function assistantMessage(): ThreadMessage {
+function assistantMessage(createdAt = defaultCreatedAt): ThreadMessage {
   return {
     id: 'assistant-1',
     role: 'assistant',
@@ -58,9 +59,15 @@ function assistantMessage(): ThreadMessage {
   } as ThreadMessage
 }
 
-function Harness({ onBranchInNewChat }: { onBranchInNewChat?: (messageId: string) => void }) {
+function Harness({
+  assistantCreatedAt,
+  onBranchInNewChat
+}: {
+  assistantCreatedAt?: Date
+  onBranchInNewChat?: (messageId: string) => void
+}) {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
-    messages: [userMessage(), assistantMessage()],
+    messages: [userMessage(), assistantMessage(assistantCreatedAt)],
     isRunning: false,
     onNew: async () => {}
   })
@@ -71,6 +78,30 @@ function Harness({ onBranchInNewChat }: { onBranchInNewChat?: (messageId: string
     </AssistantRuntimeProvider>
   )
 }
+
+describe('MessageAge', () => {
+  it('advances relative age on the shared clock without an unrelated render', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-01T00:08:00.000Z'))
+
+    render(<Harness assistantCreatedAt={new Date('2026-05-01T00:00:00.000Z')} />)
+    await act(async () => {})
+
+    expect(screen.getByText('8m ago')).toBeTruthy()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+
+    expect(screen.getByText('9m ago')).toBeTruthy()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(51 * 60_000)
+    })
+
+    expect(screen.getByText('1h ago')).toBeTruthy()
+  })
+})
 
 describe('AssistantMessage branch button visibility (bug #2 fix)', () => {
   it('shows the Branch in new chat button when a handler is provided (open chat)', async () => {

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -7,7 +7,7 @@ import {
   useMessageRuntime
 } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
-import { type FC, useCallback, useMemo, useState } from 'react'
+import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { ChangedFilesCard } from '@/components/assistant-ui/thread/changed-files-card'
 import {
@@ -38,6 +38,43 @@ import { $voicePlayback } from '@/store/voice-playback'
 // Stable empty identity for the settled-parts selector — a fresh [] per render
 // would re-derive the changed-files card on every message re-render.
 const EMPTY_PARTS: readonly unknown[] = []
+const MESSAGE_AGE_TICK_MS = 30_000
+
+const messageAgeClockListeners = new Set<(nowMs: number) => void>()
+let messageAgeClockTimer: ReturnType<typeof setInterval> | null = null
+
+function emitMessageAgeTick() {
+  const nowMs = Date.now()
+
+  for (const listener of messageAgeClockListeners) {
+    listener(nowMs)
+  }
+}
+
+function subscribeMessageAgeClock(listener: (nowMs: number) => void) {
+  messageAgeClockListeners.add(listener)
+
+  if (messageAgeClockTimer === null) {
+    messageAgeClockTimer = setInterval(emitMessageAgeTick, MESSAGE_AGE_TICK_MS)
+  }
+
+  return () => {
+    messageAgeClockListeners.delete(listener)
+
+    if (messageAgeClockListeners.size === 0 && messageAgeClockTimer !== null) {
+      clearInterval(messageAgeClockTimer)
+      messageAgeClockTimer = null
+    }
+  }
+}
+
+function useMessageAgeNow() {
+  const [nowMs, setNowMs] = useState(() => Date.now())
+
+  useEffect(() => subscribeMessageAgeClock(setNowMs), [])
+
+  return nowMs
+}
 
 interface MessageActionProps {
   messageId: string
@@ -303,6 +340,7 @@ const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ get
 const MessageAge: FC = () => {
   const { t } = useI18n()
   const createdAt = useAuiState(s => s.message.createdAt)
+  const nowMs = useMessageAgeNow()
   const date = createdAt ? new Date(createdAt) : null
 
   if (!date || Number.isNaN(date.getTime())) {
@@ -315,7 +353,7 @@ const MessageAge: FC = () => {
       className="px-0.5 text-[0.6875rem] tabular-nums text-muted-foreground"
       title={formatMessageTimestamp(date, t.assistant.thread) || undefined}
     >
-      {formatAgo(date.getTime(), t.agents)}
+      {formatAgo(date.getTime(), t.agents, nowMs)}
     </span>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -38,7 +38,7 @@ import { $voicePlayback } from '@/store/voice-playback'
 // Stable empty identity for the settled-parts selector — a fresh [] per render
 // would re-derive the changed-files card on every message re-render.
 const EMPTY_PARTS: readonly unknown[] = []
-const MESSAGE_AGE_TICK_MS = 30_000
+const MESSAGE_AGE_TICK_MS = 1_000
 
 const messageAgeClockListeners = new Set<(nowMs: number) => void>()
 let messageAgeClockTimer: ReturnType<typeof setInterval> | null = null


### PR DESCRIPTION
## Summary
- add a shared renderer clock for assistant message age labels so they refresh while a chat stays open
- keep one timer for all visible message-age consumers instead of one timer per message
- add a fake-timer regression test for `8m ago` → `9m ago` → `1h ago` without forcing an unrelated render

Fixes #74923

## Tests
- `npm --prefix apps/desktop test -- --project ui src/components/assistant-ui/thread/assistant-message.test.tsx`
- `npm exec eslint src/components/assistant-ui/thread/assistant-message.tsx src/components/assistant-ui/thread/assistant-message.test.tsx` from `apps/desktop`
- `npm --prefix apps/desktop run typecheck`
- `git diff --check`
