### PR TITLE
fix(anthropic): jitter Retry-After waits to decorrelate concurrent retries

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5299,7 +5299,16 @@ def run_conversation(
                                 _retry_after = min(float(_ra_raw), 600)
                             except (TypeError, ValueError):
                                 pass
-                wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                wait_time = (
+                    jittered_backoff(
+                        1,
+                        base_delay=_retry_after,
+                        max_delay=_retry_after,
+                        jitter_ratio=0.05,
+                    )
+                    if _retry_after
+                    else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                )
                 _backoff_policy = None
                 if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
                     wait_time, _backoff_policy = adaptive_rate_limit_backoff(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1618,10 +1618,19 @@ class TestRetryAfterCap:
         agent.run_conversation("hello")
         return next((m for m in captured if "Waiting" in m), "")
 
-    def test_retry_after_under_cap_is_honored(self, agent):
-        # 300s > old 120s cap but < new 600s cap → used verbatim.
-        status = self._drive_once(agent, 300)
-        assert "Waiting 300.0s" in status
+    def test_retry_after_under_cap_is_jittered_above_floor(self, agent):
+        # Respect the provider's 300s floor, but decorrelate concurrent callers
+        # so a gateway fleet does not wake and retry at the exact same instant.
+        with patch("agent.conversation_loop.jittered_backoff", return_value=307.5) as jitter:
+            status = self._drive_once(agent, 300)
+
+        assert "Waiting 307.5s" in status
+        jitter.assert_called_once_with(
+            1,
+            base_delay=300.0,
+            max_delay=300.0,
+            jitter_ratio=0.05,
+        )
 
 
 


### PR DESCRIPTION
## Problem
When the Anthropic API returns a `Retry-After` header, current main honors it as a fixed delay (`agent/conversation_loop.py:5302`). When multiple sessions get rate-limited off the same account at the same instant, they all sleep the same fixed interval and wake to retry simultaneously — thundering-herd retry alignment.

## Fix
Feed the `Retry-After` value through `jittered_backoff()` with the server value as the floor and a small (5%) jitter ratio, so concurrent callers decorrelate while still respecting the provider's minimum wait (`agent/conversation_loop.py`).

## Tests
- `tests/run_agent/test_run_agent.py::TestRetryAfterCap` — updated to assert the Retry-After path routes through `jittered_backoff(1, base_delay=<retry_after>, max_delay=<retry_after>, jitter_ratio=0.05)`.

## Re-scope note
An earlier revision of this PR also touched `agent/credential_pool.py` (adding `account_uuid` to `_EXTRA_KEYS`) claiming cooldown-state persistence. Per review, that hunk did not implement the stated fix — current main already persists cooldown state in `_mark_exhausted()` (`agent/credential_pool.py:712-723`) and preserves newer on-disk cooldown state in `hermes_cli/auth.py` — and no `account_uuid` producer/consumer exists on main. The credential-pool hunk and its serialization-only test have been dropped; this PR is now the retry-jitter fix alone.
