### PR TITLE
docs(quickstart): clarify session resume requires --tui for TUI sessions (#74901)

### DIFF
--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -212,11 +212,14 @@ If that works, you're past the hardest part.
 Before moving on, make sure resume works:
 
 ```bash
-hermes --continue    # Resume the most recent session
-hermes -c            # Short form
+hermes --continue    # Resume the most recent CLI session
+hermes -c            # Short form (CLI only)
+hermes --tui -c      # Resume a TUI session
 ```
 
 That should bring you back to the session you just had. If it doesn't, check whether you're in the same profile and whether the session actually saved. This matters later when you're juggling multiple setups or machines.
+
+**Note:** If you started your session with `hermes --tui`, use `hermes --tui -c` to resume it. The plain `hermes -c` form resumes CLI sessions opened without `--tui`.
 
 ## 5. Try Key Features
 


### PR DESCRIPTION
## Problem

The quickstart documentation shows `hermes -c` and `hermes --continue` to resume sessions but doesn't clarify that these only work for CLI sessions (opened without `--tui`). When a user starts Hermes with `hermes --tui`, trying `hermes -c` fails.

## Fix

Update the session resume section to:
1. Add `hermes --tui -c` as the form needed to resume TUI sessions
2. Clarify comments on each command variant
3. Add a note explaining the difference between CLI and TUI session resume

## Testing

Docs-only change - verified markdown renders correctly.

Closes #74901