### PR TITLE
fix(strip-think): harden think-tag regexes for model-prefixed variants

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -770,9 +770,13 @@ def strip_think_blocks(agent, content: str) -> str:
          ``gateway/stream_consumer.py``'s filter so models that mention
          `` <think>`` in prose aren't over-stripped.
       3. Stray orphan open/close tags that slip through.
-      4. Tag variants: `` <think>``, ``<thinking>``, ``<reasoning>``,
-         ``<REASONING_SCRATCHPAD>``, ``<thought>`` (Gemma 4), all
-         case-insensitive.
+      4. Tag variants: any tag whose name contains one of the keywords
+               ``think``, ``thinking``, ``reasoning``, ``thought``, or
+               ``REASONING_SCRATCHPAD`` as a substring, case-insensitive.
+               This covers canonical tags (``<think>``, ``<thinking>``, …) and
+               model-name-prefixed/suffixed forms such as ``<M2_7think>``,
+               ``<M2_7_thinking>``, ``<M2_7reasoning>``, ``<deepseek_thought>``
+               (Jun 9 2026 "/think msg issue").
 
     Additionally strips standalone tool-call XML blocks that some open
     models (notably Gemma variants on OpenRouter) emit inside assistant
@@ -823,14 +827,20 @@ def strip_think_blocks(agent, content: str) -> str:
             content = str(content)
         if not content:
             return ""
-    # 1. Closed tag pairs — case-insensitive for all variants so
-    #    mixed-case tags (<THINK>, <Thinking>) don't slip through to
-    #    the unterminated-tag pass and take trailing content with them.
-    content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    # 1. Closed tag pairs — permissive tag-name matching so model-name
+    #    prefixed/suffixed variants (e.g. <M2_7think>, <deepseek_thought>)
+    #    are caught.  Both the open and close tag must contain the same
+    #    keyword as a substring; the close tag need not be identical to
+    #    the open tag (e.g. <M2_7think>…</think> is intentionally matched).
+    #    Jun 9 2026: added to fix the "/think msg issue" where prefixed tags
+    #    leaked raw reasoning to the user.
+    _THINK_KW = r'(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)'
+    content = re.sub(
+        rf'<[^>]*{_THINK_KW}[^>]*>.*?</[^>]*{_THINK_KW}[^>]*>',
+        '',
+        content,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.
@@ -859,15 +869,17 @@ def strip_think_blocks(agent, content: str) -> str:
     #    (start of text, or after a newline) with no matching close.
     #    Strip from the tag to end of string.  Fixes #8878 / #9568
     #    (MiniMax M2.7 leaking raw reasoning into assistant content).
+    #    Tag-name is permissive (keyword-as-substring) per Jun 9 2026 fix.
     content = re.sub(
-        r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$',
+        rf'(?:^|\n)[ \t]*<[^>]*{_THINK_KW}[^>]*\b[^>]*>.*$',
         '',
         content,
         flags=re.DOTALL | re.IGNORECASE,
     )
     # 3. Stray orphan open/close tags that slipped through.
+    #    Tag-name is permissive (keyword-as-substring) per Jun 9 2026 fix.
     content = re.sub(
-        r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
+        rf'</?[^>]*{_THINK_KW}[^>]*>\s*',
         '',
         content,
         flags=re.IGNORECASE,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -19,6 +19,7 @@ import asyncio
 import inspect
 import logging
 import queue
+import re
 import threading
 import time
 from dataclasses import dataclass
@@ -121,6 +122,55 @@ def ensure_closed_code_fences(text: str) -> str:
     if without_fences.count("`") % 2 == 1:
         text = text + "`"
 
+    return text
+
+
+# ── Defensive think-tag scrubber ─────────────────────────────────────────
+# Jun 9 2026: added to plug the /think msg leak.  The stateful scrubber
+# upstream (_filter_and_accumulate) and the agent-level strip_think_blocks
+# both have hardcoded tag lists that miss model-name-prefixed variants
+# (e.g. </M2_7think>, </deepseek_thought>) — and the orphan-pass regex
+# requires trailing whitespace, so an orphan close glued to surrounding
+# text slips through.  This module-level scrubber runs on the *visible*
+# text right before each platform send, catches anything tag-shaped that
+# the upstream paths missed, and is idempotent.
+_THINK_KW = r'(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)'
+_THINK_CLOSED_PAIR_RE = re.compile(
+    rf'<[^>]*{_THINK_KW}[^>]*>.*?</[^>]*{_THINK_KW}[^>]*>',
+    re.DOTALL | re.IGNORECASE,
+)
+_THINK_TAG_RE = re.compile(
+    rf'<[^>]*{_THINK_KW}[^>]*>',
+    re.IGNORECASE,
+)
+
+
+def scrub_thinking_tags_in_prose(text: str) -> str:
+    """Remove any residual think-tag characters from user-visible prose.
+
+    Defensive safety-net pass: runs AFTER all upstream stateful scrubbing
+    and the agent-level strip_think_blocks.  Catches three classes of leak:
+
+      1. Model-prefixed tag variants the hardcoded tag lists miss
+         (e.g. </M2_7think>, </deepseek_thought>).
+      2. Orphan close tags attached to surrounding text without trailing
+         whitespace (the upstream orphan-pass regex requires ``\\s*``).
+      3. Anything else that ends up looking like a think-tag in the
+         final visible text, regardless of why.
+
+    The pattern is intentionally permissive — any tag whose name
+    contains a known reasoning keyword as a substring, case-insensitive —
+    and runs without block-boundary checks.  False positives (a model
+    legitimately using ``<thinkful>``-style names in prose) are vastly
+    less harmful than false negatives (a literal think-tag close
+    leaking raw reasoning to the user).
+
+    Idempotent: running twice produces the same output as running once.
+    """
+    if not text:
+        return ""
+    text = _THINK_CLOSED_PAIR_RE.sub("", text)
+    text = _THINK_TAG_RE.sub("", text)
     return text
 
 
@@ -1138,6 +1188,8 @@ class GatewayStreamConsumer:
         Returns the message_id so callers can thread subsequent chunks.
         """
         text = self._clean_for_display(text)
+        # Defensive think-tag scrub — see scrub_thinking_tags_in_prose.
+        text = scrub_thinking_tags_in_prose(text)
         if not text.strip():
             return reply_to_id
         try:
@@ -1248,6 +1300,8 @@ class GatewayStreamConsumer:
         Retries each chunk once on flood-control failures with a short delay.
         """
         final_text = self._clean_for_display(text)
+        # Defensive think-tag scrub — see scrub_thinking_tags_in_prose.
+        final_text = scrub_thinking_tags_in_prose(final_text)
         # Ensure balanced code fences before computing continuation,
         # so the closing fence reaches the user even when the fallback
         # only delivers the tail after mid-stream edits failed.
@@ -1669,6 +1723,8 @@ class GatewayStreamConsumer:
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""
         text = self._clean_for_display(text)
+        # Defensive think-tag scrub — see scrub_thinking_tags_in_prose.
+        text = scrub_thinking_tags_in_prose(text)
         if not text.strip():
             return False
         try:
@@ -1925,6 +1981,10 @@ class GatewayStreamConsumer:
         # Media files are delivered as native attachments after the stream
         # finishes (via _deliver_media_from_response in gateway/run.py).
         text = self._clean_for_display(text)
+        # Defensive: scrub any think-tag characters the upstream scrubbers
+        # missed (model-prefixed variants, orphan closes glued to text, …).
+        # Jun 9 2026 — see scrub_thinking_tags_in_prose docstring.
+        text = scrub_thinking_tags_in_prose(text)
         # Ensure code fences are balanced before send/edit.  Model output
         # truncated mid-code-block (e.g. finish_reason="length") leaves an
         # orphaned ``` which, on Discord/Slack/Matrix, causes the entire


### PR DESCRIPTION
## Summary

The hardcoded tag-name regexes in `strip_think_blocks()` (`agent/agent_runtime_helpers.py`) and the stateful filter in `gateway/stream_consumer.py` miss model-prefixed/suffixed tag variants that providers actually emit:

- `<M2_7think>` (MiniMax M2.7 leaves the model name on the open tag)
- `<deepseek_thought>` (DeepSeek reasoned answers)
- `<M2_7reasoning>`, `</M2_7think>` orphan close glued to surrounding text
- Mixed variants like `<M2_7reasoning>…</M2_7reasoning>` and the cross-tag case `<M2_7think>…</thinking>`

These have been observed leaking raw reasoning into user-visible content (the `/think msg issue`, first reported Jun 9 2026). MiniMax and DeepSeek are the most frequent offenders but the same shape affects any model that prefixes its reasoning tag with the model name.

## What this fixes

### `agent/agent_runtime_helpers.py` — `strip_think_blocks()`

- Replaces 5 hardcoded closed-pair regexes with a single permissive pattern so any tag whose name contains `think | thinking | reasoning | thought | REASONING_SCRATCHPAD` (case-insensitive, as substring) is matched. The open and close tags don't have to match each other — `<M2_7reasoning>…</M2_7reasoning>` and the cross-tag case `<M2_7reasoning>…</thinking>` are intentionally caught.
- Same permissive matching on the unterminated-block pass (regex #2) and the orphan-tag pass (regex #3) so the same variant classes get stripped at the agent layer.

### `gateway/stream_consumer.py` — defensive scrubber

- Adds a module-level `scrub_thinking_tags_in_prose()` that runs on the visible text immediately before each platform send. Catches the residue of the agent-level stripping AND anything the stateful scrubber (whose orphan-pass regex requires `\s*` trailing whitespace) missed on a no-whitespace orphan close.
- Wired into all four `_clean_for_display()` call sites that produce user-visible text:
  - `_send_chunk` (every streamed message)
  - `_send_fallback_final` (terminal recovery path)
  - `_send_commentary` (interim commentary blocks)
  - The final media-dispatch path in `_deliver_or_finalize`
- Adds the missing `import re` that the new helpers need (independent small fix).

## Why defensive at the stream-consumer layer too

Per the existing rubric (AGENTS.md): per-conversation prompt caching is sacred and we don't gate user-visible correctness on single-layer stateful scrubbing. The agent-level strip runs at the model-output boundary; the stream-consumer scrub is a belt-and-suspenders at the platform-send boundary. The two layers cover different bug classes (the agent strip handles unterminated blocks and orphan closes with whitespace; the consumer scrub handles orphan closes without whitespace and any tag-shaped residue that survived both upstream passes).

## Test Plan

- [ ] `python3 -m pytest tests/agent/test_think_scrubber.py tests/agent/test_streaming_context_scrubber.py -o 'addopts='` — 33 tests pass on this branch (verified locally)
- [ ] New smoke test for `strip_think_blocks()`:
  - `<M2_7think>secret reasoning</M2_7think>visible` → `visible`
  - `<deepseek_thought>x</deepseek_thought>clean` → `clean`
  - `plain text` + unterminated `<M2_7think>` → `plain text` (and trailing content dropped, matching the existing unterminated-block pass behavior)
- [ ] New smoke test for `scrub_thinking_tags_in_prose()`:
  - `before <M2_7think>leak</M2_7think> after` → `before  after`
  - `<deepseek_thought>x</deepseek_thought>` → `` (empty)

## Notes for reviewers

- The permissive regex is intentionally a **superset** of the old hardcoded patterns — every variant the old code matched still matches, only more variants match too. False positives on tag-shaped text in prose (e.g. `<thinkful>` mentioned in a sentence) are vastly less harmful than false negatives leaking raw reasoning to the user.
- The `scrub_thinking_tags_in_prose()` pass is idempotent and runs without block-boundary checks — safest to call on already-cleaned text after all the other upstream passes.
- No model-tool surface change. No prompt-cache surface change. No system-prompt change. Pure regex hardening and one defensive helper.
