### PR TITLE
fix(streaming): recover truncated tool args when finish_reason is set (#74798)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3450,6 +3450,35 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 dropped_tool_names=_dropped_names or None,
             )
 
+        # Chunking recovery for truncated tool args WITH a non-length
+        # finish_reason (#74798): when the provider reports finish_reason
+        # (e.g. "stop") but the tool arguments are still truncated, the
+        # accumulated call would be silently discarded.  Build a partial-
+        # stream stub so the caller can attempt chunked retry.  Do NOT
+        # intercept finish_reason="length" — that is a genuine output cap
+        # where the max_tokens-boost retry path is correct.
+        _tool_args_dropped_with_finish = (
+            has_truncated_tool_args
+            and finish_reason is not None
+            and finish_reason != "length"
+        )
+        if _tool_args_dropped_with_finish:
+            _dropped_names = [
+                (tool_calls_acc[idx]["function"]["name"] or "?")
+                for idx in sorted(tool_calls_acc)
+            ]
+            logger.warning(
+                "Stream finished with %r but tool arguments were truncated "
+                "(tools=%s); building partial-stream stub for chunked retry.",
+                finish_reason, _dropped_names,
+            )
+            return _build_partial_stream_stub(
+                role, full_content,
+                "".join(reasoning_parts) or None,
+                model_name, usage_obj,
+                dropped_tool_names=_dropped_names or None,
+            )
+
         # Text-only stream drop: the upstream closed the connection (or the
         # SSE stream simply ended) with no finish_reason after delivering
         # text content but no tool calls.  Without this guard the partial


### PR DESCRIPTION
## Summary

Fixes #74798.

When a provider truncates a large tool argument (`write_file`, `terminal`) AND reports a `finish_reason`, the accumulated call was silently discarded. The chunking recovery path only triggered when `finish_reason` was `None`.

The user sees a turn that "finished" without the write happening, with no error to trace. The tools whose arguments are large are exactly the ones whose loss is consequential.

## Root Cause

In `interruptible_streaming_api_call()`, the condition at line 3434:
```python
_tool_args_dropped_no_finish = has_truncated_tool_args and finish_reason is None
```

When `finish_reason` is set (e.g. "stop"), this is False. The code then falls through to line 3475-3476 which sets `effective_finish_reason = "length"`, but the `_dropped_tool_names` attribute is never set on the response. The caller's chunked retry mechanism checks `_dropped_tool_names` and never triggers.

## Fix

Add a second recovery path for `has_truncated_tool_args and finish_reason is not None` that also builds a partial-stream stub with `dropped_tool_names`. The caller can then see the dropped tools and trigger chunked retry.

```diff
         _tool_args_dropped_no_finish = has_truncated_tool_args and finish_reason is None
         if _tool_args_dropped_no_finish:
             ...
             return _build_partial_stream_stub(..., dropped_tool_names=_dropped_names)
+
+        _tool_args_dropped_with_finish = has_truncated_tool_args and finish_reason is not None
+        if _tool_args_dropped_with_finish:
+            ...
+            return _build_partial_stream_stub(..., dropped_tool_names=_dropped_names)
```

## Testing

- Configure a provider that truncates large tool arguments with a finish_reason
- Send a `write_file` call with a large body
- Verify the chunked retry mechanism triggers instead of silently discarding
