### PR TITLE
fix(cron): route execution ledger to the active profile home

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -12,21 +12,42 @@ import sqlite3
 import threading
 import uuid
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
 EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
+_IMPORT_TIME_EXECUTIONS_FILE = EXECUTIONS_FILE
 MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
 
 
+def _executions_file() -> Path:
+    """Resolve the ledger path for the current execution context.
+
+    A deliberately re-pointed module constant wins (the documented
+    test/embedder surface — monkeypatching EXECUTIONS_FILE keeps working).
+    Otherwise delegate to ``cron.jobs._current_cron_store`` so EVERY
+    scoping mechanism — the use_cron_store() ContextVar (highest
+    precedence there), re-pointed jobs constants, and context-local
+    set_hermes_home_override — routes the row to the active profile's
+    ledger instead of the import-time frozen one.
+    """
+    if EXECUTIONS_FILE != _IMPORT_TIME_EXECUTIONS_FILE:
+        return EXECUTIONS_FILE
+    from cron.jobs import _current_cron_store
+
+    return _current_cron_store().cron_dir / "executions.db"
+
+
 def _connect() -> sqlite3.Connection:
-    EXECUTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    return sqlite3.connect(EXECUTIONS_FILE, timeout=5)
+    target = _executions_file()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(target, timeout=5)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -397,3 +397,73 @@ def test_job_listing_exposes_latest_execution(monkeypatch, tmp_path):
     listed = jobs.list_jobs(include_disabled=True)
     assert listed[0]["latest_execution"]["id"] == record["id"]
     assert listed[0]["latest_execution"]["status"] == "running"
+
+
+def test_execution_lands_in_active_profile_home(monkeypatch, tmp_path):
+    """Multiplex: an execution created under a profile home override must
+    land in THAT profile's ledger, not the import-time frozen one.
+
+    Regression: EXECUTIONS_FILE was frozen at import time, so under
+    multiplex_profiles every profile's execution rows went into the launch
+    profile's executions.db and secondary profiles showed empty history.
+    """
+    import cron.executions as executions
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from cron.jobs import use_cron_store
+
+    profile_home = tmp_path / "profileB"
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        with use_cron_store(profile_home):
+            executions.create_execution("job-B", source="cron")
+    finally:
+        reset_hermes_home_override(token)
+
+    db = profile_home / "cron" / "executions.db"
+    assert db.exists()
+    rows = sqlite3.connect(db).execute(
+        "SELECT job_id, source, status FROM executions"
+    ).fetchall()
+    assert rows == [("job-B", "cron", "claimed")]
+
+    # The import-time ledger must NOT have received the row.
+    frozen = executions._IMPORT_TIME_EXECUTIONS_FILE
+    if frozen.exists():
+        frozen_rows = sqlite3.connect(frozen).execute(
+            "SELECT job_id FROM executions WHERE job_id = 'job-B'"
+        ).fetchall()
+        assert frozen_rows == []
+
+
+def test_execution_lands_in_cron_store_only_context(monkeypatch, tmp_path):
+    """A use_cron_store()-only scope (no hermes-home override) must route
+    the ledger too — the ContextVar has highest precedence in
+    cron.jobs._current_cron_store, so the ledger resolver must follow it,
+    not just get_hermes_home()."""
+    import cron.executions as executions
+    from cron.jobs import use_cron_store
+
+    store_home = tmp_path / "storeOnly"
+    with use_cron_store(store_home):
+        rec = executions.create_execution("job-S", source="cron")
+        # Reads resolve through the same context (lookup, not just write).
+        latest = executions.latest_execution("job-S")
+        assert latest is not None and latest["id"] == rec["id"]
+
+    db = store_home / "cron" / "executions.db"
+    assert db.exists()
+    rows = sqlite3.connect(db).execute(
+        "SELECT job_id, source, status FROM executions"
+    ).fetchall()
+    assert rows == [("job-S", "cron", "claimed")]
+
+    # The import-time ledger must NOT have received the row.
+    frozen = executions._IMPORT_TIME_EXECUTIONS_FILE
+    if frozen.exists():
+        frozen_rows = sqlite3.connect(frozen).execute(
+            "SELECT job_id FROM executions WHERE job_id = 'job-S'"
+        ).fetchall()
+        assert frozen_rows == []


### PR DESCRIPTION
## What does this PR do?

Fixes the cron execution ledger ignoring per-profile scoping under `multiplex_profiles`.

`cron/executions.py` froze `EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"` at import time and used it verbatim in `_connect()`. Every other piece of the cron store was made profile-aware — `cron/jobs.py` resolves paths per call through `_current_cron_store()`, and the multiplex ticker (`cron/scheduler_provider.py`) wraps each profile's tick in `set_hermes_home_override(home)` + `use_cron_store(home)`. The ledger honored neither mechanism.

Concretely, under multiplex mode:

- all profiles' execution rows are written into the **launch** profile's `executions.db`
- `hermes cron list` / `hermes cron executions` for a secondary profile shows **empty history** (its own `executions.db` is never created)
- the launch profile's ledger mixes rows from every profile's jobs — cross-profile `job_id` collisions corrupt `latest_execution`

The fix resolves the ledger path per `_connect()` call: a deliberately re-pointed module constant wins (the documented test/embedder surface — existing `monkeypatch.setattr(executions, "EXECUTIONS_FILE", ...)` tests keep working unchanged), otherwise it delegates to `cron.jobs._current_cron_store()` so **every** scoping mechanism applies — the `use_cron_store()` ContextVar (highest precedence there), re-pointed jobs constants, and context-local `set_hermes_home_override`. Default single-profile behavior is unchanged.

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/executions.py`: new `_executions_file()` resolver implementing the precedence above; `_connect()` uses it per call instead of the frozen constant.
- `tests/cron/test_execution_ledger.py`: two regression tests — an execution created under `set_hermes_home_override` + `use_cron_store` (exactly what the multiplex ticker installs) lands in the override profile's ledger; and a `use_cron_store()`-only context (no home override) routes both the write and a `latest_execution` lookup to the ContextVar's store, not the import-time ledger.

## How to Test

Reproduction (against pre-fix code):

```python
import cron.executions as ex            # imported with HERMES_HOME=homeA
from hermes_constants import set_hermes_home_override
from cron.jobs import use_cron_store

token = set_hermes_home_override("/path/homeB")
with use_cron_store("/path/homeB"):
    ex.create_execution("jobB123", source="cron")
# pre-fix:  homeA/cron/executions.db exists, homeB's is never created (BUG)
# post-fix: row lands in homeB/cron/executions.db; default context still writes homeA
```

Focused validation completed:

1. `bash scripts/run_tests.sh tests/cron/test_execution_ledger.py` — 20/20 pass.
2. Sabotage checks: stashing the whole change → the profile-home test fails (18 pass). Reverting to a `get_hermes_home()`-only resolver (no ContextVar delegation) → the cron-store-only test fails (19 pass) — each scoping mechanism is pinned by its own test.
3. Cron suites: `tests/cron/ tests/test_journal_mode_config.py tests/hermes_cli/test_cron.py tests/gateway/test_cron_fire_webhook.py` — 402/402 pass. (The existing `monkeypatch.setattr(EXECUTIONS_FILE)` tests pass unchanged, confirming the documented test surface is preserved.)
4. Full repo-wide suite, `bash scripts/run_tests.sh` (branch): 22,819 pass / 97 fail. Baseline on clean `main` (this branch's parent), same machine: 22,816 pass / 99 fail — the failing-file sets are **identical** (48 files, environment-dependent lanes: LSP e2e, browser, MCP, voice/TTS; no API keys/services locally). Zero new failures; nothing in the cron/state surface fails.
4. `uvx --from ruff==0.15.10 ruff check cron/executions.py tests/cron/test_execution_ledger.py` — clean.
5. `git diff --check` — clean.
6. Adversarial cases executed live: override context routes to the override home with the correct row contents; default context (no override) still writes the import-time home; re-pointed constant keeps precedence over the override (test surface).

The full repo-wide suite was run locally with results verified identical to clean `main` (see How to Test); GitHub CI remains the final confirmation environment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite run locally via `scripts/run_tests.sh`; failures are pre-existing/environment-dependent and verified identical to clean `main` (see How to Test, item 4)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (resolver docstring documents the precedence)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — path resolution only, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Logs

Sabotage verification output:

```
# pre-fix code:
=== Summary: 1 files, 18 tests passed, 1 failed ===   (profile-home test)
# get_hermes_home()-only resolver (no ContextVar delegation):
=== Summary: 1 files, 19 tests passed, 1 failed ===   (cron-store-only test)
# full fix:
=== Summary: 1 files, 20 tests passed, 0 failed ===
```

