### PR TITLE
fix(agent): align iteration-budget default (90→500) and refund api_call_count on execute-code-only turns (#75097)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -455,7 +455,7 @@ def init_agent(
     command: str = None,
     args: list[str] | None = None,
     model: str = "",
-    max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
+    max_iterations: int = 500,  # Default tool-calling iterations; each subagent gets its own independent budget
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     save_trajectories: bool = False,
@@ -528,7 +528,7 @@ def init_agent(
         requested_provider (str): Original provider identity before runtime canonicalization
         api_mode (str): API mode override: "chat_completions" or "codex_responses"
         model (str): Model name to use (default: "anthropic/claude-opus-4.6")
-        max_iterations (int): Maximum number of tool calling iterations (default: 90)
+        max_iterations (int): Maximum number of tool calling iterations (default: 500)
         enabled_toolsets (List[str]): Only enable tools from these toolsets (optional)
         disabled_toolsets (List[str]): Disable tools from these toolsets (optional)
         save_trajectories (bool): Whether to save conversation trajectories to JSONL files (default: False)
@@ -570,9 +570,8 @@ def init_agent(
     _install_safe_stdio()
 
     agent.model = model
+    # Subagent gets its own independent budget (set by parent via delegation config).
     agent.max_iterations = max_iterations
-    # Shared iteration budget — parent creates, children inherit.
-    # Consumed by every LLM turn across parent + all subagents.
     agent.iteration_budget = iteration_budget or IterationBudget(max_iterations)
     agent.save_trajectories = save_trajectories
     agent.verbose_logging = verbose_logging

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6154,6 +6154,10 @@ def run_conversation(
                 _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                 if _tc_names == {"execute_code"}:
                     agent.iteration_budget.refund()
+                    # Refund the api_call_count too so execute-code-only iterations
+                    # don't count against the max_iterations cap.
+                    api_call_count -= 1
+                    agent._api_call_count = api_call_count
                 
                 # Use real token counts from the API response to decide
                 # compression.  prompt_tokens + completion_tokens is the

--- a/run_agent.py
+++ b/run_agent.py
@@ -440,7 +440,7 @@ class AIAgent:
         command: str = None,
         args: list[str] | None = None,
         model: str = "",
-        max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
+        max_iterations: int = 500,  # Default tool-calling iterations; each subagent gets its own independent budget
         tool_delay: float = None,  # Deprecated: accepted for compatibility, ignored
         enabled_toolsets: List[str] = None,
         disabled_toolsets: List[str] = None,


### PR DESCRIPTION
Fixes #75097.

## Changes

1. **Default `max_iterations`: 90 → 500** — `AIAgent()` and `init_agent()` defaulted to 90 while `DEFAULT_CONFIG` and the Python-library docs specify 500. This caused direct Python callers and internal construction paths (one-shot CLI, ACP sessions) to silently cap at 90 turns.

2. **Refund `api_call_count` on execute-code-only turns** — The main loop guard checks both `api_call_count < max_iterations` and `iteration_budget.remaining > 0`. After an execute-code-only iteration, only `IterationBudget` was refunded; `api_call_count` remained incremented. This meant a refunded execute-code turn still consumed one of the limited tool-calling slots, defeating the documented intent that these cheap RPC-style calls "shouldn't eat the budget".

3. **Stale comments about shared budget removed** — Several comments still described parent/subagent budget sharing, but the current delegation implementation gives each subagent its own independent budget.

## Tests
- `tests/run_agent/`: **1264 passed, 4 skipped, 0 failed** (after installing the missing `anthropic` test dependency in the local venv; the 7 pre-existing failures all traced to that missing package and pass once installed)
- Syntax/import check on all 3 modified files passed
