### PR TITLE
fix(model-picker): use config key instead of display-name slug for named custom providers (#75087)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3149,13 +3149,11 @@ def select_provider_and_model(args=None):
             base_url = (entry.get("base_url") or "").strip()
             if not name or not base_url:
                 continue
-            key = "custom:" + name.lower().replace(" ", "-")
             provider_key = (entry.get("provider_key") or "").strip()
             if provider_key:
-                try:
-                    resolve_provider(provider_key)
-                except AuthError:
-                    key = provider_key
+                key = provider_key
+            else:
+                key = "custom:" + name.lower().replace(" ", "-")
             custom_provider_map[key] = {
                 "name": name,
                 "base_url": base_url,


### PR DESCRIPTION
## Summary

Fixes #75087.

`select_provider_and_model()` generated the picker key for named custom providers as `custom:<name-lowercased-and-spaces-replaced>`, derived from the **display name**. The actual config key under `providers:` was only used when `resolve_provider()` raised `AuthError` — exactly backwards.

When a user selects a provider via the interactive `hermes model` picker, the slug is saved to `model.provider`. `resolve_provider_full()` then does a direct `providers_dict.get()` with that slug, which returns `None` because the real key is different. The agent still works at runtime via the credential-pool fallback, but any code path using `resolve_provider_full()` (most prominently the Desktop model-switch menu) triggers "Unknown provider" warnings and falls back to default settings.

## Fix

Always use `provider_key` when available; fall back to the display-name slug only when no config key exists.

```diff
-            key = "custom:" + name.lower().replace(" ", "-")
             provider_key = (entry.get("provider_key") or "").strip()
             if provider_key:
-                try:
-                    resolve_provider(provider_key)
-                except AuthError:
-                    key = provider_key
+                key = provider_key
+            else:
+                key = "custom:" + name.lower().replace(" ", "-")
```

## Testing

- Configured a named custom provider with a config key different from its display name (e.g. `providers: { litellm: { name: "LiteLLM Proxy", ... } }`)
- Ran `hermes model` and selected the provider
- Verified `model.provider` is saved as `litellm` (not `custom:litellm-proxy`)
- Verified no "Unknown provider" warnings in subsequent resolution
