### PR TITLE
fix(agent): unescape quoted .env values in secret_scope.load_env_file

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -181,9 +181,11 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
     """Parse a ``.env`` file into a plain dict WITHOUT touching ``os.environ``.
 
     Used to load a profile's secrets into an isolated mapping for
-    ``set_secret_scope``. Mirrors python-dotenv's basic parsing (KEY=VALUE,
-    ``export`` prefix, ``#`` comments, optional matching quotes) but never
-    mutates the process environment — that isolation is the whole point.
+    ``set_secret_scope``. Parses the small KEY=VALUE subset Hermes writes
+    itself (``export`` prefix, ``#`` comments, matching quotes with the
+    writer's ``\\"``/``\\\\`` escapes reversed — the same semantics as
+    ``hermes_cli.config._parse_env_value``) but never mutates the process
+    environment — that isolation is the whole point.
     """
     secrets: Dict[str, str] = {}
     try:
@@ -203,10 +205,15 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
         key = key.strip()
         if not key:
             continue
-        value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-            value = value[1:-1]
-        secrets[key] = value
+        # Parse values with the canonical Hermes parser: save_env_value
+        # escapes " and \ inside double quotes, and every other reader
+        # (load_env, python-dotenv) reverses those escapes. Stripping only
+        # the outer quotes here would corrupt credentials containing "
+        # or \ — they work interactively but fail in scoped (cron /
+        # multiplex) resolution.
+        from hermes_cli.config import _parse_env_value
+
+        secrets[key] = _parse_env_value(value)
 
     return secrets
 

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -113,6 +113,30 @@ class TestScopeIsolation:
 class TestEnvFileParsing:
     """load_env_file parses without mutating os.environ."""
 
+    def test_load_env_file_unescapes_quoted_values(self, tmp_path):
+        """Values written by save_env_value must round-trip byte-exactly.
+
+        Regression: load_env_file stripped only the outer quotes, leaving
+        the writer's \\" and \\\\ escapes literal — credentials containing
+        '\"' or '\\' worked interactively but were corrupted under scoped
+        (cron / multiplex) resolution.
+        """
+        from hermes_cli.config import _quote_env_value
+
+        original = 'tok"en\\with spaces'
+        (tmp_path / ".env").write_text(f"MY_TOKEN={_quote_env_value(original)}\n")
+        assert ss.load_env_file(tmp_path / ".env") == {"MY_TOKEN": original}
+
+    def test_load_env_file_single_quotes_and_plain_values(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            "PLAIN=abc123\nQUOTED='single quoted'\nEMPTY=\n"
+        )
+        assert ss.load_env_file(tmp_path / ".env") == {
+            "PLAIN": "abc123",
+            "QUOTED": "single quoted",
+            "EMPTY": "",
+        }
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes credential corruption in scoped secret resolution: `agent/secret_scope.py:load_env_file` — the `.env` parser behind `build_profile_secret_scope`, which wraps **every cron job** (`cron/scheduler.py`) and **every multiplexed gateway turn** (`gateway/run.py:_profile_runtime_scope`), plus tui_gateway session paths and the dashboard MCP OAuth flow — did not unescape double-quoted values.

The repo has a writer/reader pair designed together in #30355: `save_env_value` escapes `"` and `\` inside double quotes (`KEY="a\"b\\c"`), and the canonical reader `_parse_env_value` (used by `load_env()`) reverses exactly those two escapes. `load_env_file` only stripped the outer quotes, leaving the escapes literal. So the same `.env` yields **different credential bytes depending on the resolution path**:

- interactive turns (via `load_env()` / `os.environ`): correct value
- cron jobs, multiplexed gateway turns, tui_gateway resume, dashboard MCP OAuth (via the scope): corrupted value with literal `\"` / `\\`

A credential containing a double quote or backslash (JSON service-account blobs, generated secrets) authenticates fine interactively but fails under scoped resolution, with no error pointing at the cause.

The fix parses values with the canonical `_parse_env_value` (function-level import, matching the codebase's existing pattern and avoiding an import cycle). Deliberately **not** upgraded to full python-dotenv semantics (`\n`, `\t`, …): the writer never emits those, and `config.load_env` is equally narrow — the two Hermes parsers now agree byte-for-byte.

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/secret_scope.py`: `load_env_file` values now parsed with `hermes_cli.config._parse_env_value`; docstring updated to state the actual contract (Hermes' own KEY=VALUE subset with the writer's escapes reversed — the old docstring claimed python-dotenv parity, which was never true).
- `tests/agent/test_secret_scope.py`: round-trip regression test (`save_env_value`-quoted value containing `"`, `\`, and spaces must come back byte-exact) plus a plain/single-quoted/empty contract test.

Not in scope (same latent mismatch, different parsers, noted for follow-up): `tools/skills_tool.py:load_env`, `hermes_cli/managed_scope.py:_parse_env`, `hermes_cli/main.py:_has_any_provider_configured` — detection/auxiliary readers, not credential-resolution paths.

## How to Test

Reproduction (against pre-fix code):

```python
from hermes_cli.config import _quote_env_value, _parse_env_value
from agent.secret_scope import load_env_file

original = 'tok"en\\with spaces'
# on disk (what save_env_value writes): MY_TOKEN="tok\"en\\with spaces"
_parse_env_value(...)              # -> 'tok"en\\with spaces'  (correct)
load_env_file(env)["MY_TOKEN"]     # pre-fix: 'tok\\"en\\\\with spaces' (escapes literal — BUG)
                                   # post-fix: 'tok"en\\with spaces'   (matches)
```

Focused validation completed:

1. `bash scripts/run_tests.sh tests/agent/test_secret_scope.py` — 14/14 pass.
2. Sabotage check: stashing the `agent/secret_scope.py` change makes exactly the round-trip test fail (13 pass); restoring it returns to 14/14.
3. Round-trip matrix executed against the real writer: 7 cases (quote+backslash+spaces, plain, quote-only, backslash-only, single-quote char, trailing space, empty) — all byte-exact through `_quote_env_value` → `load_env_file`.
4. Related suites: `tests/secret_sources/ test_env_loader_secret_sources.py test_command_secret_source.py test_multiplex_credential_isolation.py test_cron_profile_isolation.py test_api_server_multiplex_secret_scope.py test_env_export_line_lifecycle.py` — 87/88 pass; the single failure (`test_command_secret_source.py`, a conftest process-group guard) fails identically on clean `main` — pre-existing and unrelated.
5. Full repo-wide suite, `bash scripts/run_tests.sh` (branch): 22,814 pass / 99 fail. Baseline on clean `main` (this branch's parent), same machine: 22,811 pass / 100 fail — the failing-file sets are **identical** (49 files, environment-dependent lanes: LSP e2e, browser, MCP, voice/TTS; no API keys/services locally). Zero new failures; nothing in the secret/credential test surface fails.
5. `uvx --from ruff==0.15.10 ruff check agent/secret_scope.py tests/agent/test_secret_scope.py` — clean.
6. `git diff --check` — clean.
7. Existing-scope audit: no test anywhere asserts the old non-unescaping behavior (every scope test uses plain unquoted values), so no expectation changes were needed.

The full repo-wide suite was run locally with results verified identical to clean `main` (see How to Test); GitHub CI remains the final confirmation environment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite run locally via `scripts/run_tests.sh`; failures are pre-existing/environment-dependent and verified identical to clean `main` (see How to Test, item 5)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `load_env_file` docstring corrected to the actual parsing contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string parsing, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Logs

Sabotage verification output:

```
# fix stashed (pre-fix behavior):
=== Summary: 1 files, 13 tests passed, 1 failed ===   (the round-trip test)
# fix restored:
=== Summary: 1 files, 14 tests passed, 0 failed ===
```

