### PR TITLE
fix(desktop): recover OAuth for active profile

### DIFF
--- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -98,4 +98,42 @@ describe('BootFailureOverlay', () => {
       restore()
     }
   })
+
+  it('offers sign-out and sign-in for an OAuth failure on the stored active profile', async () => {
+    const original = window.hermesDesktop
+    const activeProfileOauth = {
+      ...remoteToken,
+      mode: 'remote',
+      profile: 'hermes-nexus',
+      remoteAuthMode: 'oauth',
+      remoteUrl: 'https://hermes-dashboard.example.test'
+    }
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        getRecentLogs: async () => ({ lines: [] }),
+        getConnectionConfig: async (profile?: string) => (profile === 'hermes-nexus' ? activeProfileOauth : { mode: 'local' }),
+        profile: { get: async () => ({ profile: 'hermes-nexus' }) },
+        probeConnectionConfig: async () => ({ providers: [] })
+      }
+    })
+    $desktopBoot.set({
+      error: 'Remote Hermes gateway uses OAuth, but you are not signed in.',
+      fakeMode: false,
+      message: 'boot failed',
+      phase: 'renderer.error',
+      progress: 40,
+      running: false,
+      timestamp: Date.now(),
+      visible: true
+    })
+
+    try {
+      render(<BootFailureOverlay />)
+      expect(await screen.findByRole('button', { name: /sign out.*sign in/i })).toBeTruthy()
+    } finally {
+      Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: original })
+    }
+  })
 })

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -101,7 +101,12 @@ export function BootFailureOverlay() {
       let config: DesktopConnectionConfig
 
       try {
-        config = await desktop.getConnectionConfig()
+        // Boot can fail before the renderer learns its active gateway profile. The
+        // persisted Desktop profile is therefore authoritative here; reading the
+        // global connection would misclassify a per-profile OAuth backend as local
+        // and hide the only viable recovery action.
+        const active = await desktop.profile?.get?.()
+        config = await desktop.getConnectionConfig(active?.profile || undefined)
       } catch {
         return
       }


### PR DESCRIPTION
## Summary
- resolve the persisted Desktop profile before classifying a boot failure
- expose the existing Sign out & sign in recovery flow for per-profile OAuth remotes
- add a regression test for the active-profile failure path

## Verification
- `npm run check`
- 867 Electron/platform tests passed (2 skipped)
- UI suite and macOS package build passed