### PR TITLE
fix(telegram): preserve conflict retry backoff after transient progress

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -753,6 +753,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._drop_delayed_deliveries = False
         self._polling_error_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
+        self._polling_conflict_recovery_generation: Optional[int] = None
         self._polling_network_error_count: int = 0
         self._polling_generation: int = 0
         self._polling_progress_event = asyncio.Event()
@@ -2097,7 +2098,10 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        self._polling_conflict_count = 0
+        if generation == self._polling_conflict_recovery_generation:
+            self._polling_conflict_recovery_generation = None
+        else:
+            self._polling_conflict_count = 0
         self._send_path_degraded = False
 
     def _observe_polling_request_result(self, request, generation, result):
@@ -3055,9 +3059,11 @@ class TelegramAdapter(BasePlatformAdapter):
             # AttributeError deep inside start_polling instead of failing fast
             # here, where the except below reschedules or escalates to fatal.
             app = self._app
+            expected_generation = self._polling_generation + 1
             try:
                 if not app:
                     raise RuntimeError("Telegram application was torn down during conflict reconnect")
+                self._polling_conflict_recovery_generation = expected_generation
                 await self._start_polling_once(
                     app,
                     drop_pending_updates=False,
@@ -3070,8 +3076,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 return
             except _PollingLifecycleAbort:
+                if self._polling_conflict_recovery_generation == expected_generation:
+                    self._polling_conflict_recovery_generation = None
                 return
             except Exception as retry_err:
+                if self._polling_conflict_recovery_generation == expected_generation:
+                    self._polling_conflict_recovery_generation = None
                 if getattr(self, "_polling_teardown_started", False):
                     return
                 logger.warning(

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -143,6 +143,44 @@ async def test_polling_conflict_retries_before_fatal(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_conflict_retry_progress_does_not_reset_retry_ladder(monkeypatch):
+    """First getUpdates progress after a conflict retry is not durable recovery.
+
+    Telegram can accept the first long-poll after a retry and then return a 409
+    from the still-expiring previous session. That transient success must not
+    reset the retry counter back to 0, or every new 409 looks like attempt 1/5
+    and the backoff never reaches the server-side expiry window.
+    """
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter.set_fatal_error_handler(AsyncMock())
+    adapter._drain_polling_connections = AsyncMock()
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    calls = {"n": 0}
+
+    async def fake_start_polling(**_kwargs):
+        calls["n"] += 1
+        adapter._record_polling_progress(adapter._polling_generation)
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(side_effect=fake_start_polling),
+        stop=AsyncMock(),
+        running=True,
+    )
+    adapter._app = SimpleNamespace(updater=updater)
+
+    conflict = type("Conflict", (Exception,), {})
+    await adapter._handle_polling_conflict(
+        conflict("Conflict: terminated by other getUpdates request")
+    )
+
+    assert calls["n"] == 1
+    assert adapter._polling_conflict_count == 1
+    assert adapter._polling_conflict_recovery_generation is None
+    assert adapter._send_path_degraded is False
+
+
+@pytest.mark.asyncio
 async def test_polling_conflict_becomes_fatal_after_retries(monkeypatch):
     """After exhausting retries, the conflict should become fatal."""
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))


### PR DESCRIPTION
## Summary
- keep conflict-retry reconnects queue-preserving with `drop_pending_updates=False`
- prevent the first successful getUpdates response after a conflict retry from resetting the conflict retry ladder
- add regression coverage for the transient-success case that previously made repeated 409s look like attempt 1/5 forever

Fixes #75017

## Tests
- `scripts/run_tests.sh tests/gateway/test_telegram_conflict.py tests/gateway/test_platform_reconnect.py -q`
- `python3 -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_conflict.py`
- `git diff --check`

## Notes
This replaces the withdrawn #75073 approach. It does not use `drop_pending_updates=True`, so queued Telegram updates remain preserved during reconnects.
