### PR TITLE
fix(docker): pass --python-platform to uv sync for linux/arm64 to select correct wheel arch (#74554)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -261,7 +261,12 @@ RUN cd plugins/platforms/photon/sidecar && \
 # The editable link is created after the source copy below.
 COPY pyproject.toml uv.lock ./
 RUN touch ./README.md
-RUN uv sync --frozen --no-install-project --extra all --extra messaging --extra otlp --extra anthropic --extra bedrock --extra azure-identity --extra hindsight --extra matrix
+RUN set -eu; \
+    case "${TARGETARCH:-amd64}" in \
+        arm64) UV_PLATFORM_FLAG="--python-platform aarch64-unknown-linux-gnu" ;; \
+        *)     UV_PLATFORM_FLAG="" ;; \
+    esac; \
+    uv sync ${UV_PLATFORM_FLAG} --frozen --no-install-project --extra all --extra messaging --extra otlp --extra anthropic --extra bedrock --extra azure-identity --extra hindsight --extra matrix
 
 # ---------- Frontend build (cached independently from Python source) ----------
 # Copy only the frontend source trees first so that Python-only changes don't


### PR DESCRIPTION
## Problem

The published linux/arm64 Docker image ships x86_64 wheels in /opt/hermes/.venv. Every hermes command fails with ImportError because the compiled .so files are the wrong architecture. The arm64 venv is byte-identical to the amd64 image's venv, indicating that uv sync resolved x86_64 wheels when building for arm64.

## Root Cause

uv sync running under QEMU emulation for cross-architecture Docker builds resolves x86_64 wheels because QEMU can report incorrect CPU architecture information. The `--python-platform` flag forces uv to select the correct platform-specific wheels regardless of the emulated environment.

## Fix

Add `--python-platform aarch64-unknown-linux-gnu` to `uv sync` when TARGETARCH=arm64, using the same case-switch pattern already established in the Dockerfile for s6-overlay architecture selection (line 113).

## Testing

- The fix follows the same ${TARGETARCH} case pattern used by the existing s6-overlay install (tested per-arch in CI)
- uv 0.11.6 (shipped in the Docker image) supports `--python-platform`
- Correctness can be verified post-build: the arm64 image should contain aarch64 .so files instead of x86_64

Closes #74554