### PR TITLE
fix(cli): dispatch /background inline instead of queuing it behind the turn

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9473,6 +9473,37 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             return False
 
+    def _should_handle_background_command_inline(
+        self, text: str, has_images: bool = False
+    ) -> bool:
+        """Return True when /background should be dispatched while the agent runs.
+
+        Same queue problem /steer had. ``/background`` (``/bg``, ``/btw``)
+        exists to start independent work *without* waiting for the current
+        turn, but a slash command typed while the agent is busy goes into
+        ``_pending_input``, and ``process_loop`` is blocked inside
+        ``self.chat()`` for the whole run. The background task therefore only
+        starts once the foreground turn has finished, which is the one moment
+        it was not needed.
+
+        The command's own ``CommandDef`` already declares
+        ``busy_policy="dispatch"``; the gateway honours that, the classic CLI
+        never consulted it. Dispatching inline on the UI thread starts the
+        background session immediately and leaves the foreground turn running
+        untouched: no interrupt, no steer.
+        """
+        if not text or has_images or not _looks_like_slash_command(text):
+            return False
+        if not getattr(self, "_agent_running", False):
+            return False
+        try:
+            from hermes_cli.commands import resolve_command
+            base = text.split(None, 1)[0].lower().lstrip('/')
+            cmd = resolve_command(base)
+            return bool(cmd and cmd.name == "background")
+        except Exception:
+            return False
+
     def _output_console(self):
         """Use prompt_toolkit-safe Rich rendering once the TUI is live."""
         if getattr(self, "_app", None):
@@ -15015,6 +15046,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     # app, so without this the submitted "/steer <text>" can
                     # linger in the input area (looking unsent) and invite an
                     # accidental re-submit. See issue #34569.
+                    event.app.invalidate()
+                    return
+
+                # Same treatment for /background (/bg, /btw) while the agent is
+                # running.  Queuing it defeats the entire point of the command:
+                # process_loop is blocked inside self.chat(), so the background
+                # task would only start once the foreground turn it was meant to
+                # run alongside has already finished (#75221).  The foreground
+                # turn is left alone: no interrupt, no steer.
+                if self._should_handle_background_command_inline(
+                    text, has_images=has_images
+                ):
+                    self.process_command(text)
+                    event.app.current_buffer.reset(append_to_history=True)
+                    # Repaint for the same reason as the /steer branch above:
+                    # process_command() prints through patch_stdout and never
+                    # invalidates the app, so the submitted text can linger in
+                    # the input area looking unsent.
                     event.app.invalidate()
                     return
 

--- a/tests/cli/test_cli_background_busy_path.py
+++ b/tests/cli/test_cli_background_busy_path.py
@@ -1,0 +1,132 @@
+"""Regression tests for classic-CLI mid-run /background dispatch.
+
+Background
+----------
+``/background`` (``/bg``, ``/btw``) exists to start independent work while
+the current turn keeps running. Typed while the agent was busy it went into
+``self._pending_input`` like ordinary input, and ``process_loop`` is blocked
+inside ``self.chat()`` for the whole run, so the background task only started
+once the foreground turn had finished. That is the one moment it was not
+needed (#75221).
+
+``/steer`` had the identical problem and was fixed by dispatching inline on
+the UI thread; the command's own ``CommandDef`` already declares
+``busy_policy="dispatch"``, which the gateway honours and the classic CLI
+never consulted.
+
+These tests exercise the detector without starting a prompt_toolkit app,
+mirroring tests/cli/test_cli_steer_busy_path.py.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+
+def _make_cli():
+    """Create a HermesCLI instance with prompt_toolkit stubbed out."""
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
+        "os.environ", clean_env, clear=False
+    ):
+        import cli as _cli_mod
+
+        _cli_mod = importlib.reload(_cli_mod)
+        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), patch.dict(
+            _cli_mod.__dict__, {"CLI_CONFIG": _clean_config}
+        ):
+            return _cli_mod.HermesCLI()
+
+
+class TestBackgroundInlineDetector:
+    def test_detects_background_when_agent_running(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        assert cli._should_handle_background_command_inline(
+            "/background inspect the test failures"
+        ) is True
+
+    def test_detects_both_aliases(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        assert cli._should_handle_background_command_inline("/bg do work") is True
+        assert cli._should_handle_background_command_inline("/btw do work") is True
+
+    def test_ignores_background_when_agent_idle(self):
+        """Idle input falls through to the normal process_loop dispatch."""
+        cli = _make_cli()
+        cli._agent_running = False
+        assert cli._should_handle_background_command_inline("/bg do work") is False
+
+    def test_ignores_non_slash_input(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        assert cli._should_handle_background_command_inline("bg without slash") is False
+        assert cli._should_handle_background_command_inline("") is False
+
+    def test_ignores_other_slash_commands(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        assert cli._should_handle_background_command_inline("/steer hello") is False
+        assert cli._should_handle_background_command_inline("/queue hello") is False
+        assert cli._should_handle_background_command_inline("/stop") is False
+
+    def test_ignores_background_with_attached_images(self):
+        """Image payloads take the normal path."""
+        cli = _make_cli()
+        cli._agent_running = True
+        assert cli._should_handle_background_command_inline(
+            "/bg look at this", has_images=True
+        ) is False
+
+    def test_case_and_whitespace_tolerant(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        assert cli._should_handle_background_command_inline("/BG do work") is True
+
+
+class TestBackgroundBusyPolicyContract:
+    """The registry already declares the intent this detector implements."""
+
+    def test_background_declares_dispatch_while_busy(self):
+        from hermes_cli.commands import resolve_command
+
+        cmd = resolve_command("background")
+        assert cmd is not None
+        assert cmd.busy_policy == "dispatch"
+
+    def test_aliases_resolve_to_background(self):
+        from hermes_cli.commands import resolve_command
+
+        for alias in ("bg", "btw"):
+            cmd = resolve_command(alias)
+            assert cmd is not None and cmd.name == "background"


### PR DESCRIPTION
Fixes #75221.

### The bug

`/background` (`/bg`, `/btw`) exists to start independent work while the current turn keeps running. Typed while the agent is busy it goes into `self._pending_input` like ordinary input, and `process_loop` is blocked inside `self.chat()` for the duration of the run. So the background task only starts once the foreground turn has finished, which is the one moment it was not needed.

`/steer` had the identical problem and was fixed the same way, by dispatching inline on the UI thread.

### Why this is not new policy

The command's own `CommandDef` already declares what it wants:

```python
CommandDef("background", "Run a prompt in the background", "Session",
           aliases=("bg", "btw"), args_hint="<prompt>", busy_policy="dispatch"),
```

`busy_policy="dispatch"` means "run the command while the agent is busy". The gateway honours that declaration (`gateway/run.py` reads `busy_policy` when routing mid-run commands); the classic CLI never consulted it and instead uses hand-written per-command checks. This change makes the CLI agree with what the registry already says.

### The fix

A `_should_handle_background_command_inline` detector mirroring `_should_handle_steer_command_inline`, and a dispatch branch directly below the `/steer` one it mirrors.

The foreground turn is untouched: no interrupt, no steer. Ordinary non-slash input keeps following the configured busy-input behaviour, and image payloads still take the normal path.

### Testing

New `tests/cli/test_cli_background_busy_path.py`, nine tests: detection while running, both aliases, no dispatch when idle, non-slash input, other slash commands, attached images, case tolerance, plus two contract tests asserting the registry declares `busy_policy="dispatch"` and that both aliases resolve to `background`.

**One thing worth stating plainly about the evidence.** Seven of these fail on `main`, but with `AttributeError` because the detector is new, which proves the method did not exist rather than that the behaviour was broken. The behavioural half is the call-site wiring, and reaching that in a test means standing up a prompt_toolkit application. The existing `/steer` fix has the same shape and `tests/cli/test_cli_steer_busy_path.py` also covers only the detector, so this matches the established convention for this path rather than inventing a weaker one. The wiring itself I verified by inspection against the `/steer` branch immediately above it.

Full `tests/cli/`, this branch and clean `main` each in its own isolated worktree: **749 passed with the change, 740 without, zero failures on either side.** The nine extra passes are the new tests.
