### PR TITLE
fix(tests): isolate credential pool routing tests from real ~/.claude/.credentials.json

### DIFF
--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -376,6 +376,13 @@ class TestFailureAttribution:
         (hermes_home / "auth.json").write_text(
             json.dumps({"version": 1, "credential_pool": {"anthropic": entries}})
         )
+        # Prevent load_pool auto-discovery from reading real ~/.claude/.credentials.json
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_hermes_oauth_credentials", lambda: None
+        )
         from agent.credential_pool import load_pool
 
         return load_pool("anthropic")


### PR DESCRIPTION
## Summary

`TestFailureAttribution._make_pool()` calls `load_pool("anthropic")` which triggers auto-discovery of real Claude Code credentials from `~/.claude/.credentials.json` on the developer's machine. This changes the fixture from the intended single-entry pool to a two-entry pool and makes `test_unmatched_key_does_not_retry_only_pool_entry` fail with `assert True is False`.

## Root Cause

The `_make_pool` helper only overrides `HERMES_HOME` via monkeypatch, but `load_pool("anthropic")` still runs the auto-discovery path at `agent/credential_pool.py:2245` which reads `~/.claude/.credentials.json` from the real home directory. When a developer has usable Claude Code OAuth credentials, the auto-discovery inserts a second `claude_code` entry into the pool, turning a single-entry test into a multi-entry test.

## Fix

Monkeypatch `read_claude_code_credentials` and `read_hermes_oauth_credentials` to return `None` before calling `load_pool()`. This matches the isolation pattern already used in `tests/agent/test_anthropic_adapter.py` (lines 235, 256, 278, 298, 318, 359, 367, 403).

## Test Plan

- [x] `pytest tests/agent/test_credential_pool_routing.py -q` -> 15 passed
- [x] Verified fix isolates from real `~/.claude/.credentials.json`

Fixes #75230