### PR TITLE
fix(update): honor --ignore-cr-at-eol on git < 2.48 via --numstat

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3073,14 +3073,36 @@ def _normalize_managed_eol(git_cmd, repo_root):
     probe = git_cmd + ["-c", "core.autocrlf=false"]
 
     def _dirty(*extra):
+        # `--name-only` does not honor `--ignore-cr-at-eol` on git < 2.48 (the
+        # flag is silently dropped), so the "real dirty" set would equal the
+        # full set and `_eol_only()` would always be empty — leaving CRLF churn
+        # uncleared and then writing the pin over it. `--numstat` honors the
+        # ignore options on every supported git version, so use it when an
+        # ignore flag is requested and derive the path set from its records.
+        ignore_eol = "--ignore-cr-at-eol" in extra
+        name_arg = "--numstat" if ignore_eol else "--name-only"
+        args = probe + ["diff", "-z", name_arg, *extra]
         out = subprocess.run(
-            probe + ["diff", "-z", "--name-only", *extra],
+            args,
             cwd=repo_root,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
         )
         if out.returncode != 0:
             return None
+        if ignore_eol:
+            paths = set()
+            for record in out.stdout.split("\0"):
+                if not record:
+                    continue
+                # numstat -z records are "added\tdeleted\tpath" (renames add a
+                # fourth field); the path fields are everything after the two
+                # counts. Binary/unknown counts appear as "-".
+                fields = record.split("\t")
+                for field in fields[2:]:
+                    if field and field != "-":
+                        paths.add(field)
+            return paths
         return {p for p in out.stdout.split("\0") if p}
 
     def _eol_only():


### PR DESCRIPTION
## What does this PR do?

Fixes `_normalize_managed_eol` (`hermes_cli/update_cmd.py`) so it actually
clears CRLF churn on managed checkouts when running on git < 2.48.

`git diff --name-only --ignore-cr-at-eol` silently ignores
`--ignore-cr-at-eol` on git < 2.48 (the flag is only honored on the
`--numstat`/`--patch`/`--quiet` output paths). As a result the
"real dirty" set equaled the full dirty set, `_eol_only()` was always
empty, and the `core.autocrlf=false` pin was written over a still-dirty
tree — the 5 regression tests from #74487 failed deterministically
(reproduced on git 2.43.0 / 2.45.2; CI passed only because it ran git 2.54).

This swaps the ignore-eol probe to `--numstat`, which honors the option on
every supported git version, and parses its path records. The non-ignore
path is unchanged.

## Related Issue

Fixes #75175

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py`: in `_normalize_managed_eol._dirty`, use
  `--numstat` instead of `--name-only` when `--ignore-cr-at-eol` is
  requested, and parse the path fields from each numstat record.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_eol_churn.py -q
```

Expected: 9 passed. On git < 2.48 (e.g. git 2.43/2.45) this was
5 failed / 4 passed before the fix.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(update): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `scripts/run_tests.sh tests/hermes_cli/test_update_eol_churn.py -q` and all tests pass
- [x] I've added tests for my changes — existing regression tests (#74487) pin the contract; this change makes them pass on git < 2.48
- [x] I've tested on my platform: macOS 26.2, git 2.45.2

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A (no user-facing behavior change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — or N/A (version-robust by construction; any platform/git)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not needed — deterministic pytest fix.