### PR TITLE
Add WRouter model-provider plugin

### DIFF
--- a/plugins/model-providers/wrouter/__init__.py
+++ b/plugins/model-providers/wrouter/__init__.py
@@ -1,0 +1,29 @@
+"""WRouter provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+# WRouter (https://wrouter.ai) is an OpenAI-compatible AI gateway that
+# aggregates Anthropic, OpenAI, Google and other upstreams behind a single
+# /v1 endpoint. Standard api_key auth, so hermes_cli/auth.py, models.py and
+# doctor.py pick it up automatically from the registry.
+wrouter = ProviderProfile(
+    name="wrouter",
+    aliases=("wr",),
+    env_vars=("WROUTER_API_KEY",),
+    display_name="WRouter",
+    description="WRouter — OpenAI-compatible AI gateway",
+    signup_url="https://wrouter.ai",
+    base_url="https://wrouter.ai/v1",
+    hostname="wrouter.ai",
+    supports_vision=True,
+    fallback_models=(
+        "claude-sonnet-5",
+        "claude-opus-4-8",
+        "gpt-5",
+        "gemini-2.5-pro",
+        "deepseek-v3",
+    ),
+)
+
+register_provider(wrouter)

--- a/plugins/model-providers/wrouter/plugin.yaml
+++ b/plugins/model-providers/wrouter/plugin.yaml
@@ -1,0 +1,5 @@
+name: wrouter-provider
+kind: model-provider
+version: 1.0.0
+description: WRouter aggregator
+author: WRouter


### PR DESCRIPTION
Adds [WRouter](https://wrouter.ai) as a model provider.

WRouter is an OpenAI-compatible AI gateway that aggregates Anthropic, OpenAI, Google and other upstreams behind a single `/v1` endpoint.

- `plugins/model-providers/wrouter/`: `ProviderProfile` (`__init__.py`) + `plugin.yaml`, mirroring the existing aggregator plugins (openrouter / ai-gateway).
- Standard `api_key` auth (`WROUTER_API_KEY`), base URL `https://wrouter.ai/v1`, so `hermes_cli/auth.py`, `models.py` and `doctor.py` pick it up automatically from the registry — no other files changed.
- Models are fetched live from `/v1/models`; `fallback_models` lists a few headline models for the picker.

Users can then select it with `model.provider: wrouter` (or alias `wr`).