### PR TITLE
docs(stt)+test: finish elevenlabs built-in registration (follow-up to #55786)

### DIFF
--- a/agent/transcription_provider.py
+++ b/agent/transcription_provider.py
@@ -8,14 +8,16 @@ register instances via
 (selected via ``stt.provider`` in ``config.yaml``) services every
 :func:`tools.transcription_tools.transcribe_audio` call **when the
 configured name is neither a built-in (``local``, ``local_command``,
-``groq``, ``openai``, ``mistral``, ``xai``) nor disabled**.
+``groq``, ``openai``, ``mistral``, ``xai``, ``elevenlabs``,
+``deepinfra``) nor disabled**.
 
 Two coexisting STT extension surfaces — in resolution order:
 
 1. **Built-in providers** (``BUILTIN_STT_PROVIDERS`` in
    :mod:`tools.transcription_tools`) — native Python implementations
-   for the 6 backends shipped today (faster-whisper, local_command,
-   Groq, OpenAI, Mistral, xAI). **Always win** — plugins cannot
+   for the 8 backends shipped today (faster-whisper, local_command,
+   Groq, OpenAI, Mistral, xAI, ElevenLabs, DeepInfra). **Always win**
+   — plugins cannot
    shadow them. The single-env-var shell escape hatch
    ``HERMES_LOCAL_STT_COMMAND`` is preserved via the built-in
    ``local_command`` path.
@@ -74,7 +76,8 @@ class TranscriptionProvider(abc.ABC):
         Lowercase, no spaces. Examples: ``openrouter``, ``sensaudio``,
         ``gemini``, ``deepgram``. Names that collide with a built-in STT
         provider (``local``, ``local_command``, ``groq``, ``openai``,
-        ``mistral``, ``xai``) are rejected at registration time.
+        ``mistral``, ``xai``, ``elevenlabs``, ``deepinfra``) are rejected
+        at registration time.
         """
 
     @property

--- a/tests/tools/test_transcription_command_providers.py
+++ b/tests/tools/test_transcription_command_providers.py
@@ -86,18 +86,34 @@ def _python_emit_stdout_command(transcript_text: str) -> str:
 
 class TestResolveCommandSTTProviderConfig:
     def test_builtin_names_are_never_command_providers(self):
+        # Configure a command entry for EVERY built-in so the loop below
+        # actually exercises the built-in guard for each name (an unconfigured
+        # name would resolve to None trivially). Kept in sync with
+        # BUILTIN_STT_PROVIDERS.
         cfg = {
             "providers": {
-                "openai": {"type": "command", "command": "echo hi"},
-                "groq": {"type": "command", "command": "echo hi"},
-                "local": {"type": "command", "command": "echo hi"},
-                "local_command": {"type": "command", "command": "echo hi"},
-                "mistral": {"type": "command", "command": "echo hi"},
-                "xai": {"type": "command", "command": "echo hi"},
+                name: {"type": "command", "command": "echo hi"}
+                for name in BUILTIN_STT_PROVIDERS
             },
         }
         for name in BUILTIN_STT_PROVIDERS:
             assert _resolve_command_stt_provider_config(name, cfg) is None
+
+    def test_elevenlabs_command_config_is_excluded(self):
+        # ElevenLabs is a native built-in; a stt.providers.elevenlabs command
+        # entry must be ignored by both command-provider resolution and
+        # iteration, never routed to a user shell command.
+        cfg = {
+            "providers": {
+                "elevenlabs": {"type": "command", "command": "echo hi"},
+                "my-cli": {"type": "command", "command": "whisper {input_path}"},
+            },
+        }
+        assert "elevenlabs" in BUILTIN_STT_PROVIDERS
+        assert _resolve_command_stt_provider_config("elevenlabs", cfg) is None
+        iterated = {name for name, _ in _iter_command_stt_providers(cfg)}
+        assert "elevenlabs" not in iterated
+        assert "my-cli" in iterated  # a genuine command provider is still yielded
 
     def test_missing_provider_returns_none(self):
         cfg = {"providers": {}}


### PR DESCRIPTION
## What does this PR do?

Follow-up to #55786 (closed once the registry sets were fixed on main). The two
additional items @teknium1 requested in that review are still open on current
`main`, so this completes them:

**1. `agent/transcription_provider.py` — extension-contract docs matched the
reservation sets.** Three docstrings still enumerated only 6 built-ins
(`local, local_command, groq, openai, mistral, xai`), omitting **elevenlabs**
— and also **deepinfra**, which was added since. `BUILTIN_STT_PROVIDERS` now
has 8 native handlers, so the ABC contract docs (which tell plugin authors
which names are reserved) were stale. Updated all three enumerations to the
full current set and "6 backends" → "8 backends".

**2. `tests/tools/test_transcription_command_providers.py` — proved the
built-in exclusion for elevenlabs.** `test_builtin_names_are_never_command_providers`
configured command entries for only 6 built-ins, so the loop's assertion for
`elevenlabs` (and `deepinfra`) was **vacuous** — an unconfigured name resolves
to `None` trivially, which was exactly the gap called out in the review.
Now the fixture is derived from `BUILTIN_STT_PROVIDERS` so every built-in is
actually exercised, plus a focused regression test asserts that a
`stt.providers.elevenlabs` command entry is excluded from **both**
`_resolve_command_stt_provider_config` and `_iter_command_stt_providers`
(while a genuine command provider is still yielded).

Docs/test only — no behavior change; the dispatcher already routes `elevenlabs`
(and `deepinfra`) natively.

## Related Issue

Follow-up to #55786 (review by @teknium1). No separate issue.

## Type of Change

- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/transcription_provider.py` — three built-in enumerations updated to the
  full 8-provider set (adds `elevenlabs`, `deepinfra`).
- `tests/tools/test_transcription_command_providers.py` — fixture derived from
  `BUILTIN_STT_PROVIDERS`; new `test_elevenlabs_command_config_is_excluded`.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_transcription_command_providers.py -q`
   → all pass (20).
2. The new exclusion test is a real guard: if `elevenlabs` were dropped from
   `BUILTIN_STT_PROVIDERS`, `_resolve_command_stt_provider_config("elevenlabs", cfg)`
   would return the configured command instead of `None`, failing the test.

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] I searched for existing PRs (this completes the closed #55786)
- [x] Only changes related to this follow-up
- [x] Affected test modules pass — `test_transcription_command_providers.py` (20),
  `test_transcription_registry.py` (also green); full 17k suite not run locally.
- [x] Docs + tests only, no behavior change
- [x] Tested on: Ubuntu (WSL2), against current `main`
