### PR TITLE
fix(providers): add Groq provider profile to prevent rejected request fields

### DIFF
--- a/plugins/model-providers/groq/__init__.py
+++ b/plugins/model-providers/groq/__init__.py
@@ -1,0 +1,68 @@
+"""Groq provider profile.
+
+Groq's OpenAI-compatible API (api.groq.com) rejects fields that the generic
+``custom`` profile emits:
+
+  - ``extra_body.think``  → 400 "property 'think' is unsupported"
+  - ``extra_body.reasoning``  → 400 "property 'reasoning' is unsupported"
+
+Groq accepts only a top-level ``reasoning_effort`` of ``"none"`` or
+``"default"``.  This profile overrides :meth:`build_api_kwargs_extras` so
+that reasoning control uses the correct wire shape and the generic
+``extra_body.reasoning`` fallback in ``_build_call_kwargs`` is suppressed.
+
+Ref: https://github.com/NousResearch/hermes-agent/issues/75089
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class GroqProfile(ProviderProfile):
+    """Groq — top-level reasoning_effort only, no think/reasoning body."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **ctx: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if not isinstance(reasoning_config, dict):
+            return extra_body, top_level
+
+        enabled = reasoning_config.get("enabled", True)
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+
+        if enabled is False or effort == "none":
+            # Groq only accepts "none" or "default" for reasoning_effort.
+            top_level["reasoning_effort"] = "none"
+        elif effort:
+            # Map non-standard effort levels to Groq's "default".
+            # Groq does not support low/medium/high/max — only "default".
+            top_level["reasoning_effort"] = "default"
+        # If enabled but no effort set, omit so the server default applies.
+
+        return extra_body, top_level
+
+
+groq = GroqProfile(
+    name="groq",
+    env_vars=("GROQ_API_KEY",),
+    display_name="Groq",
+    description="Groq — fast inference on LPU hardware",
+    signup_url="https://console.groq.com/",
+    fallback_models=(
+        "llama-3.3-70b-versatile",
+        "mixtral-8x7b-32768",
+    ),
+    base_url="https://api.groq.com/openai/v1",
+)
+
+register_provider(groq)

--- a/plugins/model-providers/groq/plugin.yaml
+++ b/plugins/model-providers/groq/plugin.yaml
@@ -1,0 +1,5 @@
+name: groq-provider
+kind: model-provider
+version: 1.0.0
+description: Groq
+author: Nous Research

--- a/tests/providers/test_groq_profile.py
+++ b/tests/providers/test_groq_profile.py
@@ -1,0 +1,54 @@
+"""Tests for the Groq provider profile."""
+from providers import get_provider_profile
+
+
+class TestGroqProfile:
+    def test_discovery(self):
+        p = get_provider_profile("groq")
+        assert p is not None
+        assert p.name == "groq"
+
+    def test_base_url(self):
+        p = get_provider_profile("groq")
+        assert "groq.com" in p.base_url
+
+    def test_env_vars(self):
+        p = get_provider_profile("groq")
+        assert "GROQ_API_KEY" in p.env_vars
+
+    def test_disabled_reasoning_sends_none(self):
+        """Groq accepts only 'none' or 'default' for reasoning_effort."""
+        p = get_provider_profile("groq")
+        eb, tl = p.build_api_kwargs_extras(reasoning_config={"enabled": False})
+        assert "think" not in eb, "extra_body must not contain 'think'"
+        assert "reasoning" not in eb, "extra_body must not contain 'reasoning'"
+        assert tl["reasoning_effort"] == "none"
+
+    def test_effort_none_explicit(self):
+        p = get_provider_profile("groq")
+        eb, tl = p.build_api_kwargs_extras(reasoning_config={"effort": "none"})
+        assert tl["reasoning_effort"] == "none"
+        assert eb == {}
+
+    def test_enabled_with_effort_sends_default(self):
+        """Groq only supports 'none' or 'default' — map any effort to 'default'."""
+        p = get_provider_profile("groq")
+        for effort in ("low", "medium", "high", "max", "ultra"):
+            eb, tl = p.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort}
+            )
+            assert tl["reasoning_effort"] == "default", f"effort={effort}"
+            assert eb == {}, f"extra_body must be empty for effort={effort}"
+
+    def test_enabled_no_effort_omits_field(self):
+        """When enabled but no effort set, omit so server default applies."""
+        p = get_provider_profile("groq")
+        eb, tl = p.build_api_kwargs_extras(reasoning_config={"enabled": True})
+        assert "reasoning_effort" not in tl
+        assert eb == {}
+
+    def test_none_config_is_noop(self):
+        p = get_provider_profile("groq")
+        eb, tl = p.build_api_kwargs_extras(reasoning_config=None)
+        assert eb == {}
+        assert tl == {}


### PR DESCRIPTION
## Summary

Adds a Groq provider profile so that Groq's OpenAI-compatible API (`api.groq.com`) receives only the wire fields it accepts.

Without this profile, Groq falls through to the generic `custom` profile which emits:
- `extra_body.think = False` → HTTP 400 "property 'think' is unsupported"
- `extra_body.reasoning = {...}` (from `_build_call_kwargs` fallback) → HTTP 400 "property 'reasoning' is unsupported"

These failures are intermittent — they only fire on turns that trigger auxiliary calls (compression, title generation, approval), making the bug particularly misleading.

## Changes

- **New file**: `plugins/model-providers/groq/__init__.py` — `GroqProfile` class that overrides `build_api_kwargs_extras` to use only Groq's native top-level `reasoning_effort` field (`"none"` or `"default"`), suppressing both rejected body fields.
- **New file**: `plugins/model-providers/groq/plugin.yaml` — plugin metadata.

## How it works

The profile's `build_api_kwargs_extras` returns:
- `extra_body = {}` (empty — no `think` or `reasoning` fields)
- `top_level = {"reasoning_effort": "none"}` or `{"reasoning_effort": "default"}`

Because the profile overrides `build_api_kwargs_extras`, the `profile_handles_reasoning` check in `_build_call_kwargs` (auxiliary_client.py:7367) is `True`, which suppresses the generic `extra_body.reasoning` fallback at line 7385-7394.

## Test plan

- [ ] Configure Groq as a custom provider and verify no 400 errors on normal conversation turns
- [ ] Verify auxiliary calls (compression, title generation) succeed without "property 'think' is unsupported"
- [ ] Verify `reasoning_effort: "none"` is sent when reasoning is disabled
- [ ] Verify `reasoning_effort: "default"` is sent when reasoning is enabled with an effort level

Fixes #75089