### PR TITLE
fix: stamp _was_thinking_only before reasoning is stripped for drop detection

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1494,6 +1494,16 @@ def run_conversation(
             # This ensures multi-turn reasoning context is preserved
             agent._copy_reasoning_content_for_api(msg, api_msg)
 
+            # Before reasoning markers are stripped below, detect
+            # thinking-only turns on the SOURCE message (which still has
+            # reasoning intact) and stamp a marker on the API copy.
+            # Without this, _drop_thinking_only_and_merge_users (which
+            # runs after stripping) cannot see the reasoning and lets
+            # the empty assistant turn survive — Gemini then 400s on
+            # "Requests ending with a model turn are not supported."
+            if agent._is_thinking_only_assistant(msg):
+                api_msg["_was_thinking_only"] = True
+
             # Remove 'reasoning' field - it's for trajectory storage only
             # We've copied it to 'reasoning_content' for the API above
             if "reasoning" in api_msg:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4236,6 +4236,10 @@ class AIAgent:
         """
         if not isinstance(msg, dict) or msg.get("role") != "assistant":
             return False
+        # Fast path: stamped before reasoning was stripped from the
+        # API copy (see conversation_loop pre-send sanitation).
+        if msg.get("_was_thinking_only"):
+            return True
         if msg.get("tool_calls"):
             return False
         # Does it have any actual output?


### PR DESCRIPTION
## Summary

When a Gemini model returns a thinking-only response (reasoning tokens but no visible text), the thinking-prefill continuation appends an empty assistant turn and re-sends. Gemini rejects any request whose last turn is the model:

```
400 INVALID_ARGUMENT: Requests ending with a model turn are not supported.
```

## Root Cause

In `run_conversation`'s API message loop (`agent/conversation_loop.py`), the order of operations is:

1. **Line 1495**: `_copy_reasoning_content_for_api(msg, api_msg)` — for non-echo-back providers (like Gemini), strips `reasoning_content` from the API copy
2. **Lines 1499-1500**: Pops `reasoning` field from the API copy
3. **Line 1640**: `_sanitize_api_messages` — `repair_empty_non_final_messages` may rewrite empty turns
4. **Line 1650**: `_drop_thinking_only_and_merge_users` — calls `_is_thinking_only_assistant` on the API copy

By step 4, all reasoning markers (`reasoning_content`, `reasoning`, `reasoning_details`, `codex_reasoning_items`) have been stripped from the API copy. `_is_thinking_only_assistant` returns False, the empty assistant turn survives, and Gemini 400s.

## Fix

Before reasoning markers are stripped (between steps 1 and 2), check the **source message** (which still has reasoning intact) for thinking-only status. If true, stamp `_was_thinking_only = True` on the API copy. `_is_thinking_only_assistant` checks this marker as a fast path before its content-based heuristic.

**Files changed:**
- `agent/conversation_loop.py`: Stamp `_was_thinking_only` marker before reasoning stripping
- `run_agent.py`: Check `_was_thinking_only` marker in `_is_thinking_only_assistant` fast path

Fixes NousResearch/hermes-agent#75121
