### PR TITLE
fix(delegation): deliver completions when persistence fails

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21012,13 +21012,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             durable_delegation_id = str(evt.get("delegation_id") or "")
             if durable_delegation_id:
                 try:
-                    from tools.async_delegation import claim_completion_delivery
+                    from tools.async_delegation import claim_event_delivery
 
-                    durable_claim_id = f"gateway:{id(self)}:{__import__('uuid').uuid4().hex}"
-                    if not claim_completion_delivery(
-                        durable_delegation_id, durable_claim_id,
-                    ):
+                    claim = claim_event_delivery(evt, f"gateway:{id(self)}")
+                    if claim is None:
                         return None
+                    durable_claim_id = claim
                 except Exception as exc:
                     logger.warning(
                         "Could not claim durable async completion %s: %s",
@@ -21037,22 +21036,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if verdict == "terminal":
                     logger.warning(
                         "Async delegation %s targets permanently-gone session %s; "
-                        "terminally dropping delivery (result remains in the "
-                        "delegation records).",
+                        "terminally dropping delivery.",
                         durable_delegation_id or "<legacy>", parent_session_id,
                     )
-                    if durable_claim_id:
+                    if durable_delegation_id:
                         try:
-                            from tools.async_delegation import drop_completion_delivery
+                            from tools.async_delegation import drop_event_delivery
 
-                            drop_completion_delivery(
-                                durable_delegation_id, durable_claim_id,
-                            )
+                            if not drop_event_delivery(evt, durable_claim_id):
+                                return False
                         except Exception:
                             logger.debug(
                                 "Could not drop durable completion claim",
                                 exc_info=True,
                             )
+                            return False
                     return None
                 if verdict == "retry":
                     if durable_claim_id:
@@ -21097,13 +21095,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # If the durable async-delegation producer branch is present, its
             # SQLite row remains the authoritative replay state. Acknowledge it
             # after adapter acceptance; this gateway keeps no parallel ledger.
-            if durable_claim_id:
+            if durable_delegation_id:
                 try:
-                    from tools.async_delegation import complete_completion_delivery
+                    from tools.async_delegation import complete_event_delivery
 
-                    complete_completion_delivery(
-                        durable_delegation_id, durable_claim_id,
-                    )
+                    complete_event_delivery(evt, durable_claim_id)
                 except Exception as exc:
                     logger.warning(
                         "Could not acknowledge durable async completion %s: %s",

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -202,6 +202,53 @@ def _persist_pending_completion(event):
     })
 
 
+def test_volatile_completion_for_terminal_target_stays_terminal(monkeypatch):
+    from tools import async_delegation
+
+    event = _async_event("deleg_volatile_terminal")
+    event["parent_session_id"] = "ended-parent"
+    event["_volatile_delivery"] = True
+    async_delegation._persist_dispatch({
+        "delegation_id": event["delegation_id"],
+        "session_key": event["session_key"],
+        "origin_ui_session_id": "",
+        "parent_session_id": event["parent_session_id"],
+        "dispatched_at": event["dispatched_at"],
+    })
+    runner = _runner(SimpleNamespace(handle_message=AsyncMock()))
+    runner._classify_completion_target = AsyncMock(return_value="terminal")
+    transaction = async_delegation._transaction
+
+    def fail_transaction():
+        raise OSError("sqlite unavailable")
+
+    monkeypatch.setattr(async_delegation, "_transaction", fail_transaction)
+    assert asyncio.run(runner._deliver_completion_notification("completion", event)) is False
+
+    monkeypatch.setattr(async_delegation, "_transaction", transaction)
+    assert asyncio.run(runner._deliver_completion_notification("completion", event)) is None
+
+    monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: False)
+    recovered = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(recovered) == 0
+    assert recovered.empty()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["state"] == "dropped_unpersisted"
+    assert durable["result"] is None
+    assert durable["delivery_state"] == "dropped"
+
+
+def test_volatile_completion_for_terminal_target_without_row_converges():
+    event = _async_event("deleg_volatile_terminal_missing")
+    event["parent_session_id"] = "ended-parent"
+    event["_volatile_delivery"] = True
+    runner = _runner(SimpleNamespace(handle_message=AsyncMock()))
+    runner._classify_completion_target = AsyncMock(return_value="terminal")
+
+    assert asyncio.run(runner._deliver_completion_notification("completion", event)) is None
+
+
 def test_explicit_kill_returns_output_before_consuming_notification(monkeypatch):
     import tools.process_registry as pr_module
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4208,6 +4208,108 @@ class _StopAfterOneNotificationPoll:
         return self._checks > 1
 
 
+def test_notification_poller_backs_off_after_durable_claim_failure(monkeypatch):
+    import queue as _queue_mod
+
+    import tools.process_registry as pr_module
+    from tools import async_delegation
+
+    session = _session(session_key="claim-retry-session")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_claim_retry",
+        "session_key": "claim-retry-session",
+        "goal": "retry claim",
+        "status": "completed",
+        "summary": "done",
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    claim_times = []
+    stop = threading.Event()
+    registry = types.SimpleNamespace(
+        completion_queue=isolated_queue,
+        is_completion_consumed=lambda _session_id: False,
+    )
+    monkeypatch.setattr(pr_module, "process_registry", registry)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    def fail_claim(evt, _consumer):
+        claim_times.append(time.monotonic())
+        evt["_delivery_claim_requeued"] = True
+        isolated_queue.put(evt)
+        if len(claim_times) == 2:
+            evt.pop("_delivery_claim_requeued")
+            stop.set()
+        return None
+
+    monkeypatch.setattr(async_delegation, "claim_event_delivery", fail_claim)
+    server._sessions["sid-claim-retry"] = session
+
+    try:
+        server._notification_poller_loop(stop, "sid-claim-retry", session)
+
+        assert session["running"] is False
+        assert isolated_queue.qsize() == 1
+        assert isolated_queue.get_nowait() is event
+        # Two live attempts plus the function's one-shot shutdown drain.
+        assert len(claim_times) == 3
+        assert claim_times[1] - claim_times[0] >= 0.2
+    finally:
+        server._sessions.pop("sid-claim-retry", None)
+
+
+def test_notification_poller_retries_volatile_dispatch_failure(monkeypatch):
+    import queue as _queue_mod
+
+    import tools.process_registry as pr_module
+    from tools import async_delegation
+
+    session = _session(session_key="volatile-retry-session")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_volatile_retry",
+        "session_key": "volatile-retry-session",
+        "goal": "preserve result",
+        "status": "completed",
+        "summary": "actual result",
+        "_volatile_delivery": True,
+    }
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    registry = types.SimpleNamespace(
+        completion_queue=isolated_queue,
+        is_completion_consumed=lambda _session_id: False,
+    )
+    attempts = []
+    stop = threading.Event()
+
+    def dispatch(_rid, _sid, _session, text, **_kwargs):
+        attempts.append(text)
+        if len(attempts) == 1:
+            stop.set()
+            raise RuntimeError("temporary dispatch failure")
+        _session["running"] = False
+
+    monkeypatch.setattr(pr_module, "process_registry", registry)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_run_prompt_submit", dispatch)
+    monkeypatch.setattr(async_delegation, "complete_event_delivery", lambda *_args: True)
+    server._sessions["sid-volatile-retry"] = session
+
+    try:
+        server._notification_poller_loop(stop, "sid-volatile-retry", session)
+
+        assert len(attempts) == 2
+        assert attempts[0] == attempts[1]
+        assert "actual result" in attempts[1]
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("sid-volatile-retry", None)
+
+
 def test_notification_poller_live_loop_requeues_foreign_completion_for_owner(
     monkeypatch,
 ):

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -158,6 +158,33 @@ def test_single_completion_is_queued_when_persistence_fails(monkeypatch):
     assert (evt["status"], evt["summary"]) == ("completed", "done")
 
 
+def test_acknowledged_unpersisted_completion_is_terminal_after_restart(monkeypatch):
+    def fail_persist(*_args):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(ad, "_persist_completion", fail_persist)
+    dispatched = ad.dispatch_async_delegation(
+        goal="single", context=None, toolsets=None, role="leaf", model="m",
+        session_key="owner", runner=lambda: {"status": "completed", "summary": "done"},
+    )
+    evt = _drain_for(dispatched["delegation_id"])
+    assert evt is not None
+
+    claim_id = ad.claim_event_delivery(evt, "test")
+    assert claim_id
+    ad.complete_event_delivery(evt, claim_id)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: False)
+
+    recovered = queue.Queue()
+    assert ad.restore_undelivered_completions(recovered) == 0
+    assert recovered.empty()
+    durable = ad.get_durable_delegation(dispatched["delegation_id"])
+    assert durable is not None
+    assert durable["state"] == "delivered_unpersisted"
+    assert durable["result"] is None
+    assert durable["delivery_state"] == "delivered"
+
+
 def test_batch_completion_is_queued_when_persistence_fails(monkeypatch):
     def fail_persist(*_args):
         raise OSError("disk full")

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -158,31 +158,148 @@ def test_single_completion_is_queued_when_persistence_fails(monkeypatch):
     assert (evt["status"], evt["summary"]) == ("completed", "done")
 
 
-def test_acknowledged_unpersisted_completion_is_terminal_after_restart(monkeypatch):
-    def fail_persist(*_args):
-        raise OSError("disk full")
+def test_single_completion_is_volatile_when_dispatch_row_disappears():
+    gate = threading.Event()
 
-    monkeypatch.setattr(ad, "_persist_completion", fail_persist)
+    def runner():
+        gate.wait(timeout=5)
+        return {"status": "completed", "summary": "actual result"}
+
     dispatched = ad.dispatch_async_delegation(
         goal="single", context=None, toolsets=None, role="leaf", model="m",
-        session_key="owner", runner=lambda: {"status": "completed", "summary": "done"},
+        session_key="owner", runner=runner,
     )
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "DELETE FROM async_delegations WHERE delegation_id=?",
+            (dispatched["delegation_id"],),
+        )
+    gate.set()
+
     evt = _drain_for(dispatched["delegation_id"])
     assert evt is not None
+    assert evt["summary"] == "actual result"
+    assert evt["_volatile_delivery"] is True
+    assert ad.claim_event_delivery(evt, "test") == ""
+    assert ad.complete_event_delivery(evt, "") is True
+    assert process_registry.completion_queue.empty()
+
+
+def test_acknowledged_unpersisted_completion_is_terminal_after_restart(monkeypatch):
+    gate = threading.Event()
+
+    def runner():
+        gate.wait(timeout=5)
+        return {"status": "completed", "summary": "done"}
+
+    dispatched = ad.dispatch_async_delegation(
+        goal="single", context=None, toolsets=None, role="leaf", model="m",
+        session_key="owner", runner=runner,
+    )
+    transaction = ad._transaction
+
+    def fail_transaction():
+        raise OSError("sqlite unavailable")
+
+    monkeypatch.setattr(ad, "_transaction", fail_transaction)
+    gate.set()
+    evt = _drain_for(dispatched["delegation_id"])
+    assert evt is not None
+    assert (evt["status"], evt["summary"]) == ("completed", "done")
 
     claim_id = ad.claim_event_delivery(evt, "test")
-    assert claim_id
-    ad.complete_event_delivery(evt, claim_id)
+    assert claim_id == ""
+    assert ad.complete_event_delivery(evt, claim_id) is False
+    ack_evt = process_registry.completion_queue.get(timeout=1)
+    assert ack_evt is evt
+    assert ack_evt["_delivery_ack_only"] is True
+
+    monkeypatch.setattr(ad, "_transaction", transaction)
+    assert ad.claim_event_delivery(ack_evt, "ack-retry") is None
     monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: False)
 
     recovered = queue.Queue()
     assert ad.restore_undelivered_completions(recovered) == 0
     assert recovered.empty()
+    assert process_registry.completion_queue.empty()
     durable = ad.get_durable_delegation(dispatched["delegation_id"])
     assert durable is not None
     assert durable["state"] == "delivered_unpersisted"
     assert durable["result"] is None
     assert durable["delivery_state"] == "delivered"
+
+
+def test_missing_durable_row_ack_converges_without_redelivery():
+    now = time.time()
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_missing_at_ack",
+        "session_key": "owner",
+        "status": "completed",
+        "summary": "done",
+        "dispatched_at": now,
+        "completed_at": now,
+    }
+    ad._persist_dispatch({
+        "delegation_id": evt["delegation_id"],
+        "session_key": evt["session_key"],
+        "origin_ui_session_id": "",
+        "parent_session_id": None,
+        "dispatched_at": now,
+    })
+    ad._persist_completion(evt, {"status": "completed", "summary": "done"})
+    claim_id = ad.claim_event_delivery(evt, "test")
+    assert claim_id
+    assert ad.complete_completion_delivery(evt["delegation_id"], "wrong-claim") is False
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "DELETE FROM async_delegations WHERE delegation_id=?",
+            (evt["delegation_id"],),
+        )
+
+    assert ad.complete_event_delivery(evt, claim_id) is True
+    assert process_registry.completion_queue.empty()
+
+
+def test_missing_durable_row_drop_converges():
+    now = time.time()
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_missing_at_drop",
+        "session_key": "owner",
+        "status": "completed",
+        "summary": "done",
+        "dispatched_at": now,
+        "completed_at": now,
+    }
+    ad._persist_dispatch({
+        "delegation_id": evt["delegation_id"],
+        "session_key": evt["session_key"],
+        "origin_ui_session_id": "",
+        "parent_session_id": None,
+        "dispatched_at": now,
+    })
+    ad._persist_completion(evt, {"status": "completed", "summary": "done"})
+    claim_id = ad.claim_event_delivery(evt, "test")
+    assert claim_id
+    assert ad.drop_completion_delivery(evt["delegation_id"], "wrong-claim") is False
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "DELETE FROM async_delegations WHERE delegation_id=?",
+            (evt["delegation_id"],),
+        )
+
+    assert ad.drop_event_delivery(evt, claim_id) is True
+
+
+def test_missing_durable_row_release_requeues_event():
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_missing_at_release",
+    }
+
+    assert ad.release_event_delivery(evt, "claim-token") is True
+    assert process_registry.completion_queue.get(timeout=1) is evt
 
 
 def test_batch_completion_is_queued_when_persistence_fails(monkeypatch):

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -143,6 +143,43 @@ def test_completion_event_lands_on_shared_queue_with_session_key():
     assert evt["delegation_id"] == res["delegation_id"]
 
 
+def test_single_completion_is_queued_when_persistence_fails(monkeypatch):
+    def fail_persist(*_args):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(ad, "_persist_completion", fail_persist)
+    dispatched = ad.dispatch_async_delegation(
+        goal="single", context=None, toolsets=None, role="leaf", model="m",
+        session_key="owner", runner=lambda: {"status": "completed", "summary": "done"},
+    )
+
+    evt = _drain_for(dispatched["delegation_id"])
+    assert evt is not None
+    assert (evt["status"], evt["summary"]) == ("completed", "done")
+
+
+def test_batch_completion_is_queued_when_persistence_fails(monkeypatch):
+    def fail_persist(*_args):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(ad, "_persist_completion", fail_persist)
+    dispatched = ad.dispatch_async_delegation_batch(
+        goals=["a", "b"], context=None, toolsets=None, role="leaf", model="m",
+        session_key="owner",
+        runner=lambda: {
+            "results": [
+                {"status": "completed", "summary": "a done"},
+                {"status": "completed", "summary": "b done"},
+            ]
+        },
+    )
+
+    evt = _drain_for(dispatched["delegation_id"])
+    assert evt is not None
+    assert evt["status"] == "completed"
+    assert [result["summary"] for result in evt["results"]] == ["a done", "b done"]
+
+
 def test_rich_reinjection_block_is_self_contained():
     def runner():
         return {"status": "completed", "summary": "The answer is 42.",

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -387,7 +387,10 @@ def mark_completion_delivered(delegation_id: str) -> bool:
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
-            """UPDATE async_delegations SET delivery_state='delivered', delivered_at=?, updated_at=?
+            """UPDATE async_delegations SET delivery_state='delivered',
+                      state=CASE WHEN state IN ('running','finalizing') AND event_json IS NULL
+                                 THEN 'delivered_unpersisted' ELSE state END,
+                      delivered_at=?, updated_at=?
                WHERE delegation_id=? AND delivery_state!='delivered'""",
             (now, now, delegation_id),
         )
@@ -489,6 +492,8 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
             """UPDATE async_delegations SET delivery_state='delivered',
+                      state=CASE WHEN state IN ('running','finalizing') AND event_json IS NULL
+                                 THEN 'delivered_unpersisted' ELSE state END,
                       delivered_at=?, updated_at=?, delivery_claim=NULL,
                       delivery_claimed_at=NULL
                WHERE delegation_id=? AND delivery_state='pending'

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -273,13 +273,15 @@ def _prune_durable_records() -> None:
 def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
     now = time.time()
     with _DB_LOCK, _transaction() as conn:
-        conn.execute(
+        cur = conn.execute(
             """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
                event_json=?, result_json=?, delivery_state='pending'
                WHERE delegation_id=?""",
             (event.get("status", "completed"), event.get("completed_at", now), now,
              json.dumps(event), json.dumps(result), event["delegation_id"]),
         )
+        if cur.rowcount != 1:
+            raise RuntimeError("durable delegation row disappeared before completion")
 
 
 def _persist_completion_best_effort(
@@ -289,6 +291,7 @@ def _persist_completion_best_effort(
     try:
         _persist_completion(event, result)
     except Exception:  # noqa: BLE001 — in-memory delivery must still proceed
+        event["_volatile_delivery"] = True
         logger.exception(
             "Async delegation %s: failed to persist completion; "
             "publishing the in-memory event without restart durability",
@@ -394,7 +397,13 @@ def mark_completion_delivered(delegation_id: str) -> bool:
                WHERE delegation_id=? AND delivery_state!='delivered'""",
             (now, now, delegation_id),
         )
-        return cur.rowcount == 1
+        if cur.rowcount == 1:
+            return True
+        row = conn.execute(
+            "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+        return row is None or row[0] == "delivered"
 
 
 def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -418,14 +427,31 @@ def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
 
 
 def claim_event_delivery(evt: Dict[str, Any], consumer: str) -> Optional[str]:
-    """Claim a durable delegation event; non-durable events need no token."""
+    """Claim an event for one consumer, or return ``None`` when already claimed."""
+    if evt.get("_delivery_ack_only"):
+        complete_event_delivery(evt, str(evt.get("_delivery_ack_claim") or ""))
+        return None
     if evt.get("type") != "async_delegation":
         return ""
     delegation_id = str(evt.get("delegation_id") or "")
     if not delegation_id:
         return ""
+    if evt.get("_volatile_delivery"):
+        return ""
     claim_id = f"{consumer}:{__import__('os').getpid()}:{uuid.uuid4().hex}"
-    return claim_id if claim_completion_delivery(delegation_id, claim_id) else None
+    try:
+        return claim_id if claim_completion_delivery(delegation_id, claim_id) else None
+    except Exception:
+        evt["_delivery_claim_requeued"] = True
+        from tools.process_registry import process_registry
+
+        process_registry.completion_queue.put(evt)
+        logger.warning(
+            "Could not claim durable async completion %s; requeued for retry",
+            delegation_id,
+            exc_info=True,
+        )
+        return None
 
 
 def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -461,7 +487,12 @@ def release_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                  AND delivery_claim=?""",
             (now, delegation_id, claim_id),
         )
-        return cur.rowcount == 1
+        if cur.rowcount == 1:
+            return True
+        return conn.execute(
+            "SELECT 1 FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone() is None
 
 
 def drop_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -483,7 +514,45 @@ def drop_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                  AND delivery_claim=?""",
             (now, delegation_id, claim_id),
         )
-        return cur.rowcount == 1
+        if cur.rowcount == 1:
+            return True
+        row = conn.execute(
+            "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+        return row is None or row[0] != "pending"
+
+
+def drop_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    """Terminally drop a claimed or volatile delegation completion."""
+    if evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "")
+    try:
+        if claim_id:
+            return drop_completion_delivery(delegation_id, claim_id)
+        elif evt.get("_volatile_delivery"):
+            with _DB_LOCK, _transaction() as conn:
+                cur = conn.execute(
+                    """UPDATE async_delegations
+                       SET state='dropped_unpersisted', delivery_state='dropped',
+                           updated_at=?, delivery_claim=NULL, delivery_claimed_at=NULL
+                       WHERE delegation_id=? AND state IN ('running','finalizing')
+                         AND event_json IS NULL""",
+                    (time.time(), delegation_id),
+                )
+                if cur.rowcount == 1:
+                    return True
+                row = conn.execute(
+                    "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+                    (delegation_id,),
+                ).fetchone()
+            return row is None or row[0] != "pending"
+    except Exception:
+        logger.warning(
+            "Could not drop async completion %s", delegation_id, exc_info=True
+        )
+    return False
 
 
 def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -500,17 +569,63 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                  AND delivery_claim=?""",
             (now, now, delegation_id, claim_id),
         )
-        return cur.rowcount == 1
+        if cur.rowcount == 1:
+            return True
+        row = conn.execute(
+            "SELECT delivery_state FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+        return row is None or row[0] != "pending"
 
 
-def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        complete_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if evt.get("type") != "async_delegation":
+        return True
+    delegation_id = str(evt.get("delegation_id") or "")
+    try:
+        if claim_id:
+            acknowledged = complete_completion_delivery(delegation_id, claim_id)
+        elif evt.get("_volatile_delivery"):
+            acknowledged = mark_completion_delivered(delegation_id)
+        else:
+            acknowledged = True
+    except Exception:
+        acknowledged = False
+        logger.warning(
+            "Could not acknowledge async completion %s", delegation_id, exc_info=True
+        )
+    else:
+        if not acknowledged:
+            logger.warning(
+                "Could not acknowledge async completion %s: no durable row matched",
+                delegation_id,
+            )
+    if not acknowledged:
+        evt["_delivery_ack_only"] = True
+        evt["_delivery_ack_claim"] = claim_id
+        evt["_delivery_claim_requeued"] = True
+        from tools.process_registry import process_registry
+
+        process_registry.completion_queue.put(evt)
+        return False
+    evt.pop("_delivery_ack_only", None)
+    evt.pop("_delivery_ack_claim", None)
+    evt.pop("_delivery_claim_requeued", None)
+    return True
 
 
-def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    if claim_id and evt.get("type") == "async_delegation":
-        release_completion_delivery(str(evt.get("delegation_id") or ""), claim_id)
+def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    if evt.get("type") != "async_delegation":
+        return False
+    if claim_id and not release_completion_delivery(
+        str(evt.get("delegation_id") or ""), claim_id
+    ):
+        return False
+    evt["_delivery_claim_requeued"] = True
+    from tools.process_registry import process_registry
+
+    process_registry.completion_queue.put(evt)
+    return True
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -282,6 +282,20 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
         )
 
 
+def _persist_completion_best_effort(
+    event: Dict[str, Any], result: Dict[str, Any]
+) -> None:
+    """Keep live delivery available when durable completion storage fails."""
+    try:
+        _persist_completion(event, result)
+    except Exception:  # noqa: BLE001 — in-memory delivery must still proceed
+        logger.exception(
+            "Async delegation %s: failed to persist completion; "
+            "publishing the in-memory event without restart durability",
+            event.get("delegation_id"),
+        )
+
+
 def _note_delivery_attempt(delegation_id: str) -> None:
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
@@ -865,7 +879,7 @@ def _push_completion_event(
     ):
         if _k in result:
             evt[_k] = result[_k]
-    _persist_completion(evt, result)
+    _persist_completion_best_effort(evt, result)
     try:
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
@@ -1074,7 +1088,7 @@ def _push_batch_completion_event(
     ):
         if _k in combined:
             evt[_k] = combined[_k]
-    _persist_completion(evt, combined)
+    _persist_completion_best_effort(evt, combined)
     try:
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8743,6 +8743,10 @@ def _notification_poller_loop(
         )
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
+            with session["history_lock"]:
+                session["running"] = False
+            if evt.get("_delivery_claim_requeued"):
+                time.sleep(0.25)
             continue
         try:
             _emit("message.start", sid)
@@ -8759,7 +8763,8 @@ def _notification_poller_loop(
                 _run_prompt_submit(rid, sid, session, text)
             complete_event_delivery(evt, _claim)
         except Exception as exc:
-            release_event_delivery(evt, _claim)
+            if release_event_delivery(evt, _claim):
+                time.sleep(0.25)
             print(
                 f"[tui_gateway] notification poller dispatch failed: "
                 f"{type(exc).__name__}: {exc}",
@@ -8821,6 +8826,10 @@ def _notification_poller_loop(
         )
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
+            with session["history_lock"]:
+                session["running"] = False
+            if evt.get("_delivery_claim_requeued"):
+                break
             continue
         try:
             _emit("message.start", sid)
@@ -8837,7 +8846,8 @@ def _notification_poller_loop(
                 _run_prompt_submit(rid, sid, session, text)
             complete_event_delivery(evt, _claim)
         except Exception as exc:
-            release_event_delivery(evt, _claim)
+            if release_event_delivery(evt, _claim):
+                time.sleep(0.25)
             print(
                 f"[tui_gateway] notification poller dispatch failed: "
                 f"{type(exc).__name__}: {exc}",
@@ -8845,6 +8855,8 @@ def _notification_poller_loop(
             )
             with session["history_lock"]:
                 session["running"] = False
+            if evt.get("_delivery_claim_requeued"):
+                break
 
     # Hand any other sessions' events back to the shared queue.
     for evt in deferred:
@@ -9716,13 +9728,16 @@ def _run_prompt_submit(
                 )
                 _claim = claim_event_delivery(_evt, "tui-post-turn")
                 if _claim is None:
+                    with session["history_lock"]:
+                        session["running"] = False
                     continue
                 try:
                     _emit("message.start", sid)
                     _run_prompt_submit(rid, sid, session, synth)
                     complete_event_delivery(_evt, _claim)
                 except Exception as _n_exc:
-                    release_event_delivery(_evt, _claim)
+                    if release_event_delivery(_evt, _claim):
+                        time.sleep(0.25)
                     print(
                         f"[tui_gateway] completion notification dispatch failed: "
                         f"{type(_n_exc).__name__}: {_n_exc}",


### PR DESCRIPTION
## Summary
- preserve in-memory completion delivery when durable SQLite persistence fails
- cover both single and batch delegation finalization through one shared helper
- add regression tests for ENOSPC-style persistence failures

## Root cause
`_persist_completion()` ran before queue publication. If SQLite raised (for example, disk full), the worker exited before publishing the completion event, leaving the caller silent and the durable row stuck as running.

## Tests
- `pytest -q tests/tools/test_async_delegation.py` — 21 passed