### PR TITLE
fix(cli): probe sys.executable for venv health check on Termux (#75148)

### DIFF
--- a/docs/changelog-21a118cb.md
+++ b/docs/changelog-21a118cb.md
@@ -1,0 +1,1 @@
+# Changelog - docs: changelog entry for PR 75161

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11111,14 +11111,29 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     the user's install stays broken no matter how many times they update
     (ryanc's incident, July 2026).
 
+    On Termux (Android) Hermes runs from the system Python with packages
+    installed system-wide rather than inside a project venv.  In that case
+    the health check probes the interpreter that is actually executing
+    Hermes (``sys.executable``) instead of the project venv, avoiding the
+    false-negative "Venv still unhealthy" loop reported in #75148.
+
     Returns ``(healthy, detail)``. Never raises; unknown states report
     healthy so a probe failure can't force needless reinstalls.
     """
+    is_termux = bool(
+        os.environ.get("TERMUX_VERSION") or "com.termux/files/usr" in os.environ.get("PREFIX", "")
+    )
+
     venv_dir = PROJECT_ROOT / "venv"
     python_name = "python.exe" if _is_windows() else "python"
     bin_dir = "Scripts" if _is_windows() else "bin"
     venv_python = venv_dir / bin_dir / python_name
-    if not venv_python.exists():
+
+    # On Termux the packages live in the system Python, not the project
+    # venv.  Probe the interpreter that is actually executing Hermes.
+    if is_termux:
+        probe_python = sys.executable
+    elif not venv_python.exists():
         # No venv interpreter at all. In a dev checkout that's normal (the
         # dev may run hermes from any interpreter), so report healthy to
         # avoid forcing reinstalls. But on a MANAGED install (the Windows
@@ -11134,6 +11149,8 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
         if any(m.exists() for m in managed_markers):
             return False, f"venv python missing ({venv_python})"
         return True, ""
+    else:
+        probe_python = str(venv_python)
 
     # Core web/serve imports plus their newest transitive deps. Import (not
     # just metadata) — a package can have intact dist-info but a missing
@@ -11149,7 +11166,7 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     )
     try:
         result = subprocess.run(
-            [str(venv_python), "-c", check],
+            [probe_python, "-c", check],
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             timeout=60,

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -119,6 +119,70 @@ def test_venv_health_probe_failure_reports_healthy(tmp_path):
     assert healthy is True
 
 
+def test_venv_health_termux_uses_sys_executable(tmp_path):
+    """On Termux the health check must probe sys.executable (system Python)
+    instead of the project venv, since packages are installed system-wide
+    and the venv may be absent or empty (#75148)."""
+    _fake_venv_python(tmp_path)
+
+    fake = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main.sys, "executable", "/data/data/com.termux/files/usr/bin/python"
+    ) as patched_exec, patch.dict(cli_main.os.environ, {"TERMUX_VERSION": "0.118.0"}, clear=False), patch.object(
+        cli_main.subprocess, "run", return_value=fake
+    ) as mock_run:
+        healthy, detail = cli_main._venv_core_imports_healthy()
+
+    # Must have probed sys.executable, not venv_python
+    assert healthy is True
+    call_args = mock_run.call_args[0][0]
+    assert call_args[0] == patched_exec
+
+
+def test_venv_health_termux_reports_missing_imports_via_sys_executable(tmp_path):
+    """On Termux, a genuinely broken import should still be reported, but
+    probed via sys.executable."""
+    _fake_venv_python(tmp_path)
+
+    fake = SimpleNamespace(
+        returncode=0,
+        stdout="fastapi: No module named 'fastapi'\\n",
+        stderr="",
+    )
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main.sys, "executable", "/data/data/com.termux/files/usr/bin/python"
+    ) as patched_exec, patch.dict(cli_main.os.environ, {"TERMUX_VERSION": "0.118.0"}, clear=False), patch.object(
+        cli_main.subprocess, "run", return_value=fake
+    ) as mock_run:
+        healthy, detail = cli_main._venv_core_imports_healthy()
+
+    assert healthy is False
+    assert "fastapi" in detail
+    call_args = mock_run.call_args[0][0]
+    assert call_args[0] == patched_exec
+
+
+def test_venv_health_non_termux_uses_venv_python(tmp_path):
+    """On non-Termux systems the health check must still probe the project
+    venv python, not sys.executable."""
+    _fake_venv_python(tmp_path)
+
+    fake = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    venv_python_path = str(tmp_path / "venv" / "bin" / "python")
+
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main.subprocess, "run", return_value=fake
+    ) as mock_run:
+        healthy, detail = cli_main._venv_core_imports_healthy()
+
+    assert healthy is True
+    call_args = mock_run.call_args[0][0]
+    assert call_args[0] == venv_python_path
+
+
 # ---------------------------------------------------------------------------
 # _detect_venv_python_processes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

修复 #75148: Termux 环境下 `hermes update` 始终报告 "Venv still unhealthy"，即使所有依赖已正确安装。

## 根因分析

`_venv_core_imports_healthy()` 始终探测 `PROJECT_ROOT/venv/bin/python` 来检查核心依赖是否安装。但在 Termux（Android）环境下，Hermes 从系统 Python 运行，依赖包安装在系统级别而非项目 venv 中。因此健康检查探测了一个不存在或空的 venv 解释器，产生误报。

## 修复方式

在 `_venv_core_imports_healthy()` 中增加 Termux 环境检测（`TERMUX_VERSION` 或 `com.termux/files/usr` 路径）。当检测到 Termux 时，使用 `sys.executable`（实际运行 Hermes 的解释器）进行健康检查探针，而非硬编码的项目 venv 路径。非 Termux 环境行为完全不变。

## 验证

- [x] 新增 3 个回归测试通过（全部 21 个测试通过）
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更

Closes #75148