### PR TITLE
fix(sync): read org state from the org endpoints, not the personal ones

### DIFF
--- a/tests/tools/test_skills_sync_client.py
+++ b/tests/tools/test_skills_sync_client.py
@@ -39,6 +39,12 @@ class _MockState:
         # when org_role_admin is False, convert org-HEAD CAS to 202 proposals.
         self.org_feature = True
         self.org_role_admin = True
+        self.org_role_present = True
+        # Org objects live in a SEPARATE scope from personal ones, mirroring
+        # production's `org:<org_id>` scope key. Keeping them in a distinct
+        # dict is what makes a personal-route read of org content 404 in tests
+        # exactly as it does against the real plane.
+        self.org_objects = {}
         self.proposals = []  # [{n, to, base}]
 
 
@@ -79,35 +85,59 @@ def _make_handler(state: _MockState):
                     if part.startswith("prefix="):
                         from urllib.parse import unquote
                         prefix = unquote(part[len("prefix="):])
+                # FAITHFUL TO PRODUCTION: the personal refs route is scoped to
+                # the caller's own owner and does NOT serve org refs. Asking it
+                # for an `refs/org/...` prefix yields the caller's personal
+                # refs, not an error — the exact trap that let a broken client
+                # look healthy against an over-permissive mock.
                 refs = [
                     {"name": n, "hash": h}
                     for n, h in state.refs.items()
-                    if n.startswith(prefix)
+                    if n.startswith(prefix) and not n.startswith("refs/org/")
                 ]
                 return self._json(200, {"refs": refs})
 
+            if path == "/v1/sync/org/refs":
+                if not state.org_feature:
+                    return self._json(404, {"error": "unknown"})
+                if not state.org_role_present:
+                    return self._json(403, {"error": "org_workflow_unavailable"})
+                refs = [
+                    {"name": n, "hash": h}
+                    for n, h in state.refs.items()
+                    if n.startswith("refs/org/")
+                ]
+                return self._json(200, {"refs": refs})
+
+            if path.startswith("/v1/sync/org/objects/"):
+                if not state.org_role_present:
+                    return self._json(403, {"error": "org_workflow_unavailable"})
+                obj_hash = path[len("/v1/sync/org/objects/"):]
+                if obj_hash not in state.org_objects:
+                    return self._json(404, {"error": "not_found"})
+                return self._send_object(*state.org_objects[obj_hash])
+
             if path.startswith("/v1/sync/objects/"):
                 obj_hash = path[len("/v1/sync/objects/"):]
+                # Org-scoped objects are NOT readable through the personal
+                # route (production scopes it to the token owner).
                 if obj_hash not in state.objects:
                     return self._json(404, {"error": "not_found"})
-                kind, data = state.objects[obj_hash]
-                if kind == ssc.KIND_BLOB:
-                    self.send_response(200)
-                    self.send_header("Content-Type", "application/octet-stream")
-                    self.send_header("X-HSP-Object-Type", "blob")
-                    self.send_header("Content-Length", str(len(data)))
-                    self.end_headers()
-                    self.wfile.write(data)
-                    return
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("X-HSP-Object-Type", kind)
-                self.send_header("Content-Length", str(len(data)))
-                self.end_headers()
-                self.wfile.write(data)
-                return
+                return self._send_object(*state.objects[obj_hash])
 
             self._json(404, {"error": "unknown"})
+
+        def _send_object(self, kind, data):
+            self.send_response(200)
+            self.send_header(
+                "Content-Type",
+                "application/octet-stream" if kind == ssc.KIND_BLOB else "application/json",
+            )
+            self.send_header("X-HSP-Object-Type", kind)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
 
         def do_POST(self):
             length = int(self.headers.get("Content-Length", 0))
@@ -115,14 +145,14 @@ def _make_handler(state: _MockState):
             path = self.path.split("?", 1)[0]  # e.g. /v1/sync/objects?scope=org
 
             if path == "/v1/sync/objects":
-                return self._handle_put_objects(raw)
+                return self._handle_put_objects(raw, org="scope=org" in self.path)
 
             if path.startswith("/v1/sync/refs/"):
                 return self._handle_cas(raw)
 
             self._json(404, {"error": "unknown"})
 
-        def _handle_put_objects(self, raw):
+        def _handle_put_objects(self, raw, org=False):
             # multipart/form-data: parse parts (field=hash, filename=type,
             # body=raw bytes). The server recomputes each hash and 422s on
             # mismatch (contract §4.2).
@@ -163,10 +193,11 @@ def _make_handler(state: _MockState):
                     return self._json(422, {
                         "error": "hash_mismatch", "claimed": claimed_hash,
                     })
-                if claimed_hash in state.objects:
+                store = state.org_objects if org else state.objects
+                if claimed_hash in store:
                     already.append(claimed_hash)
                 else:
-                    state.objects[claimed_hash] = (kind, body)
+                    store[claimed_hash] = (kind, body)
                     accepted.append(claimed_hash)
             return self._json(200, {"accepted": accepted, "already_present": already})
 
@@ -890,7 +921,9 @@ class TestOrgEndToEnd:
         assert result.get("merged") is True
         head = state.refs["refs/org/org-1/HEAD"]
         assert head == result["head"]
-        commit = json.loads(state.objects[head][1])
+        # Org content lands in the ORG object scope, not the personal one.
+        assert head not in state.objects, "org commit must not be personal-scoped"
+        commit = json.loads(state.org_objects[head][1])
         assert commit["parents"] == []  # first org commit
 
     def test_member_propose_becomes_202_proposal(self, mock_server, synced_env):
@@ -931,8 +964,8 @@ class TestOrgEndToEnd:
         member_ident = {**identity, "org_id": "org-1", "org_role": "MEMBER"}
         result = ssc.propose_skill("alpha", client, identity=member_ident)
         # Walk the proposed commit's root: both skills present.
-        commit = json.loads(state.objects[result["commit"]][1])
-        root = json.loads(state.objects[commit["tree"]][1])
+        commit = json.loads(state.org_objects[result["commit"]][1])
+        root = json.loads(state.org_objects[commit["tree"]][1])
         names = {e["name"] for e in root["entries"]}
         assert "alpha" in names and "devops" in names
 
@@ -976,3 +1009,107 @@ class TestOrgEndToEnd:
         monkeypatch.setattr(auth_mod, "resolve_nous_runtime_credentials",
                             lambda **kw: {"api_key": token})
         assert ssc.maybe_pull_org_skills() is None
+
+
+class TestOrgEndpointScoping:
+    """Org reads must use the ORG endpoints, not the personal ones.
+
+    The personal refs route is scoped to the caller's own owner: asked for an
+    ``refs/org/...`` prefix it returns the caller's PERSONAL refs rather than
+    erroring. A client reading org state through it therefore concludes "this
+    org has no content" and every subsequent CAS races a head it never saw —
+    which is exactly how a second propose used to die on a raw SyncConflict.
+    """
+
+    def _admin(self, identity):
+        return {**identity, "org_id": "org-1", "org_role": "ADMIN"}
+
+    def test_org_head_is_not_visible_on_the_personal_route(
+        self, mock_server, synced_env
+    ):
+        base, state = mock_server
+        home, skills, identity = synced_env
+        state.refs["refs/org/org-1/HEAD"] = "sha256:" + "a" * 64
+        client = ssc.SyncClient(base, identity["api_key"])
+
+        personal = client.get_refs("refs/org/org-1/")
+        assert personal == [], (
+            "the personal refs route must not serve org refs — if it does, "
+            "the mock is more permissive than production and will hide bugs"
+        )
+        org = client.get_refs("refs/org/org-1/", org_scope=True)
+        assert [r["name"] for r in org] == ["refs/org/org-1/HEAD"]
+
+    def test_second_propose_splices_onto_the_existing_org_head(
+        self, mock_server, synced_env
+    ):
+        """The regression: propose #1 works, propose #2 used to raise."""
+        base, state = mock_server
+        home, skills, identity = synced_env
+        admin = self._admin(identity)
+        client = ssc.SyncClient(base, identity["api_key"])
+
+        # `synced_env` already seeds alpha and beta (beta under devops/).
+        first = ssc.propose_skill("alpha", client, identity=admin)
+        assert first["ok"] is True
+
+        # Previously: base_head read as None -> CAS from None -> 409 ->
+        # SyncConflict escaped to the caller.
+        second = ssc.propose_skill("beta", client, identity=admin)
+        assert second["ok"] is True
+
+        # And the splice preserved the first skill rather than replacing it.
+        head = state.refs["refs/org/org-1/HEAD"]
+        commit = json.loads(state.org_objects[head][1])
+        root = json.loads(state.org_objects[commit["tree"]][1])
+        names = {e["name"] for e in root["entries"]}
+        # beta is seeded under the devops/ category, so it appears as that
+        # category tree at the root.
+        assert "alpha" in names and "devops" in names
+        assert commit["parents"], "second commit must descend from the first"
+
+    def test_pull_org_skills_sees_an_existing_org_head(
+        self, mock_server, synced_env
+    ):
+        """pull_org_skills used to report head=None for a populated org."""
+        base, state = mock_server
+        home, skills, identity = synced_env
+        admin = self._admin(identity)
+        client = ssc.SyncClient(base, identity["api_key"])
+        ssc.propose_skill("alpha", client, identity=admin)
+
+        result = ssc.pull_org_skills(client=client, identity=admin)
+        assert result["ok"] is True
+        assert result["head"] == state.refs["refs/org/org-1/HEAD"], (
+            "pull must resolve the real org HEAD, not None"
+        )
+        assert result["updated"], "the org's skill must materialize"
+
+
+class TestEmptyActualConflict:
+    """A 409 with an empty ``actual`` means the ref does not exist."""
+
+    def test_conflict_actual_empty_becomes_none(self):
+        c = ssc.SyncConflict("")
+        assert c.actual is None
+        assert "does not exist" in str(c)
+
+    def test_push_recovers_from_a_stale_local_head(self, mock_server, synced_env):
+        """Switching sync planes leaves a foreign head in local state.
+
+        The CAS then fails against a ref that does not exist, and the server
+        answers 409 with an empty ``actual``. The client must redo the CAS as
+        a create rather than trying to fetch "" as a commit (which surfaced as
+        the bizarre `object  not found`, with a doubled space).
+        """
+        base, state = mock_server
+        home, skills, identity = synced_env
+        st = ssc.read_sync_state()
+        st["head"] = "sha256:" + "f" * 64  # head from another plane
+        ssc.write_sync_state(st)
+
+        client = ssc.SyncClient(base, identity["api_key"])
+        result = ssc.push_skills(client=client, identity=identity)
+        assert result["ok"] is True
+        assert result.get("recovered_stale_head") is True
+        assert state.refs[ssc.user_head_ref(identity["owner"])] == result["head"]

--- a/tools/skills_sync_client.py
+++ b/tools/skills_sync_client.py
@@ -744,12 +744,24 @@ class SyncError(RuntimeError):
 
 
 class SyncConflict(RuntimeError):
-    """CAS lost (409). ``actual`` is the current head to merge against
-    (contract §4.4). NOT a rejection -- pushed objects are already durable."""
+    """CAS lost (409). NOT a rejection -- pushed objects are already durable.
 
-    def __init__(self, actual: str):
-        super().__init__(f"CAS conflict; actual head {actual}")
-        self.actual = actual
+    ``actual`` is the current head to merge against, or **None** when the ref
+    does not exist server-side (the server reports that as an empty string).
+    None means "there is nothing to merge against, retry as a create" -- it
+    must never be fetched as an object.
+    """
+
+    def __init__(self, actual: Optional[str]):
+        # Normalize here, not at the call site: the server sends "" for a
+        # non-existent ref, and every consumer must see that as None rather
+        # than an empty hash it might try to fetch.
+        self.actual: Optional[str] = actual or None
+        super().__init__(
+            f"CAS conflict; actual head {self.actual}"
+            if self.actual
+            else "CAS conflict; the ref does not exist yet"
+        )
 
 
 class SyncClient:
@@ -777,22 +789,39 @@ class SyncClient:
             raise SyncError(f"capabilities failed: {r.status_code}", status=r.status_code)
         return r.json()
 
-    def get_refs(self, prefix: str) -> List[Dict[str, str]]:
-        """GET /v1/sync/refs?prefix=... (sync contract)."""
-        r = self._session.get(
-            self._url("refs"), params={"prefix": prefix}, timeout=self.timeout
-        )
+    def get_refs(self, prefix: str, *, org_scope: bool = False) -> List[Dict[str, str]]:
+        """GET /v1/sync/refs?prefix=... (or the org route when ``org_scope``).
+
+        Org refs live behind a SEPARATE endpoint, not behind a prefix filter on
+        the personal one: the personal route is hard-scoped to the token's own
+        owner, so asking it for ``refs/org/<id>/`` silently returns the
+        caller's personal refs instead of an error. Callers reading an org ref
+        MUST pass ``org_scope=True``.
+        """
+        path = "org/refs" if org_scope else "refs"
+        params = None if org_scope else {"prefix": prefix}
+        r = self._session.get(self._url(path), params=params, timeout=self.timeout)
         if r.status_code != 200:
             raise SyncError(f"get_refs failed: {r.status_code}", status=r.status_code)
-        return (r.json() or {}).get("refs", [])
+        refs = (r.json() or {}).get("refs", [])
+        if org_scope:
+            # The org route returns the org's refs unfiltered; apply the
+            # prefix client-side so both modes have the same contract.
+            refs = [r_ for r_ in refs if str(r_.get("name", "")).startswith(prefix)]
+        return refs
 
-    def get_object(self, obj_hash: str) -> Tuple[str, bytes]:
-        """GET /v1/sync/objects/:hash (sync contract). Returns (kind, bytes).
+    def get_object(self, obj_hash: str, *, org_scope: bool = False) -> Tuple[str, bytes]:
+        """GET /v1/sync/objects/:hash (or the org route when ``org_scope``).
 
         Kind comes from the object-type response header for tree/commit; a blob
         (application/octet-stream) is returned as ``blob``.
+
+        Org objects are stored under the ``org:<org_id>`` scope key and are NOT
+        readable through the personal route (it scopes to the token's owner),
+        so walking an org commit requires ``org_scope=True`` on every hop.
         """
-        r = self._session.get(self._url(f"objects/{obj_hash}"), timeout=self.timeout)
+        path = f"org/objects/{obj_hash}" if org_scope else f"objects/{obj_hash}"
+        r = self._session.get(self._url(path), timeout=self.timeout)
         if r.status_code == 404:
             raise SyncError(f"object {obj_hash} not found", status=404)
         if r.status_code == 403:
@@ -802,16 +831,20 @@ class SyncClient:
         kind = r.headers.get("X-HSP-Object-Type") or KIND_BLOB
         return kind, r.content
 
-    def get_commit_json(self, commit_hash: str) -> Dict[str, Any]:
+    def get_commit_json(
+        self, commit_hash: str, *, org_scope: bool = False
+    ) -> Dict[str, Any]:
         """Fetch a commit object and parse its canonical JSON."""
-        kind, data = self.get_object(commit_hash)
+        kind, data = self.get_object(commit_hash, org_scope=org_scope)
         if kind != KIND_COMMIT:
             raise SyncError(f"{commit_hash} is {kind}, expected commit")
         return json.loads(data.decode("utf-8"))
 
-    def get_tree_json(self, tree_hash: str) -> Dict[str, Any]:
+    def get_tree_json(
+        self, tree_hash: str, *, org_scope: bool = False
+    ) -> Dict[str, Any]:
         """Fetch a tree object and parse its canonical JSON."""
-        kind, data = self.get_object(tree_hash)
+        kind, data = self.get_object(tree_hash, org_scope=org_scope)
         if kind != KIND_TREE:
             raise SyncError(f"{tree_hash} is {kind}, expected tree")
         return json.loads(data.decode("utf-8"))
@@ -884,8 +917,10 @@ class SyncClient:
             body = r.json() if r.content else {}
             return {"proposal_pending": True, **body}
         if r.status_code == 409:
-            actual = (r.json() or {}).get("actual", "")
-            raise SyncConflict(actual)
+            # An EMPTY `actual` means the ref does not exist server-side (the
+            # CAS lost against "no head"), NOT that there is a commit to merge
+            # against. Callers must not try to fetch it as an object.
+            raise SyncConflict((r.json() or {}).get("actual", ""))
         if r.status_code == 403:
             raise SyncError("forbidden (403) -- owner/permission", status=403)
         if r.status_code != 200:
@@ -983,7 +1018,9 @@ def write_sync_state(data: Dict[str, Any]) -> None:
 # Tree materialization (pull) -- write a tree back to a skill directory
 # ---------------------------------------------------------------------------
 
-def materialize_tree(client: SyncClient, tree_hash: str, dest: Path) -> None:
+def materialize_tree(
+    client: SyncClient, tree_hash: str, dest: Path, *, org_scope: bool = False
+) -> None:
     """Write the tree at *tree_hash* into *dest* (created if needed).
 
     Blobs become files (with +x restored for ``exec`` mode), nested trees
@@ -991,7 +1028,7 @@ def materialize_tree(client: SyncClient, tree_hash: str, dest: Path) -> None:
     caller decides removal semantics. Refuses path traversal via entry names.
     """
     dest.mkdir(parents=True, exist_ok=True)
-    tree = client.get_tree_json(tree_hash)
+    tree = client.get_tree_json(tree_hash, org_scope=org_scope)
     for entry in tree.get("entries", []):
         name = entry.get("name", "")
         if not name or "/" in name or name in (".", ".."):
@@ -1000,9 +1037,9 @@ def materialize_tree(client: SyncClient, tree_hash: str, dest: Path) -> None:
         target = dest / name
         kind = entry.get("kind")
         if kind == KIND_TREE:
-            materialize_tree(client, entry["hash"], target)
+            materialize_tree(client, entry["hash"], target, org_scope=org_scope)
         elif kind == KIND_BLOB:
-            _, data = client.get_object(entry["hash"])
+            _, data = client.get_object(entry["hash"], org_scope=org_scope)
             target.write_bytes(data)
             if entry.get("mode") == MODE_EXEC:
                 try:
@@ -1140,12 +1177,16 @@ def user_conflict_ref(owner: str, n: int) -> str:
     return f"refs/user/{owner}/conflict/{n}"
 
 
-def _root_tree_of_commit(client: "SyncClient", commit_hash: str) -> str:
+def _root_tree_of_commit(
+    client: "SyncClient", commit_hash: str, *, org_scope: bool = False
+) -> str:
     """Return the tree hash referenced by a commit."""
-    return client.get_commit_json(commit_hash)["tree"]
+    return client.get_commit_json(commit_hash, org_scope=org_scope)["tree"]
 
 
-def _skill_trees_of_root(client: "SyncClient", root_tree_hash: str) -> Dict[str, str]:
+def _skill_trees_of_root(
+    client: "SyncClient", root_tree_hash: str, *, org_scope: bool = False
+) -> Dict[str, str]:
     """Flatten a profile-root tree into ``{posix_rel_path: skill_tree_hash}``.
 
     A skill tree is any tree containing a ``SKILL.md`` blob entry. We walk the
@@ -1155,7 +1196,7 @@ def _skill_trees_of_root(client: "SyncClient", root_tree_hash: str) -> Dict[str,
     result: Dict[str, str] = {}
 
     def _walk(tree_hash: str, prefix: str) -> None:
-        tree = client.get_tree_json(tree_hash)
+        tree = client.get_tree_json(tree_hash, org_scope=org_scope)
         entries = tree.get("entries", [])
         has_skill_md = any(
             e.get("name") == "SKILL.md" and e.get("kind") == KIND_BLOB for e in entries
@@ -1272,6 +1313,20 @@ def push_skills(
         write_sync_state(manifest)
         return {"ok": True, "head": commit_hash, "pushed_objects": len(objects)}
     except SyncConflict as conflict:
+        if not conflict.actual:
+            # The ref does not exist server-side: our `from` was a stale head
+            # (commonly a local state file carried over from another sync
+            # plane). There is nothing to merge — redo the CAS as a create.
+            client.cas_ref(ref, None, commit_hash)
+            manifest["head"] = commit_hash
+            manifest["root"] = root_hash
+            write_sync_state(manifest)
+            return {
+                "ok": True,
+                "head": commit_hash,
+                "pushed_objects": len(objects),
+                "recovered_stale_head": True,
+            }
         return _resolve_push_conflict(
             client, identity, conflict.actual, root_hash, commit_hash,
             objects, skill_names, message, base_head,
@@ -1718,6 +1773,26 @@ def org_sync_available() -> bool:
         return False
 
 
+# How many times a propose will re-splice onto a moved org HEAD before giving
+# up. Small: contention means other members are actively proposing, and an
+# unbounded loop would spin.
+_ORG_CAS_MAX_ATTEMPTS = 5
+
+
+def _read_org_head(client: "SyncClient", org_id: str) -> Optional[str]:
+    """Current ``refs/org/<org_id>/HEAD``, or None if the org has no content.
+
+    Reads through the ORG endpoint. The personal refs route is scoped to the
+    caller's own owner and answers an ``refs/org/...`` prefix with the caller's
+    PERSONAL refs, so a personal-route read here silently reports "no org head"
+    and every subsequent CAS races against a head it never saw.
+    """
+    refs = client.get_refs(f"refs/org/{org_id}/", org_scope=True)
+    return next(
+        (r["hash"] for r in refs if r.get("name") == org_head_ref(org_id)), None
+    )
+
+
 def org_head_ref(org_id: str) -> str:
     return f"refs/org/{org_id}/HEAD"
 
@@ -1755,10 +1830,7 @@ def pull_org_skills(
     if "org" not in (caps.get("features") or []):
         raise SyncInertError("this server does not support org-shared skills")
 
-    refs = client.get_refs(f"refs/org/{org_id}/")
-    head = next(
-        (r["hash"] for r in refs if r.get("name") == org_head_ref(org_id)), None
-    )
+    head = _read_org_head(client, org_id)
     # TOKEN-GATED resolution marker (agent/skill_utils.read_active_org_id):
     # written HERE because this function only runs after resolve_org_identity
     # verified the token's org_id + org_role. Discovery scans only the marked
@@ -1768,9 +1840,9 @@ def pull_org_skills(
     if not head:
         return {"ok": True, "org_id": org_id, "head": None, "updated": []}
 
-    head_commit = client.get_commit_json(head)
+    head_commit = client.get_commit_json(head, org_scope=True)
     root_tree = head_commit["tree"]
-    skill_trees = _skill_trees_of_root(client, root_tree)
+    skill_trees = _skill_trees_of_root(client, root_tree, org_scope=True)
 
     dest_root = _org_dir() / org_id
     updated: List[str] = []
@@ -1797,7 +1869,7 @@ def pull_org_skills(
 
                 shutil.rmtree(dest)
             dest.mkdir(parents=True, exist_ok=True)
-            materialize_tree(client, tree_hash, dest)
+            materialize_tree(client, tree_hash, dest, org_scope=True)
             baseline[rel_path] = {
                 "fingerprint": _skill_dir_fingerprint(dest),
                 "tree": tree_hash,
@@ -1991,29 +2063,51 @@ def propose_skill(
     # Base = current org HEAD (None for the org's first content). The proposed
     # root is HEAD's skill-tree map with this one skill spliced in — proposals
     # are per-skill deltas, never a wholesale replace of the org set.
-    refs = client.get_refs(f"refs/org/{org_id}/")
-    base_head = next(
-        (r["hash"] for r in refs if r.get("name") == org_head_ref(org_id)), None
-    )
-    if base_head:
-        base_root = _root_tree_of_commit(client, base_head)
-        skill_map = _skill_trees_of_root(client, base_root)
-    else:
-        skill_map = {}
-    skill_map[str(rel)] = skill_tree
+    #
+    # Wrapped in a bounded retry: between reading HEAD and the CAS, another
+    # member's propose (or an admin merge) can advance it. The server answers
+    # 409 with the new head; we re-splice this one skill onto THAT head and try
+    # again rather than surfacing a raw conflict. Re-splicing (not replaying
+    # the old root) is what keeps the other member's skill from being dropped.
+    attempts = 0
+    while True:
+        attempts += 1
+        base_head = _read_org_head(client, org_id)
+        if base_head:
+            base_root = _root_tree_of_commit(client, base_head, org_scope=True)
+            skill_map = _skill_trees_of_root(client, base_root, org_scope=True)
+        else:
+            skill_map = {}
+        skill_map[str(rel)] = skill_tree
 
-    root_hash = _assemble_root_from_skill_trees(client, skill_map, objects)
-    commit_hash = build_commit(
-        root_hash,
-        [base_head] if base_head else [],
-        owner=identity["owner"],
-        device=stable_device_id(),
-        message=message or f"propose {skill_name}",
-        objects=objects,
-    )
+        root_hash = _assemble_root_from_skill_trees(client, skill_map, objects)
+        commit_hash = build_commit(
+            root_hash,
+            [base_head] if base_head else [],
+            owner=identity["owner"],
+            device=stable_device_id(),
+            message=message or f"propose {skill_name}",
+            objects=objects,
+        )
 
-    client.put_objects(objects.objects, org_scope=True)
-    result = client.cas_ref(org_head_ref(org_id), base_head, commit_hash)
+        client.put_objects(objects.objects, org_scope=True)
+        try:
+            result = client.cas_ref(org_head_ref(org_id), base_head, commit_hash)
+            break
+        except SyncConflict as conflict:
+            if attempts >= _ORG_CAS_MAX_ATTEMPTS:
+                raise SyncError(
+                    "the organisation's skills changed while this was being "
+                    f"proposed, and {attempts} attempts to catch up all lost "
+                    "the race — run the command again",
+                    status=409,
+                ) from conflict
+            logger.debug(
+                "propose_skill: org HEAD moved (actual=%r), re-splicing (attempt %d)",
+                conflict.actual,
+                attempts,
+            )
+            continue
 
     if result.get("proposal_pending"):
         return {


### PR DESCRIPTION
![Org sync endpoint fix](https://v3b.fal.media/files/b/0aa46b65/Zo9-4-VxyO1pK4c3dVRQs_eCOTVx6I.png)

fix(sync): read org state from the org endpoints, not the personal ones

Org-shared skills were unusable past the first propose. Three defects, one
root cause plus two that it masked.

ROOT CAUSE — org reads went to the personal endpoint.

`SyncClient.get_refs()` / `get_object()` only ever called `/v1/sync/refs`
and `/v1/sync/objects/:hash`. Those routes are hard-scoped server-side to
the token's own owner, so asking them for `refs/org/<id>/` returns the
caller's PERSONAL refs rather than an error, and org objects 404. Both org
call sites read org state through them:

- `pull_org_skills` resolved head=None for a populated org and reported
  `{"ok": true, "head": null, "updated": []}` — org skills silently never
  arrived, which reads as "my org has no skills" rather than as a failure.
- `propose_skill` resolved base_head=None, so the FIRST propose to an org
  succeeded by accident (`from: null` happened to be correct) and EVERY
  later one CAS'd against a head it had never seen -> 409 -> a raw
  `SyncConflict` traceback. Worse, it built its root from an empty skill
  map, so a landed CAS would have REPLACED the org set rather than splicing
  into it — the 409 was accidentally preventing data loss.

Fix: `org_scope=True` on `get_refs`/`get_object`, threaded through
`get_commit_json`, `get_tree_json`, `_root_tree_of_commit`,
`_skill_trees_of_root`, and `materialize_tree` — walking an org commit needs
the org route on every hop, not just the first. Both org call sites now go
through one `_read_org_head()` helper.

ALSO FIXED

- `propose_skill` retries on conflict. When the org HEAD moves between the
  read and the CAS (another member proposing, an admin merging), it
  re-splices this one skill onto the NEW head and retries, bounded at 5
  attempts. Re-splicing rather than replaying the old root is what stops a
  concurrent proposal being dropped.
- An empty `actual` in a 409 means "the ref does not exist", not "here is a
  commit". `SyncConflict` normalizes "" to None in its constructor, and the
  personal push path redoes the CAS as a create instead of fetching "" as an
  object — which surfaced as the baffling `object  not found` (doubled
  space). This is what a client hits after switching sync planes, since
  `.sync_state` is not environment-scoped and carries a foreign head.

THE MOCK WAS THE REASON THIS SHIPPED

The test mock served org refs and org objects off the personal routes, so
21 org tests passed against a client that could not work against the real
plane. The mock now mirrors production: `/v1/sync/org/refs` and
`/v1/sync/org/objects/:hash` exist, org objects live in a separate scope,
and the personal routes refuse org content. Two existing tests had to be
corrected to assert against the org scope — they had been passing on the
mock's over-permissiveness.

Tests: 5 new (org head invisible on the personal route; second propose
splices and preserves the first; pull resolves a real org head; empty
`actual` -> None; push recovers from a stale cross-plane head). Verified
they FAIL without the fix: reverting just `_read_org_head` to the personal
route fails the second-propose test and the pre-existing splice test.
1278 passed / 0 failed across 54 suites via scripts/run_tests.sh.

Verified against PRODUCTION with a real org token, not just the mock:
- `pull_org_skills` -> head `sha256:1adf9333…`, materialized
  `software-development/gateway-gateway-connector` into the `_org` mirror
  (was head=None, updated=[]).
- A second `hermes sync propose` succeeded where it previously raised, and
  the org set afterwards contains BOTH skills with the new commit
  descending from the first.

