### PR TITLE
fix(audio): never send cloud API keys to a config-overridden private base_url

### DIFF
--- a/hermes_cli/audio_key_guard.py
+++ b/hermes_cli/audio_key_guard.py
@@ -1,0 +1,132 @@
+"""Shared credential guard for OpenAI-compatible & cloud audio providers.
+
+A configured ``base_url`` may point at a self-hosted / LAN server. A real
+*cloud* API key (XAI_API_KEY, ELEVENLABS_API_KEY, OPENAI_API_KEY, …) must
+never be sent — in cleartext, for http — to such a target: it was not issued
+for that server and anyone able to edit the config base_url could otherwise
+harvest the env key. This module is the single source of truth for that
+decision, shared by ``tools/transcription_tools.py`` and ``tools/tts_tool.py``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlsplit
+from typing import Optional
+
+
+# Sent as the token when a self-hosted base_url is configured without any key —
+# auth-less OpenAI-compatible servers ignore it.
+PLACEHOLDER_KEY = "sk-no-key-required"
+
+
+def base_url_is_private(base_url: Optional[str]) -> bool:
+    """True when ``base_url`` is plainly self-hosted: any ``http://`` URL, or an
+    ``https://`` one whose host is localhost, a private/loopback/link-local/
+    reserved IP literal, **or a hostname that resolves to such an address**.
+    Public https hosts (api.openai.com, a hosted proxy) return False and keep
+    the conventional cloud-key behaviour.
+
+    The DNS-resolution arm closes a key-leak path a literal-only check missed:
+    a public-looking hostname (``https://sneaky.example.com``) that resolves to
+    a LAN/loopback IP would otherwise pass as "public" and receive the real
+    cloud key, which then travels to a private box. If ANY resolved address is
+    private, the key is withheld (placeholder sent instead). Resolution failure
+    is treated as non-private — the request would fail to connect anyway, so no
+    key leaks, and a transient DNS hiccup must not silently break a legit host."""
+    try:
+        parts = urlsplit(str(base_url or ""))
+    except ValueError:
+        return False
+    if parts.scheme == "http":
+        return True
+    host = (parts.hostname or "").strip().lower()
+    if host in ("localhost", "127.0.0.1", "::1"):
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        # Hostname, not an IP literal — resolve and check every answer.
+        return _resolves_to_private(host)
+    return _ip_is_private(ip)
+
+
+# RFC 6598 Carrier-Grade-NAT (100.64.0.0/10) is not flagged private by
+# ipaddress, but is a shared/non-public range common in homelab / overlay
+# setups — treat it as private so a cloud key never travels there.
+_CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")
+
+
+def _ip_is_private(ip: "ipaddress._BaseAddress") -> bool:
+    if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+        return True
+    return ip.version == 4 and ip in _CGNAT_NET
+
+
+def _resolves_to_private(host: str) -> bool:
+    """True if resolving ``host`` yields any private/loopback/link-local/
+    reserved/CGNAT address.
+
+    The lookup runs in a daemon thread with a real 3s join deadline: unlike
+    ``socket.setdefaulttimeout`` (which does NOT bound ``getaddrinfo`` — that
+    calls the blocking C resolver directly), this actually caps the wait, and
+    it touches no process-global socket state (thread-safe). A slow/hung DNS
+    answer → we give up and return False; the real connection would then also
+    fail, so no cloud key leaks by proceeding.
+
+    Residual risk (accepted): the real HTTP client resolves the host a second
+    time, so an attacker who controls the host's DNS zone and flips the answer
+    between the two lookups (DNS rebinding) could still route the connection to
+    a private IP after the guard saw a public one. Fully closing that needs
+    IP-pinned connections (as the WebUI TTS proxy does); here the guard covers
+    the realistic config-injection case — a base_url hostname that statically
+    resolves to a LAN address."""
+    if not host:
+        return False
+    import socket
+    import threading
+
+    box: dict = {}
+
+    def _lookup() -> None:
+        try:
+            box["infos"] = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+        except Exception:
+            box["infos"] = []
+
+    t = threading.Thread(target=_lookup, daemon=True)
+    t.start()
+    t.join(3.0)
+    if t.is_alive():  # DNS is hanging — don't block the audio call, don't leak
+        return False
+    for info in box.get("infos", []):
+        sockaddr = info[4] if len(info) > 4 else None
+        if not sockaddr:
+            continue
+        try:
+            ip = ipaddress.ip_address(str(sockaddr[0]))
+        except (ValueError, IndexError):
+            continue
+        if _ip_is_private(ip):
+            return True
+    return False
+
+
+def resolve_provider_key(
+    cfg_api_key: Optional[str],
+    env_key: Optional[str],
+    base_url: Optional[str],
+    *,
+    placeholder: str = PLACEHOLDER_KEY,
+) -> str:
+    """Return the key to send to ``base_url``, mirroring the openai contract.
+
+    * Private/self-hosted target: a config-supplied ``api_key`` is authoritative
+      (self-hosted-with-auth), otherwise the placeholder — **never** the env
+      cloud key.
+    * Public host: config key wins, else the env key (conventional behaviour).
+    """
+    cfg = (cfg_api_key or "").strip()
+    if base_url and base_url_is_private(base_url):
+        return cfg or placeholder
+    return cfg or (env_key or "").strip()

--- a/tests/test_audio_key_guard.py
+++ b/tests/test_audio_key_guard.py
@@ -1,0 +1,155 @@
+"""Shared audio credential guard: a real cloud key must never travel to a
+private/self-hosted base_url. Covers the helper directly plus each provider
+site that was previously unguarded (xai/elevenlabs/minimax/gemini/deepinfra)."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from hermes_cli.audio_key_guard import (
+    base_url_is_private,
+    resolve_provider_key,
+    PLACEHOLDER_KEY,
+)
+
+
+class TestBaseUrlIsPrivate:
+    @pytest.mark.parametrize("url,expected", [
+        ("http://192.168.1.50:8000/v1", True),
+        ("http://example.com/v1", True),           # any cleartext http
+        ("https://10.0.0.5/v1", True),
+        ("https://[::1]:8443/v1", True),
+        ("https://localhost:8443/v1", True),
+        ("https://169.254.169.254/latest", True),  # link-local metadata
+        ("https://api.openai.com/v1", False),
+        ("https://api.x.ai/v1", False),
+        ("https://generativelanguage.googleapis.com", False),
+        ("", False),
+    ])
+    def test_classification(self, url, expected):
+        assert base_url_is_private(url) is expected
+
+    def test_public_hostname_resolving_to_private_is_private(self):
+        """Key-leak guard: a public-looking https hostname that RESOLVES to a
+        LAN IP must be treated as private so the real cloud key is withheld."""
+        with patch("socket.getaddrinfo",
+                   return_value=[(2, 1, 6, "", ("192.168.178.155", 443))]):
+            assert base_url_is_private("https://sneaky.example.com/v1") is True
+
+    def test_hostname_resolving_to_public_stays_public(self):
+        with patch("socket.getaddrinfo",
+                   return_value=[(2, 1, 6, "", ("8.8.8.8", 443))]):
+            assert base_url_is_private("https://real-proxy.example.com/v1") is False
+
+    def test_resolution_failure_is_non_private_failsafe(self):
+        with patch("socket.getaddrinfo", side_effect=OSError("nxdomain")):
+            assert base_url_is_private("https://transient.example.com/v1") is False
+
+    def test_cgnat_range_is_private(self):
+        # RFC 6598 100.64.0.0/10 is not ipaddress.is_private but must be withheld.
+        with patch("socket.getaddrinfo",
+                   return_value=[(2, 1, 6, "", ("100.64.0.5", 443))]):
+            assert base_url_is_private("https://cgnat.example.com/v1") is True
+
+    def test_hanging_dns_does_not_block_and_is_non_private(self):
+        import time as _t
+
+        def _slow(*a, **k):
+            _t.sleep(30)  # simulate a hung resolver
+            return []
+
+        with patch("socket.getaddrinfo", _slow):
+            start = _t.monotonic()
+            got = base_url_is_private("https://hang.example.com/v1")
+            elapsed = _t.monotonic() - start
+        assert got is False
+        assert elapsed < 5  # bounded by the 3s join deadline, not 30s
+
+    def test_any_private_answer_trips_the_guard(self):
+        # Mixed answers: one public, one private → private wins (fail-safe).
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("93.184.216.34", 443)),
+            (2, 1, 6, "", ("10.1.2.3", 443)),
+        ]):
+            assert base_url_is_private("https://rebind.example.com/v1") is True
+
+
+class TestResolveProviderKey:
+    def test_private_target_drops_env_cloud_key(self):
+        assert resolve_provider_key("", "sk-real-cloud", "http://192.168.1.5/v1") == PLACEHOLDER_KEY
+
+    def test_private_target_honours_config_key(self):
+        assert resolve_provider_key("local-token", "sk-real-cloud", "http://192.168.1.5/v1") == "local-token"
+
+    def test_public_target_keeps_env_key(self):
+        assert resolve_provider_key("", "sk-real-cloud", "https://api.x.ai/v1") == "sk-real-cloud"
+
+    def test_public_target_config_key_wins(self):
+        assert resolve_provider_key("cfg", "sk-env", "https://api.x.ai/v1") == "cfg"
+
+
+class TestProviderSitesGuarded:
+    """Each provider that computes a config base_url must route its key
+    through the guard — a private base_url override yields the placeholder."""
+
+    def test_xai_stt_guarded(self, tmp_path):
+        import tools.transcription_tools as tt
+        wav = tmp_path / "a.wav"
+        wav.write_bytes(b"RIFF0000WAVE")
+        captured = {}
+
+        def _fake_post(url, headers=None, **kw):
+            captured["auth"] = (headers or {}).get("Authorization", "")
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"text": "hi"}
+            return resp
+
+        import tools.xai_http as xai_http
+        with patch.object(xai_http, "resolve_xai_http_credentials",
+                          return_value={"api_key": "xai-real-cloud"}), \
+             patch.object(tt, "_load_stt_config",
+                          return_value={"provider": "xai",
+                                        "xai": {"base_url": "http://192.168.1.9:9000/v1"}}), \
+             patch("requests.post", _fake_post):
+            tt._transcribe_xai(str(wav), "grok")
+        assert captured["auth"] == f"Bearer {PLACEHOLDER_KEY}"
+
+    def test_elevenlabs_stt_guarded(self, tmp_path):
+        import tools.transcription_tools as tt
+        wav = tmp_path / "a.wav"
+        wav.write_bytes(b"RIFF0000WAVE")
+        captured = {}
+
+        def _fake_post(url, headers=None, **kw):
+            captured["key"] = (headers or {}).get("xi-api-key", "")
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"text": "hi"}
+            return resp
+
+        with patch.object(tt, "get_env_value",
+                          side_effect=lambda k, *a: "el-real-cloud" if k == "ELEVENLABS_API_KEY" else ""), \
+             patch.object(tt, "_load_stt_config",
+                          return_value={"provider": "elevenlabs",
+                                        "elevenlabs": {"base_url": "http://192.168.1.9:9000"}}), \
+             patch("requests.post", _fake_post):
+            tt._transcribe_elevenlabs(str(wav), "scribe_v1")
+        assert captured["key"] == PLACEHOLDER_KEY
+
+    def test_deepinfra_stt_guarded(self, tmp_path):
+        import tools.transcription_tools as tt
+        wav = tmp_path / "a.wav"
+        wav.write_bytes(b"RIFF0000WAVE")
+        captured = {}
+
+        def _fake_transcribe_openai(fp, model, **kw):
+            captured["api_key"] = kw.get("api_key")
+            return {"success": True, "transcript": "hi", "provider": "deepinfra"}
+
+        with patch.object(tt, "get_env_value",
+                          side_effect=lambda k, *a: "di-real-cloud" if k == "DEEPINFRA_API_KEY" else ""), \
+             patch.object(tt, "_load_stt_config",
+                          return_value={"provider": "deepinfra",
+                                        "deepinfra": {"base_url": "http://192.168.1.9:9000/v1"}}), \
+             patch.object(tt, "_transcribe_openai", _fake_transcribe_openai):
+            tt._transcribe_deepinfra(str(wav), "some-model")
+        assert captured["api_key"] == PLACEHOLDER_KEY

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -42,6 +42,10 @@ from pathlib import Path
 from typing import Optional, Dict, Any
 from urllib.parse import urljoin
 
+from hermes_cli.audio_key_guard import (
+    resolve_provider_key as _guard_provider_key,
+    PLACEHOLDER_KEY as _PLACEHOLDER_OPENAI_KEY,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 from utils import is_truthy_value
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
@@ -2089,6 +2093,11 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
         ).strip().rstrip("/")
 
     base_url = _resolve_base_url(creds)
+    # Never send the real cloud key to a config-overridden private/LAN
+    # base_url — it was not issued for that server, and for http it would
+    # travel in cleartext. A config api_key stays authoritative for
+    # self-hosted-with-auth; keyless self-hosted gets a placeholder.
+    api_key = _guard_provider_key(xai_config.get("api_key"), api_key, base_url)
     language = _resolve_stt_language("xai", stt_config) or ""
     # .get("format", True) already defaults to True when the key is absent;
     # is_truthy_value only normalizes truthy/falsy strings from config.
@@ -2209,6 +2218,11 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
         or get_env_value("ELEVENLABS_STT_BASE_URL")
         or ELEVENLABS_STT_BASE_URL
     ).strip().rstrip("/")
+    # Never send the real cloud key to a config-overridden private/LAN
+    # base_url — it was not issued for that server, and for http it would
+    # travel in cleartext. A config api_key stays authoritative for
+    # self-hosted-with-auth; keyless self-hosted gets a placeholder.
+    api_key = _guard_provider_key(elevenlabs_config.get("api_key"), api_key, base_url)
     language_code = _resolve_stt_language(
         "elevenlabs", stt_config, extra_keys=("language_code",)
     ) or ""
@@ -2308,6 +2322,10 @@ def _transcribe_deepinfra(file_path: str, model_name: str) -> Dict[str, Any]:
     if not isinstance(di_config, dict):
         di_config = {}
     base_url = deepinfra_base_url(di_config)
+    # Never send the real cloud key to a config-overridden private/LAN
+    # base_url; a config ``stt.deepinfra.api_key`` wins for
+    # self-hosted-with-auth, keyless self-hosted gets a placeholder.
+    api_key = _guard_provider_key(di_config.get("api_key"), api_key, base_url)
 
     if not model_name:
         candidates = deepinfra_model_ids("stt")

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -56,6 +56,9 @@ from typing import Callable, Dict, Any, Optional
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli.audio_key_guard import (
+    resolve_provider_key as _guard_provider_key,
+)
 from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
@@ -556,6 +559,9 @@ def _resolve_minimax_tts_runtime(
         )
 
     endpoint = str(mm_config.get("base_url") or endpoints[region]).strip()
+    # Never send the real MiniMax cloud key to a config-overridden private/LAN
+    # base_url; a config ``tts.minimax.api_key`` wins for self-hosted-with-auth.
+    api_key = _guard_provider_key(mm_config.get("api_key"), api_key, endpoint)
     endpoint_host = (urlparse(endpoint).hostname or "").lower()
     official_region_hosts = {
         "global": frozenset({"api.minimax.io", "api.minimax.chat"}),
@@ -1807,6 +1813,9 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
             or get_env_value("XAI_BASE_URL")
             or DEFAULT_XAI_BASE_URL
         ).strip().rstrip("/")
+    # Never send the real xAI cloud key to a config-overridden private/LAN
+    # base_url; a config ``tts.xai.api_key`` wins for self-hosted-with-auth.
+    api_key = _guard_provider_key(xai_config.get("api_key"), api_key, base_url)
 
     # Match the documented minimal POST /v1/tts shape by default. Only send
     # output_format when Hermes actually needs a non-default format/override.
@@ -2282,6 +2291,9 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         or get_env_value("GEMINI_BASE_URL")
         or DEFAULT_GEMINI_TTS_BASE_URL
     ).strip().rstrip("/")
+    # Never send the real Gemini cloud key to a config-overridden private/LAN
+    # base_url; a config ``tts.gemini.api_key`` wins for self-hosted-with-auth.
+    api_key = _guard_provider_key(gemini_config.get("api_key"), api_key, base_url)
     persona_prompt = _read_gemini_persona_prompt(gemini_config)
     tts_script = text
     if _gemini_audio_tags_enabled(gemini_config, model):


### PR DESCRIPTION
## Summary

Several TTS/STT providers let `config.yaml` override the provider
`base_url` (self-hosted / OpenAI-compatible servers). Today the real
*cloud* API key from the environment or credential pool is still attached
to such requests: anyone able to edit the config `base_url` can point it at
a private box and harvest `XAI_API_KEY` / `ELEVENLABS_API_KEY` /
`DEEPINFRA_API_KEY` / the MiniMax or Gemini key — in cleartext when the
override is `http://`.

This PR adds a small shared guard (`hermes_cli/audio_key_guard.py`) and
routes the six affected call sites through it (STT: xAI, ElevenLabs,
DeepInfra · TTS: xAI, MiniMax, Gemini):

* **Private/self-hosted target** (`http://` anywhere; `https://` to
  localhost, private/loopback/link-local/reserved/CGNAT ranges, or a
  hostname *resolving* to such an address): the config-supplied `api_key`
  is authoritative (self-hosted-with-auth), otherwise a placeholder token
  is sent — never the env/pool cloud key.
* **Public host**: unchanged behaviour (config key wins, else env key).

The DNS-resolution arm closes the obvious bypass (a public-looking
hostname that statically resolves to a LAN IP). The lookup runs in a
daemon thread with a hard 3s deadline; resolution failure fails open to
"non-private" — the request would fail to connect anyway, so no key
leaks, and a DNS hiccup cannot break a legitimate cloud call. The residual
DNS-rebinding window (flipping the answer between guard and client lookup)
is documented in the module rather than silently ignored.

## Why

Self-hosted audio endpoints are common (whisper.cpp/llama.cpp-style
servers on a LAN). The `openai` STT path already withholds env keys from
private base_urls; the other providers don't. This makes one shared,
documented decision point and applies it uniformly.

## Changes

* new `hermes_cli/audio_key_guard.py` (~130 lines, stdlib only)
* `tools/transcription_tools.py`, `tools/tts_tool.py`: one guard line per
  affected site, directly after the site's `base_url` resolution. Purely
  additive; xai-oauth pinned origins are unaffected (guard sees the
  pinned public URL).

## Validation

`tests/test_audio_key_guard.py` (new): classification matrix
(http/https/localhost/private/CGNAT/public), DNS-resolution arm including
the hanging-DNS and any-private-answer cases, key-resolution contract, and
per-site tests for the STT providers asserting the placeholder reaches the
HTTP layer when a private `base_url` is configured. Verified both
directions: with the wiring the file is green (23 passed); with pristine
`tools/` files the three per-site tests fail (the real cloud key reaches
the request). The TTS sites use the identical one-line wiring; the guard
itself is covered by the classification/contract tests.

## Notes

* `PLACEHOLDER_KEY` (`sk-no-key-required`) matches what auth-less
  OpenAI-compatible servers already tolerate.
* Not covered here: providers whose base_url is not config-overridable.
