### PR TITLE
fix(agent): stop double-counting api_content in the token estimator

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2965,6 +2965,52 @@ def _count_image_tokens(msg: Dict[str, Any], cost_per_image: int) -> int:
     return count * cost_per_image
 
 
+def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
+    """Shadow of a message holding only what the provider actually receives.
+
+    Two adjustments to the raw persisted dict:
+
+    * ``api_content`` is a SUBSTITUTE for ``content``, not an addition to it.
+      ``turn_context.substitute_api_content()`` pops the sidecar and overwrites
+      ``content`` at every API-bound build site, so exactly one of the two is
+      ever sent. Counting both double-counts any message whose sidecar differs
+      from its clean stored content (2.00x on a 40KB sidecar).
+    * Base64 image payloads are replaced with a placeholder; they are charged
+      separately at a flat rate by ``_count_image_tokens``, and counting their
+      raw chars here would massively overestimate usage.
+    """
+    shadow: Dict[str, Any] = {}
+    for k, v in msg.items():
+        if k == "_anthropic_content_blocks":
+            continue
+        if k == "api_content":
+            shadow["content"] = v
+            continue
+        if k == "content":
+            if "api_content" in msg:
+                # The sidecar wins on the wire; skip the clean copy so the
+                # same logical content is not counted twice.
+                continue
+            if isinstance(v, list):
+                cleaned = []
+                for part in v:
+                    if isinstance(part, dict):
+                        if part.get("type") in {"image", "image_url", "input_image"}:
+                            cleaned.append({"type": part.get("type"), "image": "[stripped]"})
+                        else:
+                            cleaned.append(part)
+                    else:
+                        cleaned.append(part)
+                shadow[k] = cleaned
+            elif isinstance(v, dict) and v.get("_multimodal"):
+                shadow[k] = v.get("text_summary", "")
+            else:
+                shadow[k] = v
+        else:
+            shadow[k] = v
+    return shadow
+
+
 def _estimate_message_chars(msg: Dict[str, Any]) -> int:
     """Char count for token estimation, excluding base64 image data.
 
@@ -2973,58 +3019,14 @@ def _estimate_message_chars(msg: Dict[str, Any]) -> int:
     """
     if not isinstance(msg, dict):
         return len(str(msg))
-    shadow: Dict[str, Any] = {}
-    for k, v in msg.items():
-        if k == "_anthropic_content_blocks":
-            continue
-        if k == "content":
-            if isinstance(v, list):
-                cleaned = []
-                for part in v:
-                    if isinstance(part, dict):
-                        if part.get("type") in {"image", "image_url", "input_image"}:
-                            cleaned.append({"type": part.get("type"), "image": "[stripped]"})
-                        else:
-                            cleaned.append(part)
-                    else:
-                        cleaned.append(part)
-                shadow[k] = cleaned
-            elif isinstance(v, dict) and v.get("_multimodal"):
-                shadow[k] = v.get("text_summary", "")
-            else:
-                shadow[k] = v
-        else:
-            shadow[k] = v
-    return len(str(shadow))
+    return len(str(_wire_message_shadow(msg)))
 
 
 def _estimate_message_tokens_without_images(msg: Dict[str, Any]) -> int:
     """Token estimate for a message shadow with image payloads stripped."""
     if not isinstance(msg, dict):
         return estimate_tokens_rough(str(msg))
-    shadow: Dict[str, Any] = {}
-    for k, v in msg.items():
-        if k == "_anthropic_content_blocks":
-            continue
-        if k == "content":
-            if isinstance(v, list):
-                cleaned = []
-                for part in v:
-                    if isinstance(part, dict):
-                        if part.get("type") in {"image", "image_url", "input_image"}:
-                            cleaned.append({"type": part.get("type"), "image": "[stripped]"})
-                        else:
-                            cleaned.append(part)
-                    else:
-                        cleaned.append(part)
-                shadow[k] = cleaned
-            elif isinstance(v, dict) and v.get("_multimodal"):
-                shadow[k] = v.get("text_summary", "")
-            else:
-                shadow[k] = v
-        else:
-            shadow[k] = v
-    return estimate_tokens_rough(str(shadow))
+    return estimate_tokens_rough(str(_wire_message_shadow(msg)))
 
 
 def estimate_request_tokens_rough(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2975,19 +2975,35 @@ def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
       ``content`` at every API-bound build site, so exactly one of the two is
       ever sent. Counting both double-counts any message whose sidecar differs
       from its clean stored content (2.00x on a 40KB sidecar).
+
+      The substitution mirrors that helper's guard exactly: only a non-empty
+      STRING sidecar on a ``user``/``assistant`` row displaces ``content``.
+      Any other sidecar shape is popped and discarded on the wire without
+      touching ``content``, so a shadow that substituted unconditionally
+      would UNDERcount those rows — the dangerous direction, since it makes
+      compaction fire too late and the turn dies on a hard context error.
     * Base64 image payloads are replaced with a placeholder; they are charged
       separately at a flat rate by ``_count_image_tokens``, and counting their
       raw chars here would massively overestimate usage.
     """
+    sidecar = msg.get("api_content")
+    sidecar_wins = (
+        isinstance(sidecar, str)
+        and bool(sidecar)
+        and msg.get("role") in ("user", "assistant")
+    )
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
         if k == "_anthropic_content_blocks":
             continue
         if k == "api_content":
-            shadow["content"] = v
+            # Always popped before the request is built; only counted when it
+            # actually replaces ``content``.
+            if sidecar_wins:
+                shadow["content"] = v
             continue
         if k == "content":
-            if "api_content" in msg:
+            if sidecar_wins:
                 # The sidecar wins on the wire; skip the clean copy so the
                 # same logical content is not counted twice.
                 continue

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -79,6 +79,43 @@ class TestEstimateMessagesTokensRough:
         # string representation.
         assert 1500 <= result < 2000
 
+    def test_api_content_substitutes_for_content_not_added_to_it(self):
+        """``api_content`` replaces ``content`` on the wire, so count one.
+
+        ``turn_context.substitute_api_content()`` pops the sidecar and
+        overwrites ``content`` at every API-bound build site. Counting both
+        doubled the estimate for any message carrying a sidecar.
+        """
+        body = "cached prompt bytes " * 2000
+        wire_shape = {"role": "user", "content": body}
+        persisted_shape = {"role": "user", "content": body, "api_content": body}
+
+        assert estimate_messages_tokens_rough([persisted_shape]) == \
+            estimate_messages_tokens_rough([wire_shape])
+
+    def test_api_content_is_counted_when_it_differs_from_content(self):
+        """The sidecar is what's sent, so its size is the one that matters."""
+        big_sidecar = "cached prompt bytes " * 2000
+        msg = {"role": "user", "content": "short", "api_content": big_sidecar}
+
+        result = estimate_messages_tokens_rough([msg])
+
+        # Lower bound: fails if the sidecar were dropped rather than
+        # substituted (which would undercount the real request).
+        assert result >= (len(big_sidecar) // 4) * 0.9
+
+    def test_api_content_does_not_defeat_image_stripping(self):
+        """A sidecar must not smuggle raw base64 past the flat image rate."""
+        import base64
+        import os
+
+        payload = "data:image/png;base64," + base64.b64encode(os.urandom(300_000)).decode()
+        msg = {"role": "user",
+               "content": [{"type": "image_url", "image_url": {"url": payload}}]}
+
+        # Raw base64 would be ~100K tokens; the flat per-image model is ~1.5K.
+        assert estimate_messages_tokens_rough([msg]) < 5_000
+
 
 
 class TestEstimateRequestTokensRough:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -104,8 +104,36 @@ class TestEstimateMessagesTokensRough:
         # substituted (which would undercount the real request).
         assert result >= (len(big_sidecar) // 4) * 0.9
 
-    def test_api_content_does_not_defeat_image_stripping(self):
-        """A sidecar must not smuggle raw base64 past the flat image rate."""
+    def test_non_string_api_content_does_not_displace_content(self):
+        """Only a sidecar shape the wire actually substitutes may displace content.
+
+        ``substitute_api_content()`` overwrites ``content`` only for a
+        non-empty STRING sidecar on a user/assistant row; every other shape
+        is popped and discarded, leaving the clean ``content`` on the wire.
+        The shadow must mirror that guard — substituting unconditionally
+        would drop the real content from the estimate and UNDERcount, which
+        is the dangerous direction (compaction fires too late and the turn
+        dies on a hard context error).
+        """
+        body = "clean stored content " * 2000
+        baseline = estimate_messages_tokens_rough([{"role": "user", "content": body}])
+
+        for bad_sidecar in (None, "", 42, ["not", "a", "string"]):
+            msg = {"role": "user", "content": body, "api_content": bad_sidecar}
+            assert estimate_messages_tokens_rough([msg]) >= baseline, bad_sidecar
+
+        # Same for a role the substitution never applies to.
+        tool_row = {"role": "tool", "content": body, "api_content": "ignored"}
+        assert estimate_messages_tokens_rough([tool_row]) >= baseline
+
+    def test_image_stripping_survives_shadow_extraction(self):
+        """Non-regression for the ``_wire_message_shadow()`` extraction.
+
+        Both estimator helpers now share one shadow builder; this pins the
+        flat per-image accounting that the extraction moved, independent of
+        the ``api_content`` fix (a valid sidecar is a string, so it cannot
+        carry an image list).
+        """
         import base64
         import os
 


### PR DESCRIPTION
## What changed and why

`api_content` is a **substitute** for `content`, not an addition to it. `turn_context.substitute_api_content()` pops the sidecar and overwrites `content` at every API-bound message-build site (the `api_messages` build in `conversation_loop`, the max-iterations summary in `chat_completion_helpers`, the chat-completions transport), so exactly one of the two is ever sent to the provider.

The preflight estimator counted **both**. Both `_estimate_message_chars` and `_estimate_message_tokens_without_images` walked every key of the persisted message dict behind a single-entry denylist (`_anthropic_content_blocks`), so any message carrying a sidecar that differs from its clean stored content was counted twice — exactly **2.00x** on a 40KB sidecar:

```
upstream estimate, wire shape       (content only)          10,008
upstream estimate, persisted shape  (content + sidecar)     20,013
                                                            = 2.00x
```

Two reasons this is worth fixing rather than tolerating as "rough":

- The sidecar exists specifically to keep the provider prompt-cache prefix byte-stable across turns, so it is written on precisely the **long, cache-pinned** messages where doubling hurts most.
- `estimate_messages_tokens_rough()` is not display-only — it feeds the compaction threshold through `context_compressor` and `conversation_loop`. An inflated estimate makes compression fire on bytes that were never sent.

## Approach

Substitute rather than sum, mirroring what `substitute_api_content()` does on the wire.

The two estimator helpers had drifted into near-identical copies of the same shadow-building loop, so rather than patch one site and leave the other subtly different, this factors the shared logic into `_wire_message_shadow()` and fixes the class once. Net effect on behaviour is limited to `api_content`; the refactor is otherwise mechanical.

Image accounting is deliberately untouched — base64 payloads are still replaced with a placeholder and charged at the flat `_count_image_tokens` rate, and the `_multimodal` `text_summary` path is preserved.

## How to test

```bash
python -m pytest tests/agent/test_model_metadata.py -q
python -m pytest tests/agent -q -k "compress or context or token or estimate or prune"
```

Three new cases in `TestEstimateMessagesTokensRough`:

1. `test_api_content_substitutes_for_content_not_added_to_it` — sidecar equal to content is counted **once** (this is the regression guard; reverting the substitution fails it).
2. `test_api_content_is_counted_when_it_differs_from_content` — a **lower bound**, so it fails if the field were dropped rather than substituted. Dropping it would undercount the real request, which is the more dangerous direction: compaction would fire too late and the turn dies on a hard context error instead of compacting early.
3. `test_api_content_does_not_defeat_image_stripping` — a sidecar cannot smuggle raw base64 past the flat image rate.

Results on this branch:

- `53 passed` — `tests/agent/test_model_metadata.py`
- `57 passed` — with `tests/agent/test_context_breakdown.py`
- `656 passed, 3 skipped` — compression/context/token/estimate/prune surface of `tests/agent`
- Mutation-tested: reverting the substitution fails case 1 above.

## Platforms tested

Linux (x86_64, Python 3.11). `scripts/check-windows-footguns.py` is not applicable — this change touches no file I/O, process management, terminal handling, subprocesses, or signals. Pure dict/str logic, so cross-platform behaviour is identical.

## Related

Same function, deliberately **not** the same bug as the reasoning-field over-count tracked in #73298 (with #72087 and #73306 in flight). Those concern the `reasoning` / `reasoning_content` / `reasoning_details` triple-count; this is the independent `api_content` double-count and touches a disjoint branch of the same loop. Kept separate to stay one-logical-change-per-PR and to avoid conflicting with that work.

One note for whoever consolidates #72087 / #73306, since it bit me: the exclusion at the top of these loops names `_anthropic_content_blocks` with a **leading underscore**, while the wire path writes `anthropic_content_blocks` (`chat_completion_helpers` → `anthropic_adapter`). The real replay channel is therefore counted only by accident today, and reshaping this loop into a field **allowlist** silently drops it — a ~1000x undercount on thinking models. Details in my comment on #72087. This PR keeps the denylist shape precisely to avoid that trap.
