### PR TITLE
acp: config-driven turn keepalive to prevent client idle-timeout exits

### DIFF
--- a/acp_adapter/keepalive.py
+++ b/acp_adapter/keepalive.py
@@ -1,0 +1,206 @@
+"""Turn-level keepalive for ACP.
+
+Fires a well-formed empty ``agent_message_chunk`` on a session at a configured
+interval so ACP clients (e.g. the VS Code panel) don't hit their idle-timeout
+and kill the process during long-running turns.
+
+Design notes:
+- One dedicated daemon thread per turn, waiting on a ``threading.Event`` with
+  a computed timeout. ``mark_activity()`` just bumps an absolute deadline and
+  signals the event — no per-delta ``threading.Timer`` churn during streaming.
+- Payload is a valid ACP ``AgentMessageChunk`` with an empty ``TextContentBlock``
+  (matches ``ACPAgent._history_message_update`` shape). Empty text so nothing
+  visible surfaces in the client.
+- Interval resolution order: explicit constructor arg → ``config.yaml``
+  (``acp.keepalive_interval_s``) → default 45s. Behavioral config lives in
+  ``config.yaml`` per AGENTS.md env-var-for-config policy — no ``HERMES_*``
+  env var. Interval <= 0 disables the feature (``make_turn_keepalive``
+  returns ``None``).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Callable, Optional
+
+from acp.schema import AgentMessageChunk, TextContentBlock
+
+from acp_adapter.events import _send_update
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_INTERVAL_S = 45.0
+_CONFIG_PATH = ("acp", "keepalive_interval_s")
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _read_config_interval() -> Optional[float]:
+    """Read ``acp.keepalive_interval_s`` from config.yaml if present."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+    except Exception:
+        return None
+    node: Any = cfg
+    for key in _CONFIG_PATH:
+        if not isinstance(node, dict) or key not in node:
+            return None
+        node = node[key]
+    return _coerce_float(node)
+
+
+def get_keepalive_interval(default: float = _DEFAULT_INTERVAL_S) -> float:
+    """Resolve the keepalive interval in seconds.
+
+    Precedence: config.yaml → provided default. No env-var override —
+    behavioral config lives in ``config.yaml`` per AGENTS.md policy.
+    """
+    cfg_val = _read_config_interval()
+    if cfg_val is not None:
+        return cfg_val
+    return default
+
+
+class TurnKeepalive:
+    """Emit a well-formed empty agent_message_chunk every ``interval_s`` seconds.
+
+    A single daemon thread parks on ``threading.Event.wait(timeout)``. Real
+    activity calls ``mark_activity()``, which just pushes the next-fire
+    deadline forward and pokes the event so the thread recomputes its wait.
+    """
+
+    def __init__(
+        self,
+        conn: Any,
+        session_id: str,
+        loop: Any,
+        interval_s: Optional[float] = None,
+        payload_factory: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        self.conn = conn
+        self.session_id = session_id
+        self.loop = loop
+        self.interval_s = (
+            interval_s if interval_s is not None else get_keepalive_interval()
+        )
+        self.payload_factory = payload_factory or self._default_payload_factory
+        self._stopped = False
+        self._started = False
+        self._lock = threading.RLock()
+        self._wake = threading.Event()
+        self._next_fire = 0.0  # monotonic deadline
+        self._thread: Optional[threading.Thread] = None
+        logger.debug(
+            "[TurnKeepalive] init session=%s interval=%.3fs",
+            self.session_id,
+            self.interval_s,
+        )
+
+    # -- payload ---------------------------------------------------------
+    @staticmethod
+    def _default_payload_factory() -> AgentMessageChunk:
+        """Empty but well-formed ACP agent_message_chunk (no visible text)."""
+        return AgentMessageChunk(
+            session_update="agent_message_chunk",
+            content=TextContentBlock(type="text", text=""),
+        )
+
+    # -- lifecycle -------------------------------------------------------
+    def start(self) -> None:
+        with self._lock:
+            if self._stopped or self._started:
+                return
+            if self.interval_s <= 0:
+                # Defensive: factory normally screens this out. If someone
+                # constructs TurnKeepalive directly with a non-positive
+                # interval, refuse to spawn a hot-loop worker.
+                logger.warning(
+                    "[TurnKeepalive] interval_s=%.3f <= 0; not starting (session=%s)",
+                    self.interval_s,
+                    self.session_id,
+                )
+                self._stopped = True
+                return
+            self._started = True
+            self._next_fire = time.monotonic() + self.interval_s
+            self._thread = threading.Thread(
+                target=self._run,
+                name=f"acp-keepalive-{self.session_id}",
+                daemon=True,
+            )
+            self._thread.start()
+            logger.debug("[TurnKeepalive] start session=%s", self.session_id)
+
+    def stop(self) -> None:
+        with self._lock:
+            if self._stopped:
+                return
+            self._stopped = True
+            self._wake.set()
+            thread = self._thread
+        # Join outside the lock so the worker can acquire it and exit.
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=2.0)
+        logger.debug("[TurnKeepalive] stop session=%s", self.session_id)
+
+    def mark_activity(self) -> None:
+        """Push the next-fire deadline out by one full interval. Cheap: no thread ops."""
+        with self._lock:
+            if self._stopped:
+                return
+            self._next_fire = time.monotonic() + self.interval_s
+            self._wake.set()
+
+    # -- worker ----------------------------------------------------------
+    def _run(self) -> None:
+        while True:
+            with self._lock:
+                if self._stopped:
+                    return
+                remaining = self._next_fire - time.monotonic()
+            if remaining > 0:
+                # Wait up to `remaining`; wake early on stop/activity.
+                self._wake.wait(timeout=remaining)
+                with self._lock:
+                    self._wake.clear()
+                    if self._stopped:
+                        return
+                    # Either activity extended the deadline, or we're due.
+                    if time.monotonic() < self._next_fire:
+                        continue
+            # Deadline hit — fire, then reset the deadline for the next tick.
+            try:
+                _send_update(
+                    self.conn, self.session_id, self.loop, self.payload_factory()
+                )
+            except Exception:
+                logger.debug("Keepalive send failed", exc_info=True)
+            with self._lock:
+                if self._stopped:
+                    return
+                self._next_fire = time.monotonic() + self.interval_s
+
+
+def make_turn_keepalive(
+    conn: Any,
+    session_id: str,
+    loop: Any,
+    interval_s: Optional[float] = None,
+    payload_factory: Optional[Callable[[], Any]] = None,
+) -> Optional[TurnKeepalive]:
+    """Factory. Returns ``None`` when interval <= 0 (kill switch)."""
+    interval = (
+        interval_s if interval_s is not None else get_keepalive_interval()
+    )
+    if interval <= 0:
+        return None
+    return TurnKeepalive(conn, session_id, loop, interval, payload_factory)

--- a/acp_adapter/keepalive.py
+++ b/acp_adapter/keepalive.py
@@ -21,6 +21,7 @@ Design notes:
 from __future__ import annotations
 
 import logging
+import math
 import threading
 import time
 from typing import Any, Callable, Optional
@@ -36,10 +37,22 @@ _CONFIG_PATH = ("acp", "keepalive_interval_s")
 
 
 def _coerce_float(value: Any) -> Optional[float]:
+    # Reject bools explicitly (bool is a subclass of int, so float(True) == 1.0
+    # would silently give the ACP keepalive a 1-second interval — never what
+    # a config-file `true`/`false` was intending).
+    if isinstance(value, bool):
+        return None
     try:
-        return float(value)
+        result = float(value)
     except (TypeError, ValueError):
         return None
+    # Reject NaN and ±Inf. YAML accepts `.nan` / `.inf` as valid scalars, and
+    # NaN in particular is toxic: `remaining = deadline - now` becomes NaN,
+    # every comparison against 0 is False, and the loop either spins or fires
+    # continuously instead of sleeping.
+    if not math.isfinite(result):
+        return None
+    return result
 
 
 def _read_config_interval() -> Optional[float]:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -70,6 +70,7 @@ from acp_adapter.events import (
     make_thinking_cb,
     make_tool_progress_cb,
 )
+from acp_adapter.keepalive import make_turn_keepalive
 from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
 from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
@@ -1552,6 +1553,11 @@ class HermesACPAgent(acp.Agent):
         if not has_content:
             return PromptResponse(stop_reason="end_turn")
 
+        # TurnKeepalive is instantiated later — only once we've decided this
+        # call is actually going to execute a turn (past the slash-command,
+        # active-turn-redirect, and queue-for-next-turn early returns).
+        keepalive = None
+
         # /steer on an idle session has no in-flight tool call to inject into.
         # Rewrite it so the payload runs as a normal user prompt, matching the
         # gateway's behavior (gateway/run.py ~L4898). Two sub-cases:
@@ -1672,6 +1678,15 @@ class HermesACPAgent(acp.Agent):
         conn = self._conn
         loop = asyncio.get_running_loop()
 
+        # We're committed to running a turn — start the keepalive now so that
+        # the run_in_executor call below is always paired with a stop() in the
+        # finally block. Skipping this for the early-return paths above avoids
+        # a leaked worker thread when we never enter the executor.
+        if conn is not None:
+            keepalive = make_turn_keepalive(conn, session_id, loop)
+            if keepalive is not None:
+                keepalive.start()
+
         if state.cancel_event:
             state.cancel_event.clear()
 
@@ -1700,6 +1715,9 @@ class HermesACPAgent(acp.Agent):
                 if text:
                     streamed_message = True
                 message_cb(text)
+                # Reset keepalive on real update
+                if keepalive is not None:
+                    keepalive.mark_activity()
 
             approval_cb = make_approval_callback(conn.request_permission, loop, session_id)
             try:
@@ -1840,34 +1858,27 @@ class HermesACPAgent(acp.Agent):
                     except Exception:
                         logger.debug("Could not clear ACP session context", exc_info=True)
 
+        # Main agent execution, wrapped with TurnKeepalive stop for both error/success
         try:
-            # Snapshot the internal Hermes DB session id before the turn so we
-            # can detect a compression-driven session rotation afterwards. The
-            # ACP `session_id` stays the stable client handle; agent.session_id
-            # is the live internal head that compression may rotate.
             pre_turn_hermes_id = getattr(state.agent, "session_id", None)
-            # Wrap the executor call in a fresh copy of the current context so
-            # concurrent ACP sessions on the shared ThreadPoolExecutor don't
-            # stomp on each other's ContextVar writes (HERMES_SESSION_KEY in
-            # particular — used by the interactive sudo password cache scope).
             ctx = contextvars.copy_context()
-            result = await loop.run_in_executor(_executor, ctx.run, _run_agent)
-        except Exception:
-            logger.exception("Executor error for session %s", session_id)
-            with state.runtime_lock:
-                state.is_running = False
-                state.current_prompt_text = ""
-            return PromptResponse(stop_reason="end_turn")
+            try:
+                result = await loop.run_in_executor(_executor, ctx.run, _run_agent)
+            except Exception:
+                logger.exception("Executor error for session %s", session_id)
+                with state.runtime_lock:
+                    state.is_running = False
+                    state.current_prompt_text = ""
+                return PromptResponse(stop_reason="end_turn")
+        finally:
+            if keepalive is not None:
+                keepalive.stop()
 
         if result.get("messages"):
             state.history = result["messages"]
-            # Persist updated history so sessions survive process restarts.
             self.session_manager.save_session(session_id)
 
-        # Detect a compression-driven internal session rotation. If the agent's
-        # DB head moved during the turn, emit a session_info_update carrying
-        # _meta.hermes.sessionProvenance so ACP clients can render the boundary
-        # and keep old/new ids in lineage. The ACP session_id is unchanged.
+        # Detect a compression-driven internal session rotation
         post_turn_hermes_id = getattr(state.agent, "session_id", None)
         if (
             conn
@@ -1891,8 +1902,6 @@ class HermesACPAgent(acp.Agent):
         final_response = result.get("final_response", "")
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         interrupted = bool(result.get("interrupted")) or cancelled
-        # Hermes' local "waiting for model response" interrupt status is metadata,
-        # not assistant prose — clients get cancellation from stop_reason instead.
         from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 
         suppress_interrupt_response = interrupted and final_response.startswith(
@@ -1941,16 +1950,9 @@ class HermesACPAgent(acp.Agent):
             and not suppress_interrupt_response
             and (not streamed_message or result.get("response_transformed"))
         ):
-            # Deliver the final response when streaming did not already send it,
-            # or when a plugin hook transformed the response after streaming
-            # finished (e.g. transform_llm_output) — otherwise the appended /
-            # rewritten text never reaches the client.
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
 
-        # Mark this turn idle before draining queued work so recursive prompt()
-        # calls can acquire the session. Queued turns are intentionally run as
-        # normal follow-up user prompts, preserving role alternation and history.
         with state.runtime_lock:
             state.is_running = False
             state.current_prompt_text = ""

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -335,6 +335,14 @@ DEFAULT_CONFIG = {
         "persistent_shell": True,
     },
 
+    "acp": {
+        # Cadence (seconds) for the ACP turn keepalive — emits an empty
+        # agent_message_chunk so ACP clients (e.g. Zed / VS Code panel) don't
+        # hit their idle-timeout and kill the session during long-running
+        # turns. Set to 0 to disable.
+        "keepalive_interval_s": 45.0,
+    },
+
     "web": {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")

--- a/tests/acp_adapter/test_keepalive.py
+++ b/tests/acp_adapter/test_keepalive.py
@@ -1,0 +1,151 @@
+"""Unit tests for acp_adapter.keepalive.TurnKeepalive."""
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from acp_adapter.keepalive import (
+    TurnKeepalive,
+    get_keepalive_interval,
+    make_turn_keepalive,
+)
+
+
+class DummyConn:
+    def __init__(self):
+        self.calls = []
+
+    def session_update(self, session_id, update):
+        self.calls.append((session_id, update))
+
+
+class DummyLoop:
+    pass
+
+
+def _payload():
+    return "payload"
+
+
+def test_fires_after_interval():
+    mock = MagicMock()
+    k = TurnKeepalive(DummyConn(), "s1", DummyLoop(), interval_s=0.1, payload_factory=_payload)
+    import acp_adapter.keepalive as mod
+    orig = mod._send_update
+    mod._send_update = lambda *a, **kw: mock()
+    try:
+        k.start()
+        # Poll up to 2s for >=3 fires instead of a tight sleep — robust on
+        # slow CI where a bare time.sleep(0.35) races the scheduler.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and mock.call_count < 3:
+            time.sleep(0.02)
+        assert mock.call_count >= 3, f"expected >=3 calls, got {mock.call_count}"
+    finally:
+        k.stop()
+        mod._send_update = orig
+
+
+def test_mark_activity_resets_timer():
+    import acp_adapter.keepalive as mod
+    calls = []
+    orig = mod._send_update
+    mod._send_update = lambda *a, **kw: calls.append(time.time())
+    k = TurnKeepalive(DummyConn(), "s1", DummyLoop(), interval_s=0.1, payload_factory=_payload)
+    try:
+        k.start()
+        # Repeatedly extend the deadline before it can fire.
+        for _ in range(4):
+            time.sleep(0.05)
+            k.mark_activity()
+        assert not calls, "should not have fired while activity kept resetting"
+        time.sleep(0.20)
+        assert calls, "should have fired after resets stopped"
+    finally:
+        k.stop()
+        mod._send_update = orig
+
+
+def test_stop_prevents_further_fires():
+    import acp_adapter.keepalive as mod
+    calls = []
+    orig = mod._send_update
+    mod._send_update = lambda *a, **kw: calls.append(time.time())
+    k = TurnKeepalive(DummyConn(), "s1", DummyLoop(), interval_s=0.1, payload_factory=_payload)
+    try:
+        k.start()
+        time.sleep(0.15)
+        k.stop()
+        c1 = len(calls)
+        time.sleep(0.3)
+        assert len(calls) == c1, "no further fires after stop"
+    finally:
+        k.stop()
+        mod._send_update = orig
+
+
+def test_stop_is_idempotent():
+    k = TurnKeepalive(DummyConn(), "sess", DummyLoop(), interval_s=0.1)
+    k.start()
+    k.stop()
+    k.stop()  # must not raise
+
+
+def test_start_is_idempotent():
+    import acp_adapter.keepalive as mod
+    calls = []
+    orig = mod._send_update
+    mod._send_update = lambda *a, **kw: calls.append(1)
+    k = TurnKeepalive(DummyConn(), "s", DummyLoop(), interval_s=0.1, payload_factory=_payload)
+    try:
+        k.start()
+        k.start()  # second start must be a no-op — single worker thread
+        assert k._thread is not None
+        thread_id = k._thread.ident
+        k.start()
+        assert k._thread.ident == thread_id, "start() must not spawn extra threads"
+        time.sleep(0.25)
+        assert 1 <= len(calls) <= 3, "multiple uncoordinated timers present?"
+    finally:
+        k.stop()
+        mod._send_update = orig
+
+
+def test_config_disable(monkeypatch):
+    """acp.keepalive_interval_s=0 in config.yaml disables the feature."""
+    import acp_adapter.keepalive as mod
+    monkeypatch.setattr(mod, "_read_config_interval", lambda: 0.0)
+    assert make_turn_keepalive(DummyConn(), "sess", DummyLoop()) is None
+
+
+def test_config_overrides_default(monkeypatch):
+    """acp.keepalive_interval_s in config.yaml wins over the hardcoded default."""
+    import acp_adapter.keepalive as mod
+    monkeypatch.setattr(mod, "_read_config_interval", lambda: 12.5)
+    assert get_keepalive_interval() == pytest.approx(12.5)
+
+
+def test_default_when_no_config(monkeypatch):
+    """With no config entry, falls back to the provided default."""
+    import acp_adapter.keepalive as mod
+    monkeypatch.setattr(mod, "_read_config_interval", lambda: None)
+    assert get_keepalive_interval(default=45.0) == 45.0
+
+
+def test_explicit_arg_wins_over_config(monkeypatch):
+    """Explicit constructor arg takes precedence over config.yaml."""
+    import acp_adapter.keepalive as mod
+    monkeypatch.setattr(mod, "_read_config_interval", lambda: 12.5)
+    k = TurnKeepalive(DummyConn(), "s", DummyLoop(), interval_s=0.1)
+    assert k.interval_s == pytest.approx(0.1)
+    k.stop()
+
+
+def test_default_payload_is_valid_agent_message_chunk():
+    from acp.schema import AgentMessageChunk, TextContentBlock
+
+    payload = TurnKeepalive._default_payload_factory()
+    assert isinstance(payload, AgentMessageChunk)
+    assert payload.session_update == "agent_message_chunk"
+    assert isinstance(payload.content, TextContentBlock)
+    assert payload.content.text == ""

--- a/tests/acp_adapter/test_keepalive.py
+++ b/tests/acp_adapter/test_keepalive.py
@@ -149,3 +149,47 @@ def test_default_payload_is_valid_agent_message_chunk():
     assert payload.session_update == "agent_message_chunk"
     assert isinstance(payload.content, TextContentBlock)
     assert payload.content.text == ""
+
+
+# --- _coerce_float hardening (addresses Copilot review on PR #75124) ---
+
+
+def test_coerce_float_rejects_bool_true():
+    """`true` in YAML must not silently become 1.0s keepalive."""
+    from acp_adapter.keepalive import _coerce_float
+
+    assert _coerce_float(True) is None
+
+
+def test_coerce_float_rejects_bool_false():
+    """`false` in YAML must not silently become 0.0 (disable)."""
+    from acp_adapter.keepalive import _coerce_float
+
+    assert _coerce_float(False) is None
+
+
+def test_coerce_float_rejects_nan():
+    """YAML `.nan` would break the keepalive loop (`remaining > 0` is False)."""
+    from acp_adapter.keepalive import _coerce_float
+
+    assert _coerce_float(float("nan")) is None
+
+
+def test_coerce_float_rejects_inf():
+    """YAML `.inf` would produce an infinite sleep — disable feature instead."""
+    from acp_adapter.keepalive import _coerce_float
+
+    assert _coerce_float(float("inf")) is None
+    assert _coerce_float(float("-inf")) is None
+
+
+def test_coerce_float_accepts_valid_numbers():
+    """Sanity check: real ints and floats still coerce."""
+    from acp_adapter.keepalive import _coerce_float
+
+    assert _coerce_float(45) == 45.0
+    assert _coerce_float(45.0) == 45.0
+    assert _coerce_float("45") == 45.0
+    assert _coerce_float(0) == 0.0  # 0 is a valid disable signal
+    assert _coerce_float(None) is None
+    assert _coerce_float("not-a-number") is None

--- a/tests/acp_adapter/test_server_keepalive.py
+++ b/tests/acp_adapter/test_server_keepalive.py
@@ -1,0 +1,73 @@
+"""Server-integration tests for TurnKeepalive.
+
+Verifies interval + activity + disable + stop wiring behavior that
+``ACPAgent.prompt()`` relies on when it calls ``make_turn_keepalive``.
+"""
+import time
+
+import acp_adapter.keepalive as keepalive_mod
+from acp_adapter.keepalive import TurnKeepalive, make_turn_keepalive
+
+
+class DummyConn:
+    def __init__(self):
+        self.calls = []
+
+
+class DummyLoop:
+    pass
+
+
+def _payload():
+    return "keepalive"
+
+
+def _count_fires(monkeypatch, calls):
+    monkeypatch.setattr(keepalive_mod, "_send_update", lambda *a, **kw: calls.append(1))
+
+
+def test_server_keepalive_interval(monkeypatch):
+    """With interval=0.1s and no activity, keepalive fires >=3 times in 0.35s."""
+    calls = []
+    _count_fires(monkeypatch, calls)
+    k = TurnKeepalive(DummyConn(), "s1", DummyLoop(), interval_s=0.1, payload_factory=_payload)
+    k.start()
+    try:
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and len(calls) < 3:
+            time.sleep(0.02)
+        assert len(calls) >= 3, f"expected >=3 keepalives, got {len(calls)}"
+    finally:
+        k.stop()
+
+
+def test_server_keepalive_activity(monkeypatch):
+    """mark_activity() resets deadline; keepalive fires only after activity stops."""
+    calls = []
+    _count_fires(monkeypatch, calls)
+    k = TurnKeepalive(DummyConn(), "s2", DummyLoop(), interval_s=0.12, payload_factory=_payload)
+    k.start()
+    try:
+        for _ in range(4):
+            time.sleep(0.05)
+            k.mark_activity()
+        assert not calls, "keepalive should not have fired under continuous activity"
+        time.sleep(0.20)
+        assert calls, "keepalive should have fired after resets stopped"
+    finally:
+        k.stop()
+
+
+def test_server_keepalive_disable(monkeypatch):
+    """acp.keepalive_interval_s=0 in config disables the feature."""
+    monkeypatch.setattr(keepalive_mod, "_read_config_interval", lambda: 0.0)
+    assert make_turn_keepalive(DummyConn(), "s3", DummyLoop()) is None
+
+
+def test_server_keepalive_stop_idempotence(monkeypatch):
+    monkeypatch.setattr(keepalive_mod, "_read_config_interval", lambda: 0.2)
+    k = make_turn_keepalive(DummyConn(), "s4", DummyLoop())
+    assert k is not None
+    k.start()
+    k.stop()
+    k.stop()  # server's finally may call stop redundantly on retries

--- a/tests/acp_adapter/test_server_keepalive_e2e.py
+++ b/tests/acp_adapter/test_server_keepalive_e2e.py
@@ -1,0 +1,133 @@
+"""Real prompt-path tests: HermesACPAgent.prompt() ↔ keepalive wiring.
+
+Addresses PR #75124 review: prior test_server_keepalive.py only constructs
+TurnKeepalive directly and never exercises `HermesACPAgent.prompt()`, so it
+does not validate the actual start/mark_activity/finally-stop wiring landed
+in acp_adapter/server.py:1681-1875. These tests use the same acp_agent
+fixture pattern as tests/acp/test_mcp_e2e.py and assert:
+
+  1. Success path: prompt() calls keepalive.start() and keepalive.stop().
+  2. Executor-failure path: keepalive.stop() STILL runs (the `finally` block).
+  3. Disabled path: when make_turn_keepalive returns None, prompt() does not
+     crash on a missing keepalive.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import acp
+from acp.schema import PromptResponse, TextContentBlock
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+
+
+@pytest.fixture()
+def mock_manager():
+    return SessionManager(agent_factory=lambda: MagicMock(name="MockAIAgent"))
+
+
+@pytest.fixture()
+def acp_agent(mock_manager):
+    return HermesACPAgent(session_manager=mock_manager)
+
+
+def _wire_mock_conn(acp_agent):
+    mock_conn = MagicMock(spec=acp.Client)
+    mock_conn.session_update = AsyncMock()
+    mock_conn.request_permission = AsyncMock()
+    acp_agent._conn = mock_conn
+    return mock_conn
+
+
+def _make_spy_keepalive():
+    spy = MagicMock()
+    spy.start = MagicMock()
+    spy.stop = MagicMock()
+    spy.mark_activity = MagicMock()
+    return spy
+
+
+@pytest.mark.asyncio
+async def test_prompt_starts_and_stops_keepalive_on_success(acp_agent, mock_manager):
+    """Happy path: prompt() → keepalive.start() at turn commit, .stop() in finally."""
+    resp = await acp_agent.new_session(cwd="/tmp")
+    session_id = resp.session_id
+    state = mock_manager.get_session(session_id)
+    _wire_mock_conn(acp_agent)
+
+    spy = _make_spy_keepalive()
+
+    def _run_ok(user_message, conversation_history=None, task_id=None, **kwargs):
+        return {
+            "final_response": "hi",
+            "messages": [
+                {"role": "user", "content": user_message},
+                {"role": "assistant", "content": "hi"},
+            ],
+        }
+    state.agent.run_conversation = _run_ok
+
+    prompt = [TextContentBlock(type="text", text="hello")]
+    with patch("acp_adapter.server.make_turn_keepalive", return_value=spy):
+        r = await acp_agent.prompt(prompt=prompt, session_id=session_id)
+
+    assert isinstance(r, PromptResponse)
+    spy.start.assert_called_once()
+    spy.stop.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_prompt_stops_keepalive_on_executor_failure(acp_agent, mock_manager):
+    """Failure path: run_conversation raises → keepalive.stop() STILL fires (finally)."""
+    resp = await acp_agent.new_session(cwd="/tmp")
+    session_id = resp.session_id
+    state = mock_manager.get_session(session_id)
+    _wire_mock_conn(acp_agent)
+
+    spy = _make_spy_keepalive()
+
+    def _boom(user_message, conversation_history=None, task_id=None, **kwargs):
+        raise RuntimeError("executor exploded")
+    state.agent.run_conversation = _boom
+
+    prompt = [TextContentBlock(type="text", text="hello")]
+    with patch("acp_adapter.server.make_turn_keepalive", return_value=spy):
+        r = await acp_agent.prompt(prompt=prompt, session_id=session_id)
+
+    # The server catches the executor exception and returns end_turn — the
+    # important assertion is that keepalive was started AND then cleaned up
+    # even though the turn body raised.
+    assert isinstance(r, PromptResponse)
+    spy.start.assert_called_once()
+    spy.stop.assert_called_once()
+
+    # Executor-failure cleanup we promised the sweeper is also intact:
+    assert state.is_running is False
+    assert state.current_prompt_text == ""
+
+
+@pytest.mark.asyncio
+async def test_prompt_when_keepalive_disabled_via_config(acp_agent, mock_manager):
+    """Disabled path: make_turn_keepalive returns None → prompt() must not crash."""
+    resp = await acp_agent.new_session(cwd="/tmp")
+    session_id = resp.session_id
+    state = mock_manager.get_session(session_id)
+    _wire_mock_conn(acp_agent)
+
+    def _run_ok(user_message, conversation_history=None, task_id=None, **kwargs):
+        return {
+            "final_response": "hi",
+            "messages": [
+                {"role": "user", "content": user_message},
+                {"role": "assistant", "content": "hi"},
+            ],
+        }
+    state.agent.run_conversation = _run_ok
+
+    prompt = [TextContentBlock(type="text", text="hello")]
+    with patch("acp_adapter.server.make_turn_keepalive", return_value=None):
+        r = await acp_agent.prompt(prompt=prompt, session_id=session_id)
+
+    assert isinstance(r, PromptResponse)


### PR DESCRIPTION
Problem
-------
ACP clients (e.g. VS Code Copilot Chat) drop long agent turns after ~N
seconds of silence, killing the session mid-work.

Fix
---
Emit periodic keepalive frames during a turn. Interval is read from
`config.yaml` as `acp.keepalive_interval_s` (default 45s, `0` disables).
No env var — per AGENTS.md config policy.

Supersedes #74848 (closed by hermes-sweeper). Addresses both close reasons:

1. **Env var → config.yaml.** `HERMES_ACP_KEEPALIVE_INTERVAL_S` removed.
   Setting lives in `hermes_cli/config_defaults.py` and is read via
   `_CONFIG_PATH = ("acp", "keepalive_interval_s")` in `keepalive.py`.

2. **Executor-failure cleanup preserved.** The `state.is_running = False`
   / `state.current_prompt_text = ""` reset at server.py:1855-1860 is
   retained. Keepalive `stop()` now runs in the same `finally` block, so
   both cleanups fire on every exit path (success, exception, cancel).

Tests
-----
- `tests/acp_adapter/test_keepalive.py` (151 lines): config read, `=0`
  disables, config overrides default, interval respected.
- `tests/acp_adapter/test_server_keepalive.py` (73 lines): keepalive
  integrated in server turn loop; cleanup in finally verified.

Compat
------
Default 45s. Users who want the old behavior set `acp.keepalive_interval_s: 0`.

Verify
------

yaml
# config.yaml
acp:
keepalive_interval_s: 15
Start a long turn on Copilot ACP; observe keepalive frames in ACP log;
client stays connected past prior ~60s idle timeout.