### PR TITLE
fix(desktop): preserve URLs in Markdown code

### DIFF
--- a/apps/desktop/src/app/chat/composer/url-refs.test.ts
+++ b/apps/desktop/src/app/chat/composer/url-refs.test.ts
@@ -92,6 +92,12 @@ describe('linkifyUrls', () => {
     expect(linkifyUrls(unfinishedInline)).toBe(unfinishedInline)
   })
 
+  it('rewrites prose links after an escaped unmatched backtick', () => {
+    expect(linkifyUrls('show \\` literally, then visit https://example.dev/api')).toBe(
+      'show \\` literally, then visit @url:`https://example.dev/api`'
+    )
+  })
+
   it('leaves text without a scheme alone', () => {
     expect(linkifyUrls('example.dev/a and src/foo.ts')).toBe('example.dev/a and src/foo.ts')
   })
@@ -170,6 +176,16 @@ describe('chipTypedUrlOnSpace', () => {
     expect(composerPlainText(editor)).toBe(
       ['```', 'https://code.dev/api', '```', 'see @url:`https://example.dev/api` '].join('\n')
     )
+
+    editor.remove()
+  })
+
+  it('chips a prose link typed after an escaped unmatched backtick', () => {
+    const text = 'show \\` literally, then visit https://example.dev/api'
+    const { editor, event } = spaceOn(text, text.length)
+
+    expect(chipTypedUrlOnSpace(event)).toBe(true)
+    expect(composerPlainText(editor)).toBe('show \\` literally, then visit @url:`https://example.dev/api` ')
 
     editor.remove()
   })

--- a/apps/desktop/src/app/chat/composer/url-refs.test.ts
+++ b/apps/desktop/src/app/chat/composer/url-refs.test.ts
@@ -46,6 +46,52 @@ describe('linkifyUrls', () => {
     expect(linkifyUrls('@url:`https://example.dev`')).toBe('@url:`https://example.dev`')
   })
 
+  it('preserves links inside fenced code while rewriting surrounding prose', () => {
+    const text = [
+      'before https://before.dev',
+      '```ini',
+      'endpoint=https://code.dev/api',
+      '```',
+      'after https://after.dev'
+    ].join('\n')
+
+    expect(linkifyUrls(text)).toBe(
+      [
+        'before @url:`https://before.dev`',
+        '```ini',
+        'endpoint=https://code.dev/api',
+        '```',
+        'after @url:`https://after.dev`'
+      ].join('\n')
+    )
+  })
+
+  it('preserves links inside tilde-fenced code', () => {
+    const text = ['~~~yaml', 'endpoint: https://code.dev/api', '~~~'].join('\n')
+
+    expect(linkifyUrls(text)).toBe(text)
+  })
+
+  it('preserves links inside inline code while rewriting surrounding prose', () => {
+    expect(linkifyUrls('see https://before.dev then `curl https://code.dev/api` and https://after.dev')).toBe(
+      'see @url:`https://before.dev` then `curl https://code.dev/api` and @url:`https://after.dev`'
+    )
+  })
+
+  it('supports arbitrary backtick runs around inline code', () => {
+    const text = 'run ``curl ` https://code.dev/api`` now'
+
+    expect(linkifyUrls(text)).toBe(text)
+  })
+
+  it('preserves links in unfinished code while the user is composing it', () => {
+    const unfinishedFence = ['```sh', 'curl https://code.dev/api'].join('\n')
+    const unfinishedInline = 'run `curl https://code.dev/api'
+
+    expect(linkifyUrls(unfinishedFence)).toBe(unfinishedFence)
+    expect(linkifyUrls(unfinishedInline)).toBe(unfinishedInline)
+  })
+
   it('leaves text without a scheme alone', () => {
     expect(linkifyUrls('example.dev/a and src/foo.ts')).toBe('example.dev/a and src/foo.ts')
   })
@@ -92,6 +138,38 @@ describe('chipTypedUrlOnSpace', () => {
 
     expect(chipTypedUrlOnSpace({ ...event, altKey: true })).toBe(false)
     expect(composerPlainText(editor)).toBe('https://example.dev')
+
+    editor.remove()
+  })
+
+  it('does not chip a link typed inside an unfinished fenced code block', () => {
+    const text = ['```sh', 'curl https://code.dev/api'].join('\n')
+    const { editor, event } = spaceOn(text, text.length)
+
+    expect(chipTypedUrlOnSpace(event)).toBe(false)
+    expect(composerPlainText(editor)).toBe(text)
+
+    editor.remove()
+  })
+
+  it('does not chip a link typed inside an unfinished inline code span', () => {
+    const text = 'run `curl https://code.dev/api'
+    const { editor, event } = spaceOn(text, text.length)
+
+    expect(chipTypedUrlOnSpace(event)).toBe(false)
+    expect(composerPlainText(editor)).toBe(text)
+
+    editor.remove()
+  })
+
+  it('still chips a link typed after a completed code block', () => {
+    const text = ['```', 'https://code.dev/api', '```', 'see https://example.dev/api'].join('\n')
+    const { editor, event } = spaceOn(text, text.length)
+
+    expect(chipTypedUrlOnSpace(event)).toBe(true)
+    expect(composerPlainText(editor)).toBe(
+      ['```', 'https://code.dev/api', '```', 'see @url:`https://example.dev/api` '].join('\n')
+    )
 
     editor.remove()
   })

--- a/apps/desktop/src/app/chat/composer/url-refs.ts
+++ b/apps/desktop/src/app/chat/composer/url-refs.ts
@@ -15,6 +15,87 @@ import { textBeforeCaret } from './text-utils'
 const URL_RE = /https?:\/\/[^\s<>[\]{}"'`]+/gi
 const TYPED_URL_RE = /(?:^|\s)(https?:\/\/[^\s<>[\]{}"'`]+)$/i
 
+interface TextRange {
+  end: number
+  start: number
+}
+
+const containsIndex = (ranges: TextRange[], index: number) =>
+  ranges.some(range => index >= range.start && index < range.end)
+
+/** Markdown fenced code blocks, including an unfinished block while composing. */
+function fencedCodeRanges(text: string) {
+  const ranges: TextRange[] = []
+  let opening: { marker: string; start: number } | undefined
+
+  for (const match of text.matchAll(/^[ \t]{0,3}(`{3,}|~{3,})([^\r\n]*)(?:\r?\n|$)/gm)) {
+    const marker = match[1]
+    const tail = match[2]
+
+    if (!opening) {
+      // Backticks in an opening backtick fence's info string are invalid
+      // Markdown, so do not turn the rest of the draft into protected code.
+      if (marker[0] === '`' && tail.includes('`')) {
+        continue
+      }
+
+      opening = { marker, start: match.index ?? 0 }
+
+      continue
+    }
+
+    const closesFence = marker[0] === opening.marker[0] && marker.length >= opening.marker.length && tail.trim() === ''
+
+    if (closesFence) {
+      ranges.push({ end: (match.index ?? 0) + match[0].length, start: opening.start })
+      opening = undefined
+    }
+  }
+
+  if (opening) {
+    ranges.push({ end: text.length, start: opening.start })
+  }
+
+  return ranges
+}
+
+/** Markdown inline code spans outside fences, including an unfinished span. */
+function inlineCodeRanges(text: string, fenced: TextRange[]) {
+  const ranges: TextRange[] = []
+  const markers = Array.from(text.matchAll(/`+/g)).filter(marker => !containsIndex(fenced, marker.index ?? 0))
+  let markerIndex = 0
+
+  while (markerIndex < markers.length) {
+    const opening = markers[markerIndex]
+
+    const closingIndex = markers.findIndex(
+      (candidate, index) => index > markerIndex && candidate[0].length === opening[0].length
+    )
+
+    if (closingIndex === -1) {
+      ranges.push({ end: text.length, start: opening.index ?? 0 })
+
+      break
+    }
+
+    const closing = markers[closingIndex]
+
+    ranges.push({
+      end: (closing.index ?? 0) + closing[0].length,
+      start: opening.index ?? 0
+    })
+    markerIndex = closingIndex + 1
+  }
+
+  return ranges
+}
+
+function markdownCodeRanges(text: string) {
+  const fenced = fencedCodeRanges(text)
+
+  return [...fenced, ...inlineCodeRanges(text, fenced)]
+}
+
 /** A URL at the end of a sentence carries the punctuation that ended it. */
 function splitUrlTail(raw: string) {
   let url = raw.replace(/[,.;:!?]+$/, '')
@@ -35,11 +116,13 @@ const hasHost = (url: string) => /^https?:\/\/[^/\s]/i.test(url)
 export function linkifyUrls(text: string) {
   REF_RE.lastIndex = 0
 
-  const fenced = Array.from(text.matchAll(REF_RE)).map(match => {
+  const protectedRanges = Array.from(text.matchAll(REF_RE)).map(match => {
     const start = match.index ?? 0
 
     return { end: start + match[0].length, start }
   })
+
+  protectedRanges.push(...markdownCodeRanges(text))
 
   let out = ''
   let cursor = 0
@@ -48,7 +131,7 @@ export function linkifyUrls(text: string) {
     const start = match.index ?? 0
     const { url } = splitUrlTail(match[0])
 
-    if (!hasHost(url) || fenced.some(span => start >= span.start && start < span.end)) {
+    if (!hasHost(url) || containsIndex(protectedRanges, start)) {
       continue
     }
 
@@ -76,10 +159,21 @@ export function chipTypedUrlOnSpace(event: KeyboardEvent<HTMLDivElement>) {
   }
 
   const before = textBeforeCaret(editor)
-  const match = before ? TYPED_URL_RE.exec(before) : null
+
+  if (!before) {
+    return false
+  }
+
+  const match = TYPED_URL_RE.exec(before)
   const token = match?.[1]
 
   if (!token) {
+    return false
+  }
+
+  const tokenStart = before.length - token.length
+
+  if (containsIndex(markdownCodeRanges(before), tokenStart)) {
     return false
   }
 

--- a/apps/desktop/src/app/chat/composer/url-refs.ts
+++ b/apps/desktop/src/app/chat/composer/url-refs.ts
@@ -23,6 +23,16 @@ interface TextRange {
 const containsIndex = (ranges: TextRange[], index: number) =>
   ranges.some(range => index >= range.start && index < range.end)
 
+function isEscaped(text: string, index: number) {
+  let backslashes = 0
+
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === '\\'; cursor -= 1) {
+    backslashes += 1
+  }
+
+  return backslashes % 2 === 1
+}
+
 /** Markdown fenced code blocks, including an unfinished block while composing. */
 function fencedCodeRanges(text: string) {
   const ranges: TextRange[] = []
@@ -62,7 +72,13 @@ function fencedCodeRanges(text: string) {
 /** Markdown inline code spans outside fences, including an unfinished span. */
 function inlineCodeRanges(text: string, fenced: TextRange[]) {
   const ranges: TextRange[] = []
-  const markers = Array.from(text.matchAll(/`+/g)).filter(marker => !containsIndex(fenced, marker.index ?? 0))
+
+  const markers = Array.from(text.matchAll(/`+/g)).filter(marker => {
+    const index = marker.index ?? 0
+
+    return !containsIndex(fenced, index) && !isEscaped(text, index)
+  })
+
   let markerIndex = 0
 
   while (markerIndex < markers.length) {


### PR DESCRIPTION
## What does this PR do?

Prevents the Desktop composer from converting URLs inside Markdown code into `@url:` reference chips.

The root cause was that both URL entry paths recognized valid URLs without checking whether the matched text belonged to a fenced or inline code region. The shared URL recognizer now protects:

- backtick and tilde fenced code blocks
- inline code spans with matching backtick-run lengths
- unfinished fenced and inline code while the user is still composing

URLs in ordinary prose keep the existing reference-chip behavior. Because the fix is in the shared recognizer, it covers paste and typed-space handling in both the main composer and the message-edit composer.

## Related Issue

Fixes #74741

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/src/app/chat/composer/url-refs.ts` to exclude Markdown code regions from URL conversion.
- Added behavior coverage in `apps/desktop/src/app/chat/composer/url-refs.test.ts` for fenced code, tilde fences, inline code, unfinished code, surrounding prose, paste conversion, and typed-space conversion.

## How to Test

1. Paste text containing URLs inside fenced and inline Markdown code into the Desktop composer.
2. Type a URL inside an unfinished fenced or inline code region and press Space.
3. Verify code URLs remain plain text, while a URL entered in ordinary prose still becomes a URL reference chip.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; this is a Desktop-only TypeScript change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Chromium

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral string and DOM logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tools changed

## Screenshots / Logs

Validation:

- Desktop UI suite under Node 22: 354 files and 3,140 tests passed.
- Targeted URL reference suite: 21 tests passed.
- `npm run check:lint`: typecheck passed; lint completed with only pre-existing warnings.
- Real Chromium verification: fenced/inline paste and typed-space paths produced zero URL chips; ordinary prose still produced a URL chip.
