### PR TITLE
Fix Groq rejection of synthesized extra_body fields

### DIFF
--- a/plugins/model-providers/groq/__init__.py
+++ b/plugins/model-providers/groq/__init__.py
@@ -1,0 +1,56 @@
+"""Groq provider profile.
+
+Groq's OpenAI-compatible endpoint"""
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class GroqProfile(ProviderProfile):
+    """Groq profile: clamp reasoning to top-level "none"/"default" and
+    avoid emitting any Ollama or nested-reasoning fields.
+    """
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **ctx: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Return (extra_body_additions, top_level_kwargs).
+
+        - If `reasoning_config` is absent: omit both fields (let Groq use its default).
+        - If `enabled` is False or effort == "none": set reasoning_effort = "none".
+        - Otherwise: set reasoning_effort = "default" (Groq only accepts "default"/"none").
+        - Never emit `extra_body.think` or a nested `reasoning` object.
+        """
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if reasoning_config and isinstance(reasoning_config, dict):
+            _enabled = reasoning_config.get("enabled", True)
+            _raw_effort = (reasoning_config.get("effort") or "").strip().lower()
+
+            if _enabled is False or _raw_effort == "none":
+                top_level["reasoning_effort"] = "none"
+            else:
+
+                top_level["reasoning_effort"] = "default"
+
+        return extra_body, top_level
+
+
+groq = GroqProfile(
+    name="groq",
+    aliases=("api.groq.com",),
+    display_name="Groq",
+    description="Groq — OpenAI-compatible endpoint",
+    signup_url="https://www.groq.ai/",
+    env_vars=("GROQ_API_KEY", "GROQ_BASE_URL"),
+    base_url="https://api.groq.com/openai/v1",
+    auth_type="api_key",
+)
+
+register_provider(groq)

--- a/plugins/model-providers/groq/plugin.yaml
+++ b/plugins/model-providers/groq/plugin.yaml
@@ -1,0 +1,5 @@
+name: groq-provider
+kind: model-provider
+version: 1.0.0
+description: Groq
+author: Nous Research


### PR DESCRIPTION
## What does this PR do?

Groq was unusable as a main or auxiliary provider. Because there is no `groq` entry in `plugins/model-providers/` so I added it and fixed 



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->
[https://github.com/NousResearch/hermes-agent/issues/75089](url)
Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ✅] 🐛 Bug fix (non-breaking change that fixes an issue)


## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

Groq is now recognized as a model provider.

