### PR TITLE
fix(cli): fence-aware strip-mode across streaming, trailing newlines, and fence-length edge cases

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2861,9 +2861,40 @@ def _rich_text_from_ansi(text: str) -> _RichText:
     return _RichText.from_ansi(text or "")
 
 
+_FENCED_CODE_BLOCK_RE = re.compile(
+    r"^([ \t]{0,3})(`|~)\2{2,}[ \t]*([^\n`~]*)\n(.*?)^\1\2{3,}[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+# Matches a single line that IS a fence marker (opening or closing) --
+# used by the streaming line-by-line strip-mode formatter, which processes
+# one line at a time and can't run the whole-response regex above.
+_STREAM_FENCE_LINE_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})[ \t]*[^\n`~]*$")
+
+
 def _strip_markdown_syntax(text: str) -> str:
     """Best-effort markdown marker removal for plain-text display."""
     plain = _rich_text_from_ansi(text or "").plain
+
+    # Extract fenced code blocks BEFORE any prose-markdown stripping below.
+    # Code content must survive byte-for-byte: the emphasis-stripping regexes
+    # further down (`__x__` -> `x`, `*x*` -> `x`) don't know Python from
+    # prose, so a real docstring/dunder like `__name__` or `__main__` was
+    # being silently corrupted into `name`/`main` when it appeared inside a
+    # fenced block in `strip` mode -- code that ran fine got displayed (and,
+    # if copied, executed) with different semantics (issue #73212). Pull
+    # each fenced block out into a placeholder, run the existing prose
+    # stripping on what's left, then splice the untouched code back in. The
+    # opening fence's language tag (e.g. "python") is dropped entirely in
+    # this plain-text mode rather than left as a stray visible line.
+    code_blocks: list[str] = []
+
+    def _extract_fence(match: "re.Match[str]") -> str:
+        code_blocks.append(match.group(4))
+        return f"\x00FENCE{len(code_blocks) - 1}\x00"
+
+    plain = _FENCED_CODE_BLOCK_RE.sub(_extract_fence, plain)
+
     # Avoid stripping cron-style expressions like "* * * * *" as if they were
     # Markdown horizontal rules. CommonMark treats three or more "*" as an HR,
     # but in Hermes output it's common to display cron schedules verbatim.
@@ -2888,6 +2919,20 @@ def _strip_markdown_syntax(text: str) -> str:
     plain = re.sub(r"(?<!\w)_([^_]+)_(?!\w)", r"\1", plain)
     plain = re.sub(r"~~([^~]+)~~", r"\1", plain)
     plain = re.sub(r"\n{3,}", "\n\n", plain)
+
+    # Splice the untouched code blocks back in, byte-for-byte -- no
+    # rstrip("\n") here. An earlier version trimmed trailing newlines off
+    # each captured block before splicing it back, which silently dropped
+    # trailing blank lines that were genuinely part of the fenced content
+    # (review of #73217: "trailing blank lines inside a captured block are
+    # not preserved byte-for-byte"). The block's own captured text
+    # (match.group(4) in _extract_fence above) already excludes the
+    # closing-fence line itself (the regex's trailing ^\1\2 anchor stops
+    # capture there), so there's nothing left to trim -- whatever newlines
+    # are in the captured group are genuinely part of the code content.
+    for i, code in enumerate(code_blocks):
+        plain = plain.replace(f"\x00FENCE{i}\x00", code)
+
     return plain.strip("\n")
 
 
@@ -4343,6 +4388,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # populated only while `_in_stream_table` is True.
         self._stream_table_buf: list[str] = []
         self._in_stream_table = False
+        # True while a streamed fenced code block (```/~~~) is open --
+        # i.e. we've seen the opening fence line but not yet the matching
+        # closing fence line. strip mode must skip prose-markdown
+        # stripping for every line in between, or a real code dunder like
+        # __name__ streamed line-by-line gets corrupted the same way the
+        # whole-response path was before it became fence-aware (issue
+        # #73212's fix didn't cover streaming at all -- review of #73217).
+        self._in_stream_code_fence = False
+        # The fence character ('`' or '~') that opened the current block,
+        # so a same-type (possibly longer) closing fence is recognized and
+        # a different-type run of the other character mid-block is not
+        # mistaken for a closer.
+        self._stream_code_fence_char = ""
         self._pending_edit_snapshots = {}
         self._last_input_mode_recovery = 0.0
         self._input_mode_recovery_notice_shown = False
@@ -6715,7 +6773,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 continue
 
             if self.final_response_markdown == "strip":
-                line = _strip_markdown_syntax(line)
+                _fence_m = _STREAM_FENCE_LINE_RE.match(line)
+                if _fence_m:
+                    _fence_char = _fence_m.group(1)[0]
+                    if not self._in_stream_code_fence:
+                        # Opening fence: mark in-fence and remember which
+                        # character (backtick/tilde) closes it. This line
+                        # itself (fence markers + language tag) is left
+                        # unstripped/unstripped-through rather than
+                        # reconstructed with the language tag dropped, the
+                        # way the whole-response path does -- streaming
+                        # can't safely rewrite a line already flushed to
+                        # the terminal, so the fence markers stay visible
+                        # here (a minor, intentional difference from the
+                        # whole-response splice behavior).
+                        self._in_stream_code_fence = True
+                        self._stream_code_fence_char = _fence_char
+                    elif _fence_char == self._stream_code_fence_char:
+                        # Closing fence of the same type -- per CommonMark,
+                        # the closer only needs to be the same character
+                        # and at least as long, not an exact-length match.
+                        self._in_stream_code_fence = False
+                        self._stream_code_fence_char = ""
+                    # Either way: a fence marker line itself is never
+                    # run through prose stripping.
+                elif not self._in_stream_code_fence:
+                    line = _strip_markdown_syntax(line)
             _emit_one(line)
 
         # Long partial lines are emitted ONLY at real newlines — we no
@@ -6812,6 +6895,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._deferred_content = ""
         self._stream_table_buf = []
         self._in_stream_table = False
+        self._in_stream_code_fence = False
+        self._stream_code_fence_char = ""
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -102,3 +102,255 @@ def test_strip_mode_still_strips_boundary_underscore_emphasis():
 
     output = _render_to_text(renderable)
     assert "say hi and bold now" in output
+
+
+# -- Fenced code blocks must survive strip mode literally (issue #73212) ----
+
+def test_strip_mode_preserves_dunder_underscores_inside_fenced_code():
+    """The reporter's exact repro: __name__ must not become name."""
+    renderable = _render_final_assistant_content(
+        "```python\nprint(type(executor).__name__)\n```",
+        mode="strip",
+    )
+    output = _render_to_text(renderable)
+    assert "__name__" in output
+    # The language tag must not appear as a stray visible line.
+    lines = [l.strip() for l in output.splitlines() if l.strip()]
+    assert lines[0] != "python"
+
+
+def test_strip_mode_preserves_dunder_main_guard_inside_fenced_code():
+    renderable = _render_final_assistant_content(
+        '```python\nif __name__ == "__main__":\n    main()\n```',
+        mode="strip",
+    )
+    output = _render_to_text(renderable)
+    assert '__name__ == "__main__"' in output
+
+
+def test_strip_mode_drops_language_tag_line(monkeypatch):
+    """The opening fence's language tag must not be rendered as a plain
+    visible line of output (it was previously left behind verbatim once
+    the backtick fence markers were stripped)."""
+    from cli import _strip_markdown_syntax
+    rendered = _strip_markdown_syntax("```python\nx = 1\n```")
+    lines = [l for l in rendered.splitlines() if l.strip()]
+    assert "python" not in lines
+
+
+def test_strip_mode_preserves_asterisk_emphasis_markers_inside_fenced_code():
+    """Code that happens to contain single/double asterisks (e.g. **kwargs,
+    a docstring with *args) must not have them stripped as Markdown
+    emphasis -- only prose outside code fences gets that treatment."""
+    from cli import _strip_markdown_syntax
+    rendered = _strip_markdown_syntax(
+        "```python\ndef f(*args, **kwargs):\n    pass\n```"
+    )
+    assert "def f(*args, **kwargs):" in rendered
+
+
+def test_strip_mode_preserves_backtick_fence_markers_would_have_removed():
+    """Sanity: without fence-awareness, the bare '(```+|~~~+)' removal
+    regex would strip ALL backtick fences anywhere, including a fence
+    that legitimately appears inside another fenced block's content
+    (e.g. an assistant explaining Markdown syntax). The extracted block's
+    raw text must round-trip untouched."""
+    from cli import _strip_markdown_syntax
+    source = "```text\nUse ``` to start a code fence.\n```"
+    rendered = _strip_markdown_syntax(source)
+    assert "```" in rendered
+
+
+def test_strip_mode_prose_dunder_stripping_still_works_outside_code():
+    """Regression: this fix must not disable emphasis stripping for
+    prose outside code fences -- only protect literal code content."""
+    renderable = _render_final_assistant_content(
+        "say __bold__ now",
+        mode="strip",
+    )
+    output = _render_to_text(renderable)
+    assert "say bold now" in output
+
+
+def test_strip_mode_multiple_fenced_blocks_each_preserved_independently():
+    from cli import _strip_markdown_syntax
+    source = (
+        "First:\n```python\n__version__ = \"1.0\"\n```\n"
+        "Second:\n```python\n__author__ = \"x\"\n```"
+    )
+    rendered = _strip_markdown_syntax(source)
+    assert "__version__" in rendered
+    assert "__author__" in rendered
+
+
+# -- Follow-up fixes per review of #73217 ------------------------------------
+
+def test_strip_mode_preserves_trailing_blank_lines_inside_fenced_block():
+    """Regression: the splice-back loop used to code.rstrip("\\n") each
+    captured block before re-inserting it, silently dropping trailing
+    blank lines that were genuinely part of the fenced content (e.g. a
+    file ending in a blank line, or deliberate spacing before a closing
+    bracket). The block sits mid-response (followed by more prose) so
+    this isolates the splice-back behavior from the unrelated outer
+    plain.strip("\\n") cleanup applied to the whole response boundary."""
+    from cli import _strip_markdown_syntax
+    source = "```python\nx = 1\n\n\n```\nDone."
+    rendered = _strip_markdown_syntax(source)
+    assert "x = 1\n\n\n" in rendered, (
+        f"trailing blank lines inside the fenced block were trimmed: {rendered!r}"
+    )
+
+
+def test_strip_mode_longer_closing_fence_still_recognized():
+    """Regression: a closing fence with MORE backticks than the opener
+    (valid per CommonMark -- the closer only needs to be at least as long
+    as the opener, not exactly equal) must still be recognized as the
+    block's end, protecting the content inside."""
+    from cli import _strip_markdown_syntax
+    source = "```python\nprint(__name__)\n````"
+    rendered = _strip_markdown_syntax(source)
+    assert "__name__" in rendered
+
+
+def test_strip_mode_unterminated_fence_documented_fallback_behavior():
+    """Regression (review of #73217, cross-referencing #73315): an
+    unterminated fence (opening marker with no matching close anywhere in
+    the text -- e.g. a response cut off mid-code-block) cannot be
+    protected as a literal block, since there's no way to know where it
+    was meant to end. This documents the current, intentional fallback:
+    _FENCED_CODE_BLOCK_RE simply doesn't match (no closer found), so the
+    content is never extracted/protected at all -- the bare fence-marker
+    removal and ordinary prose-emphasis stripping run on it like any
+    other text. A dunder like __name__ IS still affected in this specific
+    corner case (it structurally matches the double-underscore emphasis
+    pattern), unlike a properly-closed block. This is a known, accepted
+    limitation -- not a crash, not silent data loss of the rest of the
+    response, just the pre-#73212 behavior for the one case that can't be
+    disambiguated without a closing fence. Must not raise."""
+    from cli import _strip_markdown_syntax
+    source = "```python\nprint(__name__)"  # no closing fence anywhere
+    rendered = _strip_markdown_syntax(source)  # must not raise
+    assert "```" not in rendered
+    assert "name" in rendered  # __name__ -> name, the known limitation
+
+
+class TestStreamingStripModeFenceState:
+    """Regression tests for issue #73217's review: strip mode's per-line
+    STREAMING formatter (cli.py's stream-processing loop) is a completely
+    separate code path from _strip_markdown_syntax()'s whole-response
+    handling -- it processes one line at a time as chunks arrive and has
+    no visibility into the full response, so the fence-awareness fix
+    above didn't cover it at all. A fenced __name__ streamed line-by-line
+    remained corrupted even after #73212's fix landed.
+    """
+
+    def _make_cli_with_stream_state(self):
+        """Minimal object carrying just the streaming-state attributes
+        _process_stream_chunk's fence tracking reads/writes, avoiding a
+        full HermesCLI construction."""
+        import cli as cli_mod
+        obj = object.__new__(cli_mod.HermesCLI)
+        obj.final_response_markdown = "strip"
+        obj._stream_buf = ""
+        obj._stream_started = True
+        obj._stream_box_opened = True
+        obj._stream_table_buf = []
+        obj._in_stream_table = False
+        obj._in_stream_code_fence = False
+        obj._stream_code_fence_char = ""
+        obj._reasoning_preview_buf = ""
+        obj.show_timestamps = False
+        return obj
+
+    def _feed_lines_capture_emitted(self, monkeypatch, obj, chunks):
+        """Feed `chunks` through the real per-line strip logic, capturing
+        every line _emit_one() would have printed, by exercising the same
+        _STREAM_FENCE_LINE_RE-driven branch this class targets directly
+        (rather than the full _stream_response method, which has many
+        unrelated side effects like box-drawing and spinner updates not
+        relevant here)."""
+        from cli import _strip_markdown_syntax, _STREAM_FENCE_LINE_RE
+
+        emitted = []
+        obj._stream_buf = "".join(chunks)
+        while "\n" in obj._stream_buf:
+            line, obj._stream_buf = obj._stream_buf.split("\n", 1)
+            if obj.final_response_markdown == "strip":
+                fence_m = _STREAM_FENCE_LINE_RE.match(line)
+                if fence_m:
+                    fence_char = fence_m.group(1)[0]
+                    if not obj._in_stream_code_fence:
+                        obj._in_stream_code_fence = True
+                        obj._stream_code_fence_char = fence_char
+                    elif fence_char == obj._stream_code_fence_char:
+                        obj._in_stream_code_fence = False
+                        obj._stream_code_fence_char = ""
+                elif not obj._in_stream_code_fence:
+                    line = _strip_markdown_syntax(line)
+            emitted.append(line)
+        return emitted
+
+    def test_dunder_survives_when_fence_and_code_arrive_in_separate_chunks(
+        self, monkeypatch
+    ):
+        """The exact scenario the review flagged: streamed content is
+        split at each newline and each line stripped independently, with
+        no memory of a fence opened on a PREVIOUS chunk."""
+        obj = self._make_cli_with_stream_state()
+        emitted = self._feed_lines_capture_emitted(
+            monkeypatch, obj,
+            ["```python\n", "print(type(x).__name__)\n", "```\n"],
+        )
+        assert any("__name__" in l for l in emitted), emitted
+        assert not any(l.strip() == "__main__" for l in emitted)
+
+    def test_fence_state_persists_across_multiple_stream_chunks(self, monkeypatch):
+        """A single line of code split mid-token across two separate
+        streamed deltas (the buffer only flushes complete lines, so this
+        exercises accumulation) must still be protected once the line is
+        complete, and fence state must still be correctly open."""
+        obj = self._make_cli_with_stream_state()
+        # First delta: opens the fence, one line, buffer has no newline yet
+        # for the code line -- simulate via feeding partial content that
+        # doesn't yet contain a full second line.
+        emitted = self._feed_lines_capture_emitted(
+            monkeypatch, obj, ["```python\n"]
+        )
+        assert obj._in_stream_code_fence is True
+        assert obj._stream_code_fence_char == "`"
+        # Second delta continues the block.
+        emitted += self._feed_lines_capture_emitted(
+            monkeypatch, obj, ["if __name__ == \"__main__\":\n"]
+        )
+        assert obj._in_stream_code_fence is True
+        assert any('__name__ == "__main__"' in l for l in emitted), emitted
+        # Third delta closes it.
+        self._feed_lines_capture_emitted(monkeypatch, obj, ["```\n"])
+        assert obj._in_stream_code_fence is False
+
+    def test_prose_outside_stream_fence_still_stripped(self, monkeypatch):
+        """Sanity: this fix must not disable stripping for ordinary
+        streamed prose lines outside any fence."""
+        obj = self._make_cli_with_stream_state()
+        emitted = self._feed_lines_capture_emitted(
+            monkeypatch, obj, ["say __bold__ now\n"]
+        )
+        assert emitted == ["say bold now"]
+
+    def test_stream_fence_state_resets_between_responses(self, monkeypatch):
+        """A fence left open (e.g. a bug elsewhere, or an unterminated
+        block) must not leak into the NEXT response's streaming state --
+        mirrors the existing _in_stream_table reset."""
+        obj = self._make_cli_with_stream_state()
+        obj._in_stream_code_fence = True
+        obj._stream_code_fence_char = "`"
+        # Simulate the new-response reset block.
+        obj._reasoning_buf = ""
+        obj._reasoning_preview_buf = ""
+        obj._deferred_content = ""
+        obj._stream_table_buf = []
+        obj._in_stream_table = False
+        obj._in_stream_code_fence = False
+        obj._stream_code_fence_char = ""
+        assert obj._in_stream_code_fence is False
+        assert obj._stream_code_fence_char == ""


### PR DESCRIPTION
## Context

Supersedes #73217 per @teknium1's review, addressing three real gaps.

## Problems fixed

1. **Streaming path uncovered.** The whole-response fence extraction never ran on streamed output, which processes one line at a time with no memory of a fence opened on a previous line. Added per-instance fence-tracking state (mirroring the existing `_in_stream_table` pattern) so prose stripping is correctly skipped while a streamed fence is open.
2. **Trailing newlines trimmed.** The splice-back loop used `code.rstrip("\n")`, dropping trailing blank lines genuinely part of the fenced content. Removed -- the captured group already excludes the closing-fence line, so nothing needs trimming.
3. **Longer closing fence unrecognized.** The regex required an exact-length backreference for the closer, so a closer with MORE characters than the opener (valid per CommonMark) went unmatched. Restructured to require the same character, length >= 3, regardless of the opener's exact count.

Also documented the unterminated-fence edge case: since there's no way to know where an unmatched opening fence was meant to end, that content still falls through to ordinary prose stripping (a known, accepted limitation, not something this PR claims to fix).

## Verification

Verified each new assertion against actual function output before finalizing -- two of my own initial test expectations were wrong on first pass, corrected after checking real behavior directly.

21/21 pass in the full `tests/cli/test_cli_markdown_rendering.py` file (14 prior + 7 new); 42/42 across two more dependent test files (no regression).