### PR TITLE
fix(desktop): keep the workspace chat mounted behind every overlay route (supersedes #39295)

### DIFF
--- a/apps/desktop/src/app/contrib/surfaces.overlay-chat-retention.test.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.overlay-chat-retention.test.tsx
@@ -1,0 +1,101 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { useEffect } from 'react'
+import { MemoryRouter, type NavigateFunction, useNavigate } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { OVERLAY_ROUTE_PATHS } from '@/app/routes'
+
+import { ChatRoutesSurface } from './surfaces'
+import type { WiringActions } from './types'
+
+const counters = vi.hoisted(() => ({ mounts: 0 }))
+
+// A sentinel ChatView that reports its own MOUNT count: "the chat stays behind
+// the overlay" means the very same instance survives, not that a fresh one is
+// rendered — a remount is what tears down the transcript and composer state.
+vi.mock('../chat', () => ({
+  ChatView: function MockChatView() {
+    useEffect(() => {
+      counters.mounts += 1
+    }, [])
+
+    return <div data-testid="chat-view" />
+  }
+}))
+
+vi.mock('../skills', () => ({ SkillsView: () => <div data-testid="skills-view" /> }))
+vi.mock('../messaging', () => ({ MessagingView: () => <div data-testid="messaging-view" /> }))
+vi.mock('../artifacts', () => ({ ArtifactsView: () => <div data-testid="artifacts-view" /> }))
+
+// ChatRoutesSurface only forwards these through `latestChatActions`; the mocked
+// ChatView never invokes them, so a bare stand-in keeps the test to the routing
+// behaviour under test.
+const actions = {
+  getGateway: () => null,
+  openAgents: () => undefined,
+  openCommandCenterSection: () => undefined,
+  requestGateway: () => undefined,
+  selectModel: () => undefined,
+  toggleCommandCenter: () => undefined
+} as unknown as WiringActions
+
+function mountAt(pathname: string) {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <ChatRoutesSurface actions={actions} />
+    </MemoryRouter>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  counters.mounts = 0
+})
+
+describe('workspace route table — chat retention behind overlays', () => {
+  it.each([...OVERLAY_ROUTE_PATHS])('keeps the workspace chat mounted at /%s', path => {
+    mountAt(`/${path}`)
+
+    expect(screen.queryByTestId('chat-view')).not.toBeNull()
+  })
+
+  it('still replaces the chat with a full-page workspace route', () => {
+    mountAt('/skills')
+
+    expect(screen.queryByTestId('chat-view')).toBeNull()
+  })
+
+  it('reconciles rather than remounts the chat when an overlay opens and closes', () => {
+    let navigate: NavigateFunction | undefined
+
+    function CaptureNavigate() {
+      const to = useNavigate()
+
+      useEffect(() => {
+        navigate = to
+      }, [to])
+
+      return null
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/session-a']}>
+        <CaptureNavigate />
+        <ChatRoutesSurface actions={actions} />
+      </MemoryRouter>
+    )
+
+    expect(counters.mounts).toBe(1)
+
+    for (const path of OVERLAY_ROUTE_PATHS) {
+      act(() => navigate!(`/${path}`))
+      expect(screen.queryByTestId('chat-view')).not.toBeNull()
+    }
+
+    act(() => navigate!('/session-a'))
+
+    // One mount for the whole tour: opening every overlay in turn never tore
+    // the live chat down.
+    expect(counters.mounts).toBe(1)
+  })
+})

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -19,7 +19,7 @@ import { $freshDraftReady, $gatewayState } from '@/store/session'
 import { ChatView } from '../chat'
 import { ChatSidebar } from '../chat/sidebar'
 import { TerminalPaneChrome } from '../right-sidebar/terminal/chrome'
-import { contributedRoutes, NEW_CHAT_ROUTE, ROUTES_AREA, sessionRoute } from '../routes'
+import { contributedRoutes, NEW_CHAT_ROUTE, OVERLAY_ROUTE_PATHS, ROUTES_AREA, sessionRoute } from '../routes'
 import { useStatusSnapshot } from '../shell/hooks/use-status-snapshot'
 import { useStatusbarItems } from '../shell/hooks/use-statusbar-items'
 import { ModelMenuPanel } from '../shell/model-menu-panel'
@@ -167,13 +167,18 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
       <Route element={page(<SkillsView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="skills" />
       <Route element={page(<MessagingView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="messaging" />
       <Route element={page(<ArtifactsView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="artifacts" />
-      <Route element={null} path="agents" />
-      <Route element={null} path="command-center" />
-      <Route element={null} path="cron" />
-      <Route element={null} path="profiles" />
-      <Route element={null} path="settings" />
-      <Route element={null} path="starmap" />
-      <Route element={null} path="webhooks" />
+      {/* OVERLAY views render on their own layer ON TOP of the workspace (see
+          `isWorkspacePageRoute`) — they float over whatever the workspace is
+          already showing. Rendering `null` here left nothing to float over, so
+          opening Settings/Agents/… mid-turn unmounted ChatView and tore down
+          the live transcript, scroll position and composer state; closing the
+          overlay remounted a fresh one. `chatView` is the same element the
+          index and `:sessionId` routes use, so React reconciles it across the
+          route change instead of remounting. Driven off OVERLAY_ROUTE_PATHS so
+          a newly declared overlay cannot reintroduce the detachment. */}
+      {OVERLAY_ROUTE_PATHS.map(path => (
+        <Route element={chatView} key={path} path={path} />
+      ))}
       {/* Registry-contributed pages (core features + plugins) render in the
           workspace pane like any built-in view — behind the same blast wall
           as every other contribution mount. */}

--- a/apps/desktop/src/app/routes.test.ts
+++ b/apps/desktop/src/app/routes.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
-import { NEW_CHAT_ROUTE, primaryRouteSelectedSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
+import {
+  appViewForPath,
+  NEW_CHAT_ROUTE,
+  OVERLAY_ROUTE_PATHS,
+  OVERLAY_VIEWS,
+  primaryRouteSelectedSessionId,
+  routeSessionId,
+  sessionRoute,
+  SETTINGS_ROUTE
+} from './routes'
 
 const SESS_A = 'sess-a'
 const SESS_B = 'sess-b'
@@ -26,5 +35,33 @@ describe('primaryRouteSelectedSessionId', () => {
 
   it('returns null on a non-chat route with no store selection', () => {
     expect(primaryRouteSelectedSessionId(SETTINGS_ROUTE, null)).toBeNull()
+  })
+})
+
+describe('OVERLAY_ROUTE_PATHS', () => {
+  // The workspace route table drives its retained-chat routes off this list, so
+  // a new overlay that never reaches it silently reintroduces the detachment.
+  it('derives a workspace route path for every overlay view', () => {
+    expect(OVERLAY_ROUTE_PATHS).toHaveLength(OVERLAY_VIEWS.size)
+    expect(new Set(OVERLAY_ROUTE_PATHS.map(path => appViewForPath(`/${path}`)))).toEqual(new Set(OVERLAY_VIEWS))
+  })
+
+  it('emits workspace-relative paths (the workspace route table is nested)', () => {
+    for (const path of OVERLAY_ROUTE_PATHS) {
+      expect(path.startsWith('/')).toBe(false)
+    }
+  })
+
+  // Mounting the chat at an overlay path must not make ChatView think the URL
+  // selects a session: a truthy routeSessionId sets isRoutedSessionView, which
+  // drives routeSessionMismatch and blanks the transcript behind a loader.
+  it('leaves every overlay path out of the session-id parser', () => {
+    for (const path of OVERLAY_ROUTE_PATHS) {
+      expect(routeSessionId(`/${path}`)).toBeNull()
+    }
+  })
+
+  it('keeps a full-page workspace route out of the overlay set', () => {
+    expect(OVERLAY_ROUTE_PATHS).not.toContain('skills')
   })
 })

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -136,6 +136,16 @@ export function isOverlayView(view: AppView): boolean {
   return OVERLAY_VIEWS.has(view)
 }
 
+/** Every overlay route as a WORKSPACE-RELATIVE path (the workspace pane's route
+ *  table is nested, so no leading slash). An overlay floats over whatever the
+ *  workspace is already showing, so the workspace route table has to keep the
+ *  chat mounted at these paths rather than render nothing. Derived from
+ *  APP_ROUTES ∩ OVERLAY_VIEWS so declaring a new overlay picks up the retained
+ *  chat by construction instead of silently detaching it again. */
+export const OVERLAY_ROUTE_PATHS: readonly string[] = APP_ROUTES.filter(route => OVERLAY_VIEWS.has(route.view)).map(
+  route => route.path.slice(SESSION_ROUTE_PREFIX.length)
+)
+
 /** The pathname of a router target. Every classifier below reasons about a
  *  PATH, but callers navigate to full targets (`/skills?tab=mcp`), and an
  *  unstripped query reaches the session-id parser — `/skills?tab=mcp` reads as


### PR DESCRIPTION
## Supersedes #39295

- **What #39295 covered:** retained the chat behind **3** of the overlay routes (agents, command-center, settings), in `apps/desktop/src/app/desktop-controller.tsx`.
- **What it did not:** the other four overlays (cron, profiles, starmap, webhooks), and it shipped no regression test — its own body notes *"full upstream Desktop test suite was not run successfully."*
- **Why it can't just be rebased:** `desktop-controller.tsx` no longer exists on `main` — the workspace route table moved to `apps/desktop/src/app/contrib/surfaces.tsx`, so the change has to be rewritten against the new home. #39295's last (and only) push was 2026-06-04, before the 2026-07-14 review on it.
- **What this adds:** all **seven** overlays, derived from `OVERLAY_VIEWS` instead of hand-listed, plus the regression tests. This is the superset that was asked for in the review on #39295: *"Please apply this retained-chat route treatment to the full current overlay set."* (`webhooks` was added after that comment, which is exactly why the derived list matters.)

## What does this PR do?

The workspace pane's route table mapped **all seven** overlay routes to `element={null}`:

```tsx
<Route element={null} path="agents" />
<Route element={null} path="command-center" />
<Route element={null} path="cron" />
<Route element={null} path="profiles" />
<Route element={null} path="settings" />
<Route element={null} path="starmap" />
<Route element={null} path="webhooks" />
```

Overlay views render on their **own layer** over the shell (`app/overlays/overlay-view.tsx`), so the workspace pane behind them rendered nothing. Opening **Settings / Agents / Command Center / Cron / Profiles / Starmap / Webhooks** mid-turn unmounted `ChatView`, tearing down the live transcript, the scroll position and the composer draft; closing the overlay remounted a fresh chat.

That contradicts the route module's own documented contract. `routes.ts`, `isWorkspacePageRoute`:

> *Does `to` land on a full page rendered INSIDE the workspace pane (skills/messaging/artifacts/contributed routes)? **Overlays don't count — they float over whatever the workspace is already showing.***

`element={null}` meant there was nothing to float over.

**Why rendering `chatView` there is correct, not just non-empty:**

- It is the **same element** the `index` and `:sessionId` routes already use with identical props, so React Router **reconciles** it across the route change rather than remounting — which is what actually preserves the state. The test asserts this directly with a mount counter, not just presence.
- Overlay paths are in `RESERVED_PATHS`, so `routeSessionId('/settings')` is `null` ⇒ `isRoutedSessionView === false` ⇒ `routeSessionMismatch === false` and `loadingSession === false` (`chat/index.tsx`). **No loader, no blanking, no route/session mismatch introduced.** Covered by a test.
- `primaryRouteSelectedSessionId`'s docstring already states the intent: *"A non-chat route (settings, an overlay) has no session opinion, so the store selection passes through unchanged."*

**Derived, not hand-listed.** The new `OVERLAY_ROUTE_PATHS` is `APP_ROUTES ∩ OVERLAY_VIEWS`, so an eighth overlay picks up the retained chat by construction. Hand-listing is precisely how `webhooks` ended up needing this after the fact.

### On the second review comment on #39295 (`use-overlay-routing.ts:43`)

That comment asked to centralize all overlay navigation behind the hook, because callers still invoke `navigate()` directly. It was aimed at **#39295's design**, which moved return-path capture into a caller-side helper — a design that does need every caller routed through it.

**`main` does not use that design.** `returnPathRef` is captured in a **location-driven `useEffect`** (`use-overlay-routing.ts:36-40`), which fires on any location change regardless of which caller navigated, so the direct `navigate(<OVERLAY>_ROUTE)` call sites are already covered. And once the chat is retained on every overlay route, a direct `navigate()` **cannot detach the chat at all** — the route table decides mounting, not the caller. So the concern the request was guarding against is subsumed here rather than ignored. No caller-side refactor is included, deliberately.

## Related Issue

No issue filed; this supersedes #39295.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/routes.ts` — add `OVERLAY_ROUTE_PATHS`, the overlay routes as workspace-relative paths, derived from `APP_ROUTES ∩ OVERLAY_VIEWS`.
- `apps/desktop/src/app/contrib/surfaces.tsx` — replace the seven `<Route element={null} …/>` lines with `OVERLAY_ROUTE_PATHS.map(path => <Route element={chatView} key={path} path={path} />)`.
- `apps/desktop/src/app/routes.test.ts` — `OVERLAY_ROUTE_PATHS` covers every `OVERLAY_VIEWS` member, emits workspace-relative paths, and every overlay path stays out of `routeSessionId`.
- `apps/desktop/src/app/contrib/surfaces.overlay-chat-retention.test.tsx` *(new)* — mounts `ChatRoutesSurface` at each overlay path and asserts the chat is present; asserts it is **absent** at `/skills`; and tours every overlay with a mount counter to prove reconciliation rather than remount.

### Site coverage (all seven — this is the superset)

`git grep -n 'element={null}'` returns exactly seven hits, one contiguous block in one file, matching `OVERLAY_VIEWS` exactly:

| overlay | fixed here | in #39295 |
|---|---|---|
| `agents` | ✅ | ✅ |
| `command-center` | ✅ | ✅ |
| `settings` | ✅ | ✅ |
| `cron` | ✅ | ❌ |
| `profiles` | ✅ | ❌ |
| `starmap` | ✅ | ❌ |
| `webhooks` | ✅ | ❌ (post-dates it) |

Other `isOverlayView` call sites (`titlebar-controls.tsx`, `use-route-overlay-active.ts`, `use-desktop-integrations.ts`) consume the overlay classification to hide chrome; they don't share this root cause and are untouched.

## How to Test

1. `cd apps/desktop && npm run test:ui` — the two files above pass.
2. Manually: start a turn, open Settings mid-stream, close it. The transcript, scroll position and composer draft survive; before this change the chat was torn down and rebuilt.
3. Negative case: navigate to `/skills`. The chat is still correctly **replaced** by the full-page view — the fix is not over-broadened to page routes.

### Red-before / green-after (three variants, all actually run)

| variant | result |
|---|---|
| **current `main`** (all seven `element={null}`) | **8 failed**, 10 passed |
| **#39295's exact 3-site shape** (agents/command-center/settings retained) | **5 failed** — `cron`, `profiles`, `starmap`, `webhooks`, + the reconciliation tour |
| **this PR** (all seven, derived) | **18 passed** |

The middle row is the point: the partial shape still fails four of the seven cases, so this is a genuine superset rather than a re-file.

<details>
<summary>Variant output — <code>main</code>'s shape</summary>

```
 × keeps the workspace chat mounted at /settings
 × keeps the workspace chat mounted at /command-center
 × keeps the workspace chat mounted at /webhooks
 × keeps the workspace chat mounted at /cron
 × keeps the workspace chat mounted at /profiles
 × keeps the workspace chat mounted at /agents
 × keeps the workspace chat mounted at /starmap
 × reconciles rather than remounts the chat when an overlay opens and closes
 Test Files  1 failed | 1 passed (2)
      Tests  8 failed | 10 passed (18)
```
</details>

<details>
<summary>Variant output — #39295's 3-site shape</summary>

```
 × keeps the workspace chat mounted at /webhooks
 × keeps the workspace chat mounted at /cron
 × keeps the workspace chat mounted at /profiles
 × keeps the workspace chat mounted at /starmap
 × reconciles rather than remounts the chat when an overlay opens and closes
 Test Files  1 failed | 1 passed (2)
      Tests  5 failed | 13 passed (18)
```
</details>

<details>
<summary>Green — this PR</summary>

```
 Test Files  2 passed (2)
      Tests  18 passed (18)
```
</details>

### Full desktop UI suite

`npm run test:ui` on this branch: **3113 passed, 0 test failures.** Eight files under `src/components/assistant-ui/` fail to *collect* on a missing `frimousse` dependency; the identical eight fail the same way on clean `origin/main` (`b1858f33a`) with these changes stashed, so they are a local-install baseline and none are in touched code. `npx eslint` and `prettier --check` are clean on all four files; `tsc --noEmit` reports zero errors in touched files (only the same pre-existing `frimousse`/`bippy` module-resolution errors present on `main`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- N/A — renderer-only change; ran the desktop vitest suite instead, output above -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (vitest/jsdom)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- docstrings on OVERLAY_ROUTE_PATHS + the route table comment -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- renderer-only React routing; no platform-specific code paths. Verified under vitest/jsdom on macOS only. -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Contract Protected

**Invariant:** every member of `OVERLAY_VIEWS` has a workspace route that renders the chat, and no full-page workspace route does.

- **Known-bad input:** the seven `element={null}` routes on `main` — 8 failures.
- **Partial input:** #39295's 3-site shape — 5 failures.
- **Future input:** an eighth overlay added to `OVERLAY_VIEWS` + `APP_ROUTES` flows into `OVERLAY_ROUTE_PATHS` automatically; if it were ever added to only one of the two, `routes.test.ts` fails on the length/coverage assertion.
- **Negative case:** `/skills` must NOT render the chat — asserted, so the fix cannot be over-broadened into page routes.
