### PR TITLE
fix(tui): don't preserve Ctrl+J as newline over SSH

### DIFF
--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -162,10 +162,6 @@ export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boole
     return true
   }
 
-  if (env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY) {
-    return true
-  }
-
   if (env.GHOSTTY_RESOURCES_DIR || env.GHOSTTY_BIN_DIR) {
     return true
   }


### PR DESCRIPTION
## What does this PR do?

Stops preserving Ctrl+J as a newline in the TUI over SSH, so it behaves like Enter (submit) — fixing corrupted multi-line input and unexpected control-sequence behavior on remote sessions.

## Related Issue

Fixes #78210

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `fix(tui)`: don't preserve Ctrl+J as newline over SSH

## How to Test

1. SSH into a host running Hermes TUI
2. Press Ctrl+J
3. Verify it submits (not inserts newline)

## Checklist

- [x] Conventional commit
- [x] Only changes related to this feature
- [x] Tested on SSH session
