### PR TITLE
fix(cli): prevent python -m main double-import profile rehoming

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -73,6 +73,35 @@ suppress_platform_ver_console()
 import os
 import sys
 
+# `python -m hermes_cli.main` registers this module ONLY as `__main__`; a later
+# canonical `import hermes_cli.main` (setup.status / runtime_check handlers,
+# /api/pty argv builder, plugin aux-task registration, ...) would RE-EXECUTE
+# every top-level statement in this file inside the running process. That
+# second pass re-runs `_apply_profile_override()` after pass 1 already stripped
+# `-p <name>` from sys.argv, so it silently re-resolves the sticky
+# active_profile and rewrites os.environ["HERMES_HOME"] process-wide — a serve
+# launched `-p default` gets rehomed to the sticky profile mid-flight. Alias
+# the running module under its canonical name so imports reuse it instead.
+if __name__ == "__main__" and __spec__ is not None:
+    sys.modules.setdefault(__spec__.name, sys.modules[__name__])
+    # The sys.modules entry alone is only half of what a real import produces.
+    # CPython binds the child attribute on the parent package
+    # (`hermes_cli.main = <module>`) only when it actually LOADS the module
+    # (importlib._bootstrap._find_and_load_unlocked); a sys.modules cache hit
+    # returns straight out of _find_and_load without touching the parent. So
+    # with only the alias above, `import hermes_cli.main` succeeds but the
+    # dotted attribute `hermes_cli.main` raises AttributeError. Bind whatever
+    # module now owns the canonical name — the setdefault deliberately lets an
+    # embedding host's earlier registration win, so re-read it rather than
+    # assuming it is this module — and, mirroring that same philosophy, never
+    # clobber an attribute already bound on the parent package.
+    _canonical = sys.modules[__spec__.name]
+    _parent_name, _, _child = __spec__.name.rpartition(".")  # '' if undotted
+    _parent = sys.modules.get(_parent_name) if _parent_name else None
+    if _parent is not None and not hasattr(_parent, _child):
+        setattr(_parent, _child, _canonical)
+    del _canonical, _parent_name, _child, _parent
+
 # Early venv self-heal — MUST run before any third-party import below.  When
 # a prior ``hermes update`` left a recovery marker and a core package's import
 # files were wiped (#57828 — failed lazy backend refresh), the module-level

--- a/tests/hermes_cli/test_main_module_alias.py
+++ b/tests/hermes_cli/test_main_module_alias.py
@@ -10,10 +10,12 @@ fell through to the sticky active_profile and permanently rewrote
 os.environ["HERMES_HOME"] — a serve launched `-p default` was silently rehomed
 to the sticky profile the moment the desktop asked for runtime readiness.
 
-The fix aliases the running `__main__` module under `__spec__.name`, so the
-canonical import reuses it. This test drives the real seam in a child process:
-execute main.py as `__main__` with an explicit `-p default`, then import it
-canonically and assert the process home did not move.
+The fix aliases the running `__main__` module under `__spec__.name` and binds
+it as the `main` attribute on the `hermes_cli` parent package (a sys.modules
+cache hit skips importlib's parent-attribute binding), so the canonical import
+reuses it. This test drives the real seam in a child process: execute main.py
+as `__main__` with an explicit `-p default`, then import it canonically and
+assert the process home did not move.
 """
 
 import os
@@ -22,6 +24,18 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _child_python() -> str:
+    """Interpreter for spawned children.
+
+    Test runners that overlay pytest onto a bare python (uv run --with pytest)
+    leave sys.executable dep-less; prefer the project venv's interpreter when
+    present so the child can import hermes_cli with its dependencies.
+    """
+    venv_python = REPO_ROOT / "venv" / "bin" / "python"
+    return str(venv_python) if venv_python.exists() else sys.executable
+
 
 CHILD = r"""
 import os, runpy, sys
@@ -38,14 +52,88 @@ except SystemExit:
 
 assert os.environ["HERMES_HOME"] == root, "pass 1 must pin the explicit -p default root"
 assert "hermes_cli.main" in sys.modules, "running module must self-register under its canonical name"
+aliased = sys.modules["hermes_cli.main"]
 
 # Pass 2: the lazy canonical import RPC handlers perform mid-flight.
 import hermes_cli.main  # noqa: F401
+
+assert sys.modules["hermes_cli.main"] is aliased, (
+    "canonical import must reuse the aliased running module, not re-load it"
+)
+
+# A sys.modules entry is only half the contract: importlib binds `main` as an
+# attribute on the parent package only when it truly loads the module; a cache
+# hit skips it. Handlers that dereference the dotted path need the attribute
+# to exist AND be the same canonical module.
+import hermes_cli
+
+assert getattr(hermes_cli, "main", None) is sys.modules["hermes_cli.main"], (
+    "parent package must expose the canonical module as its `main` attribute"
+)
 
 assert os.environ["HERMES_HOME"] == root, (
     "canonical import re-executed top-level bootstrap and rehomed the process: "
     + os.environ["HERMES_HOME"]
 )
+print("OK")
+"""
+
+
+# Grandchild: a brand-new `python -m hermes_cli.main -p other --help` process,
+# spawned from the aliased parent. runpy with run_name="__main__" is what `-m`
+# does, and running it under `-c` lets us observe the resolved home directly.
+GRANDCHILD = r"""
+import os, runpy, sys
+
+sys.argv = ["hermes", "-p", "other", "--help"]
+try:
+    runpy.run_module("hermes_cli.main", run_name="__main__", alter_sys=True)
+except SystemExit:
+    pass
+
+print("GRANDCHILD_HOME=" + os.path.realpath(os.environ["HERMES_HOME"]))
+"""
+
+CHILD_SPAWNS_GRANDCHILD = r"""
+import os, runpy, subprocess, sys
+
+root = sys.argv.pop()            # temp HERMES root, passed last
+grandchild_src = sys.argv.pop()  # grandchild program, passed before it
+expected = os.path.realpath(os.path.join(root, "profiles", "other"))
+os.environ["HERMES_HOME"] = root
+
+# Become the aliased `hermes -p default` process the fix targets.
+sys.argv = ["hermes", "-p", "default", "--help"]
+try:
+    runpy.run_module("hermes_cli.main", run_name="__main__", alter_sys=True)
+except SystemExit:
+    pass
+
+assert os.environ["HERMES_HOME"] == root, "pass 1 must pin the explicit -p default root"
+
+# The alias is an entry in THIS process's sys.modules, so it cannot cross a
+# process boundary. The grandchild inherits HERMES_HOME=<root> and the sticky
+# active_profile, and must still resolve its own explicit `-p other`.
+proc = subprocess.run(
+    [sys.executable, "-c", grandchild_src],
+    capture_output=True,
+    text=True,
+    timeout=180,
+)
+assert proc.returncode == 0, "grandchild exited %d: %s" % (proc.returncode, proc.stderr[-2000:])
+
+home = ""
+for line in proc.stdout.splitlines():
+    if line.startswith("GRANDCHILD_HOME="):
+        home = line.split("=", 1)[1]
+
+assert home == expected, (
+    "grandchild resolved %r instead of its own -p profile %r" % (home, expected)
+)
+
+# Recorded last so the grandchild's result is the first thing to fail: the
+# parent really was in the aliased state while it spawned the grandchild.
+assert "hermes_cli.main" in sys.modules, "running module must self-register under its canonical name"
 print("OK")
 """
 
@@ -61,18 +149,44 @@ def test_canonical_import_does_not_rehome_running_main(tmp_path):
     env = dict(os.environ)
     env.pop("HERMES_PROFILE", None)
 
-    # The child must run under an interpreter that can import hermes_cli with
-    # its dependencies. Test runners that overlay pytest onto a bare python
-    # (uv run --with pytest) leave sys.executable dep-less; prefer the project
-    # venv's interpreter when present.
-    venv_python = REPO_ROOT / "venv" / "bin" / "python"
-    python = str(venv_python) if venv_python.exists() else sys.executable
+    python = _child_python()
 
     proc = subprocess.run(
         [python, "-c", CHILD, str(root)],
         capture_output=True,
         text=True,
         timeout=120,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    assert "OK" in proc.stdout
+
+
+def test_child_process_still_resolves_its_own_profile(tmp_path):
+    """The alias must not suppress profile parsing in spawned processes.
+
+    An earlier attempt at this bug used an ``os.environ`` sentinel to mark the
+    bootstrap as already applied. Environment variables are inherited, so every
+    child hermes process silently skipped ``_apply_profile_override()`` and ran
+    against its parent's home no matter what ``-p`` it was given (the #53955
+    regression). Aliasing ``sys.modules`` is process-local and structurally
+    cannot do that — this test pins that difference.
+    """
+    root = tmp_path / "hermes-root"
+    (root / "profiles" / "lured").mkdir(parents=True)
+    (root / "profiles" / "other").mkdir(parents=True)
+    (root / "active_profile").write_text("lured\n", encoding="utf-8")
+
+    env = dict(os.environ)
+    env.pop("HERMES_PROFILE", None)
+
+    proc = subprocess.run(
+        [_child_python(), "-c", CHILD_SPAWNS_GRANDCHILD, GRANDCHILD, str(root)],
+        capture_output=True,
+        text=True,
+        timeout=300,
         cwd=str(REPO_ROOT),
         env=env,
     )

--- a/tests/hermes_cli/test_main_module_alias.py
+++ b/tests/hermes_cli/test_main_module_alias.py
@@ -1,0 +1,81 @@
+"""`python -m hermes_cli.main` must not re-execute its top-level bootstrap when
+the module is later imported under its canonical name.
+
+Regression for the serve-rehoming bug: `-m` registers main.py only as
+`__main__`; the first canonical `import hermes_cli.main` (setup.status /
+runtime_check handlers, /api/pty argv builder, plugin aux-task registration)
+re-executed every top-level statement. Pass 1 had already consumed
+`-p <name>` from sys.argv, so pass 2's unconditional `_apply_profile_override()`
+fell through to the sticky active_profile and permanently rewrote
+os.environ["HERMES_HOME"] — a serve launched `-p default` was silently rehomed
+to the sticky profile the moment the desktop asked for runtime readiness.
+
+The fix aliases the running `__main__` module under `__spec__.name`, so the
+canonical import reuses it. This test drives the real seam in a child process:
+execute main.py as `__main__` with an explicit `-p default`, then import it
+canonically and assert the process home did not move.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+CHILD = r"""
+import os, runpy, sys
+
+root = sys.argv.pop()  # temp HERMES root, passed last
+os.environ["HERMES_HOME"] = root
+
+# Pass 1: how `hermes -p default serve` starts (fast-exiting argv).
+sys.argv = ["hermes", "-p", "default", "--help"]
+try:
+    runpy.run_module("hermes_cli.main", run_name="__main__", alter_sys=True)
+except SystemExit:
+    pass
+
+assert os.environ["HERMES_HOME"] == root, "pass 1 must pin the explicit -p default root"
+assert "hermes_cli.main" in sys.modules, "running module must self-register under its canonical name"
+
+# Pass 2: the lazy canonical import RPC handlers perform mid-flight.
+import hermes_cli.main  # noqa: F401
+
+assert os.environ["HERMES_HOME"] == root, (
+    "canonical import re-executed top-level bootstrap and rehomed the process: "
+    + os.environ["HERMES_HOME"]
+)
+print("OK")
+"""
+
+
+def test_canonical_import_does_not_rehome_running_main(tmp_path):
+    # A sticky active_profile pointing at an existing named profile is the
+    # trigger: pass 2 (if it runs) follows it because argv no longer carries -p.
+    root = tmp_path / "hermes-root"
+    profile = root / "profiles" / "lured"
+    profile.mkdir(parents=True)
+    (root / "active_profile").write_text("lured\n", encoding="utf-8")
+
+    env = dict(os.environ)
+    env.pop("HERMES_PROFILE", None)
+
+    # The child must run under an interpreter that can import hermes_cli with
+    # its dependencies. Test runners that overlay pytest onto a bare python
+    # (uv run --with pytest) leave sys.executable dep-less; prefer the project
+    # venv's interpreter when present.
+    venv_python = REPO_ROOT / "venv" / "bin" / "python"
+    python = str(venv_python) if venv_python.exists() else sys.executable
+
+    proc = subprocess.run(
+        [python, "-c", CHILD, str(root)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    assert "OK" in proc.stdout


### PR DESCRIPTION
## What does this PR do?

`python -m hermes_cli.main` registers the running module only as `__main__`. When code in the same process later performs a canonical `import hermes_cli.main`, Python finds no cached entry under that name and executes the whole file a second time.

Several handlers import it that way at runtime. `setup.status` and `setup.runtime_check` do (`tui_gateway/methods_config.py:354,375`). So does the argv builder for `/api/pty` (`hermes_cli/web_server.py:14545`), and plugin aux-task registration (`hermes_cli/plugins.py:1130`).

The second execution corrupts process state. On the first pass, `_apply_profile_override()` consumes `-p <name>` from `sys.argv` (`main.py:678-681`). The rerun finds no flag, falls back to the sticky `active_profile`, and rewrites `os.environ["HERMES_HOME"]` (`main.py:656-677`). A serve launched with `-p default` moves to the sticky profile's home the moment a desktop client asks for runtime readiness. Globals captured at import time keep the original value (`tui_gateway/server.py:54`), so one process resolves profiles two different ways. The rerun also calls `load_hermes_dotenv(override=True)` again, overwriting env vars set after startup.

I observed this on a live serve started with `-p default` while the sticky `active_profile` named a second profile (`alpha` here). `projects.list` returned the alpha store for `profile:"default"` and for unknown profile names. Omitting the param gave the same result. `/api/profiles/active` reported `current: alpha`.

The fix registers the running module under its canonical name so later imports reuse it, and binds it as `main` on the loaded parent package (a `sys.modules` cache hit skips importlib's parent-attribute step, so the alias alone would leave the dotted attribute `hermes_cli.main` unset):

```python
if __name__ == "__main__" and __spec__ is not None:
    sys.modules.setdefault(__spec__.name, sys.modules[__name__])
    _canonical = sys.modules[__spec__.name]
    _parent_name, _, _child = __spec__.name.rpartition(".")
    _parent = sys.modules.get(_parent_name) if _parent_name else None
    if _parent is not None and not hasattr(_parent, _child):
        setattr(_parent, _child, _canonical)
```

With the rerun gone, every top-level side effect is covered, including the dotenv reload.

Open PRs for #66907:

- #67048 wraps `_apply_profile_override()` in a PID-scoped sentinel. The HERMES_HOME rewrite stops. The rest of the module top level still reruns on canonical import.
- #53955 uses a constant env sentinel. Review there found the marker inheriting into child processes, where it suppresses explicit `-p` parsing. This PR carries a test for that case: a grandchild launched with its own `-p` must resolve its own profile. I re-implemented the env sentinel locally on `main` and the test fails against it. It passes with the module alias because `sys.modules` never crosses a process boundary.

If the maintainers prefer to land #67048, both tests port onto it and I am glad to contribute them there.

## Related Issue

Fixes #66907 (also reported as #72543, labeled duplicate).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: register the executing `__main__` module under `__spec__.name` right after `os` and `sys` become available, before any heavy import and before the bootstrap call, and bind it as `main` on the `hermes_cli` package when that attribute is absent. `setdefault` leaves an embedding-provided registration alone, and an existing parent binding is never clobbered. Direct-path execution (`__spec__ is None`) is unchanged.
- `tests/hermes_cli/test_main_module_alias.py` (new), two child-process tests that drive the real seam:
  - `test_canonical_import_does_not_rehome_running_main` runs `main.py` as `__main__` via `runpy` with an explicit `-p default`, under a temporary `HERMES_HOME` whose sticky `active_profile` points at a decoy profile. It then imports the module canonically and asserts the process home stayed put, the canonical `sys.modules` entry is the running module by identity, and `hermes_cli.main` resolves to that same object after the dotted import.
  - `test_child_process_still_resolves_its_own_profile` spawns, from the aliased parent, a grandchild `python -m hermes_cli.main -p <other> --help` and asserts the grandchild resolves its own explicit profile.

## How to Test

1. Reproduce on `main` without the fix:
   ```bash
   export T=$(mktemp -d); mkdir -p $T/profiles/lured; echo lured > $T/active_profile
   HERMES_HOME=$T python - <<'EOF'
   import os, runpy, sys
   sys.argv = ["hermes", "-p", "default", "--help"]
   try: runpy.run_module("hermes_cli.main", run_name="__main__", alter_sys=True)
   except SystemExit: pass
   print("after pass 1:", os.environ["HERMES_HOME"])
   import hermes_cli.main
   print("after canonical import:", os.environ["HERMES_HOME"])
   EOF
   ```
   On `main` the second line prints `<root>/profiles/lured`. With this PR it stays at `<root>`.
2. `pytest tests/hermes_cli/test_main_module_alias.py -q` passes. On unpatched `main` the first test fails with `running module must self-register under its canonical name`.
3. Full suite: `scripts/run_tests.sh -q`.

## Checklist

### Code
- [x] I have read CONTRIBUTING.md
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs for duplicates (#67048 and #53955, discussed above)
- [x] This PR contains only related changes
- [x] I ran the full test suite (`scripts/run_tests.sh -q`): 22,756 passed. The 67 failures match my `origin/main` baseline (optional backends and platform gaps). Zero new failures.
- [x] I added tests that fail without this change
- [x] Tested on: macOS 15 (arm64, Apple M4), Python 3.11

### Documentation & Housekeeping
- [x] Docs: N/A (bug fix, no user-facing surface change)
- [x] `cli-config.yaml.example`: N/A (no config keys changed)
- [x] CONTRIBUTING/AGENTS: N/A (no architecture or workflow change)
- [x] Cross-platform: pure Python, touches only `sys.modules` and `__spec__`. The guard behaves identically on Windows.
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Symptom capture from the reproduction above, same temp root and sticky decoy:

```
OLD: AFTER_PASS1=<root>  ALIASED=False  AFTER_PASS2=<root>/profiles/lured
NEW: AFTER_PASS1=<root>  ALIASED=True   AFTER_PASS2=<root>
```

