### PR TITLE
chore: gitignore local .codegraph tooling directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ native/fts5_cjk/*.so
 # interrupted; consumed by launch-time recovery. Never commit it (was tracked
 # by accident via 3a69e34702, removed in the #72002 salvage).
 .lazy-refresh-incomplete
+
+# CodeGraph tooling (codegraph DB + daemon logs; machine-local, regenerated on demand)
+.codegraph/


### PR DESCRIPTION
## What does this PR do?

Adds `.codegraph/` to `.gitignore`. CodeGraph (local agent tooling) writes a SQLite DB and daemon files into `.codegraph/` — these are local tooling artifacts that should never be committed.

## Type of Change

- [x] 📝 Chore (housekeeping)

## Changes Made

- `.gitignore` — add `.codegraph/`

## How to Test

1. Run CodeGraph locally (creates `.codegraph/`)
2. `git status` — `.codegraph/` no longer shows as untracked

## Checklist

- [x] Conventional commit
- [x] Only changes related to this feature
