### PR TITLE
docs(delegate): discourage transcript polling loops

### DIFF
--- a/tests/tools/test_delegate_apiserver_background.py
+++ b/tests/tools/test_delegate_apiserver_background.py
@@ -128,6 +128,12 @@ def test_apiserver_session_with_id_dispatches_background(monkeypatch):
     parsed = json.loads(out)
     assert parsed["status"] == "dispatched", parsed
     assert parsed["mode"] == "background"
+    assert "If no independent work remains" in parsed["note"]
+    assert "Do not repeatedly check task status" in parsed["note"]
+    assert "live_transcripts" in parsed
+    assert "explicit user-requested live monitoring or diagnostics" in parsed["live_transcripts_hint"]
+    assert "not a completion signal" in parsed["live_transcripts_hint"]
+    assert "Read or `tail -f`" not in parsed["live_transcripts_hint"]
 
     evt = _drain_one()
     assert evt is not None

--- a/tests/tools/test_delegate_tool_description.py
+++ b/tests/tools/test_delegate_tool_description.py
@@ -11,9 +11,7 @@ def test_top_level_description_discourages_polling_live_transcripts(monkeypatch)
 
     description = dt._build_top_level_description()
 
-    assert "do NOT poll status, transcript files, or output files" in description
-    assert "explicit user-requested live monitoring or diagnostics" in description
-    assert "not completion signals" in description
-    assert "For ordinary delegation, wait for the consolidated result" in description
+    assert "Do NOT wait or poll" in description
+    assert "live transcripts are append-only logs, not completion signals" in description
     assert "tail -f" not in description
     assert "Read or `tail -f`" not in description

--- a/tests/tools/test_delegate_tool_description.py
+++ b/tests/tools/test_delegate_tool_description.py
@@ -1,0 +1,19 @@
+"""Regression tests for delegate_task tool-schema description guidance."""
+
+
+def test_top_level_description_discourages_polling_live_transcripts(monkeypatch):
+    """The schema description must match the background dispatch payload guidance."""
+    import tools.delegate_tool as dt
+
+    monkeypatch.setattr(dt, "_get_max_concurrent_children", lambda: 3)
+    monkeypatch.setattr(dt, "_get_max_spawn_depth", lambda: 1)
+    monkeypatch.setattr(dt, "_get_orchestrator_enabled", lambda: True)
+
+    description = dt._build_top_level_description()
+
+    assert "do NOT poll status, transcript files, or output files" in description
+    assert "explicit user-requested live monitoring or diagnostics" in description
+    assert "not completion signals" in description
+    assert "For ordinary delegation, wait for the consolidated result" in description
+    assert "tail -f" not in description
+    assert "Read or `tail -f`" not in description

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4503,15 +4503,22 @@ def delegate_task(
             n = len(_goals)
             note = (
                 "Subagent is running in the background. You and the user can "
-                "keep working; its full result re-enters the conversation as a "
-                "new message when it finishes. Do not wait or poll — just "
-                "continue."
+                "keep working; its full result re-enters the conversation as "
+                "a new message when it finishes. Continue any independent "
+                "work that does not depend on its result. If no independent "
+                "work remains, end the current turn and wait for the "
+                "automatic completion message. Do not repeatedly check task "
+                "status, transcript files, or output files."
                 if n == 1 else
                 f"{n} subagents are running in parallel in the background. You "
                 f"and the user can keep working; they wait on each other and "
                 f"their consolidated results re-enter the conversation as a "
-                f"single message once ALL of them finish. Do not wait or poll "
-                f"— just continue."
+                f"single message once ALL of them finish. Continue any "
+                f"independent work that does not depend on their results. If "
+                f"no independent work remains, end the current turn and wait "
+                f"for the automatic consolidated completion message. Do not "
+                f"repeatedly check task status, transcript files, or output "
+                f"files."
             )
             payload = {
                 "status": "dispatched",
@@ -4538,8 +4545,11 @@ def delegate_task(
                 payload["live_transcripts_hint"] = (
                     "Each subagent streams a human-readable transcript of its "
                     "operations to the file listed above (append-only, one per "
-                    "task). Read or `tail -f` these paths at any time to watch "
-                    "a child work while it runs."
+                    "task). These transcripts are available for explicit "
+                    "user-requested live monitoring or diagnostics only; they "
+                    "may be incomplete while a child is running and are not a "
+                    "completion signal. For ordinary delegation, wait for the "
+                    "automatic consolidated result."
                 )
             return json.dumps(payload, ensure_ascii=False)
 
@@ -5001,9 +5011,9 @@ def _build_top_level_description() -> str:
         "Runs in the background: dispatch returns immediately with live "
         "transcript paths, and the completed result (one consolidated message, "
         "results in task order) re-enters the conversation on its own. Do NOT "
-        "wait or poll; continue other work. While children run, `action` "
-        "(list/steer/stop) controls them live — steer when a transcript shows "
-        "a child drifting.\n\n"
+        "wait or poll; live transcripts are append-only logs, not completion "
+        "signals. While children run, `action` (list/steer/stop) controls "
+        "them live — steer when a transcript shows a child drifting.\n\n"
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
         "with intermediate data, or independent parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3359,15 +3359,22 @@ def delegate_task(
             n = len(_goals)
             note = (
                 "Subagent is running in the background. You and the user can "
-                "keep working; its full result re-enters the conversation as a "
-                "new message when it finishes. Do not wait or poll — just "
-                "continue."
+                "keep working; its full result re-enters the conversation as "
+                "a new message when it finishes. Continue any independent "
+                "work that does not depend on its result. If no independent "
+                "work remains, end the current turn and wait for the "
+                "automatic completion message. Do not repeatedly check task "
+                "status, transcript files, or output files."
                 if n == 1 else
                 f"{n} subagents are running in parallel in the background. You "
                 f"and the user can keep working; they wait on each other and "
                 f"their consolidated results re-enter the conversation as a "
-                f"single message once ALL of them finish. Do not wait or poll "
-                f"— just continue."
+                f"single message once ALL of them finish. Continue any "
+                f"independent work that does not depend on their results. If "
+                f"no independent work remains, end the current turn and wait "
+                f"for the automatic consolidated completion message. Do not "
+                f"repeatedly check task status, transcript files, or output "
+                f"files."
             )
             payload = {
                 "status": "dispatched",
@@ -3382,8 +3389,11 @@ def delegate_task(
                 payload["live_transcripts_hint"] = (
                     "Each subagent streams a human-readable transcript of its "
                     "operations to the file listed above (append-only, one per "
-                    "task). Read or `tail -f` these paths at any time to watch "
-                    "a child work while it runs."
+                    "task). These transcripts are available for explicit "
+                    "user-requested live monitoring or diagnostics only; they "
+                    "may be incomplete while a child is running and are not a "
+                    "completion signal. For ordinary delegation, wait for the "
+                    "automatic consolidated result."
                 )
             return json.dumps(payload, ensure_ascii=False)
 
@@ -3685,8 +3695,14 @@ def _build_top_level_description() -> str:
         "(limits and nesting rules are in the parameter descriptions).\n\n"
         "Runs in the background: dispatch returns immediately with live "
         "transcript paths, and the completed result (one consolidated message "
-        "for a batch) re-enters the conversation on its own. Do NOT wait or "
-        "poll; continue other work.\n\n"
+        "for a batch) re-enters the conversation on its own. Continue any "
+        "independent work that does not depend on their results; if none "
+        "remains, end the turn and wait for the automatic completion message. "
+        "Do NOT poll status, transcript files, or output files.\n\n"
+        "LIVE TRANSCRIPTS: those paths are append-only logs for explicit "
+        "user-requested monitoring or diagnostics only; they may be incomplete "
+        "while children run and are NOT completion signals — for ordinary "
+        "delegation, wait for the consolidated result.\n\n"
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
         "with intermediate data, or independent parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"


### PR DESCRIPTION
## Summary
- clarify `delegate_task` background dispatch wording so agents continue independent work or end the turn instead of polling
- reframe live transcript paths as explicit user-requested monitoring/diagnostics, not ordinary completion signals
- add regression coverage for the dispatched payload so the hint does not reintroduce `tail -f`-style polling guidance

Fixes #74892

## Tests
- `scripts/run_tests.sh tests/tools/test_delegate_apiserver_background.py -q`
- `python3 -m py_compile tools/delegate_tool.py tests/tools/test_delegate_apiserver_background.py`
- `git diff --check`
