### PR TITLE
chore(release): drop my personal email from LEGACY_AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -486,7 +486,6 @@ LEGACY_AUTHOR_MAP = {
     "alfred@my-cloud.me": "alfred-smith-0",
     "tangtaizhong792@gmail.com": "tangtaizong666",
     "github@aldo.pw": "aldoeliacim",
-    "max@c60spaceship.com": "MaxFreedomPollard",
     "achaljhawar03@gmail.com": "achaljhawar",
     "claytonchew@ClaytonMacMiniM4.local": "claytonchew",
     "hbentel@gmail.com": "hbentel",


### PR DESCRIPTION
### What this changes

Removes one line from `LEGACY_AUTHOR_MAP` in `scripts/release.py`: the mapping for my own personal email address.

### Why

It is my address and I would rather it not sit in a public file. Every commit I have authored since June uses `272618364+MaxFreedomPollard@users.noreply.github.com`, and `resolve_author()` already resolves that shape through its existing noreply branch:

```python
noreply_match = re.match(r"(\d+)\+(.+)@users\.noreply\.github\.com", email)
if noreply_match:
    return f"@{noreply_match.group(2)}"
```

So no map entry is needed for anything I send now or later, and `contributors/emails/MaxFreedomPollard@users.noreply.github.com` is untouched and still covers the plain noreply form.

### What it costs

Five older commits of mine (June: #44951, #47617, #47648, #55126) were authored with the old address. With this line gone they fall through to the git author name instead of the `@` handle in any regenerated notes. That is fine by me, and those release windows have already shipped.

### Testing

`tests/scripts/test_contributor_map.py` passes (7 passed). Nothing asserts this entry, and the legacy-into-effective-map invariant still holds, since the entry is absent from both sides of the comparison rather than orphaned on one.

I know the legacy dict is described as frozen with respect to additions, which is why new mappings go in `contributors/emails/`. This is a single deletion rather than an addition, so it does not reintroduce the merge-conflict problem that policy exists to avoid. Happy to close it if you would rather the dict stay untouched.
