### PR TITLE
fix(gateway): keep rich sent index private

### DIFF
--- a/gateway/rich_sent_store.py
+++ b/gateway/rich_sent_store.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import time
 from typing import Optional
 
@@ -60,10 +61,21 @@ def record(chat_id, message_id, text: Optional[str]) -> None:
                 data.items(), key=lambda kv: kv[1].get("ts", 0)
             )[: len(data) - _MAX_ENTRIES]:
                 data.pop(k, None)
-        tmp = f"{path}.tmp.{os.getpid()}"
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, ensure_ascii=False)
-        os.replace(tmp, path)  # atomic; tolerates concurrent writers racing
+        fd, tmp = tempfile.mkstemp(
+            prefix=f"{os.path.basename(path)}.tmp.",
+            dir=os.path.dirname(path),
+            text=True,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, ensure_ascii=False)
+            os.replace(tmp, path)  # atomic; tolerates concurrent writers racing
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
     except Exception:
         return
 

--- a/tests/gateway/test_rich_sent_store.py
+++ b/tests/gateway/test_rich_sent_store.py
@@ -1,0 +1,37 @@
+import os
+import stat
+
+from gateway import rich_sent_store
+
+
+def _record_under_permissive_umask(chat_id, message_id, text):
+    previous_umask = os.umask(0o022)
+    try:
+        rich_sent_store.record(chat_id, message_id, text)
+    finally:
+        os.umask(previous_umask)
+
+
+def test_record_creates_private_index_under_permissive_umask(tmp_path, monkeypatch):
+    profile_home = tmp_path / "tracker-home"
+    store_path = profile_home / "state" / "rich_sent_index.json"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    _record_under_permissive_umask("chat-1", 42, "private preview")
+
+    assert rich_sent_store.lookup("chat-1", 42) == "private preview"
+    assert stat.S_IMODE(store_path.stat().st_mode) == 0o600
+
+
+def test_record_replaces_broad_index_with_private_file(tmp_path, monkeypatch):
+    profile_home = tmp_path / "tracker-home"
+    store_path = profile_home / "state" / "rich_sent_index.json"
+    store_path.parent.mkdir(parents=True)
+    store_path.write_text("{}", encoding="utf-8")
+    store_path.chmod(0o644)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    _record_under_permissive_umask("chat-2", 84, "new private preview")
+
+    assert rich_sent_store.lookup("chat-2", 84) == "new private preview"
+    assert stat.S_IMODE(store_path.stat().st_mode) == 0o600


### PR DESCRIPTION
## Summary
- create rich-message index temp files with owner-only permissions
- preserve same-directory atomic replacement and best-effort cleanup
- cover new and previously broad index files under umask 022

## Test plan
- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_rich_sent_store.py tests/gateway/test_whatsapp_cloud.py tests/gateway/test_telegram_reply_quote.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_rich_newlines.py -q`
- 76 passed