### PR TITLE
fix(desktop): honor configured context in usage status

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7381,6 +7381,28 @@ def test_session_compress_sync_failure_discards_lcm_notification(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_get_usage_prefers_configured_context_length_for_status_denominator():
+    agent = types.SimpleNamespace(
+        _config_context_length=200_000,
+        context_compressor=types.SimpleNamespace(
+            compression_count=0,
+            context_length=128_000,
+            last_prompt_tokens=40_000,
+        ),
+        model="local-model",
+        session_api_calls=1,
+        session_input_tokens=40_000,
+        session_output_tokens=1_000,
+        session_total_tokens=41_000,
+    )
+
+    usage = server._get_usage(agent)
+
+    assert usage["context_used"] == 40_000
+    assert usage["context_max"] == 200_000
+    assert usage["context_percent"] == 20
+
+
 def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
     class _ExplodingWorker:
         def __init__(self, *args, **kwargs):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4591,7 +4591,13 @@ def _get_usage(agent) -> dict:
         last_prompt = getattr(comp, "last_prompt_tokens", 0) or 0
         if last_prompt < 0:
             last_prompt = 0
-        ctx_max = getattr(comp, "context_length", 0) or 0
+        configured_ctx = getattr(agent, "_config_context_length", 0) or 0
+        configured_ctx = (
+            configured_ctx
+            if isinstance(configured_ctx, int) and not isinstance(configured_ctx, bool) and configured_ctx > 0
+            else 0
+        )
+        ctx_max = configured_ctx or getattr(comp, "context_length", 0) or 0
         if ctx_max and last_prompt:
             usage["context_used"] = last_prompt
             usage["context_max"] = ctx_max


### PR DESCRIPTION
Fixes #75208.

## Summary

- Make the gateway usage snapshot prefer the configured `model.context_length` when computing `context_max` for the live context/status denominator.
- Keep the compressor-reported context length as the fallback when no positive configured limit exists.
- Cover the regression where a configured 200K limit would otherwise display the catalog/native 128K value.

## Tests

- `scripts/run_tests.sh tests/test_tui_gateway_server.py -q -k 'get_usage_prefers_configured_context_length_for_status_denominator or slash_exec_r7_read_commands_use_metadata_mirror_flag_on'`
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -q` — 497 passed after built-in retry; first attempt hit pre-existing flaky `test_write_json_serializes_concurrent_writes`
- `python -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`
