### PR TITLE
fix(gateway): skip inherited secondary adapters

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3347,6 +3347,58 @@ def _reconnect_backoff(attempt: int) -> int:
     return min(30 * (2 ** (attempt - 1)), _RECONNECT_BACKOFF_CAP)
 
 
+def _local_profile_platforms(
+    profile_home: Union[Path, str],
+) -> Optional[frozenset[str]]:
+    """Return platforms explicitly declared by a named profile's config.
+
+    A secondary profile inherits the default configuration for its routed agent
+    turn, but inherited transport configuration must not create another inbound
+    adapter. ``None`` is reserved for synthetic/nonexistent homes used by older
+    callers that cannot provide config provenance.
+    """
+    profile_home = Path(profile_home)
+    if not profile_home.exists():
+        return None
+
+    config_path = profile_home / "config.yaml"
+    if not config_path.is_file():
+        return frozenset()
+
+    try:
+        import yaml
+    except ImportError:
+        logger.warning(
+            "PyYAML is unavailable; skipping secondary adapter ownership lookup"
+        )
+        return frozenset()
+
+    try:
+        raw_config = yaml.safe_load(config_path.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        logger.warning(
+            "Could not read profile config while determining adapter ownership: %s",
+            config_path,
+            exc_info=True,
+        )
+        return frozenset()
+
+    if not isinstance(raw_config, dict):
+        return frozenset()
+
+    platform_maps = [raw_config.get("platforms")]
+    gateway = raw_config.get("gateway")
+    if isinstance(gateway, dict):
+        platform_maps.append(gateway.get("platforms"))
+    return frozenset(
+        str(platform)
+        for platform_map in platform_maps
+        if isinstance(platform_map, dict)
+        for platform, platform_config in platform_map.items()
+        if isinstance(platform_config, dict)
+    )
+
+
 class TurnRunner:
     """Per-turn collaborator carrying the tool-progress callbacks that used to
     be nested closures inside ``GatewayRunner._run_agent_inner``.
@@ -12520,7 +12572,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         with _profile_runtime_scope(profile_home):
             profile_cfg = load_gateway_config()
-            violation = _own_policy_open_startup_violation(profile_cfg)
+        local_platforms = _local_profile_platforms(profile_home)
+        if local_platforms is not None:
+            profile_cfg = dataclasses.replace(
+                profile_cfg,
+                platforms={
+                    platform: platform_config
+                    for platform, platform_config in profile_cfg.platforms.items()
+                    if platform.value in local_platforms
+                },
+            )
+        violation = _own_policy_open_startup_violation(profile_cfg)
         if violation:
             raise MultiplexConfigError(
                 f"Profile '{profile_name}' enables {violation}. "

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -241,6 +241,80 @@ class TestSecondaryProfileFatalRecovery:
 class TestSecondaryProfileConfigHandling:
     """Secondary config errors degrade only when the profile is safe to skip."""
 
+    def test_secondary_skips_inherited_platforms_not_declared_locally(
+        self, tmp_path, monkeypatch
+    ):
+        """A routed profile must not connect adapters it merely inherits."""
+        profile_home = tmp_path / "profiles" / "life"
+        profile_home.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text("agent:\n  name: life\n")
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        inherited_cfg = GatewayConfig(multiplex_profiles=True)
+        inherited_cfg.platforms = {
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="inherited"),
+            Platform.WHATSAPP: PlatformConfig(enabled=True),
+            Platform.WEBHOOK: PlatformConfig(enabled=True),
+        }
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: inherited_cfg
+        )
+        created = []
+        monkeypatch.setattr(
+            runner,
+            "_create_adapter",
+            lambda platform, config: created.append(platform),
+        )
+
+        connected = asyncio.run(
+            runner._start_one_profile_adapters("life", profile_home, {})
+        )
+
+        assert connected == 0
+        assert created == []
+        assert runner._profile_adapters["life"] == {}
+
+    def test_secondary_starts_platform_explicitly_declared_locally(
+        self, tmp_path, monkeypatch
+    ):
+        """A named profile may still own a distinct explicitly configured adapter."""
+        profile_home = tmp_path / "profiles" / "research"
+        profile_home.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    enabled: true\n"
+            "gateway:\n"
+            "  platforms:\n"
+            "    whatsapp:\n"
+            "      enabled: true\n"
+        )
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+        profile_cfg = GatewayConfig(multiplex_profiles=True)
+        profile_cfg.platforms = {
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="distinct"),
+            Platform.WHATSAPP: PlatformConfig(enabled=True),
+        }
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
+        created = []
+        monkeypatch.setattr(
+            runner,
+            "_create_adapter",
+            lambda platform, config: created.append(platform),
+        )
+
+        asyncio.run(
+            runner._start_one_profile_adapters("research", str(profile_home), {})
+        )
+
+        assert created == [Platform.TELEGRAM, Platform.WHATSAPP]
+
 
     @pytest.mark.asyncio
     async def test_secondary_reports_all_port_binding_platforms(self, monkeypatch):

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -97,11 +97,15 @@ gateway:
 ```
 
 (The flag is also accepted as a top-level `multiplex_profiles: true` for
-convenience.) On the next start the default gateway enumerates every profile,
-brings up each profile's enabled platforms under that profile's own
-credentials, and routes each inbound message to the profile it belongs to. Each
-turn resolves the routed profile's config, skills, memory, SOUL, **and provider
-keys** — credentials are never shared across profiles.
+convenience.) On the next start, the default gateway owns the shared inbound
+transports and routes each inbound message to the profile it belongs to. A
+named profile starts a secondary adapter only when that profile explicitly
+declares the platform in its own `config.yaml` (for example, with a distinct
+bot credential). Inherited default-platform settings remain available while
+that profile runs a routed turn, but do **not** cause it to poll or connect a
+second transport. Each turn resolves the routed profile's config, skills,
+memory, SOUL, **and provider keys** — credentials are never shared across
+profiles.
 
 You do **not** run `hermes gateway start` for the secondary profiles — the
 default gateway serves them. See the contract changes below.
@@ -181,14 +185,19 @@ configuration errors remain fatal: for example, an `open` own-policy platform
 without `GATEWAY_ALLOW_ALL_USERS` or its platform-specific allow-all opt-in
 still aborts gateway startup rather than silently dropping the unsafe profile.
 
-#### 3. Per-credential platforms still need their own token per profile
+#### 3. Explicit per-profile transports need their own token
 
-Polling/connection platforms (Telegram, Discord, Slack, Matrix, Signal, …) work
-fine multiplexed, but each profile that enables one must supply its **own** bot
+Polling/connection platforms (Telegram, Discord, Slack, Matrix, Signal, …) can
+run as a secondary adapter only when the named profile explicitly declares that
+platform in its local `config.yaml`. That profile must supply its **own** bot
 token — the same token cannot be polled by two profiles at once. If two profiles
-configure the same `(platform, token)`, startup fails fast naming both profiles
-(see [Token-conflict safety](#token-conflict-safety) — the rule is unchanged,
-it's just enforced inside the one process now).
+explicitly configure the same `(platform, token)`, startup fails fast naming
+both profiles (see [Token-conflict safety](#token-conflict-safety)).
+
+For several communities sharing one bot credential, configure the transport only
+on the default profile and use [`profile_routes`](#routing-shared-bot-chats-to-profiles-profile_routes)
+to select the profile after the shared adapter receives a message. Do not copy
+the default transport configuration into each routed profile.
 
 #### 4. Session keys are namespaced by profile
 


### PR DESCRIPTION
## Summary

- prevent multiplexed secondary profiles from starting inbound adapters solely because they inherit the default profile's platform configuration
- preserve secondary adapters for platforms explicitly declared in the named profile's `config.yaml`
- document shared-transport ownership and the distinction between shared-token routes and explicit per-profile transports

## Why

A routed profile needs inherited configuration for its agent runtime, but it does not own the default profile's inbound credentials. Starting adapters from that inherited configuration causes duplicate pollers, unpaired-session attempts, missing-token errors, and secondary port-binding failures.

## Related

Follow-up to #64835 and the shared-credential routing model in #57871. This is separate from #70625, which handles outbound adapter selection when a secondary profile intentionally owns a distinct credential.

## Verification

- `python -m pytest -q tests/gateway/test_multiplex_adapter_registry.py::TestSecondaryProfileConfigHandling::test_secondary_skips_inherited_platforms_not_declared_locally tests/gateway/test_multiplex_adapter_registry.py::TestSecondaryProfileConfigHandling::test_secondary_starts_platform_explicitly_declared_locally`
- `python -m py_compile gateway/run.py tests/gateway/test_multiplex_adapter_registry.py`
- `git diff --check`

The local runtime lacks the repository's `uv`/full dev test environment, so the complete async-enabled test module was not run here.
