### PR TITLE
fix(cli): split panel text on newlines before wrapping

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2484,10 +2484,20 @@ def _panel_box_width(title: str, content_lines: list[str], min_width: int = 46, 
 
 
 def _wrap_panel_text(text: str, width: int, subsequent_indent: str = "", *, keep_ws: bool = False) -> list[str]:
-    """Wrap panel text; ``keep_ws`` preserves whitespace (command/detail previews)."""
+    """Wrap panel text; ``keep_ws`` preserves whitespace (command/detail previews).
+
+    Split on newlines first, then wrap each line. ``textwrap.wrap`` treats
+    embedded ``\\n`` as ordinary whitespace, so a multi-line command (e.g. a
+    heredoc pending approval) would otherwise collapse into a few unreadable
+    long lines and push approve/deny choices off-screen (#72580).
+    """
     kw = dict(replace_whitespace=False, drop_whitespace=False) if keep_ws else dict(break_long_words=False, break_on_hyphens=False)
-    wrapped = textwrap.wrap(text, width=max(8, width), subsequent_indent=subsequent_indent, **kw)
-    return wrapped or [""]
+    result: list[str] = []
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    for line in normalized.split("\n"):
+        wrapped = textwrap.wrap(line, width=max(8, width), subsequent_indent=subsequent_indent, **kw)
+        result.extend(wrapped or [""])
+    return result or [""]
 
 
 _wrap_panel_text_keep_ws = functools.partial(_wrap_panel_text, keep_ws=True)

--- a/cli.py
+++ b/cli.py
@@ -4202,6 +4202,50 @@ class _VoiceInputMessage:
         return self.text
 
 
+def _wrap_panel_text(
+    text: str,
+    width: int,
+    subsequent_indent: str = "",
+    *,
+    replace_whitespace: bool = False,
+    drop_whitespace: bool = False,
+    break_long_words: bool = True,
+    break_on_hyphens: bool = True,
+) -> list[str]:
+    # Split on newlines first, then wrap each line individually.
+    # textwrap.wrap treats embedded \n as ordinary whitespace and does not
+    # split on it, collapsing a multi-line command (e.g. a heredoc pending
+    # approval) into a few unreadable long lines that push the panel's
+    # approve/deny choices off-screen (#72580).
+    result: list[str] = []
+    for line in text.split("\n"):
+        wrapped = textwrap.wrap(
+            line,
+            width=max(8, width),
+            replace_whitespace=replace_whitespace,
+            drop_whitespace=drop_whitespace,
+            break_long_words=break_long_words,
+            break_on_hyphens=break_on_hyphens,
+            subsequent_indent=subsequent_indent,
+        )
+        result.extend(wrapped or [""])
+    return result or [""]
+
+
+def _wrap_clarify_panel_text(text: str, width: int, subsequent_indent: str = "") -> list[str]:
+    # The clarify panel wraps prose (questions/choices), not commands:
+    # keep textwrap's whitespace handling and don't break mid-word.
+    return _wrap_panel_text(
+        text,
+        width,
+        subsequent_indent,
+        replace_whitespace=True,
+        drop_whitespace=True,
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
+
+
 class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     """
     Interactive CLI for the Hermes Agent.
@@ -8850,16 +8894,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             inner = min(max(longest + 4, min_width - 2), max_width - 2, max(24, term_cols - 6))
             return inner + 2
 
-        def _wrap_panel_text(text: str, width: int, subsequent_indent: str = "") -> list[str]:
-            wrapped = textwrap.wrap(
-                text,
-                width=max(8, width),
-                replace_whitespace=False,
-                drop_whitespace=False,
-                subsequent_indent=subsequent_indent,
-            )
-            return wrapped or [""]
-
         def _append_panel_line(lines, border_style: str, content_style: str, text: str, box_width: int) -> None:
             inner_width = max(0, box_width - 2)
             lines.append((border_style, "│ "))
@@ -13457,16 +13491,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             inner = min(max(longest + 4, min_width - 2), max_width - 2, max(24, term_cols - 6))
             return inner + 2
 
-        def _wrap_panel_text(text: str, width: int, subsequent_indent: str = "") -> list[str]:
-            wrapped = textwrap.wrap(
-                text,
-                width=max(8, width),
-                replace_whitespace=False,
-                drop_whitespace=False,
-                subsequent_indent=subsequent_indent,
-            )
-            return wrapped or [""]
-
         def _append_panel_line(lines, border_style: str, content_style: str, text: str, box_width: int) -> None:
             inner_width = max(0, box_width - 2)
             lines.append((border_style, "│ "))
@@ -16659,15 +16683,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             inner = min(max(longest + 4, min_width - 2), max_width - 2, max(24, term_cols - 6))
             return inner + 2  # account for the single leading/trailing spaces inside borders
 
-        def _wrap_panel_text(text: str, width: int, subsequent_indent: str = "") -> list[str]:
-            wrapped = textwrap.wrap(
-                text,
-                width=max(8, width),
-                break_long_words=False,
-                break_on_hyphens=False,
-                subsequent_indent=subsequent_indent,
-            )
-            return wrapped or [""]
+        # Prose variant for the clarify panel (keeps textwrap's whitespace
+        # handling, never breaks mid-word); shares the newline-split fix.
+        _wrap_panel_text = _wrap_clarify_panel_text
 
         def _append_panel_line(lines, border_style: str, content_style: str, text: str, box_width: int) -> None:
             inner_width = max(0, box_width - 2)

--- a/cli.py
+++ b/cli.py
@@ -13633,6 +13633,244 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         lines.append(('class:approval-border', '╰' + ('─' * box_width) + '╯\n'))
         return lines
 
+    def _get_clarify_display_fragments(self):
+        """Render the clarify question/choices panel for the prompt_toolkit UI.
+
+        Layout priority: choices + Other option must always render even if
+        the question is very long. The question is budgeted to leave enough
+        rows for the choices and trailing chrome; anything over the budget
+        is truncated with a marker. Shares the newline-split fix (#72580)
+        via ``_wrap_clarify_panel_text`` so a multi-line question never
+        collapses into rows that push the selectable choices off-screen.
+        """
+        state = self._clarify_state
+        if not state:
+            return []
+
+        def _panel_box_width(title: str, content_lines: list[str], min_width: int = 46, max_width: int = 76) -> int:
+            term_cols = shutil.get_terminal_size((100, 20)).columns
+            longest = max([len(title)] + [len(line) for line in content_lines] + [min_width - 4])
+            inner = min(max(longest + 4, min_width - 2), max_width - 2, max(24, term_cols - 6))
+            return inner + 2
+
+        def _append_panel_line(lines, border_style: str, content_style: str, text: str, box_width: int) -> None:
+            inner_width = max(0, box_width - 2)
+            lines.append((border_style, "│ "))
+            lines.append((content_style, text.ljust(inner_width)))
+            lines.append((border_style, " │\n"))
+
+        def _append_blank_panel_line(lines, border_style: str, box_width: int) -> None:
+            lines.append((border_style, "│" + (" " * box_width) + "│\n"))
+
+        question = state["question"]
+        choices = state.get("choices") or []
+        selected = state.get("selected", 0)
+        # multi-select support
+        multi_select = state.get("multi_select", False)
+        selected_indices = state.get("selected_indices", set()) if multi_select else set()
+        preview_lines = _wrap_clarify_panel_text(question, 60)
+        for i, choice in enumerate(choices):
+            # Show number prefix for quick selection (1-9 for items 1-9, 0 for 10th item)
+            if i < 9:
+                num_prefix = str(i + 1)
+            elif i == 9:
+                num_prefix = '0'
+            else:
+                num_prefix = ' '
+            if multi_select:
+                cb = "[x]" if i in selected_indices else "[ ]"
+                if i == selected and not self._clarify_freetext:
+                    prefix = f"❯ {cb} {num_prefix}. "
+                else:
+                    prefix = f"  {cb} {num_prefix}. "
+            elif i == selected and not self._clarify_freetext:
+                prefix = f"❯ {num_prefix}. "
+            else:
+                prefix = f"  {num_prefix}. "
+            preview_lines.extend(_wrap_clarify_panel_text(f"{prefix}{choice}", 60, subsequent_indent="    "))
+        # "Other" option in preview
+        other_num = len(choices) + 1
+        if other_num < 10:
+            other_num_prefix = str(other_num)
+        elif other_num == 10:
+            other_num_prefix = '0'
+        else:
+            other_num_prefix = ' '
+        other_idx_val = len(choices)
+        if multi_select:
+            cb = "[x]" if other_idx_val in selected_indices else "[ ]"
+            other_label = (
+                f"❯ {cb} {other_num_prefix}. Other (type below)" if self._clarify_freetext
+                else f"❯ {cb} {other_num_prefix}. Other (type your answer)" if selected == other_idx_val
+                else f"  {cb} {other_num_prefix}. Other (type your answer)"
+            )
+        else:
+            other_label = (
+                f"❯ {other_num_prefix}. Other (type below)" if self._clarify_freetext
+                else f"❯ {other_num_prefix}. Other (type your answer)" if selected == len(choices)
+                else f"  {other_num_prefix}. Other (type your answer)"
+            )
+        preview_lines.extend(_wrap_clarify_panel_text(other_label, 60, subsequent_indent="    "))
+        box_width = _panel_box_width("Hermes needs your input", preview_lines)
+        inner_text_width = max(8, box_width - 2)
+
+        # Pre-wrap choices + Other option — these are mandatory.
+        choice_wrapped: list[tuple[int, str]] = []
+        if choices:
+            for i, choice in enumerate(choices):
+                # Show number prefix for quick selection (1-9 for items 1-9, 0 for 10th item)
+                if i < 9:
+                    num_prefix = str(i + 1)
+                elif i == 9:
+                    num_prefix = '0'
+                else:
+                    num_prefix = ' '
+                # multi-select support: add checkbox after cursor indicator
+                if multi_select:
+                    cb = "[x]" if i in selected_indices else "[ ]"
+                    if i == selected and not self._clarify_freetext:
+                        prefix = f'❯ {cb} {num_prefix}. '
+                    else:
+                        prefix = f'  {cb} {num_prefix}. '
+                elif i == selected and not self._clarify_freetext:
+                    prefix = f'❯ {num_prefix}. '
+                else:
+                    prefix = f'  {num_prefix}. '
+                for wrapped in _wrap_clarify_panel_text(f"{prefix}{choice}", inner_text_width, subsequent_indent="    "):
+                    choice_wrapped.append((i, wrapped))
+            # Trailing Other row(s)
+            other_idx = len(choices)
+            other_num = other_idx + 1
+            if other_num < 10:
+                other_num_prefix = str(other_num)
+            elif other_num == 10:
+                other_num_prefix = '0'
+            else:
+                other_num_prefix = ' '
+            # multi-select support: add checkbox to Other option
+            if multi_select:
+                cb = "[x]" if other_idx in selected_indices else "[ ]"
+                if selected == other_idx and not self._clarify_freetext:
+                    other_label_mand = f'❯ {cb} {other_num_prefix}. Other (type your answer)'
+                elif self._clarify_freetext:
+                    other_label_mand = f'❯ {cb} {other_num_prefix}. Other (type below)'
+                else:
+                    other_label_mand = f'  {cb} {other_num_prefix}. Other (type your answer)'
+            else:
+                if selected == other_idx and not self._clarify_freetext:
+                    other_label_mand = f'❯ {other_num_prefix}. Other (type your answer)'
+                elif self._clarify_freetext:
+                    other_label_mand = f'❯ {other_num_prefix}. Other (type below)'
+                else:
+                    other_label_mand = f'  {other_num_prefix}. Other (type your answer)'
+            other_wrapped = _wrap_clarify_panel_text(other_label_mand, inner_text_width, subsequent_indent="    ")
+        elif self._clarify_freetext:
+            # Freetext-only mode: the guidance line takes the place of choices.
+            other_wrapped = _wrap_clarify_panel_text(
+                "Type your answer in the prompt below, then press Enter.",
+                inner_text_width,
+            )
+        else:
+            other_wrapped = []
+
+        # Budget the question so mandatory rows always render.
+        # Chrome layouts:
+        #   full : top border + blank_after_title + blank_after_question
+        #          + blank_before_bottom + bottom border = 5 rows
+        #   tight: top border + bottom border = 2 rows (drop all blanks)
+        #
+        # reserved_below matches the approval-panel budget (~6 rows for
+        # spinner/tool-progress + status + input + separators + prompt).
+        term_rows = shutil.get_terminal_size((100, 24)).lines
+        chrome_full = 5
+        chrome_tight = 2
+        reserved_below = 6
+
+        available = max(0, term_rows - reserved_below)
+        # The compact decision must reserve room for at least one question
+        # row on top of the choices, otherwise full chrome (3 blank
+        # separators) gets kept when there is no room for it and the panel
+        # overflows the viewport — HSplit then clips the panel's tail,
+        # silently dropping the choices (the reported bug).
+        mandatory_full = chrome_full + 1 + len(choice_wrapped) + len(other_wrapped)
+
+        use_compact_chrome = mandatory_full > available
+        chrome_rows = chrome_tight if use_compact_chrome else chrome_full
+
+        max_question_rows = max(1, available - chrome_rows - len(choice_wrapped) - len(other_wrapped))
+        max_question_rows = min(max_question_rows, 12)  # soft cap on huge terminals
+
+        # When the choices alone (plus compact chrome) already exceed the
+        # viewport, drop the question entirely — the choices are the only
+        # thing the user must see to make a selection. Without this the
+        # question would still claim its 1-row floor above and push the
+        # tail of the choices off-screen (HSplit clips the overflow).
+        choices_overflow = chrome_rows + len(choice_wrapped) + len(other_wrapped) >= available
+        if choices_overflow:
+            max_question_rows = 0
+
+        question_wrapped = _wrap_clarify_panel_text(question, inner_text_width)
+        if max_question_rows <= 0:
+            question_wrapped = []
+        elif len(question_wrapped) > max_question_rows:
+            # The truncation marker is itself a row, so it must count
+            # against the budget. With a 1-row budget there is no room for
+            # both a question line and the marker — show the marker alone
+            # so the rendered question never exceeds max_question_rows.
+            keep = max(0, max_question_rows - 1)
+            question_wrapped = question_wrapped[:keep] + ["… (question truncated)"]
+
+        lines = []
+        # Box top border
+        lines.append(('class:clarify-border', '╭─ '))
+        lines.append(('class:clarify-title', 'Hermes needs your input'))
+        lines.append(('class:clarify-border', ' ' + ('─' * max(0, box_width - len("Hermes needs your input") - 3)) + '╮\n'))
+        if not use_compact_chrome:
+            _append_blank_panel_line(lines, 'class:clarify-border', box_width)
+
+        # Question text (bounded)
+        for wrapped in question_wrapped:
+            _append_panel_line(lines, 'class:clarify-border', 'class:clarify-question', wrapped, box_width)
+        if not use_compact_chrome:
+            _append_blank_panel_line(lines, 'class:clarify-border', box_width)
+
+        if self._clarify_freetext and not choices:
+            for wrapped in other_wrapped:
+                _append_panel_line(lines, 'class:clarify-border', 'class:clarify-choice', wrapped, box_width)
+            if not use_compact_chrome:
+                _append_blank_panel_line(lines, 'class:clarify-border', box_width)
+
+        if choices:
+            # Multiple-choice mode: show selectable options
+            for i, wrapped in choice_wrapped:
+                style = 'class:clarify-selected' if i == selected and not self._clarify_freetext else 'class:clarify-choice'
+                _append_panel_line(lines, 'class:clarify-border', style, wrapped, box_width)
+
+            # "Other" option (trailing row(s), only shown when choices exist)
+            other_idx = len(choices)
+            # Calculate number prefix for "Other" option
+            other_num = other_idx + 1
+            if other_num < 10:
+                other_num_prefix = str(other_num)
+            elif other_num == 10:
+                other_num_prefix = '0'
+            else:
+                other_num_prefix = ' '
+
+            if selected == other_idx and not self._clarify_freetext:
+                other_style = 'class:clarify-selected'
+            elif self._clarify_freetext:
+                other_style = 'class:clarify-active-other'
+            else:
+                other_style = 'class:clarify-choice'
+            for wrapped in other_wrapped:
+                _append_panel_line(lines, 'class:clarify-border', other_style, wrapped, box_width)
+
+        if not use_compact_chrome:
+            _append_blank_panel_line(lines, 'class:clarify-border', box_width)
+        lines.append(('class:clarify-border', '╰' + ('─' * box_width) + '╯\n'))
+        return lines
+
     def _secret_capture_callback(self, var_name: str, prompt: str, metadata=None) -> dict:
         return prompt_for_secret(self, var_name, prompt, metadata)
 
@@ -16696,230 +16934,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         def _append_blank_panel_line(lines, border_style: str, box_width: int) -> None:
             lines.append((border_style, "│" + (" " * box_width) + "│\n"))
 
-        def _get_clarify_display():
-            """Build styled text for the clarify question/choices panel.
-
-            Layout priority: choices + Other option must always render even if
-            the question is very long. The question is budgeted to leave enough
-            rows for the choices and trailing chrome; anything over the budget
-            is truncated with a marker.
-            """
-            state = cli_ref._clarify_state
-            if not state:
-                return []
-
-            question = state["question"]
-            choices = state.get("choices") or []
-            selected = state.get("selected", 0)
-            # multi-select support
-            multi_select = state.get("multi_select", False)
-            selected_indices = state.get("selected_indices", set()) if multi_select else set()
-            preview_lines = _wrap_panel_text(question, 60)
-            for i, choice in enumerate(choices):
-                # Show number prefix for quick selection (1-9 for items 1-9, 0 for 10th item)
-                if i < 9:
-                    num_prefix = str(i + 1)
-                elif i == 9:
-                    num_prefix = '0'
-                else:
-                    num_prefix = ' '
-                if multi_select:
-                    cb = "[x]" if i in selected_indices else "[ ]"
-                    if i == selected and not cli_ref._clarify_freetext:
-                        prefix = f"❯ {cb} {num_prefix}. "
-                    else:
-                        prefix = f"  {cb} {num_prefix}. "
-                elif i == selected and not cli_ref._clarify_freetext:
-                    prefix = f"❯ {num_prefix}. "
-                else:
-                    prefix = f"  {num_prefix}. "
-                preview_lines.extend(_wrap_panel_text(f"{prefix}{choice}", 60, subsequent_indent="    "))
-            # "Other" option in preview
-            other_num = len(choices) + 1
-            if other_num < 10:
-                other_num_prefix = str(other_num)
-            elif other_num == 10:
-                other_num_prefix = '0'
-            else:
-                other_num_prefix = ' '
-            other_idx_val = len(choices)
-            if multi_select:
-                cb = "[x]" if other_idx_val in selected_indices else "[ ]"
-                other_label = (
-                    f"❯ {cb} {other_num_prefix}. Other (type below)" if cli_ref._clarify_freetext
-                    else f"❯ {cb} {other_num_prefix}. Other (type your answer)" if selected == other_idx_val
-                    else f"  {cb} {other_num_prefix}. Other (type your answer)"
-                )
-            else:
-                other_label = (
-                    f"❯ {other_num_prefix}. Other (type below)" if cli_ref._clarify_freetext
-                    else f"❯ {other_num_prefix}. Other (type your answer)" if selected == len(choices)
-                    else f"  {other_num_prefix}. Other (type your answer)"
-                )
-            preview_lines.extend(_wrap_panel_text(other_label, 60, subsequent_indent="    "))
-            box_width = _panel_box_width("Hermes needs your input", preview_lines)
-            inner_text_width = max(8, box_width - 2)
-
-            # Pre-wrap choices + Other option — these are mandatory.
-            choice_wrapped: list[tuple[int, str]] = []
-            if choices:
-                for i, choice in enumerate(choices):
-                    # Show number prefix for quick selection (1-9 for items 1-9, 0 for 10th item)
-                    if i < 9:
-                        num_prefix = str(i + 1)
-                    elif i == 9:
-                        num_prefix = '0'
-                    else:
-                        num_prefix = ' '
-                    # multi-select support: add checkbox after cursor indicator
-                    if multi_select:
-                        cb = "[x]" if i in selected_indices else "[ ]"
-                        if i == selected and not cli_ref._clarify_freetext:
-                            prefix = f'❯ {cb} {num_prefix}. '
-                        else:
-                            prefix = f'  {cb} {num_prefix}. '
-                    elif i == selected and not cli_ref._clarify_freetext:
-                        prefix = f'❯ {num_prefix}. '
-                    else:
-                        prefix = f'  {num_prefix}. '
-                    for wrapped in _wrap_panel_text(f"{prefix}{choice}", inner_text_width, subsequent_indent="    "):
-                        choice_wrapped.append((i, wrapped))
-                # Trailing Other row(s)
-                other_idx = len(choices)
-                other_num = other_idx + 1
-                if other_num < 10:
-                    other_num_prefix = str(other_num)
-                elif other_num == 10:
-                    other_num_prefix = '0'
-                else:
-                    other_num_prefix = ' '
-                # multi-select support: add checkbox to Other option
-                if multi_select:
-                    cb = "[x]" if other_idx in selected_indices else "[ ]"
-                    if selected == other_idx and not cli_ref._clarify_freetext:
-                        other_label_mand = f'❯ {cb} {other_num_prefix}. Other (type your answer)'
-                    elif cli_ref._clarify_freetext:
-                        other_label_mand = f'❯ {cb} {other_num_prefix}. Other (type below)'
-                    else:
-                        other_label_mand = f'  {cb} {other_num_prefix}. Other (type your answer)'
-                else:
-                    if selected == other_idx and not cli_ref._clarify_freetext:
-                        other_label_mand = f'❯ {other_num_prefix}. Other (type your answer)'
-                    elif cli_ref._clarify_freetext:
-                        other_label_mand = f'❯ {other_num_prefix}. Other (type below)'
-                    else:
-                        other_label_mand = f'  {other_num_prefix}. Other (type your answer)'
-                other_wrapped = _wrap_panel_text(other_label_mand, inner_text_width, subsequent_indent="    ")
-            elif cli_ref._clarify_freetext:
-                # Freetext-only mode: the guidance line takes the place of choices.
-                other_wrapped = _wrap_panel_text(
-                    "Type your answer in the prompt below, then press Enter.",
-                    inner_text_width,
-                )
-            else:
-                other_wrapped = []
-
-            # Budget the question so mandatory rows always render.
-            # Chrome layouts:
-            #   full : top border + blank_after_title + blank_after_question
-            #          + blank_before_bottom + bottom border = 5 rows
-            #   tight: top border + bottom border = 2 rows (drop all blanks)
-            #
-            # reserved_below matches the approval-panel budget (~6 rows for
-            # spinner/tool-progress + status + input + separators + prompt).
-            term_rows = shutil.get_terminal_size((100, 24)).lines
-            chrome_full = 5
-            chrome_tight = 2
-            reserved_below = 6
-
-            available = max(0, term_rows - reserved_below)
-            # The compact decision must reserve room for at least one question
-            # row on top of the choices, otherwise full chrome (3 blank
-            # separators) gets kept when there is no room for it and the panel
-            # overflows the viewport — HSplit then clips the panel's tail,
-            # silently dropping the choices (the reported bug).
-            mandatory_full = chrome_full + 1 + len(choice_wrapped) + len(other_wrapped)
-
-            use_compact_chrome = mandatory_full > available
-            chrome_rows = chrome_tight if use_compact_chrome else chrome_full
-
-            max_question_rows = max(1, available - chrome_rows - len(choice_wrapped) - len(other_wrapped))
-            max_question_rows = min(max_question_rows, 12)  # soft cap on huge terminals
-
-            # When the choices alone (plus compact chrome) already exceed the
-            # viewport, drop the question entirely — the choices are the only
-            # thing the user must see to make a selection. Without this the
-            # question would still claim its 1-row floor above and push the
-            # tail of the choices off-screen (HSplit clips the overflow).
-            choices_overflow = chrome_rows + len(choice_wrapped) + len(other_wrapped) >= available
-            if choices_overflow:
-                max_question_rows = 0
-
-            question_wrapped = _wrap_panel_text(question, inner_text_width)
-            if max_question_rows <= 0:
-                question_wrapped = []
-            elif len(question_wrapped) > max_question_rows:
-                # The truncation marker is itself a row, so it must count
-                # against the budget. With a 1-row budget there is no room for
-                # both a question line and the marker — show the marker alone
-                # so the rendered question never exceeds max_question_rows.
-                keep = max(0, max_question_rows - 1)
-                question_wrapped = question_wrapped[:keep] + ["… (question truncated)"]
-
-            lines = []
-            # Box top border
-            lines.append(('class:clarify-border', '╭─ '))
-            lines.append(('class:clarify-title', 'Hermes needs your input'))
-            lines.append(('class:clarify-border', ' ' + ('─' * max(0, box_width - len("Hermes needs your input") - 3)) + '╮\n'))
-            if not use_compact_chrome:
-                _append_blank_panel_line(lines, 'class:clarify-border', box_width)
-
-            # Question text (bounded)
-            for wrapped in question_wrapped:
-                _append_panel_line(lines, 'class:clarify-border', 'class:clarify-question', wrapped, box_width)
-            if not use_compact_chrome:
-                _append_blank_panel_line(lines, 'class:clarify-border', box_width)
-
-            if cli_ref._clarify_freetext and not choices:
-                for wrapped in other_wrapped:
-                    _append_panel_line(lines, 'class:clarify-border', 'class:clarify-choice', wrapped, box_width)
-                if not use_compact_chrome:
-                    _append_blank_panel_line(lines, 'class:clarify-border', box_width)
-
-            if choices:
-                # Multiple-choice mode: show selectable options
-                for i, wrapped in choice_wrapped:
-                    style = 'class:clarify-selected' if i == selected and not cli_ref._clarify_freetext else 'class:clarify-choice'
-                    _append_panel_line(lines, 'class:clarify-border', style, wrapped, box_width)
-
-                # "Other" option (trailing row(s), only shown when choices exist)
-                other_idx = len(choices)
-                # Calculate number prefix for "Other" option
-                other_num = other_idx + 1
-                if other_num < 10:
-                    other_num_prefix = str(other_num)
-                elif other_num == 10:
-                    other_num_prefix = '0'
-                else:
-                    other_num_prefix = ' '
-                
-                if selected == other_idx and not cli_ref._clarify_freetext:
-                    other_style = 'class:clarify-selected'
-                elif cli_ref._clarify_freetext:
-                    other_style = 'class:clarify-active-other'
-                else:
-                    other_style = 'class:clarify-choice'
-                for wrapped in other_wrapped:
-                    _append_panel_line(lines, 'class:clarify-border', other_style, wrapped, box_width)
-
-            if not use_compact_chrome:
-                _append_blank_panel_line(lines, 'class:clarify-border', box_width)
-            lines.append(('class:clarify-border', '╰' + ('─' * box_width) + '╯\n'))
-            return lines
-
         clarify_widget = ConditionalContainer(
             Window(
-                FormattedTextControl(_get_clarify_display),
+                FormattedTextControl(self._get_clarify_display_fragments),
                 wrap_lines=True,
             ),
             filter=Condition(lambda: cli_ref._clarify_state is not None),

--- a/tests/cli/test_wrap_panel_text.py
+++ b/tests/cli/test_wrap_panel_text.py
@@ -1,0 +1,88 @@
+"""Regression tests for #72580: approval panel multi-line text wrapping.
+
+``_wrap_panel_text`` must split on newlines before wrapping. textwrap.wrap
+treats embedded \\n as ordinary whitespace, so a multi-line command (e.g.
+a heredoc pending approval) previously collapsed into a few long lines
+and pushed the approve/deny choices off-screen.
+"""
+
+from cli import _wrap_panel_text, _wrap_panel_text_keep_ws
+
+
+HEREDOC = (
+    "python3 << 'EOF'\n"
+    "import sqlite3\n"
+    "conn = sqlite3.connect('db')\n"
+    "cur.execute('SELECT * FROM sessions')\n"
+    "print(cur.fetchall())\n"
+    "conn.close()\n"
+    "EOF"
+)
+
+
+def test_multiline_command_keeps_one_display_line_per_source_line():
+    lines = _wrap_panel_text_keep_ws(HEREDOC, width=60)
+    assert lines == HEREDOC.split("\n")
+
+
+def test_no_embedded_newlines_in_output():
+    lines = _wrap_panel_text_keep_ws(HEREDOC, width=20)
+    assert all("\n" not in line for line in lines)
+    assert len(lines) > len(HEREDOC.split("\n"))
+
+
+def test_empty_lines_are_preserved():
+    assert _wrap_panel_text("a\n\nb", width=60) == ["a", "", "b"]
+    assert _wrap_panel_text_keep_ws("a\n\nb", width=60) == ["a", "", "b"]
+
+
+def test_all_line_ending_styles_are_normalized_without_losing_empty_lines():
+    expected = ["a", "", "b", ""]
+    for text in ("a\n\nb\n", "a\r\n\r\nb\r\n", "a\r\rb\r"):
+        lines = _wrap_panel_text_keep_ws(text, width=60)
+        assert lines == expected
+        assert all("\r" not in line and "\n" not in line for line in lines)
+
+
+def test_single_line_behaviour_unchanged():
+    assert _wrap_panel_text("short", width=60) == ["short"]
+    long_line = "x" * 130
+    lines = _wrap_panel_text_keep_ws(long_line, width=60)
+    assert lines == ["x" * 60, "x" * 60, "x" * 10]
+
+
+def test_empty_input_returns_single_empty_line():
+    assert _wrap_panel_text("", width=60) == [""]
+
+
+def test_subsequent_indent_applies_to_continuations_only():
+    lines = _wrap_panel_text("aa bb cc dd ee", width=4, subsequent_indent="> ")
+    assert lines[0].startswith("aa")
+    assert all(line.startswith("> ") for line in lines[1:])
+    assert all(len(line) <= 8 for line in lines)
+
+
+def test_narrow_width_floor():
+    lines = _wrap_panel_text_keep_ws("x" * 20, width=2)
+    assert lines == ["x" * 8, "x" * 8, "x" * 4]
+
+
+def test_clarify_panel_prose_does_not_break_words():
+    word = "supercalifragilisticexpialidocious"
+    lines = _wrap_panel_text(f"hello {word} world", width=10)
+    assert any(word in line for line in lines)
+
+
+def test_clarify_splits_multiline_question():
+    question = "Which database should I use?\nContext:\nthe sessions table is large"
+    lines = _wrap_panel_text(question, width=72)
+    assert lines == question.split("\n")
+    assert all("\n" not in line for line in lines)
+
+
+def test_clarify_preserves_empty_lines():
+    assert _wrap_panel_text("question?\n\nmore context", width=72) == [
+        "question?",
+        "",
+        "more context",
+    ]

--- a/tests/cli/test_wrap_panel_text.py
+++ b/tests/cli/test_wrap_panel_text.py
@@ -103,3 +103,86 @@ def test_clarify_wrapper_preserves_empty_lines():
         "",
         "more context",
     ]
+
+
+# --- Clarify panel binding regression (exercises the actual panel renderer) ---
+
+
+def _make_clarify_cli():
+    """Stub HermesCLI instance with a set clarify state (mirrors test_cli_approval_ui)."""
+    import queue
+    import threading
+    from cli import HermesCLI
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._clarify_state = None
+    cli._clarify_freetext = False
+    cli._clarify_response_queue = None
+    cli._clarify_lock = threading.Lock()
+    cli._clarify_deadline = 0
+    cli._invalidate = lambda: None
+    return cli
+
+
+def test_clarify_panel_binding_renders_all_choices_with_multiline_question():
+    """Panel-binding regression for #72580: a multi-line clarify question must
+    not push the selectable choices off-screen — the panel renderer (not just
+    the wrapper) must keep every choice visible."""
+    import shutil as _shutil
+    from unittest.mock import patch
+
+    cli = _make_clarify_cli()
+    cli._clarify_state = {
+        "question": "Which option do you want?\nContext:\nline two of a long question",
+        "choices": ["option alpha", "option beta", "option gamma"],
+        "selected": 0,
+        "multi_select": False,
+        "response_queue": __import__("queue").Queue(),
+    }
+
+    with patch("cli.shutil.get_terminal_size",
+               return_value=_shutil.os.terminal_size((100, 24))):
+        fragments = cli._get_clarify_display_fragments()
+
+    rendered = "".join(text for _style, text in fragments)
+
+    # Every choice must be present in the rendered panel.
+    for label in ("option alpha", "option beta", "option gamma"):
+        assert label in rendered, f"choice {label!r} missing from clarify panel"
+
+    # Other (type your answer) row must render as the fallback selection.
+    assert "Other (type your answer)" in rendered
+
+    # The multi-line question keeps one display line per source line
+    # (newline-split fix) instead of collapsing.
+    assert "\n" not in rendered.replace("\n", ""), "embedded newlines in panel text"
+    assert "line two of a long question" in rendered
+
+
+def test_clarify_panel_binding_drops_question_on_tiny_terminal():
+    """When the choices alone overflow the viewport, the question is dropped
+    entirely so the choices (the only thing needed to select) still render."""
+    import shutil as _shutil
+    from unittest.mock import patch
+
+    cli = _make_clarify_cli()
+    # 20 choices at ~64 cols each exceed a 10-row terminal even with compact chrome.
+    cli._clarify_state = {
+        "question": "A very long question " + ("that should be dropped " * 20),
+        "choices": [f"choice number {i}" for i in range(20)],
+        "selected": 0,
+        "multi_select": False,
+        "response_queue": __import__("queue").Queue(),
+    }
+
+    with patch("cli.shutil.get_terminal_size",
+               return_value=_shutil.os.terminal_size((80, 10))):
+        fragments = cli._get_clarify_display_fragments()
+
+    rendered = "".join(text for _style, text in fragments)
+
+    # All choices still render on a tiny terminal.
+    for i in range(20):
+        assert f"choice number {i}" in rendered, f"choice {i} missing on tiny terminal"
+    # Question dropped entirely (not just truncated) when choices overflow.
+    assert "that should be dropped" not in rendered
+    assert "Other (type your answer)" in rendered

--- a/tests/cli/test_wrap_panel_text.py
+++ b/tests/cli/test_wrap_panel_text.py
@@ -1,0 +1,105 @@
+"""Regression tests for #72580: approval panel multi-line text wrapping.
+
+_wrap_panel_text must split on newlines before wrapping. textwrap.wrap
+treats embedded \\n as ordinary whitespace, so a multi-line command (e.g.
+a heredoc pending approval) previously collapsed into a few long lines
+with literal newlines, pushing the approve/deny choices off-screen.
+"""
+
+from cli import _wrap_clarify_panel_text, _wrap_panel_text
+
+
+HEREDOC = (
+    "python3 << 'EOF'\n"
+    "import sqlite3\n"
+    "conn = sqlite3.connect('db')\n"
+    "cur.execute('SELECT * FROM sessions')\n"
+    "print(cur.fetchall())\n"
+    "conn.close()\n"
+    "EOF"
+)
+
+
+def test_multiline_command_keeps_one_display_line_per_source_line():
+    lines = _wrap_panel_text(HEREDOC, width=60)
+    # 7 source lines, all short: one display line each, in order.
+    assert lines == HEREDOC.split("\n")
+
+
+def test_no_embedded_newlines_in_output():
+    lines = _wrap_panel_text(HEREDOC, width=20)
+    assert all("\n" not in line for line in lines)
+    # Narrow width wraps long source lines but never merges source lines.
+    assert len(lines) > len(HEREDOC.split("\n"))
+
+
+def test_empty_lines_are_preserved():
+    lines = _wrap_panel_text("a\n\nb", width=60)
+    assert lines == ["a", "", "b"]
+
+
+def test_single_line_behaviour_unchanged():
+    assert _wrap_panel_text("short", width=60) == ["short"]
+    long_line = "x" * 130
+    lines = _wrap_panel_text(long_line, width=60)
+    assert lines == ["x" * 60, "x" * 60, "x" * 10]
+
+
+def test_empty_input_returns_single_empty_line():
+    assert _wrap_panel_text("", width=60) == [""]
+
+
+def test_subsequent_indent_applies_to_continuations_only():
+    # width floors at 8, so use text longer than 8 chars to force wrapping.
+    lines = _wrap_panel_text("aa bb cc dd ee", width=4, subsequent_indent="> ")
+    assert lines[0].startswith("aa")
+    assert all(line.startswith("> ") for line in lines[1:])
+    assert all(len(line) <= 8 for line in lines)
+
+
+def test_narrow_width_floor():
+    # width is floored at 8, matching the previous inline behaviour.
+    lines = _wrap_panel_text("x" * 20, width=2)
+    assert lines == ["x" * 8, "x" * 8, "x" * 4]
+
+
+def test_clarify_panel_prose_kwargs_do_not_break_words():
+    # The clarify panel delegates with break_long_words=False and
+    # break_on_hyphens=False; long words must survive intact.
+    word = "supercalifragilisticexpialidocious"
+    lines = _wrap_panel_text(
+        f"hello {word} world",
+        width=10,
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
+    assert any(word in line for line in lines)
+
+
+# --- Clarify panel delegation path (_wrap_clarify_panel_text) ---
+
+
+def test_clarify_wrapper_splits_multiline_question():
+    # Rendering-path regression: a multi-line clarify question must keep
+    # one display line per source line instead of collapsing.
+    question = "Which database should I use?\nContext:\nthe sessions table is large"
+    lines = _wrap_clarify_panel_text(question, width=72)
+    assert lines == question.split("\n")
+    assert all("\n" not in line for line in lines)
+
+
+def test_clarify_wrapper_keeps_prose_wrapping():
+    # Prose kwargs preserved through the delegation: words never break,
+    # even when longer than the width.
+    word = "supercalifragilisticexpialidocious"
+    lines = _wrap_clarify_panel_text(f"Pick one: {word} or the other option", width=10)
+    assert any(word in line for line in lines)
+    assert all("\n" not in line for line in lines)
+
+
+def test_clarify_wrapper_preserves_empty_lines():
+    assert _wrap_clarify_panel_text("question?\n\nmore context", width=72) == [
+        "question?",
+        "",
+        "more context",
+    ]


### PR DESCRIPTION
## Bug

When a dangerous command contains embedded newlines (e.g. a `python3 << 'EOF' ... EOF` heredoc), the TUI approval panel renders it as a few long lines with literal `\n` characters, making the command unreadable and pushing the approve/deny choices off-screen.

Fixes #72580.

## Root Cause

`_wrap_panel_text` in `cli.py` (3 copies: approval panel, sudo panel, clarify panel) called `textwrap.wrap()` directly on the full command string. `textwrap.wrap` treats `\n` as ordinary whitespace — it does **not** split on newlines. A multi-line heredoc script gets collapsed into a handful of long lines with embedded newlines.

## Fix

- Extracted the triplicated wrapper (slash-confirmation panel, approval panel, clarify panel — the sudo panel uses a fixed password display and is unaffected) into one module-level `_wrap_panel_text` in `cli.py` that **splits on `\n` first, then wraps each line individually** (preserving empty lines, the `width>=8` floor, and `subsequent_indent` semantics).
- The slash-confirm and approval panels (identical copies) now resolve to the shared helper directly.
- The clarify panel's copy had intentionally different `textwrap` kwargs (`break_long_words=False, break_on_hyphens=False`, default whitespace handling — prose wrapping). It now binds to `_wrap_clarify_panel_text`, a module-level delegator with those kwargs, so its wrapping behaviour is byte-identical to before; it only gains the newline split.
- Note: the Ink TUI already splits command lines itself (`ui-tui/src/components/prompts.tsx:102-104`); this fix covers the prompt_toolkit CLI path.

No signature changes for callers; the nested call sites are untouched.

## Regression Tests

`tests/cli/test_wrap_panel_text.py` (11 tests): per-source-line preservation for a heredoc, no embedded newlines in output, empty-line preservation, single-line behaviour unchanged, empty input, `subsequent_indent` on continuations only, the width floor, the no-word-break kwargs — plus 3 rendering-path tests for the clarify delegation (`_wrap_clarify_panel_text`: multiline question split, prose no-word-break, empty lines). Verified to fail against the pre-fix implementation (3 behaviour failures; the module functions obviously don't exist pre-fix at all).

Existing `tests/cli/test_cli_approval_ui.py` (15 tests) passes unchanged.

## Checklist

- [x] Reproduced the bug (in the issue body, and via the new tests against the old implementation)
- [x] Fix addresses the root cause (split before wrap), applied to all 3 panel copies
- [x] Clarify panel's divergent wrapping kwargs preserved byte-for-byte
- [x] Regression tests added
- [x] No new dependencies
