### PR TITLE
fix(kanban): throttle repeated same-reason respawn_guarded events

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7862,6 +7862,46 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
+# How long to suppress repeated same-reason ``respawn_guarded`` events for a
+# task. The dispatcher ticks roughly every minute; without a throttle, a card
+# held by a persistent guard (e.g. ``active_pr`` while a PR waits in review)
+# accumulates hundreds of identical event rows. One event per material state
+# change plus an hourly heartbeat keeps the tail diagnosable without spam
+# (t_de3555cc).
+_RESPAWN_GUARD_EVENT_THROTTLE_SECONDS = 3600
+
+
+def _should_log_respawn_guard(
+    conn: sqlite3.Connection, task_id: str, reason: str
+) -> bool:
+    """Return True if a ``respawn_guarded`` event should be appended now.
+
+    Logs when (a) the task has no prior ``respawn_guarded`` event, (b) the
+    most recent one carries a DIFFERENT reason (material state change), or
+    (c) the most recent same-reason event is older than
+    ``_RESPAWN_GUARD_EVENT_THROTTLE_SECONDS`` (periodic heartbeat).
+    Never weakens the guard itself — callers still skip the spawn either way.
+    """
+    row = conn.execute(
+        "SELECT payload, created_at FROM task_events "
+        "WHERE task_id = ? AND kind = 'respawn_guarded' "
+        "ORDER BY created_at DESC, id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return True
+    try:
+        prev_reason = (json.loads(row["payload"]) or {}).get("reason")
+    except Exception:
+        prev_reason = None
+    if prev_reason != reason:
+        return True
+    return (
+        int(time.time()) - int(row["created_at"])
+        >= _RESPAWN_GUARD_EVENT_THROTTLE_SECONDS
+    )
+
+
 def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -8363,7 +8403,18 @@ def _dispatch_once_locked(
             # Emit an event so operators can see why the task was
             # skipped when reading `hermes kanban tail` — without
             # this the task appears stuck in ready with no diagnosis.
-            if not dry_run:
+            # Throttled: the dispatcher ticks every minute, so a card
+            # held by a persistent guard (e.g. active_pr while a PR sits
+            # in review for hours) would otherwise accumulate hundreds
+            # of identical events. We append only when the guard reason
+            # CHANGED since the last recorded guard event, or when the
+            # last same-reason event is older than the throttle window
+            # — one visible event per material state change, plus a
+            # periodic heartbeat so the tail still shows the hold is
+            # current (t_de3555cc).
+            if not dry_run and _should_log_respawn_guard(
+                conn, row["id"], guard_reason
+            ):
                 with write_txn(conn):
                     _append_event(
                         conn, row["id"], "respawn_guarded",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -502,6 +502,101 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+def test_respawn_guard_event_throttled_for_repeated_active_pr(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Repeated same-reason (active_pr) guarded passes must NOT append a new
+    respawn_guarded event every dispatcher tick — only the first pass records
+    one, until the throttle window elapses (t_de3555cc)."""
+    import hermes_cli.kanban_db as _kb
+
+    now = 6_000_000
+    monkeypatch.setattr(_kb.time, "time", lambda: now)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="pr-held", assignee="alice")
+        kb.add_comment(
+            conn, t, "w", "opened https://github.com/acme/repo/pull/42"
+        )
+
+        # First guarded pass: event recorded, no spawn.
+        res = kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        assert (t, "active_pr") in res.respawn_guarded
+        events = [e for e in kb.list_events(conn, t) if e.kind == "respawn_guarded"]
+        assert len(events) == 1
+        assert events[0].payload.get("reason") == "active_pr"
+
+        # Simulate 5 more dispatcher ticks a minute apart: still guarded
+        # (no spawn), but no new events appended.
+        for i in range(1, 6):
+            monkeypatch.setattr(_kb.time, "time", lambda i=i: now + i * 60)
+            res = kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+            assert (t, "active_pr") in res.respawn_guarded
+        events = [e for e in kb.list_events(conn, t) if e.kind == "respawn_guarded"]
+        assert len(events) == 1, (
+            f"expected repeated same-reason passes to be throttled; "
+            f"got {len(events)} events"
+        )
+
+        # After the throttle window elapses, one heartbeat event is allowed.
+        monkeypatch.setattr(
+            _kb.time,
+            "time",
+            lambda: now + _kb._RESPAWN_GUARD_EVENT_THROTTLE_SECONDS + 60,
+        )
+        kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        events = [e for e in kb.list_events(conn, t) if e.kind == "respawn_guarded"]
+        assert len(events) == 2
+
+
+def test_respawn_guard_event_logged_on_reason_change(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """A material state change (guard reason changes) is recorded even inside
+    the throttle window."""
+    import hermes_cli.kanban_db as _kb
+
+    now = 6_100_000
+    monkeypatch.setattr(_kb.time, "time", lambda: now)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="reason-change", assignee="alice")
+        # blocker_auth first: quota-flavored last failure error.
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("quota exceeded", t),
+        )
+        kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        events = [e for e in kb.list_events(conn, t) if e.kind == "respawn_guarded"]
+        assert [e.payload.get("reason") for e in events] == ["blocker_auth"]
+
+        # Reason changes to active_pr (clear error, add PR comment) one
+        # minute later — still well inside the throttle window, but the
+        # reason changed, so a new event must be appended.
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = NULL WHERE id = ?", (t,)
+        )
+        kb.add_comment(
+            conn, t, "w", "PR: https://github.com/acme/repo/pull/7"
+        )
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 60)
+        res = kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        assert (t, "active_pr") in res.respawn_guarded
+        events = [e for e in kb.list_events(conn, t) if e.kind == "respawn_guarded"]
+        assert [e.payload.get("reason") for e in events] == [
+            "blocker_auth",
+            "active_pr",
+        ]
+
+
+def test_should_log_respawn_guard_first_event_always_logs(kanban_home):
+    """No prior respawn_guarded event -> log."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="fresh", assignee="alice")
+        assert kb._should_log_respawn_guard(conn, t, "active_pr") is True
+
+
+
 
 
 


### PR DESCRIPTION
Dispatcher appended a respawn_guarded {reason} event every tick (~1/min) for ready cards held by a persistent guard (e.g. active_pr while a PR waits in review), spamming the task event log with hundreds of identical rows.

Fix: dispatch_once now appends the event only when (a) it's the first guard event for the task, (b) the guard reason CHANGED (material state change), or (c) the last same-reason event is older than a 1h throttle window (periodic heartbeat). The spawn guard itself is unchanged — guarded cards are still never spawned.

Regression coverage in tests/hermes_cli/test_kanban_db.py: first active_pr pass logs exactly one event; 5 subsequent per-minute passes log nothing; post-window heartbeat logs one more; reason change (blocker_auth -> active_pr) logs immediately inside the window.

Verified: 38 passed (test_kanban_db.py + test_kanban_diagnostics.py).