### PR TITLE
fix: avoid optional dependency upgrades during setup

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -956,17 +956,17 @@ def _install_neutts_deps() -> bool:
     from hermes_cli.tools_config import _pip_install
 
     try:
-        result = _pip_install(["-U", "neutts[all]", "--quiet"], timeout=300)
+        result = _pip_install(["neutts[all]", "--quiet"], timeout=300)
     except Exception as e:
         print_error(f"Failed to install neutts: {e}")
-        print_info("Try manually: uv pip install -U 'neutts[all]'")
+        print_info("Try manually: uv pip install 'neutts[all]'")
         return False
     if result.returncode == 0:
         print_success("neutts installed successfully")
         return True
     err = (result.stderr or "").strip()
     print_error(f"Failed to install neutts: {err[:300] if err else 'install failed'}")
-    print_info("Try manually: uv pip install -U 'neutts[all]'")
+    print_info("Try manually: uv pip install 'neutts[all]'")
     return False
 
 
@@ -984,17 +984,17 @@ def _install_kittentts_deps() -> bool:
     from hermes_cli.tools_config import _pip_install
 
     try:
-        result = _pip_install(["-U", wheel_url, "soundfile", "--quiet"], timeout=300)
+        result = _pip_install([wheel_url, "soundfile", "--quiet"], timeout=300)
     except Exception as e:
         print_error(f"Failed to install kittentts: {e}")
-        print_info(f"Try manually: uv pip install -U '{wheel_url}' soundfile")
+        print_info(f"Try manually: uv pip install '{wheel_url}' soundfile")
         return False
     if result.returncode == 0:
         print_success("kittentts installed successfully")
         return True
     err = (result.stderr or "").strip()
     print_error(f"Failed to install kittentts: {err[:300] if err else 'install failed'}")
-    print_info(f"Try manually: uv pip install -U '{wheel_url}' soundfile")
+    print_info(f"Try manually: uv pip install '{wheel_url}' soundfile")
     return False
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1768,7 +1768,7 @@ def _run_post_setup(post_setup_key: str):
             pass
         _print_info("    Installing faster-whisper (model ~150MB downloads on first use)...")
         try:
-            result = _pip_install(["-U", "faster-whisper", "--quiet"], timeout=300)
+            result = _pip_install(["faster-whisper", "--quiet"], timeout=300)
             if result.returncode == 0:
                 _print_success("    faster-whisper installed")
                 _print_info("    Model sizes: tiny, base (default), small, medium, large-v3")
@@ -1776,10 +1776,10 @@ def _run_post_setup(post_setup_key: str):
             else:
                 _print_warning("    faster-whisper install failed:")
                 _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                _print_info("    Run manually: uv pip install -U faster-whisper")
+                _print_info("    Run manually: uv pip install faster-whisper")
         except subprocess.TimeoutExpired:
             _print_warning("    faster-whisper install timed out (>5min)")
-            _print_info("    Run manually: uv pip install -U faster-whisper")
+            _print_info("    Run manually: uv pip install faster-whisper")
 
     elif post_setup_key == "kittentts":
         try:
@@ -1794,7 +1794,7 @@ def _run_post_setup(post_setup_key: str):
             "0.8.1/kittentts-0.8.1-py3-none-any.whl"
         )
         try:
-            result = _pip_install(["-U", wheel_url, "soundfile", "--quiet"], timeout=300)
+            result = _pip_install([wheel_url, "soundfile", "--quiet"], timeout=300)
             if result.returncode == 0:
                 _print_success("    kittentts installed")
                 _print_info("    Voices: Jasper, Bella, Luna, Bruno, Rosie, Hugo, Kiki, Leo")
@@ -1802,10 +1802,10 @@ def _run_post_setup(post_setup_key: str):
             else:
                 _print_warning("    kittentts install failed:")
                 _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                _print_info(f"    Run manually: uv pip install -U '{wheel_url}' soundfile")
+                _print_info(f"    Run manually: uv pip install '{wheel_url}' soundfile")
         except subprocess.TimeoutExpired:
             _print_warning("    kittentts install timed out (>5min)")
-            _print_info(f"    Run manually: uv pip install -U '{wheel_url}' soundfile")
+            _print_info(f"    Run manually: uv pip install '{wheel_url}' soundfile")
 
     elif post_setup_key == "piper":
         try:
@@ -1814,17 +1814,17 @@ def _run_post_setup(post_setup_key: str):
         except ImportError:
             _print_info("    Installing piper-tts (~14MB wheel, voices downloaded on first use)...")
             try:
-                result = _pip_install(["-U", "piper-tts", "--quiet"], timeout=300)
+                result = _pip_install(["piper-tts", "--quiet"], timeout=300)
                 if result.returncode == 0:
                     _print_success("    piper-tts installed")
                 else:
                     _print_warning("    piper-tts install failed:")
                     _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                    _print_info("    Run manually: uv pip install -U piper-tts")
+                    _print_info("    Run manually: uv pip install piper-tts")
                     return
             except subprocess.TimeoutExpired:
                 _print_warning("    piper-tts install timed out (>5min)")
-                _print_info("    Run manually: uv pip install -U piper-tts")
+                _print_info("    Run manually: uv pip install piper-tts")
                 return
         _print_info("    Default voice: en_US-lessac-medium (downloaded on first TTS call)")
         _print_info("    Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md")
@@ -1837,17 +1837,17 @@ def _run_post_setup(post_setup_key: str):
         except ImportError:
             _print_info("    Installing ddgs (DuckDuckGo search package)...")
             try:
-                result = _pip_install(["-U", "ddgs", "--quiet"], timeout=300)
+                result = _pip_install(["ddgs", "--quiet"], timeout=300)
                 if result.returncode == 0:
                     _print_success("    ddgs installed")
                 else:
                     _print_warning("    ddgs install failed:")
                     _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                    _print_info("    Run manually: uv pip install -U ddgs")
+                    _print_info("    Run manually: uv pip install ddgs")
                     return
             except subprocess.TimeoutExpired:
                 _print_warning("    ddgs install timed out (>5min)")
-                _print_info("    Run manually: uv pip install -U ddgs")
+                _print_info("    Run manually: uv pip install ddgs")
                 return
         _print_info("    No API key required. DuckDuckGo enforces server-side rate limits.")
         _print_info("    Pair with an extract provider if you also need web_extract.")

--- a/tests/hermes_cli/test_post_setup_dependency_installs.py
+++ b/tests/hermes_cli/test_post_setup_dependency_installs.py
@@ -1,0 +1,72 @@
+"""Regression tests for Python dependency post-setup hooks."""
+
+import builtins
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hermes_cli import setup, tools_config
+
+
+@pytest.mark.parametrize(
+    ("post_setup_key", "module_name"),
+    [
+        ("faster_whisper", "faster_whisper"),
+        ("kittentts", "kittentts"),
+        ("piper", "piper"),
+        ("ddgs", "ddgs"),
+    ],
+)
+def test_missing_python_backend_install_does_not_force_dependency_upgrades(
+    monkeypatch: pytest.MonkeyPatch,
+    post_setup_key: str,
+    module_name: str,
+) -> None:
+    """Post-setup can run beside a live Gateway using the same venv."""
+    real_import = builtins.__import__
+
+    def import_with_backend_missing(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == module_name:
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    install_calls: list[list[str]] = []
+
+    def record_install(args: list[str], **_kwargs: Any) -> SimpleNamespace:
+        install_calls.append(args)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(builtins, "__import__", import_with_backend_missing)
+    monkeypatch.setattr(tools_config, "_pip_install", record_install)
+
+    tools_config._run_post_setup(post_setup_key)
+
+    assert len(install_calls) == 1
+    assert "-U" not in install_calls[0]
+    assert "--upgrade" not in install_calls[0]
+
+
+@pytest.mark.parametrize(
+    "installer",
+    [setup._install_neutts_deps, setup._install_kittentts_deps],
+)
+def test_setup_backend_install_does_not_force_dependency_upgrades(
+    monkeypatch: pytest.MonkeyPatch,
+    installer: Callable[[], bool],
+) -> None:
+    """Re-running setup must not eagerly upgrade a live Gateway's venv."""
+    install_calls: list[list[str]] = []
+
+    def record_install(args: list[str], **_kwargs: Any) -> SimpleNamespace:
+        install_calls.append(args)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(setup, "_check_espeak_ng", lambda: True)
+    monkeypatch.setattr(tools_config, "_pip_install", record_install)
+
+    assert installer() is True
+    assert len(install_calls) == 1
+    assert "-U" not in install_calls[0]
+    assert "--upgrade" not in install_calls[0]


### PR DESCRIPTION
## Summary

- remove unconditional upgrade flags from optional dependency installs
- keep manual fallback commands consistent with that behavior
- add regression coverage for post-setup and repeatable setup flows

## Why

A running Gateway can retain already imported modules while setup upgrades package files in the same virtual environment. Later lazy imports may then combine modules from different versions and fail until the Gateway restarts.

This is a narrow mitigation; broader lifecycle coordination or dependency isolation remains tracked in #75118.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_post_setup_dependency_installs.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_setup.py tests/hermes_cli/test_setup_tts_xai_oauth.py -q`
- `uv run ruff check hermes_cli/tools_config.py hermes_cli/setup.py tests/hermes_cli/test_post_setup_dependency_installs.py`
- `git diff --check`

Relates to #75118
