### PR TITLE
fix(kanban): wake origin session on triage escalation

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -612,7 +612,14 @@ class GatewayKanbanWatchersMixin:
                         #   claim exactly like a failed send() above, so the
                         #   next tick retries.
                         task_terminal = task and task.status in {"done", "archived"}
-                        _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
+                        # Triage is the terminal escalation of a repeated
+                        # blocked state. It already has a subscriber ping above;
+                        # include it here so the originating session receives
+                        # the same wakeup path as a direct block.
+                        _WAKE_KINDS = (
+                            "completed", "gave_up", "crashed", "timed_out",
+                            "blocked", "block_loop_detected",
+                        )
                         _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
                         from gateway.wake import adapter_supports_push as _adapter_push_ok
 
@@ -629,7 +636,8 @@ class GatewayKanbanWatchersMixin:
                             if "gave_up" in _wake_kinds: _parts.append(t("gateway.kanban.wake.gave_up"))
                             if "crashed" in _wake_kinds: _parts.append(t("gateway.kanban.wake.crashed"))
                             if "timed_out" in _wake_kinds: _parts.append(t("gateway.kanban.wake.timed_out"))
-                            if "blocked" in _wake_kinds: _parts.append(t("gateway.kanban.wake.blocked"))
+                            if {"blocked", "block_loop_detected"} & _wake_kinds:
+                                _parts.append(t("gateway.kanban.wake.blocked"))
                             _status = t("gateway.kanban.wake.status_joiner").join(_parts) or t("gateway.kanban.wake.status_default")
                             _synth = t(
                                 "gateway.kanban.wake.message",

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -363,8 +363,8 @@ def test_kanban_notifier_isolates_per_subscription_failure(tmp_path, monkeypatch
     assert tid_good in adapter.sent[0]["text"]
 
 
-def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch):
-    """A `block_loop_detected` event must reach the subscriber as a triage ping.
+def test_notifier_delivers_block_loop_detected_triage_ping_and_wakes_origin(tmp_path, monkeypatch):
+    """A `block_loop_detected` event must ping and wake its Telegram origin.
 
     Regression for the silent-triage gap (PR #62712): kanban_db routes a task
     to `triage` after BLOCK_RECURRENCE_LIMIT re-blocks for the same cause and
@@ -380,8 +380,19 @@ def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch
 
     conn = kb.connect()
     try:
-        tid = kb.create_task(conn, title="loops forever", assignee="worker")
-        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        tid = kb.create_task(
+            conn,
+            title="loops forever",
+            assignee="worker",
+            session_id="agent:main:telegram:dm:chat-1",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+            chat_type="dm",
+        )
         kb._append_event(
             conn, tid, "block_loop_detected",
             {"reason": "needs credentials", "kind": "needs_input",
@@ -400,6 +411,12 @@ def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch
     assert "TRIAGE" in text
     assert tid in text
     assert "needs credentials" in text
+    assert len(adapter.handled) == 1
+    wake = adapter.handled[0]
+    assert wake.source.platform is Platform.TELEGRAM
+    assert wake.source.chat_id == "chat-1"
+    assert wake.source.chat_type == "dm"
+    assert tid in wake.text
     # Cursor advanced: the event is claimed and not re-delivered.
     conn = kb.connect()
     try:


### PR DESCRIPTION
## What does this PR do?

`block_loop_detected` already sends a loud TRIAGE notification to the subscribed chat, but it was not part of the notifier's synthetic wake set. On push platforms such as Telegram, the user received the message while the originating Main session remained asleep.

This change routes the triage escalation through the existing wake path used by ordinary blocked events. It preserves the dedicated human-facing TRIAGE ping, session reconstruction, cursor handling, and push/non-push delivery semantics.

## Related Issue

Follow-up to #62712, which added the subscriber TRIAGE ping for `block_loop_detected`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Include `block_loop_detected` in the existing Kanban synthetic wake classification.
- Reuse the localized blocked-attention status for triage escalation, deduplicated when both event forms appear in one batch.
- Extend the notifier regression to prove that a session-bound Telegram DM receives both the existing TRIAGE ping and exactly one correctly scoped Main-session wake.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_kanban_notifier.py -k block_loop_detected`
2. `scripts/run_tests.sh tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_notifier_apiserver_wake.py`
3. `.venv/bin/ruff check gateway/kanban_watchers.py tests/gateway/test_kanban_notifier.py`

Local results: focused regression **1 passed**; notifier plus API-server wake suites **7 passed**; lint and diff checks passed. A base negative control failed on the missing `adapter.handle_message` call, confirming the regression test detects the bug. The full repository suite was not run locally; CI remains the full-suite gate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: internal notifier routing correction, no user-facing configuration or workflow change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — existing platform-neutral wake path is reused
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; the behavior is covered by gateway notifier regression tests.
