### PR TITLE
fix(mem0): make self-hosted HTTP timeout configurable

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -88,6 +88,12 @@ def _load_config() -> dict:
         "api_key": os.environ.get("MEM0_API_KEY", ""),
         "host": os.environ.get("MEM0_HOST", ""),
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
+        # HTTP client timeout (seconds) for the self-hosted backend. A
+        # self-hosted /memories add fans out into several server-side LLM
+        # rounds, so a slow local model can exceed the old fixed 30s ceiling.
+        # Behavioral setting -> lives in mem0.json, not an env var. 120s keeps
+        # slow-model adds working while still bounding a truly hung server.
+        "http_timeout": 120.0,
         "oss": {},
     }
     # Only carry user_id when the operator explicitly configured one (env or
@@ -282,7 +288,12 @@ class Mem0MemoryProvider(MemoryProvider):
                 return OSSBackend(self._config.get("oss", {}))
             if self._host:
                 from ._backend import SelfHostedBackend
-                return SelfHostedBackend(self._api_key, self._host)
+                cfg = self._config or {}
+                try:
+                    timeout = float(cfg.get("http_timeout", 120.0))
+                except (TypeError, ValueError):
+                    timeout = 120.0
+                return SelfHostedBackend(self._api_key, self._host, timeout=timeout)
             from ._backend import PlatformBackend
             return PlatformBackend(self._api_key)
         except Exception as e:

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -91,7 +91,7 @@ class SelfHostedBackend(Mem0Backend):
     ``/search`` routes.
     """
 
-    def __init__(self, api_key: str, host: str, transport=None):
+    def __init__(self, api_key: str, host: str, transport=None, timeout: float = 30.0):
         import httpx
 
         headers = {"Content-Type": "application/json"}
@@ -102,8 +102,14 @@ class SelfHostedBackend(Mem0Backend):
         # ``transport`` is injectable for tests (httpx.MockTransport).
         if transport is None:
             transport = httpx.HTTPTransport(retries=2)
+        # ``timeout`` is configurable (via mem0.json ``http_timeout``) because a
+        # self-hosted /memories add fans out into several server-side LLM rounds
+        # (fact extraction + per-fact update decision). Against a slow local
+        # model (e.g. a 27B on llama.cpp at ~30 tok/s) one add can exceed the
+        # historical 30s default and time out even though the server is still
+        # working. Default stays 30.0 for backward compatibility.
         self._client = httpx.Client(
-            base_url=host.rstrip("/"), headers=headers, timeout=30.0,
+            base_url=host.rstrip("/"), headers=headers, timeout=timeout,
             transport=transport,
         )
 

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -201,6 +201,18 @@ class TestSelfHostedBackend:
         assert "authorization" not in b._client.headers  # NOT the cloud 'Token' scheme
 
 
+    def test_default_http_timeout_is_30s(self):
+        # Backward compatibility: unspecified timeout keeps the historical 30s.
+        b = SelfHostedBackend("adminkey", "http://sh:8888")
+        assert b._client.timeout.read == 30.0
+
+    def test_http_timeout_is_configurable(self):
+        # A slow self-hosted server + slow local LLM needs a larger ceiling so
+        # a multi-round /memories add doesn't time out mid-flight.
+        b = SelfHostedBackend("adminkey", "http://sh:8888", timeout=120.0)
+        assert b._client.timeout.read == 120.0
+
+
     # --- search ----------------------------------------------------------
 
 

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -371,8 +371,9 @@ class TestCreateBackendRouting:
         captured = {}
 
         class SH(_SentinelBackend):
-            def __init__(self, api_key, host):
+            def __init__(self, api_key, host, timeout=30.0):
                 captured["args"] = (api_key, host)
+                captured["timeout"] = timeout
 
         monkeypatch.setattr("plugins.memory.mem0._backend.SelfHostedBackend", SH)
         provider = self._provider(monkeypatch, host="http://sh:8888", api_key="adminkey")


### PR DESCRIPTION
## Problem

The self-hosted Mem0 backend (`SelfHostedBackend` in `plugins/memory/mem0/_backend.py`) hardcodes its `httpx.Client` timeout to **30s**:

```python
self._client = httpx.Client(base_url=..., headers=..., timeout=30.0, transport=transport)
```

A self-hosted `POST /memories` add is **not** a single request — the Mem0 server fans it out into several LLM rounds (fact extraction, then a per-fact ADD/UPDATE/DELETE decision against existing memories). Against a **slow local model** — e.g. a 27B GGUF on llama.cpp at ~30 tok/s — a single `add` routinely takes ~30s and sits **right on the hardcoded ceiling**, so `mem0_add` spuriously times out on the client side even though the server is still working and ultimately persists the memory.

Measured on such a setup: one `/memories` add took **29.3s** end-to-end and succeeded server-side (`event: ADD`), but the client raised a timeout at 30s.

## Fix

Make the self-hosted HTTP timeout configurable.

- Per the contribution guide (`.env` is for secrets only; behavioral settings live in config), the timeout is exposed as **`http_timeout` in `mem0.json`**, not a new env var.
- Default is **120s** — comfortably covers a multi-round slow-model add while still bounding a genuinely hung server.
- `SelfHostedBackend.__init__` keeps `timeout: float = 30.0` as its **parameter default for backward compatibility**; the plugin reads `http_timeout` from config and passes it through in `_create_backend()`.

Platform and OSS backends are unaffected.

## Changes

- `plugins/memory/mem0/_backend.py` — `SelfHostedBackend.__init__` gains a `timeout` param; replaces the hardcoded `30.0`.
- `plugins/memory/mem0/__init__.py` — `_load_config()` defaults `http_timeout` to 120.0 (overridable via `mem0.json`); `_create_backend()` passes it to `SelfHostedBackend`.
- Tests — new regression tests for the default (30s) and configured (120s) timeout; routing stub updated to accept the new kwarg.

## Testing

```
$ pytest tests/plugins/memory/test_mem0_backend.py tests/plugins/memory/test_mem0_v3.py \
    --deselect tests/plugins/memory/test_mem0_v3.py::TestMem0ModeSwitch::test_is_available_platform_needs_key
31 passed, 1 deselected
```

(The one deselected test is a pre-existing failure unrelated to this change — it asserts `is_available() is False` but doesn't clear the ambient `MEM0_HOST` env var, so it fails on `main` too whenever `MEM0_HOST` is set. It passes cleanly with `env -u MEM0_HOST`.)
