### PR TITLE
fix(kimi): use hermes-cli User-Agent instead of impersonating Claude Code (#74739)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1147,8 +1147,9 @@ def init_agent(
 
                 client_kwargs["default_headers"] = copilot_default_headers()
             elif base_url_host_matches(effective_base, "api.kimi.com"):
+                from hermes_cli import __version__ as _hermes_ver
                 client_kwargs["default_headers"] = {
-                    "User-Agent": "claude-code/0.1.0",
+                    "User-Agent": f"hermes-cli/{_hermes_ver}",
                 }
             elif base_url_host_matches(effective_base, "portal.qwen.ai"):
                 client_kwargs["default_headers"] = _ra()._qwen_portal_headers()

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -845,12 +845,12 @@ def build_anthropic_client(
     )
 
     if _is_kimi_coding_endpoint(base_url):
-        # Kimi's /coding endpoint requires User-Agent: claude-code/0.1.0
-        # to be recognized as a valid Coding Agent. Without it, returns 403.
+        # Kimi's /coding endpoint requires a valid User-Agent.
         # Check this BEFORE _requires_bearer_auth since both match api.kimi.com/coding.
+        from hermes_cli import __version__ as _hermes_ver
         kwargs["api_key"] = api_key
         kwargs["default_headers"] = {
-            "User-Agent": "claude-code/0.1.0",
+            "User-Agent": f"hermes-cli/{_hermes_ver}",
             **( {"anthropic-beta": ",".join(common_betas)} if common_betas else {} )
         }
     elif _requires_bearer_auth(normalized_base_url):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2082,7 +2082,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                     return GeminiNativeClient(api_key=api_key, base_url=base_url), model
             extra = {}
             if base_url_host_matches(base_url, "api.kimi.com"):
-                extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+                extra["default_headers"] = {"User-Agent": f"hermes-cli/{_HERMES_VERSION}"}
             elif base_url_host_matches(base_url, "githubcopilot.com"):
                 from hermes_cli.models import copilot_default_headers
 
@@ -2122,7 +2122,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 return GeminiNativeClient(api_key=api_key, base_url=base_url), model
         extra = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
-            extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+            extra["default_headers"] = {"User-Agent": f"hermes-cli/{_HERMES_VERSION}"}
         elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.models import copilot_default_headers
 
@@ -5098,7 +5098,7 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
             is_agent_turn=True, is_vision=is_vision
         )
     elif base_url_host_matches(sync_base_url, "api.kimi.com"):
-        async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+        async_kwargs["default_headers"] = {"User-Agent": f"hermes-cli/{_HERMES_VERSION}"}
     elif base_url_host_matches(sync_base_url, "integrate.api.nvidia.com"):
         async_kwargs["default_headers"] = build_nvidia_nim_headers(sync_base_url)
     elif base_url_host_matches(sync_base_url, "x.ai"):
@@ -5462,7 +5462,7 @@ def resolve_provider_client(
             if _dq:
                 extra["default_query"] = _dq
             if base_url_host_matches(custom_base, "api.kimi.com"):
-                extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+                extra["default_headers"] = {"User-Agent": f"hermes-cli/{_HERMES_VERSION}"}
             elif base_url_host_matches(custom_base, "githubcopilot.com"):
                 from hermes_cli.copilot_auth import copilot_request_headers
                 extra["default_headers"] = copilot_request_headers(
@@ -5719,7 +5719,7 @@ def resolve_provider_client(
         # Provider-specific headers
         headers = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
-            headers["User-Agent"] = "claude-code/0.1.0"
+            headers["User-Agent"] = f"hermes-cli/{_HERMES_VERSION}"
         elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.copilot_auth import copilot_request_headers
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2283,7 +2283,8 @@ def run_doctor(args):
                 "User-Agent": _HERMES_USER_AGENT,
             }
             if base_url_host_matches(base, "api.kimi.com"):
-                headers["User-Agent"] = "claude-code/0.1.0"
+                # Kimi: keep the hermes-cli User-Agent (no impersonation)
+                pass
             # Google's Generative Language API (generativelanguage.googleapis.com)
             # rejects ``Authorization: Bearer <api-key>`` with 401
             # ``ACCESS_TOKEN_TYPE_UNSUPPORTED`` — that header is reserved for

--- a/run_agent.py
+++ b/run_agent.py
@@ -5251,7 +5251,7 @@ class AIAgent:
 
             self._client_kwargs["default_headers"] = copilot_default_headers()
         elif base_url_host_matches(base_url, "api.kimi.com"):
-            self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+            self._client_kwargs["default_headers"] = {"User-Agent": f"hermes-cli/{_HERMES_VERSION}"}
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):


### PR DESCRIPTION
## Summary

Fixes #74739.

Hermes injected `User-Agent: claude-code/0.1.0` for requests to Kimi endpoints (`api.kimi.com`). This identifies Hermes as a different product.

Kimi's documentation requires third-party tools to preserve their real client identity and warns that altering the User-Agent may result in suspension of membership benefits. The current default is a compliance and account-risk bug for Kimi Code users.

## Fix

Replace the hardcoded Claude Code identity with the proper Hermes identity (`hermes-cli/<version>`) across all 5 affected files:

| File | Change |
|------|--------|
| `agent/agent_init.py` | `claude-code/0.1.0` → `hermes-cli/{version}` (local import) |
| `agent/anthropic_adapter.py` | `claude-code/0.1.0` → `hermes-cli/{version}` (local import) |
| `agent/auxiliary_client.py` | 2 call sites: `claude-code/0.1.0` → `hermes-cli/{_HERMES_VERSION}` |
| `hermes_cli/doctor.py` | Remove Kimi override (default `_HERMES_USER_AGENT` is already correct) |
| `run_agent.py` | `claude-code/0.1.0` → `hermes-cli/{_HERMES_VERSION}` |

Zero `claude-code/0.1.0` references remain in the codebase after this change.

## Testing

- `rg -n 'claude-code/0\.1\.0' agent hermes_cli run_agent.py` returns 0 matches
- All 5 modified files pass `py_compile`
- Existing Kimi-related tests continue to pass
