### PR TITLE
fix(cli): stop false unknown-key warning for gateway-resolved display keys

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4678,6 +4678,26 @@ def _suggest_closest_key(key: str, candidates: set[str], cutoff: float = 0.6) ->
     return matches[0] if matches else None
 
 
+def _gateway_display_overrideable_keys() -> frozenset:
+    """Display keys resolved by the gateway display layer, not DEFAULT_CONFIG.
+
+    ``gateway/display_config.py`` keeps its own defaults
+    (``_GLOBAL_DEFAULTS`` / ``OVERRIDEABLE_KEYS``) for the settings that
+    support per-platform overrides — several of them (``tool_progress``,
+    ``long_running_notifications``, ``busy_ack_detail``, ...) are read at
+    runtime but have no seed in ``DEFAULT_CONFIG['display']``.  A plain
+    DEFAULT_CONFIG walk therefore flags them as unknown even though Hermes
+    reads them (e.g. ``hermes config set display.tool_progress verbose``
+    warned and suggested ``display.tool_progress_command``).
+    Fail-open: an import problem just disables the extra allowlist.
+    """
+    try:
+        from gateway.display_config import OVERRIDEABLE_KEYS
+        return OVERRIDEABLE_KEYS
+    except Exception:
+        return frozenset()
+
+
 def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     """Validate a dotted config-key path against the known schema.
 
@@ -4760,8 +4780,18 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
             # leaf with a dict, matching pre-existing behavior).
             return True, None
         if seg not in node:
+            # ``display.*`` has a second schema source: the gateway display
+            # resolver (see _gateway_display_overrideable_keys). Treat a hit
+            # there like a DEFAULT_CONFIG scalar leaf — the key is known,
+            # and anything deeper is handled by write-time coercion.
+            extra = (
+                _gateway_display_overrideable_keys()
+                if consumed == ["display"] else frozenset()
+            )
+            if seg in extra:
+                return True, None
             # Suggest the closest sibling at this depth.
-            sibling_suggestion = _suggest_closest_key(seg, set(node.keys()))
+            sibling_suggestion = _suggest_closest_key(seg, set(node.keys()) | set(extra))
             if sibling_suggestion is not None:
                 fixed_path = ".".join(consumed + [sibling_suggestion])
                 return False, fixed_path

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -492,6 +492,17 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        # display keys resolved by gateway/display_config rather than
+        # DEFAULT_CONFIG: the runtime reads these, so the validator must
+        # not warn on them.
+        "display.tool_progress",
+        "display.long_running_notifications",
+        "display.busy_ack_detail",
+        "display.cleanup_progress",
+        "display.live_status",
+        # ...while keys with a DEFAULT_CONFIG seed keep passing too.
+        "display.tool_progress_command",
+        "display.tool_progress_grouping",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key
@@ -502,6 +513,10 @@ class TestValidateConfigKey:
         ("gateway.discord.gateway_restart_notification", None),  # no close suggestion
         ("disco", "discord"),
         ("agent.max_turn", "agent.max_turns"),
+        # Typo of a gateway-resolved display key must suggest the real key
+        # (the old candidate set sent display.tool_progress users to
+        # display.tool_progress_command).
+        ("display.tool_progres", "display.tool_progress"),
     ])
     def test_unknown_keys_with_suggestion(self, key, expected_in_suggestion):
         from hermes_cli.config import _validate_config_key


### PR DESCRIPTION
## Problem

`hermes config set` validates dotted keys by walking `DEFAULT_CONFIG`, but five display settings have their defaults in `gateway/display_config._GLOBAL_DEFAULTS` instead of `DEFAULT_CONFIG['display']`:

- `display.tool_progress`
- `display.long_running_notifications`
- `display.busy_ack_detail`
- `display.cleanup_progress`
- `display.live_status`

Setting any of them prints a false warning — and the difflib suggestion actively points users at an unrelated key:

```
$ hermes config set display.tool_progress verbose
✓ Set display.tool_progress = verbose in ~/.hermes/config.yaml
⚠ 'display.tool_progress' is not a recognized config key — it was saved anyway, but Hermes may not read it.
  Did you mean: display.tool_progress_command
```

The gateway does read `display.tool_progress` at runtime (`resolve_display_setting`, step 2 "Global user setting"), so the warning is wrong, and following the suggestion would silently change a different feature (the `/verbose` command toggle).

The gap looks accidental rather than intentional: `focus_saved_tool_progress` — the key `/focus` uses to *back up* the `tool_progress` mode — is in `DEFAULT_CONFIG`, while `tool_progress` itself is not.

## Fix

Teach `_validate_config_key` about the gateway display layer's `OVERRIDEABLE_KEYS` (lazy import, fail-open) when walking the `display` subtree, and include those keys in the sibling-suggestion candidates.

Deliberately **not** chosen: seeding `"tool_progress": "all"` into `DEFAULT_CONFIG['display']` — that would make new installs carry an explicit global value, which outranks the built-in per-platform defaults (`_PLATFORM_DEFAULTS`, e.g. Slack/Discord default `off`) in the resolution order and would change behavior. The validator-side fix keeps runtime behavior untouched.

## Before / after

```
_validate_config_key('display.tool_progress')  # (False, 'display.tool_progress_command') → (True, None)
_validate_config_key('display.tool_progres')   # typo: now suggests 'display.tool_progress'
_validate_config_key('display.bogus_key')      # still (False, None)
```

## Tests

- Added the five gateway-resolved keys (plus two `DEFAULT_CONFIG`-seeded siblings as regression guards) to `TestValidateConfigKey::test_known_keys_pass`
- Added a typo-suggestion case (`display.tool_progres` → `display.tool_progress`)
- `python3 -m pytest tests/hermes_cli/test_set_config_value.py -q` → 79 passed