### PR TITLE
fix(discord): claim dedup ID in missed-message backfill dispatch

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2129,9 +2129,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 scanned += 1
                 message_id = str(getattr(message, "id", ""))
                 self._record_discord_message_seen(message, status="discovered")
-                # A live gateway event may race this REST scan. Check without
-                # claiming the ID; the shared ingress helper owns the dedup
-                # write immediately before normal auth/filter dispatch.
+                # A live gateway event may race this REST scan. Cheap
+                # pre-filter only: the actual claim happens atomically in
+                # _dispatch_recovered_message via claim=True, so whichever
+                # path (live or backfill) claims first wins and the other
+                # drops the duplicate.
                 if self._dedup.contains(message_id):
                     continue
                 if not await self._should_backfill_discord_message(message):
@@ -2215,7 +2217,12 @@ class DiscordAdapter(BasePlatformAdapter):
             ):
                 return False
         admitted, role_authorized = self._discord_message_admission(
-            message, claim=False,
+            # Claim the ID: without this the message never enters the dedup
+            # cache, so a live gateway replay of the same event (Discord
+            # replays missed events on resume, racing this REST scan) is
+            # admitted again and the user gets two runs / two replies.
+            # Failure paths in the caller release the claim via discard().
+            message, claim=True,
         )
         if not admitted:
             return False

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -458,3 +458,81 @@ async def test_iter_candidates_keeps_latest_messages_when_window_exceeds_limit(a
     assert got == [2, 3, 4]
 
 
+
+
+@pytest.mark.asyncio
+async def test_recovered_dispatch_claims_dedup_id(adapter):
+    """Backfilled messages must enter the dedup cache.
+
+    Regression: the backfill path admitted with claim=False, so a recovered
+    message never entered the dedup cache — a live gateway replay of the same
+    event (Discord replays missed events on resume) was admitted again and
+    the user got two runs / two replies.
+    """
+    bot_user = adapter._client.user
+    message = make_message(
+        message_id=555,
+        content=f"<@{bot_user.id}> please ingest",
+        mentions=[bot_user],
+    )
+
+    assert await adapter._dispatch_recovered_message(message) is True
+    assert adapter._handle_message.call_count == 1
+    assert adapter._dedup.contains("555") is True
+
+    # A live replay of the same message must now be dropped.
+    admitted, _ = adapter._discord_message_admission(message, claim=True)
+    assert admitted is False
+    assert adapter._handle_message.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_recovered_dispatch_second_attempt_dropped(adapter):
+    """A second backfill dispatch of the same message is a no-op."""
+    bot_user = adapter._client.user
+    message = make_message(
+        message_id=777,
+        content=f"<@{bot_user.id}> please ingest",
+        mentions=[bot_user],
+    )
+
+    assert await adapter._dispatch_recovered_message(message) is True
+    assert await adapter._dispatch_recovered_message(message) is False
+    assert adapter._handle_message.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_recovered_dispatch_releases_claim_for_retry(adapter, monkeypatch):
+    """A dispatch that raises must release the claimed dedup ID.
+
+    The backfill now claims the ID at dispatch time; the scan loop's error
+    path calls discard() so a transient failure doesn't permanently suppress
+    the message from a later retry (or the live replay).
+    """
+    bot_user = adapter._client.user
+    message = make_message(
+        message_id=888,
+        content=f"<@{bot_user.id}> please ingest",
+        mentions=[bot_user],
+    )
+
+    async def fake_candidates(_channels):
+        yield message
+
+    monkeypatch.setenv("DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS", "123")
+    monkeypatch.setattr(adapter, "_iter_missed_message_backfill_candidates", fake_candidates)
+    monkeypatch.setattr(adapter, "_should_backfill_discord_message", AsyncMock(return_value=True))
+    monkeypatch.setattr(adapter, "_missed_message_backfill_max_dispatches", lambda: 10)
+    monkeypatch.setattr(adapter, "_missed_message_backfill_channels", lambda: {"123"})
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    # First pass: dispatch fails -> claim must be released by the error path.
+    adapter._handle_message = AsyncMock(side_effect=RuntimeError("transient"))
+    await adapter._run_missed_message_backfill()
+    assert adapter._dedup.contains("888") is False
+
+    # Retry with a healthy handler: the message dispatches and stays claimed.
+    adapter._handle_message = AsyncMock(return_value=True)
+    await adapter._run_missed_message_backfill()
+    assert adapter._handle_message.call_count == 1
+    assert adapter._dedup.contains("888") is True


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate processing of Discord messages after a reconnect: the missed-message backfill never claims the dedup ID, so a message it recovers can be dispatched a second time by the live gateway.

Two Discord behaviors make this fire in practice: the gateway replays missed events on a successful resume, and `on_ready` — which kicks off the missed-message backfill — fires after resumes too. The backfill scans channel history over REST and dispatches what it finds; the replayed live event for the same message races or follows it.

The backfill's dispatch (`_dispatch_recovered_message`) admitted messages with `claim=False`, so:

- the scan loop's `contains()` check and the admission check only ever *looked* — the recovered message never entered the dedup cache;
- after a successful backfill dispatch, a replayed live event for the same message passed the live ingress (`claim=True` admission) and dispatched again — **two agent runs, two replies for one user message**;
- the failure-path `discard()` calls ("Release a **claimed** message ID") were no-ops, proving the claim was always intended.

The fix admits recovered messages with `claim=True`. Whichever path — live ingress or backfill — claims the ID first wins; the other drops the duplicate. The existing `discard()` calls on the cancel/error paths now correctly release the claim so a later retry can proceed.

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py`: `_dispatch_recovered_message` admits with `claim=True` (with a comment explaining why); the scan-loop comment updated to describe the actual claim ownership (cheap pre-filter at scan time, atomic claim at dispatch).
- `tests/gateway/test_discord_missed_message_backfill.py`: three regression tests — a backfilled message enters the dedup cache and a subsequent live admission of the same message is dropped; a second backfill dispatch of the same message is a no-op; a dispatch that raises releases the claim (via the pre-existing `discard()` error path) so a retry dispatches and stays claimed.

Behavior notes:

- `_discord_message_admission` claims before applying bot/self filters, so a backfill message rejected on policy grounds now consumes the ID. Both ingress paths use the identical admission function, so there is no divergence between live and backfill policy.
- The dedup cache TTL is 300s (`MessageDeduplicator` default): a live replay arriving more than 5 minutes after a backfill dispatch would be admitted. Resume replays arrive within seconds of reconnect, so this boundary doesn't affect the reported symptom.

## How to Test

Reproduction (against pre-fix code, using the existing test fixtures):

```python
admitted = await adapter._dispatch_recovered_message(msg)   # True, _handle_message called once
adapter._dedup.contains(str(msg.id))                        # pre-fix: False (never claimed!)
admitted2, _ = adapter._discord_message_admission(msg, claim=True)
# pre-fix: admitted2 is True  -> live replay dispatches a second time (BUG)
# post-fix: admitted2 is False -> replay dropped
```

Focused validation completed:

1. `bash scripts/run_tests.sh tests/gateway/test_discord_missed_message_backfill.py` — 18/18 pass.
2. Sabotage check: reverting the adapter to `main` makes exactly the 3 new tests fail (15 pass); restoring it returns to 18/18.
3. Related suites: `test_discord_double_dispatch.py test_discord_connect.py test_discord_send.py test_discord_free_response.py test_message_deduplicator.py test_duplicate_reply_suppression.py test_dedupe_user_turns.py` + the backfill file — 79/79 pass. (Note: the existing `test_discord_double_dispatch.py` covers the thread-starter pre-seed path, a different double-dispatch vector.)
4. `uvx --from ruff==0.15.10 ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_missed_message_backfill.py` — clean.
5. `git diff --check` — clean.
6. Adversarial cases executed live: backfill → live replay dropped; backfill → second backfill attempt dropped; `_handle_message` invoked exactly once across all three; a dispatch raising mid-loop releases the claim via the pre-existing `discard()` error path and a retry then dispatches and stays claimed (driven through the real `_run_missed_message_backfill` loop).

The full repo-wide suite was not run for this change; the Discord/dedup suites above cover the changed path, and GitHub CI owns full-suite validation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite not run locally (see How to Test; all Discord/dedup suites pass)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comments updated to match the new claim ownership)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform surface (async dedup-cache admission)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Logs

Sabotage verification output:

```
# fix reverted to main:
=== Summary: 1 files, 15 tests passed, 3 failed ===   (all 3 new regression tests)
# fix restored:
=== Summary: 1 files, 18 tests passed, 0 failed ===
```
