### PR TITLE
fix(state): self-heal orphaned FK references in state.db

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2168,6 +2168,16 @@ def _run_state_db_auto_maintenance(session_db) -> None:
                 min_interval_hours=int(cfg.get("min_interval_hours", 24)),
             )
 
+        # FK integrity self-heal is independent of both auto_archive and the
+        # destructive auto_prune sweep — run it before any early return so
+        # default installs (auto_prune off) still self-heal.
+        try:
+            session_db.maybe_repair_orphan_references(
+                min_interval_hours=int(cfg.get("min_interval_hours", 24)),
+            )
+        except Exception as _heal_exc:
+            logger.debug("state.db orphan self-heal skipped: %s", _heal_exc)
+
         if not cfg.get("auto_prune", False):
             return
         session_db.maybe_auto_prune_and_vacuum(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6055,6 +6055,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         idle_days=float(_sess_cfg.get("auto_archive_days", 3)),
                         min_interval_hours=int(_sess_cfg.get("min_interval_hours", 24)),
                     )
+                # FK integrity self-heal is independent of the destructive
+                # auto_prune sweep — default installs (auto_prune off) still
+                # self-heal. Own min_interval gate in state_meta; never raises.
+                self._session_db._db.maybe_repair_orphan_references(
+                    min_interval_hours=int(_sess_cfg.get("min_interval_hours", 24)),
+                )
                 if _sess_cfg.get("auto_prune", False):
                     # Construction-time, before the loop serves traffic; sync DB is fine.
                     self._session_db._db.maybe_auto_prune_and_vacuum(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9054,10 +9054,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         every later ``create_session`` upsert (the ON CONFLICT DO UPDATE
         re-writes the stale ``parent_session_id`` and fails the FK check).
 
-        Fixes the three orphan classes in one transaction:
+        Fixes the four orphan classes in one transaction:
           * ``sessions.parent_session_id`` → NULL (parent gone)
           * ``messages`` rows → deleted (owning session gone)
           * ``session_model_usage`` rows → deleted (owning session gone)
+          * ``telegram_dm_topic_bindings`` rows → deleted (owning session gone)
 
         Idempotent and safe to run at any time; no-op when the DB is already
         consistent. Returns counts of repaired rows per class.
@@ -9066,6 +9067,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             "parent_pointers_nulled": 0,
             "orphan_messages_deleted": 0,
             "orphan_usage_deleted": 0,
+            "orphan_topic_bindings_deleted": 0,
         }
 
         def _do(conn):
@@ -9100,6 +9102,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "DELETE FROM session_model_usage "
                 "WHERE session_id NOT IN (SELECT id FROM sessions)"
             )
+            # telegram_dm_topic_bindings is created on /topic opt-in only
+            # (apply_telegram_topic_migration); guard so default DBs skip it.
+            has_bindings = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='telegram_dm_topic_bindings'"
+            ).fetchone()
+            if has_bindings:
+                cur = conn.execute(
+                    "SELECT COUNT(*) FROM telegram_dm_topic_bindings b "
+                    "LEFT JOIN sessions s ON b.session_id = s.id "
+                    "WHERE s.id IS NULL"
+                )
+                result["orphan_topic_bindings_deleted"] = cur.fetchone()[0]
+                conn.execute(
+                    "DELETE FROM telegram_dm_topic_bindings "
+                    "WHERE session_id NOT IN (SELECT id FROM sessions)"
+                )
             return result
 
         try:
@@ -9111,6 +9130,49 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return repaired
         except Exception as exc:
             logger.warning("state.db orphan repair failed: %s", exc)
+            result["error"] = str(exc)
+            return result
+
+    def maybe_repair_orphan_references(
+        self,
+        min_interval_hours: int = 24,
+    ) -> Dict[str, Any]:
+        """Idempotent FK self-heal, decoupled from the destructive auto-prune.
+
+        Runs :meth:`repair_orphan_references` at most once per
+        ``min_interval_hours`` (tracked independently in state_meta), so
+        default installations whose ``sessions.auto_prune`` is off still
+        self-heal FK corruption left by legacy FK-off deletions.
+
+        Never raises. On any failure, logs a warning and returns a dict
+        with ``\"error\"`` set.
+
+        Returns a dict with keys:
+          - ``\"skipped\"`` (bool) — true if within min_interval_hours of last run
+          - ``\"repaired\"`` (dict) — orphan-reference repair counts (see
+            :meth:`repair_orphan_references`); absent on error or skip
+          - ``\"error\"`` (str, optional) — present only on failure
+        """
+        result: Dict[str, Any] = {"skipped": False}
+        try:
+            last_raw = self.get_meta("last_orphan_repair")
+            now = time.time()
+            if last_raw:
+                try:
+                    last_ts = float(last_raw)
+                    if now - last_ts < min_interval_hours * 3600:
+                        result["skipped"] = True
+                        return result
+                except (TypeError, ValueError):
+                    pass  # corrupt meta; treat as no prior run
+
+            repaired = self.repair_orphan_references()
+            if not repaired.get("error"):
+                self.set_meta("last_orphan_repair", str(now))
+            result["repaired"] = repaired
+            return result
+        except Exception as exc:
+            logger.warning("state.db orphan self-heal failed: %s", exc)
             result["error"] = str(exc)
             return result
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9044,6 +9044,76 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._conn.execute("VACUUM")
         return optimized
 
+    def repair_orphan_references(self) -> Dict[str, int]:
+        """Repair dangling foreign-key references left by legacy deletions.
+
+        Deleting a session row with ``PRAGMA foreign_keys=OFF`` (e.g. a
+        connection opened before this class enforced it, or an external tool
+        touching the DB) skips the ON DELETE CASCADE on ``session_model_usage``
+        and the explicit message cleanup, stranding orphan rows that then trip
+        every later ``create_session`` upsert (the ON CONFLICT DO UPDATE
+        re-writes the stale ``parent_session_id`` and fails the FK check).
+
+        Fixes the three orphan classes in one transaction:
+          * ``sessions.parent_session_id`` → NULL (parent gone)
+          * ``messages`` rows → deleted (owning session gone)
+          * ``session_model_usage`` rows → deleted (owning session gone)
+
+        Idempotent and safe to run at any time; no-op when the DB is already
+        consistent. Returns counts of repaired rows per class.
+        """
+        result: Dict[str, int] = {
+            "parent_pointers_nulled": 0,
+            "orphan_messages_deleted": 0,
+            "orphan_usage_deleted": 0,
+        }
+
+        def _do(conn):
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM sessions s "
+                "LEFT JOIN sessions p ON s.parent_session_id = p.id "
+                "WHERE s.parent_session_id IS NOT NULL AND p.id IS NULL"
+            )
+            result["parent_pointers_nulled"] = cur.fetchone()[0]
+            conn.execute(
+                "UPDATE sessions SET parent_session_id = NULL "
+                "WHERE parent_session_id IS NOT NULL "
+                "AND parent_session_id NOT IN (SELECT id FROM sessions)"
+            )
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM messages m "
+                "LEFT JOIN sessions s ON m.session_id = s.id "
+                "WHERE s.id IS NULL"
+            )
+            result["orphan_messages_deleted"] = cur.fetchone()[0]
+            conn.execute(
+                "DELETE FROM messages "
+                "WHERE session_id NOT IN (SELECT id FROM sessions)"
+            )
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM session_model_usage u "
+                "LEFT JOIN sessions s ON u.session_id = s.id "
+                "WHERE s.id IS NULL"
+            )
+            result["orphan_usage_deleted"] = cur.fetchone()[0]
+            conn.execute(
+                "DELETE FROM session_model_usage "
+                "WHERE session_id NOT IN (SELECT id FROM sessions)"
+            )
+            return result
+
+        try:
+            repaired = self._execute_write(_do)
+            if any(repaired.values()):
+                logger.info(
+                    "state.db orphan repair: %s", repaired,
+                )
+            return repaired
+        except Exception as exc:
+            logger.warning("state.db orphan repair failed: %s", exc)
+            result["error"] = str(exc)
+            return result
+
     def maybe_auto_prune_and_vacuum(
         self,
         retention_days: int = 90,
@@ -9071,10 +9141,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Returns a dict with keys:
           - ``"skipped"`` (bool) — true if within min_interval_hours of last run
           - ``"pruned"`` (int)   — number of sessions deleted
+          - ``"repaired"`` (dict) — orphan-reference repair counts (see
+            :meth:`repair_orphan_references`); absent on error or skip
           - ``"vacuumed"`` (bool) — true if VACUUM ran
           - ``"error"`` (str, optional) — present only on failure
         """
-        result: Dict[str, Any] = {"skipped": False, "pruned": 0, "vacuumed": False}
+        result: Dict[str, Any] = {
+            "skipped": False, "pruned": 0, "vacuumed": False,
+        }
         try:
             # Skip if another process/call did maintenance recently.
             last_raw = self.get_meta("last_auto_prune")
@@ -9093,6 +9167,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 sessions_dir=sessions_dir,
             )
             result["pruned"] = pruned
+
+            # FK integrity self-heal: legacy deletions (pre-FK-on connections)
+            # can strand orphan rows that trip every later create_session upsert.
+            repaired = self.repair_orphan_references()
+            if repaired.get("error"):
+                logger.warning(
+                    "state.db auto-maintenance: orphan repair failed: %s",
+                    repaired["error"],
+                )
+            else:
+                result["repaired"] = repaired
 
             # Only VACUUM if we actually freed rows, and no more often than
             # once every min_vacuum_interval_days -- a large prune (e.g. the

--- a/tests/gateway/test_async_session_db.py
+++ b/tests/gateway/test_async_session_db.py
@@ -97,10 +97,10 @@ _GATEWAY_FILES = ("gateway/run.py", "gateway/slash_commands.py")
 #   - self._session_db._db.<x>: the sync escape, allowed ONLY where the call is
 #     provably off the event loop — construction (__init__, before the loop
 #     serves) and the run_sync closure (executed in a thread-pool executor).
-#     Four such sites today (maybe_auto_archive joined maybe_auto_prune_and_vacuum
-#     in the construction-time maintenance block); a fifth must be justified and
-#     this count bumped.
-_ALLOWED_SYNC_DB_ESCAPES = 4
+#     Five such sites today (maybe_auto_archive, maybe_repair_orphan_references,
+#     and maybe_auto_prune_and_vacuum in the construction-time maintenance block);
+#     a sixth must be justified and this count bumped.
+_ALLOWED_SYNC_DB_ESCAPES = 5
 
 # Sync helpers that touch SessionDB but are NEVER invoked bare on the loop:
 # every loop-side call wraps them in ``asyncio.to_thread(...)`` and the only

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2334,28 +2334,44 @@ class TestAutoMaintenance:
         db.append_message(session_id="child", role="user", content="hello")
 
         # Simulate a legacy FK-off deletion of `parent`: rows that reference it
-        # are now orphaned. FK is enforced on this connection, so delete the
-        # parent via raw SQL with FK off to mimic the historical bug.
-        db._conn.execute("PRAGMA foreign_keys=OFF")
-        db._conn.execute("DELETE FROM sessions WHERE id = 'parent'")
-        db._conn.execute("PRAGMA foreign_keys=ON")
-        db._conn.commit()
+        # are now orphaned. SQLite ignores PRAGMA foreign_keys changes inside a
+        # pending transaction, so each corruption block commits its FK-off DML
+        # BEFORE re-enabling FKs — this exercises repair under production FK
+        # enforcement (same as the real-world bug).
+        self._fk_off_execute_commit(
+            db,
+            "DELETE FROM sessions WHERE id = 'parent'",
+        )
 
         # Orphan usage row pointing at a session that no longer exists
-        # (FK off here too — an FK-off connection could also have written this)
-        db._conn.execute("PRAGMA foreign_keys=OFF")
-        db._conn.execute(
+        self._fk_off_execute_commit(
+            db,
             "INSERT INTO session_model_usage "
             "(session_id, model, billing_provider, api_call_count) "
-            "VALUES ('ghost_session', 'test-model', 'test', 1)"
+            "VALUES ('ghost_session', 'test-model', 'test', 1)",
         )
-        db._conn.execute("PRAGMA foreign_keys=ON")
-        db._conn.commit()
+
+        # Topic bindings table only exists after /topic opt-in migration —
+        # create it so the 4th orphan class is exercised.
+        db.apply_telegram_topic_migration()
+
+        # Orphan topic binding pointing at a session that no longer exists
+        self._fk_off_execute_commit(
+            db,
+            "INSERT INTO telegram_dm_topic_bindings "
+            "(chat_id, thread_id, user_id, session_key, session_id, linked_at, updated_at) "
+            "VALUES ('chat1', 'thread1', 'user1', 'key1', 'ghost_session', ?, ?)",
+            (time.time(), time.time()),
+        )
+
+        # Repair must run under real FK enforcement
+        assert db._conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
 
         repaired = db.repair_orphan_references()
 
         assert repaired["parent_pointers_nulled"] == 1  # child.parent → NULL
         assert repaired["orphan_usage_deleted"] == 1  # ghost usage row
+        assert repaired["orphan_topic_bindings_deleted"] == 1  # ghost binding
         # child has no orphan messages (parent had none), so 0 expected here
         assert repaired["orphan_messages_deleted"] == 0
 
@@ -2368,30 +2384,46 @@ class TestAutoMaintenance:
         assert child is not None
         assert child["parent_session_id"] is None
 
+    def _fk_off_execute_commit(self, db, sql, params=()):
+        """Run corrupting DML on an FK-off connection, commit, then re-enable FK.
+
+        Mirrors the historical bug (deletion via a connection opened before FK
+        enforcement) while keeping the shared connection's FK pragma ON for the
+        repair itself. SQLite ignores PRAGMA foreign_keys changes mid-transaction,
+        so the DML is committed BEFORE re-enabling enforcement.
+        """
+        conn = db._conn
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute(sql, params)
+        conn.commit()
+        conn.execute("PRAGMA foreign_keys=ON")
+        # Verify enforcement really is back on — the whole point of the fix.
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
     def test_repair_orphan_references_deletes_orphan_messages(self, db):
         """Messages whose session row is gone are removed by repair."""
         db.create_session(session_id="alive", source="cli")
         db.append_message(session_id="alive", role="user", content="keep me")
 
         # Orphan message rows (session deleted out-of-band)
-        db._conn.execute("PRAGMA foreign_keys=OFF")
-        db._conn.execute(
+        self._fk_off_execute_commit(
+            db,
             "INSERT INTO messages (session_id, role, content, timestamp) "
             "VALUES ('gone1', 'user', 'orphan msg', ?)",
             (time.time(),),
         )
-        db._conn.execute(
+        self._fk_off_execute_commit(
+            db,
             "INSERT INTO messages (session_id, role, content, timestamp) "
             "VALUES ('gone2', 'user', 'orphan msg', ?)",
             (time.time(),),
         )
-        db._conn.execute("PRAGMA foreign_keys=ON")
-        db._conn.commit()
 
         repaired = db.repair_orphan_references()
 
         assert repaired["orphan_messages_deleted"] == 2
         assert repaired["orphan_usage_deleted"] == 0
+        assert repaired["orphan_topic_bindings_deleted"] == 0
         # Alive session's messages untouched
         assert len(db.search_messages("keep me")) == 1
 
@@ -2402,19 +2434,18 @@ class TestAutoMaintenance:
         """maybe_auto_prune_and_vacuum self-heals FK orphans in the same pass."""
         # Prunable old session with an orphan child pointer
         self._make_old_ended(db, "old", days_old=100)
-        db._conn.execute("PRAGMA foreign_keys=OFF")
-        db._conn.execute(
+        self._fk_off_execute_commit(
+            db,
             "INSERT INTO sessions (id, source, parent_session_id, started_at) "
             "VALUES ('orphan_child', 'cli', 'no_such_parent', ?)",
             (time.time(),),
         )
-        db._conn.execute(
+        self._fk_off_execute_commit(
+            db,
             "INSERT INTO session_model_usage "
             "(session_id, model, billing_provider, api_call_count) "
-            "VALUES ('ghost', 'm', 'p', 1)"
+            "VALUES ('ghost', 'm', 'p', 1)",
         )
-        db._conn.execute("PRAGMA foreign_keys=ON")
-        db._conn.commit()
 
         result = db.maybe_auto_prune_and_vacuum(retention_days=90)
 
@@ -2422,6 +2453,37 @@ class TestAutoMaintenance:
         assert "repaired" in result
         assert result["repaired"]["parent_pointers_nulled"] == 1
         assert result["repaired"]["orphan_usage_deleted"] == 1
+
+        violations = db._conn.execute("PRAGMA foreign_key_check").fetchall()
+        assert violations == []
+
+    def test_maybe_repair_orphan_references_runs_without_auto_prune(self, db):
+        """Standalone FK self-heal works even when auto_prune is off (default)."""
+        db.create_session(session_id="parent", source="cli")
+        db.create_session(session_id="child", source="cli", parent_session_id="parent")
+        self._fk_off_execute_commit(
+            db,
+            "DELETE FROM sessions WHERE id = 'parent'",
+        )
+        db.apply_telegram_topic_migration()
+        self._fk_off_execute_commit(
+            db,
+            "INSERT INTO telegram_dm_topic_bindings "
+            "(chat_id, thread_id, user_id, session_key, session_id, linked_at, updated_at) "
+            "VALUES ('chat1', 'thread1', 'user1', 'key1', 'ghost_session', ?, ?)",
+            (time.time(), time.time()),
+        )
+
+        # auto_prune NOT called at all — the decoupled entrypoint alone
+        result = db.maybe_repair_orphan_references(min_interval_hours=24)
+
+        assert result["skipped"] is False
+        assert result["repaired"]["parent_pointers_nulled"] == 1
+        assert result["repaired"]["orphan_topic_bindings_deleted"] == 1
+
+        # Second call within the interval is a no-op skip
+        result2 = db.maybe_repair_orphan_references(min_interval_hours=24)
+        assert result2["skipped"] is True
 
         violations = db._conn.execute("PRAGMA foreign_key_check").fetchall()
         assert violations == []

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2327,6 +2327,105 @@ class TestAutoMaintenance:
         # Active session's transcript is untouched
         assert (sessions_dir / "new.jsonl").exists()
 
+    def test_repair_orphan_references_cleans_all_three_classes(self, db):
+        """Repair nulls dangling parents and deletes orphan messages/usage rows."""
+        db.create_session(session_id="parent", source="cli")
+        db.create_session(session_id="child", source="cli", parent_session_id="parent")
+        db.append_message(session_id="child", role="user", content="hello")
+
+        # Simulate a legacy FK-off deletion of `parent`: rows that reference it
+        # are now orphaned. FK is enforced on this connection, so delete the
+        # parent via raw SQL with FK off to mimic the historical bug.
+        db._conn.execute("PRAGMA foreign_keys=OFF")
+        db._conn.execute("DELETE FROM sessions WHERE id = 'parent'")
+        db._conn.execute("PRAGMA foreign_keys=ON")
+        db._conn.commit()
+
+        # Orphan usage row pointing at a session that no longer exists
+        # (FK off here too — an FK-off connection could also have written this)
+        db._conn.execute("PRAGMA foreign_keys=OFF")
+        db._conn.execute(
+            "INSERT INTO session_model_usage "
+            "(session_id, model, billing_provider, api_call_count) "
+            "VALUES ('ghost_session', 'test-model', 'test', 1)"
+        )
+        db._conn.execute("PRAGMA foreign_keys=ON")
+        db._conn.commit()
+
+        repaired = db.repair_orphan_references()
+
+        assert repaired["parent_pointers_nulled"] == 1  # child.parent → NULL
+        assert repaired["orphan_usage_deleted"] == 1  # ghost usage row
+        # child has no orphan messages (parent had none), so 0 expected here
+        assert repaired["orphan_messages_deleted"] == 0
+
+        # FK check is now clean
+        violations = db._conn.execute("PRAGMA foreign_key_check").fetchall()
+        assert violations == []
+
+        # child survived and its parent pointer was nulled, not deleted
+        child = db.get_session("child")
+        assert child is not None
+        assert child["parent_session_id"] is None
+
+    def test_repair_orphan_references_deletes_orphan_messages(self, db):
+        """Messages whose session row is gone are removed by repair."""
+        db.create_session(session_id="alive", source="cli")
+        db.append_message(session_id="alive", role="user", content="keep me")
+
+        # Orphan message rows (session deleted out-of-band)
+        db._conn.execute("PRAGMA foreign_keys=OFF")
+        db._conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES ('gone1', 'user', 'orphan msg', ?)",
+            (time.time(),),
+        )
+        db._conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES ('gone2', 'user', 'orphan msg', ?)",
+            (time.time(),),
+        )
+        db._conn.execute("PRAGMA foreign_keys=ON")
+        db._conn.commit()
+
+        repaired = db.repair_orphan_references()
+
+        assert repaired["orphan_messages_deleted"] == 2
+        assert repaired["orphan_usage_deleted"] == 0
+        # Alive session's messages untouched
+        assert len(db.search_messages("keep me")) == 1
+
+        violations = db._conn.execute("PRAGMA foreign_key_check").fetchall()
+        assert violations == []
+
+    def test_auto_prune_runs_orphan_repair(self, db):
+        """maybe_auto_prune_and_vacuum self-heals FK orphans in the same pass."""
+        # Prunable old session with an orphan child pointer
+        self._make_old_ended(db, "old", days_old=100)
+        db._conn.execute("PRAGMA foreign_keys=OFF")
+        db._conn.execute(
+            "INSERT INTO sessions (id, source, parent_session_id, started_at) "
+            "VALUES ('orphan_child', 'cli', 'no_such_parent', ?)",
+            (time.time(),),
+        )
+        db._conn.execute(
+            "INSERT INTO session_model_usage "
+            "(session_id, model, billing_provider, api_call_count) "
+            "VALUES ('ghost', 'm', 'p', 1)"
+        )
+        db._conn.execute("PRAGMA foreign_keys=ON")
+        db._conn.commit()
+
+        result = db.maybe_auto_prune_and_vacuum(retention_days=90)
+
+        assert result["pruned"] == 1  # old session pruned
+        assert "repaired" in result
+        assert result["repaired"]["parent_pointers_nulled"] == 1
+        assert result["repaired"]["orphan_usage_deleted"] == 1
+
+        violations = db._conn.execute("PRAGMA foreign_key_check").fetchall()
+        assert violations == []
+
 
 
 


### PR DESCRIPTION
## Problem

Deleting sessions through an FK-off connection (legacy code paths, external DB tools) skips the `ON DELETE CASCADE` on `session_model_usage` and the explicit `messages` cleanup. The stranded orphan rows then trip **every** later `create_session()` upsert: the `ON CONFLICT DO UPDATE` re-writes the stale `parent_session_id` via `COALESCE` and fails the FK check, producing a repeated `Session DB creation failed (will retry next turn): FOREIGN KEY constraint failed` warning every turn for that session — the session can never be re-created, and the log spams indefinitely.

## Fix

Add `SessionDB.repair_orphan_references()` which, in a single transaction:

- NULLs `sessions.parent_session_id` rows pointing at missing parents
- deletes `messages` rows whose owning session no longer exists
- deletes `session_model_usage` rows whose owning session no longer exists

Wire it into `maybe_auto_prune_and_vacuum()` so long-lived entrypoints (CLI, gateway, cron scheduler) self-heal during their existing startup maintenance pass. The method is idempotent and a no-op when the DB is already consistent, so it is safe to run unconditionally.

## Verification

- New tests cover all three orphan classes plus the auto-prune integration path:
  - `test_repair_orphan_references_cleans_all_three_classes`
  - `test_repair_orphan_references_deletes_orphan_messages`
  - `test_auto_prune_runs_orphan_repair`
- `TestAutoMaintenance` suite: 6 passed (3 existing + 3 new)
- After repair, `PRAGMA foreign_key_check` returns zero rows in all test scenarios

## Notes

- The FK-on connection (`hermes_state.py:1852`) means new orphans are unlikely, but the repair is cheap insurance against any FK-off path and cleans up legacy databases in the wild.
- Behavior-preserving: no schema change, no new config, no destructive action on consistent DBs.