### PR TITLE
fix(copilot): normalize prefixed and short Copilot model IDs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4842,14 +4842,27 @@ def validate_requested_model(
         except Exception:
             catalog_models = []
         if catalog_models:
-            if requested_for_lookup in set(catalog_models):
+            # Copilot catalogs may contain vendor-prefixed IDs
+            # (e.g. ``anthropic/claude-opus-4.8``) while users commonly type
+            # the bare model slug (``claude-opus-4.8``). Normalize catalog
+            # entries to canonical forms before exact/close-match checks.
+            normalized_catalog: list[str] = []
+            seen_catalog: set[str] = set()
+            for model_id in catalog_models:
+                canonical = normalize_copilot_model_id(model_id) or str(model_id or "").strip()
+                if not canonical or canonical in seen_catalog:
+                    continue
+                seen_catalog.add(canonical)
+                normalized_catalog.append(canonical)
+
+            if requested_for_lookup in set(normalized_catalog):
                 return {
                     "accepted": True,
                     "persist": True,
                     "recognized": True,
                     "message": None,
                 }
-            auto = get_close_matches(requested_for_lookup, catalog_models, n=1, cutoff=0.9)
+            auto = get_close_matches(requested_for_lookup, normalized_catalog, n=1, cutoff=0.9)
             if auto:
                 return {
                     "accepted": True,
@@ -4858,7 +4871,7 @@ def validate_requested_model(
                     "corrected_model": auto[0],
                     "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
                 }
-            suggestions = get_close_matches(requested_for_lookup, catalog_models, n=3, cutoff=0.5)
+            suggestions = get_close_matches(requested_for_lookup, normalized_catalog, n=3, cutoff=0.5)
             suggestion_text = ""
             if suggestions:
                 suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3854,6 +3854,8 @@ _COPILOT_MODEL_ALIASES = {
     # Google Gemini models (Copilot catalog uses google/ prefix)
     "google/gemini-3.5-flash": "gemini-3.5-flash",
     "google/gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
+    "gemini-3.5": "gemini-3.5-flash",
+    "google/gemini-3.5": "gemini-3.5-flash",
     "gemini-3.5-flash": "gemini-3.5-flash",
     "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
     # Kimi and MAI models

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -292,23 +292,27 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "copilot-acp",
     ],
     "copilot": [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",
         "gpt-5.3-codex",
-        "gpt-5.2-codex",
-        "gpt-4.1",
-        "gpt-4o",
-        "gpt-4o-mini",
-        "claude-sonnet-4.6",
         "claude-sonnet-5",
-        "claude-sonnet-4",
+        "claude-opus-4.8",
+        "claude-opus-4.8-fast",
+        "claude-opus-4.7",
+        "claude-opus-4.6",
+        "claude-opus-4.5",
+        "claude-sonnet-4.6",
         "claude-sonnet-4.5",
         "claude-haiku-4.5",
+        "gemini-3.5-flash",
         "gemini-3.1-pro-preview",
-        "gemini-3-pro-preview",
-        "gemini-3-flash-preview",
-        "gemini-2.5-pro",
+        "kimi-k2.7-code",
+        "mai-code-1-flash-picker",
     ],
     "gemini": [
         "gemini-3.1-pro-preview",
@@ -3825,6 +3829,36 @@ _COPILOT_MODEL_ALIASES = {
     "anthropic/claude-sonnet-4-0": "claude-sonnet-4",
     "anthropic/claude-sonnet-4-5": "claude-sonnet-4.5",
     "anthropic/claude-haiku-4-5": "claude-haiku-4.5",
+    # Newer Claude Opus models (Copilot catalog uses anthropic/ prefix)
+    "anthropic/claude-opus-4.8": "claude-opus-4.8",
+    "anthropic/claude-opus-4.8-fast": "claude-opus-4.8-fast",
+    "anthropic/claude-opus-4.7": "claude-opus-4.7",
+    "claude-opus-4.8": "claude-opus-4.8",
+    "claude-opus-4.8-fast": "claude-opus-4.8-fast",
+    "claude-opus-4.7": "claude-opus-4.7",
+    # Dash-notation for newer Opus models
+    "claude-opus-4-8": "claude-opus-4.8",
+    "claude-opus-4-8-fast": "claude-opus-4.8-fast",
+    "claude-opus-4-7": "claude-opus-4.7",
+    "anthropic/claude-opus-4-8": "claude-opus-4.8",
+    "anthropic/claude-opus-4-8-fast": "claude-opus-4.8-fast",
+    "anthropic/claude-opus-4-7": "claude-opus-4.7",
+    # Claude Opus 4.5
+    "anthropic/claude-opus-4.5": "claude-opus-4.5",
+    "anthropic/claude-opus-4-5": "claude-opus-4.5",
+    "claude-opus-4.5": "claude-opus-4.5",
+    "claude-opus-4-5": "claude-opus-4.5",
+    # Dash-notation for Sonnet models
+    "claude-sonnet-5": "claude-sonnet-5",
+    "anthropic/claude-sonnet-5": "claude-sonnet-5",
+    # Google Gemini models (Copilot catalog uses google/ prefix)
+    "google/gemini-3.5-flash": "gemini-3.5-flash",
+    "google/gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
+    "gemini-3.5-flash": "gemini-3.5-flash",
+    "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
+    # Kimi and MAI models
+    "kimi-k2.7-code": "kimi-k2.7-code",
+    "mai-code-1-flash-picker": "mai-code-1-flash-picker",
 }
 
 
@@ -4796,6 +4830,48 @@ def validate_requested_model(
             "recognized": False,
             "message": message,
         }
+
+    # Copilot: validate using the alias-aware catalog so vendor-prefixed IDs
+    # (e.g. anthropic/claude-opus-4.8 → claude-opus-4.8) compare correctly
+    # against the bare names users type.  Without this, the generic
+    # fetch_api_models path returns raw prefixed IDs, the bare name misses,
+    # and fuzzy matching silently downgrades to an older model.
+    if normalized in {"copilot", "copilot-acp"}:
+        try:
+            catalog_models = provider_model_ids(normalized)
+        except Exception:
+            catalog_models = []
+        if catalog_models:
+            if requested_for_lookup in set(catalog_models):
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+            auto = get_close_matches(requested_for_lookup, catalog_models, n=1, cutoff=0.9)
+            if auto:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "corrected_model": auto[0],
+                    "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                }
+            suggestions = get_close_matches(requested_for_lookup, catalog_models, n=3, cutoff=0.5)
+            suggestion_text = ""
+            if suggestions:
+                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": False,
+                "message": (
+                    f"Note: `{requested}` was not found in the Copilot model listing. "
+                    "It may still work if your account has access to a newer or gated model."
+                    f"{suggestion_text}"
+                ),
+            }
 
     # Providers with non-standard catalog validation — /v1/models probing is not the right path.
     if normalized in {"openai-codex", "xai-oauth"}:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -244,6 +244,9 @@ class TestCopilotNormalization:
         assert copilot_model_api_mode("gpt-5.2-codex") == "codex_responses"
         assert copilot_model_api_mode("gpt-5.2") == "codex_responses"
 
+    def test_copilot_normalizes_gemini_short_alias(self):
+        assert normalize_copilot_model_id("gemini-3.5") == "gemini-3.5-flash"
+
     def test_validate_copilot_accepts_bare_id_when_catalog_is_vendor_prefixed(self):
         with patch(
             "hermes_cli.models.provider_model_ids",
@@ -549,4 +552,3 @@ class TestProbeApiModelsUserAgent:
         assert ua and ua.startswith("hermes-cli/")
         # No Authorization was set, but UA must still be present.
         assert req.get_header("Authorization") is None
-

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -244,6 +244,37 @@ class TestCopilotNormalization:
         assert copilot_model_api_mode("gpt-5.2-codex") == "codex_responses"
         assert copilot_model_api_mode("gpt-5.2") == "codex_responses"
 
+    def test_validate_copilot_accepts_bare_id_when_catalog_is_vendor_prefixed(self):
+        with patch(
+            "hermes_cli.models.provider_model_ids",
+            return_value=[
+                "anthropic/claude-opus-4.8",
+                "google/gemini-3.5-flash",
+            ],
+        ):
+            result = validate_requested_model("claude-opus-4.8", "copilot")
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result["message"] is None
+
+    def test_validate_copilot_autocorrects_using_normalized_prefixed_catalog(self):
+        with patch(
+            "hermes_cli.models.provider_model_ids",
+            return_value=[
+                "anthropic/claude-opus-4.8",
+                "google/gemini-3.5-flash",
+            ],
+        ):
+            result = validate_requested_model("claude-opus-4.9", "copilot")
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result["corrected_model"] == "claude-opus-4.8"
+        assert "claude-opus-4.8" in (result["message"] or "")
+
 
 
 
@@ -518,5 +549,4 @@ class TestProbeApiModelsUserAgent:
         assert ua and ua.startswith("hermes-cli/")
         # No Authorization was set, but UA must still be present.
         assert req.get_header("Authorization") is None
-
 


### PR DESCRIPTION
## Summary
Re-scoped to the Copilot model-catalog/alias validation path only.

This change fixes Copilot model validation when the live catalog returns vendor-prefixed IDs (for example anthropic/claude-opus-4.8) but users configure bare IDs (for example claude-opus-4.8), and normalizes gemini-3.5 to the catalog-supported gemini-3.5-flash.

### What changed
- Sync `_PROVIDER_MODELS["copilot"]` to current live Copilot catalog entries
- Extend `_COPILOT_MODEL_ALIASES` for newer Copilot IDs and dash-notation variants
- Normalize Copilot catalog entries inside `validate_requested_model()` before exact/close-match checks so prefixed catalog IDs match bare user input
- Add explicit short-alias normalization: `gemini-3.5` -> `gemini-3.5-flash`

### Related issue
Closes #45813

### Verification
Manual:
- `hermes chat --provider github-copilot -m gemini-3.5-flash --cli -q "Introduce yourself"`

Automated:
- `scripts/run_tests.sh tests/hermes_cli/test_model_validation.py tests/test_copilot_initiator.py tests/hermes_cli/test_copilot_token_exchange.py tests/run_agent/test_switch_model_reapplies_headers.py -q`
- Result: 50 passed, 0 failed

### Notes
- No changes to Copilot initiator-turn runtime contract.
- No new enterprise endpoint discovery path added in this PR.