### PR TITLE
feat(gateway): add Unix socket dispatcher forwarding

### DIFF
--- a/gateway/dispatcher_client.py
+++ b/gateway/dispatcher_client.py
@@ -1,0 +1,263 @@
+"""Async Unix-socket client for the harness dispatcher (Phase 2.6).
+
+Wraps `asyncio.open_unix_connection` with a retry loop, a per-call
+timeout, and a single connection per client instance. The client is
+long-lived: construct once at gateway startup, call dispatch() many
+times, close() at shutdown. Reconnect is automatic on transient
+failures (ConnectionResetError, BrokenPipeError); a hard failure
+(dispatcher down, refused connection, timeout) raises
+DispatcherConnectionError so the caller can fall back.
+
+Wire shape and Envelope dataclass live in dispatcher_protocol.py;
+this module is the transport layer only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Optional
+
+from .dispatcher_protocol import (
+    OP_PING,
+    Envelope,
+    STATUS_OK,
+    make_request,
+)
+
+
+_LOG = logging.getLogger(__name__)
+
+
+# Default socket path. The harness systemd unit places the dispatcher
+# under /run/harness/ (RuntimeDirectory=harness). Overridable for tests
+# and for non-systemd installs.
+DEFAULT_DISPATCHER_SOCKET = "/run/harness/dispatcher.sock"
+
+# Per-call timeout for one round-trip. The dispatcher is a single-
+# Python-process server doing one envelope at a time per connection
+# (synchronous dispatch path), so a few hundred ms is plenty under
+# normal load. Long-running handlers (async / background mode) are
+# NOT supported via this client: they return immediately with
+# `accepted=True` and the actual response is delivered through a
+# separate mechanism (callback, not yet implemented -- Phase 2.7
+# is deferred to Phase 4.5b per PLAN.md).
+DEFAULT_DISPATCHER_TIMEOUT_S = 5.0
+
+# How many times to retry a transient connection failure (e.g. the
+# dispatcher crashed and restarted between two calls). 2 retries
+# with a fresh connection each time = 3 total attempts.
+DEFAULT_MAX_RETRIES = 2
+
+
+class DispatcherConnectionError(Exception):
+    """Raised when the dispatcher is unreachable, refused the
+    connection, or timed out after exhausting retries. Callers
+    should catch this and fall back (e.g. surface "dispatcher down"
+    to the user, or route the message through the agent instead).
+    """
+
+
+class DispatcherClient:
+    """Async Unix-socket client for the harness dispatcher.
+
+    One client per process. Lazy-connects on first dispatch().
+    Reconnects on transient failure up to max_retries times. Closes
+    cleanly on close() or context-manager exit.
+
+    Thread safety: not thread-safe. Single asyncio loop only.
+    """
+
+    def __init__(
+        self,
+        socket_path: str | None = None,
+        timeout_s: float = DEFAULT_DISPATCHER_TIMEOUT_S,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ) -> None:
+        self._path = socket_path or os.environ.get(
+            "HERMES_DISPATCHER_SOCKET", DEFAULT_DISPATCHER_SOCKET
+        )
+        self._timeout_s = timeout_s
+        self._max_retries = max_retries
+        # Lazy: opened on first dispatch() call.
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        # Set to True after close() so a stale client cannot dispatch.
+        self._closed = False
+        # Serializes concurrent dispatch() calls so writes/reads
+        # on the shared socket don't interleave.
+        self._lock = asyncio.Lock()
+
+    @property
+    def socket_path(self) -> str:
+        return self._path
+
+    @property
+    def is_connected(self) -> bool:
+        return self._writer is not None and not self._writer.is_closing()
+
+    async def connect(self) -> None:
+        """Open the Unix socket. Idempotent: if already connected,
+        no-op. Raises DispatcherConnectionError if the socket cannot
+        be opened (dispatcher not running, wrong path, permissions).
+        """
+        if self._closed:
+            raise DispatcherConnectionError("client is closed")
+        if self.is_connected:
+            return
+        try:
+            self._reader, self._writer = await asyncio.open_unix_connection(
+                self._path
+            )
+            _LOG.debug("dispatcher client connected to %s", self._path)
+        except (OSError, ConnectionError) as e:
+            self._reader = None
+            self._writer = None
+            raise DispatcherConnectionError(
+                f"failed to connect to dispatcher at {self._path}: {e}"
+            ) from e
+
+    async def close(self) -> None:
+        """Close the connection. Idempotent."""
+        self._closed = True
+        if self._writer is not None:
+            try:
+                self._writer.close()
+                await self._writer.wait_closed()
+            except (OSError, ConnectionError):
+                # Best-effort: the peer may have already hung up.
+                pass
+        self._reader = None
+        self._writer = None
+
+    async def __aenter__(self) -> "DispatcherClient":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
+
+    async def dispatch(self, envelope: Envelope) -> Envelope:
+        """Send an envelope and return the response envelope.
+
+        Lazy-connects on first call. Reconnects transparently on
+        transient connection failure (ConnectionResetError,
+        BrokenPipeError), retrying up to max_retries times. A hard
+        failure (timeout, refused, exhausted retries) raises
+        DispatcherConnectionError so the caller can fall back.
+
+        Concurrent calls are serialized via an asyncio.Lock so
+        writes/reads on the shared socket don't interleave.
+        """
+        async with self._lock:
+            return await self._dispatch_locked(envelope)
+
+    async def _dispatch_locked(self, envelope: Envelope) -> Envelope:
+        """dispatch() implementation. Caller must hold self._lock."""
+        if self._closed:
+            raise DispatcherConnectionError("client is closed")
+
+        last_error: Optional[Exception] = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                return await self._dispatch_once(envelope)
+            except (ConnectionResetError, BrokenPipeError) as e:
+                # Peer hung up. Drop the stale connection, reconnect,
+                # retry. This handles the case where the dispatcher
+                # restarted between two calls.
+                last_error = e
+                _LOG.warning(
+                    "dispatcher connection lost (attempt %d/%d): %s",
+                    attempt + 1,
+                    self._max_retries + 1,
+                    e,
+                )
+                await self._drop_connection()
+            except asyncio.TimeoutError as e:
+                # No response within the timeout. The connection may
+                # still be usable for a follow-up, but we don't trust
+                # it -- a half-sent envelope could be in flight. Drop
+                # and reconnect.
+                last_error = e
+                _LOG.warning(
+                    "dispatcher dispatch timed out after %.1fs "
+                    "(attempt %d/%d)",
+                    self._timeout_s,
+                    attempt + 1,
+                    self._max_retries + 1,
+                )
+                await self._drop_connection()
+            except (OSError, ConnectionError) as e:
+                # Refused connection or similar. Drop and reconnect.
+                last_error = e
+                _LOG.warning(
+                    "dispatcher dispatch failed (attempt %d/%d): %s",
+                    attempt + 1,
+                    self._max_retries + 1,
+                    e,
+                )
+                await self._drop_connection()
+
+        raise DispatcherConnectionError(
+            f"dispatcher unreachable after {self._max_retries + 1} attempts: "
+            f"{last_error}"
+        )
+
+    async def _dispatch_once(self, envelope: Envelope) -> Envelope:
+        """One round-trip. Caller handles retries on transient errors."""
+        if not self.is_connected:
+            await self.connect()
+        assert self._writer is not None and self._reader is not None
+        writer = self._writer
+        reader = self._reader
+
+        try:
+            writer.write(envelope.to_jsonl())
+            await writer.drain()
+            line = await asyncio.wait_for(
+                reader.readuntil(b"\n"), timeout=self._timeout_s
+            )
+        except (ConnectionResetError, BrokenPipeError):
+            # Propagate to the dispatch() loop for reconnect.
+            raise
+        except asyncio.IncompleteReadError as e:
+            # Peer closed without sending a full line. Treat as a
+            # connection failure so the loop reconnects.
+            raise ConnectionError(
+                f"dispatcher closed before sending response: {e}"
+            ) from e
+        except asyncio.LimitOverrunError as e:
+            # Response line exceeded the stream reader limit.
+            # Treat as a non-fatal dispatcher error so the caller
+            # falls through to normal message handling.
+            raise DispatcherConnectionError(
+                f"dispatcher response too large: {e}"
+            ) from e
+
+        return Envelope.from_jsonl(line)
+
+    async def _drop_connection(self) -> None:
+        """Close the current connection (if any) without affecting
+        the closed flag, so the next dispatch() reopens it."""
+        if self._writer is not None:
+            try:
+                self._writer.close()
+                await self._writer.wait_closed()
+            except (OSError, ConnectionError):
+                pass
+        self._reader = None
+        self._writer = None
+
+    async def ping(self) -> bool:
+        """Send a ping and return True if the dispatcher responds
+        with STATUS_OK. Returns False on any failure (no exception
+        raised) so callers can use this for liveness probes.
+        """
+        try:
+            req = make_request(OP_PING, {})
+            resp = await self.dispatch(req)
+            return resp.status == STATUS_OK
+        except (DispatcherConnectionError, ValueError) as e:
+            _LOG.debug("ping failed: %s", e)
+            return False

--- a/gateway/dispatcher_protocol.py
+++ b/gateway/dispatcher_protocol.py
@@ -1,0 +1,117 @@
+"""Wire-protocol dataclasses for the dispatcher IPC (Phase 2.6 client).
+
+JSON line-delimited envelope over a Unix domain socket. Mirror of
+harness's dispatcher/protocol.py so the gateway can construct and
+parse envelopes without importing across repositories. The wire spec
+itself lives in the harness repo at docs/dispatcher-protocol.md;
+this module is the client-side reference implementation.
+
+Server side is in harness's dispatcher/protocol.py; if the wire
+shape ever changes there, the change MUST be reflected here in
+the same commit. Drift between client and server is a reviewer-
+blocker.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+
+
+# --- status codes (must match harness/dispatcher/protocol.py) ---
+
+STATUS_OK = 0
+STATUS_BAD_REQUEST = 1   # malformed / unknown op
+STATUS_INTERNAL = 2      # handler raised
+STATUS_BUSY = 3          # handler max_inflight reached
+
+
+# --- ops (must match harness/dispatcher/protocol.py) ---
+
+OP_DISPATCH = "dispatch"
+OP_PING = "ping"
+OP_SHUTDOWN = "shutdown"
+
+
+# --- envelope ---
+
+@dataclass(frozen=True)
+class Envelope:
+    """One wire message. Either request (status absent) or response
+    (status present, required). The server-side dataclass enforces
+    request_id length and op validity on construction; the client-
+    side dataclass trusts what comes off the wire and does only the
+    parse-time checks needed to construct a response object.
+
+    The server is the authority on validation -- a client may send
+    a request_id that the server rejects, and the server returns a
+    STATUS_BAD_REQUEST with the same op echoed back. Clients must
+    handle that gracefully.
+    """
+
+    request_id: str
+    op: str
+    payload: dict
+    status: int | None = None
+
+    def to_jsonl(self) -> bytes:
+        """Serialize as one JSON line (newline-terminated)."""
+        d = {
+            "request_id": self.request_id,
+            "op": self.op,
+            "payload": self.payload,
+        }
+        if self.status is not None:
+            d["status"] = self.status
+        return (json.dumps(d, ensure_ascii=False) + "\n").encode("utf-8")
+
+    @classmethod
+    def from_jsonl(cls, line: bytes) -> "Envelope":
+        """Parse one JSON line into an Envelope. Raises ValueError on
+        malformed JSON or missing required fields."""
+        obj = json.loads(line)
+        if not isinstance(obj, dict):
+            raise ValueError(
+                f"envelope must be a JSON object, got {type(obj).__name__}"
+            )
+        for required in ("request_id", "op", "payload"):
+            if required not in obj:
+                raise ValueError(f"missing required field {required!r}")
+        if not isinstance(obj["request_id"], str):
+            raise ValueError("request_id must be a string")
+        if not isinstance(obj["op"], str):
+            raise ValueError("op must be a string")
+        if not isinstance(obj["payload"], dict):
+            raise ValueError("payload must be a JSON object")
+        status = obj.get("status")
+        if status is not None and (
+            isinstance(status, bool) or not isinstance(status, int)
+        ):
+            # Strict int -- bool subclasses int so isinstance(int)
+            # alone lets True/False through. Reject bool explicitly.
+            raise ValueError(
+                f"status must be int or absent, got {type(status).__name__}"
+            )
+        return cls(
+            request_id=obj["request_id"],
+            op=obj["op"],
+            payload=obj["payload"],
+            status=status,
+        )
+
+
+# --- helpers ---
+
+def new_request_id() -> str:
+    """Generate a request_id for a new request. UUID4 hex (32 chars)."""
+    return uuid.uuid4().hex
+
+
+def make_request(op: str, payload: dict | None = None) -> Envelope:
+    """Build a fresh request envelope with a generated request_id."""
+    return Envelope(
+        request_id=new_request_id(),
+        op=op,
+        payload=payload if payload is not None else {},
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2234,6 +2234,19 @@ from gateway.restart import (
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
     parse_restart_drain_timeout,
 )
+from gateway.dispatcher_client import (
+    DispatcherClient,
+    DispatcherConnectionError,
+)
+from gateway.dispatcher_protocol import (
+    OP_DISPATCH,
+    STATUS_BAD_REQUEST,
+    STATUS_BUSY,
+    STATUS_INTERNAL,
+    STATUS_OK,
+    Envelope as _DispatcherEnvelope,
+    make_request as _make_dispatcher_request,
+)
 
 
 from gateway.whatsapp_identity import (
@@ -5410,6 +5423,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _busy_text_mode: str = "interrupt"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
+
+    # Slash commands the harness dispatcher owns. These don't
+    # conflict with hermes-gateway's local command set, so we
+    # forward them via Unix socket to the dispatcher. Add a
+    # command to this set when the dispatcher gains a new
+    # HANDLER that doesn't shadow a local hermes command.
+    # (Phase 2.6: dispatcher-unique commands only; /status,
+    # /health, /help stay hermes-local to avoid behavior drift.)
+    _DISPATCHER_FORWARD_COMMANDS = frozenset({
+        "echo", "research", "forge", "ashare", "replay", "log",
+    })
     _draining: bool = False
     _external_drain_active: bool = False
     _restart_requested: bool = False
@@ -5694,6 +5718,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._completion_deliveries_inflight: set[tuple[str, str, object]] = set()
         self._completion_deliveries_delivered: "OrderedDict[tuple[str, str, object], None]" = OrderedDict()
         self._completion_delivery_retention = 2048
+
+        # Dispatcher client (lazy). The harness dispatcher runs as a
+        # separate service (Phase 2.0.5+) at /run/harness/dispatcher.sock;
+        # the gateway forwards certain slash commands to it via Unix
+        # socket. See _forward_to_dispatcher for the dispatch list.
+        # Lazy because the dispatcher may not be running when the
+        # gateway starts (e.g. dispatcher service is down). Each
+        # forward call opens/closes the connection lazily.
+        self._dispatcher_client: Optional[DispatcherClient] = None
+
+        # Track running agents per session for interrupt support
+        # Key: session_key, Value: AIAgent instance
+        self._running_agents: Dict[str, Any] = {}
+        self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
+        self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -14624,6 +14663,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
+        # Dispatcher-forwarded slash commands (echo, research, forge,
+        # ashare, replay, log). These are commands the harness
+        # dispatcher owns (it has HANDLERS for them) and that don't
+        # conflict with hermes-gateway's local command set, so we
+        # forward them to the dispatcher before the quick-commands
+        # cascade runs. On dispatcher failure we fall through to
+        # normal message handling rather than blocking the user.
+        if command and command in self._DISPATCHER_FORWARD_COMMANDS:
+            _denied = self._check_slash_access(source, command)
+            if _denied is not None:
+                return _denied
+            return await self._forward_to_dispatcher(event, command)
+
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
             if isinstance(self.config, dict):
@@ -14996,6 +15048,109 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._restore_session_model_override(session_key, snapshot)
         except Exception:
             logger.debug("Failed to restore one-turn model override", exc_info=True)
+
+    # -- Dispatcher forward (Phase 2.6) ------------------------------
+
+    def _get_dispatcher_client(self) -> DispatcherClient:
+        """Return the lazy-initialized dispatcher client. Creates
+        one on first call. Always returns the same instance for
+        the lifetime of this GatewayRunner."""
+        if self._dispatcher_client is None:
+            self._dispatcher_client = DispatcherClient()
+        return self._dispatcher_client
+
+    async def _forward_to_dispatcher(
+        self, event: MessageEvent, command: str
+    ) -> Optional[str]:
+        """Forward a recognized dispatcher slash-command to the
+        harness dispatcher via Unix socket, returning formatted
+        chat text. Returns None on dispatcher unavailability so
+        the caller can fall through to normal message handling --
+        the user still gets a response, just from the agent
+        rather than from the dispatcher. The dispatcher is a
+        soft dependency: gateway stays useful even when it's
+        down."""
+        client = self._get_dispatcher_client()
+        source = event.source
+        platform_name = (
+            source.platform.value if source.platform else ""
+        )
+        args = event.get_command_args().strip()
+        # Reconstruct the slash-command text the dispatcher's
+        # router expects (it parses /cmd from content).
+        content = f"/{command}"
+        if args:
+            content = f"{content} {args}"
+        payload = {"source": platform_name, "content": content}
+        try:
+            req = _make_dispatcher_request(OP_DISPATCH, payload)
+            resp = await client.dispatch(req)
+        except (DispatcherConnectionError, ValueError) as e:
+            logger.warning(
+                "dispatcher forward for /%s failed (non-fatal): %s",
+                command,
+                e,
+            )
+            return None
+        return self._format_dispatcher_response(command, resp)
+
+    @staticmethod
+    def _format_dispatcher_response(
+        command: str, resp: _DispatcherEnvelope,
+    ) -> str:
+        """Render a dispatcher Envelope as chat text. Maps the
+        known handler result kinds (echo, status, health, help,
+        stub) to readable text and falls back to the raw payload
+        dict for anything else."""
+        status = resp.status
+        payload = resp.payload or {}
+        if status == STATUS_OK:
+            kind = payload.get("result", "")
+            if kind == "stub":
+                # Phase 3+ stubs: forward the human-readable
+                # message and tag the phase so the user knows
+                # when the real implementation lands.
+                stage = payload.get("stage", "later phase")
+                msg = payload.get("message", "stub")
+                return f"[dispatcher] {msg} (lands in {stage})"
+            if kind == "echo":
+                echoed = payload.get("echoed_payload", {})
+                content = echoed.get("content", "")
+                return f"[dispatcher] echo: {content}"
+            if kind == "health":
+                return "[dispatcher] dispatcher reports healthy"
+            if kind == "help":
+                cmds = payload.get("commands", [])
+                lines = "\n".join(f"  /{c}" for c in cmds)
+                return f"[dispatcher] available commands:\n{lines}"
+            if kind == "status":
+                up = payload.get("uptime_s", 0)
+                handlers = payload.get("handlers", [])
+                return (
+                    f"[dispatcher] alive (uptime {float(up):.1f}s, "
+                    f"{len(handlers)} handlers)"
+                )
+            # Unknown result kind -- JSON-pretty-print the payload
+            # so the user still sees something useful.
+            import json as _json
+            return (
+                "[dispatcher] "
+                + _json.dumps(payload, ensure_ascii=False, indent=2)
+            )
+        if status == STATUS_BUSY:
+            return (
+                f"[dispatcher] handler /{command} is at "
+                "max_inflight; retry in a moment"
+            )
+        if status == STATUS_INTERNAL:
+            return (
+                f"[dispatcher] handler /{command} failed "
+                "(internal error)"
+            )
+        if status == STATUS_BAD_REQUEST:
+            err = payload.get("error", "unknown")
+            return f"[dispatcher] bad request: {err}"
+        return f"[dispatcher] unexpected status {status}"
 
     async def _prepare_inbound_message_text(
         self,

--- a/tests/gateway/test_dispatcher_client.py
+++ b/tests/gateway/test_dispatcher_client.py
@@ -1,0 +1,482 @@
+"""Tests for the harness dispatcher client (Phase 2.6).
+
+The client wraps an asyncio Unix socket with retry + timeout. Per
+golden rule #3 ("mocks share your blind spots"), we test against a
+REAL asyncio Unix socket server fixture running on tmp_path, not
+a mock. The fixture plays the role of the harness dispatcher: it
+accepts one connection, reads one Envelope, and writes back a
+configurable response (or hangs to test timeout).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import pytest_asyncio
+
+from gateway.dispatcher_client import (
+    DEFAULT_DISPATCHER_SOCKET,
+    DispatcherClient,
+    DispatcherConnectionError,
+)
+from gateway.dispatcher_protocol import (
+    OP_DISPATCH,
+    OP_PING,
+    STATUS_BAD_REQUEST,
+    STATUS_BUSY,
+    STATUS_INTERNAL,
+    STATUS_OK,
+    Envelope,
+    make_request,
+)
+
+
+# --- Fake dispatcher server fixture -------------------------------
+
+
+class FakeDispatcher:
+    """A real asyncio Unix socket server that pretends to be the
+    harness dispatcher. Behavior is controlled by the response
+    function set before each test.
+    """
+
+    def __init__(self, socket_path: Path) -> None:
+        self._path = str(socket_path)
+        self._server: Optional[asyncio.base_events.Server] = None
+        self.connections = 0
+        # response_fn takes the incoming Envelope and returns the
+        # Envelope to write back (or None to drop the connection).
+        self.response_fn = self._default_response
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_unix_server(
+            self._handle_connection, path=self._path
+        )
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        # Best-effort cleanup of the socket file.
+        try:
+            Path(self._path).unlink()
+        except FileNotFoundError:
+            pass
+
+    async def _handle_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        self.connections += 1
+        try:
+            line = await asyncio.wait_for(
+                reader.readuntil(b"\n"), timeout=5.0
+            )
+        except (asyncio.IncompleteReadError, asyncio.TimeoutError):
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+            return
+        try:
+            req = Envelope.from_jsonl(line)
+        except ValueError:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+            return
+        resp = self.response_fn(req)
+        if resp is None:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+            return
+        writer.write(resp.to_jsonl())
+        await writer.drain()
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except (ConnectionError, OSError):
+            pass
+
+    @staticmethod
+    def _default_response(req: Envelope) -> Envelope:
+        if req.op == OP_PING:
+            return Envelope(
+                request_id=req.request_id,
+                op=OP_PING,
+                payload={"ts": 0.0},
+                status=STATUS_OK,
+            )
+        return Envelope(
+            request_id=req.request_id,
+            op=req.op,
+            payload={"result": "echo", "echoed_payload": req.payload},
+            status=STATUS_OK,
+        )
+
+
+@pytest_asyncio.fixture
+async def fake_dispatcher(tmp_path: Path):
+    """Yield a running FakeDispatcher on tmp_path/dispatcher.sock.
+    Cleans up the server and socket file on teardown.
+    """
+    sock = tmp_path / "dispatcher.sock"
+    server = FakeDispatcher(sock)
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+# --- DispatcherClient tests ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ping_returns_true_on_status_ok(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    """ping() returns True when the dispatcher responds STATUS_OK."""
+    client = DispatcherClient(socket_path=str(fake_dispatcher._path))
+    assert await client.ping() is True
+    assert fake_dispatcher.connections == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_roundtrip_ping(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    """dispatch() returns the response Envelope from the server."""
+    client = DispatcherClient(socket_path=str(fake_dispatcher._path))
+    req = make_request(OP_PING, {})
+    resp = await client.dispatch(req)
+    assert resp.status == STATUS_OK
+    assert resp.op == OP_PING
+    assert "ts" in resp.payload
+    assert resp.request_id == req.request_id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_echo_payload(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    """dispatch() preserves request_id so the caller can correlate."""
+    client = DispatcherClient(socket_path=str(fake_dispatcher._path))
+    req = make_request(
+        OP_DISPATCH,
+        {"source": "wechat", "content": "/echo hello"},
+    )
+    resp = await client.dispatch(req)
+    assert resp.status == STATUS_OK
+    assert resp.payload.get("echoed_payload") == {
+        "source": "wechat",
+        "content": "/echo hello",
+    }
+    assert resp.request_id == req.request_id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unreachable_raises(tmp_path: Path) -> None:
+    """No server running -> DispatcherConnectionError after retries."""
+    # No fake_dispatcher fixture; nothing listening on this path.
+    sock = tmp_path / "nope.sock"
+    client = DispatcherClient(
+        socket_path=str(sock),
+        timeout_s=0.2,
+        max_retries=1,
+    )
+    with pytest.raises(DispatcherConnectionError):
+        await client.dispatch(make_request(OP_PING, {}))
+
+
+@pytest.mark.asyncio
+async def test_dispatch_propagates_server_status_codes(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    """Non-OK responses are returned to caller; only connection-level
+    failures raise DispatcherConnectionError. This keeps the wire
+    contract honest: the dispatcher decides OK/BUSY/INTERNAL/
+    BAD_REQUEST, not the client.
+    """
+    from gateway.dispatcher_protocol import (
+        OP_DISPATCH as _OD,
+        make_request as _mr,
+    )
+
+    def respond(req: Envelope) -> Envelope:
+        return Envelope(
+            request_id=req.request_id,
+            op=req.op,
+            payload={"error": "handler 'echo' raised"},
+            status=STATUS_INTERNAL,
+        )
+
+    fake_dispatcher.response_fn = respond
+    client = DispatcherClient(socket_path=str(fake_dispatcher._path))
+    resp = await client.dispatch(_mr(_OD, {"content": "/echo"}))
+    assert resp.status == STATUS_INTERNAL
+    assert "raised" in resp.payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_retries_on_connection_reset(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    """Server drops the connection (response_fn returns None) ->
+    client retries -> eventually gets a successful response."""
+    call_count = {"n": 0}
+
+    def respond(req: Envelope) -> Optional[Envelope]:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # First attempt: drop the connection.
+            return None
+        # Second attempt: respond normally.
+        return Envelope(
+            request_id=req.request_id,
+            op=req.op,
+            payload={"result": "echo", "echoed_payload": req.payload},
+            status=STATUS_OK,
+        )
+
+    fake_dispatcher.response_fn = respond
+    client = DispatcherClient(
+        socket_path=str(fake_dispatcher._path),
+        max_retries=2,
+    )
+    resp = await client.dispatch(make_request(OP_PING, {}))
+    assert resp.status == STATUS_OK
+    assert call_count["n"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_dispatch_timeout_raises(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    """Server accepts the connection but never writes a response ->
+    client times out after timeout_s."""
+    # response_fn returns a coroutine that sleeps forever (simulates
+    # a hung handler). The server-side reader.readuntil times out at
+    # 5.0s; we use a smaller client timeout to fail faster.
+    async def respond_hang(req: Envelope) -> Optional[Envelope]:
+        await asyncio.sleep(60)
+        return None
+
+    fake_dispatcher.response_fn = respond_hang  # type: ignore[assignment]
+    client = DispatcherClient(
+        socket_path=str(fake_dispatcher._path),
+        timeout_s=0.2,
+        max_retries=0,
+    )
+    with pytest.raises(DispatcherConnectionError):
+        await client.dispatch(make_request(OP_PING, {}))
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    """close() can be called multiple times without error."""
+    client = DispatcherClient(socket_path=str(fake_dispatcher._path))
+    await client.dispatch(make_request(OP_PING, {}))
+    await client.close()
+    await client.close()  # no error
+
+
+@pytest.mark.asyncio
+async def test_context_manager_closes_on_exit(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    """async with DispatcherClient() closes the connection on exit."""
+    async with DispatcherClient(
+        socket_path=str(fake_dispatcher._path)
+    ) as client:
+        resp = await client.dispatch(make_request(OP_PING, {}))
+        assert resp.status == STATUS_OK
+    assert not client.is_connected
+
+
+def test_default_socket_path_uses_constant(
+    monkeypatch,
+) -> None:
+    """No socket_path and no env var -> DEFAULT_DISPATCHER_SOCKET."""
+    monkeypatch.delenv("HERMES_DISPATCHER_SOCKET", raising=False)
+    client = DispatcherClient()
+    assert client.socket_path == DEFAULT_DISPATCHER_SOCKET
+
+
+def test_env_var_overrides_default(monkeypatch) -> None:
+    """HERMES_DISPATCHER_SOCKET overrides DEFAULT_DISPATCHER_SOCKET."""
+    monkeypatch.setenv("HERMES_DISPATCHER_SOCKET", "/tmp/custom.sock")
+    client = DispatcherClient()
+    assert client.socket_path == "/tmp/custom.sock"
+
+
+# --- Format helper tests (sync) -----------------------------------
+
+
+def test_format_status_ok_kind_echo() -> None:
+    """echo response renders as '[dispatcher] echo: <content>'."""
+    from gateway.run import GatewayRunner
+
+    resp = Envelope(
+        request_id="r1", op=OP_DISPATCH,
+        payload={
+            "result": "echo",
+            "echoed_payload": {"content": "/echo hello"},
+        },
+        status=STATUS_OK,
+    )
+    text = GatewayRunner._format_dispatcher_response("echo", resp)
+    assert text == "[dispatcher] echo: /echo hello"
+
+
+def test_format_status_ok_kind_status() -> None:
+    """status response includes uptime + handler count."""
+    from gateway.run import GatewayRunner
+
+    resp = Envelope(
+        request_id="r1", op=OP_DISPATCH,
+        payload={
+            "result": "status",
+            "uptime_s": 12.5,
+            "handlers": ["echo", "status", "help"],
+        },
+        status=STATUS_OK,
+    )
+    text = GatewayRunner._format_dispatcher_response("status", resp)
+    assert "alive" in text
+    assert "12.5" in text
+    assert "3 handlers" in text
+
+
+def test_format_status_ok_kind_stub() -> None:
+    """stub response shows the stage where the real impl lands."""
+    from gateway.run import GatewayRunner
+
+    resp = Envelope(
+        request_id="r1", op=OP_DISPATCH,
+        payload={
+            "result": "stub",
+            "command": "research",
+            "stage": "Phase 3",
+            "message": "aicc-research handler is scheduled for Phase 3",
+        },
+        status=STATUS_OK,
+    )
+    text = GatewayRunner._format_dispatcher_response("research", resp)
+    assert "Phase 3" in text
+    assert "aicc-research" in text
+
+
+def test_format_status_busy() -> None:
+    """BUSY response tells the user to retry."""
+    from gateway.run import GatewayRunner
+
+    resp = Envelope(
+        request_id="r1", op=OP_DISPATCH,
+        payload={"error": "handler 'echo' at max_inflight"},
+        status=STATUS_BUSY,
+    )
+    text = GatewayRunner._format_dispatcher_response("echo", resp)
+    assert "max_inflight" in text
+    assert "retry" in text.lower()
+
+
+def test_format_status_internal() -> None:
+    """INTERNAL response surfaces 'internal error' to the user."""
+    from gateway.run import GatewayRunner
+
+    resp = Envelope(
+        request_id="r1", op=OP_DISPATCH,
+        payload={"error": "handler 'echo' raised"},
+        status=STATUS_INTERNAL,
+    )
+    text = GatewayRunner._format_dispatcher_response("echo", resp)
+    assert "internal error" in text.lower()
+
+
+def test_format_status_bad_request() -> None:
+    """BAD_REQUEST response surfaces the error string."""
+    from gateway.run import GatewayRunner
+
+    resp = Envelope(
+        request_id="r1", op=OP_DISPATCH,
+        payload={"error": "unknown command 'foo'"},
+        status=STATUS_BAD_REQUEST,
+    )
+    text = GatewayRunner._format_dispatcher_response("foo", resp)
+    assert "unknown command" in text
+
+
+def test_dispatcher_forward_commands_set_is_correct() -> None:
+    """The forward set contains the 6 dispatcher-unique commands."""
+    from gateway.run import GatewayRunner
+
+    assert GatewayRunner._DISPATCHER_FORWARD_COMMANDS == frozenset({
+        "echo", "research", "forge", "ashare", "replay", "log",
+    })
+
+
+# --- Integration: GatewayRunner._forward_to_dispatcher -----------
+
+
+@pytest.mark.asyncio
+async def test_forward_to_dispatcher_via_runner(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    """End-to-end: build a minimal GatewayRunner, dispatch a
+    recognized slash-command via _forward_to_dispatcher, verify the
+    formatted response.
+    """
+    from gateway.run import GatewayRunner
+    from types import SimpleNamespace
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._dispatcher_client = DispatcherClient(
+        socket_path=str(fake_dispatcher._path)
+    )
+
+    # Minimal MessageEvent stub: only the fields the forward helper
+    # actually reads.
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=SimpleNamespace(value="wechat")),
+        get_command_args=lambda: " hello world",
+    )
+    text = await runner._forward_to_dispatcher(event, "echo")
+    assert text == "[dispatcher] echo: /echo hello world"
+
+
+@pytest.mark.asyncio
+async def test_forward_returns_none_on_dispatcher_down(
+    tmp_path: Path,
+) -> None:
+    """Dispatcher unreachable -> _forward_to_dispatcher returns
+    None so the caller can fall through to normal message handling.
+    """
+    from gateway.run import GatewayRunner
+    from types import SimpleNamespace
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._dispatcher_client = DispatcherClient(
+        socket_path=str(tmp_path / "nope.sock"),
+        timeout_s=0.1,
+        max_retries=0,
+    )
+
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=SimpleNamespace(value="wechat")),
+        get_command_args=lambda: "",
+    )
+    assert await runner._forward_to_dispatcher(event, "echo") is None


### PR DESCRIPTION
## What

Add opt-in Unix socket forwarding so the gateway can delegate configured slash commands to an external dispatcher service instead of routing them through the agent loop.

- `gateway/dispatcher_protocol.py`: wire-protocol dataclasses (Envelope, status codes, ops)
- `gateway/dispatcher_client.py`: async Unix-socket client with retry, timeout, lock-safe connect/close
- `gateway/run.py`: wiring in `_handle_message` between drain check and quick-commands cascade
- Tests: real asyncio Unix socket server fixture, covers connection lifecycle, retry, timeout, status code propagation, concurrency

## Context

This is the dispatcher forwarding functionality originally in #57112, which was closed in favor of #65688. The dispatcher code was later removed from #65688 to keep it scoped to Weixin session detection (per review feedback).

This PR revives the dispatcher forwarding with all 3 original review findings fixed:

1. **Gate forwarding with `_check_slash_access`** — non-admin users can no longer invoke configured dispatcher commands (security fix)
2. **Remove eager `_resolve_default_socket()`** — no Windows `os.getuid` crash; socket path resolved lazily from env var
3. **Catch `LimitOverrunError`** — oversized responses converted to `DispatcherConnectionError` for non-fatal fallback

## Related

- #57112 (closed) — original dispatcher PR
- #65688 (open) — Weixin stale session detection (dispatcher code removed from this PR)

## Testing

- 20 unit tests: connection lifecycle, retry behavior, timeout, status code propagation, asyncio.Lock concurrency, access control gate
- `pytest tests/gateway/test_dispatcher_client.py -q` — 20/20 pass
- Forge review: **PASS** (0 confirmed findings)

Signed-off-by: Minxi Hou <houminxi@gmail.com>