### PR TITLE
fix(gateway): redact secrets at the actual active progress_callback boundary

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3366,6 +3366,28 @@ class TurnRunner:
     def progress_callback(self, event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
         """Callback invoked by agent on tool lifecycle events."""
         ctx = self._ctx
+        # Redact recognizable secrets in args/preview BEFORE any sink below
+        # reads them -- this is the single boundary every source (native
+        # tools, MCP tools, the Codex bridge in agent/codex_runtime.py,
+        # etc.) funnels through on its way to a display or log surface, so
+        # sanitizing here covers the live status phrase just below, the log
+        # mode append, the verbose-mode arg serialization, and the
+        # compact/new-mode preview render all at once -- rather than
+        # requiring a separate fix at each upstream caller and each sink
+        # (issue #72298, #10520; a prior attempt at gateway/platforms/base.py
+        # redacted a renderer GatewayEventDispatcher that production gateway
+        # delivery never instantiates -- this callback is the actual active
+        # path). tool_name-specific dict redaction (browser_type's typed
+        # text) plus a general pattern-based text scan on the preview string
+        # (which may already be a truncated/formatted summary, not
+        # necessarily args-shaped) together cover both representations of
+        # the same underlying call.
+        if args:
+            from agent.display import redact_tool_args_for_display
+            args = redact_tool_args_for_display(tool_name, args) or args
+        if preview:
+            from agent.redact import redact_sensitive_text
+            preview = redact_sensitive_text(preview, force=True)
         # Live status line (Slack's assistant status): stash the current
         # tool phrase on the adapter; the _keep_typing refresh renders it
         # within a couple of seconds. Handled before every other gate

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1399,3 +1399,46 @@ async def test_compact_mode_redacts_secret_from_codex_bridge_preview(monkeypatch
     assert secret_prefix not in all_content, (
         f"Secret prefix leaked into compact-mode chat history: {all_content!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_log_mode_redacts_secret_from_codex_bridge_preview(monkeypatch, tmp_path):
+    """Log mode (display.tool_progress: log): a secret in the raw preview
+    string forwarded by the Codex bridge must not reach the persisted
+    tool-call log queue -- the sink at gateway/run.py's log-mode branch,
+    reached via ctx.log_queue.put(preview_str), BEFORE the verbose/compact
+    branches further down in progress_callback. Regression requested in
+    review of #75074: the existing verbose/compact tests don't cover this
+    sink, so a regression in the redaction's ordering (moved to run AFTER
+    this branch instead of before it) would go undetected.
+
+    Captures queue.Queue.put() calls SYNCHRONOUSLY (via a wrapped put
+    method) rather than inspecting the queue's contents after the run
+    completes: gateway/run.py spawns a background write_tool_log() task
+    (asyncio.create_task) that concurrently drains the SAME queue via
+    get_nowait() and writes to the log file, so by the time a test
+    function resumes after the turn completes, the queue may already be
+    empty -- checking put() calls directly avoids that race entirely.
+    """
+    import queue as _queue_mod
+
+    captured_puts: list[str] = []
+    _real_put = _queue_mod.Queue.put
+
+    def _capturing_put(self, item, *a, **kw):
+        captured_puts.append(item)
+        return _real_put(self, item, *a, **kw)
+
+    monkeypatch.setattr(_queue_mod.Queue, "put", _capturing_put)
+
+    adapter, result = await _run_with_agent(
+        monkeypatch, tmp_path, CodexLikeAgent,
+        session_id="sess-codex-log-redact",
+        config_data={"display": {"tool_progress": "log"}},
+    )
+    assert result["final_response"] == "done"
+
+    joined = " ".join(str(item) for item in captured_puts)
+    assert CodexLikeAgent.SECRET not in joined, (
+        f"Secret leaked into the tool-call log queue: {captured_puts!r}"
+    )

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1318,3 +1318,84 @@ class TestSlackReplyInThreadProgressRouting:
         ) is None
 
 
+
+# ── Progress-callback redaction: the real active path (review of #72432) ───
+#
+# A prior fix redacted gateway/platforms/base.py::format_tool_event(), a
+# renderer GatewayEventDispatcher instantiates -- but production gateway
+# delivery routes through TurnRunner.progress_callback (this file) instead,
+# and agent/codex_runtime.py forwards raw MCP args/preview into that SAME
+# callback. These tests exercise the real, active path end to end: a fake
+# Agent (mimicking agent/codex_runtime.py's calling convention) invokes the
+# real bound progress_callback with a browser_type call carrying a
+# recognizable secret, through the full _run_with_agent harness (real
+# GatewayRunner, real adapter, real config-driven display mode).
+
+
+class CodexLikeAgent:
+    """Mimics agent/codex_runtime.py forwarding a browser_type call's raw
+    MCP args and a raw preview string (both carrying an unredacted secret)
+    to tool_progress_callback, exactly as the real Codex bridge does."""
+
+    SECRET = "sk-ant-api03-FAKEsecretvalue1234567890abcdefgh"
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback(
+            "tool.started", "browser_type",
+            f'typing "{self.SECRET}" into @e3',  # raw preview, as codex_runtime builds it
+            {"ref": "@e3", "text": self.SECRET},  # raw MCP args
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "session_input_tokens": 0, "session_output_tokens": 0,
+            "session_cache_read_tokens": 0, "session_cache_write_tokens": 0,
+            "session_prompt_tokens": 0, "session_completion_tokens": 0,
+            "session_total_tokens": 0, "api_calls": 1,
+        }
+
+
+@pytest.mark.asyncio
+async def test_verbose_mode_redacts_secret_from_codex_bridge_args(monkeypatch, tmp_path):
+    """Verbose mode: a secret in the raw args dict forwarded by the Codex
+    bridge must not reach chat history."""
+    adapter, result = await _run_with_agent(
+        monkeypatch, tmp_path, CodexLikeAgent,
+        session_id="sess-codex-verbose-redact",
+        config_data={"display": {"tool_progress": "verbose", "tool_preview_length": 0}},
+    )
+    assert result["final_response"] == "done"
+    all_content = " ".join(c["content"] for c in adapter.sent)
+    all_content += " ".join(c["content"] for c in adapter.edits)
+    assert CodexLikeAgent.SECRET not in all_content, (
+        f"Secret leaked into verbose-mode chat history: {all_content!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_compact_mode_redacts_secret_from_codex_bridge_preview(monkeypatch, tmp_path):
+    """Default (compact/new) mode: a secret in the raw preview string
+    forwarded by the Codex bridge must not reach chat history."""
+    adapter, result = await _run_with_agent(
+        monkeypatch, tmp_path, CodexLikeAgent,
+        session_id="sess-codex-compact-redact",
+        config_data={"display": {"tool_progress": "all"}},
+    )
+    assert result["final_response"] == "done"
+    all_content = " ".join(c["content"] for c in adapter.sent)
+    all_content += " ".join(c["content"] for c in adapter.edits)
+    # Compact mode truncates the preview to a short cap by design (a UX
+    # feature, unrelated to redaction) -- so even with the fix applied,
+    # the FULL secret string is never present regardless. What must never
+    # appear is a recognizable PREFIX of the secret: a truncated-but-still
+    # -unredacted leak (e.g. "sk-ant-api03-FAKEs...") is still a real
+    # credential exposure, just a shorter one.
+    secret_prefix = CodexLikeAgent.SECRET[:20]
+    assert secret_prefix not in all_content, (
+        f"Secret prefix leaked into compact-mode chat history: {all_content!r}"
+    )


### PR DESCRIPTION
## Context

Supersedes #72432 per @teknium1's review -- the prior fix redacted a renderer (`gateway/platforms/base.py::format_tool_event()`) that production gateway delivery doesn't instantiate at all.

## Problem

The actual active path is `TurnRunner.progress_callback` (`gateway/run.py`), which independently serializes raw args in verbose mode, logs a raw preview in log mode, and renders a raw preview in compact/new modes. `agent/codex_runtime.py` forwards raw MCP args and a raw preview string into this same callback.

## Fix

Sanitize `args` and `preview` at the TOP of `progress_callback`, before all four sinks (live-status phrase, log_queue append, verbose serialization, compact/new preview) read them -- one redaction point covering all of them.

## Verification

Added two real production-path regression tests through the full turn-execution harness with a fake Agent mimicking `agent/codex_runtime.py`'s exact calling convention: verbose mode and compact/new mode. Reverting only the fix (keeping the tests) reproduces the exact leak.

**Scope note:** a log-mode regression test was attempted but dropped -- couldn't reliably capture the queue content within available time, and a test that doesn't actually exercise the assertion would be worse than none. The log_queue read is covered by the same code fix (same `preview` local), just not independently test-verified here.

17/17 pass in the full `tests/gateway/test_run_progress_topics.py` file; 8/8 across three more dependent test files (no regression).