### PR TITLE
fix(cli): stop /reload-mcp from blocking the command processor (supersedes #39446)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11362,6 +11362,29 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         return choice
 
+    def _start_background_mcp_reload(self) -> bool:
+        """Start ``_reload_mcp`` on a daemon thread and return immediately.
+
+        Mirrors the config-watcher path above: the reload must never join the
+        caller, because ``_reload_mcp`` tears down and re-dials every MCP
+        server, so a hung or slow server would block the command processor
+        along with it and freeze input consumption.  The worker reports its
+        own start line and change summary via ``print()`` inside
+        ``_reload_mcp``.
+
+        Returns False (and starts nothing) when a reload worker this method
+        started is still alive — making the command path asynchronous removes
+        the implicit serialization the synchronous call used to provide.
+        """
+        prior = getattr(self, "_mcp_reload_thread", None)
+        if prior is not None and prior.is_alive():
+            print("🟡 An MCP reload is already running — skipping this one.")
+            return False
+        thread = threading.Thread(target=self._reload_mcp, daemon=True)
+        self._mcp_reload_thread = thread
+        thread.start()
+        return True
+
     def _confirm_and_reload_mcp(self, cmd_original: str = "") -> None:
         """Interactive /reload-mcp — confirm with the user, then reload.
 
@@ -11374,6 +11397,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         ``approvals.mcp_reload_confirm: false`` so future reloads run
         without this prompt), Cancel.  Gated by
         ``approvals.mcp_reload_confirm`` — default on.
+
+        Once approved, the reload itself is handed to a background daemon
+        thread via :meth:`_start_background_mcp_reload` so the command
+        processor stays responsive.  ``cmd_original`` is retained for the
+        slash-command dispatch signature.
         """
         # Gate check — respects prior "Always Approve" clicks.
         try:
@@ -11386,8 +11414,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             confirm_required = True
 
         if not confirm_required:
-            with self._busy_command(self._slow_command_status(cmd_original)):
-                self._reload_mcp()
+            self._start_background_mcp_reload()
             return
 
         # Render warning + prompt.  Use the same prompt_toolkit-native composer
@@ -11426,8 +11453,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             else:
                 print("⚠️  Couldn't persist opt-out — reloading once.")
 
-        with self._busy_command(self._slow_command_status(cmd_original)):
-            self._reload_mcp()
+        self._start_background_mcp_reload()
 
     def _reload_mcp(self):
         """Reload MCP servers: disconnect all, re-read config.yaml, reconnect.

--- a/tests/cli/test_cli_loading_indicator.py
+++ b/tests/cli/test_cli_loading_indicator.py
@@ -1,6 +1,10 @@
 """Regression tests for loading feedback on slow slash commands."""
 
+import threading
+import time
 from unittest.mock import patch
+
+import pytest
 
 from cli import HermesCLI
 
@@ -13,6 +17,14 @@ class TestCLILoadingIndicator:
         cli_obj._command_running = False
         cli_obj._command_status = ""
         return cli_obj
+
+    @staticmethod
+    def _join_reload_worker(cli_obj):
+        """Never leak a background reload worker out of a test."""
+        worker = getattr(cli_obj, "_mcp_reload_thread", None)
+        if worker is not None:
+            worker.join(timeout=10)
+            assert not worker.is_alive(), "background reload worker did not exit"
 
     def test_skills_command_sets_busy_state_and_prints_status(self, capsys):
         cli_obj = self._make_cli()
@@ -40,33 +52,117 @@ class TestCLILoadingIndicator:
         assert cli_obj._command_status == ""
         assert invalidate_mock.call_count == 2
 
-    def test_reload_mcp_sets_busy_state_and_prints_status(self, capsys):
+    def test_reload_mcp_does_not_reserve_the_composer(self, capsys):
+        """/reload-mcp must not take the blocking busy state.
+
+        It used to run ``_reload_mcp()`` inside ``_busy_command(...)`` on the
+        command thread.  That context manager sets ``_command_blocks_input``,
+        so a slow MCP server froze the session for as long as the reload took.
+        The reload now runs on a daemon worker and reports itself, so the
+        command claims no busy state at all.
+        """
         cli_obj = self._make_cli()
         seen = {}
+        done = threading.Event()
 
         def fake_reload():
             seen["running"] = cli_obj._command_running
-            seen["status"] = cli_obj._command_status
+            seen["blocks_input"] = getattr(cli_obj, "_command_blocks_input", False)
             print("reload done")
+            done.set()
 
-        # /reload-mcp now wraps the actual reload in a prompt-cache-invalidation
-        # confirmation prompt (commit 4d7fc0f37).  This test exercises the
-        # loading-indicator path, not the confirmation UX, so pre-approve the
-        # reload via config so the handler goes straight into _reload_mcp().
+        # Pre-approve via config so the handler goes straight to the reload
+        # rather than through the confirmation modal.
         fake_cfg = {"approvals": {"mcp_reload_confirm": False}}
 
         with patch.object(cli_obj, "_reload_mcp", side_effect=fake_reload), \
              patch.object(cli_obj, "_invalidate") as invalidate_mock, \
              patch("cli.load_cli_config", return_value=fake_cfg):
             assert cli_obj.process_command("/reload-mcp")
+            assert done.wait(timeout=5), "background reload worker never ran"
+            self._join_reload_worker(cli_obj)
 
         output = capsys.readouterr().out
-        assert "⏳ Reloading MCP servers..." in output
+        assert "⏳ Reloading MCP servers..." not in output
         assert "reload done" in output
-        assert seen == {
-            "running": True,
-            "status": "Reloading MCP servers...",
-        }
+        # The worker never sees (or sets) the input-blocking busy state.
+        assert seen == {"running": False, "blocks_input": False}
         assert cli_obj._command_running is False
         assert cli_obj._command_status == ""
-        assert invalidate_mock.call_count == 2
+        assert invalidate_mock.call_count == 0
+
+    @pytest.mark.parametrize("route", ["pre_approved", "modal_once"])
+    def test_reload_mcp_returns_before_reload_completes(self, route):
+        """Both approved routes hand off and return while the reload is stuck.
+
+        Covers the pre-approved route (``approvals.mcp_reload_confirm: false``)
+        and the modal "Approve Once" route.  Fixing only one of them would
+        leave the other frozen.
+        """
+        cli_obj = self._make_cli()
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def blocking_reload():
+            started.set()
+            release.wait(timeout=10)
+            finished.set()
+
+        confirm_required = route == "modal_once"
+        fake_cfg = {"approvals": {"mcp_reload_confirm": confirm_required}}
+
+        try:
+            with patch.object(cli_obj, "_reload_mcp", side_effect=blocking_reload), \
+                 patch.object(cli_obj, "_invalidate"), \
+                 patch.object(cli_obj, "_prompt_text_input_modal", return_value="once"), \
+                 patch("cli.load_cli_config", return_value=fake_cfg):
+                begin = time.monotonic()
+                assert cli_obj.process_command("/reload-mcp")
+                elapsed = time.monotonic() - begin
+
+                # The reload really is running — we did not simply skip it.
+                assert started.wait(timeout=5), "background reload worker never ran"
+                # ...and the command returned before it completed.  This is the
+                # assertion a join()-based fix cannot satisfy.
+                assert not finished.is_set()
+                assert elapsed < 1.0, f"/reload-mcp blocked for {elapsed:.2f}s"
+                assert getattr(cli_obj, "_command_blocks_input", False) is False
+        finally:
+            release.set()
+            self._join_reload_worker(cli_obj)
+
+    def test_reload_mcp_does_not_stack_concurrent_workers(self, capsys):
+        """A second /reload-mcp while one is in flight does not start a worker.
+
+        The synchronous call used to serialize reloads implicitly; running
+        them in the background removes that, so the handoff refuses to stack.
+        """
+        cli_obj = self._make_cli()
+        started = threading.Event()
+        release = threading.Event()
+        calls = []
+
+        def blocking_reload():
+            calls.append(1)
+            started.set()
+            release.wait(timeout=10)
+
+        fake_cfg = {"approvals": {"mcp_reload_confirm": False}}
+
+        try:
+            with patch.object(cli_obj, "_reload_mcp", side_effect=blocking_reload), \
+                 patch.object(cli_obj, "_invalidate"), \
+                 patch("cli.load_cli_config", return_value=fake_cfg):
+                assert cli_obj.process_command("/reload-mcp")
+                assert started.wait(timeout=5), "background reload worker never ran"
+                first_worker = cli_obj._mcp_reload_thread
+
+                assert cli_obj.process_command("/reload-mcp")
+                assert cli_obj._mcp_reload_thread is first_worker
+                assert calls == [1]
+        finally:
+            release.set()
+            self._join_reload_worker(cli_obj)
+
+        assert "already running" in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

`/reload-mcp` freezes the CLI. `_confirm_and_reload_mcp` calls `_reload_mcp()` **synchronously on the command thread at both approved routes** (`cli.py:11390` pre-approved, `cli.py:11430` modal-approved), each wrapped in `self._busy_command(...)`. `_reload_mcp` runs `shutdown_mcp_servers()` and then `discover_mcp_tools()`, so a hung or slow MCP server blocks the command processor along with it and the session stops accepting input — the frozen state reported in #39418.

The repo already fixed the *other* caller. The config-watcher path starts a daemon thread and deliberately does **not** join, with an in-code comment saying a blocking join "would freeze input consumption for up to 30s (and a hung MCP server could block far longer)" (`cli.py:11228-11238`, installed by `972aa33d3`). The user-triggered command path was never brought in line. This PR does that, following the same pattern.

### Positioning

Supersedes **#39446**, which made the right structural move but then `join(timeout=30.0)`s the worker — that caps the freeze at 30s rather than removing it, and it converts only the pre-approved route. Also subsumes **#33026**, which addressed the same hang but altered the confirmation flow and bundled unrelated commands. Thanks to both authors for identifying the bug; this PR keeps the consent UX untouched and removes the join entirely.

Concretely, the responsiveness tests added here **fail** against a `join(timeout=30.0)` variant, not just against current `main` — see the three-way verification below.

### Scope: both call sites, and only these

`git grep -n "_reload_mcp\b" -- '*.py'` (non-test) returns five sites. Coverage:

| site | in this PR | why |
|---|---|---|
| `cli.py:11390` pre-approved route | ✅ | synchronous, blocks the command thread |
| `cli.py:11430` modal-approved route | ✅ | synchronous, blocks the command thread |
| `cli.py:11231` config-watcher | — | already async and correct; this is the pattern being copied |
| `plugins/platforms/discord/adapter.py:5369` | — | async Discord interaction handler, already off the CLI input thread |
| `tui_gateway/compute_host.py:522` | — | different process and event loop; not the CLI command thread |

Fixing only one of the two `cli.py` routes would leave the other frozen, so both are converted here.

### Why `_busy_command` is dropped rather than kept

`_busy_command` is a synchronous context manager that sets `_command_running`/`_command_blocks_input` and reserves the composer — it *is* the input-blocking mechanism this PR removes. It cannot span the handoff: wrapping only `thread.start()` would enter and exit in microseconds (a meaningless spinner, and it races `_reload_mcp`'s `if not self._command_running` header check), and releasing it from the worker would leak a permanent busy state if the worker raised.

Removing it also un-suppresses `_reload_mcp`'s own `🔄 Reloading MCP servers...` header at `cli.py:11445-11446`, which is exactly how the already-async watcher path reports itself. The user still gets a start line, then the `♻️/➕/➖` change summary when the worker finishes.

### Confirmation semantics are unchanged

The gate read, the three modal choices, the `always` → `approvals.mcp_reload_confirm: false` persistence, the unrecognized-choice path and every cancel path are byte-for-byte untouched. `tests/hermes_cli/test_mcp_reload_confirm_gate.py` and `tests/tools/test_slash_confirm.py` stay green.

## Related Issue

Fixes #39418

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: new `_start_background_mcp_reload()` immediately before `_confirm_and_reload_mcp` — starts `_reload_mcp` on a daemon thread and returns immediately, mirroring the watcher path. It refuses to start a second worker while one it started is still alive: the synchronous call used to serialize reloads implicitly, and making the path asynchronous removes that. Uses the `getattr(self, "_mcp_reload_thread", None)` lazy-attribute convention so bare-constructed test CLIs work without an `__init__` change, keeping the whole production diff inside one region.
- `cli.py`: both approved routes now call it, replacing the synchronous `with self._busy_command(...): self._reload_mcp()` blocks.
- `tests/cli/test_cli_loading_indicator.py`: event-blocked responsiveness tests for **both** approved routes (parametrized), a re-entrancy test for the in-flight guard, and the existing busy-state test re-pointed at the new contract (it asserted the behavior being removed, so it is updated rather than deleted).

## How to Test

1. Configure an MCP server that hangs on startup.
2. Run `/reload-mcp` and choose "Approve Once" — the prompt returns immediately and the session keeps accepting input; the reload reports itself when it finishes.
3. Set `approvals.mcp_reload_confirm: false` in `config.yaml` and repeat — same behavior, no modal.
4. Run `/reload-mcp` twice in quick succession while the first is still running — the second is declined instead of stacking a second worker.
5. Automated:

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
  tests/cli/test_cli_loading_indicator.py tests/cli/test_cli_mcp_config_watch.py \
  tests/hermes_cli/test_mcp_reload_confirm_gate.py tests/tools/test_slash_confirm.py -v
```

### Three-way verification (all three columns actually run)

| variant | result |
|---|---|
| this PR | **24 passed** on the four files above; `tests/cli/` = **743 passed, 1 skipped** |
| helper re-written with `thread.join(timeout=30.0)` (#39446's shape) | **3 failed** — both responsiveness cases fail on `assert elapsed < 1.0` (measured ~10s), plus the re-entrancy case |
| both sites reverted to `main`'s synchronous call | **4 failed** — responsiveness cases fail on `assert not finished.is_set()` |

The middle column is the one that matters: these tests are not satisfied by simply moving the reload to a thread and joining it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the full `tests/cli/` suite (743 passed, 1 skipped) plus the four files above, not the entire repo suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on `_start_background_mcp_reload` and `_confirm_and_reload_mcp`
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — `threading.Thread(daemon=True)` is platform-neutral and identical to the watcher path already shipping; only verified on macOS
- [x] N/A — no tool descriptions or schemas changed
