### PR TITLE
fix: retry OmniRoute admission saturation

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -75,8 +75,11 @@ from agent.prompt_caching import (
 )
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
+    admission_retry_wait,
+    is_omniroute_admission_error,
     is_zai_coding_overload_error,
     jittered_backoff,
+    omniroute_admission_retry_ceiling,
     zai_coding_overload_retry_ceiling,
 )
 from agent.trajectory import has_incomplete_scratchpad
@@ -3662,6 +3665,7 @@ def run_conversation(
 
                 status_code = getattr(api_error, "status_code", None)
                 error_context = agent._extract_api_error_context(api_error)
+                _is_omniroute_admission = is_omniroute_admission_error(api_error)
 
                 # ── Classify the error for structured recovery decisions ──
                 _compressor = getattr(agent, "context_compressor", None)
@@ -3713,12 +3717,14 @@ def run_conversation(
                         )
                         continue
 
-                recovered_with_pool, _retry.has_retried_429 = agent._recover_with_credential_pool(
-                    status_code=status_code,
-                    has_retried_429=_retry.has_retried_429,
-                    classified_reason=classified.reason,
-                    error_context=error_context,
-                )
+                recovered_with_pool = False
+                if not _is_omniroute_admission:
+                    recovered_with_pool, _retry.has_retried_429 = agent._recover_with_credential_pool(
+                        status_code=status_code,
+                        has_retried_429=_retry.has_retried_429,
+                        classified_reason=classified.reason,
+                        error_context=error_context,
+                    )
                 if recovered_with_pool:
                     continue
 
@@ -4275,9 +4281,14 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                if _is_omniroute_admission:
+                    max_retries = max(max_retries, omniroute_admission_retry_ceiling())
                 _should_fallback = (
-                    is_rate_limited
-                    or (_is_transport_failure and retry_count >= 2)
+                    not _is_omniroute_admission
+                    and (
+                        is_rate_limited
+                        or (_is_transport_failure and retry_count >= 2)
+                    )
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
@@ -5085,7 +5096,7 @@ def run_conversation(
                     # client once for transient transport errors (stale
                     # connection pool, TCP reset).  Only attempted once
                     # per API call block.
-                    if not _retry.primary_recovery_attempted and agent._try_recover_primary_transport(
+                    if not _is_omniroute_admission and not _retry.primary_recovery_attempted and agent._try_recover_primary_transport(
                         api_error, retry_count=retry_count, max_retries=max_retries,
                     ):
                         _retry.primary_recovery_attempted = True
@@ -5099,9 +5110,9 @@ def run_conversation(
                         agent._fallback_activated = False
                         continue
                     # Try fallback before giving up entirely
-                    if agent._has_pending_fallback():
+                    if not _is_omniroute_admission and agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if not _is_omniroute_admission and agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -5299,7 +5310,11 @@ def run_conversation(
                                 _retry_after = min(float(_ra_raw), 600)
                             except (TypeError, ValueError):
                                 pass
-                wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                if _is_omniroute_admission:
+                    _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
+                    wait_time = admission_retry_wait(retry_count, _resp_headers)
+                else:
+                    wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
                 if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
                     wait_time, _backoff_policy = adaptive_rate_limit_backoff(
@@ -5309,7 +5324,12 @@ def run_conversation(
                         error=api_error,
                         default_wait=wait_time,
                     )
-                if is_rate_limited or _is_zai_coding_overload:
+                if _is_omniroute_admission:
+                    agent._emit_status(
+                        f"⏱️ Local gateway busy. Waiting {wait_time:.1f}s "
+                        f"(attempt {retry_count + 1}/{max_retries})..."
+                    )
+                elif is_rate_limited or _is_zai_coding_overload:
                     _policy_note = ""
                     if _backoff_policy == "zai_coding_overload_long":
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -34,6 +34,12 @@ _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 # the two from silently desyncing if the short-retry count is ever tuned.
 _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
 
+# OmniRoute holds admission leases for the lifetime of a heavy streaming
+# response. Give a saturated local queue a bounded two-minute window to drain,
+# while keeping each sleep short enough for useful progress and interrupts.
+_OMNIROUTE_ADMISSION_RETRY_ATTEMPTS = 8
+_OMNIROUTE_ADMISSION_RETRY_AFTER_CAP = 30.0
+
 
 def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     """Parse a ``Retry-After`` value into non-negative seconds.
@@ -137,6 +143,57 @@ def _error_text(error: Any) -> str:
         getattr(error, "response", None),
     ]
     return " ".join(str(part) for part in parts if part is not None).lower()
+
+
+def _structured_error_code(error: Any) -> str | None:
+    """Extract an error code from SDK response data without text matching."""
+    candidates = [getattr(error, "body", None)]
+    response = getattr(error, "response", None)
+    if response is not None:
+        json_method = getattr(response, "json", None)
+        if callable(json_method):
+            try:
+                candidates.append(json_method())
+            except Exception:
+                pass
+    for payload in candidates:
+        if not isinstance(payload, dict):
+            continue
+        detail = payload.get("error", payload)
+        if isinstance(detail, dict) and isinstance(detail.get("code"), str):
+            return detail["code"]
+    return None
+
+
+def is_omniroute_admission_error(error: Any) -> bool:
+    """Return True only for structured OmniRoute admission-busy HTTP 503s."""
+    return (
+        getattr(error, "status_code", None) == 503
+        and _structured_error_code(error) == "chat_admission_busy"
+    )
+
+
+def omniroute_admission_retry_ceiling() -> int:
+    """Retry ceiling for local admission saturation."""
+    return _OMNIROUTE_ADMISSION_RETRY_ATTEMPTS
+
+
+def admission_retry_wait(attempt: int, headers: Any) -> float:
+    """Compute a bounded, jittered admission wait respecting Retry-After.
+
+    Retry-After is treated as a minimum rather than an exact delay so a burst
+    does not synchronize all rejected clients on the same second boundary.
+    """
+    retry_after = parse_retry_after_seconds(headers)
+    if retry_after is not None:
+        retry_after = min(retry_after, _OMNIROUTE_ADMISSION_RETRY_AFTER_CAP)
+    backoff = jittered_backoff(
+        attempt,
+        base_delay=2.0,
+        max_delay=_OMNIROUTE_ADMISSION_RETRY_AFTER_CAP,
+        jitter_ratio=0.2,
+    )
+    return max(retry_after or 0.0, backoff)
 
 
 def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, error: Any) -> bool:

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -35,9 +35,9 @@ _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
 
 # OmniRoute holds admission leases for the lifetime of a heavy streaming
-# response. Give a saturated local queue a bounded two-minute window to drain,
+# response. Give a saturated local queue a bounded six-minute window to drain,
 # while keeping each sleep short enough for useful progress and interrupts.
-_OMNIROUTE_ADMISSION_RETRY_ATTEMPTS = 8
+_OMNIROUTE_ADMISSION_RETRY_ATTEMPTS = 16
 _OMNIROUTE_ADMISSION_RETRY_AFTER_CAP = 30.0
 
 
@@ -193,7 +193,14 @@ def admission_retry_wait(attempt: int, headers: Any) -> float:
         max_delay=_OMNIROUTE_ADMISSION_RETRY_AFTER_CAP,
         jitter_ratio=0.2,
     )
-    return max(retry_after or 0.0, backoff)
+    # ``jittered_backoff`` applies jitter after capping its base delay, so its
+    # result can exceed ``max_delay``. Clamp the final admission wait as well:
+    # a hostile Retry-After value and jitter must both stay inside the bounded
+    # local-admission window.
+    return min(
+        _OMNIROUTE_ADMISSION_RETRY_AFTER_CAP,
+        max(retry_after or 0.0, backoff),
+    )
 
 
 def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, error: Any) -> bool:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -17,7 +17,7 @@ import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from agent.codex_responses_adapter import _normalize_codex_response
@@ -1622,6 +1622,50 @@ class TestRetryAfterCap:
         # 300s > old 120s cap but < new 600s cap → used verbatim.
         status = self._drive_once(agent, 300)
         assert "Waiting 300.0s" in status
+
+
+class TestOmniRouteAdmissionRetry:
+    def test_structured_admission_503_survives_default_ceiling_without_rotation(
+        self, agent
+    ):
+        class _AdmissionError(Exception):
+            status_code = 503
+            body = {
+                "error": {
+                    "code": "chat_admission_busy",
+                    "message": "Structurally heavy chat request capacity is busy",
+                }
+            }
+            response = SimpleNamespace(headers={"Retry-After": "1"})
+
+            def __str__(self):
+                return "Error code: 503 - admission busy"
+
+        calls = 0
+
+        def _fake_api_call(api_kwargs):
+            nonlocal calls
+            calls += 1
+            if calls <= agent._api_max_retries:
+                raise _AdmissionError()
+            return _mock_response(content="Recovered after admission wait")
+
+        agent._interruptible_api_call = _fake_api_call
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+        agent._recover_with_credential_pool = Mock(side_effect=AssertionError("rotated credentials"))
+        agent._try_activate_fallback = Mock(side_effect=AssertionError("activated fallback"))
+        agent._try_recover_primary_transport = Mock(side_effect=AssertionError("rebuilt transport"))
+
+        with patch("agent.conversation_loop.time.sleep", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after admission wait"
+        assert calls == agent._api_max_retries + 1
+        agent._recover_with_credential_pool.assert_not_called()
+        agent._try_activate_fallback.assert_not_called()
+        agent._try_recover_primary_transport.assert_not_called()
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1657,7 +1657,9 @@ class TestOmniRouteAdmissionRetry:
         agent._try_activate_fallback = Mock(side_effect=AssertionError("activated fallback"))
         agent._try_recover_primary_transport = Mock(side_effect=AssertionError("rebuilt transport"))
 
-        with patch("agent.conversation_loop.time.sleep", return_value=None):
+        # The incremental sleeper is already covered by interrupt/activity tests.
+        # Make this policy integration test independent of wall-clock time.
+        with patch("agent.conversation_loop.admission_retry_wait", return_value=0):
             result = agent.run_conversation("hello")
 
         assert result["completed"] is True
@@ -1666,6 +1668,36 @@ class TestOmniRouteAdmissionRetry:
         agent._recover_with_credential_pool.assert_not_called()
         agent._try_activate_fallback.assert_not_called()
         agent._try_recover_primary_transport.assert_not_called()
+
+    def test_backoff_remains_interruptible(self, agent):
+        class _AdmissionError(Exception):
+            status_code = 503
+            body = {"error": {"code": "chat_admission_busy"}}
+            response = SimpleNamespace(headers={"Retry-After": "30"})
+
+        agent._interruptible_api_call = Mock(side_effect=_AdmissionError())
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+
+        statuses = []
+        original_emit = agent._emit_status
+
+        def _capture_status(msg, *args, **kwargs):
+            statuses.append(msg)
+            if "Local gateway busy" in msg:
+                agent._interrupt_requested = True
+            return original_emit(msg, *args, **kwargs)
+
+        agent._emit_status = _capture_status
+        result = agent.run_conversation("hello")
+
+        assert result["interrupted"] is True
+        from agent.retry_utils import omniroute_admission_retry_ceiling
+
+        assert any(
+            f"attempt 2/{omniroute_admission_retry_ceiling()}" in msg
+            for msg in statuses
+        )
 
 
 

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -5,7 +5,14 @@ import threading
 import agent.retry_utils as retry_utils
 from types import SimpleNamespace
 
-from agent.retry_utils import adaptive_rate_limit_backoff, is_zai_coding_overload_error, jittered_backoff
+from agent.retry_utils import (
+    adaptive_rate_limit_backoff,
+    admission_retry_wait,
+    is_omniroute_admission_error,
+    is_zai_coding_overload_error,
+    jittered_backoff,
+    omniroute_admission_retry_ceiling,
+)
 
 
 def test_backoff_is_exponential():
@@ -208,3 +215,41 @@ class TestParseRetryAfterSeconds:
                 raise RuntimeError("boom")
 
         assert parse_retry_after_seconds(Explosive()) is None
+
+
+def _omniroute_admission_error(*, code="chat_admission_busy", status=503, headers=None):
+    return SimpleNamespace(
+        status_code=status,
+        body={"error": {"code": code, "message": "capacity busy"}},
+        response=SimpleNamespace(headers=headers or {}),
+    )
+
+
+class TestOmniRouteAdmissionRetry:
+    def test_detects_only_exact_structured_code_on_503(self):
+        assert is_omniroute_admission_error(_omniroute_admission_error())
+        assert not is_omniroute_admission_error(
+            _omniroute_admission_error(code="gateway_draining")
+        )
+        assert not is_omniroute_admission_error(
+            _omniroute_admission_error(status=429)
+        )
+        assert not is_omniroute_admission_error(
+            SimpleNamespace(status_code=503, body="chat_admission_busy")
+        )
+
+    def test_extended_ceiling_outlives_default_retry_count(self):
+        assert omniroute_admission_retry_ceiling() > 3
+
+    def test_retry_after_is_a_floor_but_hostile_values_are_bounded(self, monkeypatch):
+        monkeypatch.setattr(
+            retry_utils,
+            "jittered_backoff",
+            lambda attempt, **kwargs: min(
+                kwargs["base_delay"] * (2 ** (attempt - 1)),
+                kwargs["max_delay"],
+            ),
+        )
+        assert admission_retry_wait(1, {"Retry-After": "5"}) == 5.0
+        assert admission_retry_wait(1, {"Retry-After": "999999999"}) == 30.0
+        assert admission_retry_wait(4, {"Retry-After": "malformed"}) == 16.0

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -239,7 +239,7 @@ class TestOmniRouteAdmissionRetry:
         )
 
     def test_extended_ceiling_outlives_default_retry_count(self):
-        assert omniroute_admission_retry_ceiling() > 3
+        assert omniroute_admission_retry_ceiling() == 16
 
     def test_retry_after_is_a_floor_but_hostile_values_are_bounded(self, monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- retry only structured OmniRoute `chat_admission_busy` HTTP 503 responses with a bounded extended ceiling
- respect `Retry-After` as a capped floor while preserving interruptible wait/activity behavior
- avoid credential rotation, transport rebuild, and model/provider fallback for local admission saturation

## Verification
- `uv run --extra dev pytest -q tests/test_retry_utils.py tests/run_agent/test_run_agent.py::TestOmniRouteAdmissionRetry` — 15 passed
- `git range-diff b1858f33a..7becc7cf1 origin/main..671dbf906` — patch equivalent after conflict-free rebase
- independent CTO review approved the original patch with no findings

## Safety
- no OmniRoute concurrency-cap change
- no cgroup limit change
- generic 503 handling remains unchanged