### PR TITLE
fix(desktop): scope project RPCs to the selected profile

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -3,11 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
 import { $sidebarAgentsGrouped } from '@/store/layout'
-import { $activeGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, setShowAllProfiles } from '@/store/profile'
 import { applyConfiguredDefaultProjectDir } from '@/store/session'
 
 import {
   $activeProjectId,
+  $projects,
   $projectScope,
   $projectsRpcAvailable,
   $projectTree,
@@ -28,8 +29,21 @@ import {
   refreshWorktrees,
   resolveNewSessionCwd,
   scanAndRecordRepos,
-  tombstoneSessions
+  tombstoneSessions,
+  fetchProjectSessions
 } from './projects'
+
+const projectScopeStorage = new Map<string, string>()
+
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  value: {
+    clear: () => projectScopeStorage.clear(),
+    getItem: (key: string) => projectScopeStorage.get(key) ?? null,
+    removeItem: (key: string) => projectScopeStorage.delete(key),
+    setItem: (key: string, value: string) => projectScopeStorage.set(key, value)
+  }
+})
 
 vi.mock('@/i18n', () => ({
   translateNow: (key: string) => key
@@ -78,6 +92,18 @@ const getHermesConfig = vi.mocked(hermes.getHermesConfig)
 const notifications = await import('@/store/notifications')
 const notify = vi.mocked(notifications.notify)
 
+// Promise.withResolvers is ES2024; the renderer tsconfig targets ES2023, so use
+// the same local deferred helper as the other store/hook tests.
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
 describe('project scope', () => {
   beforeEach(() => {
     window.localStorage.clear()
@@ -109,6 +135,50 @@ describe('project scope', () => {
   it('persists the scope to localStorage', () => {
     enterProject('p_abc')
     expect(window.localStorage.getItem('hermes.desktop.projectScope')).toBe('p_abc')
+  })
+})
+
+describe('projects RPC profile forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    $activeGatewayProfile.set('default')
+    $activeProjectId.set(null)
+    $projectTree.set([])
+    setShowAllProfiles(false)
+  })
+
+  it('forwards the normalized active profile to project read RPCs', async () => {
+    const request = vi.fn(async () => ({ active_id: null, projects: [], scoped_session_ids: [] }))
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+    $activeGatewayProfile.set('  coder  ')
+
+    await refreshProjects()
+    await refreshProjectTree()
+    await fetchProjectSessions('p_123')
+
+    expect(request).toHaveBeenNthCalledWith(1, 'projects.list', { profile: 'coder' })
+    expect(request).toHaveBeenNthCalledWith(2, 'projects.tree', { preview_limit: 3, profile: 'coder' })
+    expect(request).toHaveBeenNthCalledWith(3, 'projects.project_sessions', {
+      profile: 'coder',
+      project_id: 'p_123'
+    })
+  })
+
+  it('skips project reads in the all-profiles view rather than forwarding its sentinel', async () => {
+    const request = vi.fn()
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+    setShowAllProfiles(true)
+
+    await refreshProjects()
+    await refreshProjectTree()
+    await fetchProjectSessions('p_123')
+
+    expect(request).not.toHaveBeenCalled()
+    setShowAllProfiles(false)
   })
 })
 
@@ -350,6 +420,7 @@ describe('repository discovery policy', () => {
     expect(scanRepos).not.toHaveBeenCalled()
     expect(request).toHaveBeenCalledWith('projects.record_repos', {
       discovery_policy: { enabled: false, exclude_paths: [], roots: [] },
+      profile: 'default',
       repos: []
     })
   })
@@ -385,6 +456,7 @@ describe('repository discovery policy', () => {
         exclude_paths: ['/work/vendor'],
         roots: ['/work']
       },
+      profile: 'default',
       repos: [{ label: 'repo', root: '/work/repo' }]
     })
   })
@@ -399,44 +471,141 @@ describe('repository discovery policy', () => {
     expect(scanRepos).not.toHaveBeenCalled()
     expect(getHermesConfig).not.toHaveBeenCalled()
   })
+
+  it('records repos under the profile the scan started with, not one focused mid-scan', async () => {
+    const { promise: scanResult, resolve: resolveScan } = deferred<Array<{ label: string; root: string }>>()
+    const { promise: scanStarted, resolve: markScanStarted } = deferred<void>()
+
+    const request = vi.fn(async (method: string) =>
+      method === 'projects.tree'
+        ? {
+            active_id: null,
+            projects: [{ id: 'p_lured', label: 'Lured', path: null, repos: [], sessionCount: 0 }],
+            scoped_session_ids: []
+          }
+        : { accepted: true, repos: [] }
+    )
+
+    gatewayWith(request)
+    const scanRepos = vi.fn(() => {
+      markScanStarted()
+      return scanResult
+    })
+    desktopGit.mockReturnValue({ scanRepos } as never)
+    getHermesConfig.mockResolvedValue({
+      desktop: {
+        repo_scan_enabled: true,
+        repo_scan_exclude_paths: [],
+        repo_scan_roots: ['/work']
+      }
+    })
+    $activeGatewayProfile.set('launch')
+    $projectTree.set([])
+
+    const pending = scanAndRecordRepos()
+    await scanStarted
+    // The user switches profiles while the disk scan is still running.
+    $activeGatewayProfile.set('coder')
+    resolveScan([{ label: 'repo', root: '/work/repo' }])
+    await pending
+
+    // The write is pinned to the profile captured when the scan started …
+    expect(request).toHaveBeenCalledWith('projects.record_repos', {
+      discovery_policy: { enabled: true, exclude_paths: [], roots: ['/work'] },
+      profile: 'launch',
+      repos: [{ label: 'repo', root: '/work/repo' }]
+    })
+    // … never to the profile focused while it ran.
+    expect(request).not.toHaveBeenCalledWith('projects.record_repos', expect.objectContaining({ profile: 'coder' }))
+    // And the completion tree refresh must not publish under the new profile.
+    expect($projectTree.get()).toEqual([])
+  })
 })
 
-describe('project tree profile isolation', () => {
-  it('does not publish a late response from the previous profile', async () => {
-    let resolveA: ((value: unknown) => void) | undefined
+describe('project profile isolation', () => {
+  beforeEach(() => {
+    setShowAllProfiles(false)
+    $activeGatewayProfile.set('default')
+    $projects.set([])
+    $projectTree.set([])
+  })
 
-    const responseA = new Promise(resolve => {
-      resolveA = resolve
-    })
+  it('does not publish a late projects.list response from the previous profile', async () => {
+    const { promise: defaultResponse, resolve: resolveDefault } = deferred<unknown>()
+    const request = vi.fn((_method: string, params: Record<string, unknown>) =>
+      params.profile === 'default'
+        ? defaultResponse
+        : Promise.resolve({
+            active_id: null,
+            projects: [{ id: 'profile-b', label: 'Profile B' }]
+          })
+    )
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
 
-    const gatewayA = { connectionState: 'open', request: vi.fn(() => responseA) }
-
-    const gatewayB = {
-      connectionState: 'open',
-      request: vi.fn().mockResolvedValue({
-        active_id: null,
-        projects: [{ id: 'profile-b', label: 'Profile B', path: null, repos: [], sessionCount: 0 }],
-        scoped_session_ids: []
-      })
-    }
-
-    let current = gatewayA
-    activeGateway.mockImplementation(() => current as never)
-    gatewayAtom.set(gatewayA as never)
-
-    const pendingA = refreshProjectTree()
-    current = gatewayB
+    const pendingDefault = refreshProjects()
     $activeGatewayProfile.set('profile-b')
-    gatewayAtom.set(gatewayB as never)
+    await refreshProjects()
+    resolveDefault({
+      active_id: null,
+      projects: [{ id: 'profile-a', label: 'Profile A' }]
+    })
+    await pendingDefault
+
+    expect($projects.get().map(project => project.id)).toEqual(['profile-b'])
+  })
+
+  it('does not publish a late projects.tree response from the previous profile', async () => {
+    const { promise: defaultResponse, resolve: resolveDefault } = deferred<unknown>()
+    const request = vi.fn((_method: string, params: Record<string, unknown>) =>
+      params.profile === 'default'
+        ? defaultResponse
+        : Promise.resolve({
+            active_id: null,
+            projects: [{ id: 'profile-b', label: 'Profile B', path: null, repos: [], sessionCount: 0 }],
+            scoped_session_ids: []
+          })
+    )
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    const pendingDefault = refreshProjectTree()
+    $activeGatewayProfile.set('profile-b')
     await refreshProjectTree()
-    resolveA?.({
+    resolveDefault({
       active_id: null,
       projects: [{ id: 'profile-a', label: 'Profile A', path: null, repos: [], sessionCount: 0 }],
       scoped_session_ids: []
     })
-    await pendingA
+    await pendingDefault
 
     expect($projectTree.get().map(project => project.id)).toEqual(['profile-b'])
+  })
+
+  it('drops a late hydrated-project response from the previous profile', async () => {
+    const { promise: defaultResponse, resolve: resolveDefault } = deferred<unknown>()
+    const request = vi.fn((_method: string, params: Record<string, unknown>) =>
+      params.profile === 'default'
+        ? defaultResponse
+        : Promise.resolve({
+            project: { id: 'profile-b', label: 'Profile B', path: null, repos: [], sessionCount: 0 }
+          })
+    )
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    const pendingDefault = fetchProjectSessions('p_123')
+    $activeGatewayProfile.set('profile-b')
+    const profileB = await fetchProjectSessions('p_123')
+    resolveDefault({
+      project: { id: 'profile-a', label: 'Profile A', path: null, repos: [], sessionCount: 0 }
+    })
+
+    expect(profileB?.id).toBe('profile-b')
+    await expect(pendingDefault).resolves.toBeNull()
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -15,7 +15,7 @@ import { persistentAtom } from '@/lib/persisted'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
 import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
-import { $activeGatewayProfile, requestFreshSession } from '@/store/profile'
+import { $activeGatewayProfile, $profileScope, ALL_PROFILES, normalizeProfileKey, requestFreshSession } from '@/store/profile'
 import { $selectedStoredSessionId, $sessions, sessionMatchesStoredId, workspaceCwdForNewSession } from '@/store/session'
 import type { ProjectInfo, ProjectsPayload } from '@/types/hermes'
 
@@ -331,6 +331,23 @@ async function gatewayRequest<T>(method: string, params: Record<string, unknown>
   return gateway.request<T>(method, params)
 }
 
+function projectProfile(): null | string {
+  const profile = normalizeProfileKey($activeGatewayProfile.get())
+
+  return $profileScope.get() === ALL_PROFILES || profile === ALL_PROFILES ? null : profile
+}
+
+function projectParams(
+  params: Record<string, unknown> = {},
+  profile: null | string = projectProfile()
+): Record<string, unknown> {
+  if (!profile) {
+    throw new Error('Projects are unavailable while viewing all profiles')
+  }
+
+  return { ...params, profile }
+}
+
 async function gatewayRequestOn<T>(
   gateway: HermesGateway,
   method: string,
@@ -345,14 +362,19 @@ interface ActiveProjectsContext {
 }
 
 async function activeProjectsContext(): Promise<ActiveProjectsContext> {
-  const profile = $activeGatewayProfile.get() || 'default'
+  const profile = projectProfile()
+
+  if (!profile) {
+    throw new Error('Projects are unavailable while viewing all profiles')
+  }
+
   let gateway = activeGateway()
 
   if (!gateway || gateway.connectionState !== 'open') {
     gateway = await ensureActiveGatewayOpen()
   }
 
-  if (!gateway || gateway !== activeGateway() || profile !== ($activeGatewayProfile.get() || 'default')) {
+  if (!gateway || gateway !== activeGateway() || profile !== projectProfile()) {
     throw new Error('Active Hermes profile changed while connecting')
   }
 
@@ -366,12 +388,42 @@ function applyPayload(payload: ProjectsPayload): void {
 
 // Pull the full project list + active pointer. Best-effort: a failure (gateway
 // not up yet) leaves the cached atoms intact so the sidebar doesn't flicker.
+// Match the sessions rail's request-id guard: a response belongs to the profile
+// that was active when it was issued, never a profile selected while it ran.
+let projectsRefreshGeneration = 0
+
 export async function refreshProjects(): Promise<void> {
+  const generation = ++projectsRefreshGeneration
+
+  let context: ActiveProjectsContext | null = null
+
   try {
-    applyPayload(await gatewayRequest<ProjectsPayload>('projects.list'))
+    context = await activeProjectsContext()
+    const payload = await gatewayRequestOn<ProjectsPayload>(
+      context.gateway,
+      'projects.list',
+      projectParams({}, context.profile)
+    )
+
+    if (
+      generation !== projectsRefreshGeneration ||
+      activeGateway() !== context.gateway ||
+      projectProfile() !== context.profile
+    ) {
+      return
+    }
+
+    applyPayload(payload)
     markProjectsRpcSuccess()
   } catch (err) {
-    markProjectsRpcFailure(err)
+    if (
+      context &&
+      generation === projectsRefreshGeneration &&
+      activeGateway() === context.gateway &&
+      projectProfile() === context.profile
+    ) {
+      markProjectsRpcFailure(err)
+    }
     // Backend may not be ready; keep the last known list.
   }
 }
@@ -384,19 +436,25 @@ interface ProjectTreePayload {
 
 let projectTreeRefreshGeneration = 0
 
-async function refreshProjectTreeOn(gateway: HermesGateway): Promise<void> {
-  const generation = ++projectTreeRefreshGeneration
+async function refreshProjectTreeOn(context: ActiveProjectsContext, generation: number): Promise<void> {
+  const { gateway, profile } = context
 
   if (activeGateway() === gateway) {
     $projectTreeLoading.set(true)
   }
 
   try {
-    const res = await gatewayRequestOn<ProjectTreePayload>(gateway, 'projects.tree', {
-      preview_limit: 3
-    })
+    const res = await gatewayRequestOn<ProjectTreePayload>(
+      gateway,
+      'projects.tree',
+      projectParams({ preview_limit: 3 }, profile)
+    )
 
-    if (generation !== projectTreeRefreshGeneration || activeGateway() !== gateway) {
+    if (
+      generation !== projectTreeRefreshGeneration ||
+      activeGateway() !== gateway ||
+      projectProfile() !== profile
+    ) {
       return
     }
 
@@ -419,7 +477,7 @@ async function refreshProjectTreeOn(gateway: HermesGateway): Promise<void> {
 
     markProjectsRpcSuccess()
   } catch (err) {
-    if (activeGateway() === gateway) {
+    if (generation === projectTreeRefreshGeneration && activeGateway() === gateway && projectProfile() === profile) {
       markProjectsRpcFailure(err)
     }
   } finally {
@@ -433,10 +491,15 @@ async function refreshProjectTreeOn(gateway: HermesGateway): Promise<void> {
 // sessions + the scoped-session-id set). Best-effort: a failure leaves the
 // cached tree intact so the sidebar doesn't flicker.
 export async function refreshProjectTree(): Promise<void> {
+  const generation = ++projectTreeRefreshGeneration
+
   try {
-    const { gateway } = await activeProjectsContext()
-    await refreshProjectTreeOn(gateway)
+    const context = await activeProjectsContext()
+    await refreshProjectTreeOn(context, generation)
   } catch {
+    if (generation === projectTreeRefreshGeneration) {
+      $projectTreeLoading.set(false)
+    }
     // Backend may not be ready; keep the last known tree.
   }
 }
@@ -444,11 +507,26 @@ export async function refreshProjectTree(): Promise<void> {
 // Fully hydrated lanes (repo -> lane -> session rows) for one project, fetched
 // when the user enters it. Same backend grouping as `projects.tree`, so ids and
 // membership match exactly.
+let projectSessionsRefreshGeneration = 0
+
 export async function fetchProjectSessions(projectId: string): Promise<SidebarProjectTree | null> {
+  const generation = ++projectSessionsRefreshGeneration
+
   try {
-    const res = await gatewayRequest<{ project: SidebarProjectTree | null }>('projects.project_sessions', {
-      project_id: projectId
-    })
+    const { gateway, profile } = await activeProjectsContext()
+    const res = await gatewayRequestOn<{ project: SidebarProjectTree | null }>(
+      gateway,
+      'projects.project_sessions',
+      projectParams({ project_id: projectId }, profile)
+    )
+
+    if (
+      generation !== projectSessionsRefreshGeneration ||
+      activeGateway() !== gateway ||
+      projectProfile() !== profile
+    ) {
+      return null
+    }
 
     return res.project ?? null
   } catch {
@@ -540,10 +618,17 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
     state.runningSignature = signature
 
     if (!policy.enabled) {
-      await gatewayRequestOn(context.gateway, 'projects.record_repos', {
-        discovery_policy: policy,
-        repos: []
-      })
+      await gatewayRequestOn(
+        context.gateway,
+        'projects.record_repos',
+        projectParams(
+          {
+            discovery_policy: policy,
+            repos: []
+          },
+          context.profile
+        )
+      )
     } else {
       scanningGatewayGenerations.set(context.gateway, generation)
       syncReposScanning()
@@ -557,10 +642,17 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
         return
       }
 
-      await gatewayRequestOn(context.gateway, 'projects.record_repos', {
-        discovery_policy: policy,
-        repos
-      })
+      await gatewayRequestOn(
+        context.gateway,
+        'projects.record_repos',
+        projectParams(
+          {
+            discovery_policy: policy,
+            repos
+          },
+          context.profile
+        )
+      )
     }
 
     if (state.generation !== generation) {
@@ -568,7 +660,15 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
     }
 
     state.completedSignature = signature
-    await refreshProjectTreeOn(context.gateway)
+
+    // Completion refresh: only when the focused profile still matches the one
+    // the scan was captured under. refreshProjectTree() re-derives the current
+    // context + generation, so the refresh is always attributed to the profile
+    // it actually reads — and skipping on mismatch keeps a stale scan from
+    // superseding the newly focused profile's own in-flight refresh.
+    if (activeGateway() === context.gateway && projectProfile() === context.profile) {
+      await refreshProjectTree()
+    }
   } catch {
     state.completedSignature = undefined
   } finally {
@@ -696,17 +796,20 @@ export async function createProject(input: CreateProjectInput): Promise<ProjectI
   let res: { project: ProjectInfo | null }
 
   try {
-    res = await gatewayRequest<{ project: ProjectInfo | null }>('projects.create', {
-      name: input.name,
-      folders: input.folders ?? [],
-      primary_path: input.primaryPath,
-      slug: input.slug,
-      description: input.description,
-      icon: input.icon,
-      color: input.color,
-      board_slug: input.boardSlug,
-      use: input.use ?? false
-    })
+    res = await gatewayRequest<{ project: ProjectInfo | null }>(
+      'projects.create',
+      projectParams({
+        name: input.name,
+        folders: input.folders ?? [],
+        primary_path: input.primaryPath,
+        slug: input.slug,
+        description: input.description,
+        icon: input.icon,
+        color: input.color,
+        board_slug: input.boardSlug,
+        use: input.use ?? false
+      })
+    )
   } catch (err) {
     if (isMissingRpcMethod(err)) {
       $projectsRpcAvailable.set(false)
@@ -779,12 +882,15 @@ export async function updateProject(
   // Backend treats null/undefined as "leave unchanged"; "" clears (stores NULL).
   // Map explicit null → "" so "no color"/"no icon" actually clear.
   await persistOrRollback(snap, () =>
-    gatewayRequest('projects.update', {
-      id,
-      ...patch,
-      ...(patch.color === null && { color: '' }),
-      ...(patch.icon === null && { icon: '' })
-    })
+    gatewayRequest(
+      'projects.update',
+      projectParams({
+        id,
+        ...patch,
+        ...(patch.color === null && { color: '' }),
+        ...(patch.icon === null && { icon: '' })
+      })
+    )
   )
 }
 
@@ -855,7 +961,10 @@ export async function addProjectFolder(
   }
 
   await persistOrRollback(snap, () =>
-    gatewayRequest('projects.add_folder', { id, path, label: opts.label, is_primary: opts.isPrimary ?? false })
+    gatewayRequest(
+      'projects.add_folder',
+      projectParams({ id, path, label: opts.label, is_primary: opts.isPrimary ?? false })
+    )
   )
   reconcileProjects()
 }
@@ -898,13 +1007,13 @@ export async function deleteProject(id: string): Promise<void> {
   }
 
   await persistOrRollback(snap, async () => {
-    applyPayload(await gatewayRequest<ProjectsPayload>('projects.delete', { id }))
+    applyPayload(await gatewayRequest<ProjectsPayload>('projects.delete', projectParams({ id })))
   })
   void refreshProjectTree()
 }
 
 export async function setActiveProject(id: null | string): Promise<void> {
-  const res = await gatewayRequest<{ active_id: null | string }>('projects.set_active', { id })
+  const res = await gatewayRequest<{ active_id: null | string }>('projects.set_active', projectParams({ id }))
   $activeProjectId.set(res.active_id ?? null)
 }
 

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 import tui_gateway.server as server
 
 
@@ -379,3 +382,180 @@ def test_nondefault_policy_rejects_stale_or_legacy_results(monkeypatch, tmp_path
     assert any(item["root"] == str(root) for item in accepted["repos"])
 
 
+# ── profile scoping (app-global remote mode) ───────────────────────────────
+#
+# One backend serves every local profile, so ``projects.*`` takes an optional
+# ``params['profile']`` naming the profile the desktop is focused on. The
+# handler binds THAT profile's HERMES_HOME (projects.db, config) and state.db
+# for the duration of the call. Omitted/unknown profile → the launch profile,
+# exactly as before.
+
+
+def _profile_dir(tmp_path: Path, name: str) -> Path:
+    home = tmp_path / "homes" / name
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _bind_profiles(monkeypatch, tmp_path: Path, homes: dict[str, Path]) -> None:
+    """Resolve profile names to this test's throwaway homes.
+
+    Unmapped names resolve to a path that does not exist, which is how the
+    gateway detects "not a real profile on this host" and stays on launch.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: homes.get(name, tmp_path / "homes" / "missing" / name),
+    )
+
+
+def _create_project(home: Path, name: str, folder: Path, *, use: bool = False) -> dict:
+    """Create a project in ``home``'s projects.db via the real RPC."""
+    token = set_hermes_home_override(home)
+    try:
+        return _call(
+            "projects.create", {"name": name, "folders": [str(folder)], "use": use}
+        )["project"]
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _create_session(home: Path, session_id: str, cwd: Path) -> None:
+    """Seed one message-bearing session in ``home``'s state.db."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        db.create_session(session_id, "cli", cwd=str(cwd))
+        db.append_message(session_id, "user", f"hello from {session_id}")
+    finally:
+        db.close()
+
+
+@contextlib.contextmanager
+def _serving_launch_profile(launch_home: Path):
+    """Run the handlers as a backend launched under ``launch_home``."""
+    from hermes_state import SessionDB
+
+    token = set_hermes_home_override(launch_home)
+    prev_db, prev_error = server._db, server._db_error
+    server._db = SessionDB(db_path=launch_home / "state.db")
+    server._db_error = None
+    try:
+        yield
+    finally:
+        server._db.close()
+        server._db, server._db_error = prev_db, prev_error
+        reset_hermes_home_override(token)
+
+
+def _cached_repo_labels(home: Path) -> list[str]:
+    """Labels in ``home``'s discovered-repo cache, read straight off disk."""
+    from hermes_cli import projects_db as pdb
+
+    with pdb.connect_closing(home / "projects.db") as conn:
+        return sorted(str(entry.get("label") or "") for entry in pdb.list_discovered_repos(conn))
+
+
+def test_projects_reads_are_scoped_to_the_requested_profile(monkeypatch, tmp_path):
+    """A ``profile`` param reads that profile's projects.db AND its state.db."""
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    launch_repo = tmp_path / "repos" / "launch-repo"
+    coder_repo = tmp_path / "repos" / "coder-repo"
+    launch_repo.mkdir(parents=True)
+    coder_repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+
+    launch_project = _create_project(launch_home, "Launch", launch_repo, use=True)
+    coder_project = _create_project(coder_home, "Coder", coder_repo, use=True)
+    _create_session(launch_home, "launch-session", launch_repo)
+    _create_session(coder_home, "coder-session", coder_repo)
+
+    with _serving_launch_profile(launch_home):
+        launch_listing = _call("projects.list")
+        coder_listing = _call("projects.list", {"profile": "coder"})
+        launch_tree = _call("projects.tree")
+        coder_tree = _call("projects.tree", {"profile": "coder"})
+        coder_sessions = _call(
+            "projects.project_sessions",
+            {"profile": "coder", "project_id": coder_project["id"]},
+        )
+        # The override must not leak: the very next unscoped read is launch again.
+        launch_again = _call("projects.list")
+
+    assert [p["name"] for p in launch_listing["projects"]] == ["Launch"]
+    assert [p["name"] for p in coder_listing["projects"]] == ["Coder"]
+    assert launch_listing["active_id"] == launch_project["id"]
+    assert coder_listing["active_id"] == coder_project["id"]
+    assert launch_again == launch_listing
+
+    assert [p["label"] for p in launch_tree["projects"]] == ["Launch"]
+    assert [p["label"] for p in coder_tree["projects"]] == ["Coder"]
+    # Session counts prove the SESSION db was swapped too, not just projects.db.
+    assert launch_tree["projects"][0]["sessionCount"] == 1
+    assert coder_tree["projects"][0]["sessionCount"] == 1
+    assert launch_tree["scoped_session_ids"] == ["launch-session"]
+    assert coder_tree["scoped_session_ids"] == ["coder-session"]
+
+    assert coder_sessions["project"]["id"] == coder_project["id"]
+    assert coder_sessions["project"]["sessionCount"] == 1
+    lane = coder_sessions["project"]["repos"][0]["groups"][0]
+    assert [s["id"] for s in lane["sessions"]] == ["coder-session"]
+
+
+def test_record_repos_writes_to_the_requested_profiles_projects_db(monkeypatch, tmp_path):
+    """The scan cache is per-profile: a scoped write must not land on launch."""
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    launch_repo = tmp_path / "repos" / "launch-scan"
+    coder_repo = tmp_path / "repos" / "coder-scan"
+    launch_repo.mkdir(parents=True)
+    coder_repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+
+    with _serving_launch_profile(launch_home):
+        _call("projects.record_repos", {"repos": [{"root": str(launch_repo), "label": "launch"}]})
+        _call(
+            "projects.record_repos",
+            {"profile": "coder", "repos": [{"root": str(coder_repo), "label": "coder"}]},
+        )
+
+        launch_repos = _call("projects.discover_repos")["repos"]
+        coder_repos = _call("projects.discover_repos", {"profile": "coder"})["repos"]
+
+    assert [repo["label"] for repo in launch_repos] == ["launch"]
+    assert [repo["label"] for repo in coder_repos] == ["coder"]
+    # ...and on disk, not merely in the response the same handler produced.
+    assert _cached_repo_labels(launch_home) == ["launch"]
+    assert _cached_repo_labels(coder_home) == ["coder"]
+
+
+def test_projects_without_a_profile_stay_on_the_launch_home(monkeypatch, tmp_path):
+    """Omitted/blank/unknown profile is a no-op — the pre-scoping behavior."""
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    repo = tmp_path / "repos" / "launch-only"
+    repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+
+    with _serving_launch_profile(launch_home):
+        created = _call(
+            "projects.create", {"name": "Launch only", "folders": [str(repo)], "use": True}
+        )["project"]
+        _call("projects.record_repos", {"repos": [{"root": str(repo), "label": "only"}]})
+
+        omitted = _call("projects.list")
+        blank = _call("projects.list", {"profile": ""})
+        unknown = _call("projects.list", {"profile": "not-a-profile"})
+
+    assert [p["name"] for p in omitted["projects"]] == ["Launch only"]
+    assert blank == omitted
+    assert unknown == omitted
+    assert omitted["active_id"] == created["id"]
+
+    # Everything landed in the launch home — never in another profile, and never
+    # in the process-wide HERMES_HOME the override was masking.
+    assert _cached_repo_labels(launch_home) == ["only"]
+    assert not (coder_home / "projects.db").exists()
+    assert not (Path(os.environ["HERMES_HOME"]) / "projects.db").exists()

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -504,6 +504,76 @@ def test_projects_reads_are_scoped_to_the_requested_profile(monkeypatch, tmp_pat
     assert [s["id"] for s in lane["sessions"]] == ["coder-session"]
 
 
+def test_projects_tree_is_scoped_to_the_requested_profile(monkeypatch, tmp_path):
+    """``projects.tree`` on its own reads the requested profile's stores.
+
+    Split out from the combined read test deliberately: there the
+    ``projects.list`` assertion fires first, so a tree-only scoping regression
+    would never reach the tree assertions.
+    """
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    launch_repo = tmp_path / "repos" / "tree-launch"
+    coder_repo = tmp_path / "repos" / "tree-coder"
+    launch_repo.mkdir(parents=True)
+    coder_repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+
+    _create_project(launch_home, "Launch", launch_repo, use=True)
+    _create_project(coder_home, "Coder", coder_repo, use=True)
+    _create_session(launch_home, "tree-launch-session", launch_repo)
+    _create_session(coder_home, "tree-coder-session", coder_repo)
+
+    with _serving_launch_profile(launch_home):
+        coder_tree = _call("projects.tree", {"profile": "coder"})
+        launch_tree = _call("projects.tree")
+
+    assert [p["label"] for p in coder_tree["projects"]] == ["Coder"]
+    assert coder_tree["scoped_session_ids"] == ["tree-coder-session"]
+    assert [p["label"] for p in launch_tree["projects"]] == ["Launch"]
+    assert launch_tree["scoped_session_ids"] == ["tree-launch-session"]
+
+
+def test_project_sessions_is_scoped_to_the_requested_profile(monkeypatch, tmp_path):
+    """``projects.project_sessions`` on its own hydrates from the requested profile.
+
+    Same reason as the tree test: drill-in must be provably scoped by itself,
+    not behind an earlier ``projects.list`` assertion.
+    """
+    launch_home = _profile_dir(tmp_path, "launch")
+    coder_home = _profile_dir(tmp_path, "coder")
+    launch_repo = tmp_path / "repos" / "drill-launch"
+    coder_repo = tmp_path / "repos" / "drill-coder"
+    launch_repo.mkdir(parents=True)
+    coder_repo.mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home, "coder": coder_home})
+
+    launch_project = _create_project(launch_home, "Launch", launch_repo, use=True)
+    coder_project = _create_project(coder_home, "Coder", coder_repo, use=True)
+    _create_session(launch_home, "drill-launch-session", launch_repo)
+    _create_session(coder_home, "drill-coder-session", coder_repo)
+
+    with _serving_launch_profile(launch_home):
+        coder_drill = _call(
+            "projects.project_sessions",
+            {"profile": "coder", "project_id": coder_project["id"]},
+        )
+        launch_drill = _call(
+            "projects.project_sessions", {"project_id": launch_project["id"]}
+        )
+
+    # The coder project id is absent from launch's projects.db, so an unscoped
+    # handler answers None here instead of the hydrated project.
+    assert coder_drill["project"] is not None
+    assert coder_drill["project"]["id"] == coder_project["id"]
+    coder_lane = coder_drill["project"]["repos"][0]["groups"][0]
+    assert [s["id"] for s in coder_lane["sessions"]] == ["drill-coder-session"]
+
+    assert launch_drill["project"]["id"] == launch_project["id"]
+    launch_lane = launch_drill["project"]["repos"][0]["groups"][0]
+    assert [s["id"] for s in launch_lane["sessions"]] == ["drill-launch-session"]
+
+
 def test_record_repos_writes_to_the_requested_profiles_projects_db(monkeypatch, tmp_path):
     """The scan cache is per-profile: a scoped write must not land on launch."""
     launch_home = _profile_dir(tmp_path, "launch")

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -18,23 +18,24 @@ _profile_scoped = _registry.profile_scoped
 def _(rid, params: dict) -> dict:
     """Repos for the desktop overview: scanned-from-disk (cached) ∪ session-derived."""
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"repos": []})
-        from hermes_cli import projects_db as pdb
+        with _projects_profile_home(params):
+            with _profile_db(params) as db:
+                if db is None:
+                    return _ok(rid, {"repos": []})
+                from hermes_cli import projects_db as pdb
 
-        policy = _repo_discovery_policy()
-        policy_key = _repo_discovery_policy_key(policy)
-        with pdb.connect_closing() as conn:
-            pdb.reconcile_discovered_repos_policy(
-                conn,
-                policy_key,
-                preserve_unversioned=_repo_discovery_policy_is_default(policy),
-            )
-            repos = _discover_repos_payload(
-                db, conn=conn, include_cached=policy["enabled"]
-            )
-        return _ok(rid, {"repos": repos, "discovery_policy": policy})
+                policy = _repo_discovery_policy()
+                policy_key = _repo_discovery_policy_key(policy)
+                with pdb.connect_closing() as conn:
+                    pdb.reconcile_discovered_repos_policy(
+                        conn,
+                        policy_key,
+                        preserve_unversioned=_repo_discovery_policy_is_default(policy),
+                    )
+                    repos = _discover_repos_payload(
+                        db, conn=conn, include_cached=policy["enabled"]
+                    )
+                return _ok(rid, {"repos": repos, "discovery_policy": policy})
     except Exception as e:
         return _err(rid, 5061, str(e))
 
@@ -47,58 +48,59 @@ def _(rid, params: dict) -> dict:
     try:
         from hermes_cli import projects_db as pdb
 
-        policy = _repo_discovery_policy()
-        policy_key = _repo_discovery_policy_key(policy)
-        incoming_raw = params.get("discovery_policy")
-        incoming_policy = (
-            _repo_discovery_policy(incoming_raw)
-            if isinstance(incoming_raw, dict)
-            else None
-        )
-        incoming_matches = (
-            incoming_policy is not None
-            and _repo_discovery_policy_key(incoming_policy) == policy_key
-        )
-        accept_legacy_default = (
-            incoming_policy is None and _repo_discovery_policy_is_default(policy)
-        )
-
-        pairs: list[tuple[str, str | None]] = []
-        for item in params.get("repos") or []:
-            if isinstance(item, str):
-                pairs.append((item, None))
-            elif isinstance(item, dict) and item.get("root"):
-                pairs.append((str(item["root"]), item.get("label")))
-
-        with pdb.connect_closing() as conn:
-            pdb.reconcile_discovered_repos_policy(
-                conn,
-                policy_key,
-                preserve_unversioned=_repo_discovery_policy_is_default(policy),
+        with _projects_profile_home(params):
+            policy = _repo_discovery_policy()
+            policy_key = _repo_discovery_policy_key(policy)
+            incoming_raw = params.get("discovery_policy")
+            incoming_policy = (
+                _repo_discovery_policy(incoming_raw)
+                if isinstance(incoming_raw, dict)
+                else None
             )
-            accepted = bool(
-                policy["enabled"] and (incoming_matches or accept_legacy_default)
+            incoming_matches = (
+                incoming_policy is not None
+                and _repo_discovery_policy_key(incoming_policy) == policy_key
             )
-            if accepted:
-                pdb.record_discovered_repos(
-                    conn, pairs, replace=True, policy_key=policy_key
-                )
-            elif not policy["enabled"]:
-                pdb.clear_discovered_repos(conn, policy_key=policy_key)
+            accept_legacy_default = (
+                incoming_policy is None and _repo_discovery_policy_is_default(policy)
+            )
 
-        db = _get_db()
-        return _ok(
-            rid,
-            {
-                "repos": _discover_repos_payload(
-                    db, include_cached=policy["enabled"]
+            pairs: list[tuple[str, str | None]] = []
+            for item in params.get("repos") or []:
+                if isinstance(item, str):
+                    pairs.append((item, None))
+                elif isinstance(item, dict) and item.get("root"):
+                    pairs.append((str(item["root"]), item.get("label")))
+
+            with pdb.connect_closing() as conn:
+                pdb.reconcile_discovered_repos_policy(
+                    conn,
+                    policy_key,
+                    preserve_unversioned=_repo_discovery_policy_is_default(policy),
                 )
-                if db is not None
-                else [],
-                "accepted": accepted,
-                "discovery_policy": policy,
-            },
-        )
+                accepted = bool(
+                    policy["enabled"] and (incoming_matches or accept_legacy_default)
+                )
+                if accepted:
+                    pdb.record_discovered_repos(
+                        conn, pairs, replace=True, policy_key=policy_key
+                    )
+                elif not policy["enabled"]:
+                    pdb.clear_discovered_repos(conn, policy_key=policy_key)
+
+            with _profile_db(params) as db:
+                return _ok(
+                    rid,
+                    {
+                        "repos": _discover_repos_payload(
+                            db, include_cached=policy["enabled"]
+                        )
+                        if db is not None
+                        else [],
+                        "accepted": accepted,
+                        "discovery_policy": policy,
+                    },
+                )
     except Exception as e:
         return _err(rid, 5061, str(e))
 
@@ -111,21 +113,27 @@ def _(rid, params: dict) -> dict:
     Lanes carry no session rows here; drill-in uses ``projects.project_sessions``.
     """
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
+        with _projects_profile_home(params):
+            with _profile_db(params) as db:
+                if db is None:
+                    return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
 
-        tree, active_id = _build_project_tree(
-            db,
-            preview_limit=int(params.get("preview_limit") or 3),
-            hydrate=False,
-            session_limit=int(params.get("session_limit") or 2000),
-            include_discovered=True,
-        )
-        return _ok(
-            rid,
-            {"projects": tree["projects"], "active_id": active_id, "scoped_session_ids": tree["scoped_session_ids"]},
-        )
+                tree, active_id = _build_project_tree(
+                    db,
+                    preview_limit=int(params.get("preview_limit") or 3),
+                    hydrate=False,
+                    session_limit=int(params.get("session_limit") or 2000),
+                    include_discovered=True,
+                    params=params,
+                )
+                return _ok(
+                    rid,
+                    {
+                        "projects": tree["projects"],
+                        "active_id": active_id,
+                        "scoped_session_ids": tree["scoped_session_ids"],
+                    },
+                )
     except Exception as e:
         return _err(rid, 5061, str(e))
 
@@ -140,18 +148,23 @@ def _(rid, params: dict) -> dict:
         if not project_id:
             return _err(rid, 5063, "project_id required")
 
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"project": None})
+        with _projects_profile_home(params):
+            with _profile_db(params) as db:
+                if db is None:
+                    return _ok(rid, {"project": None})
 
-        # Drill-in only needs the entered project (which has sessions), so skip
-        # the zero-session discovery tier entirely.
-        tree, _active = _build_project_tree(
-            db, preview_limit=0, hydrate=True, session_limit=int(params.get("session_limit") or 5000),
-            include_discovered=False,
-        )
-        proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
-        return _ok(rid, {"project": proj})
+                # Drill-in only needs the entered project (which has sessions), so skip
+                # the zero-session discovery tier entirely.
+                tree, _active = _build_project_tree(
+                    db,
+                    preview_limit=0,
+                    hydrate=True,
+                    session_limit=int(params.get("session_limit") or 5000),
+                    include_discovered=False,
+                    params=params,
+                )
+                proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
+                return _ok(rid, {"project": proj})
     except Exception as e:
         return _err(rid, 5061, str(e))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1253,6 +1253,26 @@ def _profile_scoped(handler):
     return wrapper
 
 
+@contextlib.contextmanager
+def _projects_profile_home(params: dict | None):
+    """Bind ``params['profile']``'s HERMES_HOME for profile-scoped projects RPCs.
+
+    Projects live in the profile's own ``projects.db`` (resolved through
+    ``get_hermes_home()``), so app-global remote mode — one backend serving every
+    profile — must bind the focused profile's home around the whole handler, not
+    just its session-db read. No-op for the launch profile.
+    """
+    home = _profile_home(params.get("profile") if isinstance(params, dict) else None)
+    if home is None:
+        yield None
+        return
+    token = set_hermes_home_override(home)
+    try:
+        yield home
+    finally:
+        reset_hermes_home_override(token)
+
+
 # Placeholder ``terminal.cwd`` values that don't name a real directory — the
 # gateway resolves these to the home dir at runtime, so they must NOT be treated
 # as an explicit workspace (mirrors gateway/run.py's config bridge).
@@ -10730,8 +10750,9 @@ def _projects_method(name: str):
             try:
                 from hermes_cli import projects_db as pdb
 
-                with pdb.connect_closing() as conn:
-                    return fn(rid, params, pdb, conn)
+                with _projects_profile_home(params):
+                    with pdb.connect_closing() as conn:
+                        return fn(rid, params, pdb, conn)
             except _NoProject:
                 return _err(rid, _E_NO_PROJECT, "no such project")
             except ValueError as e:
@@ -11073,7 +11094,7 @@ def _project_tree_row(r: dict) -> dict:
 
 
 def _project_tree_inputs(
-    db, session_limit: int, *, include_discovered: bool
+    db, session_limit: int, *, include_discovered: bool, params: dict | None = None
 ) -> tuple[list[dict], list[dict], list[dict], str | None]:
     """Gather (sessions, projects, discovered_repos, active_id) for build_tree.
 
@@ -11099,28 +11120,31 @@ def _project_tree_inputs(
 
     from hermes_cli import projects_db as pdb
 
-    policy = _repo_discovery_policy()
-    policy_key = _repo_discovery_policy_key(policy)
-    with pdb.connect_closing() as conn:
-        if include_discovered:
-            pdb.reconcile_discovered_repos_policy(
-                conn,
-                policy_key,
-                preserve_unversioned=_repo_discovery_policy_is_default(policy),
+    # projects.db + the discovery policy are profile-local, so the whole read
+    # runs under the requested profile's home (app-global remote mode).
+    with _projects_profile_home(params):
+        policy = _repo_discovery_policy()
+        policy_key = _repo_discovery_policy_key(policy)
+        with pdb.connect_closing() as conn:
+            if include_discovered:
+                pdb.reconcile_discovered_repos_policy(
+                    conn,
+                    policy_key,
+                    preserve_unversioned=_repo_discovery_policy_is_default(policy),
+                )
+            projects = [p.to_dict() for p in pdb.list_projects(conn)]
+            active_id = pdb.get_active_id(conn)
+            # backfill stays off the hot tree path — grouping uses the live resolver.
+            discovered = (
+                _discover_repos_payload(
+                    db,
+                    conn=conn,
+                    backfill=False,
+                    include_cached=policy["enabled"],
+                )
+                if include_discovered
+                else []
             )
-        projects = [p.to_dict() for p in pdb.list_projects(conn)]
-        active_id = pdb.get_active_id(conn)
-        # backfill stays off the hot tree path — grouping uses the live resolver.
-        discovered = (
-            _discover_repos_payload(
-                db,
-                conn=conn,
-                backfill=False,
-                include_cached=policy["enabled"],
-            )
-            if include_discovered
-            else []
-        )
 
     return sessions, projects, discovered, active_id
 
@@ -11147,14 +11171,20 @@ def _dir_exists_cached(path: str) -> bool:
 
 
 def _build_project_tree(
-    db, *, preview_limit: int, hydrate: bool, session_limit: int, include_discovered: bool
+    db,
+    *,
+    preview_limit: int,
+    hydrate: bool,
+    session_limit: int,
+    include_discovered: bool,
+    params: dict | None = None,
 ) -> tuple[dict, str | None]:
     """Gather inputs and run the one authoritative builder. Returns (tree, active_id)."""
     from tui_gateway import project_tree
 
     _DIR_EXISTS_CACHE.clear()
     sessions, projects, discovered, active_id = _project_tree_inputs(
-        db, session_limit, include_discovered=include_discovered
+        db, session_limit, include_discovered=include_discovered, params=params
     )
     tree = project_tree.build_tree(
         projects,


### PR DESCRIPTION
## What does this PR do?

Scopes the `projects.*` RPC family to the profile the desktop has focused. In app-global remote mode, where one backend serves every profile, the projects handlers today resolve the launch profile's `projects.db` for every request. The Projects rail shows the launch store's projects no matter which profile is focused, and `projects.record_repos` writes discovered repos into the launch profile's store. A red-on-old test in this PR shows such a write clobbering the launch store's cache.

#54278 reports this defect. The approach here comes from #54310, whose author identified the fix shape: the desktop names the focused profile on every projects call, and the gateway binds that profile's `HERMES_HOME` around the whole handler. The dispatcher refactor that moved the direct project handlers into `tui_gateway/methods_config.py` landed after #54310, so its diff no longer applies. This PR carries the design onto current `main` and adds guards on the client so late responses cannot cross profiles. If the maintainers would rather land an updated #54310, everything here, tests included, is offered toward that.

Gateway side: `projects.*` accept an optional `params.profile`. `_projects_profile_home()` binds the requested profile's home for the duration of the handler through a context override, balanced per request, so nothing leaks across frames on a shared connection. Omitted, blank, and launch-profile values are no-ops. Own-profile backends and single-profile setups keep their current behavior, pinned by a dedicated test that also passes on old code.

Desktop side: every projects RPC carries the focused profile via `projectParams()`. Each request captures the gateway and profile it was issued under, and generation guards on `refreshProjects`, `refreshProjectTree`, and `fetchProjectSessions` drop responses that arrive after the user has moved on. The pattern mirrors the request-id guard the sessions rail already uses. The all-profiles sentinel (`__all__`) never reaches the wire.

#58215 and #58224 describe repo-scan writes racing profile switches. The profile-stamped `record_repos` route and the capture-at-issue guards here cover the same family, and I am glad to coordinate with #58224 on the async-scan case. #70235 asks for profile-relative persisted project paths; that is adjacent work and this PR does not address it.

## Related Issue

Fixes #54278. Related: #58215, #58224. Carries the approach of #54310 forward onto the refactored dispatcher.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: `_profile_home()` and `_projects_profile_home()` resolve and bind the requested profile's home with balanced context overrides; project session reads select the profile's session db.
- `tui_gateway/methods_config.py`: the direct projects handlers (`list`, `tree`, `record_repos`, `project_sessions`, mutations) accept `params.profile` and bind it around the whole handler.
- `apps/desktop/src/store/projects.ts`: `projectProfile()` and `projectParams()` put the focused profile on every call and reject the `__all__` sentinel; requests capture their gateway and profile at issue time; generation guards cover the three read paths.
- `tests/tui_gateway/test_projects_rpc.py`: cross-profile scoping tests against two distinct on-disk stores for `projects.list`, `projects.tree`, and `projects.project_sessions`; a test that `record_repos` writes into the requested profile's `projects.db`; tests pinning no-profile and unknown-profile requests to launch-home behavior with no ContextVar leakage.
- `apps/desktop/src/store/projects.test.ts`: profile forwarding on reads and on discovery-policy writes; the all-profiles view issues no scoped RPC; late responses from a previous profile are dropped for `list`, `tree`, and `project_sessions`; a switch-during-scan test that holds a scan open across a profile switch and asserts `record_repos` carries the profile captured at scan start. Async gating uses a local `deferred()` helper because the renderer library target is ES2023 and `Promise.withResolvers` is ES2024.

## How to Test

1. `scripts/run_tests.sh tests/tui_gateway/test_projects_rpc.py -q` passes 24 tests.
2. `cd apps/desktop && npx vitest run --project ui src/store/projects.test.ts` passes 30 tests on Node 22 (see note below).
3. Red-on-old, overlaying only the two test files onto `main`:
   - Python, 4 failures. `projects.list` with `profile=coder` returns the launch store's project (`assert ['Launch'] == ['Coder']`). `projects.tree` fails the same way. `projects.project_sessions` resolves `None` because the requested profile's project id is absent from the launch store. `record_repos` writes into the launch profile's `projects.db` and clobbers it (`assert ['coder'] == ['launch']`).
   - JS, 5 failures: reads carry no `profile` param, the all-profiles view still issues reads, discovery-policy writes lack the profile key, and a late `fetchProjectSessions` response publishes instead of being dropped.
   - Two of the three late-response guards (`list`, `tree`) pass on old code because old code sends no param and the mock's race never arms. Those two are regression guards. All three were verified live by mutation: with the generation guards neutralized, exactly those three tests fail.
4. Manual, remote mode: one `hermes serve` backend, two profiles with different project stores. Focus each profile in the desktop. The Projects rail shows only that profile's store, and repo discovery records into the focused profile's `projects.db`.

## Checklist

### Code
- [x] I have read CONTRIBUTING.md
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs for duplicates (#54310's approach adopted with credit; #58224, #61335, #65408, and #58634 reviewed for overlap)
- [x] This PR contains only related changes
- [x] Full suites: `scripts/run_tests.sh -q` gives 22,759 passed with 67 failures, every one present in my `origin/main` baseline list (optional backends and platform gaps), zero new. Desktop vitest on Node 22: `ui` project 354 files, 3,138 tests, 0 failed; `electron` project 867 passed, 0 failed. `npm run typecheck` (renderer, Electron, and e2e projects) exits clean.
- [x] I added tests that fail without this change (4 Python and 3 JS red-on-old; the remaining guards are mutation-verified as described)
- [x] Tested on: macOS 15 (arm64, Apple M4), Python 3.11, Node 22.23.2

### Documentation & Housekeeping
- [x] Docs: N/A (restores intended per-profile behavior, no new user-facing surface)
- [x] `cli-config.yaml.example`: N/A (no config keys)
- [x] CONTRIBUTING/AGENTS: N/A
- [x] Cross-platform: profile homes resolve through the existing `get_profile_dir` and `get_hermes_home` helpers with `pathlib` throughout, no platform-specific paths. Local note: Node 26 produces roughly 200 spurious jsdom `localStorage` failures on unmodified `main`, so a clean local run needs CI's pinned Node 22.
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Red-on-old core failures, two distinct on-disk stores, launch profile `launch`, requested profile `coder`:

```
projects.list  (profile=coder):  AssertionError: assert ['Launch'] == ['Coder']
projects.tree  (profile=coder):  AssertionError: assert ['Launch'] == ['Coder']
projects.project_sessions:       assert None is not None   (coder's project absent from launch store)
record_repos   (profile=coder):  assert ['coder'] == ['launch']  (write landed in launch's projects.db)
```

