### PR TITLE
fix(auth): a transient read failure is not corruption

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1124,18 +1124,45 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
 
     try:
         raw = json.loads(auth_file.read_text(encoding="utf-8"))
+    except OSError:
+        # The file exists (checked above) but could not be READ: EMFILE under
+        # fd exhaustion, EACCES, EIO, a stalled network mount. None of those
+        # mean the contents are bad, and this module does read-modify-write in
+        # ~15 places, so degrading to an empty store here is one
+        # _save_auth_store() away from erasing every stored credential.
+        # Fail loudly instead and leave the file on disk untouched.
+        logger.warning(
+            "auth: could not read %s, leaving the store on disk untouched "
+            "rather than degrading to an empty one",
+            auth_file, exc_info=True,
+        )
+        raise
     except Exception as exc:
+        # Genuine corruption: unparseable JSON, or bytes that are not UTF-8.
         corrupt_path = auth_file.with_suffix(".json.corrupt")
+        preserved = False
         try:
             import shutil
             shutil.copy2(auth_file, corrupt_path)
+            preserved = True
         except Exception:
-            pass
-        logger.warning(
-            "auth: failed to parse %s (%s) — starting with empty store. "
-            "Corrupt file preserved at %s",
-            auth_file, exc, corrupt_path,
-        )
+            logger.debug(
+                "auth: could not preserve a copy of the corrupt store at %s",
+                corrupt_path, exc_info=True,
+            )
+        if preserved:
+            logger.warning(
+                "auth: failed to parse %s (%s), starting with empty store. "
+                "Corrupt file preserved at %s",
+                auth_file, exc, corrupt_path,
+            )
+        else:
+            # Do not advertise a backup that was never written.
+            logger.warning(
+                "auth: failed to parse %s (%s), starting with empty store. "
+                "A copy could NOT be preserved at %s",
+                auth_file, exc, corrupt_path,
+            )
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
     if isinstance(raw, dict) and (

--- a/tests/hermes_cli/test_auth_store_read_failure.py
+++ b/tests/hermes_cli/test_auth_store_read_failure.py
@@ -1,0 +1,98 @@
+"""A transient read failure on auth.json must not degrade to an empty store.
+
+``_load_auth_store`` treated every exception as corruption and returned
+``{"version": ..., "providers": {}}``. This module does read-modify-write in
+roughly fifteen places, so an ``OSError`` (EMFILE under fd exhaustion, EACCES,
+EIO, a stalled mount) followed by any ``_save_auth_store`` rewrote auth.json
+with an empty provider set and destroyed every stored credential.
+
+Genuine corruption still degrades, still preserves a copy, and now only claims
+to have preserved one when the copy actually landed.
+"""
+
+import errno
+import json
+import logging
+
+import pytest
+
+import hermes_cli.auth as auth
+
+
+@pytest.fixture
+def store_file(tmp_path):
+    f = tmp_path / "auth.json"
+    f.write_text(
+        json.dumps({"version": 1, "providers": {"nous": {"api_key": "secret"}}}),
+        encoding="utf-8",
+    )
+    return f
+
+
+def _fail_read(exc):
+    def _read(self, *args, **kwargs):
+        raise exc
+    return _read
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        OSError(errno.EMFILE, "Too many open files"),
+        PermissionError(errno.EACCES, "Permission denied"),
+        OSError(errno.EIO, "Input/output error"),
+    ],
+    ids=["emfile", "eacces", "eio"],
+)
+def test_read_failure_raises_and_leaves_the_store_alone(store_file, monkeypatch, exc):
+    from pathlib import Path
+
+    before = store_file.read_bytes()
+    monkeypatch.setattr(Path, "read_text", _fail_read(exc))
+
+    with pytest.raises(OSError):
+        auth._load_auth_store(store_file)
+
+    assert store_file.read_bytes() == before, "the store on disk was modified"
+    assert not store_file.with_suffix(".json.corrupt").exists(), (
+        "a read failure is not corruption and must not write a .corrupt sidecar"
+    )
+
+
+def test_unparseable_json_still_degrades_and_preserves_a_copy(store_file):
+    store_file.write_text("{ not json", encoding="utf-8")
+
+    result = auth._load_auth_store(store_file)
+
+    assert result == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
+    corrupt = store_file.with_suffix(".json.corrupt")
+    assert corrupt.exists(), "genuine corruption must still be preserved"
+    assert corrupt.read_text(encoding="utf-8") == "{ not json"
+
+
+def test_healthy_store_is_returned_unchanged(store_file):
+    result = auth._load_auth_store(store_file)
+    assert result["providers"]["nous"]["api_key"] == "secret"
+
+
+def test_log_does_not_claim_a_backup_that_was_not_written(
+    store_file, monkeypatch, caplog
+):
+    """The old message advertised the .corrupt path even when copy2 failed."""
+    import shutil
+
+    store_file.write_text("{ not json", encoding="utf-8")
+
+    def _no_copy(*args, **kwargs):
+        raise OSError(errno.EMFILE, "Too many open files")
+
+    monkeypatch.setattr(shutil, "copy2", _no_copy)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+        result = auth._load_auth_store(store_file)
+
+    assert result == {"version": auth.AUTH_STORE_VERSION, "providers": {}}
+    assert not store_file.with_suffix(".json.corrupt").exists()
+    text = caplog.text
+    assert "could NOT be preserved" in text
+    assert "Corrupt file preserved at" not in text


### PR DESCRIPTION
Fixes #75206.

### The bug

`_load_auth_store()` treated every exception from reading `auth.json` as corruption and returned `{"version": ..., "providers": {}}`. `OSError` reaches that branch: EMFILE under fd exhaustion, EACCES, EIO, a stalled network mount. None of those mean the contents are bad.

That matters because this module does read-modify-write in roughly fifteen places. A load that silently degrades to an empty store, followed by any `_save_auth_store()`, rewrites `auth.json` with an empty provider set. An OAuth token refresh landing in that window is enough.

The backup was also unreliable in exactly the conditions that triggered it. `shutil.copy2` opens a file, so under EMFILE it failed too, its bare `except: pass` swallowed that, and the log still said `Corrupt file preserved at ...` when nothing had been written.

### The fix

Split the two cases:

- **`OSError`** now propagates. The file exists (already checked) but could not be read, so the real cause surfaces and the file on disk is left untouched.
- **Everything else** keeps the existing behaviour: unparseable JSON and non-UTF-8 bytes still preserve a copy and start empty.
- The corrupt-copy log tracks whether `copy2` actually landed and no longer advertises a backup that was never written.

`json.JSONDecodeError` and `UnicodeDecodeError` are both `ValueError` subclasses, so the split is clean: genuine corruption still takes the old path.

### On the behaviour change

Callers that previously saw "no credentials" on an unreadable store now see the underlying `OSError`. That is the point of the change, and it is also better diagnostically. `tests/docker/test_docker_exec_privilege_drop.py` documents the old shape: when the gateway UID could not read a root-owned `auth.json`, the swallow surfaced downstream as `"Hermes is not logged into Nous Portal"` on every message, which points at the wrong thing entirely.

### Testing

New `tests/hermes_cli/test_auth_store_read_failure.py`, six tests:

- EMFILE, EACCES and EIO each propagate, leave the file byte-identical, and write no `.corrupt` sidecar
- unparseable JSON still degrades and still preserves a copy (unchanged behaviour, pinned)
- a healthy store loads unchanged
- when `copy2` fails, the log says the copy could not be preserved rather than claiming it was

On `main` four of the six fail; the two that pass are the unchanged-behaviour controls.

Full `tests/hermes_cli/` run, this branch and clean `main` each in their own isolated worktree: **118 failed / 3526 passed with the change, 119 failed / 3519 passed without it. Zero regressions.** The extra passes are the six new tests plus one pre-existing flake (`test_update_eol_churn`). That suite has a large pre-existing failure count in my environment which is unrelated to this change and identical on both sides; `tests/hermes_cli -k auth` is 461 passed, 1 skipped.
