### PR TITLE
fix(docker): accept full Linux UID/GID range in stage2 remap validation (#75143)

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -85,12 +85,17 @@ fi
 # is a no-op if the dir already exists. (#18482, salvages #18488)
 mkdir -p "$HERMES_HOME"
 
-# Numeric UID/GID validation: must be digits only, non-root, 1-65534.
-# NAS hosts such as Unraid commonly use low non-root IDs (99:100).
+# Numeric UID/GID validation: must be digits only, non-root, 1-4294967294.
+# The Linux kernel and shadow-utils accept 32-bit IDs up to 2^32-2
+# (4294967294); 65535 is reserved for "nobody" in many distributions and
+# 4294967295 is the sentinel (-1) value. NAS hosts such as Unraid commonly
+# use low non-root IDs (99:100), while Synology DSM 7 assigns custom groups
+# GIDs above 65534 (e.g. 65536+), so a tighter cap silently skipped the
+# remap for those hosts. See #75143.
 validate_uid_gid() {
     case "$1" in
         ''|*[!0-9]*) return 1 ;;
-        *) [ "$1" -ge 1 ] && [ "$1" -le 65534 ] ;;
+        *) [ "$1" -ge 1 ] && [ "$1" -le 4294967294 ] ;;
     esac
 }
 


### PR DESCRIPTION
## Summary

Fixes #75143.

`validate_uid_gid()` in `docker/stage2-hook.sh` capped UID/GID values at 65534. Synology DSM 7 assigns custom groups GIDs above that range (e.g. 65536+), so the `HERMES_GID`/`PGID` remap was silently skipped — the container ran with the default hermes GID and created files with an invalid GID on the bind-mounted volume.

## Change

Expand the validation cap to the full Linux 32-bit ID range (`1`–`4294967294`), keeping the digits-only and non-root checks. Verified against the Debian base image that `groupmod -o -g 100000` and `usermod -u 100001` both succeed.

## Tests

- `bash -n docker/stage2-hook.sh` — syntax OK
- Functional extraction test of `validate_uid_gid()`: 15 cases pass (Synology high GIDs 65536/100000 now accepted; root/empty/non-numeric/negative/sentinel/overflow still rejected)
- `pytest tests/tools/test_stage2_hook_symlink_chown.py tests/tools/test_stage2_hook_seed_one_symlinks.py` — 7 passed
