### PR TITLE
[codex] separate app-server auth error sources

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import threading
 import time
 from dataclasses import dataclass, field
@@ -198,13 +199,9 @@ def _coerce_turn_input_text(user_input: Any) -> str:
     return "" if user_input is None else str(user_input)
 
 
-# Substrings in codex stderr / JSON-RPC error messages that signal the
-# subprocess died because its OAuth credentials are no longer valid.
-# Kept conservative: we only redirect users to `codex login` when we're
-# reasonably sure that's the actual failure, otherwise we surface the
-# original error verbatim. Mirrors openclaw beta.8's auth-refresh
-# classification.
-_OAUTH_REFRESH_FAILURE_HINTS = (
+# Strong credential failure signals that are safe to classify in either the
+# primary operation error or ambient app-server stderr.
+_OAUTH_CREDENTIAL_FAILURE_HINTS = (
     "invalid_grant",
     "invalid grant",
     "refresh token",
@@ -213,41 +210,59 @@ _OAUTH_REFRESH_FAILURE_HINTS = (
     "token_refresh",
     "token has expired",
     "expired_token",
+    "token_expired",
     "expired token",
     "not authenticated",
     "unauthenticated",
-    "unauthorized",
-    "401 unauthorized",
     "re-authenticate",
     "reauthenticate",
     "please log in",
     "please login",
-    "auth profile",
     "no auth profile",
+    "missing auth profile",
+    "auth profile not found",
+)
+
+# Generic auth words are authoritative in the primary JSON-RPC/turn error, but
+# not in stderr. Codex writes independent ChatGPT plugin prewarm failures to
+# stderr, so a plugin HTTP 401 must not hide an unrelated core runtime error.
+_PRIMARY_OAUTH_FAILURE_HINTS = (
+    *_OAUTH_CREDENTIAL_FAILURE_HINTS,
+    "unauthorized",
+    "401 unauthorized",
     "oauth",
+    "auth profile",
 )
 
 
-def _classify_oauth_failure(*parts: str) -> Optional[str]:
-    """Return a user-friendly re-auth hint if any of the provided strings
-    look like a codex OAuth/token-refresh failure; otherwise None.
+def _classify_oauth_failure(
+    primary_error: str = "",
+    *,
+    stderr: str = "",
+) -> Optional[str]:
+    """Return a re-auth hint when the primary error or stderr proves that
+    Codex credentials are invalid.
 
-    Used for both `turn/start` JSON-RPC errors and post-mortem stderr
-    inspection when the subprocess exits unexpectedly. Conservative on
-    purpose — we only redirect users to `codex login` when the signal
-    is strong, so unrelated runtime failures still surface verbatim.
+    Generic 401/unauthorized/OAuth text is accepted only from the primary
+    operation error. Ambient stderr requires a stronger refresh/token/profile
+    signal because ChatGPT plugin prewarm failures are independent of the core
+    app-server request.
     """
-    haystack = " ".join(p for p in parts if p).lower()
-    if not haystack:
-        return None
-    for needle in _OAUTH_REFRESH_FAILURE_HINTS:
-        if needle in haystack:
-            return (
-                "Codex authentication failed — your ChatGPT/Codex login "
-                "looks expired or invalid. Run `codex login` to refresh, "
-                "then retry. (Fall back to default runtime with "
-                "`/codex-runtime auto` if the issue persists.)"
-            )
+    primary_haystack = str(primary_error or "").lower()
+    stderr_haystack = str(stderr or "").lower()
+    primary_match = any(
+        needle in primary_haystack for needle in _PRIMARY_OAUTH_FAILURE_HINTS
+    ) or re.search(r"\b401\b", primary_haystack) is not None
+    stderr_match = any(
+        needle in stderr_haystack for needle in _OAUTH_CREDENTIAL_FAILURE_HINTS
+    )
+    if primary_match or stderr_match:
+        return (
+            "Codex authentication failed — your ChatGPT/Codex login "
+            "looks expired or invalid. Run `codex login` to refresh, "
+            "then retry. (Fall back to default runtime with "
+            "`/codex-runtime auto` if the issue persists.)"
+        )
     return None
 
 
@@ -531,7 +546,7 @@ class CodexAppServerSession:
             # Classify auth/refresh failures so the user gets a clear
             # `codex login` pointer instead of a raw RPC error string.
             stderr_blob = "\n".join(self._client.stderr_tail(40))
-            hint = _classify_oauth_failure(exc.message, stderr_blob)
+            hint = _classify_oauth_failure(exc.message, stderr=stderr_blob)
             if hint is not None:
                 result.error = hint
                 # Subprocess is fine on a JSON-RPC level here, but the
@@ -548,7 +563,7 @@ class CodexAppServerSession:
         except TimeoutError as exc:
             # turn/start hanging is a strong signal the subprocess is wedged.
             stderr_blob = "\n".join(self._client.stderr_tail(40))
-            hint = _classify_oauth_failure(stderr_blob)
+            hint = _classify_oauth_failure(stderr=stderr_blob)
             result.error = hint or self._format_error_with_stderr(
                 "turn/start timed out", exc
             )
@@ -579,7 +594,7 @@ class CodexAppServerSession:
             # rather than waiting for the full turn deadline.
             if not self._client.is_alive():
                 stderr_blob = "\n".join(self._client.stderr_tail(60))
-                hint = _classify_oauth_failure(stderr_blob)
+                hint = _classify_oauth_failure(stderr=stderr_blob)
                 if hint is not None:
                     result.error = hint
                 else:
@@ -748,7 +763,10 @@ class CodexAppServerSession:
                         stderr_blob = "\n".join(
                             self._client.stderr_tail(40)
                         )
-                        hint = _classify_oauth_failure(err_msg, stderr_blob)
+                        hint = _classify_oauth_failure(
+                            err_msg,
+                            stderr=stderr_blob,
+                        )
                         if hint is not None:
                             result.error = hint
                             result.should_retire = True
@@ -824,7 +842,7 @@ class CodexAppServerSession:
             )
         except CodexAppServerError as exc:
             stderr_blob = "\n".join(self._client.stderr_tail(40))
-            hint = _classify_oauth_failure(exc.message, stderr_blob)
+            hint = _classify_oauth_failure(exc.message, stderr=stderr_blob)
             if hint is not None:
                 result.error = hint
                 result.should_retire = True
@@ -835,7 +853,7 @@ class CodexAppServerSession:
             return result
         except TimeoutError as exc:
             stderr_blob = "\n".join(self._client.stderr_tail(40))
-            hint = _classify_oauth_failure(stderr_blob)
+            hint = _classify_oauth_failure(stderr=stderr_blob)
             result.error = hint or self._format_error_with_stderr(
                 "thread/compact/start timed out", exc
             )
@@ -853,7 +871,7 @@ class CodexAppServerSession:
 
             if not self._client.is_alive():
                 stderr_blob = "\n".join(self._client.stderr_tail(60))
-                hint = _classify_oauth_failure(stderr_blob)
+                hint = _classify_oauth_failure(stderr=stderr_blob)
                 if hint is not None:
                     result.error = hint
                 else:
@@ -957,7 +975,10 @@ class CodexAppServerSession:
                     err_obj = turn_obj.get("error")
                     err_msg = _format_responses_error(err_obj, str(turn_status))
                     stderr_blob = "\n".join(self._client.stderr_tail(40))
-                    hint = _classify_oauth_failure(err_msg, stderr_blob)
+                    hint = _classify_oauth_failure(
+                        err_msg,
+                        stderr=stderr_blob,
+                    )
                     if hint is not None:
                         result.error = hint
                         result.should_retire = True

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -366,6 +366,48 @@ class TestRunTurn:
         assert "sk-stalled-secret-abc123" not in r.error
         assert r.should_retire is True
 
+    def test_turn_start_failure_preserves_error_when_plugin_stderr_has_401(self):
+        """A background ChatGPT plugin failure is not evidence that the
+        primary app-server request failed authentication."""
+        client = FakeClient()
+        client.set_stderr_tail([
+            "WARN failed to warm featured plugin ids cache: HTTP 401 Unauthorized",
+        ])
+        from agent.transports.codex_app_server import CodexAppServerError
+
+        def boom(method, params):
+            if method == "turn/start":
+                raise CodexAppServerError(
+                    code=-32603,
+                    message="workspace initialization failed",
+                )
+            return {"thread": {"id": "t"}, "activePermissionProfile": {"id": "x"}}
+
+        client._request_handler = boom
+        r = make_session(client).run_turn("hi", turn_timeout=2.0)
+
+        assert r.error is not None
+        assert "workspace initialization failed" in r.error
+        assert "codex login" not in r.error
+
+    def test_turn_start_timeout_is_not_reclassified_by_plugin_401_stderr(self):
+        client = FakeClient()
+        client.set_stderr_tail([
+            "WARN failed to warm featured plugin ids cache: HTTP 401 Unauthorized",
+        ])
+
+        def stall(method, params):
+            if method == "turn/start":
+                raise TimeoutError("codex method 'turn/start' timed out after 10s")
+            return {"thread": {"id": "t"}, "activePermissionProfile": {"id": "x"}}
+
+        client._request_handler = stall
+        r = make_session(client).run_turn("hi", turn_timeout=2.0)
+
+        assert r.error is not None
+        assert "turn/start timed out" in r.error
+        assert "codex login" not in r.error
+
 
 
 
@@ -437,6 +479,26 @@ class TestCompactThread:
         assert r.final_text == "compacted"
         assert r.token_usage_last["totalTokens"] == 12
         assert r.model_context_window == 200000
+
+    def test_compact_start_timeout_is_not_reclassified_by_plugin_401_stderr(self):
+        client = FakeClient()
+        client.set_stderr_tail([
+            "WARN failed to warm featured plugin ids cache: HTTP 401 Unauthorized",
+        ])
+
+        def stall(method, params):
+            if method == "thread/compact/start":
+                raise TimeoutError(
+                    "codex method 'thread/compact/start' timed out after 10s"
+                )
+            return {"thread": {"id": "t"}, "activePermissionProfile": {"id": "x"}}
+
+        client._request_handler = stall
+        r = make_session(client).compact_thread(turn_timeout=2.0)
+
+        assert r.error is not None
+        assert "thread/compact/start timed out" in r.error
+        assert "codex login" not in r.error
 
     def test_compact_thread_ignores_foreign_child_completion(self):
         client = FakeClient()
@@ -887,6 +949,44 @@ class TestClassifyOAuthFailure:
         hint = _classify_oauth_failure("HTTP 401 Unauthorized")
         assert hint is not None
 
+    def test_bare_401_primary_error_is_classified(self):
+        from agent.transports.codex_app_server_session import (
+            _classify_oauth_failure,
+        )
+        hint = _classify_oauth_failure("request failed with HTTP status 401")
+        assert hint is not None
+
+    def test_plugin_401_stderr_does_not_override_non_auth_primary_error(self):
+        from agent.transports.codex_app_server_session import (
+            _classify_oauth_failure,
+        )
+        hint = _classify_oauth_failure(
+            "workspace initialization failed",
+            stderr=(
+                "failed to warm featured plugin ids cache: HTTP 401 Unauthorized"
+            ),
+        )
+        assert hint is None
+
+    def test_informational_auth_profile_stderr_is_not_classified(self):
+        from agent.transports.codex_app_server_session import (
+            _classify_oauth_failure,
+        )
+        hint = _classify_oauth_failure(
+            "workspace initialization failed",
+            stderr='using auth profile "custom-provider"',
+        )
+        assert hint is None
+
+    def test_token_expired_stderr_is_classified(self):
+        from agent.transports.codex_app_server_session import (
+            _classify_oauth_failure,
+        )
+        hint = _classify_oauth_failure(
+            stderr="OAuth refresh failed: token_expired"
+        )
+        assert hint is not None
+
 
     def test_empty_inputs(self):
         from agent.transports.codex_app_server_session import (
@@ -894,5 +994,4 @@ class TestClassifyOAuthFailure:
         )
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
-        assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-
+        assert _classify_oauth_failure(stderr=None) is None  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- distinguish authoritative JSON-RPC/turn errors from ambient Codex app-server stderr when classifying OAuth failures
- keep generic `401`, `unauthorized`, and `oauth` matching for primary operation errors only
- require strong refresh-token, expiry, or missing-profile evidence before treating stderr as a credential failure
- apply the distinction consistently to turns, compaction, timeouts, failed-turn notifications, and dead-process handling

## Root cause

`_classify_oauth_failure(*parts)` merged the primary operation error and subprocess stderr into one string. ChatGPT plugin prewarm/discovery can independently emit `401 Unauthorized` to stderr while the core app-server remains usable, so an unrelated RPC failure or timeout was replaced with misleading `codex login` guidance.

## User impact

Hermes now preserves the real Codex app-server error when only background plugin stderr contains a generic 401. Genuine primary 401s and strong stderr credential failures still receive the existing re-login guidance.

## Validation

- `scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py -q` — 41 passed
- adjacent Codex runtime/session tests — 102 passed
- Ruff — passed
- `ty check agent/transports/codex_app_server_session.py` — passed
- Windows footgun check — passed
- `git diff --check` — passed

The full `scripts/run_tests.sh` suite was also attempted. It reached roughly 6,777 passing tests before being stopped with 10 environment-related failures: six require the optional `anthropic` SDK missing from this venv, and four resolve `files.slack.com` to `198.18.0.47`, which intentionally triggers the SSRF guard. None touch the changed files.

Fixes #75167
