### PR TITLE
fix(auth): preserve store on transient read errors

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1124,18 +1124,38 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
 
     try:
         raw = json.loads(auth_file.read_text(encoding="utf-8"))
-    except Exception as exc:
+    except OSError:
+        logger.warning(
+            "auth: could not read %s — leaving the store on disk untouched "
+            "rather than degrading to an empty one",
+            auth_file,
+            exc_info=True,
+        )
+        raise
+    except json.JSONDecodeError as exc:
         corrupt_path = auth_file.with_suffix(".json.corrupt")
+        copied = False
         try:
             import shutil
             shutil.copy2(auth_file, corrupt_path)
-        except Exception:
-            pass
-        logger.warning(
-            "auth: failed to parse %s (%s) — starting with empty store. "
-            "Corrupt file preserved at %s",
-            auth_file, exc, corrupt_path,
-        )
+            copied = True
+        except Exception as copy_exc:
+            logger.warning(
+                "auth: failed to preserve corrupt auth store %s at %s (%s)",
+                auth_file, corrupt_path, copy_exc,
+            )
+        if copied:
+            logger.warning(
+                "auth: failed to parse %s (%s) — starting with empty store. "
+                "Corrupt file preserved at %s",
+                auth_file, exc, corrupt_path,
+            )
+        else:
+            logger.warning(
+                "auth: failed to parse %s (%s) — starting with empty store. "
+                "Could not preserve corrupt file at %s",
+                auth_file, exc, corrupt_path,
+            )
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
     if isinstance(raw, dict) and (

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1132,7 +1132,7 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
             exc_info=True,
         )
         raise
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         corrupt_path = auth_file.with_suffix(".json.corrupt")
         copied = False
         try:

--- a/tests/hermes_cli/test_auth_store_read_errors.py
+++ b/tests/hermes_cli/test_auth_store_read_errors.py
@@ -25,6 +25,17 @@ def test_load_auth_store_propagates_transient_read_errors(tmp_path):
     assert not auth_file.with_suffix(".json.corrupt").exists()
 
 
+def test_load_auth_store_preserves_invalid_utf8_before_empty_store(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    raw = b'{"version": 1, "providers": {"nous": "\xff"}}'
+    auth_file.write_bytes(raw)
+
+    store = auth._load_auth_store(auth_file)
+
+    assert store == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
+    assert auth_file.with_suffix(".json.corrupt").read_bytes() == raw
+
+
 def test_load_auth_store_preserves_corrupt_json_before_empty_store(tmp_path):
     auth_file = tmp_path / "auth.json"
     raw = '{"version": 1, "providers": {'

--- a/tests/hermes_cli/test_auth_store_read_errors.py
+++ b/tests/hermes_cli/test_auth_store_read_errors.py
@@ -1,0 +1,37 @@
+import errno
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from hermes_cli import auth
+
+
+def test_load_auth_store_propagates_transient_read_errors(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    original = {"version": 1, "providers": {"nous": {"access_token": "tok"}}}
+    auth_file.write_text(json.dumps(original), encoding="utf-8")
+
+    with mock.patch.object(
+        Path,
+        "read_text",
+        side_effect=OSError(errno.EMFILE, "Too many open files"),
+    ):
+        with pytest.raises(OSError):
+            auth._load_auth_store(auth_file)
+
+    assert json.loads(auth_file.read_text(encoding="utf-8")) == original
+    assert not auth_file.with_suffix(".json.corrupt").exists()
+
+
+def test_load_auth_store_preserves_corrupt_json_before_empty_store(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    raw = '{"version": 1, "providers": {'
+    auth_file.write_text(raw, encoding="utf-8")
+
+    store = auth._load_auth_store(auth_file)
+
+    assert store == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
+    corrupt_file = auth_file.with_suffix(".json.corrupt")
+    assert corrupt_file.read_text(encoding="utf-8") == raw


### PR DESCRIPTION
Fixes #75206.

## Summary

- Treat auth-store `OSError` read failures as transient I/O failures, not JSON corruption, and propagate them so callers do not read-modify-write an empty credential store over the real file.
- Keep the malformed-JSON recovery path intact, but only claim a `.corrupt` sidecar was preserved after the copy succeeds.
- Add regression coverage for both transient read errors and genuine corrupt JSON preservation.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_auth_store_read_errors.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_auth_toctou_file_modes.py tests/hermes_cli/test_auth_nous_provider.py -q`
- `python -m py_compile hermes_cli/auth.py tests/hermes_cli/test_auth_store_read_errors.py`
- `git diff --check`
