### PR TITLE
fix(security): respect tirith_fail_open when circuit breaker is open (#74922)

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -750,7 +750,10 @@ def check_command_security(command: str) -> dict:
     # → fail-open → agent retry loop, hanging the user for 20+ minutes
     # (issue #41400).
     if _circuit_open:
-        return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        fail_open = cfg["tirith_fail_open"]
+        if fail_open:
+            return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        return {"action": "block", "findings": [], "summary": "tirith disabled (circuit breaker, fail-closed)"}
 
     # Unsupported platform (Windows etc.) — tirith has no binary here and
     # never will. Skip the resolver entirely so we don't even try to spawn.


### PR DESCRIPTION
## Summary

Fixes #74922.

`check_command_security()` has a circuit breaker that disables Tirith after `_CRASH_LIMIT = 3` consecutive scanner failures. When the breaker is open, the function returns `{"action": "allow"}` **without reading `tirith_fail_open`** — the only failure path in the entire function that ignores this config.

Every other failure path correctly respects `fail_open`:
- `tirith_path is None` → block when fail_open=False
- `OSError` on spawn → block when fail_open=False
- `TimeoutExpired` → block when fail_open=False
- Unknown exit code → block when fail_open=False
- **Circuit breaker → always allow** ← this PR fixes this

An operator who sets `tirith_fail_open: false` does so specifically to make scanner unavailability **block** commands. The circuit breaker silently granted access, contradicting the operator's security policy.

## Fix

Read `tirith_fail_open` before the circuit breaker return. When `fail_open` is `False`, return `"block"` instead of `"allow"`.

```diff
     if _circuit_open:
-        return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        fail_open = cfg["tirith_fail_open"]
+        if fail_open:
+            return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        return {"action": "block", "findings": [], "summary": "tirith disabled (circuit breaker, fail-closed)"}
```

## Testing

- Set `security.tirith_fail_open: false` in config
- Trigger 3+ consecutive tirith failures (e.g. corrupt the tirith binary path)
- Verify subsequent commands return `"block"` instead of `"allow"`
