### PR TITLE
fix(tts): use additional_headers for websockets v15 in xAI streaming TTS

### DIFF
--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -455,7 +455,7 @@ class XAIStreamer(StreamingTTSProvider):
         ).strip()
 
         async with websockets.connect(
-            ws_url, extra_headers={"Authorization": f"Bearer {api_key}"}
+            ws_url, additional_headers={"Authorization": f"Bearer {api_key}"}
         ) as ws:
             await ws.send(_json.dumps({
                 "text": text,


### PR DESCRIPTION
## Problem

`websockets` v15.0 renamed the `connect()` kwarg `extra_headers` → `additional_headers`. The xAI streaming TTS path (`XAIStreamer._async_frames`) was still passing `extra_headers`, causing **every** streaming synthesis call to crash with:

```
BaseEventLoop.create_connection() got an unexpected keyword argument 'extra_headers'
```

## Cascading failure

The crash was worse than "no streaming audio":

1. **Audio still played** — the dispatcher fell back to the non-streaming POST endpoint, so responses were still audible. This masked the bug.
2. **Mic jammed** — the broken WebSocket's lifecycle left the wake-word detector stuck in a `pause → resume` loop. After the first spoken reply, the mic felt stuck and wouldn't re-arm cleanly.
3. **Logs flooded** — `speak-stream synthesis failed` warnings on every TTS call.

Timeline from `gui.log`:

```
22:08:39 WARNING hermes_cli.web_server: speak-stream synthesis failed: BaseEventLoop.create_connection() got an unexpected keyword argument 'extra_headers'
22:08:56 WARNING hermes_cli.web_server: speak-stream synthesis failed: BaseEventLoop.create_connection() got an unexpected keyword argument 'extra_headers'
... (repeats on every TTS call)
22:11:19 INFO tui_gateway.server: wake.resume: detector resumed=True
22:11:20 INFO tui_gateway.server: wake.pause: detector paused=True   ← stuck loop
```

## Fix

One-line kwarg rename in `tools/tts_streaming.py:458`:

```diff
-            ws_url, extra_headers={"Authorization": f"Bearer {api_key}"}
+            ws_url, additional_headers={"Authorization": f"Bearer {api_key}"}
```

Verified against the installed websockets version:

```python
>>> import websockets, inspect
>>> [p for p in inspect.signature(websockets.connect).parameters if 'headers' in p]
['additional_headers']
```

## Testing

- [x] Import check passes: `venv/bin/python -c "from tools.tts_streaming import XAIStreamer; print('import OK')"`
- [x] No other `extra_headers` usage in `tts_streaming.py` (grep confirmed)
- [x] Kwarg matches installed websockets v15 API signature
- [ ] E2E: restart gateway, say "hey hermes", confirm streaming TTS plays without `speak-stream synthesis failed` warnings and mic re-arms cleanly

## Notes

- No existing tests for `tts_streaming.py` — this is a one-line API-compliance fix, not a behavioral change.
- The `.bak` backup file was removed from the staging area; only the one-line fix is committed.