### PR TITLE
fix(mcp): recover cached server after terminal OAuth startup failure

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -376,6 +376,56 @@ class TestCheckFunction:
         assert check() is False
 
 
+    def test_registration_recreates_cached_server_after_its_task_exited(self, monkeypatch):
+        """A terminal OAuth startup failure must be recoverable on later discovery."""
+        import tools.mcp_tool as mcp_tool
+
+        dead = _make_mock_server("test_server", session=None)
+        dead._task = MagicMock()
+        dead._task.done.return_value = True
+        connected = _make_mock_server("test_server", session=object())
+        connected._registered_tool_names = ["mcp__test_server__ping"]
+        discovered = []
+
+        async def fake_discover(name, config):
+            discovered.append((name, config))
+            with mcp_tool._lock:
+                mcp_tool._servers[name] = connected
+            return list(connected._registered_tool_names)
+
+        def run_now(factory, timeout=120):
+            return asyncio.run(factory())
+
+        with mcp_tool._lock:
+            previous = mcp_tool._servers.pop("test_server", None)
+            mcp_tool._servers["test_server"] = dead
+        try:
+            monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+            monkeypatch.setattr(
+                mcp_tool, "_filter_suspicious_mcp_servers", lambda servers: servers
+            )
+            monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+            monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", run_now)
+            monkeypatch.setattr(
+                mcp_tool, "_discover_and_register_server", fake_discover
+            )
+
+            names = mcp_tool.register_mcp_servers(
+                {"test_server": {"url": "https://example.invalid/mcp"}}
+            )
+
+            assert discovered == [
+                ("test_server", {"url": "https://example.invalid/mcp"})
+            ]
+            assert "mcp__test_server__ping" in names
+            assert mcp_tool._servers["test_server"] is connected
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.pop("test_server", None)
+                if previous is not None:
+                    mcp_tool._servers["test_server"] = previous
+
+
     def test_recycled_stdio_server_remains_available_for_lazy_reconnect(self):
         from tools.mcp_tool import _make_check_fn, _servers
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5917,9 +5917,26 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         logger.debug("No explicit MCP servers provided")
         return []
 
-    # Only attempt servers that aren't already connected and are enabled
-    # (enabled: false skips the server entirely without removing its config)
+    # A terminal startup failure (notably OAuthNonInteractiveError) leaves the
+    # server cached after its lifecycle task has exited.  Such an object cannot
+    # receive the reconnect signal below; evict it so discovery creates a new
+    # lifecycle task on the next foreground/cron attempt.
     with _lock:
+        for name in servers:
+            cached = _servers.get(name)
+            task = getattr(cached, "_task", None) if cached is not None else None
+            if (
+                cached is not None
+                and getattr(cached, "session", None) is None
+                and task is not None
+                and task.done()
+            ):
+                _servers.pop(name, None)
+                logger.info(
+                    "MCP server '%s': evicted dead cached lifecycle before rediscovery",
+                    name,
+                )
+
         new_servers = {
             k: v
             for k, v in servers.items()


### PR DESCRIPTION
## Summary

- evict an MCP server cached with no session after its lifecycle task has already exited
- let subsequent discovery create a fresh lifecycle instead of signalling a dead reconnect event
- add a regression test for the terminal OAuth startup-failure state

## Root cause

`register_mcp_servers()` treated every cached server as reconnectable. A terminal initial-connect failure such as `OAuthNonInteractiveError` can leave the server object in `_servers` after its lifecycle task has exited. Later cron discovery called `_signal_reconnect()` on that object, but no task remained to receive the event. Stale MCP tool definitions could therefore remain discoverable while their availability checks rejected them.

A fresh CLI MCP probe or gateway restart hid the bug because both create a new server object; the failure reproduced only in the long-lived gateway/scheduled runtime.

## Test plan

- `venv/bin/python -m pytest -q tests/tools/test_mcp_tool.py tests/cron/test_scheduler_mcp_init.py tests/cron/test_scheduler.py::TestPerJobToolsetMcpMerge`
  - 94 passed
- `git diff --check origin/main...HEAD`
- production read-only cron smoke test successfully called Fastmail `search_email` with `limit: 1`; no mailbox mutation
