### PR TITLE
fix(terminal): prevent delegated child marker snapshot leak

### DIFF
--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -50,6 +50,7 @@ def test_export_snippet_shape():
     assert "${!HERMES_SESSION_*}" in snippet
     assert "${!HERMES_CRON_AUTO_DELIVER_*}" in snippet
     assert "HERMES_UI_SESSION_ID" in snippet
+    assert "HERMES_DELEGATED_CHILD_CONTEXT" in snippet
     assert "grep -vE" not in snippet
     assert "/tmp/snap.tmp.$BASHPID" in snippet
     # The redirection must be attached to a brace group wrapping the dump,
@@ -103,5 +104,45 @@ def test_shared_snapshot_no_cross_session_leak(tmp_path):
         if os.path.exists(snap):
             with open(snap) as f:
                 assert "HERMES_SESSION_ID" not in f.read()
+    finally:
+        env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_shared_snapshot_does_not_leak_delegated_child_lineage(tmp_path):
+    """Child lineage is per subprocess, not persistent shell state.
+
+    ``delegate_task`` children and their parent intentionally share the
+    default LocalEnvironment. A child must retain its marker for the command
+    it runs, but neither a subsequent parent command nor a stale snapshot from
+    an older Hermes process may inherit it.
+    """
+    from agent.delegation_context import delegated_child_context
+    from tools.environments.local import LocalEnvironment
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    try:
+        # Simulate a snapshot written by an affected pre-fix Hermes process.
+        with open(env._snapshot_path, "a", encoding="utf-8") as snapshot:
+            snapshot.write('declare -x HERMES_DELEGATED_CHILD_CONTEXT="1"\n')
+
+        parent = env.execute(
+            'printf "parent=[%s]\\n" "${HERMES_DELEGATED_CHILD_CONTEXT-}"'
+        )
+        assert "parent=[]" in parent["output"], parent["output"]
+
+        with delegated_child_context():
+            child = env.execute(
+                'printf "child=[%s]\\n" "${HERMES_DELEGATED_CHILD_CONTEXT-}"'
+            )
+        assert "child=[1]" in child["output"], child["output"]
+
+        later_parent = env.execute(
+            'printf "later-parent=[%s]\\n" "${HERMES_DELEGATED_CHILD_CONTEXT-}"'
+        )
+        assert "later-parent=[]" in later_parent["output"], later_parent["output"]
+
+        with open(env._snapshot_path, encoding="utf-8") as snapshot:
+            assert "HERMES_DELEGATED_CHILD_CONTEXT" not in snapshot.read()
     finally:
         env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -397,11 +397,13 @@ def _cwd_marker(session_id: str) -> str:
 # set), not Hermes' per-turn session identity.
 #
 # Kept in sync with gateway.session_context._VAR_MAP: every bridged name starts
-# with one of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests
-# as the Python-side contract for the exclusion set; the dump path unsets by
-# name/prefix instead of grepping declare lines (see below / issue #71296).
+# with one of these prefixes (or is HERMES_UI_SESSION_ID). The delegated-child
+# marker is also transient per-command lineage, not shell state. Used by unit
+# tests as the Python-side contract for the exclusion set; the dump path unsets
+# by name/prefix instead of grepping declare lines (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|"
+    "HERMES_CRON_AUTO_DELIVER_|HERMES_DELEGATED_CHILD_CONTEXT)"
 )
 
 
@@ -431,7 +433,7 @@ def _export_dump_excluding_session_vars(tmp_path: str) -> str:
     return (
         "{ ( "
         "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
-        "HERMES_UI_SESSION_ID 2>/dev/null; "
+        "HERMES_UI_SESSION_ID HERMES_DELEGATED_CHILD_CONTEXT 2>/dev/null; "
         "export -p; "
         ") || true; } "
         f"> {tmp_path}"
@@ -677,8 +679,22 @@ class BaseEnvironment(ABC):
         # vars into every tool response (issue #15459).  Linux bash is
         # silent here, but the redirect is harmless.
         if self._snapshot_ready:
+            # ``delegate_task`` children receive the marker from their fresh
+            # subprocess env. Capture that state before sourcing so an old
+            # snapshot cannot turn a top-level command into a child, while a
+            # real child keeps its marker after the snapshot is restored.
+            parts.append(
+                "if [ -n \"${HERMES_DELEGATED_CHILD_CONTEXT+x}\" ]; then "
+                "__hermes_child_context_at_spawn=1; else "
+                "__hermes_child_context_at_spawn=0; fi"
+            )
             parts.append(
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
+            )
+            parts.append(
+                "if [ \"$__hermes_child_context_at_spawn\" = 0 ]; then "
+                "unset HERMES_DELEGATED_CHILD_CONTEXT; fi; "
+                "unset __hermes_child_context_at_spawn"
             )
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through


### PR DESCRIPTION
## Summary
- keep `HERMES_DELEGATED_CHILD_CONTEXT` out of persistent terminal snapshots
- discard stale snapshot-only child lineage before a parent command runs
- retain child lineage when it was injected into the child subprocess at spawn
- cover stale snapshots, real child marker propagation, and subsequent parent cleanup in a shared `LocalEnvironment`

## Reproduction
`delegate_task` children and their parent intentionally share the default persistent terminal environment. Before this change, a child command persisted `HERMES_DELEGATED_CHILD_CONTEXT=1` into the shared bash snapshot. A later top-level command sourced that snapshot and Kanban correctly—but incorrectly for the parent—treated it as a delegated child.

## Test plan
- [x] `pytest -q tests/tools/test_snapshot_session_id_leak.py tests/tools/test_snapshot_multiline_session_env_injection.py tests/tools/test_delegate_kanban_isolation.py tests/tools/test_local_shell_init.py`
- [x] `ruff check tools/environments/base.py tests/tools/test_snapshot_session_id_leak.py`

The regression test uses a real `LocalEnvironment`, simulates a snapshot created by an affected release, confirms child commands still receive the marker, and confirms subsequent parent commands do not.