### PR TITLE
Add Qwen Flash to OpenRouter model catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -73,6 +73,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("deepseek/deepseek-v4-flash-0731",        "dated snapshot of v4-flash"),
     # Qwen
     ("qwen/qwen3.8-max",                       ""),
+    ("qwen/qwen3.7-flash",                     ""),
     # MoonshotAI
     ("moonshotai/kimi-k3",                     "recommended"),
     # MiniMax

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -270,22 +270,6 @@ class TestDefaultModelFromCache:
                 f"must match PREFERRED_SILENT_DEFAULT_MODEL"
             )
 
-    def test_shipped_manifest_includes_openrouter_qwen_flash(self, isolated_home):
-        """Regression for #74144: Qwen Flash should be selectable from the
-        curated OpenRouter catalog. OpenRouter lists the canonical slug without
-        a hyphen between qwen and 3.7.
-        """
-        import hermes_cli.model_catalog as model_catalog
-
-        repo_root = Path(model_catalog.__file__).resolve().parent.parent
-        manifest = json.loads(
-            (repo_root / "website" / "static" / "api" / "model-catalog.json").read_text()
-        )
-        openrouter_ids = [m["id"] for m in manifest["providers"]["openrouter"]["models"]]
-
-        assert "qwen/qwen3.7-flash" in openrouter_ids
-        assert "qwen/qwen-3.7-flash" not in openrouter_ids
-
 
 class TestProviderOverride:
     def test_override_url_takes_precedence(self, isolated_home):

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -270,6 +270,22 @@ class TestDefaultModelFromCache:
                 f"must match PREFERRED_SILENT_DEFAULT_MODEL"
             )
 
+    def test_shipped_manifest_includes_openrouter_qwen_flash(self, isolated_home):
+        """Regression for #74144: Qwen Flash should be selectable from the
+        curated OpenRouter catalog. OpenRouter lists the canonical slug without
+        a hyphen between qwen and 3.7.
+        """
+        import hermes_cli.model_catalog as model_catalog
+
+        repo_root = Path(model_catalog.__file__).resolve().parent.parent
+        manifest = json.loads(
+            (repo_root / "website" / "static" / "api" / "model-catalog.json").read_text()
+        )
+        openrouter_ids = [m["id"] for m in manifest["providers"]["openrouter"]["models"]]
+
+        assert "qwen/qwen3.7-flash" in openrouter_ids
+        assert "qwen/qwen-3.7-flash" not in openrouter_ids
+
 
 class TestProviderOverride:
     def test_override_url_takes_precedence(self, isolated_home):

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -105,6 +105,10 @@
           "description": ""
         },
         {
+          "id": "qwen/qwen3.7-flash",
+          "description": ""
+        },
+        {
           "id": "moonshotai/kimi-k3",
           "description": "recommended"
         },


### PR DESCRIPTION
## Summary
- add the canonical OpenRouter Qwen Flash slug (`qwen/qwen3.7-flash`) to the curated fallback model list
- regenerate the published model catalog so Desktop/CLI pickers can surface it
- add regression coverage that keeps the canonical slug in the shipped manifest and guards against the dashed typo from #74144

Note: OpenRouter currently lists the model as `qwen/qwen3.7-flash` (without the extra hyphen after `qwen`), so this PR uses that canonical slug while addressing #74144.

Fixes #74144

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_model_catalog.py -q`
- `python3 -m json.tool website/static/api/model-catalog.json >/dev/null`
- `git diff --check`
