### PR TITLE
fix(secrets): hydrate cold multiplex sources locally

### DIFF
--- a/agent/secret_sources/base.py
+++ b/agent/secret_sources/base.py
@@ -39,16 +39,35 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+from contextvars import ContextVar, Token
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Dict, FrozenSet, List, Optional, Sequence
+from typing import Dict, FrozenSet, List, MutableMapping, Optional, Sequence
 
 # Bump ONLY for breaking changes to the required contract surface
 # (abstract-method signatures, FetchResult required fields).  Additive
 # optional hooks must ship with defaults and must NOT bump this.
 SECRET_SOURCE_API_VERSION = 1
+
+_SOURCE_ENVIRONMENT: ContextVar[Optional[MutableMapping[str, str]]]
+_SOURCE_ENVIRONMENT = ContextVar("hermes_secret_source_environment", default=None)
+
+
+def set_source_environment(environ: MutableMapping[str, str]) -> Token:
+    """Install a per-fetch environment view without changing ``os.environ``."""
+    return _SOURCE_ENVIRONMENT.set(environ)
+
+
+def reset_source_environment(token: Token) -> None:
+    _SOURCE_ENVIRONMENT.reset(token)
+
+
+def get_source_environment() -> MutableMapping[str, str]:
+    """Return the active per-fetch environment, or the process environment."""
+    environ = _SOURCE_ENVIRONMENT.get()
+    return environ if environ is not None else os.environ
 
 # Timeout the orchestrator enforces around fetch() when the source's
 # config section doesn't override it.  Generous because a first run may

--- a/agent/secret_sources/base.py
+++ b/agent/secret_sources/base.py
@@ -149,9 +149,17 @@ class SecretSource(ABC):
             ``api_key`` fields), so scheme collisions are rejected at
             registration time to keep that future possible.
         api_version: Contract version this source was built against.
+        supports_isolated_environment: Whether this source is safe to run
+            during cold multiplex hydration.  Sources that opt in must read
+            bootstrap values through :func:`get_source_environment` (and pass
+            only that mapping to child processes), never directly from
+            ``os.environ``.  Legacy plugin sources default to ``False`` and
+            are skipped rather than allowed to observe another profile's
+            process-global credentials.
     """
 
     api_version: int = SECRET_SOURCE_API_VERSION
+    supports_isolated_environment: bool = False
     name: str = ""
     label: str = ""
     shape: str = "mapped"  # "mapped" | "bulk"

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -58,6 +58,7 @@ from agent.secret_sources._cache import (
     is_valid_env_name as _is_valid_env_name,
 )
 from agent.secret_sources.base import ErrorKind, SecretSource
+from agent.secret_sources.base import get_source_environment
 
 logger = logging.getLogger(__name__)
 
@@ -667,10 +668,15 @@ def _run_bws_list(
     bws: Path, access_token: str, project_id: str, server_url: str = ""
 ) -> Tuple[Dict[str, str], List[str]]:
     cmd = [str(bws), "secret", "list", project_id, "--output", "json"]
-    # bws child intentionally receives the access token; exact preservation
-    # (BWS_SERVER_URL manual overrides etc. must survive untouched).
-    from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    # bws child intentionally receives the access token.  Under a profile-local
+    # fetch it must not inherit sibling credentials from process-global env.
+    source_env = get_source_environment()
+    if source_env is os.environ:
+        from tools.environments.local import build_subprocess_env
+
+        env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    else:
+        env = dict(source_env)
     env["BWS_ACCESS_TOKEN"] = access_token
     # Make sure we're not echoing telemetry / colour codes into json.
     env.setdefault("NO_COLOR", "1")
@@ -908,7 +914,7 @@ class BitwardenSource(SecretSource):
         result = FetchResult()
 
         access_token_env = str(cfg.get("access_token_env") or "BWS_ACCESS_TOKEN")
-        access_token = os.environ.get(access_token_env, "").strip()
+        access_token = get_source_environment().get(access_token_env, "").strip()
         if not access_token:
             result.error = (
                 f"secrets.bitwarden.enabled is true but {access_token_env} is "

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -861,6 +861,7 @@ class BitwardenSource(SecretSource):
     name = "bitwarden"
     label = "Bitwarden Secrets Manager"
     shape = "bulk"
+    supports_isolated_environment = True
     scheme = "bws"
 
     def override_existing(self, cfg: dict) -> bool:

--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -44,6 +44,7 @@ from typing import Dict, Optional
 # Reuse the exact result shape the bitwarden source returns so
 # hermes_cli.env_loader can consume both providers identically.
 from agent.secret_sources.base import ErrorKind, SecretSource
+from agent.secret_sources.base import get_source_environment
 from agent.secret_sources.bitwarden import FetchResult
 
 __all__ = [
@@ -181,8 +182,17 @@ def _run_helper(
 
     # User-configured secret-helper command: runs with the user's full shell
     # env by design (it may need any credential to resolve the secret).
-    from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    source_env = get_source_environment()
+    if source_env is os.environ:
+        # Legacy single-profile startup intentionally preserves the existing
+        # helper contract, which may rely on the user's full environment.
+        from tools.environments.local import build_subprocess_env
+        env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    else:
+        # A multiplex profile must never inherit sibling secrets from the
+        # process-global environment.  hydrate_profile_secret_sources seeds
+        # only global-safe values plus this profile's own .env.
+        env = dict(source_env)
     env["HERMES_SECRET_KEY"] = secret_key
 
     try:

--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -420,6 +420,7 @@ class CommandSource(SecretSource):
     name = "command"
     label = "Command helper"
     shape = "bulk"
+    supports_isolated_environment = True
 
     def config_schema(self) -> dict:
         return {

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -55,6 +55,7 @@ from agent.secret_sources._cache import (
     is_valid_env_name,
 )
 from agent.secret_sources.base import ErrorKind, SecretSource
+from agent.secret_sources.base import get_source_environment
 
 logger = logging.getLogger(__name__)
 
@@ -182,15 +183,16 @@ def _auth_fingerprint(token_env: str) -> str:
     previous identity is never served under a new one.  Never logged or
     displayed; the raw token never leaves this hash.
     """
+    source_env = get_source_environment()
     parts: List[str] = [
-        f"token={os.environ.get(token_env, '')}",
-        f"account={os.environ.get('OP_ACCOUNT', '')}",
-        f"connect_host={os.environ.get('OP_CONNECT_HOST', '')}",
-        f"connect_token={os.environ.get('OP_CONNECT_TOKEN', '')}",
+        f"token={source_env.get(token_env, '')}",
+        f"account={source_env.get('OP_ACCOUNT', '')}",
+        f"connect_host={source_env.get('OP_CONNECT_HOST', '')}",
+        f"connect_token={source_env.get('OP_CONNECT_TOKEN', '')}",
     ]
-    for key in sorted(os.environ):
+    for key in sorted(source_env):
         if key.startswith("OP_SESSION_"):
-            parts.append(f"{key}={os.environ[key]}")
+            parts.append(f"{key}={source_env[key]}")
     material = "\n".join(parts)
     return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
 
@@ -238,13 +240,14 @@ def _scrub(text: str) -> str:
 
 def _op_child_env(token_value: str) -> Dict[str, str]:
     """Build a minimal allowlisted environment for the ``op`` child process."""
+    source_env = get_source_environment()
     env: Dict[str, str] = {}
     for key in _OP_ENV_ALLOWLIST:
-        val = os.environ.get(key)
+        val = source_env.get(key)
         if val is not None:
             env[key] = val
     # Desktop / interactive session credentials.
-    for key, val in os.environ.items():
+    for key, val in source_env.items():
         if key.startswith("OP_SESSION_"):
             env[key] = val
     # `op` reads OP_SERVICE_ACCOUNT_TOKEN regardless of which env var the user
@@ -340,7 +343,7 @@ def fetch_onepassword_secrets(
     if not valid:
         return {}, warnings
 
-    token_value = os.environ.get(token_env, "").strip()
+    token_value = get_source_environment().get(token_env, "").strip()
     cache_key: _CacheKey = (
         _auth_fingerprint(token_env),
         account or "",

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -511,6 +511,7 @@ class OnePasswordSource(SecretSource):
     name = "onepassword"
     label = "1Password"
     shape = "mapped"
+    supports_isolated_environment = True
     scheme = "op"
 
     def override_existing(self, cfg: dict) -> bool:

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -32,7 +32,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, MutableMapping, Optional
 
 from agent.secret_sources.base import (
     SECRET_SOURCE_API_VERSION,
@@ -40,6 +40,8 @@ from agent.secret_sources.base import (
     FetchResult,
     SecretSource,
     is_valid_env_name,
+    reset_source_environment,
+    set_source_environment,
 )
 
 logger = logging.getLogger(__name__)
@@ -196,7 +198,8 @@ def _reset_registry_for_tests() -> None:
 
 
 def _fetch_with_timeout(
-    source: SecretSource, cfg: dict, home_path: Path
+    source: SecretSource, cfg: dict, home_path: Path,
+    environ: MutableMapping[str, str],
 ) -> FetchResult:
     """Run source.fetch() under a wall-clock budget; never raises.
 
@@ -211,7 +214,14 @@ def _fetch_with_timeout(
         max_workers=1, thread_name_prefix=f"secret-src-{source.name}"
     )
     try:
-        future = executor.submit(source.fetch, cfg, home_path)
+        def _fetch() -> FetchResult:
+            token = set_source_environment(environ)
+            try:
+                return source.fetch(cfg, home_path)
+            finally:
+                reset_source_environment(token)
+
+        future = executor.submit(_fetch)
         try:
             result = future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
@@ -321,7 +331,7 @@ def _profile_alias_target(var: str, profile: str) -> Optional[str]:
 
 
 def apply_all(secrets_cfg: dict, home_path: Path,
-              environ: Optional[Dict[str, str]] = None) -> ApplyReport:
+              environ: Optional[MutableMapping[str, str]] = None) -> ApplyReport:
     """Fetch from every enabled source and apply the merged result to env.
 
     ``environ`` defaults to ``os.environ``; injectable for tests.
@@ -376,7 +386,7 @@ def apply_all(secrets_cfg: dict, home_path: Path,
     for source in ordered:
         cfg = secrets_cfg.get(source.name)
         cfg = cfg if isinstance(cfg, dict) else {}
-        result = _fetch_with_timeout(source, cfg, home_path)
+        result = _fetch_with_timeout(source, cfg, home_path, env)
         fetches.append((source, cfg, result))
         try:
             for var in source.protected_env_vars(cfg):

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -198,17 +198,30 @@ def _reset_registry_for_tests() -> None:
 
 
 def _fetch_with_timeout(
-    source: SecretSource, cfg: dict, home_path: Path,
+    source: SecretSource,
+    cfg: dict,
+    home_path: Path,
     environ: MutableMapping[str, str],
+    *,
+    isolated_environment: bool = False,
 ) -> FetchResult:
     """Run source.fetch() under a wall-clock budget; never raises.
 
-    The budget is enforced with a daemon worker thread: a source that
-    blows its budget is reported as ``TIMEOUT`` and its (eventual)
-    result is discarded.  The thread itself may linger until process
-    exit — acceptable for a startup-only path, and strictly better than
-    an unbounded hang on every ``hermes`` invocation.
+    Cold multiplex hydration is an isolation boundary, not merely a different
+    mapping passed to test helpers.  Legacy plugin sources may read
+    ``os.environ`` directly, so they are fail-closed there unless they
+    explicitly implement the documented isolated-environment contract.
     """
+    if isolated_environment and not source.supports_isolated_environment:
+        return FetchResult(
+            error=(
+                "source does not declare supports_isolated_environment; "
+                "skipped during cold multiplex hydration to protect "
+                "profile credentials"
+            ),
+            error_kind=ErrorKind.INTERNAL,
+        )
+
     timeout = source.fetch_timeout_seconds(cfg)
     executor = concurrent.futures.ThreadPoolExecutor(
         max_workers=1, thread_name_prefix=f"secret-src-{source.name}"
@@ -330,11 +343,19 @@ def _profile_alias_target(var: str, profile: str) -> Optional[str]:
     return alias
 
 
-def apply_all(secrets_cfg: dict, home_path: Path,
-              environ: Optional[MutableMapping[str, str]] = None) -> ApplyReport:
+def apply_all(
+    secrets_cfg: dict,
+    home_path: Path,
+    environ: Optional[MutableMapping[str, str]] = None,
+    *,
+    isolated_environment: bool = False,
+) -> ApplyReport:
     """Fetch from every enabled source and apply the merged result to env.
 
-    ``environ`` defaults to ``os.environ``; injectable for tests.
+    ``environ`` defaults to ``os.environ``; injectable for tests.  Set
+    ``isolated_environment`` only for a cold multiplex profile: it prevents
+    legacy plugin sources from running unless they explicitly declare that
+    they use the per-fetch environment contract.
 
     Precedence per env var (most-specific intent wins):
 
@@ -386,7 +407,13 @@ def apply_all(secrets_cfg: dict, home_path: Path,
     for source in ordered:
         cfg = secrets_cfg.get(source.name)
         cfg = cfg if isinstance(cfg, dict) else {}
-        result = _fetch_with_timeout(source, cfg, home_path, env)
+        result = _fetch_with_timeout(
+            source,
+            cfg,
+            home_path,
+            env,
+            isolated_environment=isolated_environment,
+        )
         fetches.append((source, cfg, result))
         try:
             for var in source.protected_env_vars(cfg):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1800,8 +1800,10 @@ def _profile_runtime_scope(profile_home: "Path"):
         set_secret_scope,
         reset_secret_scope,
     )
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
+    hydrate_profile_secret_sources(Path(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
     try:
         yield

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -6,6 +6,7 @@ import codecs
 import io
 import os
 import sys
+import threading
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -48,6 +49,7 @@ _SECRET_SOURCE_VALUES_BY_HOME: dict[str, dict[str, str]] = {}
 # in-process cache prevents redundant network calls, but the print, the
 # config re-parse, and the ASCII sanitization sweep still ran every time.
 _APPLIED_HOMES: set[str] = set()
+_SECRET_SOURCE_CACHE_LOCK = threading.RLock()
 
 
 def get_secret_source(env_var: str) -> str | None:
@@ -69,6 +71,69 @@ def get_secret_source_values(
     """Return the external-secret value snapshot for ``hermes_home``."""
     home_key = str(Path(hermes_home).resolve())
     return dict(_SECRET_SOURCE_VALUES_BY_HOME.get(home_key, {}))
+
+
+def hydrate_profile_secret_sources(
+    hermes_home: str | os.PathLike,
+) -> dict[str, str]:
+    """Resolve one profile's configured sources without mutating ``os.environ``.
+
+    Multiplex gateways can route a first turn to a secondary profile that has
+    never run the process-global dotenv startup path.  Resolve that profile's
+    sources against a private mapping seeded from its own ``.env`` and record
+    the usual per-home snapshot for ``build_profile_secret_scope()``.
+
+    Fail-open and once-per-home semantics intentionally mirror
+    ``_apply_external_secret_sources``.  The returned mapping contains only
+    values actually contributed by external sources, never the profile's
+    plaintext ``.env`` entries.
+    """
+    with _SECRET_SOURCE_CACHE_LOCK:
+        return _hydrate_profile_secret_sources(Path(hermes_home))
+
+
+def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
+    """Locked implementation for :func:`hydrate_profile_secret_sources`."""
+    home_key = str(home.resolve())
+    if home_key in _APPLIED_HOMES:
+        return get_secret_source_values(home)
+
+    try:
+        cfg = _load_secrets_config(home)
+    except Exception:  # noqa: BLE001 — external sources must not block routing
+        return {}
+    if not cfg:
+        return {}
+
+    try:
+        from agent.secret_scope import _is_global_env, load_env_file
+        from agent.secret_sources.registry import apply_all
+
+        local_env = {
+            name: value
+            for name, value in os.environ.items()
+            if _is_global_env(name)
+        }
+        local_env.update(load_env_file(home / ".env"))
+        local_env["HERMES_HOME"] = str(home)
+        report = apply_all(cfg, home, environ=local_env)
+    except Exception:  # noqa: BLE001 — preserve fail-open startup behavior
+        return {}
+
+    if not report.sources:
+        return {}
+
+    _APPLIED_HOMES.add(home_key)
+    values: dict[str, str] = {}
+    for name, applied in report.provenance.items():
+        value = local_env.get(name)
+        if value is None:
+            continue
+        _SECRET_SOURCES[name] = applied.source
+        values[name] = value
+    if values:
+        _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
+    return dict(values)
 
 
 def reset_secret_source_cache() -> None:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -30,13 +30,10 @@ _WARNED_KEYS: set[str] = set()
 # is enough.
 _WARNED_UTF32_PATHS: set[str] = set()
 
-# Map of env-var name → source label ("bitwarden", etc.) for credentials
-# that were injected by an external secret source during load_hermes_dotenv().
-# Used by setup / `hermes model` flows to label detected credentials so
-# users understand WHERE a key came from when their .env doesn't contain it
-# directly (otherwise the "credentials detected ✓" line looks identical to
-# the .env case and they don't know Bitwarden is wired up).
-_SECRET_SOURCES: dict[str, str] = {}
+# Provenance follows the same resolved-home boundary as secret values.  A
+# process-global ``var -> source`` map can mislabel the same variable when two
+# profiles hydrate it through different backends.
+_SECRET_SOURCES_BY_HOME: dict[str, dict[str, str]] = {}
 # Applied values are immutable per-home snapshots.  ``os.environ`` is shared
 # across profiles and may be overwritten by a later home's source apply.
 _SECRET_SOURCE_VALUES_BY_HOME: dict[str, dict[str, str]] = {}
@@ -57,18 +54,26 @@ _SECRET_SOURCE_HYDRATION_LOCKS: dict[str, threading.Lock] = {}
 _SECRET_SOURCE_CACHE_GENERATION = 0
 
 
-def get_secret_source(env_var: str) -> str | None:
-    """Return the label of the secret source that supplied ``env_var``, if any.
+def get_secret_source(
+    env_var: str, hermes_home: str | os.PathLike | None = None
+) -> str | None:
+    """Return the source label for ``env_var`` at one resolved Hermes home.
 
-    Returns ``"bitwarden"`` for keys pulled from Bitwarden Secrets Manager
-    during the current process's ``load_hermes_dotenv()`` call.  Returns
-    ``None`` for keys that came from ``.env``, the shell environment, or
-    aren't tracked.  The returned label is metadata only: credential-pool
-    persistence may store it to explain the origin of a borrowed secret, but
-    must never treat it as authorization to persist the raw value.
+    Pass ``hermes_home`` whenever a caller already knows which profile it is
+    serving.  The no-home compatibility path returns a label only when every
+    loaded home that supplied the variable agrees, avoiding a cross-profile
+    provenance lie.
     """
     with _SECRET_SOURCE_CACHE_LOCK:
-        return _SECRET_SOURCES.get(env_var)
+        if hermes_home is not None:
+            home_key = str(Path(hermes_home).resolve())
+            return _SECRET_SOURCES_BY_HOME.get(home_key, {}).get(env_var)
+        labels = {
+            sources[env_var]
+            for sources in _SECRET_SOURCES_BY_HOME.values()
+            if env_var in sources
+        }
+        return labels.pop() if len(labels) == 1 else None
 
 
 def get_secret_source_values(
@@ -154,7 +159,12 @@ def _hydrate_profile_secret_sources(
         for name, value in load_env_file(home / ".op.env").items():
             local_env.setdefault(name, value)
         local_env["HERMES_HOME"] = str(home)
-        report = apply_all(cfg, home, environ=local_env)
+        report = apply_all(
+            cfg,
+            home,
+            environ=local_env,
+            isolated_environment=True,
+        )
     except Exception:  # noqa: BLE001 — preserve fail-open startup behavior
         return {}, False
 
@@ -168,14 +178,16 @@ def _hydrate_profile_secret_sources(
             return get_secret_source_values(home), False
 
         values: dict[str, str] = {}
+        provenance: dict[str, str] = {}
         for name, applied in report.provenance.items():
             value = local_env.get(name)
             if value is None:
                 continue
-            _SECRET_SOURCES[name] = applied.source
+            provenance[name] = applied.source
             values[name] = value
         if values:
             _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
+            _SECRET_SOURCES_BY_HOME[home_key] = provenance
         _APPLIED_HOMES.add(home_key)
         return dict(values), False
 
@@ -185,8 +197,8 @@ def reset_secret_source_cache() -> None:
 
     The first call to ``_apply_external_secret_sources(home_path)`` in a
     process pulls from Bitwarden (or other configured backend), records the
-    applied keys in ``_SECRET_SOURCES``, and remembers ``home_path`` so
-    subsequent calls in the same process are no-ops.  Call this to force the
+    applied keys in its resolved-home provenance map, and remembers
+    ``home_path`` so subsequent calls in the same process are no-ops. Call this
     next call to re-pull — useful for tests, and for long-running processes
     that want to refresh after a config change.
     """
@@ -194,11 +206,13 @@ def reset_secret_source_cache() -> None:
     with _SECRET_SOURCE_CACHE_LOCK:
         _SECRET_SOURCE_CACHE_GENERATION += 1
         _APPLIED_HOMES.clear()
-        _SECRET_SOURCES.clear()
+        _SECRET_SOURCES_BY_HOME.clear()
         _SECRET_SOURCE_VALUES_BY_HOME.clear()
 
 
-def format_secret_source_suffix(env_var: str) -> str:
+def format_secret_source_suffix(
+    env_var: str, hermes_home: str | os.PathLike | None = None
+) -> str:
     """Return a human-readable suffix like ``" (from Bitwarden)"`` or ``""``.
 
     Use this when printing a detected credential so the user can see where
@@ -206,7 +220,7 @@ def format_secret_source_suffix(env_var: str) -> str:
     the shell — those are the implicit / "default" cases users already
     understand.
     """
-    source = get_secret_source(env_var)
+    source = get_secret_source(env_var, hermes_home)
     if not source:
         return ""
     if source == "bitwarden":
@@ -501,8 +515,8 @@ def _apply_external_secret_sources_locked(home_path: Path) -> None:
     first-claim-wins conflict handling, override semantics, provenance)
     lives in ``agent.secret_sources.registry.apply_all``; this wrapper
     owns the once-per-HERMES_HOME guard, the post-apply ASCII
-    sanitization sweep, the ``_SECRET_SOURCES`` provenance map that
-    UI surfaces read, and the startup status lines.
+    sanitization sweep, the resolved-home provenance map that UI surfaces
+    read, and the startup status lines.
 
     Idempotent within a process: subsequent calls for the same
     ``home_path`` are no-ops.  ``load_hermes_dotenv()`` runs at import
@@ -570,10 +584,12 @@ def _apply_external_secret_sources_locked(home_path: Path) -> None:
             # Remember where each var came from so setup / `hermes model`
             # flows can label detected credentials with their source.
             values: dict[str, str] = {}
+            provenance: dict[str, str] = {}
             for name, applied in report.provenance.items():
-                _SECRET_SOURCES[name] = applied.source
+                provenance[name] = applied.source
                 if name in os.environ:
                     values[name] = os.environ[name]
+            _SECRET_SOURCES_BY_HOME[home_key] = provenance
             _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
 
     for src in report.sources:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -49,7 +49,12 @@ _SECRET_SOURCE_VALUES_BY_HOME: dict[str, dict[str, str]] = {}
 # in-process cache prevents redundant network calls, but the print, the
 # config re-parse, and the ASCII sanitization sweep still ran every time.
 _APPLIED_HOMES: set[str] = set()
+# Cache metadata is shared by normal startup and multiplex profile hydration.
+# Keep the global lock short: source fetches can involve a network/CLI timeout,
+# so a separate lock serializes only concurrent hydration for the *same* home.
 _SECRET_SOURCE_CACHE_LOCK = threading.RLock()
+_SECRET_SOURCE_HYDRATION_LOCKS: dict[str, threading.Lock] = {}
+_SECRET_SOURCE_CACHE_GENERATION = 0
 
 
 def get_secret_source(env_var: str) -> str | None:
@@ -62,7 +67,8 @@ def get_secret_source(env_var: str) -> str | None:
     persistence may store it to explain the origin of a borrowed secret, but
     must never treat it as authorization to persist the raw value.
     """
-    return _SECRET_SOURCES.get(env_var)
+    with _SECRET_SOURCE_CACHE_LOCK:
+        return _SECRET_SOURCES.get(env_var)
 
 
 def get_secret_source_values(
@@ -70,7 +76,8 @@ def get_secret_source_values(
 ) -> dict[str, str]:
     """Return the external-secret value snapshot for ``hermes_home``."""
     home_key = str(Path(hermes_home).resolve())
-    return dict(_SECRET_SOURCE_VALUES_BY_HOME.get(home_key, {}))
+    with _SECRET_SOURCE_CACHE_LOCK:
+        return dict(_SECRET_SOURCE_VALUES_BY_HOME.get(home_key, {}))
 
 
 def hydrate_profile_secret_sources(
@@ -79,32 +86,56 @@ def hydrate_profile_secret_sources(
     """Resolve one profile's configured sources without mutating ``os.environ``.
 
     Multiplex gateways can route a first turn to a secondary profile that has
-    never run the process-global dotenv startup path.  Resolve that profile's
+    never run the process-global dotenv startup path. Resolve that profile's
     sources against a private mapping seeded from its own ``.env`` and
     ``.op.env`` bootstrap file, then record the usual per-home snapshot for
     ``build_profile_secret_scope()``.
 
     Fail-open and once-per-home semantics intentionally mirror
-    ``_apply_external_secret_sources``.  The returned mapping contains only
+    ``_apply_external_secret_sources``. The returned mapping contains only
     values actually contributed by external sources, never the profile's
     plaintext ``.env`` entries.
     """
-    with _SECRET_SOURCE_CACHE_LOCK:
-        return _hydrate_profile_secret_sources(Path(hermes_home))
-
-
-def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
-    """Locked implementation for :func:`hydrate_profile_secret_sources`."""
+    home = Path(hermes_home)
     home_key = str(home.resolve())
-    if home_key in _APPLIED_HOMES:
-        return get_secret_source_values(home)
 
+    # Do not hold the metadata lock while a source fetches: different cold
+    # profiles can resolve concurrently, while same-home calls share one fetch.
+    while True:
+        with _SECRET_SOURCE_CACHE_LOCK:
+            if home_key in _APPLIED_HOMES:
+                return get_secret_source_values(home)
+            home_lock = _SECRET_SOURCE_HYDRATION_LOCKS.setdefault(
+                home_key, threading.Lock()
+            )
+
+        with home_lock:
+            with _SECRET_SOURCE_CACHE_LOCK:
+                if home_key in _APPLIED_HOMES:
+                    return get_secret_source_values(home)
+                generation = _SECRET_SOURCE_CACHE_GENERATION
+
+            values, reset_during_fetch = _hydrate_profile_secret_sources(
+                home, home_key, generation
+            )
+            if not reset_during_fetch:
+                return values
+
+
+def _hydrate_profile_secret_sources(
+    home: Path, home_key: str, generation: int
+) -> tuple[dict[str, str], bool]:
+    """Fetch a cold profile outside the metadata lock.
+
+    Returns ``(values, reset_during_fetch)``. A reset invalidates an in-flight
+    fetch so the caller retries against the post-reset cache generation.
+    """
     try:
         cfg = _load_secrets_config(home)
     except Exception:  # noqa: BLE001 — external sources must not block routing
-        return {}
+        return {}, False
     if not cfg:
-        return {}
+        return {}, False
 
     try:
         from agent.secret_scope import _is_global_env, load_env_file
@@ -118,29 +149,35 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
         local_env.update(load_env_file(home / ".env"))
         # Mirror load_hermes_dotenv(): .op.env supplies the 1Password
         # bootstrap token for headless/cold-profile resolution, but never
-        # overrides profile .env values.  Keep it local so neither the token
+        # overrides profile .env values. Keep it local so neither the token
         # nor resolved source values escape into the shared process environment.
         for name, value in load_env_file(home / ".op.env").items():
             local_env.setdefault(name, value)
         local_env["HERMES_HOME"] = str(home)
         report = apply_all(cfg, home, environ=local_env)
     except Exception:  # noqa: BLE001 — preserve fail-open startup behavior
-        return {}
+        return {}, False
 
     if not report.sources:
-        return {}
+        return {}, False
 
-    _APPLIED_HOMES.add(home_key)
-    values: dict[str, str] = {}
-    for name, applied in report.provenance.items():
-        value = local_env.get(name)
-        if value is None:
-            continue
-        _SECRET_SOURCES[name] = applied.source
-        values[name] = value
-    if values:
-        _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
-    return dict(values)
+    with _SECRET_SOURCE_CACHE_LOCK:
+        if generation != _SECRET_SOURCE_CACHE_GENERATION:
+            return {}, True
+        if home_key in _APPLIED_HOMES:
+            return get_secret_source_values(home), False
+
+        values: dict[str, str] = {}
+        for name, applied in report.provenance.items():
+            value = local_env.get(name)
+            if value is None:
+                continue
+            _SECRET_SOURCES[name] = applied.source
+            values[name] = value
+        if values:
+            _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
+        _APPLIED_HOMES.add(home_key)
+        return dict(values), False
 
 
 def reset_secret_source_cache() -> None:
@@ -153,9 +190,12 @@ def reset_secret_source_cache() -> None:
     next call to re-pull — useful for tests, and for long-running processes
     that want to refresh after a config change.
     """
-    _APPLIED_HOMES.clear()
-    _SECRET_SOURCES.clear()
-    _SECRET_SOURCE_VALUES_BY_HOME.clear()
+    global _SECRET_SOURCE_CACHE_GENERATION
+    with _SECRET_SOURCE_CACHE_LOCK:
+        _SECRET_SOURCE_CACHE_GENERATION += 1
+        _APPLIED_HOMES.clear()
+        _SECRET_SOURCES.clear()
+        _SECRET_SOURCE_VALUES_BY_HOME.clear()
 
 
 def format_secret_source_suffix(env_var: str) -> str:
@@ -473,8 +513,10 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     (tests, long-running processes after a config change).
     """
     home_key = str(Path(home_path).resolve())
-    if home_key in _APPLIED_HOMES:
-        return
+    with _SECRET_SOURCE_CACHE_LOCK:
+        if home_key in _APPLIED_HOMES:
+            return
+        generation = _SECRET_SOURCE_CACHE_GENERATION
 
     try:
         cfg = _load_secrets_config(home_path)
@@ -506,28 +548,33 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         # mid-process takes effect on the next call.
         return
 
-    # A real fetch attempt happened (success OR error).  Mark the home now
-    # so the 3-5 import-time load_hermes_dotenv() calls per startup don't
-    # re-fetch / re-print — error retries within one process are opt-in via
-    # reset_secret_source_cache().  Marking AFTER the attempt (not before,
-    # see #40597) is what lets the earlier failure paths stay retryable.
-    _APPLIED_HOMES.add(home_key)
-
+    # Re-run the ASCII sanitization pass: vault values are user-supplied and
+    # might have the same copy-paste corruption as a manually edited .env.
     if report.applied_any:
-        # Re-run the ASCII sanitization pass: vault values are
-        # user-supplied and might have the same copy-paste corruption as
-        # a manually edited .env (see #6843).
         _sanitize_loaded_credentials()
-        # Remember where each var came from so setup / `hermes model`
-        # flows can label detected credentials with "(from Bitwarden)" /
-        # "(from 1Password)" — otherwise users see "credentials ✓" with
-        # no hint the value came from a vault rather than .env.
-        values: dict[str, str] = {}
-        for name, applied in report.provenance.items():
-            _SECRET_SOURCES[name] = applied.source
-            if name in os.environ:
-                values[name] = os.environ[name]
-        _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
+
+    with _SECRET_SOURCE_CACHE_LOCK:
+        # A concurrent reset invalidates cache metadata for this completed
+        # fetch. Leave it retryable rather than re-marking stale state.
+        if generation != _SECRET_SOURCE_CACHE_GENERATION:
+            return
+        if home_key in _APPLIED_HOMES:
+            return
+
+        # A real fetch attempt happened (success OR error). Mark the home now
+        # so repeated import-time loads do not re-fetch / re-print. Marking
+        # after the attempt keeps malformed/disabled configs retryable.
+        _APPLIED_HOMES.add(home_key)
+
+        if report.applied_any:
+            # Remember where each var came from so setup / `hermes model`
+            # flows can label detected credentials with their source.
+            values: dict[str, str] = {}
+            for name, applied in report.provenance.items():
+                _SECRET_SOURCES[name] = applied.source
+                if name in os.environ:
+                    values[name] = os.environ[name]
+            _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
 
     for src in report.sources:
         if src.applied:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -80,8 +80,9 @@ def hydrate_profile_secret_sources(
 
     Multiplex gateways can route a first turn to a secondary profile that has
     never run the process-global dotenv startup path.  Resolve that profile's
-    sources against a private mapping seeded from its own ``.env`` and record
-    the usual per-home snapshot for ``build_profile_secret_scope()``.
+    sources against a private mapping seeded from its own ``.env`` and
+    ``.op.env`` bootstrap file, then record the usual per-home snapshot for
+    ``build_profile_secret_scope()``.
 
     Fail-open and once-per-home semantics intentionally mirror
     ``_apply_external_secret_sources``.  The returned mapping contains only
@@ -115,6 +116,12 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
             if _is_global_env(name)
         }
         local_env.update(load_env_file(home / ".env"))
+        # Mirror load_hermes_dotenv(): .op.env supplies the 1Password
+        # bootstrap token for headless/cold-profile resolution, but never
+        # overrides profile .env values.  Keep it local so neither the token
+        # nor resolved source values escape into the shared process environment.
+        for name, value in load_env_file(home / ".op.env").items():
+            local_env.setdefault(name, value)
         local_env["HERMES_HOME"] = str(home)
         report = apply_all(cfg, home, environ=local_env)
     except Exception:  # noqa: BLE001 — preserve fail-open startup behavior

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -489,7 +489,7 @@ def _apply_managed_env() -> None:
     _load_dotenv_with_fallback(managed_env, override=True)
 
 
-def _apply_external_secret_sources(home_path: Path) -> None:
+def _apply_external_secret_sources_locked(home_path: Path) -> None:
     """Pull secrets from every enabled external source into env.
 
     Runs AFTER dotenv loads so .env values are visible (sources use them
@@ -592,6 +592,21 @@ def _apply_external_secret_sources(home_path: Path) -> None:
             print(f"  {src.label}: {warn}", file=sys.stderr)
     for conflict in report.conflicts:
         print(f"  Secret sources: {conflict}", file=sys.stderr)
+
+
+def _apply_external_secret_sources(home_path: Path) -> None:
+    """Apply one home's process-global sources exactly once at a time.
+
+    Multiplex hydration uses the same per-home lock, so a direct startup apply
+    cannot race a cold turn for that home or duplicate an external fetch.
+    """
+    home_key = str(Path(home_path).resolve())
+    with _SECRET_SOURCE_CACHE_LOCK:
+        home_lock = _SECRET_SOURCE_HYDRATION_LOCKS.setdefault(
+            home_key, threading.Lock()
+        )
+    with home_lock:
+        _apply_external_secret_sources_locked(home_path)
 
 
 def _remediation_hint(source_name: str, error_kind, secrets_cfg: dict) -> str:

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -88,3 +88,81 @@ class TestProfilePathResolutionUnderMultiplexScope:
         assert b_seen == prof_b / "skills"
 
 
+def test_cold_profile_hydrates_external_source_without_global_env(
+    tmp_path, monkeypatch
+):
+    """The first routed secondary turn must resolve its own source locally."""
+    import os
+
+    from agent.secret_sources.base import FetchResult
+    from agent.secret_sources.registry import AppliedVar, ApplyReport, SourceReport
+    from agent.secret_sources import registry
+    from agent.secret_scope import get_secret
+    from hermes_cli import env_loader
+    from gateway.run import _profile_runtime_scope
+
+    profile = tmp_path / "profiles" / "secondary"
+    sibling = tmp_path / "profiles" / "sibling"
+    profile.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+    (profile / ".env").write_text(
+        "EXPLICIT_API_KEY=dotenv-wins\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("TEST_PROVIDER_API_KEY", raising=False)
+    monkeypatch.delenv("EXPLICIT_API_KEY", raising=False)
+    monkeypatch.setattr(
+        env_loader,
+        "_load_secrets_config",
+        lambda home: (
+            {"fake-source": {"enabled": True}}
+            if Path(home).resolve() == profile.resolve()
+            else {}
+        ),
+    )
+
+    calls = {"count": 0}
+
+    def _fake_apply_all(_cfg, _home, *, environ=None):
+        calls["count"] += 1
+        assert environ is not os.environ
+        assert environ is not None
+        assert environ["EXPLICIT_API_KEY"] == "dotenv-wins"
+        environ["TEST_PROVIDER_API_KEY"] = "profile-only"
+        return ApplyReport(
+            sources=[
+                SourceReport(
+                    name="fake-source",
+                    label="Fake Source",
+                    result=FetchResult(),
+                    applied=["TEST_PROVIDER_API_KEY"],
+                )
+            ],
+            provenance={
+                "TEST_PROVIDER_API_KEY": AppliedVar(
+                    name="TEST_PROVIDER_API_KEY",
+                    source="fake-source",
+                    shape="mapped",
+                    overrode_env=False,
+                )
+            },
+        )
+
+    monkeypatch.setattr(registry, "apply_all", _fake_apply_all)
+    env_loader.reset_secret_source_cache()
+
+    with _profile_runtime_scope(profile):
+        assert get_secret("TEST_PROVIDER_API_KEY") == "profile-only"
+        assert get_secret("EXPLICIT_API_KEY") == "dotenv-wins"
+        assert env_loader.get_secret_source_values(profile) == {
+            "TEST_PROVIDER_API_KEY": "profile-only"
+        }
+    with _profile_runtime_scope(profile):
+        assert get_secret("TEST_PROVIDER_API_KEY") == "profile-only"
+    with _profile_runtime_scope(sibling):
+        assert get_secret("TEST_PROVIDER_API_KEY") is None
+
+    assert calls["count"] == 1
+    assert "TEST_PROVIDER_API_KEY" not in os.environ
+    assert "EXPLICIT_API_KEY" not in os.environ
+
+

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -122,7 +122,8 @@ def test_cold_profile_hydrates_external_source_without_global_env(
 
     calls = {"count": 0}
 
-    def _fake_apply_all(_cfg, _home, *, environ=None):
+    def _fake_apply_all(_cfg, _home, *, environ=None, isolated_environment=False):
+        assert isolated_environment is True
         calls["count"] += 1
         assert environ is not os.environ
         assert environ is not None

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -166,3 +166,75 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     assert "EXPLICIT_API_KEY" not in os.environ
 
 
+def test_cold_profile_onepassword_uses_profile_op_env_without_global_leak(
+    tmp_path, monkeypatch
+):
+    """A first routed profile gets its own .op.env bootstrap token locally."""
+    import os
+    from types import SimpleNamespace
+
+    import agent.secret_sources.onepassword as onepassword
+    from agent.secret_scope import get_secret
+    from hermes_cli import env_loader
+    from gateway.run import _profile_runtime_scope
+
+    profile = tmp_path / "profiles" / "secondary"
+    profile.mkdir(parents=True)
+    (profile / ".env").write_text(
+        "EXPLICIT_API_KEY=dotenv-wins\n", encoding="utf-8"
+    )
+    (profile / ".op.env").write_text(
+        "OP_SERVICE_ACCOUNT_TOKEN=profile-bootstrap\n", encoding="utf-8"
+    )
+    (profile / "config.yaml").write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    enabled: true\n"
+        "    env:\n"
+        "      TEST_PROVIDER_API_KEY: op://Vault/Item/credential\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
+    monkeypatch.delenv("TEST_PROVIDER_API_KEY", raising=False)
+    monkeypatch.delenv("EXPLICIT_API_KEY", raising=False)
+    monkeypatch.setattr(onepassword, "find_op", lambda _path: Path("/fake/op"))
+
+    child_env: dict[str, str] = {}
+
+    def _fake_run(_command, **kwargs):
+        child_env.update(kwargs["env"])
+        return SimpleNamespace(
+            returncode=0, stdout="profile-provider-key\n", stderr=""
+        )
+
+    monkeypatch.setattr(onepassword.subprocess, "run", _fake_run)
+    env_loader.reset_secret_source_cache()
+    onepassword._reset_cache_for_tests(profile)
+
+    with _profile_runtime_scope(profile):
+        assert get_secret("TEST_PROVIDER_API_KEY") == "profile-provider-key"
+        assert get_secret("EXPLICIT_API_KEY") == "dotenv-wins"
+
+    assert child_env["OP_SERVICE_ACCOUNT_TOKEN"] == "profile-bootstrap"
+
+    # Match the normal loader's precedence: a profile .env token is explicit
+    # and therefore wins over the .op.env bootstrap fallback.
+    (profile / ".env").write_text(
+        "OP_SERVICE_ACCOUNT_TOKEN=dotenv-bootstrap\n"
+        "EXPLICIT_API_KEY=dotenv-wins\n",
+        encoding="utf-8",
+    )
+    child_env.clear()
+    env_loader.reset_secret_source_cache()
+    onepassword._reset_cache_for_tests(profile)
+
+    with _profile_runtime_scope(profile):
+        assert get_secret("TEST_PROVIDER_API_KEY") == "profile-provider-key"
+
+    assert child_env["OP_SERVICE_ACCOUNT_TOKEN"] == "dotenv-bootstrap"
+    assert "TEST_PROVIDER_API_KEY" not in child_env
+    assert "OP_SERVICE_ACCOUNT_TOKEN" not in os.environ
+    assert "TEST_PROVIDER_API_KEY" not in os.environ
+    assert "EXPLICIT_API_KEY" not in os.environ
+
+

--- a/tests/secret_sources/test_profile_secrets.py
+++ b/tests/secret_sources/test_profile_secrets.py
@@ -123,5 +123,55 @@ def test_hyphenated_profile_name_matches_underscore_suffix():
     assert env["SLACK_APP_TOKEN"] == "xapp-1"
 
 
+def test_source_fetch_reads_injected_environment_without_global_mutation(
+    monkeypatch, tmp_path
+):
+    """Cold-profile bootstrap values reach sources through the local mapping."""
+    from agent.secret_sources.base import get_source_environment
+
+    class _BootstrapSource(SecretSource):
+        name = "bootstrap"
+        shape = "mapped"
+
+        def fetch(self, cfg, home_path):
+            result = FetchResult()
+            result.secrets = {
+                "RESOLVED_API_KEY": get_source_environment()["BOOTSTRAP_TOKEN"]
+            }
+            return result
+
+    registry.register_source(_BootstrapSource())
+    monkeypatch.delenv("BOOTSTRAP_TOKEN", raising=False)
+    env = {"BOOTSTRAP_TOKEN": "profile-token"}
+    _, applied = _apply(
+        {},
+        cfg_extra={"bootstrap": {"enabled": True}},
+        home=tmp_path,
+        env=env,
+    )
+
+    assert applied["RESOLVED_API_KEY"] == "profile-token"
+    assert "BOOTSTRAP_TOKEN" not in __import__("os").environ
+
+
+def test_empty_injected_environment_does_not_fall_back_to_process(monkeypatch, tmp_path):
+    from agent.secret_sources.base import get_source_environment
+
+    class _CanarySource(SecretSource):
+        name = "canary"
+        shape = "mapped"
+
+        def fetch(self, cfg, home_path):
+            result = FetchResult()
+            assert get_source_environment().get("LEAK_CANARY") is None
+            return result
+
+    registry.register_source(_CanarySource())
+    monkeypatch.setenv("LEAK_CANARY", "global-secret")
+    registry.apply_all(
+        {"canary": {"enabled": True}}, tmp_path, environ={}
+    )
+
+
 
 

--- a/tests/secret_sources/test_profile_secrets.py
+++ b/tests/secret_sources/test_profile_secrets.py
@@ -154,6 +154,39 @@ def test_source_fetch_reads_injected_environment_without_global_mutation(
     assert "BOOTSTRAP_TOKEN" not in __import__("os").environ
 
 
+def test_legacy_plugin_source_is_skipped_during_isolated_hydration(monkeypatch, tmp_path):
+    """A legacy plugin that reads os.environ cannot observe another profile."""
+    import os
+
+    calls = 0
+
+    class _LegacyPluginSource(SecretSource):
+        name = "legacy_plugin"
+        label = "Legacy plugin"
+        shape = "mapped"
+
+        def fetch(self, cfg, home_path):
+            nonlocal calls
+            calls += 1
+            # This is intentionally unsafe legacy-plugin behavior.  The
+            # orchestrator must refuse to invoke it at the isolated boundary.
+            return FetchResult(secrets={"RESOLVED_API_KEY": os.environ["CANARY"]})
+
+    registry.register_source(_LegacyPluginSource())
+    monkeypatch.setenv("CANARY", "default-profile-secret")
+
+    report = registry.apply_all(
+        {"legacy_plugin": {"enabled": True}},
+        tmp_path,
+        environ={"CANARY": "secondary-profile-secret"},
+        isolated_environment=True,
+    )
+
+    assert calls == 0
+    assert report.sources[0].result.error_kind is ErrorKind.INTERNAL
+    assert "supports_isolated_environment" in (report.sources[0].result.error or "")
+
+
 def test_empty_injected_environment_does_not_fall_back_to_process(monkeypatch, tmp_path):
     from agent.secret_sources.base import get_source_environment
 

--- a/tests/test_command_secret_source.py
+++ b/tests/test_command_secret_source.py
@@ -35,11 +35,16 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from agent.secret_sources.command import (  # noqa: E402
+    _run_helper,
     apply_command_secrets,
     get_command_secret,
     list_command_secrets,
     parse_secret_output,
     unquote_dotenv_value,
+)
+from agent.secret_sources.base import (  # noqa: E402
+    reset_source_environment,
+    set_source_environment,
 )
 from hermes_cli import env_loader  # noqa: E402
 
@@ -55,6 +60,22 @@ def _write_helper(tmp_path: Path, body: str, name: str = "helper.sh") -> Path:
     script.write_text("#!/bin/sh\n" + body + "\n", encoding="utf-8")
     script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return script
+
+
+def test_profile_helper_does_not_inherit_process_secret(monkeypatch):
+    monkeypatch.setenv("LEAK_CANARY", "global-secret")
+    token = set_source_environment({"PROFILE_ONLY": "profile-value"})
+    try:
+        output = _run_helper(
+            'printf "%s|%s" "${LEAK_CANARY-unset}" "$PROFILE_ONLY"',
+            "",
+            1.0,
+            1024,
+        )
+    finally:
+        reset_source_environment(token)
+
+    assert output == "unset|profile-value"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_command_secret_source.py
+++ b/tests/test_command_secret_source.py
@@ -82,12 +82,12 @@ def test_profile_helper_does_not_inherit_process_secret(monkeypatch):
 def _clean_env(monkeypatch):
     """Each test starts with a clean source map, applied-home guard, and no
     leftover test keys in os.environ."""
-    env_loader._SECRET_SOURCES.clear()
+    env_loader._SECRET_SOURCES_BY_HOME.clear()
     env_loader.reset_secret_source_cache()
     for key in ("CMDTEST_API_KEY", "CMDTEST_TOKEN", "CMDTEST_OTHER_KEY"):
         monkeypatch.delenv(key, raising=False)
     yield
-    env_loader._SECRET_SOURCES.clear()
+    env_loader._SECRET_SOURCES_BY_HOME.clear()
     env_loader.reset_secret_source_cache()
     for key in ("CMDTEST_API_KEY", "CMDTEST_TOKEN", "CMDTEST_OTHER_KEY"):
         os.environ.pop(key, None)

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -135,6 +135,45 @@ def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkey
     )
 
 
+def test_cold_profile_bitwarden_uses_profile_bootstrap_without_global_env(
+    tmp_path, monkeypatch
+):
+    """Real Bitwarden adapter reads its token from the profile-local view."""
+    monkeypatch.delenv("BWS_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    (tmp_path / ".env").write_text(
+        "BWS_ACCESS_TOKEN=profile-bootstrap\n", encoding="utf-8"
+    )
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    import agent.secret_sources.bitwarden as bw_module
+    from agent.secret_sources import registry as reg_module
+
+    captured = {}
+    monkeypatch.setattr(bw_module, "find_bws", lambda **_kw: Path("/fake/bws"))
+
+    def _fake_fetch(**kwargs):
+        captured.update(kwargs)
+        return {"ANTHROPIC_API_KEY": "profile-provider-key"}, []
+
+    monkeypatch.setattr(bw_module, "fetch_bitwarden_secrets", _fake_fetch)
+    reg_module._reset_registry_for_tests()
+
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {
+        "ANTHROPIC_API_KEY": "profile-provider-key"
+    }
+    assert captured["access_token"] == "profile-bootstrap"
+    assert os.environ.get("BWS_ACCESS_TOKEN") is None
+    assert os.environ.get("ANTHROPIC_API_KEY") is None
+
+
 def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch):
     """Disabled Bitwarden config must not touch the source map."""
 

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -547,3 +547,48 @@ def test_reset_during_cold_profile_hydration_retries_for_a_complete_snapshot(
     assert calls["count"] == 2
     assert result == {"TEST_PROVIDER_API_KEY": "profile-only"}
     assert env_loader.get_secret_source_values(home) == result
+
+
+def test_startup_source_apply_shares_the_same_home_hydration_lock(
+    tmp_path, monkeypatch
+):
+    """Concurrent startup calls for one home produce exactly one source fetch."""
+    from types import SimpleNamespace
+
+    from agent.secret_sources import registry
+
+    home = tmp_path / "secondary"
+    home.mkdir()
+    monkeypatch.setattr(
+        env_loader, "_load_secrets_config", lambda _home: {"fake": {"enabled": True}}
+    )
+    first_fetch_started = threading.Event()
+    release_first_fetch = threading.Event()
+    calls = {"count": 0}
+
+    def _fake_apply_all(_cfg, _home):
+        calls["count"] += 1
+        first_fetch_started.set()
+        assert release_first_fetch.wait(timeout=5)
+        return SimpleNamespace(
+            sources=[
+                SimpleNamespace(applied=[], result=SimpleNamespace(error="", warnings=[]))
+            ],
+            applied_any=False,
+            conflicts=[],
+        )
+
+    monkeypatch.setattr(registry, "apply_all", _fake_apply_all)
+    workers = [
+        threading.Thread(target=env_loader._apply_external_secret_sources, args=(home,))
+        for _ in range(2)
+    ]
+    workers[0].start()
+    assert first_fetch_started.wait(timeout=5)
+    workers[1].start()
+    release_first_fetch.set()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert calls["count"] == 1

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -22,14 +22,21 @@ if str(ROOT) not in sys.path:
 from hermes_cli import env_loader  # noqa: E402
 
 
+_TEST_HOME = Path("/tmp/hermes-secret-source-test-home")
+
+
+def _record_source(name: str, source: str, home: Path = _TEST_HOME) -> None:
+    env_loader._SECRET_SOURCES_BY_HOME.setdefault(str(home.resolve()), {})[name] = source
+
+
 @pytest.fixture(autouse=True)
 def _reset_sources():
     """Each test starts with a clean source map and applied-home guard."""
-    env_loader._SECRET_SOURCES.clear()
+    env_loader._SECRET_SOURCES_BY_HOME.clear()
     env_loader._SECRET_SOURCE_VALUES_BY_HOME.clear()
     env_loader.reset_secret_source_cache()
     yield
-    env_loader._SECRET_SOURCES.clear()
+    env_loader._SECRET_SOURCES_BY_HOME.clear()
     env_loader._SECRET_SOURCE_VALUES_BY_HOME.clear()
     env_loader.reset_secret_source_cache()
 
@@ -39,8 +46,22 @@ def test_get_secret_source_returns_none_for_untracked_var():
 
 
 def test_get_secret_source_returns_label_for_tracked_var():
-    env_loader._SECRET_SOURCES["ANTHROPIC_API_KEY"] = "bitwarden"
+    _record_source("ANTHROPIC_API_KEY", "bitwarden")
     assert env_loader.get_secret_source("ANTHROPIC_API_KEY") == "bitwarden"
+
+
+def test_get_secret_source_is_scoped_by_resolved_home(tmp_path):
+    """Two profiles may attribute the same key to different source backends."""
+    home_a = tmp_path / "alpha"
+    home_b = tmp_path / "beta"
+    _record_source("SHARED_API_KEY", "bitwarden", home_a)
+    _record_source("SHARED_API_KEY", "onepassword", home_b)
+
+    assert env_loader.get_secret_source("SHARED_API_KEY", home_a) == "bitwarden"
+    assert env_loader.get_secret_source("SHARED_API_KEY", home_b) == "onepassword"
+    assert env_loader.format_secret_source_suffix("SHARED_API_KEY", home_a) == " (from Bitwarden)"
+    assert env_loader.format_secret_source_suffix("SHARED_API_KEY", home_b) == " (from 1Password)"
+    assert env_loader.get_secret_source("SHARED_API_KEY") is None
 
 
 def test_get_secret_source_values_returns_home_snapshot_copy(tmp_path):
@@ -71,7 +92,7 @@ def test_format_secret_source_suffix_empty_for_untracked():
 
 
 def test_format_secret_source_suffix_bitwarden_uses_proper_name():
-    env_loader._SECRET_SOURCES["ANTHROPIC_API_KEY"] = "bitwarden"
+    _record_source("ANTHROPIC_API_KEY", "bitwarden")
     assert (
         env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
         == " (from Bitwarden)"
@@ -81,7 +102,7 @@ def test_format_secret_source_suffix_bitwarden_uses_proper_name():
 def test_format_secret_source_suffix_generic_label_for_future_sources():
     # Future-proofing: a new secret source (e.g. "vault") should still
     # produce a sensible label without needing to edit every call site.
-    env_loader._SECRET_SOURCES["OPENAI_API_KEY"] = "vault"
+    _record_source("OPENAI_API_KEY", "vault")
     assert (
         env_loader.format_secret_source_suffix("OPENAI_API_KEY")
         == " (from vault)"
@@ -89,7 +110,7 @@ def test_format_secret_source_suffix_generic_label_for_future_sources():
 
 
 def test_format_secret_source_suffix_onepassword_uses_proper_name():
-    env_loader._SECRET_SOURCES["OPENAI_API_KEY"] = "onepassword"
+    _record_source("OPENAI_API_KEY", "onepassword")
     assert (
         env_loader.format_secret_source_suffix("OPENAI_API_KEY")
         == " (from 1Password)"
@@ -468,7 +489,8 @@ def test_cold_profile_hydration_allows_distinct_homes_to_fetch_concurrently(
     )
     fetch_barrier = threading.Barrier(2, timeout=2)
 
-    def _fake_apply_all(_cfg, home, *, environ):
+    def _fake_apply_all(_cfg, home, *, environ, isolated_environment=False):
+        assert isolated_environment is True
         fetch_barrier.wait()
         key = f"{home.name.upper()}_API_KEY"
         environ[key] = f"{home.name}-only"
@@ -518,7 +540,8 @@ def test_reset_during_cold_profile_hydration_retries_for_a_complete_snapshot(
     release_first_fetch = threading.Event()
     calls = {"count": 0}
 
-    def _fake_apply_all(_cfg, _home, *, environ):
+    def _fake_apply_all(_cfg, _home, *, environ, isolated_environment=False):
+        assert isolated_environment is True
         calls["count"] += 1
         if calls["count"] == 1:
             first_fetch_started.set()

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -449,3 +450,100 @@ def test_apply_external_secret_sources_bad_ttl_does_not_crash(tmp_path, monkeypa
 
     # Coerced to the 300s default rather than raising ValueError.
     assert captured["cache_ttl_seconds"] == 300
+
+
+def test_cold_profile_hydration_allows_distinct_homes_to_fetch_concurrently(
+    tmp_path, monkeypatch
+):
+    """A slow source for one cold profile must not stall another profile."""
+    from types import SimpleNamespace
+
+    from agent.secret_sources import registry
+
+    homes = [tmp_path / "alpha", tmp_path / "beta"]
+    for home in homes:
+        home.mkdir()
+    monkeypatch.setattr(
+        env_loader, "_load_secrets_config", lambda _home: {"fake": {"enabled": True}}
+    )
+    fetch_barrier = threading.Barrier(2, timeout=2)
+
+    def _fake_apply_all(_cfg, home, *, environ):
+        fetch_barrier.wait()
+        key = f"{home.name.upper()}_API_KEY"
+        environ[key] = f"{home.name}-only"
+        return SimpleNamespace(
+            sources=[SimpleNamespace()],
+            provenance={key: SimpleNamespace(source="fake")},
+        )
+
+    monkeypatch.setattr(registry, "apply_all", _fake_apply_all)
+    results: dict[str, dict[str, str]] = {}
+    errors: list[BaseException] = []
+
+    def _hydrate(home):
+        try:
+            results[home.name] = env_loader.hydrate_profile_secret_sources(home)
+        except BaseException as exc:  # test thread must report failures
+            errors.append(exc)
+
+    workers = [threading.Thread(target=_hydrate, args=(home,)) for home in homes]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert not errors
+    assert all(not worker.is_alive() for worker in workers)
+    assert results == {
+        "alpha": {"ALPHA_API_KEY": "alpha-only"},
+        "beta": {"BETA_API_KEY": "beta-only"},
+    }
+
+
+def test_reset_during_cold_profile_hydration_retries_for_a_complete_snapshot(
+    tmp_path, monkeypatch
+):
+    """A reset cannot leave a home marked applied with no snapshot."""
+    from types import SimpleNamespace
+
+    from agent.secret_sources import registry
+
+    home = tmp_path / "secondary"
+    home.mkdir()
+    monkeypatch.setattr(
+        env_loader, "_load_secrets_config", lambda _home: {"fake": {"enabled": True}}
+    )
+    first_fetch_started = threading.Event()
+    release_first_fetch = threading.Event()
+    calls = {"count": 0}
+
+    def _fake_apply_all(_cfg, _home, *, environ):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            first_fetch_started.set()
+            assert release_first_fetch.wait(timeout=5)
+        environ["TEST_PROVIDER_API_KEY"] = "profile-only"
+        return SimpleNamespace(
+            sources=[SimpleNamespace()],
+            provenance={
+                "TEST_PROVIDER_API_KEY": SimpleNamespace(source="fake")
+            },
+        )
+
+    monkeypatch.setattr(registry, "apply_all", _fake_apply_all)
+    result: dict[str, str] = {}
+
+    worker = threading.Thread(
+        target=lambda: result.update(env_loader.hydrate_profile_secret_sources(home))
+    )
+    worker.start()
+    assert first_fetch_started.wait(timeout=5)
+    env_loader.reset_secret_source_cache()
+    release_first_fetch.set()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert calls["count"] == 2
+    assert result == {"TEST_PROVIDER_API_KEY": "profile-only"}
+    assert env_loader.get_secret_source_values(home) == result

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1104,8 +1104,11 @@ class TestBuildSafeEnv:
         from hermes_cli import env_loader
         from tools.mcp_tool import _build_safe_env
 
-        monkeypatch.setitem(env_loader._SECRET_SOURCES, "ALPACA_API_KEY", "bitwarden")
-        monkeypatch.setitem(env_loader._SECRET_SOURCES, "NOTION_TOKEN", "onepassword")
+        monkeypatch.setitem(
+            env_loader._SECRET_SOURCES_BY_HOME,
+            "test-home",
+            {"ALPACA_API_KEY": "bitwarden", "NOTION_TOKEN": "onepassword"},
+        )
         fake_env = {
             "PATH": "/usr/bin",
             "ALPACA_API_KEY": "from-bws-key",


### PR DESCRIPTION
## Summary

Fixes #74317 by hydrating a cold multiplex profile’s configured external secret sources into an **isolated, per-profile mapping** before its first runtime secret scope is constructed.

This preserves the existing profile-local `.env` / `.op.env` bootstrap behavior and closes the review-identified extension and metadata boundaries:

- cold multiplex hydration is now an explicit **isolated-environment** boundary;
- legacy plugin secret sources are skipped at that boundary unless they declare `supports_isolated_environment = True` and use `get_source_environment()` / its mapping for bootstrap and child-process inputs;
- bundled Bitwarden, 1Password, and command sources declare and use that contract;
- source provenance now follows the resolved home, just like the existing per-home external-secret value snapshots.

## Why this route

- **Rejected:** process-global source application from `_profile_runtime_scope()`, because it can expose a profile’s bootstrap or resolved credentials to siblings.
- **Rejected:** treating the existing `ContextVar` alone as sufficient isolation. A third-party source could legally use `os.environ` under the prior public `SecretSource.fetch(cfg, home_path)` contract.
- **Chosen:** an additive, fail-closed plugin contract. Normal startup remains compatible with existing sources; only cold multiplex hydration requires the explicit isolation opt-in. A legacy plugin is reported and skipped rather than receiving another profile’s process environment.

## Behavior

1. A first routed secondary profile seeds a private mapping from its own `.env` and non-overriding `.op.env`.
2. The registry invokes only sources that declare isolated-environment support.
3. Those sources resolve against the private mapping; no bootstrap or resolved value is written to `os.environ`.
4. Resolved values **and provenance** are persisted only under the resolved profile home.
5. A lookup with a resolved home returns that profile’s source label. The compatibility lookup without a home returns a label only when all matching loaded homes agree, never a misleading cross-profile label.

## Regression coverage

- Existing cold-secondary gateway-path isolation, `.op.env` bootstrap, same-home fetch sharing, concurrency, reset/retry, and no-global-env-leak coverage.
- New plugin-style regression: a legacy source that directly reads `os.environ` is not invoked during isolated hydration and cannot observe a default-profile canary.
- New provenance regression: two homes may resolve the same key from different sources without overwriting one another’s label; an ambiguous no-home lookup returns no label.
- Existing built-in and MCP safe-environment coverage updated for resolved-home provenance.

## Validation

```text
/home/allenkaplan07_gmail_com/.hermes-venv-py31115-sqlite3534-fts5/bin/python -m pytest -q \
  tests/gateway/test_multiplex_credential_isolation.py \
  tests/test_env_loader_secret_sources.py \
  tests/test_env_loader_op_bootstrap.py \
  tests/secret_sources/test_profile_secrets.py \
  tests/test_command_secret_source.py \
  tests/tools/test_mcp_tool.py
135 passed

/home/allenkaplan07_gmail_com/.hermes-venv-py31115-sqlite3534-fts5/bin/python -m ruff check [changed Python files]
All checks passed

git diff --check
```

## Prior art / related work

- #69250 — per-home external-source snapshots and scoped consumption foundation.
- #74549 — original profile-local hydration implementation, preserved with attribution.
- #75047 — identified the cold-profile call site but used process-global source application, which violates multiplex isolation.
- Review feedback incorporated: [#74549 review](https://github.com/NousResearch/hermes-agent/pull/74549#pullrequestreview-4821840193), [#75047 comment](https://github.com/NousResearch/hermes-agent/pull/75047#issuecomment-5136677361), and the current #75263 review.

*Prepared with AI assistance; implementation and validation were reviewed against the current PR feedback and current source.*
