### PR TITLE
fix(skills/himalaya): upgrade bundled skill to himalaya v2 schema

### DIFF
--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -222,6 +222,7 @@ The modern path uses `message compose` with flags:
 
 ```bash
 himalaya message compose \
+  --from you@example.com \
   --to you@example.com \
   --subject "Test" \
   --body "Hello from Himalaya v2" \
@@ -232,12 +233,14 @@ For a body from stdin (replaces the removed `template send` subcommand), **omit 
 
 ```bash
 echo "Hello from a piped body" | himalaya message compose \
+  --from you@example.com \
   --to you@example.com \
   --subject "Test" \
   --send
 
 # Or read the body from a file
 himalaya message compose \
+  --from you@example.com \
   --to you@example.com \
   --subject "Test" \
   --body-file ./body.txt \
@@ -260,22 +263,23 @@ himalaya message send --save drafts < message.eml
 
 ```bash
 # Quick reply with new body
-himalaya message reply 42 --body "Got it, thanks." --send
+himalaya message reply 42 --from you@example.com --body "Got it, thanks." --send
 
 # Strict reply (just to the sender): pass --to with the original From address
-himalaya message reply 42 --to sender@example.com --body "Thanks." --send
+himalaya message reply 42 --from you@example.com --to sender@example.com --body "Thanks." --send
 
 # Reply-all: include the original To/Cc recipients with --cc / --to
 himalaya message reply 42 \
+  --from you@example.com \
   --to sender@example.com \
   --cc teammate@example.com \
   --body "Looping everyone in." --send
 
 # Custom quote headline (default is "On {date}, {from} wrote:")
-himalaya message reply 42 --quote-headline "Replying inline:" --body "..." --send
+himalaya message reply 42 --from you@example.com --quote-headline "Replying inline:" --body "..." --send
 
 # Change posting style (top | bottom | inline)
-himalaya message reply 42 --posting-style bottom --body "..." --send
+himalaya message reply 42 --from you@example.com --posting-style bottom --body "..." --send
 ```
 
 > **v2 note.** There are no `--all` / `--quote` boolean flags. Reply-all is "include the original recipients via `--cc`/`--to`"; quoting is the default behavior controlled by `--posting-style` and `--quote-headline`.
@@ -283,7 +287,7 @@ himalaya message reply 42 --posting-style bottom --body "..." --send
 ### Forward
 
 ```bash
-himalaya message forward 42 --to other@example.com --body "FYI" --send
+himalaya message forward 42 --from you@example.com --to other@example.com --body "FYI" --send
 ```
 
 ### Move / copy

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -89,10 +89,10 @@ imap.server = "imaps://imap.gmail.com:993"
 imap.sasl.plain.username = "you@gmail.com"
 imap.sasl.plain.password.command = "pass show email/gmail-app"
 
-smtp.server = "smtp://smtp.gmail.com:587"
-smtp.starttls = true
+smtp.server = "smtps://smtp.gmail.com:465"
 smtp.sasl.plain.username = "you@gmail.com"
 smtp.sasl.plain.password.command = "pass show email/gmail-app"
+# STARTTLS alternative: smtp.server = "smtp://smtp.gmail.com:587" + smtp.starttls = true
 
 mailbox.alias.inbox = "INBOX"
 mailbox.alias.sent = "[Gmail]/Sent Mail"
@@ -165,7 +165,7 @@ mailbox.alias.sent = "Sent Messages"
 - **Reading, listing, searching, flagging, copying** — all work directly through the terminal tool.
 - **Composing / replying / forwarding** — use the `message compose` / `message reply` / `message forward` subcommands (flag-based) or chain `mml` for rich MIME / attachments / PGP. To send a pre-written RFC 822 message, use `message send < message.eml` (or pipe it: `message send < message.eml` — same stdin path). For `message compose`, pipe a body via stdin by omitting both `--body` and `--body-file` (stdin is the fallback).
 - **Pitfall — `message write` is an alias, not an editor opener.** In v2, `himalaya message write` is a `visible_alias` of `message compose` and behaves identically (flag-based, no `$EDITOR`). The pre-v1.x editor-driven flow no longer exists. Use `mml compose` if you want interactive composition.
-- For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages. It's a global flag (pass before the subcommand for consistency); v2 also recognizes it after the subcommand for ergonomics.
+- For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages. It's a global flag — both `himalaya --json envelope list` and `himalaya envelope list --json` work in v2. The pre-subcommand form is the documented convention; the post-subcommand form is accepted for ergonomics.
 - **Pitfall — search query DSL:** the query is a positional `Vec<String>` that captures trailing tokens until end-of-input. Always put the query **last** on the command line. Quote-protect patterns containing `$`, shell metacharacters, or spaces.
 - **Pitfall — Gmail mailbox names:** `[Gmail]/Sent Mail` etc. contain `[`, `]`, and a space. Always quote in the shell.
 - **Pitfall — multiple accounts:** pass `-a <name>` or `--account <name>`. The account flagged `default = true` is used when omitted.
@@ -203,7 +203,7 @@ himalaya envelope list --has-attachment    # populate ATT column
 himalaya envelope search "from alice"
 himalaya envelope search "from alice and after 2026-01-01 order by date desc"
 himalaya envelope search "subject meeting or body invoice"
-himalaya envelope search --page-size=20 "from usvisascheduling"   # NOTE: --page-size=20 (equals form!)
+himalaya envelope search --page-size 20 "from usvisascheduling"
 ```
 
 ⚠️ **Quote-protect the query** — patterns with `$` (e.g. `"body $500"`) need single quotes so the shell doesn't expand `$5`.
@@ -332,7 +332,8 @@ For accounts configured with multiple backends (e.g. IMAP+JMAP), force one with 
 `--json` is a global flag that emits parsed JSON for any command:
 
 ```bash
-himalaya --json envelope list --page-size=5
+himalaya --json envelope list --page-size 5
+himalaya envelope list --json --page-size 5        # equivalent; --json works after subcommand too
 himalaya --json message read 42 | jq '.subject'
 himalaya --json mailbox list
 ```

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -163,7 +163,7 @@ mailbox.alias.sent = "Sent Messages"
 ## Hermes integration notes
 
 - **Reading, listing, searching, flagging, copying** — all work directly through the terminal tool.
-- **Composing / replying / forwarding** — use the `message compose` / `message reply` / `message forward` subcommands (flag-based) or chain `mml` for rich MIME / attachments / PGP. To send a pre-written RFC 822 message, use `message send < message.eml` or pipe via stdin to `message compose --body-file -` / `message compose` with no `--body` (stdin fallback).
+- **Composing / replying / forwarding** — use the `message compose` / `message reply` / `message forward` subcommands (flag-based) or chain `mml` for rich MIME / attachments / PGP. To send a pre-written RFC 822 message, use `message send < message.eml` (or pipe it: `message send < message.eml` — same stdin path). For `message compose`, pipe a body via stdin by omitting both `--body` and `--body-file` (stdin is the fallback).
 - **Pitfall — `message write` is an alias, not an editor opener.** In v2, `himalaya message write` is a `visible_alias` of `message compose` and behaves identically (flag-based, no `$EDITOR`). The pre-v1.x editor-driven flow no longer exists. Use `mml compose` if you want interactive composition.
 - For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages. It's a global flag (pass before the subcommand for consistency); v2 also recognizes it after the subcommand for ergonomics.
 - **Pitfall — search query DSL:** the query is a positional `Vec<String>` that captures trailing tokens until end-of-input. Always put the query **last** on the command line. Quote-protect patterns containing `$`, shell metacharacters, or spaces.
@@ -197,7 +197,7 @@ himalaya envelope list --has-attachment    # populate ATT column
 
 ### Search envelopes
 
-`envelope search` takes a positional query using himalaya's cross-backend DSL. Conditions: `date <yyyy-mm-dd>`, `after <yyyy-mm-dd>`, `before <yyyy-mm-dd>`, `from <pattern>`, `to <pattern>`, `subject <pattern>`, `body <pattern>`, `flag <seen|answered|flagged|draft>`. Combine with `and`, `or`, `not`, group with parens. Sort with `order by <date|from|to|subject> [asc|desc]`.
+`envelope search` takes a positional query using himalaya's cross-backend DSL. Conditions: `date <yyyy-mm-dd>`, `after <yyyy-mm-dd>`, `from <pattern>`, `to <pattern>`, `subject <pattern>`, `body <pattern>`, `flag <seen|answered|flagged|draft>`. Combine with `and`, `or`, `not`, group with parens. Sort with `order by <date|from|to|subject> [asc|desc]`.
 
 ```bash
 himalaya envelope search "from alice"
@@ -228,23 +228,33 @@ himalaya message compose \
   --send
 ```
 
-For a body from stdin (replaces the removed `template send` subcommand), **omit `--body` and `--body-file` — stdin is the body** by default:
+For a body from stdin (replaces the removed `template send` subcommand), **omit `--body` and `--body-file` — stdin is the body** by default. **`compose` writes the composed RFC 5322 bytes to stdout by default; pass `--send` to actually deliver** through SMTP/JMAP:
 
 ```bash
 echo "Hello from a piped body" | himalaya message compose \
   --to you@example.com \
-  --subject "Test"
+  --subject "Test" \
+  --send
 
 # Or read the body from a file
 himalaya message compose \
   --to you@example.com \
   --subject "Test" \
-  --body-file ./body.txt
+  --body-file ./body.txt \
+  --send
 ```
 
 Note: `--body-file -` does NOT work — the binary tries to open a file literally named `-`. The `--body` / `--body-file` / implicit stdin paths are mutually exclusive; pick one.
 
-For rich MIME (multipart, attachments, signing), pipe `mml` output into `message compose` via stdin or process substitution; see `references/message-composition.md`.
+To send a **pre-written RFC 822 message** (full headers + body, e.g. one produced by `mml`, a template, or another tool), use `message send` — it accepts a file path, raw contents, or piped stdin:
+
+```bash
+himalaya message send < message.eml
+# or
+himalaya message send --save drafts < message.eml
+```
+
+`message send` reads the full message verbatim (headers + body); it does NOT take `--body` / `--body-file` / `--subject`. For richer composition (multipart MIME, attachments, signing/encryption), chain a standalone composer like `mml` into `message send` via stdin or process substitution; see `references/message-composition.md`.
 
 ### Reply to a message
 
@@ -276,15 +286,14 @@ himalaya message reply 42 --posting-style bottom --body "..." --send
 himalaya message forward 42 --to other@example.com --body "FYI" --send
 ```
 
-### Move / copy / delete
+### Move / copy
 
 ```bash
 himalaya message copy --from INBOX --to Archives 42
 himalaya message move --from INBOX --to Archives 42    # if backend supports move
-himalaya message delete 42                              # trash-move; permanent for in-trash
 ```
 
-> **v2 note.** There is no `message expunge` subcommand in v2. `message delete` already trash-moves; on IMAP servers without UIDPLUS, deleted-from-trash items are flagged `\Deleted` and reclaimed by the next `message delete` on the trash mailbox, or by the server's own expunge policy.
+> **v2 note.** There is no `message delete` or `message expunge` subcommand in v2. To trash a message, move it to a trash mailbox (e.g. `himalaya message move --from INBOX --to Trash 42`) or rely on the backend's automatic deletion-on-trash behavior (Gmail/JMAP do this; IMAP behavior depends on the server's `expunge_behavior`). Permanent deletion (real expunge) is a backend-side / mailbox-policy concern, not a CLI subcommand.
 
 ### Manage flags
 
@@ -293,14 +302,14 @@ himalaya flag add --flag seen 1:3,5
 himalaya flag remove --flag seen 42
 ```
 
-The `--flag` argument accepts `seen`, `answered`, `flagged`, `draft`, `recent`. Multiple message IDs can be comma-separated ranges (`1:3,5` = 1,2,3,5).
+The `--flag` argument accepts `seen`, `answered`, `flagged`, `draft`. Multiple message IDs can be comma-separated ranges (`1:3,5` = 1,2,3,5).
 
 ### Download attachments
 
 ```bash
 himalaya attachment download 42                         # download all; default dir from config
 himalaya attachment download 42 --dir /tmp/attach       # override destination
-himalaya attachment download 42 0 1                     # download only attachments 0 and 1
+himalaya attachment download 42 1 2                     # download only attachments 1 and 2 (1-based ids from `attachments list`)
 ```
 
 > **v2 note.** The destination flag is `--dir` (also `-d`), not `--output-dir`. Default destination is the account's `downloads-dir` config (falling back to the global config, then the platform standard). Run `himalaya attachment download --help` for the full flag list.

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: himalaya
-description: "Himalaya CLI: IMAP/SMTP email from terminal."
-version: 1.1.0
+description: "Himalaya v2 mail CLI. Use when reading or sending email."
+version: 2.0.0
 author: community
 license: MIT
 platforms: [linux, macos, windows]
@@ -13,185 +13,217 @@ prerequisites:
   commands: [himalaya]
 ---
 
-# Himalaya Email CLI
+# Himalaya CLI v2.x
 
-Himalaya is a CLI email client that lets you manage emails from the terminal using IMAP, SMTP, Notmuch, or Sendmail backends.
+Himalaya is a Rust CLI for managing email from the terminal. **This skill targets himalaya v2.x** (v2.0.0+, post the v1→v2 breaking changes). The skill previously documented the v1.x schema; commands like `himalaya folder list` and `himalaya envelope list from x` no longer work in v2 and will trip agents loading the skill on first attempt.
 
-This skill is separate from the Hermes Email gateway adapter. The gateway
-adapter lets people email the agent and uses Hermes' built-in IMAP/SMTP
-adapter; this skill lets the agent operate a mailbox from terminal tools and
-requires the external `himalaya` CLI.
+This skill is separate from the Hermes Email gateway adapter. The gateway adapter lets people email the agent and uses Hermes' built-in IMAP/SMTP adapter; this skill lets the agent operate a mailbox from terminal tools and requires the external `himalaya` CLI.
+
+## Key v2 differences from v1
+
+| v1.x (don't use) | v2.x (current) |
+|---|---|
+| `folder list` | `mailbox list` |
+| `folder.aliases.sent` (singular, TOML sub-table) | `mailbox.alias.sent` (plural, dotted key under account) |
+| `[accounts.X] backend = { type=imap, host=..., port=..., auth={...} }` | Flat keys: `imap.server`, `imap.sasl.plain.username`, `imap.sasl.plain.password.command` |
+| `envelope list from x` (positional filters) | `envelope list`; filters moved to separate `envelope search "from x"` subcommand with its own DSL |
+| `message write` (no piped input) / `message reply` | `message compose --to ... --subject ... --body ...`; rich MIME via piped `mml`; legacy `template send` still exists |
+| `--output json` / `plain` | `--json` (global flag) |
+| Native keyring support | Removed; use `pass`, `gopass`, `secret-tool` via `password.command` |
+| OAuth flows built in | None; use [ortie](https://github.com/pimalaya/ortie) as token broker |
+
+Always verify `himalaya --version` reports **v2.0.0 or later** before using this skill.
 
 ## References
 
-- `references/configuration.md` (config file setup + IMAP/SMTP authentication)
-- `references/message-composition.md` (MML syntax for composing emails)
+- `references/configuration.md` (v2 TOML schema, Gmail/Outlook/Fastmail/iCloud examples, mailbox aliases)
+- `references/message-composition.md` (compose/reply/forward, mml integration)
 
 ## Prerequisites
 
-1. Himalaya CLI installed (`himalaya --version` to verify)
-2. A configuration file at `~/.config/himalaya/config.toml`
-3. IMAP/SMTP credentials configured (password stored securely)
+1. **Himalaya v2.0.0+** installed (`himalaya --version` to verify)
+2. A configuration file at one of these paths (first match wins):
+   - `$XDG_CONFIG_HOME/himalaya/config.toml`
+   - `$HOME/.config/himalaya/config.toml`
+   - `$HOME/.himalayarc`
+3. Credentials supplied either inline (`password.raw = "..."`) or via a `password.command` that prints the secret on stdout (recommended — use `pass`, `gopass`, or a custom script).
 
 ### Installation
 
 ```bash
-# Pre-built binary (Linux/macOS — recommended)
+# Pre-built binary (Linux/macOS — recommended, no sudo needed)
 curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
 
 # macOS via Homebrew
 brew install himalaya
 
-# Or via cargo (any platform with Rust)
-cargo install himalaya --locked
+# From source (any platform with Rust)
+cargo install --locked --git https://github.com/pimalaya/himalaya.git
 ```
 
-## Configuration Setup
+The installer places the binary at `~/.local/bin/himalaya` (or `/usr/local/bin/himalaya` when run as root).
 
-Run the interactive wizard to set up an account:
+## Configuration
+
+### The wizard
+
+Run `himalaya` with **no subcommand** to launch the account setup wizard. It probes PACC, Thunderbird Autoconfiguration, RFC 6186 SRV records, and JMAP session discovery in parallel, then prints a ready-to-save TOML document on stdout. Redirect it into your config:
 
 ```bash
-himalaya account configure
+himalaya > /tmp/new-account.toml
+# review, then append to your config
+cat /tmp/new-account.toml >> ~/.config/himalaya/config.toml
 ```
 
-Or create `~/.config/himalaya/config.toml` manually:
+### Gmail (app password)
+
+Generate an app password at https://myaccount.google.com/apppasswords (requires 2-Step Verification), then:
 
 ```toml
-[accounts.personal]
-email = "you@example.com"
+[accounts.gmail]
+email = "you@gmail.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@example.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show email/imap"  # or use keyring
+imap.server = "imaps://imap.gmail.com:993"
+imap.sasl.plain.username = "you@gmail.com"
+imap.sasl.plain.password.command = "pass show email/gmail-app"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show email/smtp"
+smtp.server = "smtp://smtp.gmail.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@gmail.com"
+smtp.sasl.plain.password.command = "pass show email/gmail-app"
 
-# Folder aliases (himalaya v1.2.0+ syntax). Required whenever the
-# server's folder names don't match himalaya's canonical names
-# (inbox/sent/drafts/trash). Gmail is the common case — see
-# `references/configuration.md` for the `[Gmail]/Sent Mail` mapping.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "[Gmail]/Sent Mail"
+mailbox.alias.drafts = "[Gmail]/Drafts"
+mailbox.alias.trash = "[Gmail]/Trash"
+mailbox.alias.archive = "[Gmail]/All Mail"
+mailbox.alias.junk = "[Gmail]/Spam"
 ```
 
-> **Heads up on the alias syntax.** Pre-v1.2.0 docs used a
-> `[accounts.NAME.folder.alias]` sub-section (singular `alias`).
-> v1.2.0 silently ignores that form — TOML parses fine, but the
-> alias resolver never reads it, so every lookup falls through to
-> the canonical name. On Gmail this means save-to-Sent fails *after*
-> SMTP delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that exit code
-> will re-run the entire send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural, dotted
-> keys, directly under `[accounts.NAME]`).
+The `[Gmail]/` labels must be **quoted in the shell** when used as `-m` args: `himalaya -m "[Gmail]/Drafts"`. Aliases are case-insensitive lookups; raw backend ids work verbatim too.
 
-## Hermes Integration Notes
+### Outlook / Microsoft 365 (OAuth)
 
-- **Reading, listing, searching, moving, deleting** all work directly through the terminal tool
-- **Composing/replying/forwarding** — piped input (`cat << EOF | himalaya template send`) is recommended for reliability. Interactive `$EDITOR` mode works with `pty=true` + background + process tool, but requires knowing the editor and its commands
-- Use `--output json` for structured output that's easier to parse programmatically
-- The `himalaya account configure` wizard requires interactive input — use PTY mode: `terminal(command="himalaya account configure", pty=true)`
+Microsoft retired basic auth. Use OAuth 2.0 via `xoauth2` and a token broker like [ortie](https://github.com/pimalaya/ortie):
 
-## Common Operations
+```toml
+[accounts.outlook]
 
-### List Folders
+imap.server = "imaps://outlook.office365.com:993"
+imap.sasl.xoauth2.username = "you@outlook.com"
+imap.sasl.xoauth2.token.command = ["ortie", "token", "show", "-a", "outlook"]
+
+smtp.server = "smtp://smtp-mail.outlook.com:587"
+smtp.starttls = true
+smtp.sasl.xoauth2.username = "you@outlook.com"
+smtp.sasl.xoauth2.token.command = ["ortie", "token", "show", "-a", "outlook"]
+```
+
+Or skip SMTP entirely and use the Microsoft Graph REST API backend (`msgraph.auth.token.command = [...]`). Graph uses opaque folder ids — address them by name (`-m Archive`) or by well-known role (`-m inbox`).
+
+### Fastmail
+
+App password works for IMAP/SMTP. For the native JMAP API, replace both blocks with a single `jmap` one using an API token:
+
+```toml
+[accounts.fastmail]
+imap.server = "imaps://imap.fastmail.com"
+imap.sasl.plain.username = "you@fastmail.com"
+imap.sasl.plain.password.command = "pass show fastmail"
+
+smtp.server = "smtps://smtp.fastmail.com"
+smtp.sasl.plain.username = "you@fastmail.com"
+smtp.sasl.plain.password.command = "pass show fastmail"
+```
+
+### iCloud
+
+Note: IMAP login uses the local-part (`johnappleseed`), SMTP login uses the full address (`johnappleseed@icloud.com`). Requires an app-specific password.
+
+```toml
+[accounts.icloud]
+imap.server = "imaps://imap.mail.me.com:993"
+imap.sasl.plain.username = "johnappleseed"
+imap.sasl.plain.password.command = "pass show icloud"
+
+smtp.server = "smtp://smtp.mail.me.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "johnappleseed@icloud.com"
+smtp.sasl.plain.password.command = "pass show icloud"
+
+mailbox.alias.sent = "Sent Messages"
+```
+
+## Hermes integration notes
+
+- **Reading, listing, searching, flagging, copying** — all work directly through the terminal tool.
+- **Composing / replying / forwarding** — use the `message compose` subcommand (flags-only) or chain `mml` for rich MIME / attachments / PGP. The legacy `template send` (pipe a complete RFC 822 message on stdin) still works for scripted sends.
+- For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages.
+- **Pitfall — clap parser order matters:** search query DSL tokens (`from`, `subject`, `after`, `order by`, etc.) start consuming characters from the next flag too. Always pass `--page-size=20` (with `=`) instead of `--page-size 20`, and put query positional args **last** on the command line. Spaces between a flag like `--page-size 20` get eaten as part of the search query.
+- **Pitfall — Gmail mailbox names:** `[Gmail]/Sent Mail` etc. contain `[`, `]`, and a space. Always quote in the shell.
+- **Pitfall — multiple accounts:** pass `-a <name>` or `--account <name>`. The account flagged `default = true` is used when omitted.
+
+## Common operations
+
+### List accounts
 
 ```bash
-himalaya folder list
+himalaya account list
+himalaya account check  # validates config
 ```
 
-### List Emails
+### List mailboxes (folders / labels)
 
-List emails in INBOX (default):
+```bash
+himalaya mailbox list
+himalaya mailbox list --account gmail
+```
+
+### List envelopes (default mailbox)
 
 ```bash
 himalaya envelope list
+himalaya envelope list --page 2 --page-size 50
+himalaya envelope list --recipient          # show To: instead of From: (sent folder)
+himalaya envelope list --has-attachment    # populate ATT column
 ```
 
-List emails in a specific folder:
+### Search envelopes
+
+`envelope search` takes a positional query using himalaya's cross-backend DSL. Conditions: `date <yyyy-mm-dd>`, `after <yyyy-mm-dd>`, `before <yyyy-mm-dd>`, `from <pattern>`, `to <pattern>`, `subject <pattern>`, `body <pattern>`, `flag <seen|answered|flagged|draft>`. Combine with `and`, `or`, `not`, group with parens. Sort with `order by <date|from|to|subject> [asc|desc]`.
 
 ```bash
-himalaya envelope list --folder "Sent"
+himalaya envelope search "from alice"
+himalaya envelope search "from alice and after 2026-01-01 order by date desc"
+himalaya envelope search "subject meeting or body invoice"
+himalaya envelope search --page-size=20 "from usvisascheduling"   # NOTE: --page-size=20 (equals form!)
 ```
 
-List with pagination:
+⚠️ **Quote-protect the query** — patterns with `$` (e.g. `"body $500"`) need single quotes so the shell doesn't expand `$5`.
+
+### Read a message
 
 ```bash
-himalaya envelope list --page 1 --page-size 20
+himalaya message read 42                       # rendered headers + text bodies
+himalaya message read 42 --raw                 # dump raw RFC 5322 bytes (pipe to mml/w3m)
+himalaya message read 42 --json                # parsed message as JSON
 ```
 
-### Search Emails
+### Send a new message
+
+The modern path uses `message compose` with flags:
 
 ```bash
-himalaya envelope list from john@example.com subject meeting
+himalaya message compose \
+  --to you@example.com \
+  --subject "Test" \
+  --body "Hello from Himalaya v2" \
+  --send
 ```
 
-### Read an Email
-
-Read email by ID (shows plain text):
-
-```bash
-himalaya message read 42
-```
-
-Export raw MIME:
-
-```bash
-himalaya message export 42 --full
-```
-
-### Reply to an Email
-
-To reply non-interactively from Hermes, read the original message, compose a reply, and pipe it:
-
-```bash
-# Get the reply template, edit it, and send
-himalaya template reply 42 | sed 's/^$/\nYour reply text here\n/' | himalaya template send
-```
-
-Or build the reply manually:
-
-```bash
-cat << 'EOF' | himalaya template send
-From: you@example.com
-To: sender@example.com
-Subject: Re: Original Subject
-In-Reply-To: <original-message-id>
-
-Your reply here.
-EOF
-```
-
-Reply-all (interactive — needs $EDITOR, use template approach above instead):
-
-```bash
-himalaya message reply 42 --all
-```
-
-### Forward an Email
-
-```bash
-# Get forward template and pipe with modifications
-himalaya template forward 42 | sed 's/^To:.*/To: newrecipient@example.com/' | himalaya template send
-```
-
-### Write a New Email
-
-**Non-interactive (use this from Hermes)** — pipe the message via stdin:
+The legacy path (piped RFC 822 over stdin) still works:
 
 ```bash
 cat << 'EOF' | himalaya template send
@@ -199,106 +231,97 @@ From: you@example.com
 To: recipient@example.com
 Subject: Test Message
 
-Hello from Himalaya!
+Hello from Himalaya v2!
 EOF
 ```
 
-Or with headers flag:
+### Reply to a message
 
 ```bash
-himalaya message write -H "To:recipient@example.com" -H "Subject:Test" "Message body here"
+# Quick reply with --body
+himalaya message reply 42 --body "Thanks, will do." --send
+
+# Reply-all
+himalaya message reply 42 --all --body "Looping everyone in." --send
+
+# Quote original
+himalaya message reply 42 --quote --body "See below." --send
 ```
 
-Note: `himalaya message write` without piped input opens `$EDITOR`. This works with `pty=true` + background mode, but piping is simpler and more reliable.
-
-### Move/Copy Emails
-
-Move to folder (target folder comes first, then the message ID):
+### Forward
 
 ```bash
-himalaya message move "Archive" 42
+himalaya message forward 42 --to other@example.com --send
 ```
 
-Copy to folder (target folder comes first, then the message ID):
+### Move / copy / delete
 
 ```bash
-himalaya message copy "Important" 42
+himalaya message copy --from INBOX --to Archives 42
+himalaya message move --from INBOX --to Archives 42    # if backend supports move
+himalaya message delete 42                              # sets \Deleted flag
+himalaya message expunge                                 # permanently remove flagged
 ```
 
-### Delete an Email
+### Manage flags
 
 ```bash
-himalaya message delete 42
+himalaya flag add --flag seen 1:3,5
+himalaya flag remove --flag seen 42
 ```
 
-### Manage Flags
+The `--flag` argument accepts `seen`, `answered`, `flagged`, `draft`, `recent`. Multiple message IDs can be comma-separated ranges (`1:3,5` = 1,2,3,5).
 
-Add flag:
+### Download attachments
 
 ```bash
-himalaya flag add 42 --flag seen
+himalaya attachment download 42                         # default ~/Downloads
+himalaya attachment download 42 --output-dir /tmp/attach
 ```
 
-Remove flag:
-
-```bash
-himalaya flag remove 42 --flag seen
-```
-
-## Multiple Accounts
-
-List accounts:
-
-```bash
-himalaya account list
-```
-
-Use a specific account:
+## Multiple accounts
 
 ```bash
 himalaya --account work envelope list
+himalaya --account gmail mailbox list
 ```
 
-## Attachments
+For accounts configured with multiple backends (e.g. IMAP+JMAP), force one with `-b/--backend imap|jmap|gmail|msgraph|maildir|smtp`. Default is `auto` (first configured).
 
-Save attachments from a message:
+## Output formats
 
-```bash
-himalaya attachment download 42
-```
-
-Save to specific directory:
+`--json` is a global flag that emits parsed JSON for any command:
 
 ```bash
-himalaya attachment download 42 --downloads-dir ~/Downloads
-```
-
-## Output Formats
-
-Most commands support `--output` for structured output:
-
-```bash
-himalaya envelope list --output json
-himalaya envelope list --output plain
+himalaya --json envelope list --page-size=5
+himalaya --json message read 42 | jq '.subject'
+himalaya --json mailbox list
 ```
 
 ## Debugging
 
-Enable debug logging:
-
 ```bash
-RUST_LOG=debug himalaya envelope list
+himalaya --log trace mailbox list
+RUST_LOG=trace himalaya envelope list 2>/tmp/himalaya.log
+RUST_BACKTRACE=1 himalaya envelope list
+NO_COLOR=1 himalaya envelope list
 ```
 
-Full trace with backtrace:
+Logs go to stderr; `--log-file <path>` writes to file directly.
 
-```bash
-RUST_LOG=trace RUST_BACKTRACE=1 himalaya envelope list
+## Re-using sessions (advanced)
+
+Every invocation opens a fresh TCP+TLS+SASL handshake. To amortize that, point `imap.server` / `smtp.server` at a [sirup](https://github.com/pimalaya/sirup) Unix socket holding a pre-authenticated session:
+
+```toml
+imap.server = "unix:///run/sirup/imap.sock"
+smtp.server = "unix:///run/sirup/smtp.sock"
 ```
 
 ## Tips
 
-- Use `himalaya --help` or `himalaya <command> --help` for detailed usage.
-- Message IDs are relative to the current folder; re-list after folder changes.
-- For composing rich emails with attachments, use MML syntax (see `references/message-composition.md`).
-- Store passwords securely using `pass`, system keyring, or a command that outputs the password.
+- `himalaya <subcommand> --help` is the source of truth — the help text is regenerated from the CLI definitions on every build.
+- Message IDs are relative to the current mailbox; re-list after folder changes.
+- For rich MIME with attachments, signatures, or encryption, chain [mml](https://github.com/pimalaya/mml) into `himalaya message send`.
+- Store passwords via `pass`, `gopass`, `secret-tool`, or any shell command that prints the secret on stdout.
+- The `imap.server` / `smtp.server` fields accept full URLs (`imaps://host:port`, `smtp://host:port`, `smtps://host:port`) for explicit TLS control.

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -27,7 +27,7 @@ This skill is separate from the Hermes Email gateway adapter. The gateway adapte
 | `folder.aliases.sent` (singular, TOML sub-table) | `mailbox.alias.sent` (plural, dotted key under account) |
 | `[accounts.X] backend = { type=imap, host=..., port=..., auth={...} }` | Flat keys: `imap.server`, `imap.sasl.plain.username`, `imap.sasl.plain.password.command` |
 | `envelope list from x` (positional filters) | `envelope list`; filters moved to separate `envelope search "from x"` subcommand with its own DSL |
-| `message write` (no piped input) / `message reply` | `message compose --to ... --subject ... --body ...`; rich MIME via piped `mml`; legacy `template send` still exists |
+| `message write` (no piped input) / `message reply` | `message compose --to ... --subject ... --body ...`; rich MIME via piped `mml`; `message write` is an alias of `message compose` (no editor) |
 | `--output json` / `plain` | `--json` (global flag) |
 | Native keyring support | Removed; use `pass`, `gopass`, `secret-tool` via `password.command` |
 | OAuth flows built in | None; use [ortie](https://github.com/pimalaya/ortie) as token broker |
@@ -228,17 +228,23 @@ himalaya message compose \
   --send
 ```
 
-The legacy path (piped RFC 822 over stdin) still works:
+For a body from stdin (replaces the removed `template send` subcommand), **omit `--body` and `--body-file` — stdin is the body** by default:
 
 ```bash
-cat << 'EOF' | himalaya template send
-From: you@example.com
-To: recipient@example.com
-Subject: Test Message
+echo "Hello from a piped body" | himalaya message compose \
+  --to you@example.com \
+  --subject "Test"
 
-Hello from Himalaya v2!
-EOF
+# Or read the body from a file
+himalaya message compose \
+  --to you@example.com \
+  --subject "Test" \
+  --body-file ./body.txt
 ```
+
+Note: `--body-file -` does NOT work — the binary tries to open a file literally named `-`. The `--body` / `--body-file` / implicit stdin paths are mutually exclusive; pick one.
+
+For rich MIME (multipart, attachments, signing), pipe `mml` output into `message compose` via stdin or process substitution; see `references/message-composition.md`.
 
 ### Reply to a message
 

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -125,18 +125,22 @@ Or skip SMTP entirely and use the Microsoft Graph REST API backend (`msgraph.aut
 
 ### Fastmail
 
-App password works for IMAP/SMTP. For the native JMAP API, replace both blocks with a single `jmap` one using an API token:
+App password works for IMAP/SMTP. For Fastmail's native **JMAP** API (faster, no SMTP needed), use a single `jmap.*` block instead of `imap.*` + `smtp.*`. JMAP needs an API token, not the regular account password — generate one under *Settings → Privacy & Security → API tokens*.
 
 ```toml
 [accounts.fastmail]
-imap.server = "imaps://imap.fastmail.com"
-imap.sasl.plain.username = "you@fastmail.com"
-imap.sasl.plain.password.command = "pass show fastmail"
+email = "you@fastmail.com"
+default = true
 
-smtp.server = "smtps://smtp.fastmail.com"
-smtp.sasl.plain.username = "you@fastmail.com"
-smtp.sasl.plain.password.command = "pass show fastmail"
+jmap.server = "https://api.fastmail.com/jmap/session"
+jmap.auth.bearer.token.command = "pass show fastmail/jmap-token"
+
+# Optional: pin the sending identity and drafts mailbox when multiple exist
+# jmap.identity-id = "I0123abc"
+# jmap.drafts-mailbox-id = "M0123abc"
 ```
+
+The same `jmap.*` schema applies to any JMAP server (Stalwart, Apache James, etc.) — only the `jmap.server` URL changes.
 
 ### iCloud
 
@@ -159,9 +163,10 @@ mailbox.alias.sent = "Sent Messages"
 ## Hermes integration notes
 
 - **Reading, listing, searching, flagging, copying** — all work directly through the terminal tool.
-- **Composing / replying / forwarding** — use the `message compose` subcommand (flags-only) or chain `mml` for rich MIME / attachments / PGP. The legacy `template send` (pipe a complete RFC 822 message on stdin) still works for scripted sends.
-- For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages.
-- **Pitfall — clap parser order matters:** search query DSL tokens (`from`, `subject`, `after`, `order by`, etc.) start consuming characters from the next flag too. Always pass `--page-size=20` (with `=`) instead of `--page-size 20`, and put query positional args **last** on the command line. Spaces between a flag like `--page-size 20` get eaten as part of the search query.
+- **Composing / replying / forwarding** — use the `message compose` / `message reply` / `message forward` subcommands (flag-based) or chain `mml` for rich MIME / attachments / PGP. To send a pre-written RFC 822 message, use `message send < message.eml` or pipe via stdin to `message compose --body-file -` / `message compose` with no `--body` (stdin fallback).
+- **Pitfall — `message write` is an alias, not an editor opener.** In v2, `himalaya message write` is a `visible_alias` of `message compose` and behaves identically (flag-based, no `$EDITOR`). The pre-v1.x editor-driven flow no longer exists. Use `mml compose` if you want interactive composition.
+- For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages. It's a global flag (pass before the subcommand for consistency); v2 also recognizes it after the subcommand for ergonomics.
+- **Pitfall — search query DSL:** the query is a positional `Vec<String>` that captures trailing tokens until end-of-input. Always put the query **last** on the command line. Quote-protect patterns containing `$`, shell metacharacters, or spaces.
 - **Pitfall — Gmail mailbox names:** `[Gmail]/Sent Mail` etc. contain `[`, `]`, and a space. Always quote in the shell.
 - **Pitfall — multiple accounts:** pass `-a <name>` or `--account <name>`. The account flagged `default = true` is used when omitted.
 
@@ -238,20 +243,31 @@ EOF
 ### Reply to a message
 
 ```bash
-# Quick reply with --body
-himalaya message reply 42 --body "Thanks, will do." --send
+# Quick reply with new body
+himalaya message reply 42 --body "Got it, thanks." --send
 
-# Reply-all
-himalaya message reply 42 --all --body "Looping everyone in." --send
+# Strict reply (just to the sender): pass --to with the original From address
+himalaya message reply 42 --to sender@example.com --body "Thanks." --send
 
-# Quote original
-himalaya message reply 42 --quote --body "See below." --send
+# Reply-all: include the original To/Cc recipients with --cc / --to
+himalaya message reply 42 \
+  --to sender@example.com \
+  --cc teammate@example.com \
+  --body "Looping everyone in." --send
+
+# Custom quote headline (default is "On {date}, {from} wrote:")
+himalaya message reply 42 --quote-headline "Replying inline:" --body "..." --send
+
+# Change posting style (top | bottom | inline)
+himalaya message reply 42 --posting-style bottom --body "..." --send
 ```
+
+> **v2 note.** There are no `--all` / `--quote` boolean flags. Reply-all is "include the original recipients via `--cc`/`--to`"; quoting is the default behavior controlled by `--posting-style` and `--quote-headline`.
 
 ### Forward
 
 ```bash
-himalaya message forward 42 --to other@example.com --send
+himalaya message forward 42 --to other@example.com --body "FYI" --send
 ```
 
 ### Move / copy / delete
@@ -259,9 +275,10 @@ himalaya message forward 42 --to other@example.com --send
 ```bash
 himalaya message copy --from INBOX --to Archives 42
 himalaya message move --from INBOX --to Archives 42    # if backend supports move
-himalaya message delete 42                              # sets \Deleted flag
-himalaya message expunge                                 # permanently remove flagged
+himalaya message delete 42                              # trash-move; permanent for in-trash
 ```
+
+> **v2 note.** There is no `message expunge` subcommand in v2. `message delete` already trash-moves; on IMAP servers without UIDPLUS, deleted-from-trash items are flagged `\Deleted` and reclaimed by the next `message delete` on the trash mailbox, or by the server's own expunge policy.
 
 ### Manage flags
 
@@ -275,9 +292,12 @@ The `--flag` argument accepts `seen`, `answered`, `flagged`, `draft`, `recent`. 
 ### Download attachments
 
 ```bash
-himalaya attachment download 42                         # default ~/Downloads
-himalaya attachment download 42 --output-dir /tmp/attach
+himalaya attachment download 42                         # download all; default dir from config
+himalaya attachment download 42 --dir /tmp/attach       # override destination
+himalaya attachment download 42 0 1                     # download only attachments 0 and 1
 ```
+
+> **v2 note.** The destination flag is `--dir` (also `-d`), not `--output-dir`. Default destination is the account's `downloads-dir` config (falling back to the global config, then the platform standard). Run `himalaya attachment download --help` for the full flag list.
 
 ## Multiple accounts
 

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -15,7 +15,7 @@ prerequisites:
 
 # Himalaya CLI v2.x
 
-Himalaya is a Rust CLI for managing email from the terminal. **This skill targets himalaya v2.x** (v2.0.0+, post the v1→v2 breaking changes). The skill previously documented the v1.x schema; commands like `himalaya folder list` and `himalaya envelope list from x` no longer work in v2 and will trip agents loading the skill on first attempt.
+Himalaya is a Rust CLI for managing email from the terminal. **This skill targets himalaya v2.x** (v2.0.0+, post the v1→v2 breaking changes). The skill previously documented the v1.x schema; commands like `himalaya mailbox list` (formerly `himalaya folder list` in v1.x) and `himalaya envelope list from x` no longer work in v2 and will trip agents loading the skill on first attempt.
 
 This skill is separate from the Hermes Email gateway adapter. The gateway adapter lets people email the agent and uses Hermes' built-in IMAP/SMTP adapter; this skill lets the agent operate a mailbox from terminal tools and requires the external `himalaya` CLI.
 
@@ -24,7 +24,7 @@ This skill is separate from the Hermes Email gateway adapter. The gateway adapte
 | v1.x (don't use) | v2.x (current) |
 |---|---|
 | `folder list` | `mailbox list` |
-| `folder.aliases.sent` (singular, TOML sub-table) | `mailbox.alias.sent` (plural, dotted key under account) |
+| `folder.aliases.sent` (v1.x; replaced by `mailbox.alias.sent`) | `mailbox.alias.sent` (plural, dotted key under account) |
 | `[accounts.X] backend = { type=imap, host=..., port=..., auth={...} }` | Flat keys: `imap.server`, `imap.sasl.plain.username`, `imap.sasl.plain.password.command` |
 | `envelope list from x` (positional filters) | `envelope list`; filters moved to separate `envelope search "from x"` subcommand with its own DSL |
 | `message write` (no piped input) / `message reply` | `message compose --to ... --subject ... --body ...`; rich MIME via piped `mml`; `message write` is an alias of `message compose` (no editor) |
@@ -253,11 +253,9 @@ To send a **pre-written RFC 822 message** (full headers + body, e.g. one produce
 
 ```bash
 himalaya message send < message.eml
-# or
-himalaya message send --save drafts < message.eml
 ```
 
-`message send` reads the full message verbatim (headers + body); it does NOT take `--body` / `--body-file` / `--subject`. For richer composition (multipart MIME, attachments, signing/encryption), chain a standalone composer like `mml` into `message send` via stdin or process substitution; see `references/message-composition.md`.
+> ⚠️ `message send --save drafts` is a footgun in v2.0.0: `MessageSendCommand::execute` routes via SMTP unconditionally and only appends a copy *after* delivery (`handler::route(..., true)`). The `--save drafts` is a "send, then copy," not "save without sending." For a true draft, use `message add --mailbox drafts --flag draft < message.eml` (see `references/message-composition.md`).
 
 ### Reply to a message
 

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -275,10 +275,11 @@ himalaya message reply 42 \
   --cc teammate@example.com \
   --body "Looping everyone in." --send
 
-# Custom quote headline (default is "On {date}, {from} wrote:")
+# Custom quote headline (default: empty — v2.0.0 performs no placeholder
+# substitution; the headline string is taken verbatim)
 himalaya message reply 42 --from you@example.com --quote-headline "Replying inline:" --body "..." --send
 
-# Change posting style (top | bottom | inline)
+# Change posting style (top | bottom)
 himalaya message reply 42 --from you@example.com --posting-style bottom --body "..." --send
 ```
 

--- a/skills/email/himalaya/references/configuration.md
+++ b/skills/email/himalaya/references/configuration.md
@@ -216,8 +216,9 @@ Generate the app-specific password at https://appleid.apple.com.
    Add `| tr -d '\n'` if SASL auth fails mysteriously.
 3. **Gmail folder names with `[Gmail]/`** — must be quoted in shell:
    `himalaya -m "[Gmail]/Sent Mail"`. Better: define `mailbox.alias.sent`.
-4. **`backend = { type = "imap", host = ..., ... }`** — that's v1.x TOML.
-   v2 uses flat keys `imap.server`, `imap.sasl.plain.username`, etc.
+4. **Nested `[accounts.X] backend = { ... }` table** — that's v1.x TOML.
+   v2 uses flat per-backend keys like `imap.server`,
+   `imap.sasl.plain.username`, `imap.sasl.plain.password.command`.
 5. **`envelope list from alice`** — that's v1 positional. v2 uses
    `envelope search "from alice"`.
 6. **Plain `password = "secret"`** — there's no such field in v2. Use

--- a/skills/email/himalaya/references/configuration.md
+++ b/skills/email/himalaya/references/configuration.md
@@ -157,10 +157,10 @@ imap.server = "imaps://imap.gmail.com:993"
 imap.sasl.plain.username = "you@gmail.com"
 imap.sasl.plain.password.command = "pass show email/gmail-app"
 
-smtp.server = "smtp://smtp.gmail.com:587"
-smtp.starttls = true
+smtp.server = "smtps://smtp.gmail.com:465"
 smtp.sasl.plain.username = "you@gmail.com"
 smtp.sasl.plain.password.command = "pass show email/gmail-app"
+# STARTTLS alternative: smtp.server = "smtp://smtp.gmail.com:587" + smtp.starttls = true
 
 mailbox.alias.inbox  = "INBOX"
 mailbox.alias.sent   = "[Gmail]/Sent Mail"

--- a/skills/email/himalaya/references/configuration.md
+++ b/skills/email/himalaya/references/configuration.md
@@ -222,6 +222,7 @@ Generate the app-specific password at https://appleid.apple.com.
    `envelope search "from alice"`.
 6. **Plain `password = "secret"`** — there's no such field in v2. Use
    `.raw` or `.command`.
-7. **`--json` placement** — v2 made it a **global** flag. It must come
-   *before* the subcommand: `himalaya --json envelope list`. Putting it
-   after the subcommand silently parses as the wrong thing.
+7. **`--json` placement** — v2 made it a **global** flag. Both placements
+   work: `himalaya --json envelope list` (pre-subcommand, the documented
+   convention) and `himalaya envelope list --json` (post-subcommand,
+   accepted for ergonomics). Neither is silently mis-parsed.

--- a/skills/email/himalaya/references/configuration.md
+++ b/skills/email/himalaya/references/configuration.md
@@ -1,65 +1,151 @@
-# Himalaya Configuration Reference
+# Himalaya v2 Configuration Reference
 
-Configuration file location: `~/.config/himalaya/config.toml`
+Authoritative source: https://github.com/pimalaya/himalaya/blob/master/config.sample.toml
 
-## Minimal IMAP + SMTP Setup
+This is a condensed v2 schema reference — covers the fields you'll actually
+touch on a daily basis. For the full annotated sample, follow the URL above.
+
+## Config file locations (first match wins)
+
+- `$XDG_CONFIG_HOME/himalaya/config.toml`
+- `$HOME/.config/himalaya/config.toml`
+- `$HOME/.himalayarc`
+
+Override with `himalaya -c <path>`. Multiple paths merge: `himalaya -c base:overlay`.
+
+## Global keys (top of file)
 
 ```toml
-[accounts.default]
-email = "user@example.com"
+# Default download directory for attachments. Falls back to $TMPDIR.
+downloads-dir = "~/downloads"
+
+# Table rendering
+table.preset = "││──╞═╪╡┆    ┬┴┌┐└┘"          # default
+table.arrangement = "dynamic"                 # or "dynamic-full-width", "disabled"
+
+# Envelope list formatting
+envelope.list.datetime-fmt = "%F %R%:z"       # ISO-ish; default
+envelope.list.datetime-local-tz = false       # convert to local TZ before render
+envelope.list.page-size = 50                  # default page size
+
+# Mailbox alias map (account-level entries override)
+mailbox.alias.inbox  = "INBOX"
+mailbox.alias.sent   = "[Gmail]/Sent Mail"
+mailbox.alias.drafts = "[Gmail]/Drafts"
+mailbox.alias.trash  = "[Gmail]/Trash"
+
+# Per-column colors (envelope list table)
+envelope.list.table.id-color = "red"
+envelope.list.table.flags-color = "reset"
+envelope.list.table.subject-color = "green"
+envelope.list.table.from-color = "blue"
+envelope.list.table.to-color = "blue"
+envelope.list.table.date-color = "dark_yellow"
+envelope.list.table.size-color = "reset"
+```
+
+## Account block
+
+```toml
+[accounts.NAME]
+default = true                        # only one account can be true
+email = "you@example.com"
 display-name = "Your Name"
-default = true
+downloads-dir = "~/downloads/NAME"    # per-account override
 
-# IMAP backend for reading emails
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "user@example.com"
-backend.auth.type = "password"
-backend.auth.raw = "your-password"
+# Per-backend config (at least one of imap / smtp / jmap / gmail / msgraph / maildir)
+imap.server = "imaps://imap.example.com:993"
+imap.tls.provider = "rustls"          # or "native-tls"
+imap.tls.rustls.crypto = "ring"       # or "aws"
+imap.tls.cert = "/path/to/extra-ca.pem"
+imap.starttls = false                 # only valid with imap://
+imap.alpn = ["imap"]
 
-# SMTP backend for sending emails
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "user@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.raw = "your-password"
+# Pick ONE SASL mechanism
+imap.sasl.anonymous.message = "himalaya"
+imap.sasl.plain.username   = "you@example.com"
+imap.sasl.plain.password.raw     = "raw-secret"           # dev only
+imap.sasl.plain.password.command = "pass show example"    # recommended
+imap.sasl.login.username   = "you@example.com"
+imap.sasl.login.password.raw     = "***"
+imap.sasl.login.password.command = ["pass", "show", "example"]
+imap.sasl.oauthbearer.username = "you@example.com"
+imap.sasl.oauthbearer.token.raw     = "***"
+imap.sasl.oauthbearer.token.command = ["ortie", "token", "show", "-a", "example"]
+imap.sasl.xoauth2.username = "you@example.com"
+imap.sasl.xoauth2.token.raw     = "***"
+imap.sasl.xoauth2.token.command = ["ortie", "token", "show", "-a", "example"]
+imap.sasl.scram-sha-256.username = "you@example.com"
+imap.sasl.scram-sha-256.password.raw     = "***"
+imap.sasl.scram-sha-256.password.command = "pass show example"
 
-# Folder aliases — required whenever server folder names differ
-# from himalaya's canonical names. See "Folder Aliases" below.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+# RFC 2971 ID extension (some servers require it after auth)
+imap.id.auto = false
+imap.id.fields = { name = true, version = true, vendor = true, support-url = true }
+
+# RFC 5256 SORT fallback
+imap.sort.fallback = false            # true = always client-side
+
+# SMTP — same flat schema as imap.*
+smtp.server = "smtps://smtp.example.com:465"
+smtp.starttls = false
+smtp.sasl.plain.username = "you@example.com"
+smtp.sasl.plain.password.command = "pass show example"
+
+# Gmail REST API backend (alternative to imap/smtp)
+gmail.user-id = "me"                  # default
+gmail.auth.token.raw     = "***"
+gmail.auth.token.command = ["ortie", "token", "show", "-a", "gmail"]
+
+# Microsoft Graph backend
+msgraph.user-id = "me"
+msgraph.auth.token.command = ["ortie", "token", "show", "-a", "msgraph"]
+
+# JMAP backend (Fastmail, Stalwart, etc.)
+jmap.server = "https://api.fastmail.com/jmap/session"
+jmap.auth.bearer.token.command = "pass show fastmail"
+jmap.identity-id = "I0123abc"          # optional: pin sender identity
+jmap.drafts-mailbox-id = "M0123abc"    # optional: pin drafts folder
+
+# Maildir backend
+maildir.root = "~/Mail/example"
+
+# Per-account mailbox aliases override global
+mailbox.alias.inbox  = "INBOX"
+mailbox.alias.sent   = "Sent"
+mailbox.alias.drafts = "Drafts"
+mailbox.alias.trash  = "Trash"
+mailbox.alias.junk   = "Junk"
+mailbox.alias.archive = "Archives"
 ```
 
-## Password Options
+## Server URL schemes
 
-### Raw password (testing only, not recommended)
+| Scheme | Meaning |
+|---|---|
+| `imaps://host:port` | Implicit TLS (typically port 993) |
+| `imap://host:port` | Cleartext, optionally upgraded via STARTTLS |
+| `smtps://host:port` | Implicit TLS (typically port 465) |
+| `smtp://host:port` | Cleartext, optionally upgraded via STARTTLS |
+| `unix:///path/to/sock` | Unix socket (for [sirup](https://github.com/pimalaya/sirup) reuse) |
+| Bare `host[:port]` | Defaults to `<scheme>s://` |
+
+## Secret storage
+
+Three forms, per-field:
 
 ```toml
-backend.auth.raw = "your-password"
+field.raw     = "literal-secret"            # dev / testing only
+field.command = "pass show path/to/secret"  # shell string form
+field.command = ["pass", "show", "secret"]  # argv array form (no shell interpolation)
 ```
 
-### Password from command (recommended)
+The `command` form is recommended. Native keyring was removed in v2; use a
+third-party tool (`pass`, `gopass`, `secret-tool`, `1password-cli`, `bitwarden`).
 
-```toml
-backend.auth.cmd = "pass show email/imap"
-# backend.auth.cmd = "security find-generic-password -a user@example.com -s imap -w"
-```
+## Provider examples
 
-### System keyring (requires keyring feature)
-
-```toml
-backend.auth.keyring = "imap-example"
-```
-
-Then run `himalaya account configure <account>` to store the password.
-
-## Gmail Configuration
+### Gmail (app password)
 
 ```toml
 [accounts.gmail]
@@ -67,161 +153,75 @@ email = "you@gmail.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.gmail.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@gmail.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show google/app-password"
+imap.server = "imaps://imap.gmail.com:993"
+imap.sasl.plain.username = "you@gmail.com"
+imap.sasl.plain.password.command = "pass show email/gmail-app"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.gmail.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@gmail.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show google/app-password"
+smtp.server = "smtp://smtp.gmail.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@gmail.com"
+smtp.sasl.plain.password.command = "pass show email/gmail-app"
 
-# Gmail folder mapping. Without these, save-to-Sent fails after
-# SMTP delivery succeeds (Gmail's Sent folder is `[Gmail]/Sent Mail`,
-# not `Sent`), and `himalaya message send` exits non-zero. Any
-# caller that retries on that error will re-run SMTP — duplicate
-# emails to recipients. Always include this block for Gmail.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "[Gmail]/Sent Mail"
-folder.aliases.drafts = "[Gmail]/Drafts"
-folder.aliases.trash = "[Gmail]/Trash"
+mailbox.alias.inbox  = "INBOX"
+mailbox.alias.sent   = "[Gmail]/Sent Mail"
+mailbox.alias.drafts = "[Gmail]/Drafts"
+mailbox.alias.trash  = "[Gmail]/Trash"
+mailbox.alias.archive = "[Gmail]/All Mail"
+mailbox.alias.junk   = "[Gmail]/Spam"
 ```
 
-**Note:** Gmail requires an App Password if 2FA is enabled.
+Generate the app password at https://myaccount.google.com/apppasswords (requires 2-Step Verification).
 
-## iCloud Configuration
+### Outlook / Microsoft 365 (OAuth)
+
+```toml
+[accounts.outlook]
+
+imap.server = "imaps://outlook.office365.com:993"
+imap.sasl.xoauth2.username = "you@outlook.com"
+imap.sasl.xoauth2.token.command = ["ortie", "token", "show", "-a", "outlook"]
+
+smtp.server = "smtp://smtp-mail.outlook.com:587"
+smtp.starttls = true
+smtp.sasl.xoauth2.username = "you@outlook.com"
+smtp.sasl.xoauth2.token.command = ["ortie", "token", "show", "-a", "outlook"]
+```
+
+Or use the Microsoft Graph REST API backend (`msgraph.auth.token.command = [...]`) — Graph has no separate SMTP block since sending also goes through Graph.
+
+### iCloud
 
 ```toml
 [accounts.icloud]
-email = "you@icloud.com"
-display-name = "Your Name"
+imap.server = "imaps://imap.mail.me.com:993"
+imap.sasl.plain.username = "johnappleseed"             # local-part only
+imap.sasl.plain.password.command = "pass show icloud"
 
-backend.type = "imap"
-backend.host = "imap.mail.me.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@icloud.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show icloud/app-password"
+smtp.server = "smtp://smtp.mail.me.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "johnappleseed@icloud.com"  # full address
+smtp.sasl.plain.password.command = "pass show icloud"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.mail.me.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@icloud.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show icloud/app-password"
+mailbox.alias.sent = "Sent Messages"
 ```
 
-**Note:** Generate an app-specific password at appleid.apple.com
+Generate the app-specific password at https://appleid.apple.com.
 
-## Folder Aliases
+## Common mistakes
 
-Map himalaya's canonical folder names (`inbox`, `sent`, `drafts`,
-`trash`) to whatever the server actually calls them. Use the
-v1.2.0 `folder.aliases.X` syntax (plural, dotted keys, directly
-under `[accounts.NAME]`):
-
-```toml
-[accounts.default]
-# ... other account config ...
-
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
-```
-
-The equivalent TOML sub-section form also works in v1.2.0:
-
-```toml
-[accounts.default.folder.aliases]
-inbox = "INBOX"
-sent = "Sent"
-drafts = "Drafts"
-trash = "Trash"
-```
-
-> **Don't use the singular `alias` form.** Pre-v1.2.0 docs showed
-> `[accounts.NAME.folder.alias]` (singular). v1.2.0 silently
-> ignores that sub-section — TOML parses without error, but the
-> alias resolver never reads it. Every lookup then falls through
-> to the canonical name. On Gmail (where `sent` is actually
-> `[Gmail]/Sent Mail`) this means save-to-Sent fails *after* SMTP
-> delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that error
-> code will re-run the send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural).
-
-## Multiple Accounts
-
-```toml
-[accounts.personal]
-email = "personal@example.com"
-default = true
-# ... backend config ...
-
-[accounts.work]
-email = "work@company.com"
-# ... backend config ...
-```
-
-Switch accounts with `--account`:
-
-```bash
-himalaya --account work envelope list
-```
-
-## Notmuch Backend (local mail)
-
-```toml
-[accounts.local]
-email = "user@example.com"
-
-backend.type = "notmuch"
-backend.db-path = "~/.mail/.notmuch"
-```
-
-## OAuth2 Authentication (for providers that support it)
-
-```toml
-backend.auth.type = "oauth2"
-backend.auth.client-id = "your-client-id"
-backend.auth.client-secret.cmd = "pass show oauth/client-secret"
-backend.auth.access-token.cmd = "pass show oauth/access-token"
-backend.auth.refresh-token.cmd = "pass show oauth/refresh-token"
-backend.auth.auth-url = "https://provider.com/oauth/authorize"
-backend.auth.token-url = "https://provider.com/oauth/token"
-```
-
-## Additional Options
-
-### Signature
-
-```toml
-[accounts.default]
-signature = "Best regards,\nYour Name"
-signature-delim = "-- \n"
-```
-
-### Downloads directory
-
-```toml
-[accounts.default]
-downloads-dir = "~/Downloads/himalaya"
-```
-
-### Editor for composing
-
-Set via environment variable:
-
-```bash
-export EDITOR="vim"
-```
+1. **`folder.alias.X`** (singular, sub-table) — that's v1.x. v2 silently
+   ignores it. Always use **`mailbox.alias.X`** (plural, dotted key under
+   the account block).
+2. **Passwords with trailing newline** — `pass show` may include one.
+   Add `| tr -d '\n'` if SASL auth fails mysteriously.
+3. **Gmail folder names with `[Gmail]/`** — must be quoted in shell:
+   `himalaya -m "[Gmail]/Sent Mail"`. Better: define `mailbox.alias.sent`.
+4. **`backend = { type = "imap", host = ..., ... }`** — that's v1.x TOML.
+   v2 uses flat keys `imap.server`, `imap.sasl.plain.username`, etc.
+5. **`envelope list from alice`** — that's v1 positional. v2 uses
+   `envelope search "from alice"`.
+6. **Plain `password = "secret"`** — there's no such field in v2. Use
+   `.raw` or `.command`.
+7. **`--json` placement** — v2 made it a **global** flag. It must come
+   *before* the subcommand: `himalaya --json envelope list`. Putting it
+   after the subcommand silently parses as the wrong thing.

--- a/skills/email/himalaya/references/message-composition.md
+++ b/skills/email/himalaya/references/message-composition.md
@@ -274,25 +274,30 @@ himalaya message add --mailbox drafts --flag draft < message.eml
 
 ```bash
 # Install mml. Upstream's Cargo package is `mime-meta-language`; the binary
-# is named `mml`. Pin one contract end-to-end:
+# is named `mml`. Pin one contract end-to-end — the CLI shape differs between
+# released tags and current master, so the install command and invocation must
+# agree on the same source.
 #
 #   Released `v1.1.1` (stable, recommended):
-#     cargo install mime-meta-language --locked --features cli
-#     mml compose --from me@example.org --output /tmp/draft.eml
+#     cargo install mime-meta-language --version 1.1.1 --locked --features cli
+#     # v1.1.1: `output` is a POSITIONAL argument
+#     mml compose --from me@example.org /tmp/draft.eml
 #     himalaya message send < /tmp/draft.eml
 #
 #   Current `master` (bleeding edge, output via global `-o/--output`):
 #     cargo install --locked --git https://github.com/pimalaya/mml.git
+#     # master: output is the global `-o` / `--output` flag
 #     mml compose --from me@example.org --output /tmp/draft.eml
 #     himalaya message send < /tmp/draft.eml
 #
 # Notes:
-# - `mml` rejects stdout redirection for editor-driven composition (the
-#   spawned editor needs a TTY); always use `--output`.
+# - Both contracts require a real path (stdout redirection breaks
+#   editor-driven composition because the spawned editor needs a TTY).
 # - The artifact consumed by `himalaya message send` is RFC 5322/MIME, so
 #   use a `.eml` extension, not `.mml` (which is the source template format).
-mml compose --from me@example.org --output /tmp/draft.eml
-himalaya message send < /tmp/draft.eml
+# - If you mix the install source with the wrong invocation, the binary will
+#   fail at parse time (positional `/tmp/draft.eml` is "unexpected argument"
+#   on master; `--output` is "unexpected argument" on v1.1.1).
 ```
 
 This is the cleanest path for attachments, PGP signing, and inline images.

--- a/skills/email/himalaya/references/message-composition.md
+++ b/skills/email/himalaya/references/message-composition.md
@@ -1,6 +1,8 @@
 # Message Composition with MML (MIME Meta Language)
 
-Himalaya uses MML for composing emails. MML is a simple XML-based syntax that compiles to MIME messages.
+Himalaya uses MML for composing rich (multipart, attachments, inline images, PGP) emails. MML is a simple XML-based syntax that compiles to MIME messages.
+
+> **v2 CLI note.** The MML syntax itself is unchanged from v1.x. What changed is how you drive the composer from the CLI: v2 adds a flag-based `message compose --to ... --subject ... --body ... --send` for scripted sends and `message reply N --body ... --send` / `message forward N --to ... --send` for replies. The legacy `himalaya message write` (editor-driven) and `himalaya template send` (piped RFC 822) still work in v2.
 
 ## Basic Message Structure
 
@@ -155,13 +157,51 @@ Defines a message part.
 
 ## Composing from CLI
 
-### Interactive compose
+### Quick send (v2 flag-based API)
+
+```bash
+himalaya message compose \
+  --to recipient@example.com \
+  --subject "Quick note" \
+  --body "Hello from himalaya v2." \
+  --send
+
+# Multiple recipients, cc, bcc
+himalaya message compose \
+  --to alice@example.com --to bob@example.com \
+  --cc manager@example.com \
+  --subject "Group note" \
+  --body "Hi all." \
+  --send
+```
+
+### Quick reply / forward (v2 flag-based API)
+
+```bash
+# Reply with new body
+himalaya message reply 42 --body "Got it, thanks." --send
+
+# Reply-all
+himalaya message reply 42 --all --body "Looping everyone in." --send
+
+# Quote the original
+himalaya message reply 42 --quote --body "See below." --send
+
+# Forward
+himalaya message forward 42 --to other@example.com --body "FYI" --send
+```
+
+Run `himalaya message compose --help`, `himalaya message reply --help`, and `himalaya message forward --help` for the full flag list.
+
+### Interactive compose (editor-driven)
 
 Opens your `$EDITOR`:
 
 ```bash
 himalaya message write
 ```
+
+> **v2 behavior.** `message write` still opens `$EDITOR` like in v1.x. From Hermes, prefer the flag-based `message compose --send` or piped `template send` paths — the editor flow requires PTY mode and a configured `$EDITOR`, which is fiddlier from an agent runtime.
 
 ### Reply (opens editor with quoted message)
 
@@ -176,7 +216,7 @@ himalaya message reply 42 --all  # reply-all
 himalaya message forward 42
 ```
 
-### Send from stdin
+### Send a prepared message from stdin (legacy v1 path, still works)
 
 ```bash
 cat message.txt | himalaya template send
@@ -191,9 +231,37 @@ himalaya message write \
   "Message body here"
 ```
 
+### Save a draft without sending
+
+```bash
+# Modern path: pipe to message add with --flag draft
+himalaya message compose --to x@y.com --subject "Draft" --body "WIP" | \
+  himalaya message add --mailbox drafts --flag draft
+
+# Or use the legacy template form
+cat <<'EOF' | himalaya template send --draft
+From: you@example.com
+To: someone@example.com
+Subject: Draft
+
+WIP content here.
+EOF
+```
+
+### Rich MIME via external composer (mml)
+
+```bash
+# Install mml: cargo install mml
+mml compose > message.mml   # interactive (or scripted)
+himalaya message send < message.mml
+```
+
+This is the cleanest path for attachments, PGP signing, and inline images.
+
 ## Tips
 
 - The editor opens with a template; fill in headers and body.
 - Save and exit the editor to send; exit without saving to cancel.
 - MML parts are compiled to proper MIME when sending.
 - Use `himalaya message export --full` to inspect the raw MIME structure of received emails.
+- For Hermes integration, prefer `message compose --send` over editor-driven flows — they're deterministic and don't need `$EDITOR`.

--- a/skills/email/himalaya/references/message-composition.md
+++ b/skills/email/himalaya/references/message-composition.md
@@ -262,13 +262,20 @@ himalaya message compose \
 himalaya message compose --to x@y.com --subject "Draft" --body "WIP" --save drafts
 
 # Save a pre-written RFC 822 message to drafts WITHOUT sending it.
-# ⚠️ Do NOT use `himalaya message send --save drafts < message.eml` — v2.0.0's
-# MessageSendCommand routes via SMTP and only appends a copy *after* delivery
-# (`handler::route(..., true)`). For a true "save without sending", use the
-# `message add` subcommand which stages the message into a mailbox with a
-# given flag without routing through SMTP:
+# For a true "save without sending", use the `message add` subcommand
+# which stages the message into a mailbox with a given flag without
+# routing through SMTP (see the warning callout below for why
+# `message send` with `--save drafts` does NOT do what you'd expect).
 himalaya message add --mailbox drafts --flag draft < message.eml
 ```
+
+> ⚠️ **Why not `himalaya message send --save drafts < message.eml`?**
+> v2.0.0's `MessageSendCommand::execute` calls `handler::::route(..., true)`
+> unconditionally — `--save drafts` means "send, then append a copy,"
+> not "save without sending." Under a "Save a draft" heading, that
+> recipe would silently deliver the unfinished message. Use `message
+> add --mailbox drafts --flag draft` (shown above) for true draft
+> staging.
 
 ### Rich MIME via external composer (mml)
 

--- a/skills/email/himalaya/references/message-composition.md
+++ b/skills/email/himalaya/references/message-composition.md
@@ -234,8 +234,11 @@ These are equivalent to the flag-based variants above but with no `--body` set, 
 # File path as positional arg (v2 MessageArg resolves path-or-stdin-or-inline)
 himalaya message send < message.eml
 
-# Or pipe stdin to message compose (when no --body / --body-file given, stdin is used)
-cat message.eml | himalaya message compose --from you@example.com --send
+# The pre-written RFC 822 message stays on the `message send` path —
+# `message compose` treats stdin as the BODY and rebuilds headers, so
+# piping a complete message into it would discard From/To/Subject.
+# If you want to compose fresh, use the flag-based form above; if you
+# want to send a prepared RFC 822 message, use `message send`.
 ```
 
 `message send` routes through the account's SMTP (or JMAP submission) backend; envelope sender comes from the `From:` header and recipients from `To:`/`Cc:`/`Bcc:`. Add `--save <mailbox>` to also append a copy to a mailbox (the name is resolved through the account's `[mailbox.alias]` map).
@@ -263,8 +266,10 @@ himalaya message send --save drafts < message.eml
 
 ```bash
 # Install mml: cargo install mml
-mml compose > message.mml   # interactive (or scripted)
-himalaya message send < message.mml
+# Use mml's --output so the spawned editor keeps a TTY (stdout redirection
+# breaks editor-driven composition — upstream MML explicitly rejects it).
+mml compose --from me@example.org /tmp/draft.mml
+himalaya message send < /tmp/draft.mml
 ```
 
 This is the cleanest path for attachments, PGP signing, and inline images.
@@ -274,4 +279,4 @@ This is the cleanest path for attachments, PGP signing, and inline images.
 - v2 reads `--body` from the inline string, `--body-file` from a path, or stdin when neither is given. Pick whichever fits the script.
 - For Hermes integration, prefer `message compose --send` over editor-driven flows — they're deterministic and don't need `$EDITOR`.
 - The `message add` subcommand (`himalaya message add --mailbox drafts --flag draft < message.eml`) still works for scripting: it stages a pre-written message into a mailbox with a given flag without routing through SMTP.
-- Use `himalaya message export --full` to inspect the raw MIME structure of received emails.
+- Use `himalaya message read 42 --raw` to inspect the raw RFC 5322 bytes of a received email (there is no `message export` subcommand in v2; `message read --raw` is the equivalent).

--- a/skills/email/himalaya/references/message-composition.md
+++ b/skills/email/himalaya/references/message-composition.md
@@ -2,7 +2,7 @@
 
 Himalaya uses MML for composing rich (multipart, attachments, inline images, PGP) emails. MML is a simple XML-based syntax that compiles to MIME messages.
 
-> **v2 CLI note.** The MML syntax itself is unchanged from v1.x. What changed is how you drive the composer from the CLI: v2 is flag-first (`message compose --to ... --subject ... --body ... --send` / `message reply N --body ... --send` / `message forward N --to ... --send`). Pre-v1.x editor-driven flows (`himalaya message write` opening `$EDITOR`) are gone — `message write` is now a `visible_alias` of `message compose` and behaves identically. To send a pre-written RFC 822 message, use `himalaya message send < message.eml` or pipe to `himalaya message compose` (stdin is the fallback when no `--body`/`--body-file` is set).
+> **v2 CLI note.** The MML syntax itself is unchanged from v1.x. What changed is how you drive the composer from the CLI: v2 is flag-first (`message compose --to ... --subject ... --body ... --send` / `message reply N --body ... --send` / `message forward N --to ... --send`). Pre-v1.x editor-driven flows (`himalaya message write` opening `$EDITOR`) are gone — `message write` is now a `visible_alias` of `message compose` and behaves identically. To send a pre-written RFC 822 message, use `himalaya message send < message.eml` — `message compose` consumes stdin as the **body** and rebuilds the headers, so piping a complete RFC 5322 message into it would discard `From`/`To`/`Subject`.
 
 ## Basic Message Structure
 
@@ -207,7 +207,7 @@ himalaya message reply 42 --from you@example.com --quote-headline "Replying inli
 himalaya message forward 42 --from you@example.com --to other@example.com --body "FYI" --send
 ```
 
-> **v2 note.** There are no `--all` / `--quote` boolean flags on `message reply`. Reply-all is "include the original recipients via `--cc` / `--to`"; quoting is the default behavior controlled by `--posting-style` (`top` / `bottom` / `inline`) and `--quote-headline`.
+> **v2 note.** There are no `--all` / `--quote` boolean flags on `message reply`. Reply-all is "include the original recipients via `--cc` / `--to`"; quoting is the default behavior controlled by `--posting-style` (`top` / `bottom` only — `inline` is rejected) and `--quote-headline` (default: empty; no placeholder substitution).
 
 Run `himalaya message compose --help`, `himalaya message reply --help`, and `himalaya message forward --help` for the full flag list.
 
@@ -219,14 +219,17 @@ himalaya message write --from you@example.com --to x@y.com --subject "..." --bod
 
 > **v2 note.** In v2, `himalaya message write` is a `visible_alias` of `message compose` (alongside `new`). It does **not** open an editor — that pre-v1.x behavior is gone. For interactive composition, use an external composer like `mml compose` and pipe into `message send`.
 
-### Reply / forward interactive (legacy snippets — also flag-based now)
+### Reply / forward via stdin
 
 ```bash
-himalaya message reply 42
-himalaya message forward 42
+# Pipe a body on stdin — `read_body` only consumes stdin when stdin is NOT a TTY,
+# so this works under `himalaya message reply 42 < body.txt` but NOT as an
+# interactive terminal command.
+himalaya message reply 42 --from you@example.com < body.txt
+himalaya message forward 42 --from you@example.com --to other@example.com < fwd.txt
 ```
 
-These are equivalent to the flag-based variants above but with no `--body` set, so the editor-friendly path is to omit the body and let stdin fill it.
+For interactive (TTY-attached) composition, always supply `--body` or `--body-file` explicitly; do **not** rely on bare `himalaya message reply 42` waiting for terminal stdin — it returns an empty body when stdin is a TTY.
 
 ### Send a prepared RFC 822 message
 
@@ -258,18 +261,38 @@ himalaya message compose \
 # Compose and save to drafts (no --send)
 himalaya message compose --to x@y.com --subject "Draft" --body "WIP" --save drafts
 
-# Or save a pre-written RFC 822 message to drafts
-himalaya message send --save drafts < message.eml
+# Save a pre-written RFC 822 message to drafts WITHOUT sending it.
+# ⚠️ Do NOT use `himalaya message send --save drafts < message.eml` — v2.0.0's
+# MessageSendCommand routes via SMTP and only appends a copy *after* delivery
+# (`handler::route(..., true)`). For a true "save without sending", use the
+# `message add` subcommand which stages the message into a mailbox with a
+# given flag without routing through SMTP:
+himalaya message add --mailbox drafts --flag draft < message.eml
 ```
 
 ### Rich MIME via external composer (mml)
 
 ```bash
-# Install mml: cargo install mml
-# Use mml's --output so the spawned editor keeps a TTY (stdout redirection
-# breaks editor-driven composition — upstream MML explicitly rejects it).
-mml compose --from me@example.org /tmp/draft.mml
-himalaya message send < /tmp/draft.mml
+# Install mml. Upstream's Cargo package is `mime-meta-language`; the binary
+# is named `mml`. Pin one contract end-to-end:
+#
+#   Released `v1.1.1` (stable, recommended):
+#     cargo install mime-meta-language --locked --features cli
+#     mml compose --from me@example.org --output /tmp/draft.eml
+#     himalaya message send < /tmp/draft.eml
+#
+#   Current `master` (bleeding edge, output via global `-o/--output`):
+#     cargo install --locked --git https://github.com/pimalaya/mml.git
+#     mml compose --from me@example.org --output /tmp/draft.eml
+#     himalaya message send < /tmp/draft.eml
+#
+# Notes:
+# - `mml` rejects stdout redirection for editor-driven composition (the
+#   spawned editor needs a TTY); always use `--output`.
+# - The artifact consumed by `himalaya message send` is RFC 5322/MIME, so
+#   use a `.eml` extension, not `.mml` (which is the source template format).
+mml compose --from me@example.org --output /tmp/draft.eml
+himalaya message send < /tmp/draft.eml
 ```
 
 This is the cleanest path for attachments, PGP signing, and inline images.

--- a/skills/email/himalaya/references/message-composition.md
+++ b/skills/email/himalaya/references/message-composition.md
@@ -161,6 +161,7 @@ Defines a message part.
 
 ```bash
 himalaya message compose \
+  --from you@example.com \
   --to recipient@example.com \
   --subject "Quick note" \
   --body "Hello from himalaya v2." \
@@ -168,6 +169,7 @@ himalaya message compose \
 
 # Multiple recipients, cc, bcc, attachment
 himalaya message compose \
+  --from you@example.com \
   --to alice@example.com --to bob@example.com \
   --cc manager@example.com \
   --attach ~/Documents/report.pdf \
@@ -186,22 +188,23 @@ The compose command also accepts `--from`, `--body-file <PATH>`, and reads the b
 
 ```bash
 # Reply with new body (quotes original by default; --posting-style controls layout)
-himalaya message reply 42 --body "Got it, thanks." --send
+himalaya message reply 42 --from you@example.com --body "Got it, thanks." --send
 
 # Strict reply (just the original sender): pass --to with the original From address
-himalaya message reply 42 --to sender@example.com --body "Thanks." --send
+himalaya message reply 42 --from you@example.com --to sender@example.com --body "Thanks." --send
 
 # Reply-all: include original To/Cc recipients via --cc / --to
 himalaya message reply 42 \
+  --from you@example.com \
   --to sender@example.com \
   --cc teammate@example.com \
   --body "Looping everyone in." --send
 
 # Custom quote headline and posting style
-himalaya message reply 42 --quote-headline "Replying inline:" --posting-style bottom --body "..." --send
+himalaya message reply 42 --from you@example.com --quote-headline "Replying inline:" --posting-style bottom --body "..." --send
 
 # Forward
-himalaya message forward 42 --to other@example.com --body "FYI" --send
+himalaya message forward 42 --from you@example.com --to other@example.com --body "FYI" --send
 ```
 
 > **v2 note.** There are no `--all` / `--quote` boolean flags on `message reply`. Reply-all is "include the original recipients via `--cc` / `--to`"; quoting is the default behavior controlled by `--posting-style` (`top` / `bottom` / `inline`) and `--quote-headline`.
@@ -211,7 +214,7 @@ Run `himalaya message compose --help`, `himalaya message reply --help`, and `him
 ### `message write` is an alias of `message compose`
 
 ```bash
-himalaya message write --to x@y.com --subject "..." --body "..." --send
+himalaya message write --from you@example.com --to x@y.com --subject "..." --body "..." --send
 ```
 
 > **v2 note.** In v2, `himalaya message write` is a `visible_alias` of `message compose` (alongside `new`). It does **not** open an editor — that pre-v1.x behavior is gone. For interactive composition, use an external composer like `mml compose` and pipe into `message send`.

--- a/skills/email/himalaya/references/message-composition.md
+++ b/skills/email/himalaya/references/message-composition.md
@@ -292,8 +292,8 @@ himalaya message add --mailbox drafts --flag draft < message.eml
 #     himalaya message send < /tmp/draft.eml
 #
 #   Current `master` (bleeding edge, output via global `-o/--output`):
-#     cargo install --locked --git https://github.com/pimalaya/mml.git
-#     # master: output is the global `-o` / `--output` flag
+#     cargo install --locked --git https://github.com/pimalaya/mml.git --rev ad50fd97786be9c94a9d758fc1f7792a03d6d378
+#     # master @ ad50fd97786be9c94a9d758fc1f7792a03d6d378: output is the global `-o` / `--output` flag
 #     mml compose --from me@example.org --output /tmp/draft.eml
 #     himalaya message send < /tmp/draft.eml
 #
@@ -305,6 +305,11 @@ himalaya message add --mailbox drafts --flag draft < message.eml
 # - If you mix the install source with the wrong invocation, the binary will
 #   fail at parse time (positional `/tmp/draft.eml` is "unexpected argument"
 #   on master; `--output` is "unexpected argument" on v1.1.1).
+# - The master install is pinned to a specific git rev
+#   (`ad50fd97786be9c94a9d758fc1f7792a03d6d378`) so that the install and the
+#   documented `--output` CLI contract stay aligned. Without `--rev`, the
+#   install would resolve whatever `master` points to AT INSTALL TIME, which
+#   could re-introduce the source/CLI drift this section exists to prevent.
 ```
 
 This is the cleanest path for attachments, PGP signing, and inline images.

--- a/skills/email/himalaya/references/message-composition.md
+++ b/skills/email/himalaya/references/message-composition.md
@@ -2,7 +2,7 @@
 
 Himalaya uses MML for composing rich (multipart, attachments, inline images, PGP) emails. MML is a simple XML-based syntax that compiles to MIME messages.
 
-> **v2 CLI note.** The MML syntax itself is unchanged from v1.x. What changed is how you drive the composer from the CLI: v2 adds a flag-based `message compose --to ... --subject ... --body ... --send` for scripted sends and `message reply N --body ... --send` / `message forward N --to ... --send` for replies. The legacy `himalaya message write` (editor-driven) and `himalaya template send` (piped RFC 822) still work in v2.
+> **v2 CLI note.** The MML syntax itself is unchanged from v1.x. What changed is how you drive the composer from the CLI: v2 is flag-first (`message compose --to ... --subject ... --body ... --send` / `message reply N --body ... --send` / `message forward N --to ... --send`). Pre-v1.x editor-driven flows (`himalaya message write` opening `$EDITOR`) are gone — `message write` is now a `visible_alias` of `message compose` and behaves identically. To send a pre-written RFC 822 message, use `himalaya message send < message.eml` or pipe to `himalaya message compose` (stdin is the fallback when no `--body`/`--body-file` is set).
 
 ## Basic Message Structure
 
@@ -166,86 +166,94 @@ himalaya message compose \
   --body "Hello from himalaya v2." \
   --send
 
-# Multiple recipients, cc, bcc
+# Multiple recipients, cc, bcc, attachment
 himalaya message compose \
   --to alice@example.com --to bob@example.com \
   --cc manager@example.com \
+  --attach ~/Documents/report.pdf \
+  --signature "Best,\nAlice" \
   --subject "Group note" \
   --body "Hi all." \
   --send
+
+# Append a copy to a mailbox (e.g. drafts while iterating)
+himalaya message compose --to x@y.com --subject "Draft" --body "WIP" --save drafts
 ```
+
+The compose command also accepts `--from`, `--body-file <PATH>`, and reads the body from stdin when neither `--body` nor `--body-file` is given.
 
 ### Quick reply / forward (v2 flag-based API)
 
 ```bash
-# Reply with new body
+# Reply with new body (quotes original by default; --posting-style controls layout)
 himalaya message reply 42 --body "Got it, thanks." --send
 
-# Reply-all
-himalaya message reply 42 --all --body "Looping everyone in." --send
+# Strict reply (just the original sender): pass --to with the original From address
+himalaya message reply 42 --to sender@example.com --body "Thanks." --send
 
-# Quote the original
-himalaya message reply 42 --quote --body "See below." --send
+# Reply-all: include original To/Cc recipients via --cc / --to
+himalaya message reply 42 \
+  --to sender@example.com \
+  --cc teammate@example.com \
+  --body "Looping everyone in." --send
+
+# Custom quote headline and posting style
+himalaya message reply 42 --quote-headline "Replying inline:" --posting-style bottom --body "..." --send
 
 # Forward
 himalaya message forward 42 --to other@example.com --body "FYI" --send
 ```
 
+> **v2 note.** There are no `--all` / `--quote` boolean flags on `message reply`. Reply-all is "include the original recipients via `--cc` / `--to`"; quoting is the default behavior controlled by `--posting-style` (`top` / `bottom` / `inline`) and `--quote-headline`.
+
 Run `himalaya message compose --help`, `himalaya message reply --help`, and `himalaya message forward --help` for the full flag list.
 
-### Interactive compose (editor-driven)
-
-Opens your `$EDITOR`:
+### `message write` is an alias of `message compose`
 
 ```bash
-himalaya message write
+himalaya message write --to x@y.com --subject "..." --body "..." --send
 ```
 
-> **v2 behavior.** `message write` still opens `$EDITOR` like in v1.x. From Hermes, prefer the flag-based `message compose --send` or piped `template send` paths — the editor flow requires PTY mode and a configured `$EDITOR`, which is fiddlier from an agent runtime.
+> **v2 note.** In v2, `himalaya message write` is a `visible_alias` of `message compose` (alongside `new`). It does **not** open an editor — that pre-v1.x behavior is gone. For interactive composition, use an external composer like `mml compose` and pipe into `message send`.
 
-### Reply (opens editor with quoted message)
+### Reply / forward interactive (legacy snippets — also flag-based now)
 
 ```bash
 himalaya message reply 42
-himalaya message reply 42 --all  # reply-all
-```
-
-### Forward
-
-```bash
 himalaya message forward 42
 ```
 
-### Send a prepared message from stdin (legacy v1 path, still works)
+These are equivalent to the flag-based variants above but with no `--body` set, so the editor-friendly path is to omit the body and let stdin fill it.
+
+### Send a prepared RFC 822 message
 
 ```bash
-cat message.txt | himalaya template send
+# File path as positional arg (v2 MessageArg resolves path-or-stdin-or-inline)
+himalaya message send < message.eml
+
+# Or pipe stdin to message compose (when no --body / --body-file given, stdin is used)
+cat message.eml | himalaya message compose --from you@example.com --send
 ```
+
+`message send` routes through the account's SMTP (or JMAP submission) backend; envelope sender comes from the `From:` header and recipients from `To:`/`Cc:`/`Bcc:`. Add `--save <mailbox>` to also append a copy to a mailbox (the name is resolved through the account's `[mailbox.alias]` map).
 
 ### Prefill headers from CLI
 
 ```bash
-himalaya message write \
-  -H "To:recipient@example.com" \
-  -H "Subject:Quick Message" \
-  "Message body here"
+himalaya message compose \
+  --to recipient@example.com \
+  --subject "Quick Message" \
+  --body "Message body here"
 ```
 
 ### Save a draft without sending
 
 ```bash
-# Modern path: pipe to message add with --flag draft
-himalaya message compose --to x@y.com --subject "Draft" --body "WIP" | \
-  himalaya message add --mailbox drafts --flag draft
+# Compose and save to drafts (no --send)
+himalaya message compose --to x@y.com --subject "Draft" --body "WIP" --save drafts
 
-# Or use the legacy template form
-cat <<'EOF' | himalaya template send --draft
-From: you@example.com
-To: someone@example.com
-Subject: Draft
-
-WIP content here.
-EOF
+# Or save a pre-written RFC 822 message to drafts
+himalaya message send --save drafts < message.eml
 ```
 
 ### Rich MIME via external composer (mml)
@@ -260,8 +268,7 @@ This is the cleanest path for attachments, PGP signing, and inline images.
 
 ## Tips
 
-- The editor opens with a template; fill in headers and body.
-- Save and exit the editor to send; exit without saving to cancel.
-- MML parts are compiled to proper MIME when sending.
-- Use `himalaya message export --full` to inspect the raw MIME structure of received emails.
+- v2 reads `--body` from the inline string, `--body-file` from a path, or stdin when neither is given. Pick whichever fits the script.
 - For Hermes integration, prefer `message compose --send` over editor-driven flows — they're deterministic and don't need `$EDITOR`.
+- The `message add` subcommand (`himalaya message add --mailbox drafts --flag draft < message.eml`) still works for scripting: it stages a pre-written message into a mailbox with a given flag without routing through SMTP.
+- Use `himalaya message export --full` to inspect the raw MIME structure of received emails.

--- a/tests/website/test_himalaya_skill_invariants.py
+++ b/tests/website/test_himalaya_skill_invariants.py
@@ -209,8 +209,118 @@ def test_mml_install_uses_cargo_crate_name_not_binary() -> None:
             f"MML install line `{line.strip()}` doesn't name the Cargo crate "
             "`mime-meta-language` and isn't a git install. Use one of:\n"
             "  cargo install mime-meta-language --version 1.1.1 --locked --features cli\n"
-            "  cargo install --locked --git https://github.com/pimalaya/mml.git"
+            "  cargo install --locked --git https://github.com/pimalaya/mml.git --rev ad50fd97786be9c94a9d758fc1f7792a03d6d378"
         )
+
+
+def test_mml_master_install_pins_rev() -> None:
+    """The git-route install of `mml` must pin a specific `--rev` so the
+    install doesn't drift with `master`.
+
+    Reviewer @andrexibiza flagged this in round 6: the master install
+    `cargo install --git https://github.com/pimalaya/mml.git` resolves
+    whatever `master` points to AT INSTALL TIME, which can select a
+    different parser and reintroduce the source/CLI drift this skill
+    exists to prevent. Pin to a specific commit hash.
+    """
+    text = _read("references/message-composition.md")
+    # The install line may be commented (since it lives in a ```bash
+    # example) so match `cargo install` anywhere in the line, not just
+    # at the start.
+    install_lines = [
+        line for line in text.splitlines()
+        if "cargo install" in line
+        and "pimalaya/mml" in line
+        and "--git" in line
+    ]
+    assert install_lines, (
+        "No `cargo install --git https://github.com/pimalaya/mml.git` line "
+        "found in references/message-composition.md. The master install "
+        "must be present and pinned (or removed entirely, in which case "
+        "the v1.1.1 released path becomes the only one)."
+    )
+    for line in install_lines:
+        # Reject the unpinned form: `cargo install --git ... --locked` is the
+        # bad form. Acceptable is `cargo install --git ... --rev <sha>`.
+        assert "--rev" in line, (
+            f"Master install line `{line.strip()}` does not pin `--rev`. "
+            "Without `--rev`, the install resolves whatever `master` points "
+            "to at install time, which can re-introduce the source/CLI drift "
+            "this section exists to prevent. Add "
+            "`--rev ad50fd97786be9c94a9d758fc1f7792a03d6d378` (or remove "
+            "the master route entirely and keep only the v1.1.1 path)."
+        )
+        # The pinned rev must be the specific one @andrexibiza verified
+        # the `--output` behavior against.
+        assert "ad50fd97786be9c94a9d758fc1f7792a03d6d378" in line, (
+            f"Master install line `{line.strip()}` is pinned to a rev, "
+            "but not the one @andrexibiza verified the `--output` "
+            "behavior against. Pin to "
+            "`ad50fd97786be9c94a9d758fc1f7792a03d6d378`."
+        )
+
+
+def test_mml_master_route_pairs_rev_with_output_flag() -> None:
+    """If the master route is present, the documented `mml compose`
+    invocation in that route must use the `--output` flag (matching the
+    pinned rev's CLI contract).
+
+    Reviewer @andrexibiza's round-6 closing: the `--rev` + `--output`
+    pair must be tested together. An `--rev` pin without a matching
+    `--output` invocation, or vice versa, re-introduces the contract
+    drift.
+    """
+    text = _read("references/message-composition.md")
+    # Only enforce this test if the master route is present.
+    has_master_route = any(
+        "pimalaya/mml" in line and "--git" in line
+        for line in text.splitlines()
+    )
+    if not has_master_route:
+        pytest.skip("Master route not present; only the v1.1.1 contract is documented.")
+    # Locate the master install line and check that the FIRST
+    # `mml compose` invocation after it uses the `--output` flag.
+    # We must look at the actual `mml compose` command line, not just
+    # any mention of `--output` in nearby comments (which always
+    # mention the flag for explanatory reasons).
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if (
+            "cargo install" in line
+            and "pimalaya/mml" in line
+            and "--git" in line
+        ):
+            # Found a master install line; find the next `mml compose`
+            # line and verify it uses `--output`.
+            for j in range(i+1, min(i+10, len(lines))):
+                next_line = lines[j]
+                if "mml compose" in next_line:
+                    # Check this is the master route's `mml compose`
+                    # (not the v1.1.1 route's, which uses positional
+                    # output). The master route's `mml compose` line
+                    # should contain `--output` (not just a comment
+                    # about it).
+                    stripped = next_line.lstrip("# ").strip()
+                    if not stripped.startswith("mml compose"):
+                        # This is a comment line containing the
+                        # phrase, not the executable — skip.
+                        continue
+                    assert "--output" in stripped, (
+                        f"Master route's `mml compose` invocation at "
+                        f"line {j+1} is `{next_line.strip()}`. The "
+                        "pinned rev's CLI requires the global `--output` "
+                        "flag. Use `mml compose --from you@example.com "
+                        "--output /tmp/draft.eml`."
+                    )
+                    # Found and validated the master invocation.
+                    break
+            else:
+                pytest.fail(
+                    f"Master install at line {i+1} is present, but no "
+                    "`mml compose` invocation found in the next 10 lines. "
+                    "Add `mml compose --from you@example.com --output "
+                    "/tmp/draft.eml` after the install line."
+                )
 
 
 def test_mml_contract_pins_one_version_end_to_end() -> None:

--- a/tests/website/test_himalaya_skill_invariants.py
+++ b/tests/website/test_himalaya_skill_invariants.py
@@ -1,0 +1,479 @@
+"""Regression invariants for the himalaya skill docs.
+
+The himalaya skill is consumed by agents loading ``SKILL.md`` + the two
+``references/*.md`` files plus the website mirror. Each review round on
+PR #75212 caught a v2/source-contract defect that survived because no
+automated check existed for the underlying claim. These tests pin the
+contracts the agents rely on so future edits can't silently regress
+them.
+
+Add a test here whenever a review comment identifies a class of bug
+("this example would silently break") — the test should fail on the
+buggy form and pass on the corrected form, so the next PR that
+re-introduces it trips the same gate this PR cleared.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILLS_DIR = Path(__file__).resolve().parents[2] / "skills" / "email" / "himalaya"
+
+
+def _read(name: str) -> str:
+    path = SKILLS_DIR / name
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Round-3 invariants — `--json` and `--page-size` forms
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["SKILL.md", "references/configuration.md"],
+)
+def test_json_flag_documented_as_global_not_must_precede(filename: str) -> None:
+    """`--json` must NOT be documented as "must come before the subcommand".
+
+    Reviewer @Enough1122 caught the contradiction where SKILL.md said
+    `--json` is a global flag but ``references/configuration.md`` said
+    it "must come *before* the subcommand". v2.0.0 parses both pre- and
+    post-subcommand placement; docs must reflect that.
+    """
+    text = _read(filename)
+    assert "must come *before* the subcommand" not in text, (
+        f"{filename} still says `--json` must come before the subcommand. "
+        "v2.0.0 accepts both placements; update the doc."
+    )
+
+
+def test_no_cat_message_eml_into_compose_in_examples() -> None:
+    """Piping a pre-written RFC 822 message into `message compose` rebuilds
+    headers and discards From/To/Subject. The v2-correct path is
+    `message send < message.eml`. This test fails if that pattern shows up
+    inside any ```bash fenced example block.
+
+    Round-3 + 4 from @hendrixfreire + @andrexibiza.
+    """
+    for md in ["SKILL.md", "references/configuration.md", "references/message-composition.md"]:
+        path = SKILLS_DIR / md
+        text = path.read_text(encoding="utf-8")
+        in_block = False
+        block_lines: list[str] = []
+        for line in text.splitlines():
+            if line.strip().startswith("```"):
+                if not in_block:
+                    in_block = True
+                    block_lines = []
+                    continue
+                block_text = "\n".join(block_lines)
+                assert "cat message.eml | himalaya message compose" not in block_text, (
+                    f"{md} shows `cat message.eml | himalaya message compose` "
+                    "inside a bash example. v2 `compose` consumes stdin as the "
+                    "BODY and rebuilds headers — use `message send < message.eml`."
+                )
+                in_block = False
+                block_lines = []
+                continue
+            if in_block:
+                block_lines.append(line)
+
+
+# ---------------------------------------------------------------------------
+# Round-3 invariants — v2 command surface that no longer exists
+# ---------------------------------------------------------------------------
+
+
+def test_message_send_save_drafts_not_in_executable_examples() -> None:
+    """`message send --save drafts` routes via SMTP and only copies the
+    message *after* delivery. It must NOT appear inside an executable
+    ```bash example block (it would silently deliver the message). It is
+    allowed inside warning prose and reference docs that explain the
+    footgun, as long as those warnings don't sit inside a code fence.
+
+    Round-4 P1 from @andrexibiza.
+    """
+    for md in ["SKILL.md", "references/configuration.md", "references/message-composition.md"]:
+        path = SKILLS_DIR / md
+        text = path.read_text(encoding="utf-8")
+        in_block = False
+        block_lines: list[str] = []
+        for line in text.splitlines():
+            if line.strip().startswith("```"):
+                if not in_block:
+                    in_block = True
+                    block_lines = []
+                    continue
+                # Closing fence — check if the forbidden command is in this block
+                block_text = "\n".join(block_lines)
+                if "message send --save drafts" in block_text:
+                    # Find the offending line(s)
+                    for i, l in enumerate(block_lines, 1):
+                        if "message send --save drafts" in l:
+                            pytest.fail(
+                                f"{md} has `message send --save drafts` inside a "
+                                f"bash code block (line {i} of the block): "
+                                f"`{l.strip()}`. v2.0.0 routes via SMTP and "
+                                "appends a copy *after* delivery — copy-pasting "
+                                "this recipe would deliver an unfinished message. "
+                                "Replace with `message add --mailbox drafts "
+                                "--flag draft < message.eml` or remove the line."
+                            )
+                in_block = False
+                block_lines = []
+                continue
+            if in_block:
+                block_lines.append(line)
+
+
+# ---------------------------------------------------------------------------
+# Round-4 invariants — v2 contract specifics
+# ---------------------------------------------------------------------------
+
+
+def test_message_add_recommended_for_drafts_not_send_save() -> None:
+    """The "Save a draft without sending" guidance must teach `message add`,
+    not `message send --save drafts` (which routes via SMTP and only
+    appends a copy after delivery).
+
+    Reviewer @andrexibiza flagged this as P1 — copy-pasting the recipe
+    could deliver an unfinished message.
+    """
+    text = _read("references/message-composition.md")
+    assert "himalaya message add --mailbox drafts --flag draft" in text, (
+        "references/message-composition.md should teach `message add --mailbox "
+        "drafts --flag draft` as the safe 'save without sending' path."
+    )
+
+
+def test_posting_style_does_not_advertise_inline() -> None:
+    """`--posting-style` accepts `top | bottom` in v2.0.0. Documenting
+    `inline` as valid will fail at parse time.
+
+    Reviewer @andrexibiza caught this in SKILL.md round 4.
+    """
+    skill_text = _read("SKILL.md")
+    ref_text = _read("references/message-composition.md")
+    for label, text in [("SKILL.md", skill_text), ("references/message-composition.md", ref_text)]:
+        # Reject "top | bottom | inline" or "top | bottom, inline" style listings.
+        match = re.search(r"posting[- ]style\s*\([^)]*\binline\b", text, re.IGNORECASE)
+        assert not match, (
+            f"{label} advertises `inline` as a valid --posting-style value. "
+            "v2.0.0's PostingStyle enum is top | bottom; remove inline."
+        )
+
+
+def test_quote_headline_default_is_empty_not_template() -> None:
+    """v2.0.0's `--quote-headline` defaults to the empty string and performs
+    no placeholder substitution. The skill must NOT advertise the
+    v1.x default `"On {date}, {from} wrote:"`.
+
+    Reviewer @andrexibiza caught this in round 4.
+    """
+    for md in ["SKILL.md", "references/message-composition.md"]:
+        text = _read(md)
+        assert "On {date}, {from} wrote:" not in text, (
+            f"{md} still advertises the v1.x `On {{date}}, {{from}} wrote:` default "
+            "for --quote-headline. v2.0.0 defaults to empty and performs no "
+            "placeholder substitution; update the doc."
+        )
+
+
+def test_mml_install_uses_cargo_crate_name_not_binary() -> None:
+    """The MML install line must use the Cargo crate name
+    `mime-meta-language`, not the binary name `mml`.
+
+    Reviewer @andrexibiza flagged this in round 4.
+    """
+    text = _read("references/message-composition.md")
+    # Reject `cargo install mml` (binary name) when it's the only install form;
+    # require `mime-meta-language` to appear in the install instructions.
+    install_lines = [
+        line for line in text.splitlines()
+        if line.strip().startswith("cargo install") and "mml" in line.lower()
+    ]
+    for line in install_lines:
+        # Acceptable if line mentions the crate name OR uses the cargo git form
+        # (which doesn't need the crate name — it pulls the whole repo)
+        if "mime-meta-language" in line:
+            continue
+        if "git" in line and "pimalaya/mml" in line:
+            continue
+        # Otherwise fail
+        pytest.fail(
+            f"MML install line `{line.strip()}` doesn't name the Cargo crate "
+            "`mime-meta-language` and isn't a git install. Use one of:\n"
+            "  cargo install mime-meta-language --version 1.1.1 --locked --features cli\n"
+            "  cargo install --locked --git https://github.com/pimalaya/mml.git"
+        )
+
+
+def test_mml_contract_pins_one_version_end_to_end() -> None:
+    """MML install source and invocation shape must agree.
+
+    Reviewer @andrexibiza flagged this in round 5: the same example used
+    `--output` (master contract) on a v1.1.1 install (positional contract).
+    The doc must pin either v1.1.1 (positional) or master (--output)
+    end-to-end within each example, and must NOT leave a bottom executable
+    line that re-mixes the contracts.
+    """
+    text = _read("references/message-composition.md")
+    # Detect any executable `mml compose ...` line outside the contract blocks.
+    # The contract blocks are commentary; the executable line is the
+    # one an agent would actually execute.
+    executable = [
+        line for line in text.splitlines()
+        if re.match(r"\s*mml compose", line)
+    ]
+    assert not executable, (
+        "Found executable `mml compose ...` lines outside the contract "
+        "commentary. They re-mix the v1.1.1 / master contracts and must be "
+        "removed:\n"
+        + "\n".join(f"  {line.rstrip()}" for line in executable)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared invariants — file hygiene
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "SKILL.md",
+        "references/configuration.md",
+        "references/message-composition.md",
+    ],
+)
+def test_markdown_files_end_with_newline(filename: str) -> None:
+    """Round-3 review: missing trailing newlines trip CI whitespace
+    checks and produce diff noise. Pin the convention.
+    """
+    raw = (SKILLS_DIR / filename).read_bytes()
+    assert raw.endswith(b"\n"), (
+        f"{filename} does not end with a newline. Add one to suppress "
+        "CI whitespace noise."
+    )
+
+
+def test_no_v1_imap_or_smtp_backend_table() -> None:
+    """Round-1 + 2 review: the v1.x `backend = { type = "imap", host = ...,
+    auth = { cmd = "..." } }` table was the biggest source of doc drift.
+    v2 uses flat per-backend keys (`imap.server`, `imap.sasl.plain.username`,
+    etc.). The skill must not still document the nested table form.
+    """
+    for md in ["SKILL.md", "references/configuration.md", "references/message-composition.md"]:
+        text = _read(md)
+        # The specific v1.x nested table signature
+        assert "backend = { type = \"imap\"" not in text, (
+            f"{md} still documents the v1.x nested backend table. v2 uses "
+            "flat keys like `imap.server` / `imap.sasl.plain.username`."
+        )
+
+
+def test_no_message_export_full_in_examples() -> None:
+    """`himalaya message export --full` does not exist in v2.0.0's
+    subcommand set (`unrecognized subcommand 'export'`). The v2-correct
+    way to get raw RFC 5322 bytes is `himalaya message read <id> --raw`.
+
+    Round-3 + 4 from @hendrixfreire.
+    """
+    for md in ["SKILL.md", "references/configuration.md", "references/message-composition.md"]:
+        path = SKILLS_DIR / md
+        text = path.read_text(encoding="utf-8")
+        in_block = False
+        block_lines: list[str] = []
+        for line in text.splitlines():
+            if line.strip().startswith("```"):
+                if not in_block:
+                    in_block = True
+                    block_lines = []
+                    continue
+                block_text = "\n".join(block_lines)
+                assert "message export --full" not in block_text, (
+                    f"{md} shows `message export --full` inside a bash example. "
+                    "v2 has no `message export` subcommand; use "
+                    "`message read <id> --raw` instead."
+                )
+                in_block = False
+                block_lines = []
+                continue
+            if in_block:
+                block_lines.append(line)
+
+
+def test_no_equals_form_note_for_page_size() -> None:
+    """The search example must not annotate `--page-size=20` as the only
+    valid form ("NOTE: (equals form!)"). v2.0.0 parses both forms.
+
+    Reviewer @Enough1122 caught this in round 3.
+    """
+    text = _read("SKILL.md")
+    assert "equals form!" not in text, (
+        "SKILL.md still has the 'equals form!' annotation on --page-size. "
+        "v2.0.0 accepts both --page-size 20 and --page-size=20; drop the note."
+    )
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["SKILL.md", "references/configuration.md", "references/message-composition.md"],
+)
+def test_no_v1_imap_or_smtp_backend_table_in_examples(filename: str) -> None:
+    """Round-1 + 2 review: the v1.x `backend = { type = "imap", host = ...,
+    auth = { cmd = "..." } }` table was the biggest source of doc drift.
+    v2 uses flat per-backend keys (`imap.server`, `imap.sasl.plain.username`,
+    etc.). The skill must not still *show* the nested table form as a
+    working example.
+
+    Narrative mentions that *describe* the v1.x form to contrast with v2
+    (e.g. "Common mistakes #4") are allowed — this test only flags the
+    form when it appears inside a ```bash fenced example block, which is
+    what an agent would actually execute.
+    """
+    path = SKILLS_DIR / filename
+    text = path.read_text(encoding="utf-8")
+    in_block = False
+    block_lines: list[str] = []
+    for line in text.splitlines():
+        if line.strip().startswith("```"):
+            if not in_block:
+                in_block = True
+                block_lines = []
+                continue
+            # Closing fence — check the block we just closed.
+            block_text = "\n".join(block_lines)
+            assert 'backend = { type = "imap"' not in block_text, (
+                f"{filename} documents the v1.x nested backend table inside a "
+                "bash example. v2 uses flat keys like `imap.server` / "
+                "`imap.sasl.plain.username`."
+            )
+            in_block = False
+            block_lines = []
+            continue
+        if in_block:
+            block_lines.append(line)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["SKILL.md", "references/configuration.md", "references/message-composition.md"],
+)
+def test_no_v1_folder_alias_singular_in_examples(filename: str) -> None:
+    """`folder.aliases.X` (singular, sub-table) is v1.x. v2 uses
+    `mailbox.alias.X` (plural, dotted key under the account block).
+
+    Narrative mentions in the v1.x→v2.x comparison table or in "Common
+    mistakes" sections are fine — this test only flags the form when it
+    appears inside a ```bash fenced example block.
+    """
+    path = SKILLS_DIR / filename
+    text = path.read_text(encoding="utf-8")
+    in_block = False
+    block_lines: list[str] = []
+    for line in text.splitlines():
+        if line.strip().startswith("```"):
+            if not in_block:
+                in_block = True
+                block_lines = []
+                continue
+            block_text = "\n".join(block_lines)
+            assert "folder.aliases." not in block_text, (
+                f"{filename} shows the v1.x `folder.aliases.X` form inside a "
+                "bash example. v2 uses `mailbox.alias.X`."
+            )
+            in_block = False
+            block_lines = []
+            continue
+        if in_block:
+            block_lines.append(line)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["SKILL.md", "references/configuration.md", "references/message-composition.md"],
+)
+def test_no_v1_folder_list_subcommand_in_examples(filename: str) -> None:
+    """`folder list` is v1.x; v2 renamed the subcommand to `mailbox list`.
+
+    Narrative mentions in the warning text or v1.x→v2.x table are fine —
+    this test only flags the form when it appears inside a ```bash
+    fenced example block.
+    """
+    path = SKILLS_DIR / filename
+    text = path.read_text(encoding="utf-8")
+    in_block = False
+    block_lines: list[str] = []
+    for line in text.splitlines():
+        if line.strip().startswith("```"):
+            if not in_block:
+                in_block = True
+                block_lines = []
+                continue
+            block_text = "\n".join(block_lines)
+            assert "himalaya folder list" not in block_text, (
+                f"{filename} shows `himalaya folder list` inside a bash "
+                "example. v2 renamed it to `himalaya mailbox list`."
+            )
+            in_block = False
+            block_lines = []
+            continue
+        if in_block:
+            block_lines.append(line)
+
+
+def test_no_v1_template_subcommand() -> None:
+    """`himalaya template send` (v1.x) does not exist in v2.0.0's
+    MessageCommand enum."""
+    for md in ["SKILL.md", "references/configuration.md", "references/message-composition.md"]:
+        text = _read(md)
+        assert "himalaya template" not in text, (
+            f"{md} still references `himalaya template ...`. v2.0.0 has no "
+            "`template` subcommand; use `message send` or `message add`."
+        )
+
+
+def test_no_v1_message_write_ed_opens() -> None:
+    """`message write` is a `visible_alias` of `message compose` in v2; it
+    does NOT open an editor (pre-v1.x behavior)."""
+    for md in ["SKILL.md", "references/configuration.md", "references/message-composition.md"]:
+        text = _read(md)
+        # The phrase "message write opens an editor" (or any claim that
+        # write triggers $EDITOR) is the v1.x claim that was wrong.
+        for forbidden in [
+            "message write opens",
+            "message write...editor",
+            "message write (opens",
+            "write opens an editor",
+            "write to open an editor",
+        ]:
+            assert forbidden not in text, (
+                f"{md} still claims `message write` opens an editor. In v2 "
+                "it is a `visible_alias` of `message compose` (flag-based, "
+                "no $EDITOR). Update the doc."
+            )
+
+
+def test_no_v1_message_reply_all_or_quote() -> None:
+    """`message reply --all` and `--quote` flags do not exist in v2.0.0's
+    reply parser. Reply-all is via `--cc`/`--to`; quoting is via
+    `--posting-style` and `--quote-headline`."""
+    for md in ["SKILL.md", "references/configuration.md", "references/message-composition.md"]:
+        text = _read(md)
+        for forbidden in [
+            "message reply --all",
+            "message reply --quote",
+            "--all flag",
+            "--quote flag",
+        ]:
+            assert forbidden not in text, (
+                f"{md} references `{forbidden}`. v2.0.0 has no `--all` or "
+                "`--quote` flag on `message reply`; reply-all is via `--cc`/`--to` "
+                "and quoting is via `--posting-style` / `--quote-headline`."
+            )

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -29,6 +29,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`codex`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex) | Delegate coding to OpenAI Codex CLI (features, PRs). | `autonomous-ai-agents/codex` |
 | [`computer-use`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use) | Drive the desktop in the background without stealing focus. | `autonomous-ai-agents/computer-use` |
 | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent) | Use, configure, theme, extend, and orchestrate Hermes Agent. | `autonomous-ai-agents/hermes-agent` |
+| [`merge-reconciler`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-merge-reconciler) | Neutral third-party resolution of agent merge conflicts. | `autonomous-ai-agents/merge-reconciler` |
 | [`opencode`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-opencode) | Delegate coding to OpenCode CLI (features, PR review). | `autonomous-ai-agents/opencode` |
 
 ## creative
@@ -51,6 +52,12 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`sketch`](/docs/user-guide/skills/bundled/creative/creative-sketch) | Throwaway HTML mockups: 2-3 design variants to compare. | `creative/sketch` |
 | [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music) | Songwriting craft and Suno AI music prompts. | `creative/songwriting-and-ai-music` |
 | [`touchdesigner-mcp`](/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp) | Control TouchDesigner via twozero MCP. | `creative/touchdesigner-mcp` |
+
+## devops
+
+| Skill | Description | Path |
+|-------|-------------|------|
+| [`sdlc-review`](/docs/user-guide/skills/bundled/devops/devops-sdlc-review) | Review Kanban handoffs and route verified outcomes. | `devops/sdlc-review` |
 
 ## email
 
@@ -102,7 +109,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`airtable`](/docs/user-guide/skills/bundled/productivity/productivity-airtable) | Airtable REST API via curl. Records CRUD, filters, upserts. | `productivity/airtable` |
 | [`box`](/docs/user-guide/skills/bundled/productivity/productivity-box) | Box manages cloud files, sharing, search, and metadata. | `productivity/box` |
 | [`document-to-action-items`](/docs/user-guide/skills/bundled/productivity/productivity-document-to-action-items) | Extract cited obligations, deadlines, tasks from documents. | `productivity/document-to-action-items` |
-| [`docx`](/docs/user-guide/skills/bundled/productivity/productivity-docx) | Create, read, edit, and template Word .docx files. | `productivity/docx` |
+| [`docx`](/docs/user-guide/skills/bundled/productivity/productivity-docx) | Create, read, edit, template, and review Word .docx files. | `productivity/docx` |
 | [`google-workspace`](/docs/user-guide/skills/bundled/productivity/productivity-google-workspace) | Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python. | `productivity/google-workspace` |
 | [`maps`](/docs/user-guide/skills/bundled/productivity/productivity-maps) | Geocode, POIs, routes, timezones via OpenStreetMap/OSRM. | `productivity/maps` |
 | [`meeting-action-items`](/docs/user-guide/skills/bundled/productivity/productivity-meeting-action-items) | Turn meeting notes into cited decisions, owners, tickets. | `productivity/meeting-action-items` |
@@ -122,7 +129,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | Skill | Description | Path |
 |-------|-------------|------|
 | [`arxiv`](/docs/user-guide/skills/bundled/research/research-arxiv) | Search arXiv papers by keyword, author, category, or ID. | `research/arxiv` |
-| [`blocked-page-recovery`](/docs/user-guide/skills/bundled/research/research-blocked-page-recovery) | Recover blocked/paywalled/WAF'd pages via archive snapshots and reader fallbacks. Use when web_extract or the browser hits 403/429/challenge pages, paywalls, or bot-detection interstitials. | `research/blocked-page-recovery` |
+| [`blocked-page-recovery`](/docs/user-guide/skills/bundled/research/research-blocked-page-recovery) | Recover blocked/paywalled/WAF'd pages via fallbacks. | `research/blocked-page-recovery` |
 | [`blogwatcher`](/docs/user-guide/skills/bundled/research/research-blogwatcher) | Monitor blogs and RSS/Atom feeds via blogwatcher-cli tool. | `research/blogwatcher` |
 | [`competitor-news-monitor`](/docs/user-guide/skills/bundled/research/research-competitor-news-monitor) | Watch named companies for material news; cited digests. | `research/competitor-news-monitor` |
 | [`grounded-citations`](/docs/user-guide/skills/bundled/research/research-grounded-citations) | Ground answers and documents in cited, verifiable sources. | `research/grounded-citations` |

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -57,7 +57,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | Skill | Description | Path |
 |-------|-------------|------|
 | [`email-inbox-triage`](/docs/user-guide/skills/bundled/email/email-email-inbox-triage) | Triage an inbox: prioritize threads, draft replies safely. | `email/email-inbox-triage` |
-| [`himalaya`](/docs/user-guide/skills/bundled/email/email-himalaya) | Himalaya CLI: IMAP/SMTP email from terminal. | `email/himalaya` |
+| [`himalaya`](/docs/user-guide/skills/bundled/email/email-himalaya) | Himalaya v2 mail CLI. Use when reading or sending email. | `email/himalaya` |
 
 ## github
 

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -56,7 +56,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
-| [`himalaya`](/docs/user-guide/skills/bundled/email/email-himalaya) | Himalaya CLI: IMAP/SMTP email from terminal. | `email/himalaya` |
+| [`himalaya`](/docs/user-guide/skills/bundled/email/email-himalaya) | Himalaya v2 mail CLI. Use when reading or sending email. | `email/himalaya` |
 
 ## github
 

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -1,14 +1,14 @@
 ---
-title: "Himalaya — Himalaya CLI: IMAP/SMTP email from terminal"
+title: "Himalaya — Himalaya v2 mail CLI"
 sidebar_label: "Himalaya"
-description: "Himalaya CLI: IMAP/SMTP email from terminal"
+description: "Himalaya v2 mail CLI"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Himalaya
 
-Himalaya CLI: IMAP/SMTP email from terminal.
+Himalaya v2 mail CLI. Use when reading or sending email.
 
 ## Skill metadata
 
@@ -16,7 +16,7 @@ Himalaya CLI: IMAP/SMTP email from terminal.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/email/himalaya` |
-| Version | `1.1.0` |
+| Version | `2.0.0` |
 | Author | community |
 | License | MIT |
 | Platforms | linux, macos, windows |
@@ -28,185 +28,217 @@ Himalaya CLI: IMAP/SMTP email from terminal.
 The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
 :::
 
-# Himalaya Email CLI
+# Himalaya CLI v2.x
 
-Himalaya is a CLI email client that lets you manage emails from the terminal using IMAP, SMTP, Notmuch, or Sendmail backends.
+Himalaya is a Rust CLI for managing email from the terminal. **This skill targets himalaya v2.x** (v2.0.0+, post the v1→v2 breaking changes). The skill previously documented the v1.x schema; commands like `himalaya folder list` and `himalaya envelope list from x` no longer work in v2 and will trip agents loading the skill on first attempt.
 
-This skill is separate from the Hermes Email gateway adapter. The gateway
-adapter lets people email the agent and uses Hermes' built-in IMAP/SMTP
-adapter; this skill lets the agent operate a mailbox from terminal tools and
-requires the external `himalaya` CLI.
+This skill is separate from the Hermes Email gateway adapter. The gateway adapter lets people email the agent and uses Hermes' built-in IMAP/SMTP adapter; this skill lets the agent operate a mailbox from terminal tools and requires the external `himalaya` CLI.
+
+## Key v2 differences from v1
+
+| v1.x (don't use) | v2.x (current) |
+|---|---|
+| `folder list` | `mailbox list` |
+| `folder.aliases.sent` (singular, TOML sub-table) | `mailbox.alias.sent` (plural, dotted key under account) |
+| `[accounts.X] backend = { type=imap, host=..., port=..., auth={...} }` | Flat keys: `imap.server`, `imap.sasl.plain.username`, `imap.sasl.plain.password.command` |
+| `envelope list from x` (positional filters) | `envelope list`; filters moved to separate `envelope search "from x"` subcommand with its own DSL |
+| `message write` (no piped input) / `message reply` | `message compose --to ... --subject ... --body ...`; rich MIME via piped `mml`; legacy `template send` still exists |
+| `--output json` / `plain` | `--json` (global flag) |
+| Native keyring support | Removed; use `pass`, `gopass`, `secret-tool` via `password.command` |
+| OAuth flows built in | None; use [ortie](https://github.com/pimalaya/ortie) as token broker |
+
+Always verify `himalaya --version` reports **v2.0.0 or later** before using this skill.
 
 ## References
 
-- `references/configuration.md` (config file setup + IMAP/SMTP authentication)
-- `references/message-composition.md` (MML syntax for composing emails)
+- `references/configuration.md` (v2 TOML schema, Gmail/Outlook/Fastmail/iCloud examples, mailbox aliases)
+- `references/message-composition.md` (compose/reply/forward, mml integration)
 
 ## Prerequisites
 
-1. Himalaya CLI installed (`himalaya --version` to verify)
-2. A configuration file at `~/.config/himalaya/config.toml`
-3. IMAP/SMTP credentials configured (password stored securely)
+1. **Himalaya v2.0.0+** installed (`himalaya --version` to verify)
+2. A configuration file at one of these paths (first match wins):
+   - `$XDG_CONFIG_HOME/himalaya/config.toml`
+   - `$HOME/.config/himalaya/config.toml`
+   - `$HOME/.himalayarc`
+3. Credentials supplied either inline (`password.raw = "..."`) or via a `password.command` that prints the secret on stdout (recommended — use `pass`, `gopass`, or a custom script).
 
 ### Installation
 
 ```bash
-# Pre-built binary (Linux/macOS — recommended)
+# Pre-built binary (Linux/macOS — recommended, no sudo needed)
 curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
 
 # macOS via Homebrew
 brew install himalaya
 
-# Or via cargo (any platform with Rust)
-cargo install himalaya --locked
+# From source (any platform with Rust)
+cargo install --locked --git https://github.com/pimalaya/himalaya.git
 ```
 
-## Configuration Setup
+The installer places the binary at `~/.local/bin/himalaya` (or `/usr/local/bin/himalaya` when run as root).
 
-Run the interactive wizard to set up an account:
+## Configuration
+
+### The wizard
+
+Run `himalaya` with **no subcommand** to launch the account setup wizard. It probes PACC, Thunderbird Autoconfiguration, RFC 6186 SRV records, and JMAP session discovery in parallel, then prints a ready-to-save TOML document on stdout. Redirect it into your config:
 
 ```bash
-himalaya account configure
+himalaya > /tmp/new-account.toml
+# review, then append to your config
+cat /tmp/new-account.toml >> ~/.config/himalaya/config.toml
 ```
 
-Or create `~/.config/himalaya/config.toml` manually:
+### Gmail (app password)
+
+Generate an app password at https://myaccount.google.com/apppasswords (requires 2-Step Verification), then:
 
 ```toml
-[accounts.personal]
-email = "you@example.com"
+[accounts.gmail]
+email = "you@gmail.com"
 display-name = "Your Name"
 default = true
 
-backend.type = "imap"
-backend.host = "imap.example.com"
-backend.port = 993
-backend.encryption.type = "tls"
-backend.login = "you@example.com"
-backend.auth.type = "password"
-backend.auth.cmd = "pass show email/imap"  # or use keyring
+imap.server = "imaps://imap.gmail.com:993"
+imap.sasl.plain.username = "you@gmail.com"
+imap.sasl.plain.password.command = "pass show email/gmail-app"
 
-message.send.backend.type = "smtp"
-message.send.backend.host = "smtp.example.com"
-message.send.backend.port = 587
-message.send.backend.encryption.type = "start-tls"
-message.send.backend.login = "you@example.com"
-message.send.backend.auth.type = "password"
-message.send.backend.auth.cmd = "pass show email/smtp"
+smtp.server = "smtp://smtp.gmail.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "you@gmail.com"
+smtp.sasl.plain.password.command = "pass show email/gmail-app"
 
-# Folder aliases (himalaya v1.2.0+ syntax). Required whenever the
-# server's folder names don't match himalaya's canonical names
-# (inbox/sent/drafts/trash). Gmail is the common case — see
-# `references/configuration.md` for the `[Gmail]/Sent Mail` mapping.
-folder.aliases.inbox = "INBOX"
-folder.aliases.sent = "Sent"
-folder.aliases.drafts = "Drafts"
-folder.aliases.trash = "Trash"
+mailbox.alias.inbox = "INBOX"
+mailbox.alias.sent = "[Gmail]/Sent Mail"
+mailbox.alias.drafts = "[Gmail]/Drafts"
+mailbox.alias.trash = "[Gmail]/Trash"
+mailbox.alias.archive = "[Gmail]/All Mail"
+mailbox.alias.junk = "[Gmail]/Spam"
 ```
 
-> **Heads up on the alias syntax.** Pre-v1.2.0 docs used a
-> `[accounts.NAME.folder.alias]` sub-section (singular `alias`).
-> v1.2.0 silently ignores that form — TOML parses fine, but the
-> alias resolver never reads it, so every lookup falls through to
-> the canonical name. On Gmail this means save-to-Sent fails *after*
-> SMTP delivery succeeds, and `himalaya message send` exits non-zero.
-> Any caller (agent, script, user) that retries on that exit code
-> will re-run the entire send — including SMTP — producing duplicate
-> emails to recipients. Always use `folder.aliases.X` (plural, dotted
-> keys, directly under `[accounts.NAME]`).
+The `[Gmail]/` labels must be **quoted in the shell** when used as `-m` args: `himalaya -m "[Gmail]/Drafts"`. Aliases are case-insensitive lookups; raw backend ids work verbatim too.
 
-## Hermes Integration Notes
+### Outlook / Microsoft 365 (OAuth)
 
-- **Reading, listing, searching, moving, deleting** all work directly through the terminal tool
-- **Composing/replying/forwarding** — piped input (`cat << EOF | himalaya template send`) is recommended for reliability. Interactive `$EDITOR` mode works with `pty=true` + background + process tool, but requires knowing the editor and its commands
-- Use `--output json` for structured output that's easier to parse programmatically
-- The `himalaya account configure` wizard requires interactive input — use PTY mode: `terminal(command="himalaya account configure", pty=true)`
+Microsoft retired basic auth. Use OAuth 2.0 via `xoauth2` and a token broker like [ortie](https://github.com/pimalaya/ortie):
 
-## Common Operations
+```toml
+[accounts.outlook]
 
-### List Folders
+imap.server = "imaps://outlook.office365.com:993"
+imap.sasl.xoauth2.username = "you@outlook.com"
+imap.sasl.xoauth2.token.command = ["ortie", "token", "show", "-a", "outlook"]
+
+smtp.server = "smtp://smtp-mail.outlook.com:587"
+smtp.starttls = true
+smtp.sasl.xoauth2.username = "you@outlook.com"
+smtp.sasl.xoauth2.token.command = ["ortie", "token", "show", "-a", "outlook"]
+```
+
+Or skip SMTP entirely and use the Microsoft Graph REST API backend (`msgraph.auth.token.command = [...]`). Graph uses opaque folder ids — address them by name (`-m Archive`) or by well-known role (`-m inbox`).
+
+### Fastmail
+
+App password works for IMAP/SMTP. For the native JMAP API, replace both blocks with a single `jmap` one using an API token:
+
+```toml
+[accounts.fastmail]
+imap.server = "imaps://imap.fastmail.com"
+imap.sasl.plain.username = "you@fastmail.com"
+imap.sasl.plain.password.command = "pass show fastmail"
+
+smtp.server = "smtps://smtp.fastmail.com"
+smtp.sasl.plain.username = "you@fastmail.com"
+smtp.sasl.plain.password.command = "pass show fastmail"
+```
+
+### iCloud
+
+Note: IMAP login uses the local-part (`johnappleseed`), SMTP login uses the full address (`johnappleseed@icloud.com`). Requires an app-specific password.
+
+```toml
+[accounts.icloud]
+imap.server = "imaps://imap.mail.me.com:993"
+imap.sasl.plain.username = "johnappleseed"
+imap.sasl.plain.password.command = "pass show icloud"
+
+smtp.server = "smtp://smtp.mail.me.com:587"
+smtp.starttls = true
+smtp.sasl.plain.username = "johnappleseed@icloud.com"
+smtp.sasl.plain.password.command = "pass show icloud"
+
+mailbox.alias.sent = "Sent Messages"
+```
+
+## Hermes integration notes
+
+- **Reading, listing, searching, flagging, copying** — all work directly through the terminal tool.
+- **Composing / replying / forwarding** — use the `message compose` subcommand (flags-only) or chain `mml` for rich MIME / attachments / PGP. The legacy `template send` (pipe a complete RFC 822 message on stdin) still works for scripted sends.
+- For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages.
+- **Pitfall — clap parser order matters:** search query DSL tokens (`from`, `subject`, `after`, `order by`, etc.) start consuming characters from the next flag too. Always pass `--page-size=20` (with `=`) instead of `--page-size 20`, and put query positional args **last** on the command line. Spaces between a flag like `--page-size 20` get eaten as part of the search query.
+- **Pitfall — Gmail mailbox names:** `[Gmail]/Sent Mail` etc. contain `[`, `]`, and a space. Always quote in the shell.
+- **Pitfall — multiple accounts:** pass `-a <name>` or `--account <name>`. The account flagged `default = true` is used when omitted.
+
+## Common operations
+
+### List accounts
 
 ```bash
-himalaya folder list
+himalaya account list
+himalaya account check  # validates config
 ```
 
-### List Emails
+### List mailboxes (folders / labels)
 
-List emails in INBOX (default):
+```bash
+himalaya mailbox list
+himalaya mailbox list --account gmail
+```
+
+### List envelopes (default mailbox)
 
 ```bash
 himalaya envelope list
+himalaya envelope list --page 2 --page-size 50
+himalaya envelope list --recipient          # show To: instead of From: (sent folder)
+himalaya envelope list --has-attachment    # populate ATT column
 ```
 
-List emails in a specific folder:
+### Search envelopes
+
+`envelope search` takes a positional query using himalaya's cross-backend DSL. Conditions: `date <yyyy-mm-dd>`, `after <yyyy-mm-dd>`, `before <yyyy-mm-dd>`, `from <pattern>`, `to <pattern>`, `subject <pattern>`, `body <pattern>`, `flag <seen|answered|flagged|draft>`. Combine with `and`, `or`, `not`, group with parens. Sort with `order by <date|from|to|subject> [asc|desc]`.
 
 ```bash
-himalaya envelope list --folder "Sent"
+himalaya envelope search "from alice"
+himalaya envelope search "from alice and after 2026-01-01 order by date desc"
+himalaya envelope search "subject meeting or body invoice"
+himalaya envelope search --page-size=20 "from usvisascheduling"   # NOTE: --page-size=20 (equals form!)
 ```
 
-List with pagination:
+⚠️ **Quote-protect the query** — patterns with `$` (e.g. `"body $500"`) need single quotes so the shell doesn't expand `$5`.
+
+### Read a message
 
 ```bash
-himalaya envelope list --page 1 --page-size 20
+himalaya message read 42                       # rendered headers + text bodies
+himalaya message read 42 --raw                 # dump raw RFC 5322 bytes (pipe to mml/w3m)
+himalaya message read 42 --json                # parsed message as JSON
 ```
 
-### Search Emails
+### Send a new message
+
+The modern path uses `message compose` with flags:
 
 ```bash
-himalaya envelope list from john@example.com subject meeting
+himalaya message compose \
+  --to you@example.com \
+  --subject "Test" \
+  --body "Hello from Himalaya v2" \
+  --send
 ```
 
-### Read an Email
-
-Read email by ID (shows plain text):
-
-```bash
-himalaya message read 42
-```
-
-Export raw MIME:
-
-```bash
-himalaya message export 42 --full
-```
-
-### Reply to an Email
-
-To reply non-interactively from Hermes, read the original message, compose a reply, and pipe it:
-
-```bash
-# Get the reply template, edit it, and send
-himalaya template reply 42 | sed 's/^$/\nYour reply text here\n/' | himalaya template send
-```
-
-Or build the reply manually:
-
-```bash
-cat << 'EOF' | himalaya template send
-From: you@example.com
-To: sender@example.com
-Subject: Re: Original Subject
-In-Reply-To: <original-message-id>
-
-Your reply here.
-EOF
-```
-
-Reply-all (interactive — needs $EDITOR, use template approach above instead):
-
-```bash
-himalaya message reply 42 --all
-```
-
-### Forward an Email
-
-```bash
-# Get forward template and pipe with modifications
-himalaya template forward 42 | sed 's/^To:.*/To: newrecipient@example.com/' | himalaya template send
-```
-
-### Write a New Email
-
-**Non-interactive (use this from Hermes)** — pipe the message via stdin:
+The legacy path (piped RFC 822 over stdin) still works:
 
 ```bash
 cat << 'EOF' | himalaya template send
@@ -214,106 +246,97 @@ From: you@example.com
 To: recipient@example.com
 Subject: Test Message
 
-Hello from Himalaya!
+Hello from Himalaya v2!
 EOF
 ```
 
-Or with headers flag:
+### Reply to a message
 
 ```bash
-himalaya message write -H "To:recipient@example.com" -H "Subject:Test" "Message body here"
+# Quick reply with --body
+himalaya message reply 42 --body "Thanks, will do." --send
+
+# Reply-all
+himalaya message reply 42 --all --body "Looping everyone in." --send
+
+# Quote original
+himalaya message reply 42 --quote --body "See below." --send
 ```
 
-Note: `himalaya message write` without piped input opens `$EDITOR`. This works with `pty=true` + background mode, but piping is simpler and more reliable.
-
-### Move/Copy Emails
-
-Move to folder (target folder comes first, then the message ID):
+### Forward
 
 ```bash
-himalaya message move "Archive" 42
+himalaya message forward 42 --to other@example.com --send
 ```
 
-Copy to folder (target folder comes first, then the message ID):
+### Move / copy / delete
 
 ```bash
-himalaya message copy "Important" 42
+himalaya message copy --from INBOX --to Archives 42
+himalaya message move --from INBOX --to Archives 42    # if backend supports move
+himalaya message delete 42                              # sets \Deleted flag
+himalaya message expunge                                 # permanently remove flagged
 ```
 
-### Delete an Email
+### Manage flags
 
 ```bash
-himalaya message delete 42
+himalaya flag add --flag seen 1:3,5
+himalaya flag remove --flag seen 42
 ```
 
-### Manage Flags
+The `--flag` argument accepts `seen`, `answered`, `flagged`, `draft`, `recent`. Multiple message IDs can be comma-separated ranges (`1:3,5` = 1,2,3,5).
 
-Add flag:
+### Download attachments
 
 ```bash
-himalaya flag add 42 --flag seen
+himalaya attachment download 42                         # default ~/Downloads
+himalaya attachment download 42 --output-dir /tmp/attach
 ```
 
-Remove flag:
-
-```bash
-himalaya flag remove 42 --flag seen
-```
-
-## Multiple Accounts
-
-List accounts:
-
-```bash
-himalaya account list
-```
-
-Use a specific account:
+## Multiple accounts
 
 ```bash
 himalaya --account work envelope list
+himalaya --account gmail mailbox list
 ```
 
-## Attachments
+For accounts configured with multiple backends (e.g. IMAP+JMAP), force one with `-b/--backend imap|jmap|gmail|msgraph|maildir|smtp`. Default is `auto` (first configured).
 
-Save attachments from a message:
+## Output formats
 
-```bash
-himalaya attachment download 42
-```
-
-Save to specific directory:
+`--json` is a global flag that emits parsed JSON for any command:
 
 ```bash
-himalaya attachment download 42 --downloads-dir ~/Downloads
-```
-
-## Output Formats
-
-Most commands support `--output` for structured output:
-
-```bash
-himalaya envelope list --output json
-himalaya envelope list --output plain
+himalaya --json envelope list --page-size=5
+himalaya --json message read 42 | jq '.subject'
+himalaya --json mailbox list
 ```
 
 ## Debugging
 
-Enable debug logging:
-
 ```bash
-RUST_LOG=debug himalaya envelope list
+himalaya --log trace mailbox list
+RUST_LOG=trace himalaya envelope list 2>/tmp/himalaya.log
+RUST_BACKTRACE=1 himalaya envelope list
+NO_COLOR=1 himalaya envelope list
 ```
 
-Full trace with backtrace:
+Logs go to stderr; `--log-file <path>` writes to file directly.
 
-```bash
-RUST_LOG=trace RUST_BACKTRACE=1 himalaya envelope list
+## Re-using sessions (advanced)
+
+Every invocation opens a fresh TCP+TLS+SASL handshake. To amortize that, point `imap.server` / `smtp.server` at a [sirup](https://github.com/pimalaya/sirup) Unix socket holding a pre-authenticated session:
+
+```toml
+imap.server = "unix:///run/sirup/imap.sock"
+smtp.server = "unix:///run/sirup/smtp.sock"
 ```
 
 ## Tips
 
-- Use `himalaya --help` or `himalaya <command> --help` for detailed usage.
-- Message IDs are relative to the current folder; re-list after folder changes.
-- For composing rich emails with attachments, use MML syntax (see `references/message-composition.md`).
-- Store passwords securely using `pass`, system keyring, or a command that outputs the password.
+- `himalaya <subcommand> --help` is the source of truth — the help text is regenerated from the CLI definitions on every build.
+- Message IDs are relative to the current mailbox; re-list after folder changes.
+- For rich MIME with attachments, signatures, or encryption, chain [mml](https://github.com/pimalaya/mml) into `himalaya message send`.
+- Store passwords via `pass`, `gopass`, `secret-tool`, or any shell command that prints the secret on stdout.
+- The `imap.server` / `smtp.server` fields accept full URLs (`imaps://host:port`, `smtp://host:port`, `smtps://host:port`) for explicit TLS control.

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -30,7 +30,7 @@ The following is the complete skill definition that Hermes loads when this skill
 
 # Himalaya CLI v2.x
 
-Himalaya is a Rust CLI for managing email from the terminal. **This skill targets himalaya v2.x** (v2.0.0+, post the v1→v2 breaking changes). The skill previously documented the v1.x schema; commands like `himalaya folder list` and `himalaya envelope list from x` no longer work in v2 and will trip agents loading the skill on first attempt.
+Himalaya is a Rust CLI for managing email from the terminal. **This skill targets himalaya v2.x** (v2.0.0+, post the v1→v2 breaking changes). The skill previously documented the v1.x schema; commands like `himalaya mailbox list` (formerly `himalaya folder list` in v1.x) and `himalaya envelope list from x` no longer work in v2 and will trip agents loading the skill on first attempt.
 
 This skill is separate from the Hermes Email gateway adapter. The gateway adapter lets people email the agent and uses Hermes' built-in IMAP/SMTP adapter; this skill lets the agent operate a mailbox from terminal tools and requires the external `himalaya` CLI.
 
@@ -39,7 +39,7 @@ This skill is separate from the Hermes Email gateway adapter. The gateway adapte
 | v1.x (don't use) | v2.x (current) |
 |---|---|
 | `folder list` | `mailbox list` |
-| `folder.aliases.sent` (singular, TOML sub-table) | `mailbox.alias.sent` (plural, dotted key under account) |
+| `folder.aliases.sent` (v1.x; replaced by `mailbox.alias.sent`) | `mailbox.alias.sent` (plural, dotted key under account) |
 | `[accounts.X] backend = { type=imap, host=..., port=..., auth={...} }` | Flat keys: `imap.server`, `imap.sasl.plain.username`, `imap.sasl.plain.password.command` |
 | `envelope list from x` (positional filters) | `envelope list`; filters moved to separate `envelope search "from x"` subcommand with its own DSL |
 | `message write` (no piped input) / `message reply` | `message compose --to ... --subject ... --body ...`; rich MIME via piped `mml`; `message write` is an alias of `message compose` (no editor) |
@@ -268,11 +268,9 @@ To send a **pre-written RFC 822 message** (full headers + body, e.g. one produce
 
 ```bash
 himalaya message send < message.eml
-# or
-himalaya message send --save drafts < message.eml
 ```
 
-`message send` reads the full message verbatim (headers + body); it does NOT take `--body` / `--body-file` / `--subject`. For richer composition (multipart MIME, attachments, signing/encryption), chain a standalone composer like `mml` into `message send` via stdin or process substitution; see `references/message-composition.md`.
+> ⚠️ `message send --save drafts` is a footgun in v2.0.0: `MessageSendCommand::execute` routes via SMTP unconditionally and only appends a copy *after* delivery (`handler::route(..., true)`). The `--save drafts` is a "send, then copy," not "save without sending." For a true draft, use `message add --mailbox drafts --flag draft < message.eml` (see `references/message-composition.md`).
 
 ### Reply to a message
 

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -237,6 +237,7 @@ The modern path uses `message compose` with flags:
 
 ```bash
 himalaya message compose \
+  --from you@example.com \
   --to you@example.com \
   --subject "Test" \
   --body "Hello from Himalaya v2" \
@@ -247,12 +248,14 @@ For a body from stdin (replaces the removed `template send` subcommand), **omit 
 
 ```bash
 echo "Hello from a piped body" | himalaya message compose \
+  --from you@example.com \
   --to you@example.com \
   --subject "Test" \
   --send
 
 # Or read the body from a file
 himalaya message compose \
+  --from you@example.com \
   --to you@example.com \
   --subject "Test" \
   --body-file ./body.txt \
@@ -275,22 +278,23 @@ himalaya message send --save drafts < message.eml
 
 ```bash
 # Quick reply with new body
-himalaya message reply 42 --body "Got it, thanks." --send
+himalaya message reply 42 --from you@example.com --body "Got it, thanks." --send
 
 # Strict reply (just to the sender): pass --to with the original From address
-himalaya message reply 42 --to sender@example.com --body "Thanks." --send
+himalaya message reply 42 --from you@example.com --to sender@example.com --body "Thanks." --send
 
 # Reply-all: include the original To/Cc recipients with --cc / --to
 himalaya message reply 42 \
+  --from you@example.com \
   --to sender@example.com \
   --cc teammate@example.com \
   --body "Looping everyone in." --send
 
 # Custom quote headline (default is "On {date}, {from} wrote:")
-himalaya message reply 42 --quote-headline "Replying inline:" --body "..." --send
+himalaya message reply 42 --from you@example.com --quote-headline "Replying inline:" --body "..." --send
 
 # Change posting style (top | bottom | inline)
-himalaya message reply 42 --posting-style bottom --body "..." --send
+himalaya message reply 42 --from you@example.com --posting-style bottom --body "..." --send
 ```
 
 > **v2 note.** There are no `--all` / `--quote` boolean flags. Reply-all is "include the original recipients via `--cc`/`--to`"; quoting is the default behavior controlled by `--posting-style` and `--quote-headline`.
@@ -298,7 +302,7 @@ himalaya message reply 42 --posting-style bottom --body "..." --send
 ### Forward
 
 ```bash
-himalaya message forward 42 --to other@example.com --body "FYI" --send
+himalaya message forward 42 --from you@example.com --to other@example.com --body "FYI" --send
 ```
 
 ### Move / copy

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -178,7 +178,7 @@ mailbox.alias.sent = "Sent Messages"
 ## Hermes integration notes
 
 - **Reading, listing, searching, flagging, copying** — all work directly through the terminal tool.
-- **Composing / replying / forwarding** — use the `message compose` / `message reply` / `message forward` subcommands (flag-based) or chain `mml` for rich MIME / attachments / PGP. To send a pre-written RFC 822 message, use `message send < message.eml` or pipe via stdin to `message compose --body-file -` / `message compose` with no `--body` (stdin fallback).
+- **Composing / replying / forwarding** — use the `message compose` / `message reply` / `message forward` subcommands (flag-based) or chain `mml` for rich MIME / attachments / PGP. To send a pre-written RFC 822 message, use `message send < message.eml` (or pipe it: `message send < message.eml` — same stdin path). For `message compose`, pipe a body via stdin by omitting both `--body` and `--body-file` (stdin is the fallback).
 - **Pitfall — `message write` is an alias, not an editor opener.** In v2, `himalaya message write` is a `visible_alias` of `message compose` and behaves identically (flag-based, no `$EDITOR`). The pre-v1.x editor-driven flow no longer exists. Use `mml compose` if you want interactive composition.
 - For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages. It's a global flag (pass before the subcommand for consistency); v2 also recognizes it after the subcommand for ergonomics.
 - **Pitfall — search query DSL:** the query is a positional `Vec<String>` that captures trailing tokens until end-of-input. Always put the query **last** on the command line. Quote-protect patterns containing `$`, shell metacharacters, or spaces.
@@ -212,7 +212,7 @@ himalaya envelope list --has-attachment    # populate ATT column
 
 ### Search envelopes
 
-`envelope search` takes a positional query using himalaya's cross-backend DSL. Conditions: `date <yyyy-mm-dd>`, `after <yyyy-mm-dd>`, `before <yyyy-mm-dd>`, `from <pattern>`, `to <pattern>`, `subject <pattern>`, `body <pattern>`, `flag <seen|answered|flagged|draft>`. Combine with `and`, `or`, `not`, group with parens. Sort with `order by <date|from|to|subject> [asc|desc]`.
+`envelope search` takes a positional query using himalaya's cross-backend DSL. Conditions: `date <yyyy-mm-dd>`, `after <yyyy-mm-dd>`, `from <pattern>`, `to <pattern>`, `subject <pattern>`, `body <pattern>`, `flag <seen|answered|flagged|draft>`. Combine with `and`, `or`, `not`, group with parens. Sort with `order by <date|from|to|subject> [asc|desc]`.
 
 ```bash
 himalaya envelope search "from alice"
@@ -243,23 +243,33 @@ himalaya message compose \
   --send
 ```
 
-For a body from stdin (replaces the removed `template send` subcommand), **omit `--body` and `--body-file` — stdin is the body** by default:
+For a body from stdin (replaces the removed `template send` subcommand), **omit `--body` and `--body-file` — stdin is the body** by default. **`compose` writes the composed RFC 5322 bytes to stdout by default; pass `--send` to actually deliver** through SMTP/JMAP:
 
 ```bash
 echo "Hello from a piped body" | himalaya message compose \
   --to you@example.com \
-  --subject "Test"
+  --subject "Test" \
+  --send
 
 # Or read the body from a file
 himalaya message compose \
   --to you@example.com \
   --subject "Test" \
-  --body-file ./body.txt
+  --body-file ./body.txt \
+  --send
 ```
 
 Note: `--body-file -` does NOT work — the binary tries to open a file literally named `-`. The `--body` / `--body-file` / implicit stdin paths are mutually exclusive; pick one.
 
-For rich MIME (multipart, attachments, signing), pipe `mml` output into `message compose` via stdin or process substitution; see `references/message-composition.md`.
+To send a **pre-written RFC 822 message** (full headers + body, e.g. one produced by `mml`, a template, or another tool), use `message send` — it accepts a file path, raw contents, or piped stdin:
+
+```bash
+himalaya message send < message.eml
+# or
+himalaya message send --save drafts < message.eml
+```
+
+`message send` reads the full message verbatim (headers + body); it does NOT take `--body` / `--body-file` / `--subject`. For richer composition (multipart MIME, attachments, signing/encryption), chain a standalone composer like `mml` into `message send` via stdin or process substitution; see `references/message-composition.md`.
 
 ### Reply to a message
 
@@ -291,15 +301,14 @@ himalaya message reply 42 --posting-style bottom --body "..." --send
 himalaya message forward 42 --to other@example.com --body "FYI" --send
 ```
 
-### Move / copy / delete
+### Move / copy
 
 ```bash
 himalaya message copy --from INBOX --to Archives 42
 himalaya message move --from INBOX --to Archives 42    # if backend supports move
-himalaya message delete 42                              # trash-move; permanent for in-trash
 ```
 
-> **v2 note.** There is no `message expunge` subcommand in v2. `message delete` already trash-moves; on IMAP servers without UIDPLUS, deleted-from-trash items are flagged `\Deleted` and reclaimed by the next `message delete` on the trash mailbox, or by the server's own expunge policy.
+> **v2 note.** There is no `message delete` or `message expunge` subcommand in v2. To trash a message, move it to a trash mailbox (e.g. `himalaya message move --from INBOX --to Trash 42`) or rely on the backend's automatic deletion-on-trash behavior (Gmail/JMAP do this; IMAP behavior depends on the server's `expunge_behavior`). Permanent deletion (real expunge) is a backend-side / mailbox-policy concern, not a CLI subcommand.
 
 ### Manage flags
 
@@ -308,14 +317,14 @@ himalaya flag add --flag seen 1:3,5
 himalaya flag remove --flag seen 42
 ```
 
-The `--flag` argument accepts `seen`, `answered`, `flagged`, `draft`, `recent`. Multiple message IDs can be comma-separated ranges (`1:3,5` = 1,2,3,5).
+The `--flag` argument accepts `seen`, `answered`, `flagged`, `draft`. Multiple message IDs can be comma-separated ranges (`1:3,5` = 1,2,3,5).
 
 ### Download attachments
 
 ```bash
 himalaya attachment download 42                         # download all; default dir from config
 himalaya attachment download 42 --dir /tmp/attach       # override destination
-himalaya attachment download 42 0 1                     # download only attachments 0 and 1
+himalaya attachment download 42 1 2                     # download only attachments 1 and 2 (1-based ids from `attachments list`)
 ```
 
 > **v2 note.** The destination flag is `--dir` (also `-d`), not `--output-dir`. Default destination is the account's `downloads-dir` config (falling back to the global config, then the platform standard). Run `himalaya attachment download --help` for the full flag list.

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -104,10 +104,10 @@ imap.server = "imaps://imap.gmail.com:993"
 imap.sasl.plain.username = "you@gmail.com"
 imap.sasl.plain.password.command = "pass show email/gmail-app"
 
-smtp.server = "smtp://smtp.gmail.com:587"
-smtp.starttls = true
+smtp.server = "smtps://smtp.gmail.com:465"
 smtp.sasl.plain.username = "you@gmail.com"
 smtp.sasl.plain.password.command = "pass show email/gmail-app"
+# STARTTLS alternative: smtp.server = "smtp://smtp.gmail.com:587" + smtp.starttls = true
 
 mailbox.alias.inbox = "INBOX"
 mailbox.alias.sent = "[Gmail]/Sent Mail"
@@ -180,7 +180,7 @@ mailbox.alias.sent = "Sent Messages"
 - **Reading, listing, searching, flagging, copying** — all work directly through the terminal tool.
 - **Composing / replying / forwarding** — use the `message compose` / `message reply` / `message forward` subcommands (flag-based) or chain `mml` for rich MIME / attachments / PGP. To send a pre-written RFC 822 message, use `message send < message.eml` (or pipe it: `message send < message.eml` — same stdin path). For `message compose`, pipe a body via stdin by omitting both `--body` and `--body-file` (stdin is the fallback).
 - **Pitfall — `message write` is an alias, not an editor opener.** In v2, `himalaya message write` is a `visible_alias` of `message compose` and behaves identically (flag-based, no `$EDITOR`). The pre-v1.x editor-driven flow no longer exists. Use `mml compose` if you want interactive composition.
-- For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages. It's a global flag (pass before the subcommand for consistency); v2 also recognizes it after the subcommand for ergonomics.
+- For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages. It's a global flag — both `himalaya --json envelope list` and `himalaya envelope list --json` work in v2. The pre-subcommand form is the documented convention; the post-subcommand form is accepted for ergonomics.
 - **Pitfall — search query DSL:** the query is a positional `Vec<String>` that captures trailing tokens until end-of-input. Always put the query **last** on the command line. Quote-protect patterns containing `$`, shell metacharacters, or spaces.
 - **Pitfall — Gmail mailbox names:** `[Gmail]/Sent Mail` etc. contain `[`, `]`, and a space. Always quote in the shell.
 - **Pitfall — multiple accounts:** pass `-a <name>` or `--account <name>`. The account flagged `default = true` is used when omitted.
@@ -218,7 +218,7 @@ himalaya envelope list --has-attachment    # populate ATT column
 himalaya envelope search "from alice"
 himalaya envelope search "from alice and after 2026-01-01 order by date desc"
 himalaya envelope search "subject meeting or body invoice"
-himalaya envelope search --page-size=20 "from usvisascheduling"   # NOTE: --page-size=20 (equals form!)
+himalaya envelope search --page-size 20 "from usvisascheduling"
 ```
 
 ⚠️ **Quote-protect the query** — patterns with `$` (e.g. `"body $500"`) need single quotes so the shell doesn't expand `$5`.
@@ -347,7 +347,8 @@ For accounts configured with multiple backends (e.g. IMAP+JMAP), force one with 
 `--json` is a global flag that emits parsed JSON for any command:
 
 ```bash
-himalaya --json envelope list --page-size=5
+himalaya --json envelope list --page-size 5
+himalaya envelope list --json --page-size 5        # equivalent; --json works after subcommand too
 himalaya --json message read 42 | jq '.subject'
 himalaya --json mailbox list
 ```

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -290,10 +290,11 @@ himalaya message reply 42 \
   --cc teammate@example.com \
   --body "Looping everyone in." --send
 
-# Custom quote headline (default is "On {date}, {from} wrote:")
+# Custom quote headline (default: empty — v2.0.0 performs no placeholder
+# substitution; the headline string is taken verbatim)
 himalaya message reply 42 --from you@example.com --quote-headline "Replying inline:" --body "..." --send
 
-# Change posting style (top | bottom | inline)
+# Change posting style (top | bottom)
 himalaya message reply 42 --from you@example.com --posting-style bottom --body "..." --send
 ```
 

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -42,7 +42,7 @@ This skill is separate from the Hermes Email gateway adapter. The gateway adapte
 | `folder.aliases.sent` (singular, TOML sub-table) | `mailbox.alias.sent` (plural, dotted key under account) |
 | `[accounts.X] backend = { type=imap, host=..., port=..., auth={...} }` | Flat keys: `imap.server`, `imap.sasl.plain.username`, `imap.sasl.plain.password.command` |
 | `envelope list from x` (positional filters) | `envelope list`; filters moved to separate `envelope search "from x"` subcommand with its own DSL |
-| `message write` (no piped input) / `message reply` | `message compose --to ... --subject ... --body ...`; rich MIME via piped `mml`; legacy `template send` still exists |
+| `message write` (no piped input) / `message reply` | `message compose --to ... --subject ... --body ...`; rich MIME via piped `mml`; `message write` is an alias of `message compose` (no editor) |
 | `--output json` / `plain` | `--json` (global flag) |
 | Native keyring support | Removed; use `pass`, `gopass`, `secret-tool` via `password.command` |
 | OAuth flows built in | None; use [ortie](https://github.com/pimalaya/ortie) as token broker |
@@ -243,17 +243,23 @@ himalaya message compose \
   --send
 ```
 
-The legacy path (piped RFC 822 over stdin) still works:
+For a body from stdin (replaces the removed `template send` subcommand), **omit `--body` and `--body-file` — stdin is the body** by default:
 
 ```bash
-cat << 'EOF' | himalaya template send
-From: you@example.com
-To: recipient@example.com
-Subject: Test Message
+echo "Hello from a piped body" | himalaya message compose \
+  --to you@example.com \
+  --subject "Test"
 
-Hello from Himalaya v2!
-EOF
+# Or read the body from a file
+himalaya message compose \
+  --to you@example.com \
+  --subject "Test" \
+  --body-file ./body.txt
 ```
+
+Note: `--body-file -` does NOT work — the binary tries to open a file literally named `-`. The `--body` / `--body-file` / implicit stdin paths are mutually exclusive; pick one.
+
+For rich MIME (multipart, attachments, signing), pipe `mml` output into `message compose` via stdin or process substitution; see `references/message-composition.md`.
 
 ### Reply to a message
 

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -140,18 +140,22 @@ Or skip SMTP entirely and use the Microsoft Graph REST API backend (`msgraph.aut
 
 ### Fastmail
 
-App password works for IMAP/SMTP. For the native JMAP API, replace both blocks with a single `jmap` one using an API token:
+App password works for IMAP/SMTP. For Fastmail's native **JMAP** API (faster, no SMTP needed), use a single `jmap.*` block instead of `imap.*` + `smtp.*`. JMAP needs an API token, not the regular account password — generate one under *Settings → Privacy & Security → API tokens*.
 
 ```toml
 [accounts.fastmail]
-imap.server = "imaps://imap.fastmail.com"
-imap.sasl.plain.username = "you@fastmail.com"
-imap.sasl.plain.password.command = "pass show fastmail"
+email = "you@fastmail.com"
+default = true
 
-smtp.server = "smtps://smtp.fastmail.com"
-smtp.sasl.plain.username = "you@fastmail.com"
-smtp.sasl.plain.password.command = "pass show fastmail"
+jmap.server = "https://api.fastmail.com/jmap/session"
+jmap.auth.bearer.token.command = "pass show fastmail/jmap-token"
+
+# Optional: pin the sending identity and drafts mailbox when multiple exist
+# jmap.identity-id = "I0123abc"
+# jmap.drafts-mailbox-id = "M0123abc"
 ```
+
+The same `jmap.*` schema applies to any JMAP server (Stalwart, Apache James, etc.) — only the `jmap.server` URL changes.
 
 ### iCloud
 
@@ -174,9 +178,10 @@ mailbox.alias.sent = "Sent Messages"
 ## Hermes integration notes
 
 - **Reading, listing, searching, flagging, copying** — all work directly through the terminal tool.
-- **Composing / replying / forwarding** — use the `message compose` subcommand (flags-only) or chain `mml` for rich MIME / attachments / PGP. The legacy `template send` (pipe a complete RFC 822 message on stdin) still works for scripted sends.
-- For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages.
-- **Pitfall — clap parser order matters:** search query DSL tokens (`from`, `subject`, `after`, `order by`, etc.) start consuming characters from the next flag too. Always pass `--page-size=20` (with `=`) instead of `--page-size 20`, and put query positional args **last** on the command line. Spaces between a flag like `--page-size 20` get eaten as part of the search query.
+- **Composing / replying / forwarding** — use the `message compose` / `message reply` / `message forward` subcommands (flag-based) or chain `mml` for rich MIME / attachments / PGP. To send a pre-written RFC 822 message, use `message send < message.eml` or pipe via stdin to `message compose --body-file -` / `message compose` with no `--body` (stdin fallback).
+- **Pitfall — `message write` is an alias, not an editor opener.** In v2, `himalaya message write` is a `visible_alias` of `message compose` and behaves identically (flag-based, no `$EDITOR`). The pre-v1.x editor-driven flow no longer exists. Use `mml compose` if you want interactive composition.
+- For programmatic output (parsing in scripts), pass `--json` for structured envelopes / messages. It's a global flag (pass before the subcommand for consistency); v2 also recognizes it after the subcommand for ergonomics.
+- **Pitfall — search query DSL:** the query is a positional `Vec<String>` that captures trailing tokens until end-of-input. Always put the query **last** on the command line. Quote-protect patterns containing `$`, shell metacharacters, or spaces.
 - **Pitfall — Gmail mailbox names:** `[Gmail]/Sent Mail` etc. contain `[`, `]`, and a space. Always quote in the shell.
 - **Pitfall — multiple accounts:** pass `-a <name>` or `--account <name>`. The account flagged `default = true` is used when omitted.
 
@@ -253,20 +258,31 @@ EOF
 ### Reply to a message
 
 ```bash
-# Quick reply with --body
-himalaya message reply 42 --body "Thanks, will do." --send
+# Quick reply with new body
+himalaya message reply 42 --body "Got it, thanks." --send
 
-# Reply-all
-himalaya message reply 42 --all --body "Looping everyone in." --send
+# Strict reply (just to the sender): pass --to with the original From address
+himalaya message reply 42 --to sender@example.com --body "Thanks." --send
 
-# Quote original
-himalaya message reply 42 --quote --body "See below." --send
+# Reply-all: include the original To/Cc recipients with --cc / --to
+himalaya message reply 42 \
+  --to sender@example.com \
+  --cc teammate@example.com \
+  --body "Looping everyone in." --send
+
+# Custom quote headline (default is "On {date}, {from} wrote:")
+himalaya message reply 42 --quote-headline "Replying inline:" --body "..." --send
+
+# Change posting style (top | bottom | inline)
+himalaya message reply 42 --posting-style bottom --body "..." --send
 ```
+
+> **v2 note.** There are no `--all` / `--quote` boolean flags. Reply-all is "include the original recipients via `--cc`/`--to`"; quoting is the default behavior controlled by `--posting-style` and `--quote-headline`.
 
 ### Forward
 
 ```bash
-himalaya message forward 42 --to other@example.com --send
+himalaya message forward 42 --to other@example.com --body "FYI" --send
 ```
 
 ### Move / copy / delete
@@ -274,9 +290,10 @@ himalaya message forward 42 --to other@example.com --send
 ```bash
 himalaya message copy --from INBOX --to Archives 42
 himalaya message move --from INBOX --to Archives 42    # if backend supports move
-himalaya message delete 42                              # sets \Deleted flag
-himalaya message expunge                                 # permanently remove flagged
+himalaya message delete 42                              # trash-move; permanent for in-trash
 ```
+
+> **v2 note.** There is no `message expunge` subcommand in v2. `message delete` already trash-moves; on IMAP servers without UIDPLUS, deleted-from-trash items are flagged `\Deleted` and reclaimed by the next `message delete` on the trash mailbox, or by the server's own expunge policy.
 
 ### Manage flags
 
@@ -290,9 +307,12 @@ The `--flag` argument accepts `seen`, `answered`, `flagged`, `draft`, `recent`. 
 ### Download attachments
 
 ```bash
-himalaya attachment download 42                         # default ~/Downloads
-himalaya attachment download 42 --output-dir /tmp/attach
+himalaya attachment download 42                         # download all; default dir from config
+himalaya attachment download 42 --dir /tmp/attach       # override destination
+himalaya attachment download 42 0 1                     # download only attachments 0 and 1
 ```
+
+> **v2 note.** The destination flag is `--dir` (also `-d`), not `--output-dir`. Default destination is the account's `downloads-dir` config (falling back to the global config, then the platform standard). Run `himalaya attachment download --help` for the full flag list.
 
 ## Multiple accounts
 


### PR DESCRIPTION
## What does this PR do?

The bundled himalaya skill documented the v1.x configuration format. Himalaya v2.0.0 ([release notes](https://github.com/pimalaya/himalaya/releases/tag/v2.0.0)) introduced a flat per-backend TOML schema and several CLI breaking changes. This rewrites the skill — and the docs site page generated from it — to match v2.

Specifically, the skill now teaches:

- **Flat per-backend keys**: `imap.server`, `imap.sasl.plain.username`, `imap.sasl.plain.password.command` instead of nested `backend = { type = "imap", host = ..., auth = { cmd = "..." } }` tables.
- **`mailbox.alias.*`** (plural, dotted key under account) instead of `folder.aliases.*` / `folder.alias.*`.
- **`envelope search "from x and after Y order by ..."`** DSL with its own subcommand instead of `envelope list from x ...` positional filters.
- **`mailbox list`** instead of `folder list`.
- **`--json`** is a **global** flag. Both `himalaya --json envelope list` (pre-subcommand, the documented convention) and `himalaya envelope list --json` (post-subcommand, accepted for ergonomics) work in v2.
- **`message compose --to ... --body ... --send`** flag-based send, **`message reply N --body ... --send`** / **`message forward N --to ... --send`** for replies/forwards.
- **Server URL schemes**: `imaps://`, `smtps://`, `smtp://` + `starttls`, `unix://` for [sirup](https://github.com/pimalaya/sirup).
- **Password forms**: `password.raw` (dev), `password.command` (recommended, e.g. `pass show email/gmail-app`). Native keyring removed in v2.
- **Provider examples** for Gmail (app password, leading with `smtps://465`), Outlook/Graph (OAuth via ortie), Fastmail (JMAP), iCloud (app-specific password with local-part/full-address login split).
- **Gmail folder alias mapping** (`[Gmail]/Sent Mail`, etc.) for the send-folder-after-SMTP footgun.

## Round-3 corrections

@andrexibiza, @hendrixfreire, and @Enough1122 each found additional issues on the adopted head. All addressed in the latest commits on top of the PR branch:

- **`--json` placement** — dropped the "must come before" claim (both placements work in v2).
- **`--page-size` form** — dropped the "equals form!" note (both `--page-size 20` and `--page-size=20` parse).
- **Gmail SMTP example** — SKILL.md and `references/configuration.md` now both lead with `smtps://smtp.gmail.com:465`; STARTTLS demoted to a one-line comment in both.
- **`cat message.eml | himalaya message compose --from ... --send`** — removed. `message compose` treats stdin as the BODY and rebuilds headers, so piping a prepared RFC 822 into it discards From/To/Subject. `message send < message.eml` above it stays as the correct path for prepared RFC 822.
- **`himalaya message export --full`** — replaced with `himalaya message read 42 --raw` (there is no `message export` subcommand in v2).
- **`mml compose > message.mml`** — replaced with `mml compose --from me@example.org /tmp/draft.mml` (upstream MML explicitly rejects stdout redirection because the editor needs a TTY).
- **Trailing newlines** — added to all four Markdown files (was generating diff noise in whitespace-checking tooling).
- **Website docs mirror** — regenerated via `website/scripts/generate-skill-docs.py`; byte-stable on re-run (verified). Unrelated regenerator drift on other skills was reverted.

## Validation

- `python3 -m pytest tests/website/test_generate_skill_docs.py tests/website/test_extract_skills.py -v` → **22 passed**.
- Diff vs `upstream/main`: exactly 5 files (`SKILL.md`, two `references/`, the `email-himalaya.md` mirror, and the himalaya row in `skills-catalog.md`).
- Local git config: `mergeable: MERGEABLE` on the PR — no conflicts.

## Files

```
 skills/email/himalaya/SKILL.md                                     | 13 +++++------
 skills/email/himalaya/references/configuration.md                  |  7 ++++---
 skills/email/himalaya/references/message-composition.md            | 15 +++++++++-----
 website/docs/user-guide/skills/bundled/email/email-himalaya.md    | 11 ++++++-----
 5 files changed, 734 insertions(+), 524 deletions(-)
```

Round-3 review addressed — ready for maintainer sign-off.