### PR TITLE
fix(gateway): ride the runtime footer on the last photo's caption instead of a trailing message (#74547)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2652,6 +2652,15 @@ class BasePlatformAdapter(ABC):
     # never see these calls.
     supports_status_text: bool = False
 
+    # Whether send_multiple_images renders each item's alt text as a real
+    # per-image caption. The default per-image loop does (send_image /
+    # send_image_file take a caption), as does Telegram's media-group
+    # batching. Signal's batch RPC carries one shared body and drops
+    # per-image alt texts, so it overrides this to False. Used by the
+    # post-stream footer routing (#74547) to decide whether the runtime
+    # footer can ride a photo caption or needs its own trailing message.
+    supports_batch_image_captions: bool = True
+
     def set_status_text(self, chat_id: str, text: Optional[str]) -> None:
         """Set or clear (``None``) the live working-state phrase for a chat.
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -259,6 +259,11 @@ class SignalAdapter(BasePlatformAdapter):
     # square behind in chat clients when edit attempts fail.
     SUPPORTS_MESSAGE_EDITING = False
 
+    # send_multiple_images drops per-image alt texts — Signal's send RPC only
+    # carries one shared message body — so a caption can never deliver the
+    # runtime footer; it keeps its own trailing message instead (#74547).
+    supports_batch_image_captions = False
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SIGNAL)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18436,21 +18436,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     non_image_media.append((media_path, is_voice))
 
             footer_attached = False
+            # send_multiple_images returns None across adapters, so caption
+            # delivery can't be confirmed from its result. Gate on the
+            # adapter's declared caption support instead: Signal's batch RPC
+            # drops per-image alt text, so the footer must keep its trailing
+            # message there.
+            _adapter_captions = bool(
+                getattr(adapter, "supports_batch_image_captions", False)
+            )
             if image_paths:
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
-                    if footer_line:
+                    if footer_line and _adapter_captions:
                         # Ride the runtime footer on the last photo's caption
                         # instead of a separate trailing message (#74547).
                         # Platform senders already clamp captions to their
                         # limits (Telegram: 1024 chars).
                         images[-1] = (images[-1][0], footer_line)
-                    result = await adapter.send_multiple_images(
+                    await adapter.send_multiple_images(
                         chat_id=event.source.chat_id,
                         images=images,
                         metadata=_thread_meta,
                     )
-                    if footer_line and getattr(result, "success", True):
+                    if footer_line and _adapter_captions:
                         footer_attached = True
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17257,17 +17257,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # partial output before the failure).  Without this guard,
             # users see the agent "stop responding without explanation."
             if agent_result.get("already_sent") and not agent_result.get("failed"):
+                _footer_attached = False
                 if response:
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
-                        await self._deliver_media_from_response(
+                        _footer_attached = await self._deliver_media_from_response(
                             response, event, _media_adapter,
+                            footer_line=_footer_line,
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
-                # Send it now as a small trailing message so Telegram/Discord/etc.
-                # still surface the runtime metadata on the final reply.
-                if _footer_line:
+                # When the turn delivered photos, the footer rode the last
+                # photo's caption above (#74547); otherwise send it as a small
+                # trailing message so Telegram/Discord/etc. still surface the
+                # runtime metadata on the final reply.
+                if _footer_line and not _footer_attached:
                     try:
                         _foot_adapter = self._adapter_for_source(source)
                         if _foot_adapter:
@@ -18360,8 +18364,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         response: str,
         event: MessageEvent,
         adapter,
-    ) -> None:
+        footer_line: str = "",
+    ) -> bool:
         """Extract explicit MEDIA: tags from a response and deliver them.
+
+        Returns True when ``footer_line`` was delivered as the caption of a
+        successfully sent photo batch, so the caller can skip its trailing
+        footer message (#74547).
 
         Called after streaming has already sent the text to the user, so the
         text itself is already delivered — this only handles file attachments
@@ -18426,14 +18435,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     non_image_media.append((media_path, is_voice))
 
+            footer_attached = False
             if image_paths:
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
-                    await adapter.send_multiple_images(
+                    if footer_line:
+                        # Ride the runtime footer on the last photo's caption
+                        # instead of a separate trailing message (#74547).
+                        # Platform senders already clamp captions to their
+                        # limits (Telegram: 1024 chars).
+                        images[-1] = (images[-1][0], footer_line)
+                    result = await adapter.send_multiple_images(
                         chat_id=event.source.chat_id,
                         images=images,
                         metadata=_thread_meta,
                     )
+                    if footer_line and getattr(result, "success", True):
+                        footer_attached = True
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
 
@@ -18461,8 +18479,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as e:
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
 
+            return footer_attached
+
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
+            return False
 
 
 

--- a/tests/gateway/test_post_stream_media_delivery.py
+++ b/tests/gateway/test_post_stream_media_delivery.py
@@ -111,3 +111,91 @@ async def test_explicit_media_tag_still_delivers_post_stream(tmp_path, monkeypat
     assert str(media_file) in images_kwargs["images"][0][0]
 
 
+
+
+class TestPostStreamFooterCaption:
+    """#74547: with streaming, the runtime footer was always sent as a separate
+    trailing text message even when the turn delivered photos. It must ride the
+    last photo's caption instead, and the helper reports whether it did so the
+    caller can skip the trailing send."""
+
+    @pytest.mark.asyncio
+    async def test_footer_rides_last_photo_caption(self, tmp_path, monkeypatch):
+        media_file = _allowed_media_path(tmp_path, monkeypatch, "sunset.png")
+        adapter = _adapter()
+
+        attached = await GatewayRunner._deliver_media_from_response(
+            _fake_runner({}),
+            f"Here you go.\nMEDIA:{media_file}",
+            _event(),
+            adapter,
+            footer_line="model-x │ 306K/1M │ 29%",
+        )
+
+        assert attached is True
+        images = adapter.send_multiple_images.await_args.kwargs["images"]
+        assert images[-1][1] == "model-x │ 306K/1M │ 29%"
+
+    @pytest.mark.asyncio
+    async def test_no_media_returns_false_for_trailing_send(self):
+        adapter = _adapter()
+
+        attached = await GatewayRunner._deliver_media_from_response(
+            _fake_runner({}),
+            "Just text, no attachments.",
+            _event(),
+            adapter,
+            footer_line="model-x │ 306K/1M │ 29%",
+        )
+
+        assert attached is False
+        adapter.send_multiple_images.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_image_media_does_not_claim_the_footer(self, tmp_path, monkeypatch):
+        media_file = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+        adapter = _adapter()
+
+        attached = await GatewayRunner._deliver_media_from_response(
+            _fake_runner({}),
+            f"MEDIA:{media_file}",
+            _event(),
+            adapter,
+            footer_line="model-x │ 306K/1M │ 29%",
+        )
+
+        assert attached is False
+        adapter.send_document.assert_awaited_once()
+        assert "footer" not in str(adapter.send_document.await_args.kwargs)
+
+    @pytest.mark.asyncio
+    async def test_failed_photo_send_returns_false(self, tmp_path, monkeypatch):
+        media_file = _allowed_media_path(tmp_path, monkeypatch, "chart.png")
+        adapter = _adapter()
+        adapter.send_multiple_images = AsyncMock(side_effect=RuntimeError("api down"))
+
+        attached = await GatewayRunner._deliver_media_from_response(
+            _fake_runner({}),
+            f"MEDIA:{media_file}",
+            _event(),
+            adapter,
+            footer_line="model-x │ 306K/1M │ 29%",
+        )
+
+        assert attached is False
+
+    @pytest.mark.asyncio
+    async def test_without_footer_captions_stay_empty(self, tmp_path, monkeypatch):
+        media_file = _allowed_media_path(tmp_path, monkeypatch, "photo.png")
+        adapter = _adapter()
+
+        attached = await GatewayRunner._deliver_media_from_response(
+            _fake_runner({}),
+            f"MEDIA:{media_file}",
+            _event(),
+            adapter,
+        )
+
+        assert attached is False
+        images = adapter.send_multiple_images.await_args.kwargs["images"]
+        assert all(alt == "" for _, alt in images)

--- a/tests/gateway/test_post_stream_media_delivery.py
+++ b/tests/gateway/test_post_stream_media_delivery.py
@@ -45,9 +45,10 @@ def _fake_runner(thread_meta):
     )
 
 
-def _adapter():
+def _adapter(supports_batch_image_captions=True):
     return SimpleNamespace(
         name="test",
+        supports_batch_image_captions=supports_batch_image_captions,
         extract_media=BasePlatformAdapter.extract_media,
         extract_images=BasePlatformAdapter.extract_images,
         extract_local_files=BasePlatformAdapter.extract_local_files,
@@ -183,6 +184,34 @@ class TestPostStreamFooterCaption:
         )
 
         assert attached is False
+
+    @pytest.mark.asyncio
+    async def test_caption_dropping_adapter_keeps_the_trailing_footer(
+        self, tmp_path, monkeypatch
+    ):
+        """Signal's batch RPC drops per-image alt text — the footer must NOT
+        be claimed by a caption that can never render it."""
+        media_file = _allowed_media_path(tmp_path, monkeypatch, "signal.png")
+        adapter = _adapter(supports_batch_image_captions=False)
+
+        attached = await GatewayRunner._deliver_media_from_response(
+            _fake_runner({}),
+            f"MEDIA:{media_file}",
+            _event(),
+            adapter,
+            footer_line="model-x │ 306K/1M │ 29%",
+        )
+
+        assert attached is False
+        images = adapter.send_multiple_images.await_args.kwargs["images"]
+        assert all(alt == "" for _, alt in images)
+
+    def test_base_adapter_declares_caption_support_and_signal_opts_out(self):
+        from gateway.platforms.base import BasePlatformAdapter as _base
+        from gateway.platforms.signal import SignalAdapter as _signal
+
+        assert _base.supports_batch_image_captions is True
+        assert _signal.supports_batch_image_captions is False
 
     @pytest.mark.asyncio
     async def test_without_footer_captions_stay_empty(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## What & why

#74547: with streaming enabled, `display.runtime_footer` never reaches a photo's `sendPhoto` caption. The body text is already delivered when the turn ends, so the footer is deliberately held back (`gateway/run.py`, the `not already_sent` gate) and then fired as a **separate trailing text message**:

```python
# Streaming already delivered the body text, but the footer was
# intentionally held back ...
if _footer_line:
    ...
    await _foot_adapter.send(source.chat_id, _footer_line, ...)
```

Meanwhile the post-stream photo batch goes out with empty captions:

```python
images = [(f"file://{_quote(p)}", "") for p in image_paths]
```

So the user sees a captionless photo followed by a footer-only message — the behavior reported in the issue.

## The change

`_deliver_media_from_response` accepts the footer line, attaches it as the caption of the **last** photo in the post-stream batch, and returns whether it did. The caller passes `_footer_line` in and only sends the trailing footer message when no photo carried it (no media in the reply, non-image media only, or a failed batch send). Platform senders already clamp captions to their limits (Telegram: 1024 chars), and the footer is ~60 chars.

Not changed: the non-streaming path (where the footer already rides the final text message), non-image media routing, and the explicit-only MEDIA: contract from #20834.

## Tests

`TestPostStreamFooterCaption` in `tests/gateway/test_post_stream_media_delivery.py`:

- footer becomes the last photo's caption and the helper reports it
- text-only reply → helper reports false so the trailing send still fires
- non-image media (document) never claims the footer
- failed photo send → footer falls back to the trailing message
- no footer configured → captions stay empty (existing behavior pinned)

All five fail on unmodified `main`:

```
FAILED tests/gateway/test_post_stream_media_delivery.py::TestPostStreamFooterCaption::test_footer_rides_last_photo_caption
FAILED ...::test_no_media_returns_false_for_trailing_send
FAILED ...::test_non_image_media_does_not_claim_the_footer
FAILED ...::test_failed_photo_send_returns_false
FAILED ...::test_without_footer_captions_stay_empty
```

With the change: `7 passed` for the file. `tests/gateway/`: failure *sets* diffed with `comm -23` — no new failures (7 with the fix; the un-fixed baseline shows 12 because the new test file errors there, which inflates it).

Known limitation: the tests drive `_deliver_media_from_response` directly; the `already_sent` caller branch in `_process_message` is not separately covered — it is a thin pass-through of the returned flag.

## Platforms

Developed and tested on macOS; the change is platform-neutral gateway code (the caption clamp lives in each platform adapter).

## Duplicate check

`gh search prs` (open + closed) for `runtime_footer` and `sendPhoto`: no PR touches footer-to-caption routing. #31860 (open) adds a default footer *config* for Telegram — orthogonal, no file overlap in the footer path. Closed footer PRs (#17026, #28978, #57256) predate or don't touch delivery.

---
*Authored by an AI agent (Claude Opus 5) operating autonomously on @jeff-mettel's behalf: the defect was traced, the patch written, and the tests run and verified end-to-end before submission.*