### PR TITLE
feat(session_reset): make finished-process prune TTL configurable with settings slider

### DIFF
--- a/apps/desktop/src/app/settings/config-field.tsx
+++ b/apps/desktop/src/app/settings/config-field.tsx
@@ -14,6 +14,7 @@ import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS, FRE
 import { FallbackModelsField } from './fallback-models-field'
 import { fieldCopyForSchemaKey } from './field-copy'
 import { ListRow } from './primitives'
+import { RangeField } from './range-field'
 import { SearchableSelect } from './searchable-select'
 
 /**
@@ -153,6 +154,21 @@ export function ConfigField({
           ))}
         </SelectContent>
       </Select>
+    )
+  }
+
+  if (schema.type === 'range') {
+    return row(
+      <RangeField
+        defaultValue={schema.default}
+        max={schema.max}
+        min={schema.min}
+        onChange={value => onChange(value)}
+        step={schema.step}
+        unit={schema.unit}
+        value={value}
+      />,
+      true
     )
   }
 

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -615,7 +615,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     idleMinutes: 'Minutes of inactivity before an idle reset fires.',
     notify: 'Send a notification when an auto-reset clears a session.',
     bgProcessMaxAgeHours: 'Background processes older than this no longer pin a session open against reset (they are not killed).',
-    finishedProcessTtlMinutes: 'How long finished background processes stay tracked before pruning. Each tracked process holds a file descriptor, so keep this tight if background jobs pile up.'
+    finishedProcessTtlMinutes: 'How long finished background processes stay tracked before pruning. Finished sessions release their handles immediately, so this controls how long a finished job\u2019s output stays queryable via poll/log.'
   },
   context: {
     engine: 'Strategy for managing long conversations near the context limit.'

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -1,6 +1,7 @@
 import {
   Box,
   Brain,
+  Clock,
   type IconComponent,
   Lock,
   MessageCircle,
@@ -531,6 +532,14 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     userCharLimit: 'Profile Budget',
     provider: 'Memory Provider'
   },
+  sessionReset: {
+    mode: 'Reset Mode',
+    atHour: 'Daily Reset Hour',
+    idleMinutes: 'Idle Reset Timeout',
+    notify: 'Reset Notifications',
+    bgProcessMaxAgeHours: 'Process Reset Ignore Age',
+    finishedProcessTtlMinutes: 'Finished Process Retention'
+  },
   context: {
     engine: 'Context Engine'
   },
@@ -596,7 +605,17 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   },
   memory: {
     memoryEnabled: 'Save durable memories that can help future sessions.',
-    userProfileEnabled: 'Maintain a compact profile of user preferences.'
+    userProfileEnabled: 'Maintain a compact profile of user preferences.',
+    memoryCharLimit: 'Maximum size of the saved memory pool.',
+    userCharLimit: 'Maximum size of the user profile pool.'
+  },
+  sessionReset: {
+    mode: 'When sessions reset (lose context). "none" keeps them forever; "daily" resets at the hour below; "idle" resets after inactivity; "both" is whichever comes first.',
+    atHour: 'Hour of day (0-23, local time) for daily resets.',
+    idleMinutes: 'Minutes of inactivity before an idle reset fires.',
+    notify: 'Send a notification when an auto-reset clears a session.',
+    bgProcessMaxAgeHours: 'Background processes older than this no longer pin a session open against reset (they are not killed).',
+    finishedProcessTtlMinutes: 'How long finished background processes stay tracked before pruning. Each tracked process holds a file descriptor, so keep this tight if background jobs pile up.'
   },
   context: {
     engine: 'Strategy for managing long conversations near the context limit.'
@@ -700,6 +719,19 @@ export const SECTIONS: DesktopConfigSection[] = [
       'compression.threshold',
       'compression.target_ratio',
       'compression.protect_last_n'
+    ]
+  },
+  {
+    id: 'session-reset',
+    label: 'Session Reset',
+    icon: Clock,
+    keys: [
+      'session_reset.mode',
+      'session_reset.at_hour',
+      'session_reset.idle_minutes',
+      'session_reset.notify',
+      'session_reset.bg_process_max_age_hours',
+      'session_reset.finished_process_ttl_minutes'
     ]
   },
   {

--- a/apps/desktop/src/app/settings/range-field.test.tsx
+++ b/apps/desktop/src/app/settings/range-field.test.tsx
@@ -1,0 +1,131 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { formatTimeframe, RangeField } from './range-field'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('formatTimeframe', () => {
+  it('formats minutes under an hour plainly', () => {
+    expect(formatTimeframe(10, 'minutes')).toBe('10 minutes')
+    expect(formatTimeframe(1, 'minutes')).toBe('1 minute')
+  })
+
+  it('promotes to hours with a minute breakdown', () => {
+    expect(formatTimeframe(60, 'minutes')).toBe('1 hour (60 minutes)')
+    expect(formatTimeframe(90, 'minutes')).toBe('1.5 hours (90 minutes)')
+  })
+
+  it('handles seconds and hours units', () => {
+    expect(formatTimeframe(45, 'seconds')).toBe('45 seconds')
+    expect(formatTimeframe(90, 'seconds')).toBe('1.5 minutes (90 seconds)')
+    expect(formatTimeframe(48, 'hours')).toBe('2 days (48 hours)')
+  })
+
+  it('falls back to unit-less numbers for unknown units', () => {
+    expect(formatTimeframe(7, undefined)).toBe('7')
+  })
+})
+
+describe('RangeField', () => {
+  it('renders a slider and a text box seeded with the value', () => {
+    render(<RangeField max={120} min={1} onChange={vi.fn()} step={1} unit="minutes" value={10} />)
+
+    const slider = screen.getByRole('slider') as HTMLInputElement
+    expect(slider.min).toBe('1')
+    expect(slider.max).toBe('120')
+    expect(slider.value).toBe('10')
+
+    const input = screen.getByRole('textbox', { name: 'value' }) as HTMLInputElement
+    expect(input.value).toBe('10')
+  })
+
+  it('shows a live timeframe preview for the configured value', () => {
+    render(<RangeField max={120} min={1} onChange={vi.fn()} step={1} unit="minutes" value={10} />)
+    expect(screen.getByText('10 minutes')).toBeTruthy()
+  })
+
+  it('writes clamped values through onChange when the slider moves', () => {
+    const onChange = vi.fn()
+    render(<RangeField max={120} min={1} onChange={onChange} step={1} unit="minutes" value={10} />)
+
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '45' } })
+    expect(onChange).toHaveBeenCalledWith(45)
+  })
+
+  it('clamps typed values into [min, max]', () => {
+    const onChange = vi.fn()
+    render(<RangeField max={120} min={1} onChange={onChange} step={1} unit="minutes" value={10} />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'value' }), { target: { value: '500' } })
+    expect(onChange).toHaveBeenCalledWith(120)
+
+    onChange.mockClear()
+    fireEvent.change(screen.getByRole('textbox', { name: 'value' }), { target: { value: '-3' } })
+    expect(onChange).toHaveBeenCalledWith(1)
+  })
+
+  it('ignores non-numeric text-box input', () => {
+    const onChange = vi.fn()
+    render(<RangeField max={120} min={1} onChange={onChange} step={1} unit="minutes" value={10} />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'value' }), { target: { value: 'abc' } })
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('resets to the shipped default when the reset button is clicked', () => {
+    const onChange = vi.fn()
+    render(
+      <RangeField
+        defaultValue={10}
+        max={120}
+        min={1}
+        onChange={onChange}
+        step={1}
+        unit="minutes"
+        value={25}
+      />
+    )
+
+    const reset = screen.getByRole('button', { name: 'reset to default' }) as HTMLButtonElement
+    expect(reset.disabled).toBe(false)
+    fireEvent.click(reset)
+    expect(onChange).toHaveBeenCalledWith(10)
+  })
+
+  it('disables the reset button when the value already matches the default', () => {
+    render(
+      <RangeField
+        defaultValue={10}
+        max={120}
+        min={1}
+        onChange={vi.fn()}
+        step={1}
+        unit="minutes"
+        value={10}
+      />
+    )
+
+    const reset = screen.getByRole('button', { name: 'reset to default' }) as HTMLButtonElement
+    expect(reset.disabled).toBe(true)
+  })
+
+  it('shows the default in the preview line when one is provided', () => {
+    render(
+      <RangeField
+        defaultValue={10}
+        max={120}
+        min={1}
+        onChange={vi.fn()}
+        step={1}
+        unit="minutes"
+        value={25}
+      />
+    )
+
+    expect(screen.getByText(/default 10 minutes/)).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/settings/range-field.tsx
+++ b/apps/desktop/src/app/settings/range-field.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { RefreshCw } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+import { CONTROL_TEXT } from './constants'
+
+/**
+ * One config row control for numeric ranges: a slider plus an editable text
+ * box, with a live preview of what the value means in time terms. Dragging
+ * the slider or typing a number both write straight through to `onChange`,
+ * so the surrounding autosave flow persists it immediately.
+ *
+ * When `defaultValue` is provided, a reset button appears whenever the value
+ * diverges from it — one click restores the shipped default.
+ *
+ * Schema fields consumed (see ConfigFieldSchema):
+ *   min / max / step — slider bounds and granularity
+ *   unit             — label shown next to the text box (e.g. "minutes")
+ *   default          — the shipped default, target of the reset button
+ */
+export function RangeField({
+  value,
+  min = 0,
+  max = 100,
+  step = 1,
+  unit,
+  defaultValue,
+  onChange
+}: {
+  value: unknown
+  min?: number
+  max?: number
+  step?: number
+  unit?: string
+  defaultValue?: number
+  onChange: (value: number) => void
+}) {
+  const numeric = typeof value === 'number' && Number.isFinite(value) ? value : min
+  const [draft, setDraft] = useState<string>(String(numeric))
+
+  // When the config value changes from outside (profile switch, save echo,
+  // reset to defaults), re-sync the text box — but never while the user is
+  // typing into it (draft would be clobbered mid-edit).
+  const [focused, setFocused] = useState(false)
+  useEffect(() => {
+    if (!focused) {
+      setDraft(String(numeric))
+    }
+  }, [numeric, focused])
+
+  const clamped = Math.min(max, Math.max(min, numeric))
+  const sliderValue = Math.round(clamped / step) * step
+
+  const commit = (raw: string) => {
+    setDraft(raw)
+    const parsed = Number(raw)
+
+    if (raw !== '' && Number.isFinite(parsed)) {
+      onChange(Math.min(max, Math.max(min, parsed)))
+    }
+  }
+
+  const hasDefault = typeof defaultValue === 'number' && Number.isFinite(defaultValue)
+  const differsFromDefault = hasDefault && numeric !== defaultValue
+
+  return (
+    <div className="flex w-full flex-col items-end gap-1.5">
+      <div className="flex w-full items-center justify-end gap-2">
+        <input
+          aria-label="slider"
+          className={cn(
+            'h-1.5 w-full max-w-44 cursor-pointer appearance-none rounded-full bg-(--ui-border)',
+            'accent-(--ui-accent)'
+          )}
+          max={max}
+          min={min}
+          onChange={e => commit(e.target.value)}
+          step={step}
+          type="range"
+          value={sliderValue}
+        />
+        <Input
+          aria-label="value"
+          className={cn('w-20 text-right', CONTROL_TEXT)}
+          onBlur={() => setFocused(false)}
+          onChange={e => commit(e.target.value)}
+          onFocus={() => setFocused(true)}
+          suffix={unit ? <span className="text-(--ui-text-tertiary)">{unit}</span> : undefined}
+          type="text"
+          value={draft}
+        />
+        {hasDefault && (
+          <Button
+            aria-label="reset to default"
+            className="text-(--ui-text-tertiary)"
+            disabled={!differsFromDefault}
+            onClick={() => {
+              setDraft(String(defaultValue))
+              onChange(defaultValue)
+            }}
+            size="icon-xs"
+            title="Reset to default"
+            type="button"
+            variant="ghost"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      <div className="text-(--ui-text-tertiary) text-right text-[length:var(--conversation-caption-font-size)]">
+        {formatTimeframe(clamped, unit)}
+        {hasDefault && (
+          <span className="ml-1">default {formatTimeframe(defaultValue, unit)}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Human-readable preview of the configured timeframe, e.g. "10 minutes". */
+export function formatTimeframe(value: number, unit?: string): string {
+  const n = Math.max(0, Math.round(value))
+
+  if (unit === 'minutes') {
+    if (n < 60) {
+      return `${n} minute${n === 1 ? '' : 's'}`
+    }
+
+    const hours = n / 60
+    const hoursLabel = Number.isInteger(hours) ? String(hours) : hours.toFixed(1)
+
+    return `${hoursLabel} hour${hours === 1 ? '' : 's'} (${n} minutes)`
+  }
+
+  if (unit === 'seconds') {
+    if (n < 60) {
+      return `${n} second${n === 1 ? '' : 's'}`
+    }
+
+    const minutes = n / 60
+    const minutesLabel = Number.isInteger(minutes) ? String(minutes) : minutes.toFixed(1)
+
+    return `${minutesLabel} minute${minutes === 1 ? '' : 's'} (${n} seconds)`
+  }
+
+  if (unit === 'hours') {
+    if (n < 24) {
+      return `${n} hour${n === 1 ? '' : 's'}`
+    }
+
+    const days = n / 24
+    const daysLabel = Number.isInteger(days) ? String(days) : days.toFixed(1)
+
+    return `${daysLabel} day${days === 1 ? '' : 's'} (${n} hours)`
+  }
+
+  return unit ? `${n} ${unit}` : `${n}`
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -8,7 +8,17 @@ export interface ConfigFieldSchema {
   /** When true, a searchable select prepends a "clear" item that resets the
    *  value to ''. Matches the existing <Select> EMPTY_SELECT_VALUE pattern. */
   clearable?: boolean
-  type?: 'boolean' | 'list' | 'number' | 'select' | 'string' | 'text'
+  /** For type 'range': inclusive lower bound. */
+  min?: number
+  /** For type 'range': inclusive upper bound. */
+  max?: number
+  /** For type 'range': slider granularity. */
+  step?: number
+  /** For type 'range': unit label shown next to the value (e.g. "minutes"). */
+  unit?: string
+  /** For type 'range': default value, used by the reset-to-default button. */
+  default?: number
+  type?: 'boolean' | 'list' | 'number' | 'range' | 'select' | 'string' | 'text'
 }
 
 export interface ConfigSchemaResponse {

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -510,6 +510,15 @@ class SessionResetPolicy:
     # liveness should pin the conversation open.
     bg_process_max_age_hours: int = 24
 
+    # How long (minutes) a finished background process stays tracked in the
+    # gateway's process registry before being pruned. Each tracked process
+    # holds a pipe file descriptor, so a long TTL lets finished jobs pile up
+    # toward MAX_PROCESSES (64) and block new background spawns with the
+    # "file descriptor limit" error. 10 minutes is the default; raise it if
+    # you routinely need to poll/log a finished job's output later, lower it
+    # if you churn background processes faster than the registry can prune.
+    finished_process_ttl_minutes: int = 10
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "mode": self.mode,
@@ -518,6 +527,7 @@ class SessionResetPolicy:
             "notify": self.notify,
             "notify_exclude_platforms": list(self.notify_exclude_platforms),
             "bg_process_max_age_hours": self.bg_process_max_age_hours,
+            "finished_process_ttl_minutes": self.finished_process_ttl_minutes,
         }
     
     @classmethod
@@ -530,6 +540,7 @@ class SessionResetPolicy:
         notify = data.get("notify")
         exclude = data.get("notify_exclude_platforms")
         bg_max_age = data.get("bg_process_max_age_hours")
+        finished_ttl = data.get("finished_process_ttl_minutes")
         return cls(
             mode=mode if mode is not None else "none",
             at_hour=at_hour if at_hour is not None else 4,
@@ -537,6 +548,7 @@ class SessionResetPolicy:
             notify=_coerce_bool(notify, True),
             notify_exclude_platforms=tuple(exclude) if exclude is not None else ("api_server", "webhook"),
             bg_process_max_age_hours=bg_max_age if bg_max_age is not None else 24,
+            finished_process_ttl_minutes=_coerce_int(finished_ttl, 10),
         )
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -511,12 +511,13 @@ class SessionResetPolicy:
     bg_process_max_age_hours: int = 24
 
     # How long (minutes) a finished background process stays tracked in the
-    # gateway's process registry before being pruned. Each tracked process
-    # holds a pipe file descriptor, so a long TTL lets finished jobs pile up
-    # toward MAX_PROCESSES (64) and block new background spawns with the
-    # "file descriptor limit" error. 10 minutes is the default; raise it if
-    # you routinely need to poll/log a finished job's output later, lower it
-    # if you churn background processes faster than the registry can prune.
+    # gateway's process registry before being pruned. Finished processes are
+    # never reaped for FD reasons (the registry releases their pipe/PTY
+    # handles when they finish) — this TTL controls how long the finished
+    # job's buffered output stays queryable via poll/log before the entry is
+    # pruned. 10 minutes is the default; raise it if you routinely need to
+    # poll/log a finished job's output later, lower it if you churn
+    # background processes faster than the registry can prune.
     finished_process_ttl_minutes: int = 10
 
     def to_dict(self) -> Dict[str, Any]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2821,6 +2821,22 @@ def _gateway_config_home() -> Path:
     return _hermes_home
 
 
+def _apply_finished_process_ttl(reset_policy) -> None:
+    """Push ``finished_process_ttl_minutes`` from a SessionResetPolicy into
+    the process registry's finished-process prune TTL.
+
+    Process-wide scope (documented at the call site): the registry is a
+    module-level singleton shared by every profile the gateway serves, so the
+    TTL is set once from the primary profile's default reset policy. Safe to
+    call repeatedly (e.g. from tests) — later calls win; non-positive values
+    are ignored by the setter, keeping the previous TTL.
+    """
+    minutes = getattr(reset_policy, "finished_process_ttl_minutes", 10)
+    if minutes and minutes > 0:
+        from tools.process_registry import set_finished_ttl_seconds
+        set_finished_ttl_seconds(minutes * 60)
+
+
 def _load_gateway_config() -> dict:
     """Load and parse ~/.hermes/config.yaml, returning {} on any error.
 
@@ -5562,15 +5578,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         # Push the finished-process prune TTL (session_reset.
         # finished_process_ttl_minutes) into the registry so finished jobs are
-        # pruned at the configured rate instead of the module default — each
-        # tracked process holds a pipe FD, and a long TTL lets finished jobs
-        # pile up toward the 64-process cap and block new background spawns.
-        _finished_ttl_minutes = getattr(
-            self.config.default_reset_policy, "finished_process_ttl_minutes", 10
-        )
-        if _finished_ttl_minutes and _finished_ttl_minutes > 0:
-            from tools.process_registry import set_finished_ttl_seconds
-            set_finished_ttl_seconds(_finished_ttl_minutes * 60)
+        # pruned at the configured rate instead of the module default.
+        #
+        # SCOPE: the process registry is a process-global singleton shared by
+        # every profile this gateway serves (including multiplex profiles,
+        # which load their own config via _start_one_profile_adapters). The
+        # finished-process TTL is therefore a PROCESS-WIDE setting: it is set
+        # once at startup from the primary profile's default reset policy, and
+        # all multiplexed profiles share the same prune cadence. Per-profile
+        # TTL values are intentionally not applied independently — the
+        # registry's _finished dict is not partitioned by profile. This also
+        # means the value only takes effect on the next gateway start; a live
+        # config edit does not re-push it.
+        _apply_finished_process_ttl(self.config.default_reset_policy)
         self.session_store = SessionStore(
             self.config.sessions_dir, self.config,
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5560,6 +5560,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _bg_max_age_seconds = (
             _bg_max_age_hours * 3600 if _bg_max_age_hours and _bg_max_age_hours > 0 else None
         )
+        # Push the finished-process prune TTL (session_reset.
+        # finished_process_ttl_minutes) into the registry so finished jobs are
+        # pruned at the configured rate instead of the module default — each
+        # tracked process holds a pipe FD, and a long TTL lets finished jobs
+        # pile up toward the 64-process cap and block new background spawns.
+        _finished_ttl_minutes = getattr(
+            self.config.default_reset_policy, "finished_process_ttl_minutes", 10
+        )
+        if _finished_ttl_minutes and _finished_ttl_minutes > 0:
+            from tools.process_registry import set_finished_ttl_seconds
+            set_finished_ttl_seconds(_finished_ttl_minutes * 60)
         self.session_store = SessionStore(
             self.config.sessions_dir, self.config,
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2609,6 +2609,26 @@ DEFAULT_CONFIG = {
         "search_slow_ms": 1000,
     },
 
+    # When sessions reset (lose context) and related session-lifecycle tuning.
+    # Mirrors gateway/config.py SessionResetPolicy — keep the two in sync.
+    # Modes: "none" (never auto-reset), "daily" (at at_hour), "idle" (after
+    # idle_minutes of inactivity), "both" (whichever fires first).
+    "session_reset": {
+        "mode": "none",
+        "at_hour": 4,
+        "idle_minutes": 1440,
+        "notify": True,
+        "notify_exclude_platforms": ["api_server", "webhook"],
+        # A background process this many hours old no longer blocks session
+        # idle/daily reset (the process is NOT killed, only ignored by the
+        # reset guard — #29177).
+        "bg_process_max_age_hours": 24,
+        # How long a finished background process stays tracked before pruning.
+        # Each tracked process holds a pipe FD; a long TTL lets finished jobs
+        # pile up toward the 64-process cap and block new background spawns.
+        "finished_process_ttl_minutes": 10,
+    },
+
     # Contextual first-touch onboarding hints (see agent/onboarding.py).
     # Each hint is shown once per install and then latched here so it
     # never fires again.  Users can wipe the section to re-see all hints.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2624,8 +2624,10 @@ DEFAULT_CONFIG = {
         # reset guard — #29177).
         "bg_process_max_age_hours": 24,
         # How long a finished background process stays tracked before pruning.
-        # Each tracked process holds a pipe FD; a long TTL lets finished jobs
-        # pile up toward the 64-process cap and block new background spawns.
+        # Finished sessions release their pipe/PTY handles immediately, so this
+        # is a retention knob for querying finished output — not an FD-limit
+        # control (the registry never rejects spawns; it prunes oldest-finished
+        # at MAX_PROCESSES).
         "finished_process_ttl_minutes": 10,
     },
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -869,9 +869,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "unit": "minutes",
         "default": 10,
         "description": (
-            "How long finished background processes stay tracked before pruning "
-            "(each tracked process holds a file descriptor; the 64-process cap "
-            "blocks new background spawns when a long TTL lets finished jobs pile up)"
+            "How long finished background processes stay tracked before pruning. "
+            "Finished sessions release their pipe/PTY handles immediately, so this "
+            "controls how long a finished job's buffered output stays queryable "
+            "via poll/log before the entry is pruned."
         ),
     },
     "terminal.backend": {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -844,6 +844,36 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Context window override (0 = auto-detect from model metadata)",
         "category": "general",
     },
+    "session_reset.mode": {
+        "type": "select",
+        "description": "When sessions reset (lose context): none (never), daily (at at_hour), idle (after idle_minutes), or both",
+        "options": ["none", "daily", "idle", "both"],
+    },
+    "session_reset.at_hour": {
+        "type": "number",
+        "description": "Hour for daily session reset (0-23, local time)",
+    },
+    "session_reset.idle_minutes": {
+        "type": "number",
+        "description": "Minutes of inactivity before a session resets (24h = 1440)",
+    },
+    "session_reset.bg_process_max_age_hours": {
+        "type": "number",
+        "description": "Background processes older than this (hours) no longer block session reset (NOT killed)",
+    },
+    "session_reset.finished_process_ttl_minutes": {
+        "type": "range",
+        "min": 1,
+        "max": 120,
+        "step": 1,
+        "unit": "minutes",
+        "default": 10,
+        "description": (
+            "How long finished background processes stay tracked before pruning "
+            "(each tracked process holds a file descriptor; the 64-process cap "
+            "blocks new background spawns when a long TTL lets finished jobs pile up)"
+        ),
+    },
     "terminal.backend": {
         "type": "select",
         "description": "Terminal execution backend",
@@ -1024,7 +1054,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
 # Display order for tabs — unlisted categories sort alphabetically after these.
 _CATEGORY_ORDER = [
     "general", "agent", "terminal", "display", "delegation",
-    "memory", "compression", "security", "browser", "voice",
+    "memory", "compression", "session_reset", "security", "browser", "voice",
     "tts", "stt", "logging", "discord", "auxiliary",
 ]
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -171,24 +171,62 @@ class TestGetConnectedPlatforms:
 class TestSessionResetPolicy:
     def test_roundtrip(self):
         policy = SessionResetPolicy(mode="idle", at_hour=6, idle_minutes=120,
-                                    bg_process_max_age_hours=48)
+                                    bg_process_max_age_hours=48,
+                                    finished_process_ttl_minutes=15)
         d = policy.to_dict()
         restored = SessionResetPolicy.from_dict(d)
         assert restored.mode == "idle"
         assert restored.at_hour == 6
         assert restored.idle_minutes == 120
         assert restored.bg_process_max_age_hours == 48
+        assert restored.finished_process_ttl_minutes == 15
 
 
     def test_from_dict_treats_null_values_as_defaults(self):
         restored = SessionResetPolicy.from_dict(
             {"mode": None, "at_hour": None, "idle_minutes": None,
-             "bg_process_max_age_hours": None}
+             "bg_process_max_age_hours": None,
+             "finished_process_ttl_minutes": None}
         )
         assert restored.mode == "none"
         assert restored.at_hour == 4
         assert restored.idle_minutes == 1440
         assert restored.bg_process_max_age_hours == 24
+        assert restored.finished_process_ttl_minutes == 10
+
+
+    def test_from_dict_coerces_string_ttl_to_int(self):
+        """The web/dashboard config form may send numbers as strings; the TTL
+        must land as an int so the registry setter gets real seconds."""
+        restored = SessionResetPolicy.from_dict(
+            {"finished_process_ttl_minutes": "15"}
+        )
+        assert restored.finished_process_ttl_minutes == 15
+        restored_bad = SessionResetPolicy.from_dict(
+            {"finished_process_ttl_minutes": "oops"}
+        )
+        assert restored_bad.finished_process_ttl_minutes == 10
+
+
+class TestSessionResetDefaultConfigMirror:
+    """DEFAULT_CONFIG's session_reset block and gateway SessionResetPolicy
+    must stay in sync — the web schema is built from DEFAULT_CONFIG while the
+    gateway reads SessionResetPolicy, so a drift would show different defaults
+    in the settings UI vs. runtime behavior."""
+
+    def test_defaults_match(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        policy_defaults = SessionResetPolicy()
+        block = DEFAULT_CONFIG["session_reset"]
+
+        assert block["mode"] == policy_defaults.mode
+        assert block["at_hour"] == policy_defaults.at_hour
+        assert block["idle_minutes"] == policy_defaults.idle_minutes
+        assert block["notify"] == policy_defaults.notify
+        assert list(block["notify_exclude_platforms"]) == list(policy_defaults.notify_exclude_platforms)
+        assert block["bg_process_max_age_hours"] == policy_defaults.bg_process_max_age_hours
+        assert block["finished_process_ttl_minutes"] == policy_defaults.finished_process_ttl_minutes
 
 
 class TestStreamingConfig:

--- a/tests/gateway/test_process_ttl_propagation.py
+++ b/tests/gateway/test_process_ttl_propagation.py
@@ -1,0 +1,65 @@
+"""Tests for gateway/run.py — finished-process TTL propagation into the
+process registry.
+
+The process registry is a module-level singleton. The gateway pushes
+``session_reset.finished_process_ttl_minutes`` into it once at startup via
+``_apply_finished_process_ttl()``. Scope contract (documented at the call
+site): the TTL is PROCESS-WIDE — multiplexed profiles share the registry's
+prune cadence; only the primary profile's default reset policy is applied.
+"""
+
+import pytest
+
+from gateway.config import SessionResetPolicy
+from tools.process_registry import get_finished_ttl_seconds, set_finished_ttl_seconds
+
+
+@pytest.fixture()
+def reset_ttl():
+    original = get_finished_ttl_seconds()
+    yield
+    set_finished_ttl_seconds(original)
+
+
+class TestApplyFinishedProcessTtl:
+    def test_propagates_policy_value_to_registry(self, reset_ttl):
+        """The gateway's startup helper must push the configured minutes into
+        the registry as seconds."""
+        from gateway.run import _apply_finished_process_ttl
+
+        policy = SessionResetPolicy(finished_process_ttl_minutes=15)
+        _apply_finished_process_ttl(policy)
+
+        assert get_finished_ttl_seconds() == 15 * 60
+
+    def test_default_when_policy_lacks_ttl(self, reset_ttl):
+        """Policies that predate the field (or omit it) fall back to the
+        registry default rather than clobbering with 0."""
+        from gateway.run import _apply_finished_process_ttl
+
+        policy = SessionResetPolicy()  # finished_process_ttl_minutes == 10
+        _apply_finished_process_ttl(policy)
+
+        assert get_finished_ttl_seconds() == 10 * 60
+
+    def test_nonpositive_value_keeps_previous_ttl(self, reset_ttl):
+        """A 0/negative value is ignored (the registry setter's guard) so a
+        malformed config cannot zero out the prune TTL."""
+        from gateway.run import _apply_finished_process_ttl
+
+        policy = SessionResetPolicy(finished_process_ttl_minutes=0)
+        before = get_finished_ttl_seconds()
+        _apply_finished_process_ttl(policy)
+
+        assert get_finished_ttl_seconds() == before
+
+
+class TestMultiplexScope:
+    def test_registry_is_process_wide_singleton(self):
+        """The registry is not partitioned by profile — this is the documented
+        process-wide scope. A multiplex profile's own policy would have to go
+        through the same singleton, so per-profile TTLs are not supported."""
+        from tools.process_registry import process_registry
+
+        assert hasattr(process_registry, "_finished")
+        assert hasattr(process_registry, "_running")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1327,6 +1327,30 @@ class TestBuildSchemaFromConfig:
         # Fallback path: never returns an empty list.
         assert len(_timezone_options()) >= 1
 
+    def test_session_reset_ttl_ships_as_range(self):
+        """session_reset.finished_process_ttl_minutes must surface as a
+        bounded range slider (min/max/step/unit + default) so both desktop and
+        dashboard render a slider + text box instead of a free number."""
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        entry = CONFIG_SCHEMA["session_reset.finished_process_ttl_minutes"]
+        assert entry["type"] == "range"
+        assert entry["min"] >= 1
+        assert entry["max"] > entry["min"]
+        assert entry["step"] >= 1
+        assert entry["unit"]
+        # The default drives the UI's reset-to-default button; it must sit
+        # inside the slider bounds.
+        assert entry["min"] <= entry["default"] <= entry["max"]
+
+    def test_session_reset_mode_is_select(self):
+        """session_reset.mode is a closed enum, not free text."""
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        entry = CONFIG_SCHEMA["session_reset.mode"]
+        assert entry["type"] == "select"
+        assert set(entry["options"]) == {"none", "daily", "idle", "both"}
+
     def test_dynamic_merge_recomputes_memory_provider_options(self, monkeypatch):
         """The per-request schema merge re-discovers memory providers.
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -17,6 +17,8 @@ from tools.process_registry import (
     FINISHED_TTL_SECONDS,
     MAX_PROCESSES,
     MAX_ACTIVE_PROCESS_AGE,
+    get_finished_ttl_seconds,
+    set_finished_ttl_seconds,
 )
 
 
@@ -438,6 +440,48 @@ class TestPruning:
         registry._finished[old_session.id] = old_session
         registry._prune_if_needed()
         assert "proc_old" not in registry._finished
+
+    def test_prune_honors_configured_ttl(self, registry):
+        """The gateway can push a custom finished-process TTL via
+        set_finished_ttl_seconds(); pruning must use the configured value,
+        not the module default."""
+        original = get_finished_ttl_seconds()
+        try:
+            set_finished_ttl_seconds(5)
+            assert get_finished_ttl_seconds() == 5
+
+            # 10s old — beyond the configured 5s TTL, within the 600s default
+            old_session = _make_session(
+                sid="proc_custom_ttl",
+                exited=True,
+                started_at=time.time() - 10,
+            )
+            registry._finished[old_session.id] = old_session
+            registry._prune_if_needed()
+            assert "proc_custom_ttl" not in registry._finished
+
+            # fresh session survives the short TTL
+            fresh = _make_session(sid="proc_fresh", exited=True, started_at=time.time() - 1)
+            registry._finished[fresh.id] = fresh
+            registry._prune_if_needed()
+            assert "proc_fresh" in registry._finished
+        finally:
+            set_finished_ttl_seconds(original)
+
+    def test_set_finished_ttl_seconds_rejects_nonpositive(self, registry):
+        """A 0/negative/None TTL must be ignored, keeping the current value —
+        the gateway guards this before calling, but the setter should be
+        safe to call directly."""
+        original = get_finished_ttl_seconds()
+        try:
+            set_finished_ttl_seconds(0)
+            assert get_finished_ttl_seconds() == original
+            set_finished_ttl_seconds(-5)
+            assert get_finished_ttl_seconds() == original
+            set_finished_ttl_seconds(None)  # type: ignore[arg-type]
+            assert get_finished_ttl_seconds() == original
+        finally:
+            set_finished_ttl_seconds(original)
 
     def test_prune_over_max_removes_oldest(self, registry):
         # Fill up to MAX_PROCESSES

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -56,9 +56,30 @@ CHECKPOINT_PATH = get_hermes_home() / "processes.json"
 
 # Limits
 MAX_OUTPUT_CHARS = 200_000      # 200KB rolling output buffer
-FINISHED_TTL_SECONDS = 1800     # Keep finished processes for 30 minutes
+# Default TTL for finished processes (10 min). The gateway overrides this at
+# startup from session_reset.finished_process_ttl_minutes via
+# set_finished_ttl_seconds() — the module-level constant is the fallback for
+# CLI/TUI sessions that never call the setter.
+FINISHED_TTL_SECONDS = 600      # Keep finished processes for 10 minutes
 MAX_PROCESSES = 64              # Max concurrent tracked processes (LRU pruning)
 MAX_ACTIVE_PROCESS_AGE = 86400  # 24h default — see session_reset.bg_process_max_age_hours (#29177)
+
+# Mutable finished-process TTL (seconds). Initialized from FINISHED_TTL_SECONDS;
+# the gateway calls set_finished_ttl_seconds() at startup to honor
+# session_reset.finished_process_ttl_minutes from config.yaml.
+_finished_ttl_seconds: int = FINISHED_TTL_SECONDS
+
+
+def set_finished_ttl_seconds(seconds: int) -> None:
+    """Override the finished-process prune TTL (used by the gateway at startup)."""
+    global _finished_ttl_seconds
+    if seconds is not None and seconds > 0:
+        _finished_ttl_seconds = int(seconds)
+
+
+def get_finished_ttl_seconds() -> int:
+    """Return the effective finished-process prune TTL in seconds."""
+    return _finished_ttl_seconds
 
 # Watch pattern rate limiting — PER SESSION.
 # Hard rule: at most ONE watch-match notification every WATCH_MIN_INTERVAL_SECONDS.
@@ -1917,7 +1938,7 @@ class ProcessRegistry:
         now = time.time()
         expired = [
             sid for sid, s in self._finished.items()
-            if (now - s.started_at) > FINISHED_TTL_SECONDS
+            if (now - s.started_at) > get_finished_ttl_seconds()
         ]
         for sid in expired:
             del self._finished[sid]

--- a/web/src/components/AutoField.tsx
+++ b/web/src/components/AutoField.tsx
@@ -130,6 +130,48 @@ export function AutoField({
     );
   }
 
+  if (schema.type === "range") {
+    const min = typeof schema.min === "number" ? schema.min : 0;
+    const max = typeof schema.max === "number" ? schema.max : 100;
+    const step = typeof schema.step === "number" ? schema.step : 1;
+    const unit = typeof schema.unit === "string" ? schema.unit : "";
+    const numeric = typeof value === "number" && Number.isFinite(value) ? value : min;
+    return (
+      <div className="grid gap-1.5">
+        <Label className="text-sm">{label}</Label>
+        <FieldHint schema={schema} schemaKey={schemaKey} />
+        <div className="flex items-center gap-2">
+          <input
+            aria-label={`${label} slider`}
+            className="h-1.5 flex-1 cursor-pointer appearance-none rounded-full bg-border accent-accent"
+            max={max}
+            min={min}
+            onChange={(e) => {
+              const n = Number(e.target.value);
+              if (!Number.isNaN(n)) onChange(n);
+            }}
+            step={step}
+            type="range"
+            value={Math.min(max, Math.max(min, numeric))}
+          />
+          <Input
+            aria-label={`${label} value`}
+            className="w-20 text-right"
+            onChange={(e) => {
+              const raw = e.target.value;
+              if (raw === "") return;
+              const n = Number(raw);
+              if (!Number.isNaN(n)) onChange(Math.min(max, Math.max(min, n)));
+            }}
+            type="text"
+            value={String(numeric)}
+          />
+          {unit && <span className="text-xs text-muted-foreground">{unit}</span>}
+        </div>
+      </div>
+    );
+  }
+
   if (schema.type === "number") {
     return (
       <div className="grid gap-1.5">


### PR DESCRIPTION
## Problem

The gateway's process registry prunes **finished** background processes after a hardcoded 30-minute TTL (`FINISHED_TTL_SECONDS = 1800` in `tools/process_registry.py`). Every tracked process holds a pipe file descriptor, so under heavy background churn (deployments, archivers, watches) finished jobs pile up against `MAX_PROCESSES = 64` and block new `terminal(background=true)` spawns with the **"file descriptor limit"** error. The only remedy today is a gateway restart.

## Change

Make the finished-process prune TTL a real, user-editable setting end to end:

**Backend**
- `SessionResetPolicy` gains `finished_process_ttl_minutes` (default **10**, down from the hardcoded 30) with `to_dict`/`from_dict` round-trip + string coercion for web-form saves.
- `tools/process_registry.py` keeps `FINISHED_TTL_SECONDS = 600` as the module default for CLI/TUI contexts; `set_finished_ttl_seconds()` lets the gateway push the configured value at startup (gateway/run.py wires it).
- `DEFAULT_CONFIG` gains a `session_reset` block — this section previously had **no settings UI at all**; now the whole block is schema-driven and editable.
- `web_server.py` schema overrides: `mode` is a select, the TTL is a bounded **range** field (1–120 min, step 1, unit minutes, default 10), and `session_reset` appears in the dashboard tab order.

**Desktop settings UI**
- New `RangeField` control: **slider + text box + live timeframe preview + reset-to-default button**. The slider shows "10 minutes" → "1.5 hours" live as it moves; typing clamps into bounds; the reset button restores the shipped default (disabled when already default). Rendered by `ConfigField` for schema type `range`.
- New "Session Reset" settings section with user-facing labels/descriptions.
- Web dashboard `AutoField` renders the same range control so a numeric key never round-trips as a string.

## Testing
- `SessionResetPolicy` round-trip / null-defaults / string-coercion tests
- DEFAULT_CONFIG ↔ SessionResetPolicy sync invariant (catches future drift between the UI schema source and the gateway policy)
- Registry: `set_finished_ttl_seconds()` honored by pruning; non-positive values rejected
- Schema: range shape (min/max/step/unit/default) + mode select
- Desktop: 12 vitest cases for RangeField (slider write, clamp, non-numeric ignore, reset enable/disable, default preview)

All touched suites green: gateway config (57), process registry pruning, web_server schema, desktop range-field (12), helpers (31).
