### PR TITLE
fix(state): build CJK FTS extension with vendored headers

### DIFF
--- a/native/fts5_cjk/README.md
+++ b/native/fts5_cjk/README.md
@@ -8,8 +8,9 @@ Build & install to `~/.hermes/lib/`:
 
     ./build.sh
 
-Uses the system `sqlite3ext.h` when available, else the vendored copy in
-`vendor/` — no libsqlite3-dev required.
+Uses the vendored public-domain SQLite extension headers in `vendor/`, so no
+libsqlite3-dev package is required and SDK headers that disable loadable
+extensions cannot break the build.
 
 Once the extension is installed, the next `SessionDB` open creates the
 `messages_fts_cjk` index (external-content, tool rows excluded — same v23

--- a/native/fts5_cjk/build.sh
+++ b/native/fts5_cjk/build.sh
@@ -1,19 +1,20 @@
 #!/bin/bash
 # Build libfts5_cjk.so and install to ~/.hermes/lib/ (or $1).
 #
-# Uses the system sqlite3ext.h when present, else the vendored copy in
-# vendor/ (public-domain SQLite amalgamation headers) so the build works
-# without libsqlite3-dev installed.
+# Uses the vendored public-domain SQLite extension headers. Some platforms
+# ship a sqlite3ext.h that exists but deliberately defines
+# SQLITE_OMIT_LOAD_EXTENSION (notably the macOS SDK), which makes a simple
+# header-presence probe produce a shared object with unresolved symbols.
 set -euo pipefail
 cd "$(dirname "$0")"
 
-CFLAGS_EXTRA=""
-if ! echo '#include <sqlite3ext.h>' | gcc -E -xc - >/dev/null 2>&1; then
-  CFLAGS_EXTRA="-Ivendor"
-fi
-
-gcc -shared -fPIC -O2 -Wall -Wextra $CFLAGS_EXTRA fts5_cjk.c -o libfts5_cjk.so
 dest="${1:-$HOME/.hermes/lib}"
 mkdir -p "$dest"
-install -m 0644 libfts5_cjk.so "$dest/libfts5_cjk.so"
+compiler="${CC:-gcc}"
+tmp_output="$(mktemp "$dest/.libfts5_cjk.XXXXXX")"
+trap 'rm -f "$tmp_output"' EXIT
+
+"$compiler" -shared -fPIC -O2 -Wall -Wextra -Ivendor \
+  fts5_cjk.c -o "$tmp_output"
+install -m 0644 "$tmp_output" "$dest/libfts5_cjk.so"
 echo "installed: $dest/libfts5_cjk.so"

--- a/tests/test_fts_cjk_bigram.py
+++ b/tests/test_fts_cjk_bigram.py
@@ -4,6 +4,7 @@ Builds the loadable tokenizer from native/fts5_cjk/fts5_cjk.c on the fly;
 skips when no C toolchain / extension loading is available.
 """
 
+import os
 import shutil
 import sqlite3
 import subprocess
@@ -49,12 +50,26 @@ def test_build_script_installs_loadable_extension(tmp_path):
     if shutil.which("gcc") is None or bash is None:
         pytest.skip("no C toolchain / bash")
 
+    # Emulate a system header that preprocesses successfully but disables the
+    # loadable-extension API. The build must prefer -Ivendor over CPATH.
+    hostile_include = tmp_path / "host-include"
+    hostile_include.mkdir()
+    vendored_ext = VENDOR / "sqlite3ext.h"
+    (hostile_include / "sqlite3ext.h").write_text(
+        "#define SQLITE_OMIT_LOAD_EXTENSION 1\n"
+        f'#include "{vendored_ext.as_posix()}"\n',
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CPATH"] = str(hostile_include)
+
     dest = tmp_path / "lib"
     subprocess.run(
         [bash, str(BUILD), str(dest)],
         check=True,
         capture_output=True,
         text=True,
+        env=env,
     )
     installed = dest / "libfts5_cjk.so"
     assert installed.is_file()

--- a/tests/test_fts_cjk_bigram.py
+++ b/tests/test_fts_cjk_bigram.py
@@ -16,6 +16,7 @@ from hermes_state import FTS_CJK_STALE_KEY, SessionDB
 REPO = Path(__file__).resolve().parent.parent
 SRC = REPO / "native" / "fts5_cjk" / "fts5_cjk.c"
 VENDOR = REPO / "native" / "fts5_cjk" / "vendor"
+BUILD = REPO / "native" / "fts5_cjk" / "build.sh"
 
 
 @pytest.fixture(scope="session")
@@ -41,6 +42,29 @@ def cjk_so(tmp_path_factory):
     finally:
         probe.close()
     return out
+
+
+def test_build_script_installs_loadable_extension(tmp_path):
+    bash = shutil.which("bash")
+    if shutil.which("gcc") is None or bash is None:
+        pytest.skip("no C toolchain / bash")
+
+    dest = tmp_path / "lib"
+    subprocess.run(
+        [bash, str(BUILD), str(dest)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    installed = dest / "libfts5_cjk.so"
+    assert installed.is_file()
+
+    probe = sqlite3.connect(":memory:")
+    try:
+        probe.enable_load_extension(True)
+        probe.load_extension(str(installed))
+    finally:
+        probe.close()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Problem

`native/fts5_cjk/build.sh` currently chooses the system `sqlite3ext.h` whenever
the header can be preprocessed. The macOS SDK ships that header but defines
`SQLITE_OMIT_LOAD_EXTENSION`, so the probe succeeds while the resulting shared
object is not a usable loadable SQLite extension.

## Fix

- Always compile against the vendored public-domain SQLite extension headers.
- Respect `CC` instead of hard-coding the compiler.
- Build into a temporary file in the destination directory and install only
  after compilation succeeds.
- Add a regression test that runs the real build script and loads the installed
  extension through Python SQLite.
- Update the native tokenizer README to describe the header choice.

## Validation

On macOS:

```text
scripts/run_tests.sh -j 1 tests/test_fts_cjk_bigram.py
10 passed
```
