### PR TITLE
fix(cli): honor skin colors in inline diffs

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -42,6 +42,12 @@ def _display_url(value: Any) -> str:
 _diff_colors_cached: dict[str, str] | None = None
 
 
+def invalidate_diff_color_cache() -> None:
+    """Clear cached diff colors so the active skin is resolved again."""
+    global _diff_colors_cached
+    _diff_colors_cached = None
+
+
 def _diff_ansi() -> dict[str, str]:
     """Return ANSI escapes for diff display, resolved from the active skin."""
     global _diff_colors_cached

--- a/agent/display.py
+++ b/agent/display.py
@@ -58,27 +58,38 @@ def _diff_ansi() -> dict[str, str]:
         from hermes_cli.skin_engine import get_active_skin
         skin = get_active_skin()
 
+        def _color_rgb(key: str, fallback: tuple[int, int, int]) -> tuple[int, int, int]:
+            value = skin.get_color(key, "")
+            if isinstance(value, str) and re.fullmatch(r"#[0-9a-fA-F]{6}", value):
+                return tuple(int(value[i:i + 2], 16) for i in (1, 3, 5))
+            return fallback
+
         def _hex_fg(key: str, fallback_rgb: tuple[int, int, int]) -> str:
-            h = skin.get_color(key, "")
-            if h and len(h) == 7 and h[0] == "#":
-                r, g, b = int(h[1:3], 16), int(h[3:5], 16), int(h[5:7], 16)
-                return f"\033[38;2;{r};{g};{b}m"
-            r, g, b = fallback_rgb
+            r, g, b = _color_rgb(key, fallback_rgb)
             return f"\033[38;2;{r};{g};{b}m"
+
+        def _hex_fg_bg(
+            fg_key: str,
+            bg_key: str,
+            fallback_fg: tuple[int, int, int],
+            fallback_bg: tuple[int, int, int],
+        ) -> str:
+            fr, fg_channel, fb = _color_rgb(fg_key, fallback_fg)
+            br, bg_channel, bb = _color_rgb(bg_key, fallback_bg)
+            return (
+                f"\033[38;2;{fr};{fg_channel};{fb};"
+                f"48;2;{br};{bg_channel};{bb}m"
+            )
 
         dim = _hex_fg("banner_dim", (150, 150, 150))
         file_c = _hex_fg("session_label", (180, 160, 255))
         hunk = _hex_fg("session_border", (120, 120, 140))
-        # minus/plus use background colors — derive from ui_error/ui_ok
-        err_h = skin.get_color("ui_error", "#ef5350")
-        ok_h = skin.get_color("ui_ok", "#4caf50")
-        if err_h and len(err_h) == 7:
-            er, eg, eb = int(err_h[1:3], 16), int(err_h[3:5], 16), int(err_h[5:7], 16)
-            # Use a dark tinted version as background
-            minus = f"\033[38;2;255;255;255;48;2;{max(er//2,20)};{max(eg//4,10)};{max(eb//4,10)}m"
-        if ok_h and len(ok_h) == 7:
-            or_, og, ob = int(ok_h[1:3], 16), int(ok_h[3:5], 16), int(ok_h[5:7], 16)
-            plus = f"\033[38;2;255;255;255;48;2;{max(or_//4,10)};{max(og//2,20)};{max(ob//4,10)}m"
+        minus = _hex_fg_bg(
+            "diff_removed_word", "diff_removed", (255, 255, 255), (120, 20, 20)
+        )
+        plus = _hex_fg_bg(
+            "diff_added_word", "diff_added", (255, 255, 255), (20, 90, 20)
+        )
     except Exception:
         pass
 

--- a/agent/display.py
+++ b/agent/display.py
@@ -41,6 +41,12 @@ def _display_url(value: Any) -> str:
 _diff_colors_cached: dict[str, str] | None = None
 
 
+def invalidate_diff_color_cache() -> None:
+    """Clear cached diff colors so the active skin is resolved again."""
+    global _diff_colors_cached
+    _diff_colors_cached = None
+
+
 def _diff_ansi() -> dict[str, str]:
     """Return ANSI escapes for diff display, resolved from the active skin."""
     global _diff_colors_cached

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -3436,6 +3436,8 @@ class CLICommandsMixin:
             return
 
         set_active_skin(new_skin)
+        from agent.display import invalidate_diff_color_cache
+        invalidate_diff_color_cache()  # Re-resolve diff colors for the new skin
         _ACCENT.reset()  # Re-resolve ANSI color for the new skin
         # _DIM is now a fixed dim+italic ANSI escape (terminal-default fg)
         # so it doesn't need re-resolving on skin switch.

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -28,6 +28,7 @@ from rich.markup import escape as _escape
 from rich.panel import Panel
 
 from hermes_constants import display_hermes_home, is_termux as _is_termux_environment
+from agent.display import invalidate_diff_color_cache
 from agent.turn_context import extract_api_content_sidecar
 from hermes_cli.browser_connect import (
     DEFAULT_BROWSER_CDP_URL,
@@ -2565,6 +2566,7 @@ class CLICommandsMixin:
             return
 
         set_active_skin(new_skin)
+        invalidate_diff_color_cache()
         _ACCENT.reset()  # Re-resolve ANSI color for the new skin
         # _DIM is now a fixed dim+italic ANSI escape (terminal-default fg)
         # so it doesn't need re-resolving on skin switch.

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -314,3 +314,30 @@ class TestBuildStatusPhrase:
             assert build_status_phrase("terminal", {"command": "ls"}) is None
         finally:
             set_friendly_tool_labels(True)
+
+
+def test_diff_color_cache_is_invalidated_after_skin_switch(monkeypatch):
+    """Switching skins must clear the cached diff colors so the new skin is used."""
+    import agent.display as d
+
+    # Reset any cached state from earlier tests.
+    d._diff_colors_cached = None
+
+    # First resolution caches colors for the current skin.
+    first = d._diff_ansi()
+    assert d._diff_colors_cached is not None
+
+    # A skin switch must invalidate the cache so the next resolve re-reads the skin.
+    assert hasattr(d, "invalidate_diff_color_cache"), (
+        "display.py must expose invalidate_diff_color_cache() so a skin switch "
+        "can clear the stale diff colors"
+    )
+    d.invalidate_diff_color_cache()
+    assert d._diff_colors_cached is None, (
+        "diff color cache must be cleared after a skin switch, otherwise the "
+        "inline diff keeps the old skin's colors"
+    )
+
+    # Re-resolving picks up the new skin rather than the stale cached colors.
+    second = d._diff_ansi()
+    assert second is not first or d._diff_colors_cached is not None

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -171,6 +171,32 @@ class TestEditDiffPreview:
         assert colors["plus"] == "\033[38;2;54;249;246;48;2;43;63;77m"
         assert colors["minus"] == "\033[38;2;255;126;219;48;2;72;40;61m"
 
+    def test_inline_diff_re_resolves_colors_after_skin_transition(self, monkeypatch):
+        class FakeSkin:
+            def __init__(self, added):
+                self.added = added
+
+            def get_color(self, key, default=""):
+                return {
+                    "diff_added": self.added,
+                    "diff_added_word": "#ffffff",
+                }.get(key, default)
+
+        active_skin = [FakeSkin("#112233")]
+        monkeypatch.setattr(
+            "hermes_cli.skin_engine.get_active_skin", lambda: active_skin[0]
+        )
+        monkeypatch.setattr(display_module, "_diff_colors_cached", None)
+        diff = "--- a/note.txt\n+++ b/note.txt\n@@ -1 +1 @@\n-old\n+new"
+
+        first_render = _render_inline_unified_diff(diff)
+        active_skin[0] = FakeSkin("#445566")
+        display_module.invalidate_diff_color_cache()
+        second_render = _render_inline_unified_diff(diff)
+
+        assert any("48;2;17;34;51m" in line for line in first_render)
+        assert any("48;2;68;85;102m" in line for line in second_render)
+
     def test_malformed_removed_color_does_not_discard_valid_added_colors(self, monkeypatch):
         class FakeSkin:
             def get_color(self, key, default=""):

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -148,7 +148,46 @@ class TestCuteToolMessagePreviewLength:
 
 class TestEditDiffPreview:
 
+    def test_inline_diff_uses_explicit_skin_background_colors(self, monkeypatch):
+        class FakeSkin:
+            def get_color(self, key, default=""):
+                return {
+                    "banner_dim": "#848bbd",
+                    "session_label": "#fffe80",
+                    "session_border": "#ff7edb",
+                    "diff_added": "#2b3f4d",
+                    "diff_removed": "#48283d",
+                    "diff_added_word": "#36f9f6",
+                    "diff_removed_word": "#ff7edb",
+                    "ui_ok": "#72f1b8",
+                    "ui_error": "#fe4450",
+                }.get(key, default)
 
+        monkeypatch.setattr("hermes_cli.skin_engine.get_active_skin", lambda: FakeSkin())
+        monkeypatch.setattr(display_module, "_diff_colors_cached", None)
+
+        colors = display_module._diff_ansi()
+
+        assert colors["plus"] == "\033[38;2;54;249;246;48;2;43;63;77m"
+        assert colors["minus"] == "\033[38;2;255;126;219;48;2;72;40;61m"
+
+    def test_malformed_removed_color_does_not_discard_valid_added_colors(self, monkeypatch):
+        class FakeSkin:
+            def get_color(self, key, default=""):
+                return {
+                    "diff_added": "#2b3f4d",
+                    "diff_added_word": "#36f9f6",
+                    "diff_removed": "#12345g",
+                    "diff_removed_word": "#ff7edb",
+                }.get(key, default)
+
+        monkeypatch.setattr("hermes_cli.skin_engine.get_active_skin", lambda: FakeSkin())
+        monkeypatch.setattr(display_module, "_diff_colors_cached", None)
+
+        colors = display_module._diff_ansi()
+
+        assert colors["plus"] == "\033[38;2;54;249;246;48;2;43;63;77m"
+        assert colors["minus"] == "\033[38;2;255;126;219;48;2;120;20;20m"
 
     def test_extract_edit_diff_uses_local_snapshot_for_write_file(self, tmp_path):
         target = tmp_path / "note.txt"

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import agent.display as display_module
 from cli import HermesCLI, _build_compact_banner, _rich_text_from_ansi
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
 
@@ -78,6 +79,15 @@ class TestCliSkinPromptIntegration:
         assert "Skin set to: ares (saved)" in output
         assert "Prompt + TUI colors updated." in output
         assert cli._app.style is not None
+
+    def test_handle_skin_command_invalidates_inline_diff_colors(self, monkeypatch):
+        cli = _make_cli_stub()
+        monkeypatch.setattr(display_module, "_diff_colors_cached", {"plus": "stale"})
+
+        with patch("cli.save_config_value", return_value=True):
+            cli._handle_skin_command("/skin ares")
+
+        assert display_module._diff_colors_cached is None
 
 
 class TestCompactBannerSkinIntegration:


### PR DESCRIPTION
## Summary
- use explicit `diff_added` and `diff_removed` skin roles for CLI inline diff backgrounds
- use `diff_added_word` and `diff_removed_word` for line text
- isolate malformed color fallbacks so one bad role does not discard valid colors

## Root cause
The CLI renderer ignored the dedicated diff skin roles and derived backgrounds from `ui_ok` and `ui_error`, forcing additions toward green and removals toward red.

## Verification
- RED regression reproduced on current main
- `scripts/run_tests.sh tests/agent/test_display.py`: 22 passed
- live `synthwave-84` renderer probe passed
- `git diff --check`: passed
- Gitleaks staged scan: no leaks
- independent read-only review: PASS