### PR TITLE
fix(update): preserve local-only commits instead of silently discarding them on reset

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3529,20 +3529,50 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     git_cmd, _m().PROJECT_ROOT, f"origin/{branch}", "HEAD"
                 )
                 backup_ref = None
-                if local_only > 0:
-                    backup_ref = (
+                # local_only < 0 means the count itself failed (bad ref, git
+                # error). Treat "unknown" the same as "there is something" —
+                # the reset below is unrecoverable, so the only safe direction
+                # to fail is toward taking a backup we may not have needed.
+                if local_only != 0:
+                    candidate_ref = (
                         f"refs/hermes-update-backups/{branch}-"
                         f"{datetime.now().strftime('%Y%m%d-%H%M%S')}"
                     )
-                    subprocess.run(
-                        git_cmd + ["update-ref", backup_ref, "HEAD"],
+                    backup_result = subprocess.run(
+                        git_cmd + ["update-ref", candidate_ref, "HEAD"],
                         cwd=_m().PROJECT_ROOT,
                         capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
                     )
-                    print(
-                        f"  ℹ Preserving {local_only} local commit(s) not on "
-                        f"origin/{branch} before resetting (backed up to {backup_ref})..."
-                    )
+                    if backup_result.returncode != 0:
+                        # Never claim a backup we do not have, and never run the
+                        # destructive reset without one.
+                        print(
+                            f"✗ Could not create backup ref {candidate_ref} for "
+                            f"local commits; refusing to reset --hard."
+                        )
+                        if (backup_result.stderr or "").strip():
+                            print(f"  {backup_result.stderr.strip()}")
+                        print(
+                            "  Your local commits are still intact. Resolve the ref "
+                            "error, or reconcile manually with:\n"
+                            f"    git rebase origin/{branch}"
+                        )
+                        sys.exit(1)
+                    backup_ref = candidate_ref
+                    if local_only > 0:
+                        print(
+                            f"  ℹ Preserving {local_only} local commit(s) not on "
+                            f"origin/{branch} before resetting (backed up to {backup_ref})..."
+                        )
+                    else:
+                        print(
+                            f"  ℹ Could not determine how many local commits are not on "
+                            f"origin/{branch}; backing up HEAD to {backup_ref} before "
+                            "resetting, to be safe..."
+                        )
 
                 print(
                     "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
@@ -3574,19 +3604,32 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         text=True, encoding="utf-8", errors="replace",
                     )
                     if cherry_result.returncode == 0:
-                        print(
-                            f"  ✓ Reapplied {local_only} local commit(s) on top of the update."
-                        )
+                        # local_only is -1 when the earlier count failed; don't
+                        # render "-1 commit(s)" at the user in that case.
+                        if local_only > 0:
+                            print(
+                                f"  ✓ Reapplied {local_only} local commit(s) on top of the update."
+                            )
+                        else:
+                            print(
+                                "  ✓ Reapplied your local commit(s) on top of the update."
+                            )
                     else:
                         subprocess.run(
                             git_cmd + ["cherry-pick", "--abort"],
                             cwd=_m().PROJECT_ROOT,
                             capture_output=True,
                         )
-                        print(
-                            f"  ⚠ Could not automatically reapply your {local_only} local "
-                            "commit(s) — they conflict with the update."
-                        )
+                        if local_only > 0:
+                            print(
+                                f"  ⚠ Could not automatically reapply your {local_only} local "
+                                "commit(s) — they conflict with the update."
+                            )
+                        else:
+                            print(
+                                "  ⚠ Could not automatically reapply your local "
+                                "commit(s) — they conflict with the update."
+                            )
                         print(f"    Nothing is lost — they're saved at: {backup_ref}")
                         print(f"    Review them with: git log {backup_ref}")
                         print(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4279,20 +4279,50 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     git_cmd, _m().PROJECT_ROOT, f"origin/{branch}", "HEAD"
                 )
                 backup_ref = None
-                if local_only > 0:
-                    backup_ref = (
+                # local_only < 0 means the count itself failed (bad ref, git
+                # error). Treat "unknown" the same as "there is something" —
+                # the reset below is unrecoverable, so the only safe direction
+                # to fail is toward taking a backup we may not have needed.
+                if local_only != 0:
+                    candidate_ref = (
                         f"refs/hermes-update-backups/{branch}-"
                         f"{datetime.now().strftime('%Y%m%d-%H%M%S')}"
                     )
-                    subprocess.run(
-                        git_cmd + ["update-ref", backup_ref, "HEAD"],
+                    backup_result = subprocess.run(
+                        git_cmd + ["update-ref", candidate_ref, "HEAD"],
                         cwd=_m().PROJECT_ROOT,
                         capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
                     )
-                    print(
-                        f"  ℹ Preserving {local_only} local commit(s) not on "
-                        f"origin/{branch} before resetting (backed up to {backup_ref})..."
-                    )
+                    if backup_result.returncode != 0:
+                        # Never claim a backup we do not have, and never run the
+                        # destructive reset without one.
+                        print(
+                            f"✗ Could not create backup ref {candidate_ref} for "
+                            f"local commits; refusing to reset --hard."
+                        )
+                        if (backup_result.stderr or "").strip():
+                            print(f"  {backup_result.stderr.strip()}")
+                        print(
+                            "  Your local commits are still intact. Resolve the ref "
+                            "error, or reconcile manually with:\n"
+                            f"    git rebase origin/{branch}"
+                        )
+                        sys.exit(1)
+                    backup_ref = candidate_ref
+                    if local_only > 0:
+                        print(
+                            f"  ℹ Preserving {local_only} local commit(s) not on "
+                            f"origin/{branch} before resetting (backed up to {backup_ref})..."
+                        )
+                    else:
+                        print(
+                            f"  ℹ Could not determine how many local commits are not on "
+                            f"origin/{branch}; backing up HEAD to {backup_ref} before "
+                            "resetting, to be safe..."
+                        )
 
                 print(
                     "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
@@ -4324,19 +4354,32 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         text=True, encoding="utf-8", errors="replace",
                     )
                     if cherry_result.returncode == 0:
-                        print(
-                            f"  ✓ Reapplied {local_only} local commit(s) on top of the update."
-                        )
+                        # local_only is -1 when the earlier count failed; don't
+                        # render "-1 commit(s)" at the user in that case.
+                        if local_only > 0:
+                            print(
+                                f"  ✓ Reapplied {local_only} local commit(s) on top of the update."
+                            )
+                        else:
+                            print(
+                                "  ✓ Reapplied your local commit(s) on top of the update."
+                            )
                     else:
                         subprocess.run(
                             git_cmd + ["cherry-pick", "--abort"],
                             cwd=_m().PROJECT_ROOT,
                             capture_output=True,
                         )
-                        print(
-                            f"  ⚠ Could not automatically reapply your {local_only} local "
-                            "commit(s) — they conflict with the update."
-                        )
+                        if local_only > 0:
+                            print(
+                                f"  ⚠ Could not automatically reapply your {local_only} local "
+                                "commit(s) — they conflict with the update."
+                            )
+                        else:
+                            print(
+                                "  ⚠ Could not automatically reapply your local "
+                                "commit(s) — they conflict with the update."
+                            )
                         print(f"    Nothing is lost — they're saved at: {backup_ref}")
                         print(f"    Review them with: git log {backup_ref}")
                         print(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4365,20 +4365,42 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 "  ✓ Reapplied your local commit(s) on top of the update."
                             )
                     else:
-                        subprocess.run(
+                        # cherry-pick can fail for reasons other than a
+                        # conflict — a merge commit needing -m, an empty
+                        # commit, a bad ref. Don't assert a cause we did not
+                        # determine; surface git's own stderr instead.
+                        abort_result = subprocess.run(
                             git_cmd + ["cherry-pick", "--abort"],
                             cwd=_m().PROJECT_ROOT,
                             capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
                         )
-                        if local_only > 0:
+                        count = (
+                            f"your {local_only} local commit(s)"
+                            if local_only > 0
+                            else "your local commit(s)"
+                        )
+                        print(f"  ⚠ Could not automatically reapply {count}.")
+                        cherry_err = (cherry_result.stderr or "").strip()
+                        if cherry_err:
+                            for line in cherry_err.splitlines():
+                                print(f"    {line}")
+                        # A failed --abort leaves the working tree mid
+                        # cherry-pick. Saying nothing here would let the user
+                        # believe the tree is clean while it still carries
+                        # conflict markers and a CHERRY_PICK_HEAD.
+                        if abort_result.returncode != 0:
                             print(
-                                f"  ⚠ Could not automatically reapply your {local_only} local "
-                                "commit(s) — they conflict with the update."
+                                "    ✗ 'git cherry-pick --abort' also failed — this "
+                                "checkout is still mid-cherry-pick."
                             )
-                        else:
+                            abort_err = (abort_result.stderr or "").strip()
+                            if abort_err:
+                                for line in abort_err.splitlines():
+                                    print(f"      {line}")
                             print(
-                                "  ⚠ Could not automatically reapply your local "
-                                "commit(s) — they conflict with the update."
+                                "      Clean it up before using the checkout:\n"
+                                "        git cherry-pick --abort   # or: git cherry-pick --quit"
                             )
                         print(f"    Nothing is lost — they're saved at: {backup_ref}")
                         print(f"    Review them with: git log {backup_ref}")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4344,69 +4344,99 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
                 if backup_ref:
                     # HEAD now equals origin/{branch}; replay the preserved
-                    # commits on top. Best-effort — on any conflict, abort
-                    # cleanly and leave the backup ref in place rather than
-                    # leaving conflict markers in source files.
-                    cherry_result = subprocess.run(
-                        git_cmd + ["cherry-pick", f"HEAD..{backup_ref}"],
+                    # commits on top, ONE AT A TIME.
+                    #
+                    # A single ``cherry-pick HEAD..<ref>`` is all-or-nothing:
+                    # git stops at the first commit that will not apply and the
+                    # recovery path aborts the ENTIRE batch, so one stale commit
+                    # discards every other carried commit. Observed on a real
+                    # install: a 69-commit backup aborted on commit #1 — a
+                    # fork-local change whose upstream PR had since been closed
+                    # — and replayed nothing, leaving ten still-wanted fixes
+                    # reachable only from the backup ref. To the operator that
+                    # is indistinguishable from data loss, and it gets more
+                    # likely the longer a fork's divergence goes untended.
+                    #
+                    # Merge commits are excluded: cherry-pick refuses them
+                    # without -m, and their content arrives anyway via the
+                    # individual commits they merged.
+                    list_result = subprocess.run(
+                        git_cmd
+                        + ["rev-list", "--reverse", "--no-merges", f"HEAD..{backup_ref}"],
                         cwd=_m().PROJECT_ROOT,
                         capture_output=True,
                         text=True, encoding="utf-8", errors="replace",
                     )
-                    if cherry_result.returncode == 0:
-                        # local_only is -1 when the earlier count failed; don't
-                        # render "-1 commit(s)" at the user in that case.
-                        if local_only > 0:
-                            print(
-                                f"  ✓ Reapplied {local_only} local commit(s) on top of the update."
-                            )
-                        else:
-                            print(
-                                "  ✓ Reapplied your local commit(s) on top of the update."
-                            )
-                    else:
-                        # cherry-pick can fail for reasons other than a
-                        # conflict — a merge commit needing -m, an empty
-                        # commit, a bad ref. Don't assert a cause we did not
-                        # determine; surface git's own stderr instead.
-                        abort_result = subprocess.run(
-                            git_cmd + ["cherry-pick", "--abort"],
-                            cwd=_m().PROJECT_ROOT,
-                            capture_output=True,
+                    replay_shas = (
+                        list_result.stdout.split() if list_result.returncode == 0 else []
+                    )
+                    if list_result.returncode != 0:
+                        print(
+                            "  ⚠ Could not enumerate your local commits to reapply them."
+                        )
+                        list_err = (list_result.stderr or "").strip()
+                        for line in list_err.splitlines():
+                            print(f"    {line}")
+                        print(f"    Nothing is lost — they're saved at: {backup_ref}")
+                        print(f"    Reapply manually with: git cherry-pick HEAD..{backup_ref}")
+
+                    replayed: list[str] = []
+                    failed: list[tuple[str, str, str]] = []
+                    for sha in replay_shas:
+                        subject = subprocess.run(
+                            git_cmd + ["log", "-1", "--format=%s", sha],
+                            cwd=_m().PROJECT_ROOT, capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
+                        ).stdout.strip()
+                        pick = subprocess.run(
+                            git_cmd + ["cherry-pick", sha],
+                            cwd=_m().PROJECT_ROOT, capture_output=True,
                             text=True, encoding="utf-8", errors="replace",
                         )
-                        count = (
-                            f"your {local_only} local commit(s)"
-                            if local_only > 0
-                            else "your local commit(s)"
+                        if pick.returncode == 0:
+                            replayed.append(sha)
+                            continue
+                        detail = (pick.stderr or pick.stdout or "").strip().splitlines()
+                        failed.append(
+                            (sha[:9], subject, detail[0] if detail else "unknown error")
                         )
-                        print(f"  ⚠ Could not automatically reapply {count}.")
-                        cherry_err = (cherry_result.stderr or "").strip()
-                        if cherry_err:
-                            for line in cherry_err.splitlines():
-                                print(f"    {line}")
-                        # A failed --abort leaves the working tree mid
-                        # cherry-pick. Saying nothing here would let the user
-                        # believe the tree is clean while it still carries
-                        # conflict markers and a CHERRY_PICK_HEAD.
-                        if abort_result.returncode != 0:
-                            print(
-                                "    ✗ 'git cherry-pick --abort' also failed — this "
-                                "checkout is still mid-cherry-pick."
-                            )
-                            abort_err = (abort_result.stderr or "").strip()
-                            if abort_err:
-                                for line in abort_err.splitlines():
-                                    print(f"      {line}")
-                            print(
-                                "      Clean it up before using the checkout:\n"
-                                "        git cherry-pick --abort   # or: git cherry-pick --quit"
-                            )
-                        print(f"    Nothing is lost — they're saved at: {backup_ref}")
+                        # Roll back THIS commit only so the next one still gets
+                        # a chance. Escalate --abort -> --quit -> reset so a
+                        # wedged pick can never strand the loop mid-conflict
+                        # with markers left in the working tree.
+                        for recovery in (
+                            ["cherry-pick", "--abort"],
+                            ["cherry-pick", "--quit"],
+                            ["reset", "--hard", "HEAD"],
+                        ):
+                            if subprocess.run(
+                                git_cmd + recovery,
+                                cwd=_m().PROJECT_ROOT, capture_output=True,
+                                text=True, encoding="utf-8", errors="replace",
+                            ).returncode == 0:
+                                break
+
+                    if replayed:
+                        print(
+                            f"  ✓ Reapplied {len(replayed)} local commit(s) on top of the update."
+                        )
+                    if failed:
+                        print(
+                            f"  ⚠ {len(failed)} local commit(s) could not be reapplied "
+                            f"automatically{' (the others were)' if replayed else ''}:"
+                        )
+                        for short_sha, subject, reason in failed:
+                            print(f"    • {short_sha} {subject[:68]}")
+                            print(f"        {reason[:110]}")
+                        print(f"    Nothing is lost — all of them remain at: {backup_ref}")
                         print(f"    Review them with: git log {backup_ref}")
                         print(
-                            f"    Reapply manually with: git cherry-pick HEAD..{backup_ref}"
+                            "    Reapply one with: git cherry-pick <sha>  "
+                            "(resolve, then git cherry-pick --continue)"
                         )
+                    elif not replayed and replay_shas:
+                        print("  ⚠ No local commits were reapplied.")
+                        print(f"    They remain at: {backup_ref}")
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4267,8 +4267,33 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
+                # force-pushed or rebase, OR the local checkout has its own
+                # COMMITTED work ahead of origin). The stash above only covers
+                # uncommitted working-tree changes — a committed local fix
+                # shows up clean in `git status` and is NOT in that stash, so
+                # a bare `reset --hard origin/{branch}` here would silently
+                # destroy it with no warning and no way to recover it. Preserve
+                # any local-only commits to a backup ref before resetting, then
+                # try to replay them on top automatically.
+                local_only = _count_commits_between(
+                    git_cmd, _m().PROJECT_ROOT, f"origin/{branch}", "HEAD"
+                )
+                backup_ref = None
+                if local_only > 0:
+                    backup_ref = (
+                        f"refs/hermes-update-backups/{branch}-"
+                        f"{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+                    )
+                    subprocess.run(
+                        git_cmd + ["update-ref", backup_ref, "HEAD"],
+                        cwd=_m().PROJECT_ROOT,
+                        capture_output=True,
+                    )
+                    print(
+                        f"  ℹ Preserving {local_only} local commit(s) not on "
+                        f"origin/{branch} before resetting (backed up to {backup_ref})..."
+                    )
+
                 print(
                     "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
                 )
@@ -4286,6 +4311,37 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
                     )
                     sys.exit(1)
+
+                if backup_ref:
+                    # HEAD now equals origin/{branch}; replay the preserved
+                    # commits on top. Best-effort — on any conflict, abort
+                    # cleanly and leave the backup ref in place rather than
+                    # leaving conflict markers in source files.
+                    cherry_result = subprocess.run(
+                        git_cmd + ["cherry-pick", f"HEAD..{backup_ref}"],
+                        cwd=_m().PROJECT_ROOT,
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                    )
+                    if cherry_result.returncode == 0:
+                        print(
+                            f"  ✓ Reapplied {local_only} local commit(s) on top of the update."
+                        )
+                    else:
+                        subprocess.run(
+                            git_cmd + ["cherry-pick", "--abort"],
+                            cwd=_m().PROJECT_ROOT,
+                            capture_output=True,
+                        )
+                        print(
+                            f"  ⚠ Could not automatically reapply your {local_only} local "
+                            "commit(s) — they conflict with the update."
+                        )
+                        print(f"    Nothing is lost — they're saved at: {backup_ref}")
+                        print(f"    Review them with: git log {backup_ref}")
+                        print(
+                            f"    Reapply manually with: git cherry-pick HEAD..{backup_ref}"
+                        )
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3517,8 +3517,33 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
+                # force-pushed or rebase, OR the local checkout has its own
+                # COMMITTED work ahead of origin). The stash above only covers
+                # uncommitted working-tree changes — a committed local fix
+                # shows up clean in `git status` and is NOT in that stash, so
+                # a bare `reset --hard origin/{branch}` here would silently
+                # destroy it with no warning and no way to recover it. Preserve
+                # any local-only commits to a backup ref before resetting, then
+                # try to replay them on top automatically.
+                local_only = _count_commits_between(
+                    git_cmd, _m().PROJECT_ROOT, f"origin/{branch}", "HEAD"
+                )
+                backup_ref = None
+                if local_only > 0:
+                    backup_ref = (
+                        f"refs/hermes-update-backups/{branch}-"
+                        f"{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+                    )
+                    subprocess.run(
+                        git_cmd + ["update-ref", backup_ref, "HEAD"],
+                        cwd=_m().PROJECT_ROOT,
+                        capture_output=True,
+                    )
+                    print(
+                        f"  ℹ Preserving {local_only} local commit(s) not on "
+                        f"origin/{branch} before resetting (backed up to {backup_ref})..."
+                    )
+
                 print(
                     "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
                 )
@@ -3536,6 +3561,37 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
                     )
                     sys.exit(1)
+
+                if backup_ref:
+                    # HEAD now equals origin/{branch}; replay the preserved
+                    # commits on top. Best-effort — on any conflict, abort
+                    # cleanly and leave the backup ref in place rather than
+                    # leaving conflict markers in source files.
+                    cherry_result = subprocess.run(
+                        git_cmd + ["cherry-pick", f"HEAD..{backup_ref}"],
+                        cwd=_m().PROJECT_ROOT,
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                    )
+                    if cherry_result.returncode == 0:
+                        print(
+                            f"  ✓ Reapplied {local_only} local commit(s) on top of the update."
+                        )
+                    else:
+                        subprocess.run(
+                            git_cmd + ["cherry-pick", "--abort"],
+                            cwd=_m().PROJECT_ROOT,
+                            capture_output=True,
+                        )
+                        print(
+                            f"  ⚠ Could not automatically reapply your {local_only} local "
+                            "commit(s) — they conflict with the update."
+                        )
+                        print(f"    Nothing is lost — they're saved at: {backup_ref}")
+                        print(f"    Review them with: git log {backup_ref}")
+                        print(
+                            f"    Reapply manually with: git cherry-pick HEAD..{backup_ref}"
+                        )
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3615,20 +3615,42 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 "  ✓ Reapplied your local commit(s) on top of the update."
                             )
                     else:
-                        subprocess.run(
+                        # cherry-pick can fail for reasons other than a
+                        # conflict — a merge commit needing -m, an empty
+                        # commit, a bad ref. Don't assert a cause we did not
+                        # determine; surface git's own stderr instead.
+                        abort_result = subprocess.run(
                             git_cmd + ["cherry-pick", "--abort"],
                             cwd=_m().PROJECT_ROOT,
                             capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
                         )
-                        if local_only > 0:
+                        count = (
+                            f"your {local_only} local commit(s)"
+                            if local_only > 0
+                            else "your local commit(s)"
+                        )
+                        print(f"  ⚠ Could not automatically reapply {count}.")
+                        cherry_err = (cherry_result.stderr or "").strip()
+                        if cherry_err:
+                            for line in cherry_err.splitlines():
+                                print(f"    {line}")
+                        # A failed --abort leaves the working tree mid
+                        # cherry-pick. Saying nothing here would let the user
+                        # believe the tree is clean while it still carries
+                        # conflict markers and a CHERRY_PICK_HEAD.
+                        if abort_result.returncode != 0:
                             print(
-                                f"  ⚠ Could not automatically reapply your {local_only} local "
-                                "commit(s) — they conflict with the update."
+                                "    ✗ 'git cherry-pick --abort' also failed — this "
+                                "checkout is still mid-cherry-pick."
                             )
-                        else:
+                            abort_err = (abort_result.stderr or "").strip()
+                            if abort_err:
+                                for line in abort_err.splitlines():
+                                    print(f"      {line}")
                             print(
-                                "  ⚠ Could not automatically reapply your local "
-                                "commit(s) — they conflict with the update."
+                                "      Clean it up before using the checkout:\n"
+                                "        git cherry-pick --abort   # or: git cherry-pick --quit"
                             )
                         print(f"    Nothing is lost — they're saved at: {backup_ref}")
                         print(f"    Review them with: git log {backup_ref}")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1966,9 +1966,42 @@ function Install-Repository {
                     # reset to the fetched remote so bootstrap/install can recover.
                     git -c windows.appendAtomically=false pull --ff-only origin $Branch
                     if ($LASTEXITCODE -ne 0) {
+                        # The autostash above only covers working-tree changes.
+                        # Committed local-only work is invisible to it, and the
+                        # reset below destroys it with no warning and no way
+                        # back. Preserve it to a backup ref first -- same
+                        # contract as ``hermes update``.
+                        $localOnly = (git rev-list --count "origin/$Branch..HEAD" 2>$null)
+                        if ($LASTEXITCODE -ne 0 -or -not $localOnly) { $localOnly = -1 }
+                        $localOnly = [int]$localOnly
+                        $backupRef = $null
+                        # -1 means the count itself failed. Treat "unknown" as
+                        # "there may be something": the reset is unrecoverable,
+                        # so the only safe direction to fail is toward a backup
+                        # we may not need.
+                        if ($localOnly -ne 0) {
+                            $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+                            $backupRef = "refs/hermes-update-backups/$Branch-$stamp"
+                            git -c windows.appendAtomically=false update-ref $backupRef HEAD
+                            if ($LASTEXITCODE -ne 0) {
+                                # Never claim a backup we do not have, and never
+                                # run the destructive reset without one.
+                                throw "Could not create backup ref $backupRef for local commits; refusing to reset --hard. Your local commits are still intact -- reconcile manually with: git rebase origin/$Branch"
+                            }
+                            if ($localOnly -gt 0) {
+                                Write-Warn "Preserving $localOnly local commit(s) not on origin/$Branch (backed up to $backupRef)..."
+                            } else {
+                                Write-Warn "Could not determine how many local commits are not on origin/$Branch; backing up HEAD to $backupRef to be safe..."
+                            }
+                        }
                         Write-Warn "Fast-forward not possible; resetting managed install to origin/$Branch..."
                         git -c windows.appendAtomically=false reset --hard "origin/$Branch"
                         if ($LASTEXITCODE -ne 0) { throw "git reset --hard origin/$Branch failed (exit $LASTEXITCODE)" }
+                        if ($backupRef) {
+                            Write-Warn "Your previous commits are saved at: $backupRef"
+                            Write-Warn "  Review with:  git log $backupRef"
+                            Write-Warn "  Reapply with: git cherry-pick HEAD..$backupRef"
+                        }
                     }
                 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1550,9 +1550,42 @@ function Install-Repository {
                     # reset to the fetched remote so bootstrap/install can recover.
                     git -c windows.appendAtomically=false pull --ff-only origin $Branch
                     if ($LASTEXITCODE -ne 0) {
+                        # The autostash above only covers working-tree changes.
+                        # Committed local-only work is invisible to it, and the
+                        # reset below destroys it with no warning and no way
+                        # back. Preserve it to a backup ref first -- same
+                        # contract as ``hermes update``.
+                        $localOnly = (git rev-list --count "origin/$Branch..HEAD" 2>$null)
+                        if ($LASTEXITCODE -ne 0 -or -not $localOnly) { $localOnly = -1 }
+                        $localOnly = [int]$localOnly
+                        $backupRef = $null
+                        # -1 means the count itself failed. Treat "unknown" as
+                        # "there may be something": the reset is unrecoverable,
+                        # so the only safe direction to fail is toward a backup
+                        # we may not need.
+                        if ($localOnly -ne 0) {
+                            $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+                            $backupRef = "refs/hermes-update-backups/$Branch-$stamp"
+                            git -c windows.appendAtomically=false update-ref $backupRef HEAD
+                            if ($LASTEXITCODE -ne 0) {
+                                # Never claim a backup we do not have, and never
+                                # run the destructive reset without one.
+                                throw "Could not create backup ref $backupRef for local commits; refusing to reset --hard. Your local commits are still intact -- reconcile manually with: git rebase origin/$Branch"
+                            }
+                            if ($localOnly -gt 0) {
+                                Write-Warn "Preserving $localOnly local commit(s) not on origin/$Branch (backed up to $backupRef)..."
+                            } else {
+                                Write-Warn "Could not determine how many local commits are not on origin/$Branch; backing up HEAD to $backupRef to be safe..."
+                            }
+                        }
                         Write-Warn "Fast-forward not possible; resetting managed install to origin/$Branch..."
                         git -c windows.appendAtomically=false reset --hard "origin/$Branch"
                         if ($LASTEXITCODE -ne 0) { throw "git reset --hard origin/$Branch failed (exit $LASTEXITCODE)" }
+                        if ($backupRef) {
+                            Write-Warn "Your previous commits are saved at: $backupRef"
+                            Write-Warn "  Review with:  git log $backupRef"
+                            Write-Warn "  Reapply with: git cherry-pick HEAD..$backupRef"
+                        }
                     }
                 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1286,8 +1286,38 @@ clone_repo() {
             # cannot succeed — mirror ``hermes update`` and reset to the
             # fetched remote so bootstrap/install can recover.
             if ! git pull --ff-only origin "$BRANCH"; then
+                # The autostash above only covers working-tree changes.
+                # Committed local-only work is invisible to it, and the reset
+                # below destroys it with no warning and no way back. Preserve
+                # it to a backup ref first — same contract as ``hermes update``.
+                local local_only
+                local_only="$(git rev-list --count "origin/$BRANCH..HEAD" 2>/dev/null || echo -1)"
+                local backup_ref=""
+                # -1 means the count itself failed. Treat "unknown" as "there
+                # may be something": the reset is unrecoverable, so the only
+                # safe direction to fail is toward a backup we may not need.
+                if [ "$local_only" != "0" ]; then
+                    backup_ref="refs/hermes-update-backups/${BRANCH}-$(date +%Y%m%d-%H%M%S)"
+                    if ! git update-ref "$backup_ref" HEAD; then
+                        # Never claim a backup we do not have, and never run
+                        # the destructive reset without one.
+                        log_error "Could not create backup ref $backup_ref for local commits; refusing to reset --hard."
+                        log_error "Your local commits are still intact. Reconcile manually with: git rebase origin/$BRANCH"
+                        exit 1
+                    fi
+                    if [ "$local_only" -gt 0 ] 2>/dev/null; then
+                        log_warn "Preserving $local_only local commit(s) not on origin/$BRANCH (backed up to $backup_ref)..."
+                    else
+                        log_warn "Could not determine how many local commits are not on origin/$BRANCH; backing up HEAD to $backup_ref to be safe..."
+                    fi
+                fi
                 log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
                 git reset --hard "origin/$BRANCH"
+                if [ -n "$backup_ref" ]; then
+                    log_warn "Your previous commits are saved at: $backup_ref"
+                    log_warn "  Review with:  git log $backup_ref"
+                    log_warn "  Reapply with: git cherry-pick HEAD..$backup_ref"
+                fi
             fi
 
             if [ -n "$autostash_ref" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1250,8 +1250,38 @@ clone_repo() {
             # cannot succeed — mirror ``hermes update`` and reset to the
             # fetched remote so bootstrap/install can recover.
             if ! git pull --ff-only origin "$BRANCH"; then
+                # The autostash above only covers working-tree changes.
+                # Committed local-only work is invisible to it, and the reset
+                # below destroys it with no warning and no way back. Preserve
+                # it to a backup ref first — same contract as ``hermes update``.
+                local local_only
+                local_only="$(git rev-list --count "origin/$BRANCH..HEAD" 2>/dev/null || echo -1)"
+                local backup_ref=""
+                # -1 means the count itself failed. Treat "unknown" as "there
+                # may be something": the reset is unrecoverable, so the only
+                # safe direction to fail is toward a backup we may not need.
+                if [ "$local_only" != "0" ]; then
+                    backup_ref="refs/hermes-update-backups/${BRANCH}-$(date +%Y%m%d-%H%M%S)"
+                    if ! git update-ref "$backup_ref" HEAD; then
+                        # Never claim a backup we do not have, and never run
+                        # the destructive reset without one.
+                        log_error "Could not create backup ref $backup_ref for local commits; refusing to reset --hard."
+                        log_error "Your local commits are still intact. Reconcile manually with: git rebase origin/$BRANCH"
+                        exit 1
+                    fi
+                    if [ "$local_only" -gt 0 ] 2>/dev/null; then
+                        log_warn "Preserving $local_only local commit(s) not on origin/$BRANCH (backed up to $backup_ref)..."
+                    else
+                        log_warn "Could not determine how many local commits are not on origin/$BRANCH; backing up HEAD to $backup_ref to be safe..."
+                    fi
+                fi
                 log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
                 git reset --hard "origin/$BRANCH"
+                if [ -n "$backup_ref" ]; then
+                    log_warn "Your previous commits are saved at: $backup_ref"
+                    log_warn "  Review with:  git log $backup_ref"
+                    log_warn "  Reapply with: git cherry-pick HEAD..$backup_ref"
+                fi
             fi
 
             if [ -n "$autostash_ref" ]; then

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -348,6 +348,7 @@ def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
 
 def _make_divergence_side_effect(
     *, local_only_count="0", cherry_pick_fails=False,
+    local_only_count_fails=False, update_ref_fails=False,
 ):
     """subprocess.run side_effect for the ff-only-fails -> reset -> preserve
     -> cherry-pick flow. Distinguishes the two different rev-list calls by
@@ -369,6 +370,11 @@ def _make_divergence_side_effect(
         if "rev-list" in joined and "HEAD..origin" in joined:
             return SimpleNamespace(stdout="3\n", stderr="", returncode=0)
         if "rev-list" in joined and "origin/main..HEAD" in joined:
+            if local_only_count_fails:
+                # _count_commits_between returns -1 for this.
+                return SimpleNamespace(
+                    stdout="", stderr="fatal: bad revision\n", returncode=128,
+                )
             return SimpleNamespace(stdout=f"{local_only_count}\n", stderr="", returncode=0)
         if "--ff-only" in joined:
             return SimpleNamespace(
@@ -376,6 +382,10 @@ def _make_divergence_side_effect(
                 returncode=128,
             )
         if "update-ref" in joined:
+            if update_ref_fails:
+                return SimpleNamespace(
+                    stdout="", stderr="fatal: cannot lock ref\n", returncode=128,
+                )
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "reset" in joined and "--hard" in joined:
             return SimpleNamespace(stdout="HEAD is now at abc123\n", stderr="", returncode=0)
@@ -471,3 +481,67 @@ def test_cmd_update_skips_backup_when_no_local_commits_diverged(monkeypatch, tmp
     calls = [" ".join(str(c) for c in cmd) for cmd in recorded]
     assert not any("update-ref" in c for c in calls)
     assert not any("cherry-pick" in c for c in calls)
+
+
+def test_cmd_update_backs_up_when_local_commit_count_is_unknown(monkeypatch, tmp_path, capsys):
+    """If the local-only commit count itself fails, the reset must still be
+    preceded by a backup ref. _count_commits_between returns -1 on error, and
+    the old `if local_only > 0` guard silently skipped the backup -- letting
+    `reset --hard` destroy exactly the commits this code exists to protect."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
+
+    side_effect, recorded = _make_divergence_side_effect(local_only_count_fails=True)
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+    monkeypatch.setattr(hermes_main, "_validate_critical_files_syntax", lambda root: (True, None, None))
+    monkeypatch.setattr(hermes_main, "_venv_core_imports_healthy", lambda: (True, ""))
+    monkeypatch.setattr(hermes_main, "_resume_windows_gateways_after_update", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_finish_dashboard_update_cleanup", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(hermes_main, "_build_web_ui", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_install_python_dependencies_with_optional_fallback", lambda *a, **kw: None)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    calls = [" ".join(str(c) for c in cmd) for cmd in recorded]
+    backup_idx = next(i for i, c in enumerate(calls) if "update-ref" in c)
+    reset_idx = next(i for i, c in enumerate(calls) if "reset --hard" in c)
+    assert backup_idx < reset_idx, "backup ref must be created before the hard reset"
+
+    out = capsys.readouterr().out
+    assert "Could not determine how many local commits" in out
+    # never render the -1 sentinel at the user
+    assert "-1 local commit" not in out
+
+
+def test_cmd_update_aborts_when_backup_ref_cannot_be_created(monkeypatch, tmp_path, capsys):
+    """If `git update-ref` fails, the destructive reset must NOT run. Previously
+    the return code was unchecked, so the code claimed 'backed up to <ref>' and
+    then reset --hard anyway, losing the commits it said it had saved."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
+
+    side_effect, recorded = _make_divergence_side_effect(
+        local_only_count="2", update_ref_fails=True,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+    monkeypatch.setattr(hermes_main, "_validate_critical_files_syntax", lambda root: (True, None, None))
+    monkeypatch.setattr(hermes_main, "_venv_core_imports_healthy", lambda: (True, ""))
+    monkeypatch.setattr(hermes_main, "_resume_windows_gateways_after_update", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_finish_dashboard_update_cleanup", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(hermes_main, "_build_web_ui", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_install_python_dependencies_with_optional_fallback", lambda *a, **kw: None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        hermes_main.cmd_update(SimpleNamespace())
+    assert excinfo.value.code == 1
+
+    calls = [" ".join(str(c) for c in cmd) for cmd in recorded]
+    assert not any("reset --hard" in c for c in calls), (
+        "must not reset --hard when the backup ref could not be created"
+    )
+
+    out = capsys.readouterr().out
+    assert "Could not create backup ref" in out
+    assert "still intact" in out

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -349,6 +349,8 @@ def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
 def _make_divergence_side_effect(
     *, local_only_count="0", cherry_pick_fails=False,
     local_only_count_fails=False, update_ref_fails=False,
+    replay_shas=("aaaaaaaaa1", "bbbbbbbbb2"), failing_shas=(),
+    replay_list_fails=False,
 ):
     """subprocess.run side_effect for the ff-only-fails -> reset -> preserve
     -> cherry-pick flow. Distinguishes the two different rev-list calls by
@@ -389,10 +391,24 @@ def _make_divergence_side_effect(
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "reset" in joined and "--hard" in joined:
             return SimpleNamespace(stdout="HEAD is now at abc123\n", stderr="", returncode=0)
-        if "cherry-pick" in joined and "--abort" in joined:
+        # The replay enumerates the preserved commits and picks them ONE AT A
+        # TIME, so a single unappliable commit cannot discard the rest.
+        if "rev-list" in joined and "--no-merges" in joined:
+            if replay_list_fails:
+                return SimpleNamespace(
+                    stdout="", stderr="fatal: bad revision\n", returncode=128,
+                )
+            return SimpleNamespace(
+                stdout="\n".join(replay_shas) + ("\n" if replay_shas else ""),
+                stderr="", returncode=0,
+            )
+        if "log" in joined and "--format=%s" in joined:
+            return SimpleNamespace(stdout="carried commit subject\n", stderr="", returncode=0)
+        if "cherry-pick" in joined and ("--abort" in joined or "--quit" in joined):
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "cherry-pick" in joined:
-            if cherry_pick_fails:
+            picked = cmd[-1]
+            if cherry_pick_fails or picked in failing_shas:
                 return SimpleNamespace(
                     stdout="", stderr="error: could not apply ...\nCONFLICT\n", returncode=1,
                 )
@@ -422,11 +438,17 @@ def test_cmd_update_preserves_and_reapplies_local_commits_on_reset(monkeypatch, 
 
     calls = [" ".join(str(c) for c in cmd) for cmd in recorded]
     update_ref_calls = [c for c in calls if "update-ref" in c]
-    cherry_pick_calls = [c for c in calls if "cherry-pick" in c and "--abort" not in c]
+    cherry_pick_calls = [
+        c for c in calls
+        if "cherry-pick" in c and "--abort" not in c and "--quit" not in c
+    ]
     assert len(update_ref_calls) == 1
     assert "refs/hermes-update-backups/main-" in update_ref_calls[0]
-    assert len(cherry_pick_calls) == 1
-    assert "HEAD..refs/hermes-update-backups/main-" in cherry_pick_calls[0]
+    # One pick PER COMMIT, not a single all-or-nothing range pick.
+    assert len(cherry_pick_calls) == 2
+    assert cherry_pick_calls[0].endswith("aaaaaaaaa1")
+    assert cherry_pick_calls[1].endswith("bbbbbbbbb2")
+    assert not any("HEAD..refs/hermes-update-backups/" in c for c in cherry_pick_calls)
 
     out = capsys.readouterr().out
     assert "Preserving 2 local commit(s)" in out
@@ -455,9 +477,58 @@ def test_cmd_update_cherry_pick_conflict_leaves_backup_ref_and_prints_recovery(m
     assert any("cherry-pick --abort" in c for c in calls)
 
     out = capsys.readouterr().out
-    assert "Could not automatically reapply your 1 local" in out
+    assert "could not be reapplied" in out
     assert "refs/hermes-update-backups/main-" in out
-    assert "git cherry-pick HEAD..refs/hermes-update-backups/main-" in out
+    assert "git cherry-pick <sha>" in out
+    # Every failing commit is named, so the operator knows exactly what to
+    # replay by hand instead of being told only that "something" failed.
+    assert "carried commit subject" in out
+
+
+def test_cmd_update_replays_remaining_commits_when_one_conflicts(monkeypatch, tmp_path, capsys):
+    """One unappliable commit must not discard the others.
+
+    Regression test for the all-or-nothing replay: a single
+    ``cherry-pick HEAD..<backup_ref>`` stopped at the first bad commit and the
+    recovery path aborted the whole batch, so one stale commit (e.g. a
+    fork-local change whose upstream PR was later closed) silently cost every
+    other carried commit. Observed on a real install with a 69-commit backup
+    that replayed zero commits.
+    """
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
+
+    # Three preserved commits; the MIDDLE one cannot be applied.
+    side_effect, recorded = _make_divergence_side_effect(
+        local_only_count="3",
+        replay_shas=("aaaaaaaaa1", "bbbbbbbbb2", "ccccccccc3"),
+        failing_shas=("bbbbbbbbb2",),
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+    monkeypatch.setattr(hermes_main, "_validate_critical_files_syntax", lambda root: (True, None, None))
+    monkeypatch.setattr(hermes_main, "_venv_core_imports_healthy", lambda: (True, ""))
+    monkeypatch.setattr(hermes_main, "_resume_windows_gateways_after_update", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_finish_dashboard_update_cleanup", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(hermes_main, "_build_web_ui", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_install_python_dependencies_with_optional_fallback", lambda *a, **kw: None)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    calls = [" ".join(str(c) for c in cmd) for cmd in recorded]
+    picks = [
+        c for c in calls
+        if "cherry-pick" in c and "--abort" not in c and "--quit" not in c
+    ]
+    # All three were attempted -- the loop did not stop at the failure.
+    assert len(picks) == 3
+    assert picks[2].endswith("ccccccccc3")
+
+    out = capsys.readouterr().out
+    assert "Reapplied 2 local commit(s)" in out       # the two good ones landed
+    assert "1 local commit(s) could not be reapplied" in out
+    assert "bbbbbbbb" in out                          # the bad one is named
+    assert "refs/hermes-update-backups/main-" in out
 
 
 def test_cmd_update_skips_backup_when_no_local_commits_diverged(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -337,3 +337,137 @@ def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
         assert (pkg / "hermes-agent.rb").read_text() == "formula\n"
     finally:
         os.chmod(pkg, 0o755)
+
+
+# ---------------------------------------------------------------------------
+# reset --hard on diverged history must not silently discard local COMMITS
+# (as opposed to uncommitted changes, which the autostash above already
+# covers). A committed local fix shows up clean in `git status` and was
+# never protected by the stash -- it needs its own preserve-and-reapply path.
+# ---------------------------------------------------------------------------
+
+def _make_divergence_side_effect(
+    *, local_only_count="0", cherry_pick_fails=False,
+):
+    """subprocess.run side_effect for the ff-only-fails -> reset -> preserve
+    -> cherry-pick flow. Distinguishes the two different rev-list calls by
+    range direction: "HEAD..origin/<branch>" is the pre-existing "how many
+    new commits" check; "origin/<branch>..HEAD" is this fix's "how many
+    local-only commits would the reset destroy" check.
+    """
+    recorded = []
+
+    def side_effect(cmd, **kwargs):
+        recorded.append(list(cmd))
+        joined = " ".join(str(c) for c in cmd)
+        if "fetch" in joined and "origin" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rev-parse" in joined and "--abbrev-ref" in joined:
+            return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if "checkout" in joined and "main" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rev-list" in joined and "HEAD..origin" in joined:
+            return SimpleNamespace(stdout="3\n", stderr="", returncode=0)
+        if "rev-list" in joined and "origin/main..HEAD" in joined:
+            return SimpleNamespace(stdout=f"{local_only_count}\n", stderr="", returncode=0)
+        if "--ff-only" in joined:
+            return SimpleNamespace(
+                stdout="", stderr="fatal: Not possible to fast-forward, aborting.\n",
+                returncode=128,
+            )
+        if "update-ref" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "reset" in joined and "--hard" in joined:
+            return SimpleNamespace(stdout="HEAD is now at abc123\n", stderr="", returncode=0)
+        if "cherry-pick" in joined and "--abort" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "cherry-pick" in joined:
+            if cherry_pick_fails:
+                return SimpleNamespace(
+                    stdout="", stderr="error: could not apply ...\nCONFLICT\n", returncode=1,
+                )
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return side_effect, recorded
+
+
+def test_cmd_update_preserves_and_reapplies_local_commits_on_reset(monkeypatch, tmp_path, capsys):
+    """Local commits ahead of origin get backed up before the hard reset and
+    cleanly reapplied on top afterward -- the fix's happy path."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
+
+    side_effect, recorded = _make_divergence_side_effect(local_only_count="2")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+    monkeypatch.setattr(hermes_main, "_validate_critical_files_syntax", lambda root: (True, None, None))
+    monkeypatch.setattr(hermes_main, "_venv_core_imports_healthy", lambda: (True, ""))
+    monkeypatch.setattr(hermes_main, "_resume_windows_gateways_after_update", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_finish_dashboard_update_cleanup", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(hermes_main, "_build_web_ui", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_install_python_dependencies_with_optional_fallback", lambda *a, **kw: None)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    calls = [" ".join(str(c) for c in cmd) for cmd in recorded]
+    update_ref_calls = [c for c in calls if "update-ref" in c]
+    cherry_pick_calls = [c for c in calls if "cherry-pick" in c and "--abort" not in c]
+    assert len(update_ref_calls) == 1
+    assert "refs/hermes-update-backups/main-" in update_ref_calls[0]
+    assert len(cherry_pick_calls) == 1
+    assert "HEAD..refs/hermes-update-backups/main-" in cherry_pick_calls[0]
+
+    out = capsys.readouterr().out
+    assert "Preserving 2 local commit(s)" in out
+    assert "Reapplied 2 local commit(s)" in out
+
+
+def test_cmd_update_cherry_pick_conflict_leaves_backup_ref_and_prints_recovery(monkeypatch, tmp_path, capsys):
+    """A conflicting reapply aborts cleanly and points at the backup ref --
+    nothing is lost, no conflict markers are left in the tree."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
+
+    side_effect, recorded = _make_divergence_side_effect(local_only_count="1", cherry_pick_fails=True)
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+    monkeypatch.setattr(hermes_main, "_validate_critical_files_syntax", lambda root: (True, None, None))
+    monkeypatch.setattr(hermes_main, "_venv_core_imports_healthy", lambda: (True, ""))
+    monkeypatch.setattr(hermes_main, "_resume_windows_gateways_after_update", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_finish_dashboard_update_cleanup", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(hermes_main, "_build_web_ui", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_install_python_dependencies_with_optional_fallback", lambda *a, **kw: None)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    calls = [" ".join(str(c) for c in cmd) for cmd in recorded]
+    assert any("cherry-pick --abort" in c for c in calls)
+
+    out = capsys.readouterr().out
+    assert "Could not automatically reapply your 1 local" in out
+    assert "refs/hermes-update-backups/main-" in out
+    assert "git cherry-pick HEAD..refs/hermes-update-backups/main-" in out
+
+
+def test_cmd_update_skips_backup_when_no_local_commits_diverged(monkeypatch, tmp_path, capsys):
+    """A pure remote-side divergence (e.g. upstream rebase) with zero local
+    commits ahead must not create a backup ref -- nothing local to lose."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr(hermes_main, "_stash_local_changes_if_needed", lambda *a, **kw: None)
+
+    side_effect, recorded = _make_divergence_side_effect(local_only_count="0")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+    monkeypatch.setattr(hermes_main, "_validate_critical_files_syntax", lambda root: (True, None, None))
+    monkeypatch.setattr(hermes_main, "_venv_core_imports_healthy", lambda: (True, ""))
+    monkeypatch.setattr(hermes_main, "_resume_windows_gateways_after_update", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_finish_dashboard_update_cleanup", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(hermes_main, "_build_web_ui", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_install_python_dependencies_with_optional_fallback", lambda *a, **kw: None)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    calls = [" ".join(str(c) for c in cmd) for cmd in recorded]
+    assert not any("update-ref" in c for c in calls)
+    assert not any("cherry-pick" in c for c in calls)


### PR DESCRIPTION
## What changed and why

When \`hermes update\`'s \`git merge --ff-only origin/<branch>\` fails because local history has diverged from origin, the fallback path does \`git reset --hard origin/<branch>\` with no check for local-only **commits**. The autostash earlier in the same flow (\`_stash_local_changes_if_needed\`) only covers uncommitted working-tree changes — a committed local fix shows up clean in \`git status\` and was never protected by it.

Confirmed on a real install: a genuine, tested local fix landed as a commit, then a later \`hermes update\` run hit exactly this path and silently reset it away — no warning, no log entry, nothing recoverable. The bug the fix addressed then quietly reappeared, with no indication the fix had ever been reverted.

## The fix

Before the hard reset, if local \`HEAD\` has commits \`origin/<branch>\` doesn't (checked via the existing \`_count_commits_between\` helper, already used elsewhere in this file for the fork-sync path), save them to \`refs/hermes-update-backups/<branch>-<timestamp>\` via \`git update-ref\`. After the reset, attempt \`git cherry-pick HEAD..<backup_ref>\` to replay them automatically:
- Clean replay → prints confirmation, done.
- Conflict → \`cherry-pick --abort\` cleanly (no conflict markers left in source files) and prints the backup ref plus exact recovery commands.
- No local-only commits → no backup ref is created at all, zero behavior change for the common case.

\`hermes update\` will never again silently destroy a local-only commit on this path — worst case it tells you exactly where the work is and how to get it back.

## How to test

\`pytest tests/hermes_cli/test_update_autostash.py -k "preserves_and_reapplies or cherry_pick_conflict or skips_backup_when_no_local"\` — three new regression tests cover: (1) local commits ahead of origin are backed up and cleanly reapplied, (2) a conflicting reapply aborts cleanly and reports the backup ref with recovery instructions, (3) a pure remote-side divergence with zero local commits creates no backup ref.

Manual repro: make a local commit on \`main\`, let origin advance independently (or simulate via a second local branch merged back), run \`hermes update\` — before this fix, the commit vanishes silently; after, it survives (either auto-reapplied or preserved at a named ref).

## What platforms tested

Windows 11 (native, Git for Windows). The bug and fix are platform-agnostic (pure git plumbing, no OS-specific code paths) — the underlying \`git merge --ff-only\` / \`git reset --hard\` / \`git cherry-pick\` behavior is identical on macOS/Linux.

## Related

No existing issue or PR covers this (searched via \`gh search prs\`/\`gh search issues\` per CONTRIBUTING.md's search-first guidance before opening). Full test suite (\`tests/hermes_cli/test_update_autostash.py\`, \`tests/cli/test_update_command.py\`, \`tests/gateway/test_update_command.py\`) passes except one pre-existing, unrelated failure (\`test_fallback_when_no_setsid\`, confirmed to fail identically on current \`main\` before this change).