### PR TITLE
fix(config): load .env with interpolate=False so $-values round-trip

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -340,10 +340,22 @@ def _sanitize_loaded_credentials() -> None:
 
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
+    # interpolate=False: credentials must round-trip byte-exactly. dotenv's
+    # default interpolation rewrites any value containing $VAR/${VAR} —
+    # splicing in an unrelated environment value if the name collides —
+    # while every other Hermes .env reader (load_env, secret scopes) treats
+    # values as literal. ${VAR} references are a config.yaml feature, not
+    # an .env one.
     try:
-        load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
+        load_dotenv(
+            dotenv_path=path, override=override, encoding="utf-8",
+            interpolate=False,
+        )
     except UnicodeDecodeError:
-        load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+        load_dotenv(
+            dotenv_path=path, override=override, encoding="latin-1",
+            interpolate=False,
+        )
     # Strip non-ASCII characters from credential env vars that were just
     # loaded.  API keys must be pure ASCII since they're sent as HTTP
     # header values (httpx encodes headers as ASCII).  Non-ASCII chars

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -263,10 +263,16 @@ def _load_hermes_env() -> None:
     env_path = home / ".env"
     if load_dotenv and env_path.exists():
         try:
-            load_dotenv(str(env_path), override=True, encoding="utf-8")
+            load_dotenv(
+                str(env_path), override=True, encoding="utf-8",
+                interpolate=False,
+            )
         except UnicodeDecodeError:
             try:
-                load_dotenv(str(env_path), override=True, encoding="latin-1")
+                load_dotenv(
+                    str(env_path), override=True, encoding="latin-1",
+                    interpolate=False,
+                )
             except Exception:
                 pass
         except Exception:

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -440,3 +440,54 @@ def test_other_profile_home_does_not_bridge_process_config(tmp_path, monkeypatch
 
     # The other profile's .env value stands; the process config was not applied.
     assert os.getenv("TERMINAL_ENV") == "docker"
+
+
+# ---------------------------------------------------------------------------
+# interpolate=False — credentials containing $ must round-trip byte-exactly
+# ---------------------------------------------------------------------------
+
+
+def test_dollar_brace_value_not_interpolated(tmp_path, monkeypatch):
+    """A credential containing ${...} must load literally, not be rewritten
+    by dotenv interpolation — including when the referenced name exists in
+    the environment (which would splice in a different secret)."""
+    from hermes_cli.env_loader import _load_dotenv_with_fallback
+
+    monkeypatch.setenv("HOME", "/should/not/appear")
+    env_file = tmp_path / ".env"
+    env_file.write_text("MY_KEY=abc${HOME}def\n", encoding="utf-8")
+    monkeypatch.delenv("MY_KEY", raising=False)
+
+    _load_dotenv_with_fallback(env_file, override=True)
+
+    assert os.environ["MY_KEY"] == "abc${HOME}def"
+
+
+def test_bare_dollar_var_value_not_interpolated(tmp_path, monkeypatch):
+    """Boundary guard: dotenv interpolates only the *braced* form
+    ``${VAR}``; a bare ``$VAR`` is never expanded — on either side of this
+    change. Pinned so a future dotenv behavior change here is visible."""
+    from hermes_cli.env_loader import _load_dotenv_with_fallback
+
+    monkeypatch.setenv("SPLICE", "wrong-secret")
+    env_file = tmp_path / ".env"
+    env_file.write_text("MY_KEY=prefix$SPLICE\n", encoding="utf-8")
+    monkeypatch.delenv("MY_KEY", raising=False)
+
+    _load_dotenv_with_fallback(env_file, override=True)
+
+    assert os.environ["MY_KEY"] == "prefix$SPLICE"
+
+
+def test_quoted_escapes_still_decoded_with_interpolation_off(tmp_path, monkeypatch):
+    """interpolate=False only stops variable expansion; the writer's
+    double-quote escapes must still decode."""
+    from hermes_cli.env_loader import _load_dotenv_with_fallback
+
+    env_file = tmp_path / ".env"
+    env_file.write_text('QUOTED="tok\\"en\\\\x"\n', encoding="utf-8")
+    monkeypatch.delenv("QUOTED", raising=False)
+
+    _load_dotenv_with_fallback(env_file, override=True)
+
+    assert os.environ["QUOTED"] == 'tok"en\\x'

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -234,3 +234,31 @@ def test_load_hermes_env_bridges_config_yaml_scalars(tmp_path, monkeypatch):
     assert os.environ.get("TELEGRAM_HOME_CHANNEL") == "5550001111"
 
 
+
+
+def test_load_hermes_env_does_not_interpolate_dollar_values(tmp_path, monkeypatch):
+    """The send_cmd dotenv path must also load $-bearing values literally.
+
+    Regression: a credential containing ${...} was spliced with the
+    environment's value for that name on every load. interpolate=False is
+    the .env contract (#20310: interpolation unsupported in .env files).
+    """
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text("MY_KEY=abc${HOME}def\n")
+    (hermes_home / "config.yaml").write_text("{}\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", "/should/not/appear")
+    monkeypatch.delenv("MY_KEY", raising=False)
+
+    from importlib import reload
+
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    send_cmd._load_hermes_env()
+
+    assert os.environ.get("MY_KEY") == "abc${HOME}def"


### PR DESCRIPTION
## What does this PR do?

Fixes silent credential mangling for any `.env` value containing `${...}`.

`save_env_value` writes credentials correctly, but every process start loads `.env` through python-dotenv with default `interpolate=True` — which rewrites `${VAR}` by splicing in the *current environment's* value for that name. A credential like `abc${HOME}def` is written exactly as given and read back as `abc/home/ratdef` — or worse, spliced with a *different secret* when the referenced name exists in the environment. Meanwhile every other Hermes `.env` reader (`load_env`/`_parse_env_value`, secret scopes) treats values as literal, so the same key resolves to different bytes depending on the load path — and no error points at the cause.

Escaping can't fix it (verified against the installed python-dotenv 1.2.2):

- the braced form `${VAR}` is interpolated in **unquoted, double-quoted, AND single-quoted** values
- `\$` and `$$` sequences are interpolated too

So the fix is at the load path: `interpolate=False` at both dotenv call sites (`env_loader._load_dotenv_with_fallback`, `send_cmd`). `${VAR}` references are a documented **config.yaml** feature (resolved by `hermes_cli/mcp_config.py` separately) — nothing documents or tests interpolation in `.env` files, so nothing relying on it breaks. Escape *decoding* (`\"`, `\\` in double-quoted values) is unaffected — only variable expansion is disabled.

## Related Issue

#20310 — `.env` interpolation is unsupported (member decision). This PR enforces that contract at the load path; `${VAR}` references remain a config.yaml feature, resolved separately by `hermes_cli/mcp_config.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/env_loader.py`: `_load_dotenv_with_fallback` passes `interpolate=False` (with a comment explaining why: byte-exact round-trip, `.env` is not the `${}` feature surface).
- `hermes_cli/send_cmd.py`: same at its two `load_dotenv` calls.
- `tests/hermes_cli/test_env_loader.py`: three tests — `${HOME}`-containing value loads literally even when `HOME` is set (the splice case); bare `$VAR` boundary guard (dotenv only interpolates the braced form); double-quote escape decoding unaffected.
- `tests/hermes_cli/test_send_cmd.py`: regression for the standalone send path — `abc${HOME}def` loads literally with `HOME` populated.

## How to Test

Reproduction (against pre-fix code, with `HOME` set in the environment):

```python
# .env contains: MY_KEY=abc${HOME}def   (written by save_env_value)
_load_dotenv_with_fallback(env_file, override=True)
os.environ["MY_KEY"]   # pre-fix: 'abc/home/ratdef'  (spliced with $HOME!)
                       # post-fix: 'abc${HOME}def'   (byte-exact)
```

Focused validation completed:

1. `bash scripts/run_tests.sh tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_send_cmd.py` — 12/12 pass. A second sabotage check reverting only `send_cmd.py` fails exactly the new send-path regression.
2. Sabotage check: stashing both source changes makes the braced-form test fail (7 pass); restoring returns to 8/8. (The bare-`$VAR` and escape tests are boundary guards that pass on both sides — dotenv only interpolates the braced form.)
3. Related suites: `test_env_sanitize_on_load.py test_env_load_cache.py test_env_export_prefix.py test_env_export_line_lifecycle.py test_env_custom_keys.py test_env_loader_secret_sources.py test_config.py` + the loader file — 110/110 pass.
4. Full repo-wide suite, `bash scripts/run_tests.sh` (branch): 22,821 pass / 96 fail. Baseline on clean `main` (this branch's parent), same machine: 22,816 pass / 99 fail — the failing-file sets are **identical** (environment-dependent lanes; no API keys/services locally). Zero new failures — notable here because this touches a load path every test uses: nothing in the suite relied on dotenv interpolation.
5. `uvx --from ruff==0.15.10 ruff check hermes_cli/env_loader.py hermes_cli/send_cmd.py tests/hermes_cli/test_env_loader.py` — clean.
6. `git diff --check` — clean.
7. Adversarial cases executed live: escape forms (`\$`, `$$`, single/double quotes) all still interpolate (proof the load-path fix is the only workable one); escape decoding of `\"`/`\\` preserved; plain unquoted values unaffected; `${}` documented for config.yaml (separate resolver in `mcp_config.py`) so no supported feature is removed.

The full repo-wide suite was run locally (item 4) with results verified identical to clean `main`; GitHub CI remains the final confirmation environment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (keyword matrix + same-file API sweep of all open PRs touching `hermes_cli/config.py`, `hermes_cli/env_loader.py`, `agent/secret_scope.py` — closest were #74283 external-secrets and #74809 MCP env blocks, both different subsystems)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite run locally via `scripts/run_tests.sh`; failures are pre-existing/environment-dependent and verified identical to clean `main` (see How to Test, item 4)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment documents the interpolate=False contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — dotenv parameter only, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Logs

Sabotage verification output:

```
# fix stashed (pre-fix behavior):
=== Summary: 1 files, 7 tests passed, 1 failed ===   (the braced-form test)
# fix restored:
=== Summary: 1 files, 8 tests passed, 0 failed ===
```
