### PR TITLE
Fix ACP custom provider restore

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -620,6 +620,7 @@ class SessionManager:
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
 
+        effective_model = model or default_model
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
@@ -629,11 +630,27 @@ class SessionManager:
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),
-            "model": model or default_model,
+            "model": effective_model,
         }
 
         try:
-            runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
+            requested_for_runtime = requested_provider or config_provider
+            if str(requested_for_runtime or "").strip().lower() == "custom":
+                from hermes_cli.runtime_provider import canonical_custom_identity
+
+                requested_for_runtime = (
+                    canonical_custom_identity(
+                        base_url=base_url,
+                        model=effective_model,
+                        config_provider=config_provider,
+                    )
+                    or requested_for_runtime
+                )
+            runtime = resolve_runtime_provider(
+                requested=requested_for_runtime,
+                explicit_base_url=base_url,
+                target_model=effective_model or None,
+            )
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -110,6 +110,83 @@ class TestCreateSession:
 
         assert state.agent.session_cwd == "/tmp/project"
 
+    def test_make_agent_recovers_named_custom_provider_from_restored_endpoint(
+        self, tmp_path, monkeypatch
+    ):
+        """Restored ACP sessions persist provider=custom, so recover the named
+        endpoint before resolving credentials.
+        """
+        restored_base_url = "https://restored.example/api/coding"
+        global_base_url = "https://global.example/api/coding"
+        calls = []
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.model = kwargs.get("model")
+
+        def fake_resolve_runtime_provider(**kwargs):
+            calls.append(kwargs)
+            return {
+                "provider": "custom",
+                "api_mode": "anthropic_messages",
+                "base_url": restored_base_url,
+                "api_key": "restored-test-key",
+                "command": None,
+                "args": [],
+            }
+
+        config = {
+            "model": {"default": "glm-5.2", "provider": "custom:global-default"},
+            "mcp_servers": {},
+            "custom_providers": [
+                {
+                    "name": "restored-provider",
+                    "base_url": restored_base_url,
+                    "api_key": "restored-key",
+                    "api_mode": "anthropic_messages",
+                    "model": "glm-5.2",
+                },
+                {
+                    "name": "global-default",
+                    "base_url": global_base_url,
+                    "api_key": "global-key",
+                    "api_mode": "chat_completions",
+                    "model": "other-model",
+                },
+            ],
+        }
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        monkeypatch.setattr("hermes_cli.runtime_provider.load_config", lambda: config)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda *_: None)
+
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+        agent = manager._make_agent(
+            session_id="restored-acp",
+            cwd="/work",
+            model="glm-5.2",
+            requested_provider="custom",
+            base_url=restored_base_url,
+            api_mode="anthropic_messages",
+        )
+
+        assert calls == [
+            {
+                "requested": "custom:restored-provider",
+                "explicit_base_url": restored_base_url,
+                "target_model": "glm-5.2",
+            }
+        ]
+        assert agent.kwargs["api_key"] == "restored-test-key"
+        assert agent.kwargs["api_mode"] == "anthropic_messages"
+        assert agent.kwargs["base_url"] == restored_base_url
+
 
 
 


### PR DESCRIPTION
```markdown
## What does this PR do?

Fixes ACP session restore for named custom providers.

ACP sessions persist the resolved provider as bare `custom`, plus metadata like `base_url` and `api_mode`. When a session was restored, Hermes passed that bare `custom` value back into runtime provider resolution, which could lose the original named provider identity such as `ark-copy`. As a result, restored ACP sessions could fail to recover the configured custom provider credentials and send requests without a valid API key.

This change recovers the named custom provider identity before resolving runtime credentials, and passes the restored base URL plus effective model into the resolver so the correct key and API mode are preserved.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/session.py`
  - Preserve the effective model used to create/restore ACP agents.
  - Recover named custom provider identity when restored session metadata only has `provider=custom`.
  - Pass `explicit_base_url` and `target_model` into `resolve_runtime_provider`.

- `tests/acp/test_session.py`
  - Added regression coverage for restoring a bare `custom` ACP session back to a named custom provider such as `ark-copy`.

## How to Test

1. Configure a named custom provider with an API key and non-default API mode, for example `ark-copy` using `api_mode: anthropic_messages`.
2. Restore or resume an ACP session whose persisted metadata contains `provider: custom`, the custom `base_url`, and model `glm-5.2`.
3. Verify Hermes resolves the named custom provider credentials and API mode instead of falling back to bare `custom`.

Automated test run:

```bash
python3 -m pytest tests/acp/test_session.py tests/acp/test_named_provider_catalogs.py -q
```

Result:

```text
22 passed
```

## Checklist

### Code

- [ ] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before this fix, restored ACP sessions for named custom providers could lose the provider identity and fail with provider authentication errors, for example sending an invalid or missing bearer token.

After this fix, the regression test verifies restored ACP sessions resolve back to the named custom provider and preserve:

- `api_key`
- `api_mode`
- `base_url`
- effective model
```