### PR TITLE
feat(desktop): extend backdrop across shell

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -8,7 +8,6 @@ import { useLocation } from 'react-router-dom'
 
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
 import { Thread } from '@/components/assistant-ui/thread'
-import { Backdrop } from '@/components/Backdrop'
 import { COMPOSER_HEART_CONFIG, HeartField } from '@/components/chat/vibe-hearts'
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { $sessionTileDragging, $sessionTileEdgeHover } from '@/components/pane-shell/tree/store'
@@ -480,7 +479,6 @@ export function ChatView({
       data-composer-target={composerScope.target}
       data-session-anchor={sessionAnchor}
     >
-      <Backdrop />
       {/* Tiles get their chrome from the layout zone (chip strip); the modal
           prompt overlays stay active-session-scoped in the primary surface. */}
       {isPrimary && (

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -6,6 +6,7 @@ import { PREVIEW_RAIL_MAX_WIDTH, PREVIEW_RAIL_MIN_WIDTH } from '@/app/chat/right
 import { SessionStatusDot } from '@/app/chat/session-status-dot'
 import { PALETTE_AREA, type PaletteContribution, paletteToggle } from '@/app/command-palette/contrib'
 import { type StatusbarItem } from '@/app/shell/statusbar-controls'
+import { Backdrop } from '@/components/Backdrop'
 import { IdleMount } from '@/components/idle-mount'
 import { $layoutEditMode, toggleLayoutEditMode } from '@/components/pane-shell/edit-mode'
 import { allPaneIds, group, groupLeafIds, split } from '@/components/pane-shell/tree/model'
@@ -679,9 +680,10 @@ export function ContribController() {
     >
       <ContribWiring>
         <div
-          className="flex h-screen min-h-0 w-screen flex-col bg-(--ui-bg-chrome) text-(--ui-text-primary)"
+          className="relative isolate flex h-screen min-h-0 w-screen flex-col bg-(--ui-bg-chrome) text-(--ui-text-primary)"
           style={{ '--titlebar-height': '0px' } as CSSProperties}
         >
+          <Backdrop />
           {/* Title bar: fixed chrome outside the grid, composable via slots.
               Layout contract (no contribution can break it):
                 - a full-bar DRAG BASE underneath (pointer-events-none, like


### PR DESCRIPTION
## Summary

The Appearance backdrop was mounted inside the chat surface, so the setting disappeared outside chat and was recreated for every mounted chat tile. Mount the existing non-interactive backdrop once at the Desktop shell instead.

- Apply the existing backdrop consistently behind shell chrome, workspace panes, and contributed plugin panes.
- Preserve the existing asset, persisted setting, opacity, and `pointer-events-none` behavior.
- Remove the chat-local mount so tiled or keep-alive chat views do not duplicate the backdrop.

## Validation

- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run lint` (0 errors; existing warnings only)
- `npm --workspace apps/desktop run test:ui` (356 files / 3157 tests passed)
- `npm --workspace apps/desktop run build`

No platform-specific APIs or configuration changes.