### PR TITLE
fix(skills): use symlink-following traversal in _find_skill

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -650,11 +650,11 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path, iter_skill_index_files
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
             if skill_md.parent.name == name:
@@ -749,7 +749,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
     matches: List[Tuple[str, Path]] = []
     try:
         from hermes_constants import get_default_hermes_root
-        from agent.skill_utils import is_excluded_skill_path
+        from agent.skill_utils import is_excluded_skill_path, iter_skill_index_files
     except Exception:
         return matches
 
@@ -793,7 +793,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
-            for skill_md in skills_dir.rglob("SKILL.md"):
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
                 if is_excluded_skill_path(skill_md):
                     continue
                 if skill_md.parent.name == name:


### PR DESCRIPTION
## Fixes #75130

`rglob("SKILL.md")` does not descend into directory symlinks, making symlinked skill directories invisible to `skill_manage` operations (create, patch, delete) while the prompt loader (which uses `os.walk(followlinks=True)`) still sees them.

The reporter measured: `rglob` found 393 skills, `os.walk(followlinks=True)` found 399 -- 6 symlinked skills were invisible to the tool.

## Changes

Replace `rglob("SKILL.md")` with `iter_skill_index_files(skills_dir, "SKILL.md")` in both:

- `_find_skill()` (line 657) -- primary skill lookup used by all `skill_manage` actions
- `_find_skill_in_other_profiles()` (line 796) -- cross-profile lookup for error messages

`iter_skill_index_files` already uses `os.walk(followlinks=True)` and is the canonical skill enumeration path used by the prompt builder and sync subsystem. This makes the tool's visibility match what the model sees.

## Known remaining sites

The same `rglob("SKILL.md")` pattern exists in ~25 other files (`skills_sync.py`, `skills_hub.py`, `skill_usage.py`, `profiles.py`, `gateway/run.py`, etc.). These affect skill counting, sync, and usage tracking but not the core skill-manage tool path. A follow-up PR could migrate those to `iter_skill_index_files` for full consistency.

## Test plan

- [ ] `python -m pytest tests/tools/test_skill_manager_tool.py -xvs` passes
- [ ] Skills installed via symlink are now found by `skill_manage`
