### PR TITLE
fix(mcp): normalise stdio args when config writers serialise as JSON scalar (#75093)

### DIFF
--- a/tests/tools/test_mcp_tool_issue_75093.py
+++ b/tests/tools/test_mcp_tool_issue_75093.py
@@ -1,0 +1,233 @@
+"""Regression tests for #75093: mcp_servers.*.args JSON-quoted YAML scalar.
+
+When a config writer serialises ``args`` as a JSON string instead of a proper
+YAML sequence, ``_run_stdio`` previously passed the entire JSON string as a
+single argv element. The MCP SDK's ``StdioServerParameters`` then iterates
+the string (pydantic ``list[str]`` coercion), the spawned server receives a
+malformed argv, exits immediately, and the caller sees
+``McpError: Connection closed``.
+
+These tests exercise the real production path: they drive ``_run_stdio`` with
+the broken shapes and capture what actually reaches ``StdioServerParameters``.
+The argv the watchdog wrapper prepends is constant
+(``[watchdog_path, --ppid, <pid>, --, <command>]``), so we extract the
+trailing user-args segment and assert on THAT. On ``upstream/main`` the
+JSON string ends up split into individual characters by pydantic; with the
+fix it splits correctly into the original argv elements.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tools.mcp_tool import MCPServerTask, _MCP_AVAILABLE
+
+# Ensure the mcp module symbols exist for patching even when the SDK isn't installed
+if not _MCP_AVAILABLE:
+    import tools.mcp_tool as _mcp_mod
+    if not hasattr(_mcp_mod, "StdioServerParameters"):
+        _mcp_mod.StdioServerParameters = MagicMock
+    if not hasattr(_mcp_mod, "stdio_client"):
+        _mcp_mod.stdio_client = MagicMock
+    if not hasattr(_mcp_mod, "ClientSession"):
+        _mcp_mod.ClientSession = MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Production-path capture: drive _run_stdio just far enough to inspect the
+# ``StdioServerParameters`` it builds, without actually spawning anything.
+# ---------------------------------------------------------------------------
+
+
+def _capture_user_args(config: dict) -> list:
+    """Return the user-supplied argv segment that reaches
+    ``StdioServerParameters`` after the watchdog wrapper has prepended its
+    fixed prefix ``[watchdog_path, --ppid, <pid>, --, <command>]``.
+
+    Returns the trailing slice (everything after the literal ``"--"`` token
+    minus the command itself), so tests can compare directly against the
+    expected user-supplied argv.
+    """
+    captured: dict = {}
+
+    def fake_params(*, command, args, env=None, **_kwargs):
+        captured["command"] = command
+        captured["args"] = list(args)
+        captured["env"] = env
+        return SimpleNamespace(command=command, args=args, env=env)
+
+    class _FakeStdioClient:
+        def __init__(self, params, errlog=None):
+            pass
+
+        async def __aenter__(self):
+            return (MagicMock(), MagicMock())
+
+        async def __aexit__(self, *_args):
+            return False
+
+    task = MCPServerTask(name="regression-75093")
+    task._config = config
+
+    async def _drive():
+        with patch("tools.mcp_tool.StdioServerParameters", side_effect=fake_params), \
+             patch("tools.mcp_tool.stdio_client", _FakeStdioClient), \
+             patch("tools.mcp_tool._kill_orphaned_mcp_children", return_value=None), \
+             patch("tools.mcp_tool._snapshot_child_pids", return_value=set()), \
+             patch("tools.mcp_tool._write_stderr_log_header"), \
+             patch("tools.mcp_tool._get_mcp_stderr_log", return_value=None), \
+             patch("tools.mcp_tool.asyncio.to_thread",
+                   new=AsyncMock(side_effect=lambda fn, *a, **kw: fn(*a, **kw))):
+            try:
+                await task._run_stdio(config)
+            except Exception:
+                # _run_stdio calls into ClientSession which we never wired up.
+                # We only care about captured args.
+                pass
+
+    asyncio.run(_drive())
+    # Watchdog wraps argv as: [watchdog_path, --ppid, <pid>, --, <command>, *user_args]
+    full = captured.get("args", [])
+    try:
+        sep_idx = full.index("--")
+    except ValueError:
+        return full  # no watchdog wrap (Windows); return as-is
+    # After `--` we get the original command followed by the user args.
+    return full[sep_idx + 2:]
+
+
+# ---------------------------------------------------------------------------
+# Test cases (RED on upstream/main; GREEN with the fix)
+# ---------------------------------------------------------------------------
+
+
+def test_json_quoted_args_string_is_split_into_list():
+    """The canonical #75093 shape: ``'["-y", "@modelcontextprotocol/server-filesystem"]'``.
+
+    On upstream/main this string is split into individual characters by
+    pydantic's ``list[str]`` coercion, then forwarded verbatim to the server.
+    After the fix the OSV preflight and ``StdioServerParameters`` see
+    ``['-y', '@modelcontextprotocol/server-filesystem', '/home/hermes']``.
+    """
+    config = {
+        "command": "npx",
+        "args": '["-y", "@modelcontextprotocol/server-filesystem", "/home/hermes"]',
+        "env": {"PATH": "/usr/bin"},
+    }
+    user_args = _capture_user_args(config)
+    assert user_args == [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home/hermes",
+    ], f"expected JSON-quoted args to split, got {user_args!r}"
+
+
+def test_json_array_with_non_string_elements_is_coerced_to_strings():
+    """JSON arrays may contain ints/floats/null — coerce each to str so the
+    watchdog wrapper and ``StdioServerParameters`` receive a uniform
+    ``list[str]``. (YAML sequences with non-strings are already a list, but a
+    JSON-quoted scalar with non-string elements exercises the same path.)
+    """
+    config = {
+        "command": "uvx",
+        "args": '[1, 2.5, "pkg", null]',
+        "env": {"PATH": "/usr/bin"},
+    }
+    user_args = _capture_user_args(config)
+    assert user_args == ["1", "2.5", "pkg", "None"], (
+        f"expected non-string JSON elements to coerce to str, got {user_args!r}"
+    )
+
+
+def test_list_args_pass_through_unchanged():
+    """The well-formed path: a real YAML sequence of strings must NOT be
+    re-normalised — preserve element order and content exactly.
+    """
+    config = {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/hermes"],
+        "env": {"PATH": "/usr/bin"},
+    }
+    user_args = _capture_user_args(config)
+    assert user_args == [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home/hermes",
+    ], f"expected list to pass through, got {user_args!r}"
+
+
+def test_empty_list_args_passes_through():
+    """``args: []`` is a legitimate config — don't trip on it."""
+    config = {"command": "npx", "args": [], "env": {"PATH": "/usr/bin"}}
+    user_args = _capture_user_args(config)
+    assert user_args == [], f"expected [] to pass through, got {user_args!r}"
+
+
+def test_empty_string_args_normalises_to_empty_list():
+    """``args: ''`` (rare but possible from a hand-edited config) should
+    behave like ``args: []`` rather than producing ``['']`` (or worse, a list
+    of single characters from pydantic coercion).
+    """
+    config = {"command": "npx", "args": "", "env": {"PATH": "/usr/bin"}}
+    user_args = _capture_user_args(config)
+    assert user_args == [], f"expected '' to normalise to [], got {user_args!r}"
+
+
+def test_shlex_quoted_scalar_is_split():
+    """A POSIX shell-quoted scalar (``'-y "@pkg/path"'``) should split via
+    ``shlex.split`` rather than being passed verbatim. This catches hand-edited
+    configs that look like shell commands.
+    """
+    config = {
+        "command": "npx",
+        "args": '-y "@modelcontextprotocol/server-filesystem"',
+        "env": {"PATH": "/usr/bin"},
+    }
+    user_args = _capture_user_args(config)
+    assert user_args == [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+    ], f"expected shlex split, got {user_args!r}"
+
+
+def test_single_json_string_scalar_wraps_into_single_element_list():
+    """A JSON scalar that's a single string (not an array) should wrap to a
+    one-element list. Without this, the user loses the value entirely.
+    """
+    config = {
+        "command": "uvx",
+        "args": '"some-package-name"',
+        "env": {"PATH": "/usr/bin"},
+    }
+    user_args = _capture_user_args(config)
+    assert user_args == ["some-package-name"], (
+        f"expected single JSON string to wrap, got {user_args!r}"
+    )
+
+
+def test_malformed_string_args_falls_through_as_single_element():
+    """Garbage that fails both JSON and shlex parsing must not crash the
+    gateway and must not be split into characters by pydantic. We pass it
+    through as a single argv element and let the OSV preflight / spawned
+    process deal with the malformed input.
+    """
+    config = {
+        "command": "npx",
+        "args": "garbage[invalid ' unmatched",
+        "env": {"PATH": "/usr/bin"},
+    }
+    user_args = _capture_user_args(config)
+    assert user_args == ["garbage[invalid ' unmatched"], (
+        f"expected malformed string to fall through as single element, got {user_args!r}"
+    )
+
+
+def test_args_key_absent_defaults_to_empty_list():
+    """``config.get('args', [])`` is the canonical default — when ``args`` is
+    omitted entirely the normalised value must still be ``[]``.
+    """
+    config = {"command": "npx", "env": {"PATH": "/usr/bin"}}
+    user_args = _capture_user_args(config)
+    assert user_args == [], f"expected missing args to default to [], got {user_args!r}"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -101,6 +101,7 @@ import math
 import os
 import random
 import re
+import shlex
 import shutil
 import sys
 import threading
@@ -725,6 +726,61 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
         *args,
     ]
     return sys.executable, watchdog_args
+
+
+def _normalize_stdio_args(args):
+    """Coerce a stdio MCP server's ``args`` config into a list.
+
+    The MCP config schema (``config.yaml`` ``mcp_servers.<name>.args``) declares
+    ``args`` as a YAML sequence, but config writers (and hand-edited files)
+    sometimes serialise the list as a JSON-quoted scalar — e.g.
+    ``args: '["-y", "@modelcontextprotocol/server-filesystem"]'`` instead of
+    the proper YAML sequence. When that happens, ``yaml.safe_load`` returns a
+    ``str`` and ``subprocess.Popen`` ends up receiving the entire JSON string
+    as one argv element. The server (typically ``npx``) then sees a malformed
+    argv, exits immediately, and ``ClientSession.initialize()`` raises
+    ``McpError: Connection closed``.
+
+    This helper detects the four broken shapes we see in the wild and converts
+    each into a list so the OSV malware preflight, the watchdog wrapper, and
+    ``StdioServerParameters`` all see the right ``args``. Pre-existing list
+    inputs are returned unchanged. Malformed strings fall through to a
+    single-element list rather than crashing — the OSV check already fails
+    open, so this preserves the observable behaviour for callers that
+    somehow get a garbage value here.
+
+    Args:
+        args: Whatever YAML produced for ``mcp_servers.<name>.args`` — usually
+            a ``list[str]``, but may also be a ``str`` (the bug case).
+
+    Returns:
+        ``list[str]`` suitable for ``subprocess.Popen`` / ``StdioServerParameters``.
+    """
+    if not isinstance(args, str):
+        return args
+    raw = args.strip()
+    if not raw:
+        return []
+    # 1. JSON-quoted scalar — the common config-writer bug.
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        parsed = None
+    if isinstance(parsed, list):
+        return [str(a) for a in parsed]
+    if isinstance(parsed, str):
+        # JSON parsed but produced a single string scalar — wrap it so the
+        # user gets one argv element rather than dropping the value.
+        return [parsed]
+    # 2. POSIX shell-style quoted scalar — `shlex.split` handles
+    #    `-y "@pkg/path"` and friends. Best-effort: never raise from here.
+    try:
+        return shlex.split(raw)
+    except ValueError:
+        # 3. Malformed string — preserve as one argv element rather than
+        # crashing the gateway at startup. OSV preflight still runs and
+        # will allow if the package is clean.
+        return [raw]
 
 
 # ---------------------------------------------------------------------------
@@ -2391,6 +2447,17 @@ class MCPServerTask:
             raise ValueError(
                 f"MCP server '{self.name}' has no 'command' in config"
             )
+
+        # Tolerate config writers that serialise ``args`` as a JSON-quoted YAML
+        # scalar (e.g. ``'["-y", "pkg"]'``) instead of a proper YAML sequence.
+        # Without this, subprocess.Popen receives the entire JSON string as a
+        # single argv element, the server exits immediately, and
+        # ClientSession.initialize() raises ``McpError: Connection closed``
+        # — see #75093. Normalise BEFORE the OSV malware preflight so the
+        # package-name extractor inspects the real argv.
+        args = _normalize_stdio_args(args)
+        if not isinstance(args, list):
+            args = list(args) if args else []
 
         safe_env = _build_safe_env(user_env)
         command, safe_env = _resolve_stdio_command(command, safe_env)


### PR DESCRIPTION
## What

When `mcp_servers.<name>.args` in `config.yaml` is stored as a JSON-quoted YAML scalar (e.g. `args: '["-y", "@modelcontextprotocol/server-filesystem"]'`) instead of a proper YAML sequence, the gateway passes the entire JSON string verbatim as a single argv element. The MCP SDK's `StdioServerParameters` (pydantic `list[str]`) then iterates the string character-by-character, the spawned server (`npx`) receives a malformed argv, exits immediately, and `ClientSession.initialize()` raises `McpError: Connection closed`.

All MCP servers configured this way are affected — in the reporter's case, 5 servers / 65 tools unavailable.

## Root Cause

`MCPServerTask._run_stdio()` reads `args = config.get("args", [])` with no type normalisation. When YAML loads the quoted scalar as a `str`, the string is passed directly to `StdioServerParameters`.

## Fix

Add a `_normalize_stdio_args()` helper that detects the broken string shapes and converts them to a proper `list[str]`:

1. **JSON-quoted array** (`'["-y", "pkg"]'`) → `json.loads()` + element coercion
2. **Single JSON scalar** (`'"some-pkg"'`) → wrap into single-element list
3. **POSIX shell-quoted** (`-y "pkg/path"`) → `shlex.split()`
4. **Malformed string** → single-element list (never crash the gateway)
5. **Empty string** → `[]`

Pre-existing list inputs pass through unchanged. The normalisation runs **before** the OSV malware preflight so the package-name extractor inspects the real argv.

## Verification

**RED on upstream/main** — 5 of 9 regression tests fail with the characteristic pydantic char-by-char split:
```
expected ["-y", "@modelcontextprotocol/server-filesystem", "/home/hermes"],
got      ["[", "\"", "-", "y", "\"", ",", " ", "\"", "@", "m", "o", "d", ...]
```

**GREEN with fix** — all 9 pass:
```
tests/tools/test_mcp_tool_issue_75093.py: 9/9 PASSED
```

**No regressions** — full MCP test suite (396 tests including pre-existing `test_mcp_tool.py`):
```
396 passed in 48.61s
```

## Scope

- `tools/mcp_tool.py` (+67 lines: helper + call site + `import shlex`)
- `tests/tools/test_mcp_tool_issue_75093.py` (+233 lines: 9 regression tests)

Closes #75093.

---
*Auto-published by Moonsong via Path B automated pipeline.*