### PR TITLE
fix(buzz): stop answering mentions addressed to another agent

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1009,7 +1009,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # In shared channels, respond only when addressed — unless
         # require_mention is disabled, in which case respond to every message.
         # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
+        if not is_dm and self.require_mention and not self._is_addressed(event, content):
             return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
@@ -1112,8 +1112,47 @@ class BuzzAdapter(BasePlatformAdapter):
         self._channel_names.setdefault(channel_id, "DM")
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
 
+    def _is_addressed(self, event: dict, content: str) -> bool:
+        """True when this agent should treat a channel message as directed at it.
+
+        The text gate stays authoritative for dispatch: Buzz resolves ``@Name``
+        into the mentioned member's pubkey, so a genuine mention is visible in
+        the content. What the ``p`` tags add is the ability to reject a *false*
+        text match — when a message addresses somebody else and merely happens
+        to contain this agent's name.
+
+        Without that, an agent named "Hermes" answers any message containing
+        the word "hermes", including one aimed at a different bot and prose
+        that only discusses Hermes. With several agents in one channel the
+        wrong one replies.
+
+        A message whose ``p`` tags exist but exclude us was addressed to
+        somebody else, so it is dropped. Everything else falls through to the
+        existing text check, which keeps clients or relays that omit mention
+        tags working exactly as before.
+        """
+        if not self._is_mentioned(content):
+            return False
+        if not self._self_pubkey:
+            return True
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return True
+        p_tags = [
+            str(tag[1]).lower()
+            for tag in tags
+            if isinstance(tag, (list, tuple)) and len(tag) > 1 and tag[0] == "p"
+        ]
+        if not p_tags:
+            return True
+        return self._self_pubkey in p_tags
+
     def _is_mentioned(self, content: str) -> bool:
-        """True when the message addresses this agent (npub, hex, or name)."""
+        """True when the message text names this agent (npub, hex, or name).
+
+        Text-only heuristic — see ``_is_addressed`` for the gate that should
+        drive dispatch decisions.
+        """
         lowered = content.lower()
         if self._self_pubkey and self._self_pubkey in lowered:
             return True

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -243,6 +243,68 @@ class TestMentionGating:
         await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
         assert len(adapter._dispatched) == 1
 
+    @pytest.mark.asyncio
+    async def test_mention_of_another_agent_is_not_hijacked(self, adapter):
+        """A message addressed to a different agent must not dispatch here.
+
+        Buzz resolves ``@Name`` to that member's pubkey and p-tags it. Gating on
+        the text alone means an agent named "Chip" answers anything containing
+        the word "chip" — including a question aimed at another bot. With
+        several agents in one channel the wrong one replies.
+        """
+        await self._poll_with(
+            adapter,
+            _tagged_event(
+                "e1",
+                CHANNEL,
+                content="@OtherBot does Chip support this?",
+                p=OTHER_PUBKEY,
+                created_at=10,
+            ),
+        )
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_p_tagged_mention_dispatches(self, adapter):
+        await self._poll_with(
+            adapter,
+            _tagged_event("e1", CHANNEL, content="@Chip hello", p=SELF_PUBKEY, created_at=10),
+        )
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_multi_mention_including_self_dispatches(self, adapter):
+        """Addressed alongside another agent still counts as addressed."""
+        event = _tagged_event(
+            "e1", CHANNEL, content="@OtherBot @Chip compare notes", p=OTHER_PUBKEY, created_at=10
+        )
+        event["tags"].append(["p", SELF_PUBKEY])
+        await self._poll_with(adapter, event)
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_name_in_prose_without_p_tags_still_dispatches(self, adapter):
+        """Fallback for relays/clients that do not emit mention p-tags."""
+        await self._poll_with(adapter, _event("e1", content="@Chip status?", created_at=10))
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_p_tags_never_widen_the_gate(self, adapter):
+        """A p-tag alone does not dispatch — the text gate still has to pass.
+
+        Guards the obvious over-correction: treating "p-tagged to me" as
+        sufficient would make every thread reply that tags us a dispatch.
+        ``_channel_meta`` marks this as a real channel so the DM-latch path
+        (which legitimately dispatches un-mentioned p-tagged messages) cannot
+        mask the gate being tested here.
+        """
+        adapter._channel_meta[CHANNEL] = {"name": "announcements", "description": ""}
+        await self._poll_with(
+            adapter,
+            _tagged_event("e1", CHANNEL, content="thanks everyone", p=SELF_PUBKEY, created_at=10),
+        )
+        assert adapter._dispatched == []
+
 
     @pytest.mark.asyncio
     async def test_allowlist_blocks_unauthorized(self, adapter):


### PR DESCRIPTION
## What

The Buzz channel mention gate decided "am I being addressed?" by matching the agent's display name against the message text:

```python
pattern = rf"(?<!\w)@?{re.escape(self._display_name.lower())}(?!\w)"
```

Any message containing that word dispatched a turn. An agent named Hermes answered a question aimed at a different bot, and ordinary prose about Hermes triggered it too.

Buzz resolves `@Name` into the mentioned member's pubkey and emits it as a `p` tag, so the event already records who was addressed. When a message carries `p` tags and none of them is ours, it was meant for somebody else and now gets dropped.

## Reproduced live

Two agents in one channel: `ResearchBot` (Buzz-managed) and a native gateway agent named `Hermes`. The message was addressed to ResearchBot:

```
@ResearchBot Nous Research offers Hermes Cloud via Nous Portal, which allows
users to provision Hermes Agent via VPS. how can i connect a Hermes Cloud agent to buzz?
```

Tags: `[["h", <channel>], ["p", <ResearchBot pubkey>]]`

The gateway answered it, because "Hermes" appears three times in the text. Running the old predicate against that content returns `True` on three separate substrings. `what is hermes?` and `I use Hermes daily` also return `True`.

## Scope

The change only narrows dispatch, never widens it. The text gate runs first and a `p` tag alone is still not sufficient, so:

- thread replies that `p`-tag us without naming us behave exactly as before
- the DM-latch path in `_maybe_latch_dm` / `_is_direct_message_event` is untouched
- events with no `p` tags fall through to the existing text check, so relays or clients that omit mention tags are unaffected

I hit that last point the hard way. My first version treated "p-tagged to me" as sufficient, which broke `test_channel_like_metadata_blocks_latch_even_without_mention` by dispatching un-mentioned p-tagged messages in real channels. The committed version keeps the text check authoritative and uses `p` tags only to reject false matches. `test_p_tags_never_widen_the_gate` locks that in.

## Tests

Five cases in `tests/gateway/test_buzz_adapter.py`, using the existing `_tagged_event` helper:

```
test_mention_of_another_agent_is_not_hijacked      the bug
test_p_tagged_mention_dispatches                   normal mention
test_multi_mention_including_self_dispatches       @Other @Chip
test_name_in_prose_without_p_tags_still_dispatches fallback preserved
test_p_tags_never_widen_the_gate                   over-correction guard
```

```
$ pytest tests/gateway -k buzz -q
33 passed, 2 skipped

# adapter reverted, tests kept
$ pytest tests/gateway/test_buzz_adapter.py -q
1 failed, 27 passed
FAILED TestMentionGating::test_mention_of_another_agent_is_not_hijacked
```

## Note

This only affects the native gateway platform (`plugins/platforms/buzz/`). It shows up as soon as a second agent shares a channel, and it gets worse the more common the agent's name is as an English word.
