### PR TITLE
fix(codex_responses): skip empty assistant entry after reasoning when tool_calls follow

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -528,9 +528,15 @@ def _chat_messages_to_responses_input(
                     # The Responses API requires a following item after each
                     # reasoning item (otherwise: missing_following_item error).
                     # When the assistant produced only reasoning with no visible
-                    # content, emit an empty assistant message as the required
-                    # following item.
-                    items.append({"role": "assistant", "content": ""})
+                    # content, emit a following item.  If tool_calls are present
+                    # they already satisfy the requirement (they are valid
+                    # follow-up items per the Responses spec); otherwise emit a
+                    # single-space assistant message so that strict providers
+                    # (e.g. Volcano Engine) that reject empty content strings
+                    # do not return 400 MissingParameter.
+                    _pending_tc = msg.get("tool_calls")
+                    if not (isinstance(_pending_tc, list) and _pending_tc):
+                        items.append({"role": "assistant", "content": " "})
 
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):


### PR DESCRIPTION
## Summary

When `has_codex_reasoning` is True and no visible content was produced, the adapter injected `{"role": "assistant", "content": ""}` as a required follow-up item for the Responses API. OpenAI and xAI tolerate empty content strings, but strict providers (e.g. Volcano Engine Agent Plan) reject them with `400 MissingParameter: input.content`.

## Root Cause

`codex_responses_adapter.py` line 533 (old): the `has_codex_reasoning` branch always emitted `{"role": "assistant", "content": ""}`. This empty content string passes OpenAI/xAI validation but fails Volcano Engine's strict non-empty content check.

## Fix

Two changes in the `has_codex_reasoning` branch:

1. **Skip the empty entry when tool_calls are present** — function calls are already valid follow-up items per the Responses spec, so the empty assistant message is unnecessary.
2. **Use `" "` (single space) instead of `""` for pure reasoning** — satisfies strict content validation without changing semantics. OpenAI/xAI accept both equally.

This is fully backwards-compatible with all currently working providers.

## Test Plan

- [ ] Verified syntax with `ast.parse()`
- [ ] Controlled replay (from issue reporter): removing empty assistant entry or replacing with `" "` yields 200 on Volcano API
- [ ] Existing codex_responses tests still pass

Fixes #75202