### PR TITLE
fix(process_registry): release Popen/PTY handles when a session finishes

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -458,6 +458,99 @@ class TestPruning:
         assert total <= MAX_PROCESSES
 
 
+class TestFinishedHandleRelease:
+    """Finished sessions must release their Popen/PTY OS handles immediately.
+
+    Regression for the "file descriptor limit" symptom: a finished-but-
+    unpruned session previously kept its Popen stdout pipe (or PTY master)
+    FD open until the finished-process TTL (FINISHED_TTL_SECONDS) elapsed.
+    Under heavy background churn the gateway could exhaust its FD limit even
+    though the registry never rejects spawns (it prunes oldest-finished at
+    MAX_PROCESSES instead) — the symptom was a retained-handle leak, not a
+    registry-cap rejection. poll()/wait()/read_log() serve from the buffered
+    output_buffer, never from the pipe, so closing the handles at finish is
+    lossless.
+    """
+
+    def test_move_to_finished_closes_popen_pipes(self, registry):
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(0.2)"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+        )
+        session = _make_session(sid="proc_handle_close", exited=False)
+        session.process = proc
+        registry._running[session.id] = session
+
+        assert proc.stdout is not None
+        assert not proc.stdout.closed
+
+        # Simulate the reader loop finishing (process exits, EOF drained).
+        proc.wait(timeout=5)
+        session.exited = True
+        session.exit_code = proc.returncode
+        session.completion_reason = "exited"
+        registry._move_to_finished(session)
+
+        assert session.id in registry._finished
+        assert proc.stdout.closed, "finished session must release its stdout pipe FD"  # type: ignore[union-attr]
+
+    def test_move_to_finished_closes_pty(self, registry):
+        """PTY-backed sessions release the PTY master on finish too."""
+        pty_closed = {"closed": False}
+
+        class _FakePty:
+            def close(self):
+                pty_closed["closed"] = True
+
+        session = _make_session(sid="proc_pty_close", exited=True)
+        session._pty = _FakePty()
+        registry._finished[session.id] = session
+
+        registry._move_to_finished(session)
+        assert pty_closed["closed"]
+
+    def test_move_to_finished_safe_without_handles(self, registry):
+        """Env-backed / detached sessions have no local Popen or PTY; the
+        release must be a no-op, not a crash."""
+        session = _make_session(sid="proc_no_handles", exited=True)
+        registry._finished[session.id] = session
+        registry._move_to_finished(session)  # must not raise
+        assert session.id in registry._finished
+
+    def test_poll_still_serves_output_after_handle_release(self, registry):
+        """Output remains queryable after the pipes close — poll() reads the
+        buffered output, never the (now-closed) pipe."""
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "print('hello-finish'); import time; time.sleep(0.2)"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            text=True,
+        )
+        session = _make_session(sid="proc_poll_after_close", exited=False)
+        session.process = proc
+        registry._running[session.id] = session
+
+        # Drain output like the reader loop would.
+        proc.wait(timeout=5)
+        try:
+            tail = proc.stdout.read() if proc.stdout else ""
+        except ValueError:
+            tail = ""
+        session.output_buffer = tail or ""
+        session.exited = True
+        session.exit_code = proc.returncode
+        session.completion_reason = "exited"
+        registry._move_to_finished(session)
+
+        assert proc.stdout.closed
+        result = registry.poll("proc_poll_after_close")
+        assert result["status"] == "exited"
+        assert "hello-finish" in result["output_preview"]
+
+
 # =========================================================================
 # Spawn env sanitization
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1149,6 +1149,16 @@ class ProcessRegistry:
         with self._lock:
             was_running = self._running.pop(session.id, None) is not None
             self._finished[session.id] = session
+        # The reader thread has drained the pipe at this point (EOF reached
+        # before _move_to_finished runs). Release the retained Popen/PTY
+        # handles now so finished sessions stop holding OS file descriptors —
+        # otherwise every finished-but-unpruned session keeps its stdout pipe
+        # (or PTY master) FD open until the finished-process TTL elapses, and
+        # heavy background churn can exhaust the gateway's FD limit.
+        # poll()/wait()/read_log() serve output from the buffered
+        # ``output_buffer``, never from the pipe, so closing the handles here
+        # is lossless.
+        self._release_finished_handles(session)
         session._completion_event.set()
         self._write_checkpoint()
 
@@ -1172,6 +1182,31 @@ class ProcessRegistry:
                 # based on which watcher notices exit first.
                 "started_at": session.started_at,
             })
+
+    def _release_finished_handles(self, session: ProcessSession):
+        """Close a finished session's OS handles (Popen pipes / PTY master).
+
+        Best-effort and idempotent: the session may have no local Popen (env
+        backends, detached recovery), or the handles may already be closed by
+        the reader loop / kill path. Closing a Popen's stream objects does not
+        kill anything — the child has already exited — it only releases the
+        parent's pipe FDs, which is exactly the retained-resource leak.
+        """
+        proc = getattr(session, "process", None)
+        if proc is not None:
+            for stream_name in ("stdout", "stderr", "stdin"):
+                stream = getattr(proc, stream_name, None)
+                if stream is not None:
+                    try:
+                        stream.close()
+                    except Exception:
+                        pass
+        pty = getattr(session, "_pty", None)
+        if pty is not None:
+            try:
+                pty.close()
+            except Exception:
+                pass
 
     # ----- Query Methods -----
 


### PR DESCRIPTION
## Bug

Background processes that finish keep their OS file descriptors open until the finished-process TTL (30 min by default) elapses. Under heavy background churn the gateway process can exhaust its file descriptor budget, and new `terminal(background=true)` spawns start failing with a "file descriptor limit" style error.

The registry **never rejects spawns** — every spawn path calls `_prune_if_needed()` first and evicts the oldest finished entry at `MAX_PROCESSES` (64). The real defect is the **retained-handle leak**, not a registry-cap rejection.

## The broken code

`tools/process_registry.py`, `_move_to_finished()`:

```python
def _move_to_finished(self, session: ProcessSession):
    with self._lock:
        was_running = self._running.pop(session.id, None) is not None
        self._finished[session.id] = session
    session._completion_event.set()
    self._write_checkpoint()
    ...
```

It moves the session to `_finished` but **never closes the handles**:
- Local spawns store a live `subprocess.Popen` on `session.process` with `stdout=PIPE` (spawn at ~line 801-815) — the parent's read-end pipe FD stays open.
- PTY spawns store a live `ptyprocess.PtyProcess` on `session._pty` (spawn at ~line 757-766) — the PTY master FD stays open.
- `_prune_if_needed()` (line 1914) deletes the dict entry but does not close the handles either.

So a finished session holds 1+ pipe/PTY FDs for the entire `FINISHED_TTL_SECONDS` window. 64 finished sessions × 1-2 FDs each can push a launchd-spawned gateway (typically a 256-FD soft limit) over the edge.

## How it was found

1. A user reported the error: *"The system has hit a file descriptor limit from all the background processes tracked in this session."* A gateway restart cleared it; nothing else did.
2. Reviewing `tools/process_registry.py` showed `MAX_PROCESSES` never blocks spawns — `_prune_if_needed()` evicts oldest-finished before insert. So the registry-count rationale was wrong; the symptom pointed at retained handles instead.
3. Confirmed the leak: `_move_to_finished()` and `_prune_if_needed()` move/delete session records without touching `session.process` (Popen) or `session._pty` (PtyProcess). The pipes were only released when the dict entry finally disappeared AND GC ran — i.e. after the TTL.
4. Wrote the failing test first (red on `main`): `tests/tools/test_process_registry.py::TestFinishedHandleRelease` — `proc.stdout.closed` stays `False` after finish on `main`.

## Reproduction

```bash
# From repo root (needs a python3 venv with pytest; run_tests.sh preferred in CI)
scripts/run_tests.sh tests/tools/test_process_registry.py::TestFinishedHandleRelease -q
# 3 of 4 tests FAIL on main — finished sessions still hold their pipe/PTY FDs
```

Or manually:

```python
import subprocess, sys, time
from tools.process_registry import ProcessRegistry, ProcessSession

reg = ProcessRegistry()
proc = subprocess.Popen([sys.executable, "-c", "print('x')"],
                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
s = ProcessSession(id="s1", command="x", task_id="t", started_at=time.time())
s.process = proc
proc.wait(timeout=5)
reg._running[s.id] = s
reg._move_to_finished(s)
print(proc.stdout.closed)  # False on main (leak) — True with the fix
```

## Fix

`_move_to_finished()` now calls `_release_finished_handles(session)`, which closes the session's `Popen` stdout/stderr/stdin streams and PTY master — right after the reader loop has drained EOF. This is lossless:

- `poll()` / `wait()` / `read_log()` serve output from the buffered `session.output_buffer` — they never touch the pipe after finish.
- `kill_process()` / `write_stdin()` / `send_eof()` early-return on `session.exited` before touching handles.
- Sessions without a local Popen (env backends, detached recovery) are a safe no-op.

## Tests

4 new cases in `TestFinishedHandleRelease`:
- `test_move_to_finished_closes_popen_pipes` — stdout pipe FD released at finish (red on main)
- `test_move_to_finished_closes_pty` — PTY master released (red on main)
- `test_move_to_finished_safe_without_handles` — env/detached sessions don't crash
- `test_poll_still_serves_output_after_handle_release` — buffered output still queryable after close (red on main)

## Related

The finished-process TTL is independently being made configurable in #75144 (retention knob for how long finished output stays queryable) — that PR does not include this handle-release fix; the two are complementary.
