### PR TITLE
fix(gateway): advance snapshot after FTS-rebuild transcript retry

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3047,6 +3047,11 @@ class SessionStore:
                             if not pending:
                                 self._dirty_transcripts.pop(queue_session_id, None)
                                 self._transcript_append_failures.pop(session_id, None)
+                                return
+                            # Refresh the snapshot before continuing: without
+                            # this the loop top re-writes the message we just
+                            # persisted, duplicating it in the transcript.
+                            msg = pending[0]
                         continue
                 with self._transcript_retry_lock:
                     failures = self._transcript_append_failures.get(session_id, 0) + 1

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1314,6 +1314,49 @@ class TestGatewaySessionDbRecovery:
         pending = store._dirty_transcripts.get("s1", [])
         assert len(pending) <= store._MAX_PENDING_PER_SESSION
 
+    def test_fts_rebuild_retry_does_not_duplicate_messages(self):
+        """After a successful FTS rebuild + retry, the loop must advance to
+        the next pending message — not re-write the one it just persisted.
+
+        Regression: the rebuild success path popped the retried message and
+        continued without refreshing the snapshot, so the loop top wrote the
+        same message a second time ([m1, m1, m2] for a two-message backlog,
+        and [m1, m1] even for a single message).
+        """
+        import threading
+
+        class FakeDb:
+            def __init__(self):
+                self.rows = []
+                self.fail_next = True
+
+            def append_message(self, session_id, role, content, **kwargs):
+                if self.fail_next:
+                    self.fail_next = False
+                    raise RuntimeError("no such table: messages_fts")
+                self.rows.append((session_id, role, content))
+
+            def rebuild_fts(self):
+                return 1
+
+        store = object.__new__(SessionStore)
+        store._db = FakeDb()
+        store._lock = threading.RLock()
+        store._entries = {}
+        store._loaded = True
+        store._save = lambda: None
+        store._transcript_retry_lock = threading.Lock()
+        store._dirty_transcripts = {}
+        store._transcript_append_failures = {}
+        store._fts_rebuild_attempted = False
+
+        store.append_to_transcript("s1", {"role": "user", "content": "m1"})
+        store.append_to_transcript("s1", {"role": "assistant", "content": "m2"})
+
+        contents = [content for _sid, _role, content in store._db.rows]
+        assert contents == ["m1", "m2"]
+        assert store._dirty_transcripts.get("s1") is None
+
 
 class TestGatewayRoutingTable:
     """state.db gateway_routing table is the primary routing index (#9006 follow-up)."""


### PR DESCRIPTION
## What does this PR do?

Fixes a duplicate transcript write in the gateway's FTS-corruption recovery path.

`_append_to_transcript_serialized` (`gateway/session.py`) retries failed transcript appends in a loop that snapshots `msg = pending[0]` and writes it at the top of each iteration. When an append fails with an FTS-corruption error, the recovery path rebuilds the FTS index, retries the write, pops the message from the pending queue — and `continue`s **without refreshing the snapshot**. The loop top then writes the just-persisted message a second time:

- single recovered message → written twice (`[m1, m1]`)
- two-message backlog → `[m1, m1, m2]`

This fires precisely when the mechanism is needed: an FTS5 corruption event where every append during the outage queued for retry. The duplicated row is permanent — every subsequent replay of that session shows the same user/assistant message twice to the model.

The normal success path (the loop's `else` branch) handles this correctly — pop, return when drained, otherwise `msg = pending[0]`. The fix mirrors it in the rebuild-retry path.

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/session.py`: the FTS-rebuild success branch now returns when the pending queue drains, and advances `msg = pending[0]` otherwise — identical semantics to the normal write-success path.
- `tests/gateway/test_session.py`: regression test driving the real retry loop with a DB that fails once with `no such table: messages_fts` then succeeds — asserts the transcript is exactly `["m1", "m2"]` and the queue drains.

## How to Test

Reproduction (against pre-fix code, using the `object.__new__(SessionStore)` harness already established in the test file):

```python
store.append_to_transcript("s1", {"role": "user", "content": "m1"})      # first write raises FTS error
store.append_to_transcript("s1", {"role": "assistant", "content": "m2"})
# pre-fix:  DB rows are [m1, m1, m2]   (m1 duplicated by the stale snapshot)
# post-fix: DB rows are [m1, m2]
```

Focused validation completed:

1. `bash scripts/run_tests.sh tests/gateway/test_session.py` — 55/55 pass.
2. Sabotage check: stashing the `gateway/session.py` change makes exactly the new test fail (54 pass); restoring it returns to 55/55.
3. Full repo-wide suite, `bash scripts/run_tests.sh` (branch): 22,812 pass / 100 fail. Baseline on clean `main` (this branch's parent), same machine: 22,811 pass / 100 fail — the failing-file sets are **identical** (49 files, environment-dependent lanes: LSP e2e, browser, MCP, voice/TTS, WhatsApp bridge; no API keys/services locally). The branch adds exactly one passing test and introduces zero new failures; nothing in the session/transcript test surface fails.
4. `uvx --from ruff==0.15.10 ruff check gateway/session.py tests/gateway/test_session.py` — clean.
5. `git diff --check` — clean.
6. Adversarial cases executed live: single-message recovery (no duplicate, queue drains), three-message backlog (exactly `["a", "b", "c"]`), persistent failure with unsuccessful rebuild (message stays queued, not lost), and the reroute-to-compression-child paths (existing tests, all pass).

The full repo-wide suite was run locally with results verified identical to clean `main` (see How to Test); GitHub CI remains the final confirmation environment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite run locally via `scripts/run_tests.sh`; failures are pre-existing/environment-dependent and verified identical to clean `main` (see How to Test, item 3)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior now matches the loop's own success-path contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform surface (SQLite retry-loop control flow)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Logs

Sabotage verification output:

```
# fix stashed (pre-fix behavior):
=== Summary: 1 files, 54 tests passed, 1 failed ===   (the new regression test)
# fix restored:
=== Summary: 1 files, 55 tests passed, 0 failed ===
```

