### PR TITLE
fix(vision): stop capping aux vision output with hardcoded max_tokens

### DIFF
--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -274,6 +274,9 @@ class TestBrowserVisionConfig:
         assert result["analysis"] == "Annotated screenshot analysis"
         assert mock_llm.call_args.kwargs["temperature"] == 1.0
         assert mock_llm.call_args.kwargs["timeout"] == 45.0
+        # No hardcoded output cap — the aux client omits max_tokens so the
+        # provider uses its full output budget (max-tokens-knob policy).
+        assert "max_tokens" not in mock_llm.call_args.kwargs
 
 
     def test_browser_vision_native_fast_path_returns_multimodal(self, tmp_path):

--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -204,6 +204,9 @@ class TestVideoAnalyzeTool:
         assert content[1]["type"] == "video_url"
         assert "video_url" in content[1]
         assert content[1]["video_url"]["url"].startswith("data:video/mp4;base64,")
+        # No hardcoded output cap — the aux client omits max_tokens so the
+        # provider uses its full output budget (max-tokens-knob policy).
+        assert "max_tokens" not in captured_kwargs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -276,9 +276,20 @@ class TestVisionConfig:
         )
         assert kwargs["temperature"] == 1.0
         assert kwargs["timeout"] == 77.0
+        # No hardcoded output cap — the aux client omits max_tokens so the
+        # provider uses its full output budget (max-tokens-knob policy).
+        assert "max_tokens" not in kwargs
 
         # Omitted values fall back to the built-in defaults.
         kwargs = await call_with({"auxiliary": {"vision": {}}})
+        assert kwargs["temperature"] == 0.1
+        assert kwargs["timeout"] == 120.0
+        assert "max_tokens" not in kwargs
+
+        # Even an explicit auxiliary.vision.max_tokens config entry must NOT
+        # be forwarded: user-facing max_tokens knobs are policy-prohibited.
+        kwargs = await call_with({"auxiliary": {"vision": {"max_tokens": 8000}}})
+        assert "max_tokens" not in kwargs
         assert kwargs["temperature"] == 0.1
         assert kwargs["timeout"] == 120.0
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4357,7 +4357,6 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
                     ],
                 }
             ],
-            "max_tokens": 2000,
             "temperature": vision_temperature,
             "timeout": vision_timeout,
         }

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1267,7 +1267,6 @@ async def vision_analyze_tool(
             "task": "vision",
             "messages": messages,
             "temperature": vision_temperature,
-            "max_tokens": 2000,
             "timeout": vision_timeout,
         }
         if model:
@@ -1774,7 +1773,6 @@ async def video_analyze_tool(
             "task": "vision",
             "messages": messages,
             "temperature": vision_temperature,
-            "max_tokens": 4000,
             "timeout": vision_timeout,
         }
         if model:


### PR DESCRIPTION
## What does this PR do?

`vision_analyze` and `browser_vision` return truncated descriptions of complex images: the auxiliary vision calls hardcoded `max_tokens` output caps (2000 for image/screenshot analysis, 4000 for video), so descriptions cut off mid-sentence at exactly the cap. This PR removes the hardcoded caps from all three vision call sites, so the auxiliary client omits `max_tokens` and the provider uses its full output budget.

This is the re-scoped fix requested by the sweeper under the `max-tokens-knob` policy (see #74945): it addresses truncation **without** adding a user-facing `max_tokens` configuration surface. It matches the direction already merged in #34845 (auxiliary calls no longer cap output by default); the vision tools were the leftover call sites that still built their own capped kwargs dicts.

## Related Issue

Fixes #10809

The symptom in #29590 (truncated vision descriptions) is also resolved, without the requested config knob, per the standing `max-tokens-knob` policy.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tools/vision_tools.py`: removed `"max_tokens": 2000` from the image-analysis `call_kwargs` (was line 1270)
- `tools/vision_tools.py`: removed `"max_tokens": 4000` from the video-analysis `call_kwargs` (was line 1777)
- `tools/browser_tool.py`: removed `"max_tokens": 2000` from the browser-screenshot `call_kwargs` (was line 4360)
- `tests/tools/test_vision_tools.py`: extended `TestVisionConfig.test_temperature_and_timeout_come_from_config_with_defaults` to assert the no-cap contract: `max_tokens` is absent from vision call kwargs with configured values, with defaults, and even when `auxiliary.vision.max_tokens` is explicitly set in config (config knobs must never be forwarded).

### Wire safety (why removing the cap can't break any provider)

The centralized aux client handles every wire when `max_tokens` is omitted:

| Wire | Behavior when omitted |
|---|---|
| OpenAI-compatible chat-completions | `max_tokens` omitted → provider model max output (per merged #34845) |
| Anthropic Messages (mandatory field) | `_resolve_anthropic_messages_max_tokens()` falls back to the model output ceiling |
| Gemini native | `maxOutputTokens` omitted → 65K ceiling |
| NVIDIA NIM / MoA | cap keys omitted with the OpenAI-compatible path |

### Deliberately out of scope

`tools/browser_tool.py` has a fourth hardcoded cap (`task: "web_extract"` snapshot summarization, `max_tokens: 4000`, at line ~2799). It is intentionally left alone: that path is designed to be lossy: `_store_full_snapshot()` persists the full snapshot to cache and appends a pointer note, so a summary cap there is intended behavior, not accidental truncation (unlike vision, where the description is the deliverable).

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Reproduce the bug before the fix: run `vision_analyze` on a dense screenshot with a text-only main model and a Gemini/OpenAI-compatible aux vision model; the description stops at ~2000 tokens (`finish_reason=length`).
2. Apply the fix and re-run: the description completes with `finish_reason=stop` at the provider's natural output budget.
3. Run the regression suite:

```bash
scripts/run_tests.sh tests/tools/test_vision_tools.py tests/tools/test_vision_native_fast_path.py tests/run_agent/test_vision_aware_preprocessing.py tests/agent/test_vision_routing_31179.py tests/agent/test_vision_resolved_args.py tests/agent/test_auxiliary_client.py tests/tools/test_browser_console.py tests/tools/test_video_analyze.py
```

Result: 261 passed, 0 failed.

4. Full suite (`scripts/run_tests.sh tests/ -q`, CI-parity runner): **20,742 tests run; 312 failures, all pre-existing environmental failures, zero in files touched by this PR.** Verified by running the same failing files (daytona, api-server bind guard, conformance vectors) on a clean `origin/main` worktree at `ce6dd1a65`, identical failures without this PR's changes. Failure domains are environment-bound: remote sandboxes (daytona), external messaging services (whatsapp/matrix/msgraph/sms/mattermost/discord), video-gen/FAL APIs, and port-binding tests. No vision or browser test fails.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. See the full-suite note in [How to Test, step 4](#how-to-test): 20,742 tests run, only pre-existing environmental failures (proven on a clean `origin/main` worktree), zero in files touched by this PR
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 --> macOS 26.5.2

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A (no config surface added or changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A (no config keys added/changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A (pure Python kwargs change, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A (no schema change; behavior change only)

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Regression suite on the PR head (261 passed, 0 failed):

```
[  9.0% |    22/~245 | ✓22 | ✗ 0] ✓ tests/tools/test_browser_console.py (22✓, 0.8s)
[ 15.1% |    37/~245 | ✓37 | ✗ 0] ✓ tests/tools/test_video_analyze.py (15✓, 0.9s)
[ 15.9% |    39/~245 | ✓39 | ✗ 0] ✓ tests/agent/test_vision_resolved_args.py (2✓, 0.9s)
[ 20.8% |    51/~245 | ✓51 | ✗ 0] ✓ tests/run_agent/test_vision_aware_preprocessing.py (12✓, 1.0s)
[ 25.7% |    63/~245 | ✓63 | ✗ 0] ✓ tests/tools/test_vision_native_fast_path.py (12✓, 1.7s)
[ 29.0% |    71/~245 | ✓71 | ✗ 0] ✓ tests/agent/test_vision_routing_31179.py (8✓, 1.9s)
[ 42.0% |   103/~245 | ✓103 | ✗  0] ✓ tests/tools/test_vision_tools.py (32✓, 1.9s)
[100.0% |   245/~245 | ✓261 | ✗  0] ✓ tests/agent/test_auxiliary_client.py (158✓, 4.0s)
=== Summary: 8 files, 261 tests passed, 0 failed (100% complete) in 4.0s (20 workers) ===
```
