### PR TITLE
fix(bluebubbles): complete send_message target resolution

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -155,6 +155,8 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 platforms["discord"] = await asyncio.to_thread(_build_discord, adapter)
             elif platform == Platform.SLACK:
                 platforms["slack"] = await _build_slack(adapter)
+            elif platform == Platform.BLUEBUBBLES:
+                platforms["bluebubbles"] = await _build_bluebubbles(adapter)
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
@@ -364,6 +366,64 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
             except Exception as e:
                 logger.debug("Channel directory: failed to resolve %s: %s", entry["id"], e)
                 continue
+
+    return channels
+
+
+async def _build_bluebubbles(adapter) -> List[Dict[str, Any]]:
+    """Enumerate BlueBubbles chats via ``/api/v1/chat/query``.
+
+    Walks paginated chat results, recording each chat's GUID (used directly as
+    the send target — ``BlueBubblesAdapter._resolve_chat_guid`` returns raw
+    GUIDs as-is) plus a human-readable display name. Falls back to session
+    history when the adapter isn't connected.
+    """
+    if not getattr(adapter, "client", None):
+        return await asyncio.to_thread(_build_from_sessions, "bluebubbles")
+
+    channels: List[Dict[str, Any]] = []
+    seen_ids: set = set()
+
+    limit = 100
+    offset = 0
+    for _page in range(50):  # safety cap on pagination
+        try:
+            payload = await adapter._api_post(
+                "/api/v1/chat/query",
+                {"limit": limit, "offset": offset},
+            )
+        except Exception as e:
+            logger.warning(
+                "Channel directory: failed to query BlueBubbles chats: %s", e
+            )
+            break
+        chats = payload.get("data") or []
+        if not chats:
+            break
+        for chat in chats:
+            guid = chat.get("guid") or chat.get("chatGuid")
+            if not guid or guid in seen_ids:
+                continue
+            seen_ids.add(guid)
+            identifier = chat.get("chatIdentifier") or chat.get("identifier") or ""
+            display = chat.get("displayName") or identifier or guid
+            # ";+;" marks group chats in BlueBubbles GUIDs; ";-;" marks DMs.
+            chat_type = "group" if ";+;" in guid else "dm"
+            channels.append({
+                "id": guid,
+                "name": display,
+                "type": chat_type,
+            })
+        if len(chats) < limit:
+            break
+        offset += limit
+
+    # Merge in entries discovered from session history so DMs we've actually
+    # received messages from remain reachable even if the server query failed.
+    for entry in await asyncio.to_thread(_build_from_sessions, "bluebubbles"):
+        if entry.get("id") not in seen_ids:
+            channels.append(entry)
+            seen_ids.add(entry.get("id"))
 
     return channels
 

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -462,19 +462,24 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             self._guid_cache.move_to_end(target)
             return self._guid_cache[target]
         try:
-            payload = await self._api_post(
-                "/api/v1/chat/query",
-                {"limit": 100, "offset": 0},
-            )
-            for chat in payload.get("data", []) or []:
-                guid = chat.get("guid") or chat.get("chatGuid")
-                identifier = chat.get("chatIdentifier") or chat.get("identifier")
-                if identifier == target:
-                    if guid:
-                        self._guid_cache[target] = guid
-                        while len(self._guid_cache) > _GUID_CACHE_SIZE:
-                            self._guid_cache.popitem(last=False)
-                    return guid
+            limit = 100
+            for page in range(50):  # safety cap for unexpectedly large servers
+                payload = await self._api_post(
+                    "/api/v1/chat/query",
+                    {"limit": limit, "offset": page * limit},
+                )
+                chats = payload.get("data", []) or []
+                for chat in chats:
+                    guid = chat.get("guid") or chat.get("chatGuid")
+                    identifier = chat.get("chatIdentifier") or chat.get("identifier")
+                    if identifier == target:
+                        if guid:
+                            self._guid_cache[target] = guid
+                            while len(self._guid_cache) > _GUID_CACHE_SIZE:
+                                self._guid_cache.popitem(last=False)
+                        return guid
+                if len(chats) < limit:
+                    break
         except Exception:
             pass
         return None

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -175,6 +175,51 @@ class TestBlueBubblesWebhookParsing:
 
 class TestBlueBubblesGuidResolution:
 
+    @pytest.mark.asyncio
+    async def test_direct_send_resolves_exact_identifier_on_second_page(self, monkeypatch):
+        """Direct email sends must search beyond the first 100 chats."""
+        adapter = _make_adapter(monkeypatch)
+        calls = []
+
+        async def fake_api_post(path, payload):
+            calls.append((path, payload))
+            if path == "/api/v1/chat/query":
+                if payload["offset"] == 0:
+                    return {
+                        "data": [
+                            {
+                                "guid": f"iMessage;-;other-{index}@example.com",
+                                "chatIdentifier": f"other-{index}@example.com",
+                            }
+                            for index in range(100)
+                        ]
+                    }
+                return {
+                    "data": [
+                        {
+                            "guid": "iMessage;-;user@example.com",
+                            "chatIdentifier": "user@example.com",
+                        }
+                    ]
+                }
+            if path == "/api/v1/message/text":
+                assert payload["chatGuid"] == "iMessage;-;user@example.com"
+                assert payload["message"] == "hello"
+                return {"data": {"guid": "message-guid"}}
+            raise AssertionError(f"unexpected path: {path}")
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send("user@example.com", "hello")
+
+        assert result.success is True
+        assert result.message_id == "message-guid"
+        assert calls[:2] == [
+            ("/api/v1/chat/query", {"limit": 100, "offset": 0}),
+            ("/api/v1/chat/query", {"limit": 100, "offset": 100}),
+        ]
+        assert calls[2][0] == "/api/v1/message/text"
+
 
     @pytest.mark.asyncio
     async def test_participant_only_match_does_not_resolve_to_group(self, monkeypatch):

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -14,6 +14,7 @@ from gateway.channel_directory import (
     format_directory_for_display,
     load_directory,
     _apply_channel_aliases,
+    _build_bluebubbles,
     _build_from_sessions,
     _build_slack,
     _slack_directory_warning_last,
@@ -208,6 +209,165 @@ class TestLookupChannelType:
         }
         with self._setup(tmp_path, platforms):
             assert lookup_channel_type("discord", "999") is None
+
+
+def _make_bluebubbles_adapter(pages):
+    """Build a stand-in for BlueBubblesAdapter exposing what _build_bluebubbles uses."""
+    adapter = SimpleNamespace(client=object())
+    adapter._api_post = AsyncMock(side_effect=pages)
+    return adapter
+
+
+class TestBuildBlueBubbles:
+    """_build_bluebubbles queries /api/v1/chat/query on the connected adapter."""
+
+    def test_no_client_falls_back_to_sessions(self, tmp_path):
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "s1": {
+                "origin": {
+                    "platform": "bluebubbles",
+                    "chat_id": "iMessage;-;user@example.com",
+                    "chat_name": "user@example.com",
+                },
+            },
+        }), encoding="utf-8")
+
+        adapter = SimpleNamespace(client=None)
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        assert len(entries) == 1
+        assert entries[0]["id"] == "iMessage;-;user@example.com"
+
+    def test_enumerates_chats_from_chat_query(self, tmp_path):
+        adapter = _make_bluebubbles_adapter([
+            {
+                "data": [
+                    {
+                        "guid": "iMessage;-;alice@example.com",
+                        "chatIdentifier": "alice@example.com",
+                        "displayName": "",
+                    },
+                    {
+                        "guid": "iMessage;+;chatABC123",
+                        "chatIdentifier": "chatABC123",
+                        "displayName": "Family",
+                    },
+                ],
+            },
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        by_id = {e["id"]: e for e in entries}
+        assert "iMessage;-;alice@example.com" in by_id
+        assert by_id["iMessage;-;alice@example.com"]["type"] == "dm"
+        assert by_id["iMessage;-;alice@example.com"]["name"] == "alice@example.com"
+        assert by_id["iMessage;+;chatABC123"]["type"] == "group"
+        assert by_id["iMessage;+;chatABC123"]["name"] == "Family"
+        adapter._api_post.assert_awaited_once_with(
+            "/api/v1/chat/query", {"limit": 100, "offset": 0}
+        )
+
+    def test_no_client_session_scan_runs_off_event_loop_thread(self):
+        loop_thread = threading.get_ident()
+        calls = []
+
+        def fake_build_from_sessions(platform_name):
+            calls.append((platform_name, threading.get_ident()))
+            return [{"id": "iMessage;-;alice@example.com", "name": "Alice", "type": "dm"}]
+
+        adapter = SimpleNamespace(client=None)
+        with patch(
+            "gateway.channel_directory._build_from_sessions",
+            side_effect=fake_build_from_sessions,
+        ):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        assert entries == [{"id": "iMessage;-;alice@example.com", "name": "Alice", "type": "dm"}]
+        assert [platform_name for platform_name, _ in calls] == ["bluebubbles"]
+        assert calls[0][1] != loop_thread
+
+    def test_session_merge_runs_off_event_loop_thread(self):
+        loop_thread = threading.get_ident()
+        calls = []
+
+        def fake_build_from_sessions(platform_name):
+            calls.append((platform_name, threading.get_ident()))
+            return [{"id": "iMessage;-;alice@example.com", "name": "Alice", "type": "dm"}]
+
+        adapter = _make_bluebubbles_adapter([{"data": []}])
+        with patch(
+            "gateway.channel_directory._build_from_sessions",
+            side_effect=fake_build_from_sessions,
+        ):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        assert entries == [{"id": "iMessage;-;alice@example.com", "name": "Alice", "type": "dm"}]
+        assert [platform_name for platform_name, _ in calls] == ["bluebubbles"]
+        assert calls[0][1] != loop_thread
+
+    def test_paginates_until_short_page(self, tmp_path):
+        page1 = {"data": [{"guid": f"iMessage;-;u{i}@e.com"} for i in range(100)]}
+        page2 = {"data": [{"guid": "iMessage;-;last@e.com"}]}
+        adapter = _make_bluebubbles_adapter([page1, page2])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        ids = {e["id"] for e in entries}
+        assert "iMessage;-;u0@e.com" in ids
+        assert "iMessage;-;last@e.com" in ids
+        assert adapter._api_post.await_count == 2
+
+    def test_api_error_returns_empty(self, tmp_path):
+        adapter = SimpleNamespace(client=object())
+        adapter._api_post = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+        assert entries == []
+
+    def test_session_dms_merged_when_not_in_api_results(self, tmp_path):
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "s1": {
+                "origin": {
+                    "platform": "bluebubbles",
+                    "chat_id": "iMessage;-;bob@example.com",
+                    "chat_name": "bob@example.com",
+                },
+            },
+            "dup": {
+                "origin": {
+                    "platform": "bluebubbles",
+                    "chat_id": "iMessage;-;alice@example.com",
+                    "chat_name": "alice@example.com",
+                },
+            },
+        }), encoding="utf-8")
+        adapter = _make_bluebubbles_adapter([
+            {"data": [{"guid": "iMessage;-;alice@example.com", "chatIdentifier": "alice@example.com"}]},
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        ids = {e["id"] for e in entries}
+        assert "iMessage;-;alice@example.com" in ids
+        assert "iMessage;-;bob@example.com" in ids
+        assert sum(1 for e in entries if e["id"] == "iMessage;-;alice@example.com") == 1
+
+    def test_skips_chats_without_guid(self, tmp_path):
+        adapter = _make_bluebubbles_adapter([
+            {"data": [
+                {"chatIdentifier": "no-guid@example.com"},
+                {"guid": "iMessage;-;ok@example.com"},
+            ]},
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+        assert {e["id"] for e in entries} == {"iMessage;-;ok@example.com"}
 
 
 def _make_slack_adapter(team_clients):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1029,6 +1029,62 @@ class TestResolveSlackUserTargets:
         assert "im:write" in err["error"]
 
 
+class TestParseTargetRefBlueBubbles:
+    """_parse_target_ref recognizes BlueBubbles raw GUIDs, emails, and phone numbers."""
+
+    def test_raw_dm_guid_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "bluebubbles", "iMessage;-;user@example.com"
+        )
+        assert chat_id == "iMessage;-;user@example.com"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_any_service_phone_guid_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "bluebubbles", "any;-;+15551234567"
+        )
+        assert chat_id == "any;-;+15551234567"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_raw_group_guid_is_explicit(self):
+        chat_id, _, is_explicit = _parse_target_ref(
+            "bluebubbles", "iMessage;+;chat1234567890abcdef"
+        )
+        assert chat_id == "iMessage;+;chat1234567890abcdef"
+        assert is_explicit is True
+
+    def test_email_handle_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "bluebubbles", "user@example.com"
+        )
+        assert chat_id == "user@example.com"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_phone_handle_is_explicit(self):
+        chat_id, _, is_explicit = _parse_target_ref("bluebubbles", "+15551234567")
+        assert chat_id == "+15551234567"
+        assert is_explicit is True
+
+    def test_whitespace_is_stripped(self):
+        chat_id, _, is_explicit = _parse_target_ref(
+            "bluebubbles", "  user@example.com  "
+        )
+        assert chat_id == "user@example.com"
+        assert is_explicit is True
+
+    def test_non_address_is_not_explicit(self):
+        assert _parse_target_ref("bluebubbles", "not-an-address")[2] is False
+        assert _parse_target_ref("bluebubbles", "incomplete@")[2] is False
+        assert _parse_target_ref("bluebubbles", "+")[2] is False
+
+    def test_bluebubbles_pattern_not_explicit_for_other_platforms(self):
+        """Email/phone handles must not flip is_explicit on unrelated platforms."""
+        assert _parse_target_ref("telegram", "user@example.com")[2] is False
+        assert _parse_target_ref("discord", "user@example.com")[2] is False
+
 class TestSendDiscordThreadId:
     """_send_discord uses thread_id when provided."""
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -52,6 +52,9 @@ _WHATSAPP_JID_RE = re.compile(
     r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
     re.IGNORECASE,
 )
+# BlueBubbles addresses chats by raw chat GUID (for example,
+# "iMessage;-;handle" or "iMessage;+;groupId").
+_BLUEBUBBLES_GUID_RE = re.compile(r"^\s*[A-Za-z0-9_+-]+;[+-];[^\s;]+\s*$")
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -609,6 +612,16 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         # them off the channel directory (mirrors the react handler).
         if _PHOTON_DM_GUID_RE.fullmatch(target_ref.strip()):
             return target_ref.strip(), None, True
+    if platform_name == "bluebubbles":
+        target = target_ref.strip()
+        # Raw chat GUID — adapter._resolve_chat_guid returns it as-is.
+        if _BLUEBUBBLES_GUID_RE.fullmatch(target_ref):
+            return target, None, True
+        # Email handle or E.164 phone — the adapter resolves to a GUID
+        # via /api/v1/chat/query, with a private-API fallback that creates
+        # a fresh chat for the address.
+        if _EMAIL_TARGET_RE.fullmatch(target_ref) or _E164_TARGET_RE.fullmatch(target_ref):
+            return target, None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit


### PR DESCRIPTION
Completes the fix proposed in #23434 for #23409 and addresses the keep_open review.

Changes:
- preserves the original contributor commit and contact/channel-directory work
- paginates exact BlueBubbles identifier lookup across chat-query pages
- keeps participant-only group matches excluded
- adds a direct-send regression with the existing chat GUID on page two
- proves no unnecessary chat creation occurs

Validation:
- 98 targeted BlueBubbles/channel-directory/send_message tests pass
- Ruff check passes
- Windows footgun scan passes
- git diff --check passes
- rebased onto current upstream/main

Supersedes the incomplete state of #23434; original contributor authorship is retained in history.