### PR TITLE
fix(desktop): honor explicit no-sandbox launch flag

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6791,6 +6791,11 @@ def _desktop_linux_sandbox_helper_is_regular_file(packaged_executable: Path) -> 
     return stat.S_ISREG(sandbox_lstat.st_mode)
 
 
+def _desktop_linux_requires_sandbox_fixup(electron_flags: list[str]) -> bool:
+    """Return False when the user explicitly disabled Electron's sandbox."""
+    return "--no-sandbox" not in electron_flags
+
+
 
 def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
     """Configure Electron's Linux SUID sandbox helper when required."""
@@ -7100,7 +7105,7 @@ def cmd_gui(args: argparse.Namespace):
         sys.exit(1)
 
     launch_command = [str(packaged_executable)]
-    if not _desktop_linux_sandbox_fixup(packaged_executable):
+    if _desktop_linux_requires_sandbox_fixup(config_electron_flags) and not _desktop_linux_sandbox_fixup(packaged_executable):
         if _desktop_linux_needs_no_sandbox() and _desktop_linux_sandbox_helper_is_regular_file(packaged_executable):
             print("⚠ Falling back to --no-sandbox because this Linux host restricts unprivileged user namespaces and the Electron sandbox helper could not be configured.")
             launch_command.append("--no-sandbox")

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -382,3 +382,25 @@ def test_relaunchable_fixup_falls_back_to_legacy_adhoc_on_failure(tmp_path, monk
 # --- desktop.* launch options (config.yaml) -------------------------------
 
 
+def test_explicit_no_sandbox_flag_skips_linux_suid_fixup(tmp_path, monkeypatch):
+    """An explicit no-sandbox launch must never attempt the sudo fixup."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="linux")
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe), "--no-sandbox"], 0)
+
+    with patch(
+        "hermes_cli.main._desktop_launch_options",
+        return_value=(["--no-sandbox"], "auto"),
+    ), patch(
+        "hermes_cli.main._desktop_linux_sandbox_fixup"
+    ) as mock_fixup, patch(
+        "hermes_cli.main.subprocess.run", return_value=launch_ok
+    ) as mock_run, pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 0
+    mock_fixup.assert_not_called()
+    assert mock_run.call_args.args[0] == [str(packaged_exe), "--no-sandbox"]
+
+


### PR DESCRIPTION
## Summary
- skip Linux chrome-sandbox sudo fixup when `desktop.electron_flags` already includes `--no-sandbox`
- preserve existing SUID fixup and AppArmor fallback for normal launches
- add a regression test for the launch predicate

## Verification
- `venv/bin/python -m ruff check hermes_cli/main.py tests/hermes_cli/test_gui_command.py`
- `venv/bin/python -m pytest tests/hermes_cli/test_gui_command.py -o addopts= -q` (10 passed)
- live launch: `hermes desktop --skip-build` exits 0 and starts the packaged app with `--no-sandbox` without attempting sudo

## Notes
The full test suite was attempted but exceeded 10 minutes at roughly 9%; failures observed before timeout were unrelated existing tests/logging teardown issues.