### PR TITLE
fix(hindsight): preserve explicit [[]] shared observation scope (#74933)

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -448,6 +448,10 @@ def _normalize_observation_scopes(value: Any) -> Any:
       * ``None`` — nothing configured; Hindsight applies its ``combined`` default.
       * a keyword string — ``"per_tag"`` / ``"combined"`` / ``"all_combinations"``.
       * ``list[list[str]]`` — custom scopes, one inner list per consolidation pass.
+        An explicit empty inner list (``[[]]``) is Hindsight's documented
+        equivalent of the ``shared`` scope — one global consolidation pass that
+        ignores volatile per-session tags — and is preserved, not discarded
+        (#74933).
 
     Accepts a keyword string, a JSON-encoded list, a flat list of tags (treated as
     a single scope), or a list of tag-lists. Anything unrecognized yields ``None``
@@ -478,8 +482,14 @@ def _normalize_observation_scopes(value: Any) -> Any:
         scopes: list[list[str]] = []
         for entry in value:
             if isinstance(entry, (list, tuple)):
+                # Keep explicitly-empty inner lists: [[]] is Hindsight's
+                # documented equivalent of the "shared" scope. Dropping it
+                # silently reverted the config to the "combined" default,
+                # fragmenting observations by session tag (#74933). Inner
+                # lists that only become empty after stripping whitespace
+                # tags are still malformed and still dropped.
                 inner = [str(tag).strip() for tag in entry if str(tag).strip()]
-                if inner:
+                if inner or not entry:
                     scopes.append(inner)
             elif isinstance(entry, str) and entry.strip():
                 scopes.append([entry.strip()])

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1169,3 +1169,43 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
                    for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Explicit shared scope — [[]] (#74933)
+# ---------------------------------------------------------------------------
+
+
+class TestSharedObservationScope:
+    """[[]] is Hindsight's documented equivalent of the "shared" scope. The
+    normalizer used to drop the empty inner list, silently reverting the
+    config to Hindsight's "combined" default — which fragments observations
+    by volatile session:<id> lineage tags (#74933)."""
+
+    def test_empty_inner_list_is_preserved(self):
+        assert _normalize_observation_scopes([[]]) == [[]]
+
+    def test_json_string_form_is_preserved(self):
+        assert _normalize_observation_scopes("[[]]") == [[]]
+
+    def test_mixed_scopes_keep_the_shared_pass(self):
+        assert _normalize_observation_scopes([["scope:private"], []]) == [
+            ["scope:private"],
+            [],
+        ]
+
+    def test_whitespace_only_inner_list_is_still_dropped(self):
+        assert _normalize_observation_scopes([["   "]]) is None
+
+    def test_flat_empty_list_still_means_unconfigured(self):
+        assert _normalize_observation_scopes([]) is None
+
+    def test_provider_config_preserves_shared_scope(self, provider_with_config):
+        p = provider_with_config(observation_scopes=[[]])
+        assert p._observation_scopes == [[]]
+
+    def test_retain_passes_shared_scope_to_client(self, provider_with_config):
+        p = provider_with_config(observation_scopes=[[]])
+        p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert item["observation_scopes"] == [[]]


### PR DESCRIPTION
## What & why

#74933: the Hindsight provider auto-adds unique `session:<id>` / `parent:<id>` lineage tags, so with scopes unconfigured, Hindsight's `combined` default makes every session tag its own observation scope — in the reported deployment, 23,428 of 24,324 observations carried session tags and consolidation never crossed them. Hindsight's documented remedies are `observation_scopes: "shared"` or its explicit equivalent `[[]]`. The normalizer discards the second form:

```python
for entry in value:
    if isinstance(entry, (list, tuple)):
        inner = [str(tag).strip() for tag in entry if str(tag).strip()]
        if inner:                     # <- [[]] produces inner == [], dropped
            scopes.append(inner)
...
return scopes or None                 # -> None; _build_retain_kwargs omits it
```

`[[]]` therefore silently reverts to `combined`, the exact behavior the config was set to avoid.

## The change

`_normalize_observation_scopes` keeps inner lists that are **explicitly** empty (`[[]]`, or `[["a"], []]`, and the JSON string form `"[[]]"`). Two guards are pinned unchanged: an inner list that only becomes empty after stripping whitespace-only tags is still dropped as malformed, and a flat `[]` still means "unconfigured". `_build_retain_kwargs` needs no change — `[[]]` is truthy.

**Scope split with #72565:** that open PR adds the `"shared"` *keyword* (expected-behavior item 1 of the issue) and does not touch the list normalization. This PR handles the `[[]]` form (item 2). No overlapping hunks — #72565 edits the keyword set and schema text; this edits the list branch.

## Tests

`TestSharedObservationScope` (7 tests): `[[]]` preserved (native and JSON-string forms), mixed `[["scope:private"], []]` keeps the shared pass, whitespace-only inner still dropped, flat `[]` still unconfigured, provider config carries `[[]]` to `_observation_scopes`, and `hindsight_retain` passes it through to `aretain_batch`.

On unmodified `main`, the 5 behavior-change tests fail:

```
FAILED ...::TestSharedObservationScope::test_empty_inner_list_is_preserved
FAILED ...::TestSharedObservationScope::test_json_string_form_is_preserved
FAILED ...::TestSharedObservationScope::test_mixed_scopes_keep_the_shared_pass
FAILED ...::TestSharedObservationScope::test_provider_config_preserves_shared_scope
FAILED ...::TestSharedObservationScope::test_retain_passes_shared_scope_to_client
```

(the 2 guard-pinning tests pass on both sides, as intended). With the change: 7/7.

`tests/plugins/memory/` failure sets diffed with `comm -23`: identical before/after — the single failure on both sides (`test_get_client_passes_idle_timeout_to_hindsight_embedded`) is a local-environment artifact (`security.allow_lazy_installs=false` on this machine blocks the `hindsight-client` install) and fails on unmodified `main` too.

## Platforms

macOS; the change is pure-Python config normalization, platform-neutral.

## Duplicate check

`gh search prs` (open + closed) for `_OBSERVATION_SCOPE_KEYWORDS` and `observation_scopes`: #72565 (open) is the keyword half, disjoint hunks as described; #46611/#46577 (closed) introduced the normalizer; #31302, #44410, #48191 unrelated. No PR touches the empty-inner-list branch.

---
*Authored by an AI agent (Claude Opus 5) operating autonomously on @jeff-mettel's behalf: the defect was traced, the patch written, and the tests run and verified end-to-end before submission.*