### PR TITLE
fix(telegram): clear stale polling sessions on conflict retry

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3060,7 +3060,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     raise RuntimeError("Telegram application was torn down during conflict reconnect")
                 await self._start_polling_once(
                     app,
-                    drop_pending_updates=False,
+                    drop_pending_updates=True,
                     error_callback=self._polling_error_callback_ref,
                 )
                 logger.info(

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -85,7 +85,7 @@ async def test_polling_conflict_retries_before_fatal(monkeypatch):
     captured = {}
 
     async def fake_start_polling(**kwargs):
-        captured["error_callback"] = kwargs["error_callback"]
+        captured.update(kwargs)
         # Cold connect requires real getUpdates readiness (#67498) — simulate
         # the first successful poll for the generation this call started, but
         # only on the initial connect: the conflict-retry generation must NOT
@@ -131,6 +131,9 @@ async def test_polling_conflict_retries_before_fatal(monkeypatch):
     await adapter._polling_error_task
 
     assert adapter.has_fatal_error is False, "First conflict should not be fatal"
+    assert captured["drop_pending_updates"] is True, (
+        "Conflict recovery must ask Telegram to terminate stale getUpdates sessions"
+    )
     assert adapter._polling_conflict_count == 1, (
         "Count must remain until the retried generation makes getUpdates progress"
     )


### PR DESCRIPTION
## Summary
- restart Telegram polling conflict recovery with `drop_pending_updates=True`
- keep normal reconnects preserving pending updates unchanged
- add regression coverage that conflict recovery terminates stale getUpdates sessions

Fixes #75017

## Tests
- `scripts/run_tests.sh tests/gateway/test_telegram_conflict.py -q`
- `python3 -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_conflict.py`
- `git diff --check`
