### PR TITLE
fix(gateway): clear stale pycache before gateway restart

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2708,6 +2708,13 @@ def cmd_gateway(args):
     """Gateway management commands."""
     _sync_bundled_skills_quietly()
 
+    # Clear stale bytecode before gateway restart so the new process
+    # compiles fresh .pyc from source.  Without this, source edits between
+    # updates (manual cherry-picks, hotfixes) can leave .pyc newer than
+    # .py — Python trusts the stale bytecode and the restart runs old code.
+    if getattr(args, 'gateway_command', None) == 'restart':
+        _clear_bytecode_cache(PROJECT_ROOT)
+
     from hermes_cli.gateway import gateway_command
 
     gateway_command(args)


### PR DESCRIPTION
## What

Clears stale `__pycache__` directories before `hermes gateway restart` spawns the new process. `_clear_bytecode_cache()` already exists and is called by `hermes update` — this adds the same guard to the restart path.

## Why

Stale `.pyc` files cause a silent class of bug: manual source edits (cherry-picks, hotfixes) between `hermes update` runs can leave `.pyc` newer than `.py`. Python trusts the bytecode timestamp and loads old compiled code on restart — no ImportError, no warning, just wrong behavior.

Real-world example: applying cron feature patches via `git cherry-pick` then restarting the gateway. The `_build_run_stats_section` function was updated in source but the old `.pyc` was newer than the patched `.py` — the restart loaded the old bytecode and displayed incorrect token statistics.

## Type of Change
- [?] 🐛 Bug fix (non-breaking change that fixes an issue)
- [?] ✨ New feature (non-breaking change that adds functionality)

Something between a bug fix and feature?

## How to Test

1. Apply a manual source edit to any module the gateway imports (e.g., change a string in `cron/scheduler.py`)
2. Run `hermes gateway restart` from outside the gateway
3. Verify `__pycache__/` directories under the project root are removed
4. Verify the new gateway process runs with the updated source

```bash
# Before: touch a .pyc to make it newer than source
touch cron/__pycache__/scheduler.cpython-*.pyc

# Restart (clears stale cache)
hermes gateway restart

# Verify: __pycache__ should be gone
ls cron/__pycache__/ 2>&1  # should show "No such file or directory"
```

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I have tested on Linux (Ubuntu 24.04)
- [ ] I have added tests for my changes — N/A (one-line dispatch guard, reuses existing tested `_clear_bytecode_cache`)

### Documentation & Housekeeping

- [ ] I have updated relevant documentation — N/A (no new API or config)
- [ ] I have updated `cli-config.yaml.example` — N/A
- [ ] I have updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I have considered cross-platform impact: `_clear_bytecode_cache` already skips `.venv`, `.git`, `node_modules` on all platforms; `getattr(args, ...)` is pure Python with no platform dependency
- [ ] I have updated tool descriptions/schemas — N/A