### PR TITLE
fix(cron): thread full Slack cron output under concise root

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -486,6 +486,110 @@ class _ReadWriteLock:
 _terminal_cwd_lock = _ReadWriteLock()
 
 
+def _format_cron_duration(seconds: float | int | None) -> str:
+    """Format a cron run duration for compact user-facing Slack summaries."""
+    if seconds is None:
+        return "unknown"
+    try:
+        total = max(0, int(round(float(seconds))))
+    except (TypeError, ValueError):
+        return "unknown"
+    hours, rem = divmod(total, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}h {minutes}m" if minutes else f"{hours}h"
+    if minutes:
+        return f"{minutes}m {secs}s" if secs else f"{minutes}m"
+    return f"{secs}s"
+
+
+def _clean_cron_summary_line(line: str) -> str:
+    """Remove Markdown list/heading noise from a root Slack summary line."""
+    text = re.sub(r"^\s{0,3}#{1,6}\s*", "", line or "")
+    text = re.sub(r"^\s*(?:[-*•]|\d+[.)])\s*", "", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _extract_cron_action_lines(content: str, limit: int = 3) -> list[str]:
+    """Prefer action/next-step lines for Slack cron root summaries."""
+    action_heading_re = re.compile(
+        r"^\s{0,3}#{1,6}\s*(?:다음\s*액션|액션\s*아이템|해야\s*할\s*일|next\s+actions?|action\s+items?|todo)\b",
+        re.IGNORECASE,
+    )
+    any_heading_re = re.compile(r"^\s{0,3}#{1,6}\s+")
+    collected: list[str] = []
+    in_action_section = False
+    for raw in (content or "").splitlines():
+        if action_heading_re.search(raw):
+            in_action_section = True
+            continue
+        if in_action_section and any_heading_re.search(raw):
+            break
+        if in_action_section:
+            cleaned = _clean_cron_summary_line(raw)
+            if cleaned:
+                collected.append(cleaned)
+                if len(collected) >= limit:
+                    return collected
+    return collected
+
+
+def _first_meaningful_cron_lines(content: str, limit: int = 3) -> list[str]:
+    """Return readable preview lines, skipping cron wrapper boilerplate."""
+    skip_prefixes = (
+        "Cronjob Response:",
+        "(job_id:",
+        "-------------",
+        "To stop or manage this job,",
+    )
+    result: list[str] = []
+    for raw in (content or "").splitlines():
+        cleaned = _clean_cron_summary_line(raw)
+        if not cleaned or any(cleaned.startswith(prefix) for prefix in skip_prefixes):
+            continue
+        result.append(cleaned)
+        if len(result) >= limit:
+            break
+    return result
+
+
+def _build_slack_cron_summary(
+    job: dict,
+    content: str,
+    duration_seconds: float | int | None = None,
+    success: bool = True,
+) -> str:
+    """Build a five-line-or-less Slack channel-root summary for cron output."""
+    job_name = job.get("name") or job.get("id") or "cron job"
+    job_id = job.get("id", "")
+    status_icon = "✅" if success else "⚠️"
+    status_text = "완료" if success else "실패"
+    first_line = f"{status_icon} {job_name} {status_text}"
+    if job_id:
+        first_line += f" · job_id `{job_id}`"
+    first_line += f" · 진행시간 {_format_cron_duration(duration_seconds)}"
+    preview_lines = (
+        _extract_cron_action_lines(content, limit=3)
+        or _first_meaningful_cron_lines(content, limit=3)
+    )
+    summary_lines = [first_line, *(f"- {line}" for line in preview_lines[:3])]
+    summary_lines.append("전체 본문은 이 메시지의 thread에 남겼습니다.")
+    return "\n".join(summary_lines[:5])
+
+
+def _slack_message_id_from_result(result) -> str | None:
+    """Extract Slack ts/message_id from dict or SendResult-style objects."""
+    if not result:
+        return None
+    if isinstance(result, dict):
+        raw = result.get("raw_response")
+        raw_ts = raw.get("ts") if isinstance(raw, dict) else None
+        return result.get("message_id") or result.get("ts") or raw_ts
+    raw = getattr(result, "raw_response", None)
+    raw_ts = raw.get("ts") if isinstance(raw, dict) else None
+    return getattr(result, "message_id", None) or getattr(result, "ts", None) or raw_ts
+
+
 def _get_parallel_pool(max_workers: Optional[int]) -> concurrent.futures.ThreadPoolExecutor:
     """Return (or create) the persistent parallel pool."""
     global _parallel_pool, _parallel_pool_max_workers
@@ -1447,7 +1551,14 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    duration_seconds: float | int | None = None,
+    success: bool = True,
+) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -1487,10 +1598,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
     wrap_response = True
+    slack_threaded_delivery = True
     user_cfg = None
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        cron_cfg = user_cfg.get("cron", {}) if isinstance(user_cfg, dict) else {}
+        wrap_response = cron_cfg.get("wrap_response", True)
+        # Keep Slack channel roots concise unless the user explicitly opts out.
+        slack_threaded_delivery = cron_cfg.get("slack_threaded_delivery", True)
     except Exception:
         pass
 
@@ -1533,6 +1648,22 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         return msg
 
     delivery_errors = []
+
+    def _run_standalone_send(platform, pconfig, chat_id, message, **kwargs):
+        """Run the standalone sender safely from synchronous cron code."""
+        coro = _send_to_platform(platform, pconfig, chat_id, message, **kwargs)
+        try:
+            return asyncio.run(coro)
+        except RuntimeError as run_err:
+            coro.close()
+            if _interpreter_shutting_down(run_err):
+                raise
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(
+                    asyncio.run,
+                    _send_to_platform(platform, pconfig, chat_id, message, **kwargs),
+                )
+                return future.result(timeout=30)
 
     for target in targets:
         platform_name = target["platform"]
@@ -1591,6 +1722,72 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
             continue
+
+        # A native Slack channel root has a stable ts/message_id contract.
+        # Send the compact root first and only then post the complete body into
+        # that thread. Relay transports stay on their existing live-adapter path:
+        # they do not guarantee a native Slack root id and must not be retried
+        # through an unrelated direct connector.
+        if (
+            slack_threaded_delivery
+            and platform == Platform.SLACK
+            and not thread_id
+            # Continuable origin jobs need their existing live-adapter/session
+            # seeding flow; only ordinary channel-root cron delivery is split.
+            and not mirror_this_target
+            and not (transport is not None and transport.is_relay)
+        ):
+            try:
+                root_result = _run_standalone_send(
+                    platform,
+                    pconfig,
+                    chat_id,
+                    _build_slack_cron_summary(
+                        job,
+                        content,
+                        duration_seconds=duration_seconds,
+                        success=success,
+                    ),
+                    thread_id=None,
+                    media_files=[],
+                )
+                if isinstance(root_result, dict) and root_result.get("error"):
+                    msg = f"delivery error: {root_result['error']}"
+                    logger.error("Job '%s': %s", job["id"], msg)
+                    delivery_errors.append(msg)
+                    continue
+                root_message_id = _slack_message_id_from_result(root_result)
+                if not root_message_id:
+                    msg = "Slack threaded cron delivery could not determine root message id"
+                    logger.error("Job '%s': %s", job["id"], msg)
+                    delivery_errors.append(msg)
+                    continue
+                thread_result = _run_standalone_send(
+                    platform,
+                    pconfig,
+                    chat_id,
+                    cleaned_delivery_content,
+                    thread_id=root_message_id,
+                    media_files=media_files,
+                )
+                if isinstance(thread_result, dict) and thread_result.get("error"):
+                    msg = f"delivery error: {thread_result['error']}"
+                    logger.error("Job '%s': %s", job["id"], msg)
+                    delivery_errors.append(msg)
+                    continue
+                logger.info(
+                    "Job '%s': delivered threaded Slack cron response to %s:%s root_ts=%s",
+                    job["id"],
+                    platform_name,
+                    chat_id,
+                    root_message_id,
+                )
+                continue
+            except Exception as exc:
+                msg = f"threaded Slack delivery to {platform_name}:{chat_id} failed: {exc}"
+                logger.error("Job '%s': %s", job["id"], msg)
+                delivery_errors.append(msg)
+                continue
 
         # Prefer the resolved live transport when the gateway is running. This
         # supports E2EE native adapters and relay-fronted logical platforms.
@@ -3916,6 +4113,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # The attempt is claimed durably before executor/provider dispatch and
         # becomes running only immediately before the actual run.
         mark_execution_running(execution_id)
+        run_started_monotonic = time.monotonic()
 
         # Run the job under the profile's secret scope. get_secret() fails
         # closed outside a scope once profile isolation is in play (multiple
@@ -3945,6 +4143,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             success, output, final_response, error = run_job(
                 job, defer_agent_teardown=_deferred_agents
             )
+            duration_seconds = time.monotonic() - run_started_monotonic
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
             # it down here so a failed run never leaks its async resources
@@ -4008,7 +4207,14 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     and not _resolve_delivery_targets(job)
                 )
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    delivery_error = _deliver_result(
+                        job,
+                        deliver_content,
+                        adapters=adapters,
+                        loop=loop,
+                        duration_seconds=duration_seconds,
+                        success=success,
+                    )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)

--- a/tests/cron/test_slack_threaded_delivery.py
+++ b/tests/cron/test_slack_threaded_delivery.py
@@ -1,0 +1,128 @@
+"""Regression tests for Slack root-summary → thread-body cron delivery."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cron import scheduler
+from gateway.config import Platform
+import gateway.delivery as delivery
+import tools.send_message_tool as send_message_tool
+
+
+def test_build_slack_cron_summary_is_five_lines_or_less() -> None:
+    summary = scheduler._build_slack_cron_summary(
+        {"id": "job-1", "name": "무즈린 리서치"},
+        "## 다음 액션\n- 첫 액션\n- 둘째 액션\n- 셋째 액션\n- 넷째 액션",
+        duration_seconds=8,
+        success=True,
+    )
+
+    assert len(summary.splitlines()) == 5
+    assert summary.splitlines()[0].startswith("✅ 무즈린 리서치 완료")
+    assert summary.splitlines()[-1] == "전체 본문은 이 메시지의 thread에 남겼습니다."
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        ({"message_id": "171.001"}, "171.001"),
+        ({"ts": "171.002"}, "171.002"),
+        ({"raw_response": {"ts": "171.003"}}, "171.003"),
+        (SimpleNamespace(message_id="171.004", raw_response=None), "171.004"),
+    ],
+)
+def test_slack_message_id_from_result_accepts_native_send_shapes(result, expected) -> None:
+    assert scheduler._slack_message_id_from_result(result) == expected
+
+
+def test_slack_channel_delivery_sends_summary_root_then_full_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent: list[tuple[str, dict]] = []
+
+    async def fake_send(_platform, _config, _chat_id, content, **kwargs):
+        sent.append((content, kwargs))
+        return {"success": True, "message_id": "171.100" if len(sent) == 1 else "171.101"}
+
+    monkeypatch.setattr(send_message_tool, "_send_to_platform", fake_send)
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_delivery_targets",
+        lambda _job: [{"platform": "slack", "chat_id": "C_TEST", "thread_id": None}],
+    )
+    monkeypatch.setattr(scheduler, "_resolve_origin", lambda _job: {})
+    monkeypatch.setattr(
+        scheduler,
+        "load_config",
+        lambda: {"cron": {"wrap_response": True, "slack_threaded_delivery": True}},
+    )
+    monkeypatch.setattr(
+        delivery,
+        "resolve_delivery_transport",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        __import__("gateway.config", fromlist=["load_gateway_config"]),
+        "load_gateway_config",
+        lambda: SimpleNamespace(
+            platforms={Platform.SLACK: SimpleNamespace(enabled=True, extra={})}
+        ),
+    )
+
+    error = scheduler._deliver_result(
+        {"id": "job-1", "name": "무즈린 리서치", "deliver": "slack:C_TEST"},
+        "## 핵심\n전체 상세 본문입니다.",
+        duration_seconds=7,
+        success=True,
+    )
+
+    assert error is None
+    assert len(sent) == 2
+    root, root_kwargs = sent[0]
+    body, body_kwargs = sent[1]
+    assert len(root.splitlines()) <= 5
+    assert root_kwargs["thread_id"] is None
+    assert body == "Cronjob Response: 무즈린 리서치\n(job_id: job-1)\n-------------\n\n## 핵심\n전체 상세 본문입니다.\n\nTo stop or manage this job, send me a new message (e.g. \"stop reminder 무즈린 리서치\")."
+    assert body_kwargs["thread_id"] == "171.100"
+
+
+def test_slack_channel_delivery_fails_without_a_root_message_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    async def fake_send(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return {"success": True}
+
+    monkeypatch.setattr(send_message_tool, "_send_to_platform", fake_send)
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_delivery_targets",
+        lambda _job: [{"platform": "slack", "chat_id": "C_TEST", "thread_id": None}],
+    )
+    monkeypatch.setattr(scheduler, "_resolve_origin", lambda _job: {})
+    monkeypatch.setattr(
+        scheduler,
+        "load_config",
+        lambda: {"cron": {"wrap_response": True, "slack_threaded_delivery": True}},
+    )
+    monkeypatch.setattr(delivery, "resolve_delivery_transport", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        __import__("gateway.config", fromlist=["load_gateway_config"]),
+        "load_gateway_config",
+        lambda: SimpleNamespace(
+            platforms={Platform.SLACK: SimpleNamespace(enabled=True, extra={})}
+        ),
+    )
+
+    error = scheduler._deliver_result(
+        {"id": "job-2", "name": "무즈리아 QA", "deliver": "slack:C_TEST"},
+        "상세 본문",
+    )
+
+    assert calls == 1
+    assert error == "Slack threaded cron delivery could not determine root message id"


### PR DESCRIPTION
## Summary
- add opt-in `cron.slack_threaded_delivery` behavior for ordinary native Slack channel cron targets
- post a five-line-or-less root summary first, then send the full cron body and media into that root thread
- fail delivery instead of falling back to a long channel-root body when Slack does not return a root message id
- preserve relay, live-adapter, continuable-session, explicit-thread, and non-Slack paths

## Tests
- `uv run --with pytest --with pyyaml pytest tests/cron/test_slack_threaded_delivery.py tests/cron/test_scheduler.py -q -o 'addopts='`
- result: `70 passed, 1 warning` (existing coroutine warning from scheduler suite)

## Context
This removes a local-only scheduler customization that repeatedly drifted after upstream updates/autostash in a multi-profile Slack cron deployment.
