### PR TITLE
fix(update): remove stale .git/shallow.lock before fetch (#75133)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1974,6 +1974,21 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     )
     depth_args = ["--depth", "1"] if is_shallow else []
 
+    # Remove stale .git/shallow.lock left by interrupted updates (#75133).
+    # A previous git fetch that was killed mid-flight (network timeout,
+    # app force-close, system sleep) leaves this lock file behind.  The
+    # next fetch then fails with "Unable to create '.git/shallow.lock':
+    # File exists", which the GUI misinterprets as a concurrent process
+    # and traps the user in an unrecoverable update loop.
+    if is_shallow:
+        _shallow_lock = os.path.join(_m().PROJECT_ROOT, ".git", "shallow.lock")
+        if os.path.exists(_shallow_lock):
+            try:
+                os.remove(_shallow_lock)
+                logger.debug("Removed stale .git/shallow.lock")
+            except OSError as exc:
+                logger.debug("Could not remove .git/shallow.lock: %s", exc)
+
     if branch == "main":
         # Probe locally (~6 ms) whether an 'upstream' remote exists at all
         # before spending a network fetch on it. Non-fork installs have no


### PR DESCRIPTION
## Summary

Fixes #75133.

When an update is interrupted (network timeout, app force-close, system sleep), Git leaves behind a stale `.git/shallow.lock` in shallow-cloned repositories. On the next update:

1. `git fetch` fails with `fatal: Unable to create '.git/shallow.lock': File exists`
2. `hermes update` exits with an error
3. The Tauri/Electron GUI misinterprets this as a concurrent process: `"UPDATE DIDN'T FINISH. Hermes is still running"`
4. The `.hermes-update-in-progress` lock file is left orphaned, trapping users in an unrecoverable update loop

## Fix

Before running `git fetch` on shallow repos, check for and remove stale `.shallow.lock` files. This is safe because the lock is only meaningful during an active fetch — a stale lock from a dead process has no holder.

```diff
     depth_args = ["--depth", "1"] if is_shallow else []

+    # Remove stale .git/shallow.lock left by interrupted updates (#75133).
+    if is_shallow:
+        _shallow_lock = os.path.join(_m().PROJECT_ROOT, ".git", "shallow.lock")
+        if os.path.exists(_shallow_lock):
+            try:
+                os.remove(_shallow_lock)
+            except OSError:
+                pass
+
     if branch == "main":
```

## Testing

1. `touch ~/.hermes/hermes-agent/.git/shallow.lock`
2. Run `hermes update`
3. Verify update proceeds without "Hermes is still running" error
