### PR TITLE
fix(desktop): adopt saved primary profile before gateway boot

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
 import { $gatewayState } from '@/store/session'
+import { $activeGatewayProfile } from '@/store/profile'
 
 import { takeGatewaySurvivor } from './gateway-hmr-survivor'
 import { useGatewayBoot } from './use-gateway-boot'
@@ -160,6 +161,7 @@ beforeEach(() => {
     timestamp: Date.now(),
     visible: true
   })
+  $activeGatewayProfile.set('default')
 })
 
 afterEach(() => {
@@ -234,6 +236,33 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     })
 
     expect($desktopBoot.get().error).toBeTruthy()
+  })
+
+  it('adopts the persisted primary profile before obtaining the primary connection', async () => {
+    const desktop = fakeDesktop()
+    const profileGet = vi.fn(async () => ({ profile: 'atlas' }))
+    const getConnection = desktop.getConnection
+    desktop.profile.get = profileGet
+    desktop.getConnection = vi.fn(async () => {
+      expect($activeGatewayProfile.get()).toBe('atlas')
+
+      return getConnection()
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect(profileGet).toHaveBeenCalledOnce()
+    expect(desktop.getConnection).toHaveBeenCalledOnce()
+    expect(profileGet.mock.invocationCallOrder[0]).toBeLessThan(desktop.getConnection.mock.invocationCallOrder[0])
+
+    // Regression: adopting a non-default primary must also move the registry's
+    // active pointer. If activeKey stays "default" while state events are
+    // tagged "atlas", reportGatewayState drops the open transition and the
+    // UI hangs at "connecting" forever.
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect($gatewayState.get()).toBe('open')
   })
 
   it('resets the old machine context before connecting an applied gateway', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -232,19 +232,37 @@ export function useGatewayBoot({
     }
 
     // Adopt the profile the primary (window) backend booted as, so same-profile
-    // resumes are no-op swaps and reconnects target the right backend.
-    // Best-effort: a missing preference means "default". Shared by boot + soft
-    // switch.
-    async function adoptPrimaryProfile() {
+    // resumes are no-op swaps and reconnects target the right backend. The IPC
+    // read is best-effort: a missing preference means "default".
+    let sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
+
+    async function readPrimaryProfile(): Promise<string> {
       try {
         const pref = await desktop.profile?.get?.()
-        const profileKey = (pref?.profile ?? '').trim() || 'default'
-        $activeGatewayProfile.set(profileKey)
-        setPrimaryGateway(gateway, profileKey)
-        void ensureGatewayForProfile(profileKey)
+
+        return normalizeProfileKey((pref?.profile ?? '').trim() || 'default')
       } catch {
-        $activeGatewayProfile.set('default')
+        return 'default'
       }
+    }
+
+    function applyPrimaryProfile(profile: string): void {
+      const profileKey = normalizeProfileKey(profile)
+      $activeGatewayProfile.set(profileKey)
+      sourceProfile = profileKey
+      setPrimaryGateway(gateway, profileKey)
+      // Align the registry's active pointer with the primary. Without this,
+      // gateway state events (tagged with primaryProfile) fail the
+      // activeKey match in reportGatewayState and the "open" state never
+      // publishes — the UI hangs at "connecting". For the primary key this
+      // is the synchronous setActive fast path, safe pre-connect.
+      void ensureGatewayForProfile(profileKey)
+    }
+
+    // A soft gateway-mode apply establishes the socket before the primary
+    // profile is available, so it also wakes the matching profile socket.
+    async function adoptPrimaryProfile() {
+      applyPrimaryProfile(await readPrimaryProfile())
     }
 
     // Seed the working dir from the backend default on a fresh view (nothing
@@ -360,7 +378,6 @@ export function useGatewayBoot({
     const gateway = adoptedFromHmr ? survivor!.gateway : new HermesGateway()
 
     callbacksRef.current.onGatewayReady(gateway)
-    setPrimaryGateway(gateway, survivor?.profile ?? normalizeProfileKey($activeGatewayProfile.get()))
     // Secondary (background-profile) sockets funnel into the same handler.
     configureGatewayRegistry({ onEvent: event => callbacksRef.current.handleGatewayEvent(event) })
 
@@ -390,7 +407,8 @@ export function useGatewayBoot({
       }
     })
 
-    const sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
+    // Set by applyPrimaryProfile() before boot starts, so every initial event
+    // carries the persisted primary profile rather than the atom's default.
 
     const offEvent = gateway.onEvent(event =>
       callbacksRef.current.handleGatewayEvent({ ...event, profile: sourceProfile })
@@ -491,13 +509,6 @@ export function useGatewayBoot({
           return
         }
 
-        // Profile adoption must land first: refreshSessions scopes its fetch by
-        // $profileScope ← $activeGatewayProfile. The remaining three fetches
-        // (cwd seed, config, sessions) are independent REST calls — running
-        // them serially added their sum to time-to-populated-sidebar when only
-        // the max is needed.
-        await adoptPrimaryProfile()
-
         setDesktopBootStep({
           phase: 'renderer.config',
           message: translateNow('boot.steps.loadingSettings'),
@@ -565,11 +576,26 @@ export function useGatewayBoot({
       await callbacksRef.current.refreshSessions().catch(() => undefined)
     }
 
-    if (adoptedFromHmr) {
-      void adoptBoot()
-    } else {
-      void boot()
+    async function startBoot() {
+      // The primary connection descriptor does not carry a profile. Seed the
+      // renderer from active-profile.json before getConnection() so the first
+      // sidebar fetch cannot issue against the atom's initial "default" value.
+      const profile = survivor?.profile ? normalizeProfileKey(survivor.profile) : await readPrimaryProfile()
+
+      if (cancelled) {
+        return
+      }
+
+      applyPrimaryProfile(profile)
+
+      if (adoptedFromHmr) {
+        void adoptBoot()
+      } else {
+        void boot()
+      }
     }
+
+    void startBoot()
 
     return () => {
       cancelled = true


### PR DESCRIPTION
## What does this PR do?

Fixes a race at cold boot in the desktop app. The renderer connects the primary gateway before it reads which profile the desktop persisted, so fetches keyed on `gatewayReady` can run while `$activeGatewayProfile` still holds its initial `'default'`.

I measured the order on unpatched `main` with `atlas` as the persisted profile. `desktop.profile.get()` runs once, after `getConnection()` has already resolved. At the moment the connection is obtained the atom reads `"default"`. The shared gateway client publishes `setState('open')` inside `connect()` before the promise resolves (`apps/shared/src/json-rpc-gateway.ts`), and boot awaits `adoptPrimaryProfile()` later. The sidebar's first sessions and projects fetches race the adoption IPC and lose. Any machine whose primary profile is a named one paints its first sidebar under the wrong profile.

PR #50529 identified this ordering problem. Its review asked for a rebase onto the current `adoptPrimaryProfile()` helper with the seed applied before cold-boot `getConnection()`. This PR implements that shape, with credit to #50529's author.

1. Read before connect. The IPC read of the persisted profile moves out of `adoptPrimaryProfile()` into `readPrimaryProfile()` and `applyPrimaryProfile()`. Cold boot applies it to the atom, to the registry's `primaryProfile`, and to event tagging before `desktop.getConnection()`. HMR-survivor adoption keeps its path, as does the catch that falls back to `'default'`.
2. Align the registry's active pointer during adoption. `applyPrimaryProfile()` also runs the primary fast path of `ensureGatewayForProfile()`, a synchronous `setActive` that is safe before connect. Skipping this step drops the `open` transition: state events tagged with the adopted primary fail the `activeKey` comparison in `reportGatewayState` and the UI sits at "connecting" forever. A test guards this.

If the preferred path is updating #50529 itself, the tests here can move there.

## Related Issue

Addresses the boot-ordering defect tracked in PR #50529's review: adopt the persisted primary profile before `getConnection()`. In-flight work on the same hook covers different lifecycle paths: #74552 handles reconnect after sleep, #74388 gates session restore. I am glad to coordinate rebases with either.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: split the read of the persisted profile from applying it. `startBoot()` reads and applies before `getConnection()`. `setPrimaryGateway` waits until the profile is known. Event tagging uses the adopted profile. `applyPrimaryProfile()` aligns the registry's active pointer.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx`: an ordering test (the persisted `atlas` must be applied before `getConnection()`, and the profile IPC must precede the connection IPC) plus an open-state test (after the socket opens on a named-primary boot, `$gatewayState` must publish `'open'`).

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/app/gateway/hooks/use-gateway-boot.test.tsx` passes 7 tests.
2. Red-on-old for the ordering test: overlay only the test file onto `main` and run it. One test fails, six pass. The mocked `getConnection` asserts the atom already carries the persisted profile; on old code adoption runs after connect, so the assertion rejects inside `getConnection`. The runner reports `expected "vi.fn()" to be called once, but got 0 times` on `profileGet`, the downstream trace of that rejection.
3. The open-state test passes on old `main` by construction. It exists to guard the hazard described in change 2. I verified it by mutation: the fix with the `ensureGatewayForProfile()` line deleted fails it with `expected 'idle' to be 'open'`.
4. Manual: put a named profile in the desktop's `active-profile.json`, cold-launch, and confirm the first sidebar population belongs to that profile and the app reaches "open".

## Checklist

### Code
- [x] I have read CONTRIBUTING.md
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs for duplicates (#50529 discussed above; #74552, #73821, and #74388 reviewed for overlap)
- [x] This PR contains only related changes
- [x] Full desktop vitest run on Node 22, matching CI: `ui` project 354 files, 3,134 tests, 0 failed; `electron` project 867 passed, 0 failed. Local note: Node 26 produces roughly 200 spurious jsdom `localStorage` failures on unmodified `main`, so a clean local run needs CI's pinned Node 22.
- [x] I added tests that fail without this change (the ordering test; the open-state test is mutation-verified as described)
- [x] Tested on: macOS 15 (arm64, Apple M4), Node 22.23.2

### Documentation & Housekeeping
- [x] Docs: N/A (bug fix, no user-facing surface change)
- [x] `cli-config.yaml.example`: N/A
- [x] CONTRIBUTING/AGENTS: N/A
- [x] Cross-platform: renderer and Electron TypeScript only, no platform-specific code paths
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Instrumented boot on unpatched `main`, persisted primary `atlas`:

```
profileAtGetConnection = "default"    (atom still at initial value when the connection is obtained)
profileGetCalls = 1                   (resolves only after getConnection)
gatewayState = "open"                 (ready is published while adoption is still pending)
```

With this PR the atom carries `atlas` before `getConnection()` runs, and the open transition still publishes.
