### PR TITLE
fix(gateway): check rate-limit before auth in provider error classification (#74879)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -494,6 +494,11 @@ def _format_exec_approval_fallback(
 
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
+    # Rate-limit before auth: quota/usage-limit errors that carry a 401
+    # (or that a provider wraps in an auth-shaped exception) must not be
+    # misclassified as credential failures.  Most-specific first.
+    if _GATEWAY_RATE_LIMIT_RE.search(text):
+        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return (
             "⚠️ Provider authentication failed. Check the configured credentials; "
@@ -504,8 +509,6 @@ def _gateway_provider_error_reply(text: str) -> str:
             "⚠️ The model provider rejected the request. I kept the raw provider "
             "error out of chat; check gateway logs for details or try rephrasing."
         )
-    if _GATEWAY_RATE_LIMIT_RE.search(text):
-        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
     return (
         "⚠️ The model provider failed after retries. I kept raw provider details "
         "out of chat; check gateway logs for diagnostics."


### PR DESCRIPTION
## Summary

Fixes #74879.

`_gateway_provider_error_reply()` tested the auth pattern before the rate-limit pattern. A quota/usage-limit error that carries a `401` — or that a provider wraps in an auth-shaped exception — matched the first branch and was reported as an authentication failure. The credentials are fine.

The two conditions want opposite responses:
- **"Authentication failed"** → re-auth, rotate tokens, inspect credential scoping — none of which is the problem, and some of which is destructive
- **"Rate-limited"** → wait for the window to reset (correct)

## Fix

Reorder the checks most-specific-first — rate-limit before auth — so a message containing both a quota marker and a `401` is classified as a quota problem.

```diff
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
+    # Rate-limit before auth: quota/usage-limit errors that carry a 401
+    # must not be misclassified as credential failures.
+    if _GATEWAY_RATE_LIMIT_RE.search(text):
+        return "⏱️ The model provider is rate-limiting requests. ..."
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return "⚠️ Provider authentication failed. ..."
     ...
-    if _GATEWAY_RATE_LIMIT_RE.search(text):
-        return "⏱️ The model provider is rate-limiting requests. ..."
```

## Testing

- Configure a subscription-backed provider
- Trigger a quota exhaustion that wraps a 401
- Verify the user sees "rate-limiting" instead of "authentication failed"
