### PR TITLE
fix(gateway): separate Feishu conversation identity from thread routing

### DIFF
--- a/docs/design/feishu-conversation-identity.md
+++ b/docs/design/feishu-conversation-identity.md
@@ -1,0 +1,20 @@
+# Feishu conversation identity
+
+Feishu exposes a top-level message root (`om_*`) and, after a thread exists,
+a native delivery thread (`omt_*`). Hermes must not use one identifier for
+both responsibilities.
+
+- `SessionSource.conversation_id` is the stable model-session lane. A
+  top-level message uses its own message ID; replies use the thread root ID.
+- `SessionSource.thread_id` is the native platform delivery target only.
+- Session keys, participant-sharing decisions, restart recovery, and resume
+  scope checks use `conversation_id`, falling back to `thread_id` for adapters
+  that expose only one identity.
+- Outbound metadata and profile route matching continue to use `thread_id`.
+- `sessions.conversation_id` persists the logical lane independently from the
+  existing `sessions.thread_id` delivery field. Compression children inherit
+  both.
+
+All gateway key construction goes through the same config-aware helper so the
+adapter guard, Feishu batching, SessionStore, and GatewayRunner agree on the
+profile namespace before a turn enters the runner.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -548,7 +548,11 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
-from gateway.session import SessionSource, build_session_key
+from gateway.session import (
+    SessionSource,
+    build_session_key,
+    build_session_key_for_config,
+)
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
 
 
@@ -5551,11 +5555,9 @@ class BasePlatformAdapter(ABC):
         # Offloaded: the sync hook must not block the loop.
         await asyncio.to_thread(self._apply_topic_recovery, event)
 
-        session_key = build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-        )
+        runner = getattr(self, "gateway_runner", None)
+        key_config = getattr(runner, "config", None) or self.config
+        session_key = build_session_key_for_config(event.source, key_config)
 
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or
@@ -6560,6 +6562,7 @@ class BasePlatformAdapter(ABC):
         user_id: Optional[str] = None,
         user_name: Optional[str] = None,
         thread_id: Optional[str] = None,
+        conversation_id: Optional[str] = None,
         chat_topic: Optional[str] = None,
         user_id_alt: Optional[str] = None,
         chat_id_alt: Optional[str] = None,
@@ -6585,9 +6588,9 @@ class BasePlatformAdapter(ABC):
             chat_topic = None
 
         # Resolve profile from configured routes (None when no match / no routes)
-        profile = None
+        profile = getattr(self, "_owned_profile", None)
         runner = getattr(self, "gateway_runner", None)
-        if runner is not None:
+        if profile is None and runner is not None:
             try:
                 profile = runner._profile_name_for_source(
                     SessionSource(
@@ -6598,6 +6601,9 @@ class BasePlatformAdapter(ABC):
                         user_id=str(user_id) if user_id else None,
                         user_name=user_name,
                         thread_id=str(thread_id) if thread_id else None,
+                        conversation_id=(
+                            str(conversation_id) if conversation_id else None
+                        ),
                         chat_topic=chat_topic.strip() if chat_topic else None,
                         user_id_alt=user_id_alt,
                         chat_id_alt=chat_id_alt,
@@ -6622,6 +6628,7 @@ class BasePlatformAdapter(ABC):
             user_id=str(user_id) if user_id else None,
             user_name=user_name,
             thread_id=str(thread_id) if thread_id else None,
+            conversation_id=str(conversation_id) if conversation_id else None,
             chat_topic=chat_topic.strip() if chat_topic else None,
             user_id_alt=user_id_alt,
             chat_id_alt=chat_id_alt,

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -198,6 +198,7 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
             or src.get("user_handle")
         ),
         thread_id=src.get("thread_id"),
+        conversation_id=src.get("conversation_id"),
         chat_topic=src.get("chat_topic"),
         user_id_alt=src.get("user_id_alt"),
         chat_id_alt=src.get("chat_id_alt"),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2191,8 +2191,10 @@ from gateway.session import (
     build_session_context_prompt,
     build_channel_continuity_note,
     build_session_key,
+    build_session_key_for_config,
     is_shared_multi_user_session,
     neutralize_untrusted_inline_text,
+    session_conversation_id,
 )
 from gateway.delivery import (
     DeliveryRouter,
@@ -3043,14 +3045,19 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    if len(parts) >= 5 and parts[0] == "agent":
         result = {
             "platform": parts[2],
             "chat_type": parts[3],
             "chat_id": parts[4],
         }
+        if parts[1] != "main":
+            result["profile"] = parts[1]
         if len(parts) > 5 and parts[3] in {"dm", "thread"}:
-            result["thread_id"] = parts[5]
+            if parts[2] == "feishu":
+                result["conversation_id"] = parts[5]
+            else:
+                result["thread_id"] = parts[5]
         return result
     return None
 
@@ -6317,26 +6324,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return session_key
             except Exception:
                 pass
-        config = getattr(self, "config", None)
-        # Mirror SessionStore._resolve_profile_for_key so this fallback path
-        # produces the same namespace as the primary path: None (legacy
-        # agent:main) unless multiplexing is on, then the active profile.
-        _profile = None
-        if getattr(config, "multiplex_profiles", False):
-            if source.profile:
-                _profile = source.profile
-            else:
-                try:
-                    from hermes_cli.profiles import get_active_profile_name
-                    _profile = get_active_profile_name() or "default"
-                except Exception:
-                    _profile = None
-        return build_session_key(
-            source,
-            group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
-            profile=_profile,
-        )
+        return build_session_key_for_config(source, getattr(self, "config", None))
 
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
@@ -11235,7 +11223,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     async def _process_handoff(self, row: Dict[str, Any]) -> None:
         """Execute one handoff row. Raises on failure (caller marks failed)."""
         from gateway.config import Platform
-        from gateway.session import SessionSource, build_session_key
+        from gateway.session import SessionSource
         from gateway.platforms.base import MessageEvent
 
         cli_session_id = row["id"]
@@ -11337,13 +11325,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # entry. For thread destinations build_session_key keys without
         # user_id (thread_sessions_per_user defaults to False) — so the
         # next real user message in the thread shares this same session.
-        platform_cfg = self.config.platforms.get(platform)
-        extra = platform_cfg.extra if platform_cfg else {}
-        session_key = build_session_key(
-            dest_source,
-            group_sessions_per_user=extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=extra.get("thread_sessions_per_user", False),
-        )
+        session_key = self._session_key_for_source(dest_source)
 
         # Make sure there's an entry in the session_store for this key. If
         # the home channel has never been used, get_or_create_session
@@ -12649,6 +12631,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform: Platform,
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
+        adapter._owned_profile = profile_name
         adapter.set_message_handler(self._make_profile_message_handler(profile_name))
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)
@@ -17605,7 +17588,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns an empty list when the source is not in a thread, or when no
         sibling runs exist — callers must still gate on authorization.
         """
-        thread_id = getattr(source, "thread_id", None)
+        thread_id = session_conversation_id(source)
         chat_id = getattr(source, "chat_id", None)
         if not thread_id or not chat_id:
             return []
@@ -17616,8 +17599,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # shared-thread key or any key with a further (user_id) segment
         # (prefix + ":") avoids cross-matching an unrelated thread whose id
         # merely starts with this one.
+        namespace = ":".join(str(own_key).split(":")[:2])
         prefix = ":".join(
-            ["agent:main", platform, chat_type, str(chat_id), str(thread_id)]
+            [namespace, platform, chat_type, str(chat_id), str(thread_id)]
         )
         matches = []
         for key, agent in self._running_agent_items():
@@ -20804,6 +20788,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             chat_id=chat_id,
             chat_type=chat_type,
             thread_id=str(evt.get("thread_id") or "").strip() or None,
+            conversation_id=(
+                str(evt.get("conversation_id") or "").strip() or None
+            ),
+            profile=str(evt.get("profile") or "").strip() or None,
             user_id=str(evt.get("user_id") or "").strip() or None,
             user_name=str(evt.get("user_name") or "").strip() or None,
         )
@@ -21143,8 +21131,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         evt["platform"] = parsed.get("platform", "")
         evt["chat_type"] = parsed.get("chat_type", "")
         evt["chat_id"] = parsed.get("chat_id", "")
+        if parsed.get("profile"):
+            evt["profile"] = parsed["profile"]
         if parsed.get("thread_id"):
             evt["thread_id"] = parsed["thread_id"]
+        if parsed.get("conversation_id"):
+            evt["conversation_id"] = parsed["conversation_id"]
 
     async def _async_delegation_watcher(self, interval: float = 2.0) -> None:
         """Drain async-delegation completions and inject them as new turns.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -162,6 +162,11 @@ class SessionSource:
     user_id: Optional[str] = None
     user_name: Optional[str] = None
     thread_id: Optional[str] = None  # For forum topics, Discord threads, etc.
+    # Stable logical conversation identity used for session isolation.  This
+    # may differ from ``thread_id`` when a platform creates a delivery thread
+    # only after replying to a top-level message (Feishu: ``om_*`` root versus
+    # native ``omt_*`` thread).  ``thread_id`` remains the outbound routing ID.
+    conversation_id: Optional[str] = None
     chat_topic: Optional[str] = None  # Channel topic/description (Discord, Slack)
     user_id_alt: Optional[str] = None  # Platform-specific stable alt ID (Signal UUID, Feishu union_id)
     chat_id_alt: Optional[str] = None  # Signal group internal ID
@@ -244,6 +249,7 @@ class SessionSource:
             "user_id": self.user_id,
             "user_name": self.user_name,
             "thread_id": self.thread_id,
+            "conversation_id": self.conversation_id,
             "chat_topic": self.chat_topic,
         }
         if self.user_id_alt:
@@ -280,6 +286,7 @@ class SessionSource:
             user_id=data.get("user_id"),
             user_name=data.get("user_name"),
             thread_id=data.get("thread_id"),
+            conversation_id=data.get("conversation_id"),
             chat_topic=data.get("chat_topic"),
             user_id_alt=data.get("user_id_alt"),
             chat_id_alt=data.get("chat_id_alt"),
@@ -1001,7 +1008,7 @@ def is_shared_multi_user_session(
     """
     if source.chat_type == "dm":
         return False
-    if source.thread_id:
+    if session_conversation_id(source):
         return not thread_sessions_per_user
     return not group_sessions_per_user
 
@@ -1026,6 +1033,58 @@ def _session_key_namespace(profile: Optional[str]) -> str:
     return f"agent:{profile}"
 
 
+def session_conversation_id(source: SessionSource) -> Optional[str]:
+    """Return the stable identity that partitions sessions within a chat.
+
+    ``conversation_id`` is authoritative when an adapter can distinguish the
+    logical conversation root from the platform's delivery thread ID.  The
+    ``thread_id`` fallback preserves every existing adapter's key format.
+    """
+    return getattr(source, "conversation_id", None) or getattr(source, "thread_id", None)
+
+
+def _session_config_value(config: Any, name: str, default: Any) -> Any:
+    """Read a session option from GatewayConfig or PlatformConfig.extra."""
+    if config is None:
+        return default
+    value = getattr(config, name, None)
+    if value is not None:
+        return value
+    extra = getattr(config, "extra", None)
+    if isinstance(extra, dict):
+        return extra.get(name, default)
+    return default
+
+
+def resolve_session_key_profile(
+    source: SessionSource, config: Any
+) -> Optional[str]:
+    """Resolve the profile namespace used by every gateway session-key path."""
+    if not _session_config_value(config, "multiplex_profiles", False):
+        return None
+    if source.profile:
+        return source.profile
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        return get_active_profile_name() or "default"
+    except Exception:
+        return None
+
+
+def build_session_key_for_config(source: SessionSource, config: Any) -> str:
+    """Build a session key using one config/profile resolution contract."""
+    return build_session_key(
+        source,
+        group_sessions_per_user=_session_config_value(
+            config, "group_sessions_per_user", True
+        ),
+        thread_sessions_per_user=_session_config_value(
+            config, "thread_sessions_per_user", False
+        ),
+        profile=resolve_session_key_profile(source, config),
+    )
+
+
 def build_session_key(
     source: SessionSource,
     group_sessions_per_user: bool = True,
@@ -1046,16 +1105,16 @@ def build_session_key(
         platforms retain their existing key format; in particular, Discord
         guild scope is intentionally not added here as a compatibility change.
       - DMs include chat_id when present, so each private conversation is isolated.
-      - thread_id further differentiates threaded DMs within the same DM chat.
-      - Without chat_id, thread_id is used as a best-effort fallback.
-      - Without thread_id or chat_id, DMs share a single session.
+      - conversation_id (falling back to thread_id) differentiates logical
+        conversations within the same DM chat.
 
     Group/channel rules:
       - Slack ``scope_id`` identifies the workspace before chat/thread ids.
       - chat_id identifies the parent group/channel.
       - user_id/user_id_alt isolates participants within that parent chat when available when
         ``group_sessions_per_user`` is enabled.
-      - thread_id differentiates threads within that parent chat.  When
+      - conversation_id (falling back to thread_id) differentiates logical
+        conversations within that parent chat.  When
         ``thread_sessions_per_user`` is False (default), threads are *shared* across all
         participants — user_id is NOT appended, so every user in the thread
         shares a single session.  This is the expected UX for threaded
@@ -1066,6 +1125,7 @@ def build_session_key(
     """
     ns = _session_key_namespace(profile)
     platform = source.platform.value
+    conversation_id = session_conversation_id(source)
     slack_scope_id = (
         str(source.scope_id)
         if source.platform == Platform.SLACK and source.scope_id
@@ -1081,8 +1141,8 @@ def build_session_key(
             dm_parts.append(slack_scope_id)
         if dm_chat_id:
             dm_parts.append(dm_chat_id)
-            if source.thread_id:
-                dm_parts.append(source.thread_id)
+            if conversation_id:
+                dm_parts.append(conversation_id)
             return ":".join(str(part) for part in dm_parts)
         # No chat_id — fall back to the sender's own identifier before the
         # bare per-platform sink.  Without this, every DM from every user that
@@ -1098,11 +1158,11 @@ def build_session_key(
             )
         if dm_participant_id:
             dm_parts.append(str(dm_participant_id))
-            if source.thread_id:
-                dm_parts.append(source.thread_id)
+            if conversation_id:
+                dm_parts.append(conversation_id)
             return ":".join(str(part) for part in dm_parts)
-        if source.thread_id:
-            dm_parts.append(source.thread_id)
+        if conversation_id:
+            dm_parts.append(conversation_id)
         return ":".join(str(part) for part in dm_parts)
 
     participant_id = source.user_id_alt or source.user_id
@@ -1117,14 +1177,14 @@ def build_session_key(
         key_parts.append(slack_scope_id)
     if source.chat_id:
         key_parts.append(source.chat_id)
-    if source.thread_id:
-        key_parts.append(source.thread_id)
+    if conversation_id:
+        key_parts.append(conversation_id)
 
     # In threads, default to shared sessions (all participants see the same
     # conversation).  Per-user isolation only applies when explicitly enabled
     # via thread_sessions_per_user, or when there is no thread (regular group).
     isolate_user = group_sessions_per_user
-    if source.thread_id and not thread_sessions_per_user:
+    if conversation_id and not thread_sessions_per_user:
         isolate_user = False
 
     if isolate_user and participant_id:
@@ -1515,15 +1575,9 @@ class SessionStore:
         to (``source.profile`` — set by the /p/<profile>/ URL prefix or
         per-credential adapter), falling back to the active profile name.
         """
-        if not getattr(self.config, "multiplex_profiles", False):
-            return None
-        if source is not None and source.profile:
-            return source.profile
-        try:
-            from hermes_cli.profiles import get_active_profile_name
-            return get_active_profile_name() or "default"
-        except Exception:
-            return None
+        if source is None:
+            source = SessionSource(platform=Platform.LOCAL, chat_id="cli")
+        return resolve_session_key_profile(source, self.config)
 
     @staticmethod
     def _profile_from_session_key(session_key: Optional[str]) -> Optional[str]:
@@ -1566,12 +1620,7 @@ class SessionStore:
 
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
-        return build_session_key(
-            source,
-            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
-            profile=self._resolve_profile_for_key(source),
-        )
+        return build_session_key_for_config(source, self.config)
 
     def _legacy_slack_session_key(self, source: SessionSource) -> Optional[str]:
         """Return the pre-workspace Slack key for an explicitly scoped source.
@@ -1693,6 +1742,7 @@ class SessionStore:
                 chat_id=source.chat_id if allow_peer_fallback else None,
                 chat_type=source.chat_type if allow_peer_fallback else None,
                 thread_id=source.thread_id,
+                conversation_id=source.conversation_id,
             )
         except Exception as exc:
             logger.debug(
@@ -1852,6 +1902,7 @@ class SessionStore:
                 chat_id=source.chat_id,
                 chat_type=source.chat_type,
                 thread_id=source.thread_id,
+                conversation_id=source.conversation_id,
                 display_name=display_name or source.chat_name,
                 origin_json=origin_json,
             )
@@ -2422,6 +2473,7 @@ class SessionStore:
                     "chat_id": source.chat_id,
                     "chat_type": source.chat_type,
                     "thread_id": source.thread_id,
+                    "conversation_id": source.conversation_id,
                     "profile_name": source.profile,
                 }
 
@@ -2741,6 +2793,9 @@ class SessionStore:
                 "chat_id": old_entry.origin.chat_id if old_entry.origin else None,
                 "chat_type": old_entry.origin.chat_type if old_entry.origin else None,
                 "thread_id": old_entry.origin.thread_id if old_entry.origin else None,
+                "conversation_id": (
+                    old_entry.origin.conversation_id if old_entry.origin else None
+                ),
                 "profile_name": old_entry.origin.profile if old_entry.origin else None,
             }
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -39,6 +39,7 @@ from gateway.session import (
     SessionSource,
     build_session_key,
     is_shared_multi_user_session,
+    session_conversation_id,
 )
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
 from utils import (
@@ -968,8 +969,8 @@ class GatewaySlashCommandsMixin:
         # WITHIN a thread, never across threads — require thread equality before
         # any sharing logic so a live origin in thread A cannot match a caller in
         # thread B of the same parent chat.
-        if str(getattr(current, "thread_id", "") or "") != str(
-            getattr(origin, "thread_id", "") or ""
+        if str(session_conversation_id(current) or "") != str(
+            session_conversation_id(origin) or ""
         ):
             return False
         chat_type = (getattr(current, "chat_type", "") or "").lower()
@@ -1071,8 +1072,8 @@ class GatewaySlashCommandsMixin:
         # or an admin override.
         caller_chat = str(getattr(source, "chat_id", "") or "")
         row_chat = str(row.get("chat_id") or "")
-        caller_thread = str(getattr(source, "thread_id", "") or "")
-        row_thread = str(row.get("thread_id") or "")
+        caller_thread = str(session_conversation_id(source) or "")
+        row_thread = str(row.get("conversation_id") or row.get("thread_id") or "")
         chat_type = (getattr(source, "chat_type", "") or "").lower()
         caller_is_dm = chat_type in {"dm", "direct", "private", ""}
         # build_session_key keys the participant on ``user_id_alt or user_id``

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2628,6 +2628,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         chat_id: str = None,
         chat_type: str = None,
         thread_id: str = None,
+        conversation_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
         profile_name: str = None,
@@ -2672,10 +2673,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             conn.execute(
                 """INSERT INTO sessions (
                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
+                   conversation_id,
                    model, model_config, system_prompt, parent_session_id, cwd,
                    profile_name, git_repo_root, started_at
                 )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
                        model = COALESCE(sessions.model, excluded.model),
                        model_config = COALESCE(sessions.model_config, excluded.model_config),
@@ -2684,6 +2686,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                        chat_id = COALESCE(sessions.chat_id, excluded.chat_id),
                        chat_type = COALESCE(sessions.chat_type, excluded.chat_type),
                        thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
+                       conversation_id = COALESCE(sessions.conversation_id, excluded.conversation_id),
                        parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id),
                        cwd = COALESCE(sessions.cwd, excluded.cwd),
                        profile_name = COALESCE(sessions.profile_name, excluded.profile_name),
@@ -2696,6 +2699,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     chat_id,
                     chat_type,
                     thread_id,
+                    conversation_id,
                     model,
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
@@ -2752,6 +2756,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                            thread_id = COALESCE(sessions.thread_id,
                                        (SELECT p.thread_id FROM sessions p
                                          WHERE p.id = sessions.parent_session_id)),
+                           conversation_id = COALESCE(sessions.conversation_id,
+                                              (SELECT p.conversation_id FROM sessions p
+                                                WHERE p.id = sessions.parent_session_id)),
                            display_name = COALESCE(sessions.display_name,
                                           (SELECT p.display_name FROM sessions p
                                             WHERE p.id = sessions.parent_session_id)),
@@ -2786,6 +2793,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         chat_id: str = None,
         chat_type: str = None,
         thread_id: str = None,
+        conversation_id: str = None,
         display_name: str = None,
         origin_json: str = None,
     ) -> None:
@@ -2804,7 +2812,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             conn.execute(
                 """UPDATE sessions
                    SET session_key = ?, source = ?, user_id = ?, chat_id = ?,
-                       chat_type = ?, thread_id = ?,
+                       chat_type = ?, thread_id = ?, conversation_id = ?,
                        display_name = COALESCE(?, display_name),
                        origin_json = COALESCE(?, origin_json)
                    WHERE id = ?""",
@@ -2815,6 +2823,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     chat_id,
                     chat_type,
                     thread_id,
+                    conversation_id,
                     display_name,
                     origin_json,
                     session_id,
@@ -3017,6 +3026,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         chat_id: Optional[str] = None,
         chat_type: Optional[str] = None,
         thread_id: Optional[str] = None,
+        conversation_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Find the latest recoverable gateway session for a routing peer.
 
@@ -3062,6 +3072,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   AND COALESCE(chat_id, '') = COALESCE(?, '')
                   AND COALESCE(chat_type, '') = COALESCE(?, '')
                   AND COALESCE(thread_id, '') = COALESCE(?, '')
+                  AND COALESCE(conversation_id, '') = COALESCE(?, '')
                   AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
@@ -3069,7 +3080,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ORDER BY started_at DESC
                 LIMIT 1
                 """,
-                (source, user_id, chat_id, chat_type, thread_id),
+                (source, user_id, chat_id, chat_type, thread_id, conversation_id),
             ).fetchone()
         return dict(row) if row else None
 
@@ -3150,7 +3161,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             parent = conn.execute(
                 """SELECT ended_at, cwd, git_branch, git_repo_root,
                           user_id, session_key, chat_id, chat_type,
-                          thread_id, display_name, origin_json, profile_name
+                          thread_id, conversation_id, display_name, origin_json, profile_name
                    FROM sessions WHERE id = ?""",
                 (parent_session_id,),
             ).fetchone()
@@ -3166,8 +3177,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    id, source, model, model_config, system_prompt,
                    parent_session_id, cwd, git_branch, git_repo_root,
                    profile_name, user_id, session_key, chat_id, chat_type,
-                   thread_id, display_name, origin_json, started_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   thread_id, conversation_id, display_name, origin_json, started_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     child_session_id,
                     source,
@@ -3189,6 +3200,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     parent["chat_id"],
                     parent["chat_type"],
                     parent["thread_id"],
+                    parent["conversation_id"],
                     parent["display_name"],
                     parent["origin_json"],
                     time.time(),

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -145,6 +145,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     chat_id TEXT,
     chat_type TEXT,
     thread_id TEXT,
+    conversation_id TEXT,
     display_name TEXT,
     origin_json TEXT,
     expiry_finalized INTEGER DEFAULT 0,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3298,7 +3298,13 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # Feishu exposes two distinct identities for an in-topic message:
+        # ``root_id`` is the stable top-level message (``om_*``), while
+        # ``thread_id`` is the native delivery topic (``omt_*``).  Keep them
+        # separate so UI routing never changes which Hermes session is loaded.
+        root_id = getattr(message, "root_id", None) or None
+        thread_id = getattr(message, "thread_id", None) or None
+        conversation_id = root_id or message_id
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
@@ -3335,6 +3341,8 @@ class FeishuAdapter(BasePlatformAdapter):
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
             thread_id=thread_id,
+            conversation_id=conversation_id,
+            message_id=message_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
         )
@@ -3374,13 +3382,11 @@ class FeishuAdapter(BasePlatformAdapter):
         )
 
     def _media_batch_key(self, event: MessageEvent) -> str:
-        from gateway.session import build_session_key
+        from gateway.session import build_session_key_for_config
 
-        session_key = build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-        )
+        runner = getattr(self, "gateway_runner", None)
+        key_config = getattr(runner, "config", None) or self.config
+        session_key = build_session_key_for_config(event.source, key_config)
         return f"{session_key}:media:{event.message_type.value}"
 
     @staticmethod
@@ -3682,14 +3688,11 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Return the session-scoped key used for Feishu text aggregation."""
-        from gateway.session import build_session_key
+        from gateway.session import build_session_key_for_config
 
-        return build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-            profile=event.source.profile,
-        )
+        runner = getattr(self, "gateway_runner", None)
+        key_config = getattr(runner, "config", None) or self.config
+        return build_session_key_for_config(event.source, key_config)
 
     @staticmethod
     def _text_batch_is_compatible(existing: MessageEvent, incoming: MessageEvent) -> bool:

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -269,6 +269,18 @@ def test_parse_session_key_with_extra_parts():
     assert result == {"platform": "discord", "chat_type": "group", "chat_id": "chan123"}
 
 
+def test_parse_named_profile_feishu_key_never_treats_root_as_delivery_thread():
+    result = _parse_session_key("agent:coder:feishu:dm:oc1:om_root")
+
+    assert result == {
+        "platform": "feishu",
+        "chat_type": "dm",
+        "chat_id": "oc1",
+        "profile": "coder",
+        "conversation_id": "om_root",
+    }
+
+
 # ---------------------------------------------------------------------------
 # api_server (stateless) wake routing — gateway/wake.py self-post path
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2266,6 +2266,64 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         self.assertIn("[Mentioned: Alice (open_id=ou_alice), Bob (open_id=ou_bob)]", event.text)
         self.assertIn("@Alice @Bob make a group", event.text)
 
+    def test_top_level_message_uses_message_id_as_conversation_identity(self):
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "hi"}),
+            message_type="text",
+            message_id="om_root",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            root_id=None,
+            thread_id=None,
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="p2p",
+                message_id="om_root",
+            )
+        )
+
+        kwargs = adapter.build_source.call_args.kwargs
+        self.assertEqual(kwargs["conversation_id"], "om_root")
+        self.assertIsNone(kwargs["thread_id"])
+        self.assertEqual(kwargs["message_id"], "om_root")
+
+    def test_thread_reply_keeps_native_thread_and_root_conversation(self):
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "follow up"}),
+            message_type="text",
+            message_id="om_reply",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_parent",
+            upper_message_id=None,
+            root_id="om_root",
+            thread_id="omt_native",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="p2p",
+                message_id="om_reply",
+            )
+        )
+
+        kwargs = adapter.build_source.call_args.kwargs
+        self.assertEqual(kwargs["conversation_id"], "om_root")
+        self.assertEqual(kwargs["thread_id"], "omt_native")
+        self.assertEqual(kwargs["message_id"], "om_reply")
+
     def test_command_message_never_injects_hint(self):
         adapter = self._build_adapter()
         bot_mention = SimpleNamespace(
@@ -2465,5 +2523,4 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
-
 

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -15,7 +15,12 @@ import yaml
 
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway.config import GatewayConfig, Platform
-from gateway.session import SessionSource, SessionStore, build_session_key
+from gateway.session import (
+    SessionSource,
+    SessionStore,
+    build_session_key,
+    build_session_key_for_config,
+)
 
 
 def _src(**kw) -> SessionSource:
@@ -62,6 +67,19 @@ class TestSessionKeyNamespacedWhenOn:
         b = build_session_key(s, profile="coder")
         c = build_session_key(s, profile="writer")
         assert a != b != c and a != c
+
+    def test_config_aware_key_keeps_profile_and_conversation_identity(self):
+        source = _src(
+            platform=Platform.FEISHU,
+            chat_id="oc1",
+            conversation_id="om_root",
+            profile="coder",
+        )
+        config = GatewayConfig(multiplex_profiles=True)
+
+        assert build_session_key_for_config(source, config) == (
+            "agent:coder:feishu:dm:oc1:om_root"
+        )
 
 
 class TestMultiplexConfigFlag:

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -236,6 +236,22 @@ class TestAdapterToSessionKeyIntegration:
         # A default-profile key would land in agent:main — must differ.
         assert key != build_session_key(source, profile=None)
 
+    def test_secondary_adapter_ownership_precedes_profile_routes(self, mock_runner):
+        adapter = _stub_adapter(Platform.FEISHU, mock_runner)
+        adapter._owned_profile = "reviewer"
+
+        source = adapter.build_source(
+            chat_id="oc1",
+            chat_type="dm",
+            thread_id="omt_native",
+            conversation_id="om_root",
+            user_id="u1",
+        )
+
+        assert source.profile == "reviewer"
+        assert source.thread_id == "omt_native"
+        assert source.conversation_id == "om_root"
+
 
 class TestMultiplexGate:
     """``profile_routes`` only activates under ``gateway.multiplex_profiles``.
@@ -256,5 +272,4 @@ class TestMultiplexGate:
         discord_source.profile = None
 
         assert mock_runner._profile_name_for_source(discord_source) is None
-
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -35,6 +35,7 @@ class TestSessionSourceRoundtrip:
             user_id="99",
             user_name="alice",
             thread_id="t1",
+            conversation_id="root-1",
         )
         d = source.to_dict()
         restored = SessionSource.from_dict(d)
@@ -46,6 +47,7 @@ class TestSessionSourceRoundtrip:
         assert restored.user_id == "99"
         assert restored.user_name == "alice"
         assert restored.thread_id == "t1"
+        assert restored.conversation_id == "root-1"
 
 
     def test_minimal_roundtrip(self):
@@ -730,6 +732,49 @@ class TestWhatsAppSessionKeyConsistency:
         assert "bob" not in build_session_key(bob)
 
 
+class TestConversationIdentitySessionKeys:
+    def test_feishu_top_level_messages_are_distinct_conversations(self):
+        first = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_dm",
+            chat_type="dm",
+            conversation_id="om_first",
+        )
+        second = replace(first, conversation_id="om_second")
+
+        assert build_session_key(first) == "agent:main:feishu:dm:oc_dm:om_first"
+        assert build_session_key(first) != build_session_key(second)
+
+    def test_feishu_root_and_thread_followup_share_session(self):
+        root = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_dm",
+            chat_type="dm",
+            conversation_id="om_root",
+        )
+        followup = replace(
+            root,
+            thread_id="omt_native",
+            conversation_id="om_root",
+        )
+
+        assert build_session_key(root) == build_session_key(followup)
+        assert "omt_native" not in build_session_key(followup)
+
+    def test_group_conversation_is_shared_across_participants(self):
+        alice = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_group",
+            chat_type="group",
+            user_id="alice",
+            conversation_id="om_root",
+        )
+        bob = replace(alice, user_id="bob", thread_id="omt_native")
+
+        assert build_session_key(alice) == build_session_key(bob)
+        assert build_session_key(alice) == "agent:main:feishu:group:oc_group:om_root"
+
+
 class TestSlackWorkspaceSessionKeys:
 
 
@@ -1369,5 +1414,4 @@ class TestGatewayRoutingTable:
         recovered = restarted.get_or_create_session(self._source())
         assert recovered.session_id == entry.session_id
         restarted._db.close()
-
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2514,6 +2514,63 @@ def test_find_session_by_origin_matching_rules(db):
     ) is None
 
 
+def test_gateway_peer_preserves_conversation_and_delivery_thread(db):
+    db.create_session(
+        "gw-conversation",
+        "feishu",
+        user_id="u1",
+        session_key="agent:main:feishu:dm:oc1:om_root",
+        chat_id="oc1",
+        chat_type="dm",
+        thread_id="omt_native",
+        conversation_id="om_root",
+    )
+    db.append_message("gw-conversation", "user", "hello")
+
+    row = db.find_latest_gateway_session_for_peer(
+        source="feishu",
+        user_id="u1",
+        session_key="missing-key-to-exercise-peer-fallback",
+        chat_id="oc1",
+        chat_type="dm",
+        thread_id="omt_native",
+        conversation_id="om_root",
+    )
+
+    assert row["id"] == "gw-conversation"
+    assert row["thread_id"] == "omt_native"
+    assert row["conversation_id"] == "om_root"
+    assert db.find_latest_gateway_session_for_peer(
+        source="feishu",
+        user_id="u1",
+        session_key="missing-other",
+        chat_id="oc1",
+        chat_type="dm",
+        thread_id="omt_native",
+        conversation_id="om_other",
+    ) is None
+
+
+def test_existing_database_adds_conversation_id_column(tmp_path):
+    db_path = tmp_path / "legacy-no-conversation-id.db"
+    initial = SessionDB(db_path=db_path)
+    initial.close()
+    conn = sqlite3.connect(db_path)
+    conn.execute("ALTER TABLE sessions DROP COLUMN conversation_id")
+    conn.commit()
+    conn.close()
+
+    upgraded = SessionDB(db_path=db_path)
+    try:
+        columns = {
+            row["name"]
+            for row in upgraded._conn.execute("PRAGMA table_info(sessions)")
+        }
+        assert "conversation_id" in columns
+    finally:
+        upgraded.close()
+
+
 
 
 


### PR DESCRIPTION
## Summary

Feishu has two different identifiers: the top-level message root (`om_*`) and the native delivery thread (`omt_*`). This PR keeps those responsibilities separate.

- New top-level messages use their own `conversation_id` and therefore start a fresh Hermes session.
- Replies use the root message as `conversation_id` and preserve the real `thread_id` only for delivery.
- Session keys, batching, profile routing, slash-command scope checks, restart recovery, and compression inheritance use the stable conversation identity.
- Existing session databases add the new column automatically on startup.

This PR intentionally does not change Feishu outbound adapter behavior; #72024 owns live-thread delivery anchors.

## Verification

- 8 focused files: **310 passed**
- Ruff: passed
- Python compile and diff checks: passed
- Includes old-schema upgrade, restart/recovery, profile, compression, and Feishu identity regressions.