### PR TITLE
feat(api-server): expose session rewind over HTTP

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -13,6 +13,7 @@ Exposes an HTTP server with endpoints:
 - GET/PATCH/DELETE /api/sessions/{session_id} — read/update/delete a session
 - GET  /api/sessions/{session_id}/messages — read session message history
 - POST /api/sessions/{session_id}/fork — branch a session using SessionDB lineage
+- POST /api/sessions/{session_id}/rewind — soft-delete from a user message onward (SessionDB.rewind_to_message)
 - POST /api/sessions/{session_id}/chat[/stream] — chat with a persisted session
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}           — retrieve current run status
@@ -1363,6 +1364,22 @@ class APIServerAdapter(BasePlatformAdapter):
             pass
         return active_api_runs, process_depth, active_delegations
 
+    _ACTIVE_RUN_STATUSES = frozenset({"queued", "running", "waiting_for_approval", "stopping"})
+
+    def _session_has_active_run(self, session_id: str) -> bool:
+        """True when a /v1/runs job for *session_id* is still in flight."""
+        session_id = str(session_id or "").strip()
+        if not session_id:
+            return False
+        for status in self._run_statuses.values():
+            if not isinstance(status, dict):
+                continue
+            if status.get("session_id") != session_id:
+                continue
+            if status.get("status") in self._ACTIVE_RUN_STATUSES:
+                return True
+        return False
+
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
         """Normalize configured CORS origins into a stable tuple."""
@@ -1822,6 +1839,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("DELETE", "/api/sessions/{session_id}", self._handle_delete_session),
             ("GET", "/api/sessions/{session_id}/messages", self._handle_session_messages),
             ("POST", "/api/sessions/{session_id}/fork", self._handle_fork_session),
+            ("POST", "/api/sessions/{session_id}/rewind", self._handle_rewind_session),
             ("POST", "/api/sessions/{session_id}/chat", self._handle_session_chat),
             ("POST", "/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream),
             ("POST", "/api/sessions/{session_id}/model", self._handle_session_model_lock),
@@ -2878,6 +2896,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat": True,
                 "session_chat_streaming": True,
                 "session_fork": True,
+                "session_rewind": True,
                 "session_model_lock": True,
                 "admin_config_rw": False,
                 "jobs_admin": False,
@@ -2910,6 +2929,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_delete": {"method": "DELETE", "path": "/api/sessions/{session_id}"},
                 "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
+                "session_rewind": {"method": "POST", "path": "/api/sessions/{session_id}/rewind"},
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
                 "session_model_lock": {"method": "POST", "path": "/api/sessions/{session_id}/model"},
@@ -3283,6 +3303,88 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "list",
             "session_id": resolved_id,
             "data": [self._message_response(m) for m in messages],
+        })
+
+    async def _handle_rewind_session(self, request: "web.Request") -> "web.Response":
+        """POST /api/sessions/{session_id}/rewind — soft-delete from a user message onward.
+
+        Wraps ``SessionDB.rewind_to_message`` (same primitive as gateway/CLI
+        ``/undo``): the target must be a ``user`` row; it and every later
+        message become ``active=0`` (kept for audit, hidden from subsequent
+        history loads). Callers that need regenerate then issue a normal
+        ``POST /v1/runs`` with the same ``session_id`` and user input.
+
+        Body: ``{"target_message_id": <int>}`` — id from GET .../messages.
+        Rejects with 409 when a /v1/runs job for this session is still active.
+        This endpoint only mutates SessionDB; it does not sync in-memory
+        Desktop/TUI live history.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info["session_id"]
+        _, err = await self._get_existing_session_or_404(session_id)
+        if err:
+            return err
+        body, err = await self._read_json_body(request)
+        if err:
+            return err
+
+        raw_target = body.get("target_message_id")
+        if raw_target is None:
+            return web.json_response(
+                _openai_error("target_message_id is required", code="invalid_target_message_id"),
+                status=400,
+            )
+        try:
+            target_message_id = int(raw_target)
+        except (TypeError, ValueError):
+            return web.json_response(
+                _openai_error("target_message_id must be an integer", code="invalid_target_message_id"),
+                status=400,
+            )
+
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web.json_response(
+                _openai_error("Session database unavailable", code="session_db_unavailable"),
+                status=503,
+            )
+        # Match GET /messages: resolve resume lineage so ids from that listing
+        # address the same transcript row set.
+        resolved_id = await asyncio.to_thread(db.resolve_resume_session_id, session_id)
+        resolved = await asyncio.to_thread(db.get_session, resolved_id)
+        if not resolved:
+            return web.json_response(
+                _openai_error(f"Session not found: {session_id}", code="session_not_found"),
+                status=404,
+            )
+
+        if self._session_has_active_run(resolved_id) or self._session_has_active_run(session_id):
+            return web.json_response(
+                _openai_error(
+                    "Session has an active run; stop or wait before rewind",
+                    code="session_busy",
+                ),
+                status=409,
+            )
+
+        try:
+            result = await asyncio.to_thread(db.rewind_to_message, resolved_id, target_message_id)
+        except ValueError as exc:
+            return web.json_response(_openai_error(str(exc), code="invalid_rewind_target"), status=400)
+
+        target_message = result.get("target_message") or {}
+        if isinstance(target_message, dict):
+            target_message = self._message_response(target_message)
+
+        return web.json_response({
+            "object": "hermes.session.rewind",
+            "ok": True,
+            "session_id": resolved_id,
+            "rewound_count": result.get("rewound_count", 0),
+            "target_message": target_message,
+            "new_head_id": result.get("new_head_id"),
         })
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1262,6 +1262,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # agent with model="" that 400s every call until manual retry.
         self._last_resolved_model: Dict[str, str] = {}
         self._session_db_lock: Optional[asyncio.Lock] = None  # Single-flight for lazy init
+        # Coordinates rewind admission with /v1/runs queued registration and
+        # session-chat turns so a run cannot slip in between the rewind busy
+        # check and SessionDB.rewind_to_message.
+        self._session_rewind_admission_lock = asyncio.Lock()
+        self._sessions_rewinding: set[str] = set()
         # Concurrency cap shared across all agent-serving endpoints
         # (/v1/chat/completions, /v1/responses, /v1/runs). Read from
         # config.yaml gateway.api_server.max_concurrent_runs; 0 disables
@@ -1379,6 +1384,92 @@ class APIServerAdapter(BasePlatformAdapter):
             if status.get("status") in self._ACTIVE_RUN_STATUSES:
                 return True
         return False
+
+    @staticmethod
+    def _session_ids_for_rewind_guard(session_id: str, resolved_id: str) -> tuple[str, ...]:
+        """Distinct non-empty session ids that share one rewind admission slot."""
+        ids: list[str] = []
+        for raw in (session_id, resolved_id):
+            sid = str(raw or "").strip()
+            if sid and sid not in ids:
+                ids.append(sid)
+        return tuple(ids)
+
+    async def _begin_session_rewind_guard(
+        self,
+        session_ids: tuple[str, ...],
+    ) -> Optional["web.Response"]:
+        """Reserve *session_ids* for rewind; reject active runs or concurrent rewind."""
+        async with self._session_rewind_admission_lock:
+            for sid in session_ids:
+                if self._session_has_active_run(sid):
+                    return web.json_response(
+                        _openai_error(
+                            "Session has an active run; stop or wait before rewind",
+                            code="session_busy",
+                        ),
+                        status=409,
+                    )
+                if sid in self._sessions_rewinding:
+                    return web.json_response(
+                        _openai_error(
+                            "Session rewind is already in progress",
+                            code="session_rewind_in_progress",
+                        ),
+                        status=409,
+                    )
+            for sid in session_ids:
+                self._sessions_rewinding.add(sid)
+        return None
+
+    async def _end_session_rewind_guard(self, session_ids: tuple[str, ...]) -> None:
+        async with self._session_rewind_admission_lock:
+            for sid in session_ids:
+                self._sessions_rewinding.discard(sid)
+
+    async def _session_rewind_blocked_response(self, session_id: str) -> Optional["web.Response"]:
+        """409 when a rewind mutation is in flight for *session_id*."""
+        session_id = str(session_id or "").strip()
+        if not session_id:
+            return None
+        async with self._session_rewind_admission_lock:
+            if session_id not in self._sessions_rewinding:
+                return None
+        return web.json_response(
+            _openai_error(
+                "Session rewind is in progress",
+                code="session_rewind_in_progress",
+            ),
+            status=409,
+        )
+
+    async def _admit_run_for_session(
+        self,
+        run_id: str,
+        session_id: str,
+        *,
+        created_at: float,
+        model: str,
+    ) -> Optional["web.Response"]:
+        """Register a queued /v1/runs job without racing session rewind."""
+        session_id = str(session_id or "").strip()
+        async with self._session_rewind_admission_lock:
+            if session_id and session_id in self._sessions_rewinding:
+                return web.json_response(
+                    _openai_error(
+                        "Session rewind is in progress",
+                        code="session_rewind_in_progress",
+                    ),
+                    status=409,
+                )
+            self._set_run_status(
+                run_id,
+                "queued",
+                created_at=created_at,
+                session_id=session_id,
+                model=model,
+            )
+        return None
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -3315,7 +3406,8 @@ class APIServerAdapter(BasePlatformAdapter):
         ``POST /v1/runs`` with the same ``session_id`` and user input.
 
         Body: ``{"target_message_id": <int>}`` — id from GET .../messages.
-        Rejects with 409 when a /v1/runs job for this session is still active.
+        Rejects with 409 when a /v1/runs job for this session is still active
+        or a rewind mutation is already in flight for this session.
         This endpoint only mutates SessionDB; it does not sync in-memory
         Desktop/TUI live history.
         """
@@ -3360,32 +3452,31 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=404,
             )
 
-        if self._session_has_active_run(resolved_id) or self._session_has_active_run(session_id):
-            return web.json_response(
-                _openai_error(
-                    "Session has an active run; stop or wait before rewind",
-                    code="session_busy",
-                ),
-                status=409,
-            )
+        guard_ids = self._session_ids_for_rewind_guard(session_id, resolved_id)
+        guard_err = await self._begin_session_rewind_guard(guard_ids)
+        if guard_err:
+            return guard_err
 
         try:
-            result = await asyncio.to_thread(db.rewind_to_message, resolved_id, target_message_id)
-        except ValueError as exc:
-            return web.json_response(_openai_error(str(exc), code="invalid_rewind_target"), status=400)
+            try:
+                result = await asyncio.to_thread(db.rewind_to_message, resolved_id, target_message_id)
+            except ValueError as exc:
+                return web.json_response(_openai_error(str(exc), code="invalid_rewind_target"), status=400)
 
-        target_message = result.get("target_message") or {}
-        if isinstance(target_message, dict):
-            target_message = self._message_response(target_message)
+            target_message = result.get("target_message") or {}
+            if isinstance(target_message, dict):
+                target_message = self._message_response(target_message)
 
-        return web.json_response({
-            "object": "hermes.session.rewind",
-            "ok": True,
-            "session_id": resolved_id,
-            "rewound_count": result.get("rewound_count", 0),
-            "target_message": target_message,
-            "new_head_id": result.get("new_head_id"),
-        })
+            return web.json_response({
+                "object": "hermes.session.rewind",
+                "ok": True,
+                "session_id": resolved_id,
+                "rewound_count": result.get("rewound_count", 0),
+                "target_message": target_message,
+                "new_head_id": result.get("new_head_id"),
+            })
+        finally:
+            await self._end_session_rewind_guard(guard_ids)
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/fork — branch via current SessionDB primitives."""
@@ -3504,6 +3595,9 @@ class APIServerAdapter(BasePlatformAdapter):
             )
             if selection_error:
                 return web.json_response(_openai_error(selection_error), status=400)
+        rewind_err = await self._session_rewind_blocked_response(session_id)
+        if rewind_err is not None:
+            return rewind_err
         history = await self._conversation_history_for_session(session_id)
         result, usage = await self._run_agent(
             user_message=user_message,
@@ -3619,6 +3713,10 @@ class APIServerAdapter(BasePlatformAdapter):
             route_source=runtime_request.get("route_source") or "global",
             model_lock=("accepted" if lock_active else ""),
         )
+
+        rewind_err = await self._session_rewind_blocked_response(session_id)
+        if rewind_err is not None:
+            return rewind_err
 
         loop = asyncio.get_running_loop()
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
@@ -6308,13 +6406,17 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
-        self._set_run_status(
+        admit_err = await self._admit_run_for_session(
             run_id,
-            "queued",
+            session_id,
             created_at=created_at,
-            session_id=session_id,
             model=body.get("model", self._model_name),
         )
+        if admit_err is not None:
+            self._run_streams.pop(run_id, None)
+            self._run_streams_created.pop(run_id, None)
+            self._run_approval_sessions.pop(run_id, None)
+            return admit_err
 
         # Background task outlives the HTTP response (and thus the middleware
         # profile scope). Capture now and re-enter inside the task/executor.

--- a/tests/gateway/test_api_server_session_rewind.py
+++ b/tests/gateway/test_api_server_session_rewind.py
@@ -1,0 +1,188 @@
+"""Tests for POST /api/sessions/{id}/rewind on api_server.
+
+Exposes SessionDB.rewind_to_message for /v1/runs clients (regenerate H3).
+Complements web_server PR #60443 — same primitive, api_server surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    cors_middleware,
+    security_headers_middleware,
+)
+from hermes_state import SessionDB
+
+
+def _make_adapter(api_key: str = "sk-secret") -> APIServerAdapter:
+    extra = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_post(
+        "/api/sessions/{session_id}/rewind",
+        adapter._handle_rewind_session,
+    )
+    app.router.add_get(
+        "/api/sessions/{session_id}/messages",
+        adapter._handle_session_messages,
+    )
+    return app
+
+
+@pytest.fixture()
+def seeded_db_path(tmp_path, monkeypatch):
+    """Seed a SessionDB on disk; return path (not a live connection).
+
+    Handler and assertions each open their own SessionDB so close() in the
+    handler cannot wipe the connection used for post-condition checks
+    (review note on #60443).
+    """
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("hermes_state.DEFAULT_DB_PATH", db_path)
+
+    writer = SessionDB(db_path=db_path)
+    writer.create_session("s1", source="api_server")
+    ids = []
+    for i in range(1, 4):
+        ids.append(writer.append_message("s1", "user", f"q{i}"))
+        ids.append(writer.append_message("s1", "assistant", f"a{i}"))
+    writer.close()
+    return db_path, ids
+
+
+@pytest.fixture()
+def adapter_with_db(seeded_db_path):
+    db_path, ids = seeded_db_path
+    adapter = _make_adapter()
+    # Keep the adapter's SessionDB open for the request lifetime (handler
+    # does not close the shared adapter db — unlike web_server's per-request open).
+    adapter._session_db = SessionDB(db_path=db_path)
+    yield adapter, ids, db_path
+    adapter._session_db.close()
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_user_message_clears_later_context(adapter_with_db):
+    adapter, ids, db_path = adapter_with_db
+    q2_id = ids[2]  # third seeded row is the 2nd user turn (q2)
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/api/sessions/s1/rewind",
+            headers={"Authorization": "Bearer sk-secret"},
+            json={"target_message_id": q2_id},
+        )
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["ok"] is True
+        assert body["object"] == "hermes.session.rewind"
+        assert body["session_id"] == "s1"
+        assert body["rewound_count"] == 4  # q2, a2, q3, a3
+        assert body["target_message"]["content"] == "q2"
+        assert body["target_message"]["role"] == "user"
+
+    # Separate connection for assertions after the request.
+    reader = SessionDB(db_path=db_path)
+    try:
+        active = reader.get_messages("s1")
+        assert [m["content"] for m in active] == ["q1", "a1"]
+        assert len(reader.get_messages("s1", include_inactive=True)) == 6
+    finally:
+        reader.close()
+
+
+@pytest.mark.asyncio
+async def test_rewind_rejects_non_user_target(adapter_with_db):
+    adapter, ids, _db_path = adapter_with_db
+    a1_id = ids[1]
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/api/sessions/s1/rewind",
+            headers={"Authorization": "Bearer sk-secret"},
+            json={"target_message_id": a1_id},
+        )
+        assert resp.status == 400
+        body = await resp.json()
+        assert body["error"]["code"] == "invalid_rewind_target"
+
+
+@pytest.mark.asyncio
+async def test_rewind_unknown_session_returns_404(adapter_with_db):
+    adapter, _ids, _db_path = adapter_with_db
+    assert adapter._session_db.get_session("does-not-exist") is None
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/api/sessions/does-not-exist/rewind",
+            headers={"Authorization": "Bearer sk-secret"},
+            json={"target_message_id": 1},
+        )
+        body = await resp.json()
+        assert resp.status == 404, body
+        assert body["error"]["code"] == "session_not_found"
+
+
+@pytest.mark.asyncio
+async def test_rewind_requires_target_message_id(adapter_with_db):
+    adapter, _ids, _db_path = adapter_with_db
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/api/sessions/s1/rewind",
+            headers={"Authorization": "Bearer sk-secret"},
+            json={},
+        )
+        assert resp.status == 400
+        body = await resp.json()
+        assert body["error"]["code"] == "invalid_target_message_id"
+
+
+@pytest.mark.asyncio
+async def test_rewind_rejects_active_run(adapter_with_db):
+    adapter, ids, _db_path = adapter_with_db
+    adapter._run_statuses["run_busy"] = {
+        "status": "running",
+        "session_id": "s1",
+    }
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/api/sessions/s1/rewind",
+            headers={"Authorization": "Bearer sk-secret"},
+            json={"target_message_id": ids[2]},
+        )
+        assert resp.status == 409
+        body = await resp.json()
+        assert body["error"]["code"] == "session_busy"
+
+
+@pytest.mark.asyncio
+async def test_capabilities_advertise_session_rewind(adapter_with_db):
+    adapter, _ids, _db_path = adapter_with_db
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(
+            "/v1/capabilities",
+            headers={"Authorization": "Bearer sk-secret"},
+        )
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["features"]["session_rewind"] is True
+        assert body["endpoints"]["session_rewind"]["path"] == (
+            "/api/sessions/{session_id}/rewind"
+        )

--- a/tests/gateway/test_api_server_session_rewind.py
+++ b/tests/gateway/test_api_server_session_rewind.py
@@ -6,6 +6,10 @@ Complements web_server PR #60443 — same primitive, api_server surface.
 
 from __future__ import annotations
 
+import asyncio
+import json
+import threading
+
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
@@ -186,3 +190,81 @@ async def test_capabilities_advertise_session_rewind(adapter_with_db):
         assert body["endpoints"]["session_rewind"]["path"] == (
             "/api/sessions/{session_id}/rewind"
         )
+
+
+@pytest.mark.asyncio
+async def test_rewind_guard_blocks_run_admission_while_rewind_in_flight(adapter_with_db):
+    """A /v1/runs queued registration cannot slip in during rewind_to_message."""
+    adapter, ids, _db_path = adapter_with_db
+    q2_id = ids[2]
+    rewind_gate = threading.Event()
+    rewind_entered = threading.Event()
+    original_rewind = adapter._session_db.rewind_to_message
+
+    def hooked_rewind(session_id: str, target_message_id: int):
+        rewind_entered.set()
+        if not rewind_gate.wait(timeout=2):
+            raise AssertionError("rewind gate timed out")
+        return original_rewind(session_id, target_message_id)
+
+    adapter._session_db.rewind_to_message = hooked_rewind
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        rewind_task = asyncio.create_task(
+            cli.post(
+                "/api/sessions/s1/rewind",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={"target_message_id": q2_id},
+            )
+        )
+        await asyncio.to_thread(rewind_entered.wait, 2)
+
+        admit_err = await adapter._admit_run_for_session(
+            "run_race",
+            "s1",
+            created_at=0.0,
+            model="test-model",
+        )
+        assert admit_err is not None
+        body = json.loads(admit_err.text)
+        assert body["error"]["code"] == "session_rewind_in_progress"
+        assert "s1" not in adapter._run_statuses
+
+        rewind_gate.set()
+        resp = await rewind_task
+        assert resp.status == 200
+
+
+@pytest.mark.asyncio
+async def test_rewind_rejects_queued_run_registered_under_guard(adapter_with_db):
+    adapter, ids, _db_path = adapter_with_db
+    admit_err = await adapter._admit_run_for_session(
+        "run_busy",
+        "s1",
+        created_at=0.0,
+        model="test-model",
+    )
+    assert admit_err is None
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/api/sessions/s1/rewind",
+            headers={"Authorization": "Bearer sk-secret"},
+            json={"target_message_id": ids[2]},
+        )
+        assert resp.status == 409
+        body = await resp.json()
+        assert body["error"]["code"] == "session_busy"
+
+
+@pytest.mark.asyncio
+async def test_session_chat_rejects_rewind_in_progress(adapter_with_db):
+    adapter, ids, _db_path = adapter_with_db
+    adapter._sessions_rewinding.add("s1")
+
+    rewind_err = await adapter._session_rewind_blocked_response("s1")
+    assert rewind_err is not None
+    body = json.loads(rewind_err.text)
+    assert body["error"]["code"] == "session_rewind_in_progress"


### PR DESCRIPTION
## What does this PR do?

Adds `POST /api/sessions/{session_id}/rewind` on **api_server** so HTTP clients that drive agents via `session_id` + `POST /v1/runs` can truncate SessionDB context before re-running a turn.

**Problem:** When a portal or API client uses persisted sessions (`session_id` on `/v1/runs`), Hermes loads history from SessionDB — not from a caller-supplied `conversation_history`. Regenerate / retry therefore needs to rewind the DB transcript first, then issue a normal run with the same `session_id`. Gateway `/retry` and CLI undo already do this in-process; there was no equivalent on the api_server HTTP surface.

**Approach:** Wrap the existing `SessionDB.rewind_to_message` primitive (same as gateway/CLI `/undo`): soft-delete (`active=0`) from a target **user** message onward. No new DB logic. Complements #60443, which adds rewind on Desktop `web_server` — same primitive, different HTTP surface for gateway api_server clients.

**Scope note:** This endpoint only mutates SessionDB. It does not sync in-memory Desktop/TUI live session history (same limitation noted on #60443).

## Related Issue

Related: #60443

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - Route `POST /api/sessions/{session_id}/rewind` → `_handle_rewind_session`
  - Body: `{"target_message_id": <int>}` (user row id from `GET .../messages`)
  - Resolve resume lineage via `resolve_resume_session_id` (same as `GET .../messages`)
  - `404` if session missing after resolve; `400` for invalid/missing target or non-user row
  - `409 session_busy` when a `/v1/runs` job for the session is still active (`queued`, `running`, `waiting_for_approval`, `stopping`)
  - `503` if SessionDB unavailable
  - Advertise `session_rewind` in `/v1/capabilities` (`features` + `endpoints`)
  - Helper `_session_has_active_run()` over `_run_statuses`
- `tests/gateway/test_api_server_session_rewind.py`
  - Success rewind, non-user target → 400, unknown session → 404, missing field → 400, active run → 409, capabilities advertisement
  - Assertions use a separate `SessionDB` reader to avoid close() flake (review note on #60443)

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_api_server_session_rewind.py -q
``` 
## Checklist
### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x]  I've run targeted tests and all pass (scripts/run_tests.sh tests/gateway/test_api_server_session_rewind.py — 6 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

scripts/run_tests.sh tests/gateway/test_api_server_session_rewind.py -q
▶ skipping venv without pytest: /Users/mmq/hermes-agent/.venv
▶ running per-file parallel test suite via run_tests_parallel.py
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)
▶ pre-compiling bytecode cache
▶ launching test runner
Discovered 1 test files (~6 tests) under ['tests/gateway/test_api_server_session_rewind.py']; running with -j 32
[100.0% |     6/~6 | ✓6 | ✗0] ✓ tests/gateway/test_api_server_session_rewind.py (6✓, 1.0s)

=== Summary: 1 files, 6 tests passed, 0 failed (100% complete) in 1.0s (32 workers) ===
  Durations cached to test_durations.json (1 files)

=== Per-file subprocess time distribution ===
  Files:   1
  Total subprocess CPU-wall: 1.0s  (runner wall: 1.0s, parallelism: 32x)
  P50: 0.97s  P90: 0.97s  P95: 0.97s  P99: 0.97s  Max: 0.97s
  <1s: 1 files (100%)  <2s: 1 files (100%)
  Top 10 slowest:
      0.97s  tests/gateway/test_api_server_session_rewind.py