### PR TITLE
fix(discord): route synthetic TTS to bound voice channel

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18324,6 +18324,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and hasattr(adapter, "is_in_voice_channel")
                     and adapter.is_in_voice_channel(guild_id)):
                 await adapter.play_in_voice_channel(guild_id, actual_path)
+            elif (
+                event.source.platform == Platform.DISCORD
+                and adapter
+                and callable(discord_play_tts := getattr(adapter, "play_tts", None))
+            ):
+                # Internal completion/watch events are synthetic and have no
+                # raw Discord message, so _get_guild_id(event) returns None even
+                # while the adapter still has a live text-channel -> VC binding.
+                # Let DiscordAdapter.play_tts() resolve that binding by chat_id
+                # before it falls back to a native audio attachment.
+                reply_anchor = self._reply_anchor_for_event(event)
+                thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+                if thread_meta is not None:
+                    thread_meta = dict(thread_meta)
+                    thread_meta["notify"] = True
+                else:
+                    thread_meta = {"notify": True}
+                await cast(Any, discord_play_tts)(
+                    chat_id=event.source.chat_id,
+                    audio_path=actual_path,
+                    reply_to=reply_anchor,
+                    metadata=thread_meta,
+                )
             elif adapter and hasattr(adapter, "send_voice"):
                 reply_anchor = self._reply_anchor_for_event(event)
                 thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -52,6 +52,40 @@ class TestAutoVoiceReplyFormat:
         adapter.send_voice.assert_awaited_once()
         assert adapter.send_voice.await_args.kwargs["audio_path"].endswith(".ogg")
 
+    @pytest.mark.asyncio
+    async def test_discord_synthetic_event_uses_adapter_voice_channel_routing(self, tmp_path):
+        """Completion events without raw_message must not become attachments.
+
+        Background completion/watch events are synthetic, so they have no raw
+        Discord message and therefore no guild_id. DiscordAdapter still knows
+        the text-channel -> voice-channel binding and resolves it in play_tts().
+        """
+        runner = _make_runner()
+        adapter = _make_adapter(Platform.DISCORD)
+        adapter.is_in_voice_channel = MagicMock(return_value=False)
+        adapter.play_tts = AsyncMock()
+        runner.adapters[Platform.DISCORD] = adapter
+        event = _make_event(Platform.DISCORD, chat_id="123")
+        assert getattr(event, "raw_message", None) is None
+
+        audio_path = tmp_path / "synthetic-discord-reply.mp3"
+
+        def fake_tts(*, text, output_path):
+            audio_path.write_bytes(b"fake mp3")
+            return json.dumps({
+                "success": True,
+                "file_path": str(audio_path),
+                "provider": "test",
+                "voice_compatible": False,
+            })
+
+        with patch("tools.tts_tool.text_to_speech_tool", side_effect=fake_tts):
+            await runner._send_voice_reply(event, "background task complete")
+
+        adapter.play_tts.assert_awaited_once()
+        assert adapter.play_tts.await_args.kwargs["chat_id"] == event.source.chat_id
+        adapter.send_voice.assert_not_awaited()
+
     def test_should_send_voice_reply_streamed_global_auto_tts_fires(self):
         """Streamed reply + global voice.auto_tts (no /voice opt-in) sends voice.
 


### PR DESCRIPTION
## Summary

- Synthetic background completion/watch events have `raw_message=None`, so the previous runner path cannot recover a Discord `guild_id` and falls back to sending an audio attachment.
- Route this Discord fallback through `adapter.play_tts(chat_id, ...)`, which reuses the adapter’s existing text-channel → voice-channel binding and plays in the connected voice channel when available.
- Preserve the normal raw-message path: events with a guild ID still use the existing direct voice-channel playback branch.
- Add regression coverage for a synthetic Discord event and keep the generic attachment fallback when no voice binding is available.

## Testing

- `python -m pytest -q tests/gateway/test_auto_voice_reply_format.py tests/gateway/test_voice_command.py tests/gateway/test_discord_voice_mixer.py tests/gateway/test_discord_opus.py` — 82 passed, 1 skipped (2 pre-existing AsyncMock warnings)
- `python -m py_compile gateway/run.py tests/gateway/test_auto_voice_reply_format.py`
- `ruff check gateway/run.py tests/gateway/test_auto_voice_reply_format.py`
- `git diff --check upstream/main...HEAD`