### PR TITLE
fix(responses): preserve explicit reasoning none

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -176,13 +176,27 @@ _OPENAI_RESPONSES_REASONING_NONE_PREFIXES = (
 )
 
 
-def _openai_responses_supports_reasoning_none(model: Any) -> bool:
+def _openai_responses_supports_reasoning_none(
+    model: Any,
+    *,
+    issuer_kind: str,
+    base_url: Any,
+) -> bool:
+    from utils import base_url_hostname
+
     normalized = str(model or "").strip().lower()
     if "/" in normalized:
         normalized = normalized.rsplit("/", 1)[-1]
-    return any(
+    model_supports_none = any(
         normalized == prefix or normalized.startswith(f"{prefix}-")
         for prefix in _OPENAI_RESPONSES_REASONING_NONE_PREFIXES
+    )
+    if not model_supports_none:
+        return False
+
+    return (
+        issuer_kind == "codex_backend"
+        or base_url_hostname(str(base_url or "")) == "api.openai.com"
     )
 
 
@@ -607,7 +621,11 @@ class ResponsesApiTransport(ProviderTransport):
         if explicit_reasoning_none and (
             is_xai_responses
             or is_github_responses
-            or not _openai_responses_supports_reasoning_none(model)
+            or not _openai_responses_supports_reasoning_none(
+                model,
+                issuer_kind=issuer_kind,
+                base_url=params.get("base_url"),
+            )
         ):
             raise ValueError(
                 f"Model {model!r} does not support reasoning_effort 'none' "

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -171,6 +171,21 @@ _EXTENDED_PROMPT_CACHE_MODEL_RE = re.compile(
 )
 
 
+_OPENAI_RESPONSES_REASONING_NONE_PREFIXES = (
+    "gpt-5.6",
+)
+
+
+def _openai_responses_supports_reasoning_none(model: Any) -> bool:
+    normalized = str(model or "").strip().lower()
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    return any(
+        normalized == prefix or normalized.startswith(f"{prefix}-")
+        for prefix in _OPENAI_RESPONSES_REASONING_NONE_PREFIXES
+    )
+
+
 def _default_prompt_cache_retention_for_request(
     model: str,
     base_url: Any,
@@ -535,10 +550,16 @@ class ResponsesApiTransport(ProviderTransport):
         # Resolve reasoning effort
         reasoning_effort = "medium"
         reasoning_enabled = True
+        explicit_reasoning_none = False
         reasoning_config = params.get("reasoning_config")
         if reasoning_config and isinstance(reasoning_config, dict):
             if reasoning_config.get("enabled") is False:
-                reasoning_enabled = False
+                # This is explicit disablement, not an unset value. On OpenAI
+                # Responses models that support it, the wire representation is
+                # ``reasoning.effort: none``; omitting ``reasoning`` silently
+                # falls back to the model default. See #75227.
+                reasoning_effort = "none"
+                explicit_reasoning_none = True
             elif reasoning_config.get("effort"):
                 reasoning_effort = reasoning_config["effort"]
 
@@ -583,6 +604,15 @@ class ResponsesApiTransport(ProviderTransport):
                 # rejected). #68365 premise confirmed.
                 _supported = codex_supported_efforts(model)
         reasoning_effort = clamp_effort(reasoning_effort, _supported)
+        if explicit_reasoning_none and (
+            is_xai_responses
+            or is_github_responses
+            or not _openai_responses_supports_reasoning_none(model)
+        ):
+            raise ValueError(
+                f"Model {model!r} does not support reasoning_effort 'none' "
+                "on the Responses API"
+            )
 
         response_tools = _responses_tools(tools)
 
@@ -720,6 +750,8 @@ class ResponsesApiTransport(ProviderTransport):
                 github_reasoning = params.get("github_reasoning_extra")
                 if github_reasoning is not None:
                     kwargs["reasoning"] = github_reasoning
+            elif explicit_reasoning_none:
+                kwargs["reasoning"] = {"effort": "none"}
             else:
                 kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
                 kwargs["include"] = (

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -116,13 +116,27 @@ _OPENAI_RESPONSES_REASONING_NONE_PREFIXES = (
 )
 
 
-def _openai_responses_supports_reasoning_none(model: Any) -> bool:
+def _openai_responses_supports_reasoning_none(
+    model: Any,
+    *,
+    issuer_kind: str,
+    base_url: Any,
+) -> bool:
+    from utils import base_url_hostname
+
     normalized = str(model or "").strip().lower()
     if "/" in normalized:
         normalized = normalized.rsplit("/", 1)[-1]
-    return any(
+    model_supports_none = any(
         normalized == prefix or normalized.startswith(f"{prefix}-")
         for prefix in _OPENAI_RESPONSES_REASONING_NONE_PREFIXES
+    )
+    if not model_supports_none:
+        return False
+
+    return (
+        issuer_kind == "codex_backend"
+        or base_url_hostname(str(base_url or "")) == "api.openai.com"
     )
 
 
@@ -328,7 +342,11 @@ class ResponsesApiTransport(ProviderTransport):
         if explicit_reasoning_none and (
             is_xai_responses
             or is_github_responses
-            or not _openai_responses_supports_reasoning_none(model)
+            or not _openai_responses_supports_reasoning_none(
+                model,
+                issuer_kind=issuer_kind,
+                base_url=params.get("base_url"),
+            )
         ):
             raise ValueError(
                 f"Model {model!r} does not support reasoning_effort 'none' "

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -111,6 +111,21 @@ _EXTENDED_PROMPT_CACHE_MODEL_RE = re.compile(
 )
 
 
+_OPENAI_RESPONSES_REASONING_NONE_PREFIXES = (
+    "gpt-5.6",
+)
+
+
+def _openai_responses_supports_reasoning_none(model: Any) -> bool:
+    normalized = str(model or "").strip().lower()
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    return any(
+        normalized == prefix or normalized.startswith(f"{prefix}-")
+        for prefix in _OPENAI_RESPONSES_REASONING_NONE_PREFIXES
+    )
+
+
 def _default_prompt_cache_retention_for_request(
     model: str,
     base_url: Any,
@@ -283,10 +298,16 @@ class ResponsesApiTransport(ProviderTransport):
         # Resolve reasoning effort
         reasoning_effort = "medium"
         reasoning_enabled = True
+        explicit_reasoning_none = False
         reasoning_config = params.get("reasoning_config")
         if reasoning_config and isinstance(reasoning_config, dict):
             if reasoning_config.get("enabled") is False:
-                reasoning_enabled = False
+                # This is explicit disablement, not an unset value. On OpenAI
+                # Responses models that support it, the wire representation is
+                # ``reasoning.effort: none``; omitting ``reasoning`` silently
+                # falls back to the model default. See #75227.
+                reasoning_effort = "none"
+                explicit_reasoning_none = True
             elif reasoning_config.get("effort"):
                 reasoning_effort = reasoning_config["effort"]
 
@@ -304,6 +325,15 @@ class ResponsesApiTransport(ProviderTransport):
             # line 1 column 1"). Clamp Hermes' wider set to the supported one.
             _effort_clamp.update({"xhigh": "high", "ultra": "max"})
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
+        if explicit_reasoning_none and (
+            is_xai_responses
+            or is_github_responses
+            or not _openai_responses_supports_reasoning_none(model)
+        ):
+            raise ValueError(
+                f"Model {model!r} does not support reasoning_effort 'none' "
+                "on the Responses API"
+            )
 
         response_tools = _responses_tools(tools)
 
@@ -415,6 +445,8 @@ class ResponsesApiTransport(ProviderTransport):
                 github_reasoning = params.get("github_reasoning_extra")
                 if github_reasoning is not None:
                     kwargs["reasoning"] = github_reasoning
+            elif explicit_reasoning_none:
+                kwargs["reasoning"] = {"effort": "none"}
             else:
                 kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
                 kwargs["include"] = (

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -308,10 +308,34 @@ def test_responses_transport_preserves_explicit_reasoning_none_for_gpt56():
         model="gpt-5.6-sol",
         messages=[{"role": "user", "content": "hi"}],
         reasoning_config={"enabled": False},
+        base_url="https://api.openai.com/v1",
     )
 
     assert kwargs["reasoning"] == {"effort": "none"}
     assert "include" not in kwargs
+
+
+def test_responses_transport_preserves_explicit_reasoning_none_for_codex_backend():
+    kwargs = ResponsesApiTransport().build_kwargs(
+        model="gpt-5.6-sol",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_config={"enabled": False},
+        base_url="https://chatgpt.com/backend-api/codex",
+        is_codex_backend=True,
+    )
+
+    assert kwargs["reasoning"] == {"effort": "none"}
+    assert "include" not in kwargs
+
+
+def test_responses_transport_rejects_reasoning_none_for_unknown_endpoint():
+    with pytest.raises(ValueError, match="does not support reasoning_effort 'none'"):
+        ResponsesApiTransport().build_kwargs(
+            model="gpt-5.6-sol",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": False},
+            base_url="https://responses-relay.example/v1",
+        )
 
 
 def test_responses_transport_rejects_reasoning_none_for_unknown_support():

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -12,6 +12,7 @@ from agent.codex_responses_adapter import (
     _preflight_codex_api_kwargs,
     _preflight_codex_input_items,
 )
+from agent.transports.codex import ResponsesApiTransport
 
 
 _HARMONY_SOURCE_SNIPPET = (
@@ -300,6 +301,28 @@ def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
 
 _OVERSIZED_ITEM_ID = "x" * 408
 _VALID_ITEM_ID = "msg_abc123"
+
+
+def test_responses_transport_preserves_explicit_reasoning_none_for_gpt56():
+    kwargs = ResponsesApiTransport().build_kwargs(
+        model="gpt-5.6-sol",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_config={"enabled": False},
+    )
+
+    assert kwargs["reasoning"] == {"effort": "none"}
+    assert "include" not in kwargs
+
+
+def test_responses_transport_rejects_reasoning_none_for_unknown_support():
+    with pytest.raises(ValueError, match="does not support reasoning_effort 'none'"):
+        ResponsesApiTransport().build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": False},
+        )
+
+
 
 
 # The codex app-server overflows the Responses 64-char call_id limit for

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -267,10 +267,34 @@ def test_responses_transport_preserves_explicit_reasoning_none_for_gpt56():
         model="gpt-5.6-sol",
         messages=[{"role": "user", "content": "hi"}],
         reasoning_config={"enabled": False},
+        base_url="https://api.openai.com/v1",
     )
 
     assert kwargs["reasoning"] == {"effort": "none"}
     assert "include" not in kwargs
+
+
+def test_responses_transport_preserves_explicit_reasoning_none_for_codex_backend():
+    kwargs = ResponsesApiTransport().build_kwargs(
+        model="gpt-5.6-sol",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_config={"enabled": False},
+        base_url="https://chatgpt.com/backend-api/codex",
+        is_codex_backend=True,
+    )
+
+    assert kwargs["reasoning"] == {"effort": "none"}
+    assert "include" not in kwargs
+
+
+def test_responses_transport_rejects_reasoning_none_for_unknown_endpoint():
+    with pytest.raises(ValueError, match="does not support reasoning_effort 'none'"):
+        ResponsesApiTransport().build_kwargs(
+            model="gpt-5.6-sol",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": False},
+            base_url="https://responses-relay.example/v1",
+        )
 
 
 def test_responses_transport_rejects_reasoning_none_for_unknown_support():

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -10,6 +10,7 @@ from agent.codex_responses_adapter import (
     _preflight_codex_api_kwargs,
     _preflight_codex_input_items,
 )
+from agent.transports.codex import ResponsesApiTransport
 
 
 _HARMONY_SOURCE_SNIPPET = (
@@ -259,6 +260,26 @@ def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
 
 _OVERSIZED_ITEM_ID = "x" * 408
 _VALID_ITEM_ID = "msg_abc123"
+
+
+def test_responses_transport_preserves_explicit_reasoning_none_for_gpt56():
+    kwargs = ResponsesApiTransport().build_kwargs(
+        model="gpt-5.6-sol",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_config={"enabled": False},
+    )
+
+    assert kwargs["reasoning"] == {"effort": "none"}
+    assert "include" not in kwargs
+
+
+def test_responses_transport_rejects_reasoning_none_for_unknown_support():
+    with pytest.raises(ValueError, match="does not support reasoning_effort 'none'"):
+        ResponsesApiTransport().build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": False},
+        )
 
 
 


### PR DESCRIPTION
Fixes #75227.

## Summary

- Preserve an explicit `reasoning_effort: none` through the OpenAI Responses transport for GPT-5.6 models by sending `reasoning.effort: "none"` instead of omitting `reasoning`.
- Fail fast when `none` is requested on a Responses route/model where Hermes does not know that value is supported, instead of silently falling back to the model default.
- Add focused transport coverage for the GPT-5.6 wire payload and the unsupported-model error path.

## Validation

- `scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py -q`
- `scripts/run_tests.sh tests/tui_gateway/test_reasoning_session_scope.py -q`
- `python -m py_compile agent/transports/codex.py tests/agent/test_codex_responses_adapter.py`
- `git diff --check`
