### PR TITLE
fix(yuanbao): await the forwarded-records loading heartbeat

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -2160,7 +2160,7 @@ class ForwardedRecordsParseMiddleware(InboundMiddleware):
     async def handle(self, ctx: InboundContext, next_fn) -> None:
         try:
             if ctx.forwarded_records:
-                self._send_loading_heartbeat(ctx)
+                await self._send_loading_heartbeat(ctx)
                 ctx.raw_text = self.build_forward_text(ctx.forwarded_records, ctx=ctx, is_dispatch=True)
         except Exception as exc:
             # Degrade gracefully: leave ctx.raw_text as-is.

--- a/tests/gateway/test_yuanbao_forwarded_heartbeat.py
+++ b/tests/gateway/test_yuanbao_forwarded_heartbeat.py
@@ -1,0 +1,74 @@
+"""ForwardedRecordsParseMiddleware must actually send its loading heartbeat.
+
+``_send_loading_heartbeat`` is a coroutine function. Calling it without
+``await`` builds a coroutine object and drops it, so the RUNNING heartbeat is
+never sent and Python raises "coroutine was never awaited" at collection time.
+Forwarded-record parsing is the slow inbound path, which is exactly where the
+user needs the loading bubble.
+"""
+
+import warnings
+
+import pytest
+
+from gateway.platforms.yuanbao import (
+    ForwardedRecordsParseMiddleware,
+    InboundContext,
+    WS_HEARTBEAT_RUNNING,
+)
+
+
+class _Heartbeat:
+    def __init__(self):
+        self.calls = []
+
+    async def send_heartbeat_once(self, chat_id, state):
+        self.calls.append((chat_id, state))
+
+
+class _Outbound:
+    def __init__(self):
+        self.heartbeat = _Heartbeat()
+
+
+class _Adapter:
+    name = "yuanbao"
+
+    def __init__(self):
+        self._outbound = _Outbound()
+
+
+@pytest.mark.asyncio
+async def test_forwarded_records_send_the_loading_heartbeat():
+    adapter = _Adapter()
+    ctx = InboundContext(adapter=adapter)
+    ctx.chat_id = "chat-1"
+    ctx.forwarded_records = [{"msgContent": {"text": "hello"}}]
+
+    called = []
+
+    async def _next():
+        called.append(True)
+
+    with warnings.catch_warnings():
+        # A dropped coroutine surfaces here as a RuntimeWarning rather than a
+        # failure; promote it so the regression cannot pass silently.
+        warnings.simplefilter("error", RuntimeWarning)
+        await ForwardedRecordsParseMiddleware().handle(ctx, _next)
+
+    assert adapter._outbound.heartbeat.calls == [("chat-1", WS_HEARTBEAT_RUNNING)]
+    assert called, "middleware must still call next_fn"
+
+
+@pytest.mark.asyncio
+async def test_no_forwarded_records_sends_no_heartbeat():
+    adapter = _Adapter()
+    ctx = InboundContext(adapter=adapter)
+    ctx.chat_id = "chat-1"
+
+    async def _next():
+        pass
+
+    await ForwardedRecordsParseMiddleware().handle(ctx, _next)
+
+    assert adapter._outbound.heartbeat.calls == []


### PR DESCRIPTION
Fixes #75232.

### The bug

`ForwardedRecordsParseMiddleware.handle()` calls the coroutine function `_send_loading_heartbeat()` without `await`, so the coroutine is built and dropped. The RUNNING heartbeat never reaches the client, and Python raises `RuntimeWarning: coroutine ... was never awaited`.

### The fix

One `await`. The helper is a `staticmethod`, so the binding was already correct.

Awaiting is safe here: `_send_loading_heartbeat` swallows every exception internally, and the call site is inside the middleware's own `try` block, which degrades gracefully by leaving `ctx.raw_text` untouched. Sending before the parse is also the intended order, since the parse is the slow part the bubble is meant to cover.

### Testing

New `tests/gateway/test_yuanbao_forwarded_heartbeat.py`:

- `test_forwarded_records_send_the_loading_heartbeat` drives the middleware with a fake adapter and asserts `send_heartbeat_once` was called once with `(chat_id, WS_HEARTBEAT_RUNNING)`, and that `next_fn` still runs. It raises `RuntimeWarning` to an error inside the call, so a future dropped coroutine fails the test rather than passing with a warning.
- `test_no_forwarded_records_sends_no_heartbeat` pins the negative case.

On `main` the first test fails with `RuntimeWarning: coroutine 'ForwardedRecordsParseMiddleware._send_loading_heartbeat' was never awaited`. With this change both pass, and `tests/gateway/ -k yuanbao` is 11 passed, 2 skipped.
