### PR TITLE
fix(transports): omit empty tool_calls from chat payloads

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -173,6 +173,8 @@ class ChatCompletionsTransport(ProviderTransport):
           gateways (e.g. opencode-go, codex.nekos.me) reject with
           ``Extra inputs are not permitted, field: 'messages[N]._empty_recovery_synthetic'``,
           which then poisons every subsequent request in the session.
+        - Empty ``tool_calls`` arrays — absence carries the same meaning and
+          strict OpenAI-compatible providers reject the explicit empty field.
         """
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
@@ -188,6 +190,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "effect_disposition" in msg
                 or "timestamp" in msg  # #47868 — strict providers reject this
                 or "api_content" in msg  # persist-what-you-send sidecar
+                or msg.get("tool_calls") == []
             ):
                 needs_sanitize = True
                 break
@@ -249,6 +252,9 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg = mutable_msg()
                 for key in internal_keys:
                     out_msg.pop(key, None)
+
+            if msg.get("tool_calls") == []:
+                mutable_msg().pop("tool_calls", None)
 
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -40,7 +40,16 @@ class TestChatCompletionsBasic:
         result = transport.convert_messages(msgs)
         assert result is msgs  # no copy needed
 
+    def test_convert_messages_drops_empty_tool_calls(self, transport):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "done", "tool_calls": []},
+        ]
 
+        result = transport.convert_messages(msgs)
+
+        assert "tool_calls" not in result[1]
+        assert msgs[1]["tool_calls"] == []
 
     def _msg_with_extra_content(self):
         return [


### PR DESCRIPTION
## Summary
- omit explicit empty `tool_calls` arrays at the Chat Completions wire boundary
- preserve the original stored message through copy-on-write sanitization
- add a regression test for strict OpenAI-compatible providers

## Problem
Some strict OpenAI-compatible APIs reject `tool_calls: []`. Omitting the field has the same semantics and matches the Chat Completions schema expected by those providers. History transforms can introduce the empty array after earlier sanitization, so the transport is the last reliable wire boundary.

## Test plan
- `scripts/run_tests.sh tests/agent/transports/ -q`
- 217 tests passed