### PR TITLE
fix(desktop): reseed stale manual model pick on cold-boot empty catalog

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient } from '@tanstack/react-query'
 import { cleanup, render, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getGlobalModelInfo } from '@/hermes'
+import { getGlobalModelInfo, getGlobalModelOptions } from '@/hermes'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
@@ -33,6 +33,7 @@ function deferred<T>() {
 
 vi.mock('@/hermes', () => ({
   getGlobalModelInfo: vi.fn(),
+  getGlobalModelOptions: vi.fn(),
   setApiRequestProfile: vi.fn(),
   setGlobalModel: (...args: Parameters<typeof setGlobalModel>) => setGlobalModel(...args)
 }))
@@ -116,6 +117,74 @@ describe('useModelControls', () => {
     expect($currentModel.get()).toBe('openai/gpt-5.5')
     expect($currentProvider.get()).toBe('openai-codex')
     expect(getCurrentModelSource()).toBe('default')
+  })
+
+  it('reseeds a stale manual pick to the default when the catalog cache is empty (cold boot)', async () => {
+    // Reproduces the voice-404 bug: after a cache wipe the model-options cache is
+    // EMPTY, so the conservative manualPickRemoved guard kept a since-delisted
+    // pick (tencent/hy3:free) and every new chat 404'd. With an empty cache the
+    // hook must fetch a fresh catalog, confirm the model is gone, and reseed from
+    // the profile default (kimi-k3).
+    setCurrentModel('tencent/hy3:free')
+    setCurrentProvider('nous')
+    setCurrentModelSource('manual')
+    // NOTE: no queryClient.setQueryData -> the catalog cache is empty (cold boot).
+
+    // Fresh catalog: provider present but no longer shipping the delisted model.
+    vi.mocked(getGlobalModelOptions).mockResolvedValue({
+      model: 'moonshotai/kimi-k3',
+      provider: 'openrouter',
+      providers: [{ name: 'Nous', slug: 'nous', models: ['hermes-4'] }]
+    })
+    // The default to fall back to.
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'moonshotai/kimi-k3',
+      provider: 'openrouter'
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    await result.current.refreshCurrentModel()
+
+    expect(getGlobalModelOptions).toHaveBeenCalled()
+    expect($currentModel.get()).toBe('moonshotai/kimi-k3')
+    expect($currentProvider.get()).toBe('openrouter')
+    expect(getCurrentModelSource()).toBe('default')
+  })
+
+  it('keeps a valid manual pick when the fresh catalog still lists it (cold boot)', async () => {
+    setCurrentModel('hermes-4')
+    setCurrentProvider('nous')
+    setCurrentModelSource('manual')
+
+    vi.mocked(getGlobalModelOptions).mockResolvedValue({
+      model: 'moonshotai/kimi-k3',
+      provider: 'openrouter',
+      providers: [{ name: 'Nous', slug: 'nous', models: ['hermes-4'] }]
+    })
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({
+      model: 'moonshotai/kimi-k3',
+      provider: 'openrouter'
+    })
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    await result.current.refreshCurrentModel()
+
+    // Still in the catalog -> the user's pick survives; default is NOT applied.
+    expect($currentModel.get()).toBe('hermes-4')
+    expect($currentProvider.get()).toBe('nous')
+    expect(getCurrentModelSource()).toBe('manual')
   })
 
   it('does not clobber the active session footer state with global model info', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -5,7 +5,7 @@ import type { ModelSelection } from '@/app/shell/model-menu-panel'
 import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
-import { manualPickRemoved, modelOptionsQueryKey } from '@/lib/model-options'
+import { manualPickRemoved, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
@@ -118,6 +118,41 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
 
         if (keepManualPick()) {
           return
+        }
+
+        // Cold-boot fix (#voice-404): on a fresh launch / cache wipe the
+        // model-options cache is EMPTY, so manualPickRemoved above conservatively
+        // returned false and a stale persisted pick (e.g. a since-delisted free
+        // model) was kept — every new chat then 404'd. When the pick is manual
+        // and the cache has no providers, fetch a fresh catalog and re-check:
+        // if the model is confirmed gone, fall through and reseed from the
+        // profile default (kimi-k3); if still present (or the fetch fails),
+        // keep the pick.
+        if (!force && $currentModel.get() && getCurrentModelSource() === 'manual') {
+          const cached = queryClient.getQueryData<ModelOptionsResponse>(
+            modelOptionsQueryKey($activeGatewayProfile.get())
+          )
+
+          if (!cached?.providers?.length) {
+            try {
+              const fresh = await requestModelOptions({})
+
+              queryClient.setQueryData(
+                modelOptionsQueryKey($activeGatewayProfile.get()),
+                fresh
+              )
+
+              if (!manualPickRemoved(fresh?.providers, $currentProvider.get(), $currentModel.get())) {
+                // Model verified still in the catalog — keep the user's pick.
+                return
+              }
+              // else: confirmed delisted -> fall through to reseed from default.
+            } catch {
+              // Catalog fetch failed (offline / re-auth): conservatively keep the
+              // pick rather than clobber a possibly-valid selection.
+              return
+            }
+          }
         }
 
         // Snapshot the selection generation before awaiting so a picker click


### PR DESCRIPTION
## Summary
When the model-options cache is empty (fresh launch or an Electron cache wipe), `keepManualPick()` in `use-model-controls.ts` could not verify a persisted **manual** model pick: `manualPickRemoved()` deliberately returns `false` on an unloaded catalog, so a since-delisted model (e.g. a removed `:free` variant) was kept — and every new chat then 404'd. In practice this made voice/chat inputs silently return nothing after a cache reset.

## Fix
When the pick is manual and the catalog cache has no providers, fetch a fresh catalog via `requestModelOptions({})` and re-check:
- model confirmed removed → fall through and reseed from the profile default
- model still present (or the fetch fails) → keep the user's pick (conservative, never clobbers a valid selection)

## Test plan
- Added two regression tests in `use-model-controls.test.tsx`: cold-boot stale pick reseeds to default; cold-boot still-valid pick is preserved.
- `npx tsc -p . --noEmit` clean; `npm run build` succeeds.
- Note: 9 tests in this file already fail on pristine `main` (pre-existing `getCurrentModelSource()` jsdom/dual-instance harness flake, unrelated to this change).