### PR TITLE
docs(anthropic): correct OAuth billing — plan allowance, not extra-usage credits

### DIFF
--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -111,7 +111,7 @@ Good defaults:
 |----------|-----------|---------------|
 | **Nous Portal** | Subscription-based, zero-config | OAuth login via `hermes model` |
 | **OpenAI Codex** | ChatGPT OAuth, uses Codex models | Device code auth via `hermes model` |
-| **Anthropic** | Claude models directly — Max plan + extra usage credits (OAuth), or API key for pay-per-token | `hermes model` → OAuth login (requires Max + extra credits), or an Anthropic API key |
+| **Anthropic** | Claude models directly — a Claude subscription via OAuth (spends your included plan allowance), or API key for pay-per-token | `hermes model` → OAuth login, or an Anthropic API key |
 | **OpenRouter** | Multi-provider routing across many models | Enter your API key |
 | **Fireworks AI** | Direct OpenAI-compatible model API | Set `FIREWORKS_API_KEY` |
 | **Z.AI** | GLM / Zhipu-hosted models | Set `GLM_API_KEY` / `ZAI_API_KEY` (also accepts `Z_AI_API_KEY`) |

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -124,6 +124,14 @@ Because OAuth spends your subscription allowance, heavy Hermes use competes with
 The behavior above was confirmed on a Team plan. Max is expected to behave the same way, and Pro has not been verified — if you have a Pro or Max subscription, the `anthropic-ratelimit-unified-*` headers described above will tell you definitively, and a report either way is welcome.
 :::
 
+:::warning `ANTHROPIC_API_KEY` silently wins if OAuth resolution fails
+`resolve_anthropic_token()` tries the Claude Code credential *before* `ANTHROPIC_API_KEY`, so a working OAuth login always takes precedence. But if OAuth resolution comes up empty and `ANTHROPIC_API_KEY` is set, Hermes falls through to the API key and bills pay-per-token instead — and every diagnostic on that path is logged at `debug`, so **nothing surfaces at default verbosity**. Your plan allowance simply goes untouched, which looks indistinguishable from "OAuth doesn't use the plan."
+
+To tell which lane you're actually on, check the response headers: an OAuth request carries `anthropic-ratelimit-unified-*` plan attribution, an `x-api-key` request does not. `hermes doctor` also reports the resolved auth method.
+
+One known trigger on macOS: Claude Code stores its MCP-server OAuth state under the *same* `Claude Code-credentials` Keychain service as your login credential. `security find-generic-password` returns only the first matching item, so an unscoped lookup could return the MCP item, find no login token in it, and give up — while you were fully signed in. Fixed by scoping the lookup to your account ([#75146](https://github.com/NousResearch/Hermes-Agent/pull/75146)). If you're on an older version and want to be certain, unset `ANTHROPIC_API_KEY` while using OAuth so there is nothing to silently fall back to.
+:::
+
 ```bash
 # With an API key (pay-per-token)
 export ANTHROPIC_API_KEY=***

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -118,6 +118,8 @@ Purchased "extra usage" credits are **not** required. Verified against a Claude 
 To check your own account, inspect the `anthropic-ratelimit-unified-*` response headers, or run `/usage` in an interactive session to see your remaining plan windows.
 
 Because OAuth spends your subscription allowance, heavy Hermes use competes with your own Claude Code and claude.ai usage for the same budget. Use an `ANTHROPIC_API_KEY` instead if you'd rather bill pay-per-token against an organization's API account, independent of any subscription.
+
+Credits are not required to *use* OAuth, but they are still the spillover once an allowance runs out: Anthropic's own wording is "usage credits cover you when you hit your plan limits." If you exhaust the allowance you will start seeing `You're out of extra usage` — that means a limit was reached and there are no credits to spill into, not that OAuth requires credits to work.
 :::
 
 :::note Untested tiers

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -18,7 +18,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
-| **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
+| **Anthropic** | `hermes model` (Claude subscription via OAuth — spends your included plan allowance; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`; aliases: `fireworks-ai`, `fw`) |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
@@ -110,10 +110,18 @@ If you're trying to switch to a provider you haven't set up yet (e.g. you only h
 
 Use Claude models directly through the Anthropic API — no OpenRouter proxy needed. Supports three auth methods:
 
-:::caution Requires Claude Max "extra usage" credits
-When you authenticate via `hermes model` → Anthropic OAuth (or via `hermes auth add anthropic --type oauth`), Hermes routes as Claude Code against your Anthropic account. **It only works if you're on a Claude Max plan and have purchased extra usage credits.** The base Max plan allowance (the usage included in Claude Code by default) is not consumed by Hermes — only the extra/overage credits you've added on top are. Claude Pro subscribers cannot use this path.
+:::info Billed against your subscription's included allowance
+When you authenticate via `hermes model` → Anthropic OAuth (or via `hermes auth add anthropic --type oauth`), Hermes routes as Claude Code against your Anthropic account, and requests draw on **the same included plan allowance Claude Code itself uses** — not a separate extra-usage pool.
 
-If you don't have Max + extra credits, use an `ANTHROPIC_API_KEY` instead — requests are billed pay-per-token against that key's organization (standard API pricing, independent of any Claude subscription).
+Purchased "extra usage" credits are **not** required. Verified against a Claude **Team** subscription with the overage lane explicitly disabled (Anthropic returned `anthropic-ratelimit-unified-overage-status: rejected`, `overage-disabled-reason: out_of_credits`): requests were served normally and attributed to the plan window, with `anthropic-ratelimit-unified-representative-claim: five_hour`.
+
+To check your own account, inspect the `anthropic-ratelimit-unified-*` response headers, or run `/usage` in an interactive session to see your remaining plan windows.
+
+Because OAuth spends your subscription allowance, heavy Hermes use competes with your own Claude Code and claude.ai usage for the same budget. Use an `ANTHROPIC_API_KEY` instead if you'd rather bill pay-per-token against an organization's API account, independent of any subscription.
+:::
+
+:::note Untested tiers
+The behavior above was confirmed on a Team plan. Max is expected to behave the same way, and Pro has not been verified — if you have a Pro or Max subscription, the `anthropic-ratelimit-unified-*` headers described above will tell you definitively, and a report either way is welcome.
 :::
 
 ```bash

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -119,7 +119,7 @@ Hermes reads environment variables from the process environment and, for user-ma
 
 ## Provider Auth (OAuth)
 
-For native Anthropic auth, Hermes prefers Claude Code's own credential files when they exist because those credentials can refresh automatically. **OAuth against Anthropic requires a Claude Max plan with purchased extra usage credits** — Hermes routes as Claude Code, which only draws from the Max plan's extra/overage credits, not the base Max allowance, and does not work on Claude Pro. Without Max + extra credits, use an API key instead. Environment variables such as `ANTHROPIC_TOKEN` remain useful as manual overrides, but they are no longer the preferred path for Claude Max login.
+For native Anthropic auth, Hermes prefers Claude Code's own credential files when they exist because those credentials can refresh automatically. **OAuth against Anthropic spends your Claude subscription's included plan allowance** — the same budget Claude Code itself draws on — so purchased "extra usage" credits are not required. Use an API key instead if you'd rather bill pay-per-token against an organization's API account. Environment variables such as `ANTHROPIC_TOKEN` remain useful as manual overrides, but they are no longer the preferred path for Claude subscription login. See [Providers → Anthropic (Native)](../integrations/providers.md#anthropic-native) for how to confirm the billing lane from Anthropic's own response headers.
 
 | Variable | Description |
 |----------|-------------|

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -51,7 +51,7 @@ hermes auth add openrouter --api-key sk-or-v1-your-second-key
 # Add a second Anthropic key
 hermes auth add anthropic --type api-key --api-key sk-ant-api03-your-second-key
 
-# Add an Anthropic OAuth credential (requires Claude Max plan + extra usage credits)
+# Add an Anthropic OAuth credential (spends your Claude subscription's included allowance)
 hermes auth add anthropic --type oauth
 # Opens browser for OAuth login
 ```


### PR DESCRIPTION
## What does this PR do?

Corrects the documented billing model for Anthropic OAuth. The docs currently state three things that measurement contradicts:

> **It only works if you're on a Claude Max plan and have purchased extra usage credits.** The base Max plan allowance (the usage included in Claude Code by default) is not consumed by Hermes — only the extra/overage credits you've added on top are. Claude Pro subscribers cannot use this path.

Measured against Anthropic's own rate-limit response headers, OAuth requests bill against the subscription's **included plan allowance**, and purchased extra-usage credits are not required.

### Evidence

Tested on a Claude **Team** subscription with the overage lane explicitly disabled. Anthropic returned:

```
anthropic-ratelimit-unified-status:                  allowed
anthropic-ratelimit-unified-representative-claim:    five_hour
anthropic-ratelimit-unified-overage-status:          rejected
anthropic-ratelimit-unified-overage-disabled-reason: out_of_credits
```

`overage-status: rejected` with `out_of_credits` means there were **no extra-usage credits available to draw on**. The request was nevertheless `allowed` and attributed to `representative-claim: five_hour` — the plan window. An allowed request on an account with no overage credits necessarily came out of the plan allowance.

Reproduced across a range of system-prompt sizes (200 → 40,000 chars, 65 → 9,178 input tokens); every request landed in the same lane. Also reproduced with and without the `x-anthropic-billing-header` marker proposed in #69844 / #72173 — on this account the lane was identical either way, which is a separate data point for those PRs and not something this one depends on.

### Why this matters beyond accuracy

The practical consequence is the **opposite** of what the docs implied, and worth stating plainly: because OAuth spends the same budget as Claude Code and claude.ai, heavy Hermes use competes with your own interactive usage. A reader following the current text would expect Hermes to be isolated from their Claude Code budget. It isn't.

The current text also actively deters valid setups — a Team or credit-free Max subscriber reads "only works if... purchased extra usage credits" and reaches for an API key they don't need.

## Related Issue

No existing issue or PR — I searched and found nothing covering this caveat.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

The claim appeared in **five** places; all are corrected consistently:

- `website/docs/integrations/providers.md` — the `:::caution` block (rewritten as `:::info`, with the header evidence and a self-check recipe) and the auth-methods summary table
- `website/docs/getting-started/quickstart.md` — provider table
- `website/docs/reference/environment-variables.md` — native-Anthropic auth prose, now cross-linked to the providers page
- `website/docs/user-guide/features/credential-pools.md` — `hermes auth add anthropic --type oauth` example comment

Also adds a short `:::note Untested tiers` admonition, so the correction doesn't silently overreach (see below).

## How to Test

Anyone with a Claude subscription can confirm the lane on their own account:

```bash
# Inspect the unified rate-limit headers on a real OAuth request
#   representative-claim=five_hour  -> billed to the plan window
#   overage-status=rejected         -> no extra-usage credits in play
```

Or run `/usage` in an interactive session to see remaining plan windows before and after a request. Both routes are now documented in the providers page so readers can verify rather than trust.

Docs-only change: no code paths touched. `ruff check .` and `python scripts/check-windows-footguns.py --all` both clean. Admonition fences verified balanced (delta +1 open / +1 close; note the file already carries a pre-existing off-by-one on `main`, untouched here).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for a docs-only change; lint gates run and clean
- [x] I've added tests for my changes — N/A, documentation
- [x] I've tested on my platform: macOS 15 (Apple silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A

---

**On scope, stated honestly:** this was verified on a **Team** plan. Max is expected to behave identically but I could not test it, and **Pro is unverified**. Rather than replace one unverified claim with another, the new text says exactly what was measured and adds a note inviting a report from Pro/Max users, with the header names they'd need. If maintainers have Pro data showing OAuth genuinely fails there, I'm glad to fold it back in — the specific correction that stands regardless is that *purchased extra-usage credits are not a requirement*, since a credit-free account demonstrably works.
