### PR TITLE
fix(api_server): trust full transcripts via _transcript_mode to stop repair-induced duplication

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5537,6 +5537,15 @@ class APIServerAdapter(BasePlatformAdapter):
     ) -> List[Dict[str, Any]]:
         """Build the stored Responses transcript without duplicating history.
 
+        ``_run_agent`` sets ``result["_transcript_mode"] = "full"`` when the
+        agent returns its authoritative full transcript (the normal AIAgent
+        path).  Message repair may rewrite prior messages in place, so the
+        transcript no longer shares an exact prefix with the input
+        ``conversation_history``; content-equality prefix detection therefore
+        cannot reliably distinguish full transcripts from delta returns.
+        When the mode is explicitly ``"full"``, trust it and store the
+        transcript verbatim — do not concatenate prior history on front.
+
         When context compression occurs during a turn the agent returns a
         compressed full transcript in ``result["messages"]`` (starting with a
         summary) and sets ``result["_compressed"] = True``.  Because the
@@ -5544,6 +5553,9 @@ class APIServerAdapter(BasePlatformAdapter):
         prefix, the normal turn-start detection fails and old code would
         concatenate the uncompressed history on front, bloating the stored
         context and re-triggering compression on every subsequent request.
+        The older ``_compressed`` flag and the exact-prefix heuristic are
+        retained as fallbacks for code paths that do not set the explicit mode
+        (mocks, legacy adapters).
         """
         prior = list(conversation_history)
         current_user = {"role": "user", "content": user_message}
@@ -5556,6 +5568,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 result,
             )
             if turn_start:
+                return list(agent_messages)
+
+            # _run_agent explicitly marks authoritative full transcripts.
+            # Trust the mode regardless of prefix drift caused by message repair
+            # or other in-place transcript rewriting.
+            if result.get("_transcript_mode") == "full":
                 return list(agent_messages)
 
             # turn_start == 0: agent_messages does not start with prior.
@@ -5850,6 +5868,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     _eff_sid = getattr(agent, "session_id", session_id)
                     if isinstance(_eff_sid, str) and _eff_sid:
                         result["session_id"] = _eff_sid
+                    # AIAgent.run_conversation returns the authoritative full
+                    # transcript in result["messages"].  Mark it explicitly so
+                    # _build_response_conversation_history can trust the transcript
+                    # even when message repair rewrites the prefix in place.
+                    if isinstance(result.get("messages"), list):
+                        result["_transcript_mode"] = "full"
                     # Signal whether context compression occurred during this turn
                     # so _build_response_conversation_history can skip the
                     # prior-concatenation path and store the compressed transcript

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5614,6 +5614,18 @@ class APIServerAdapter(BasePlatformAdapter):
             return len(expected_prefix)
         if prior and agent_messages[:len(prior)] == prior:
             return len(prior)
+
+        # _run_agent explicitly marks authoritative full transcripts.  When
+        # repair or other in-place rewriting has changed the prefix, the
+        # exact-prefix comparison fails; fall back to a reverse anchor on the
+        # last user message in the transcript, which corresponds to this turn's
+        # user input (possibly merged with adjacent prior user messages by
+        # repair_message_sequence).
+        if result.get("_transcript_mode") == "full":
+            for i in range(len(agent_messages) - 1, -1, -1):
+                if agent_messages[i].get("role") == "user":
+                    return i + 1
+
         return 0
 
     @classmethod

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2733,6 +2733,77 @@ class TestRepairedTranscriptDuplication:
             assert stored2["conversation_history"] == second_transcript
             assert len(stored2["conversation_history"]) == 4
 
+    @pytest.mark.asyncio
+    async def test_repaired_adjacent_user_input_output_boundary(self, adapter):
+        """Multiple user items in input[] become adjacent user messages; repair
+        merges them, breaking exact-prefix detection. Output must still contain
+        only the current turn's assistant reply, not historical tool calls."""
+        prior_history = [
+            {"role": "user", "content": "search the web for X"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "web_search",
+                            "arguments": '{"query": "X"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "results..."},
+            {"role": "assistant", "content": "Here is what I found about X."},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(prior_history),
+                "session_id": "api-test-session",
+            },
+        )
+
+        # Repair merges the two adjacent user input items into one message.
+        repaired_transcript = prior_history + [
+            {"role": "user", "content": "follow up A\n\nfollow up B"},
+            {"role": "assistant", "content": "reply"},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "reply",
+                        "messages": list(repaired_transcript),
+                        "_transcript_mode": "full",
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"role": "user", "content": "follow up A"},
+                            {"role": "user", "content": "follow up B"},
+                        ],
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            # Output must contain only the current turn's assistant message,
+            # not replay the historical function_call / function_call_output.
+            output_types = [item["type"] for item in data["output"]]
+            assert output_types == ["message"]
+            stored = adapter._response_store.get(data["id"])
+            assert stored["conversation_history"] == repaired_transcript
+
 
 class TestRunAgentTranscriptMode:
     """Unit tests for the _transcript_mode annotation applied by _run_agent."""

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2618,3 +2618,146 @@ class TestCreateAgentModelRecovery:
         assert captured[1]["model"] == "minimax/minimax-m3"
 
 
+# ---------------------------------------------------------------------------
+# Regression tests for repaired transcript duplication
+# ---------------------------------------------------------------------------
+
+
+class TestRepairedTranscriptDuplication:
+    """repair_message_sequence (runs before every LLM call) may merge
+    adjacent user/assistant messages, rewriting the transcript prefix.
+    The exact prefix-match in _build_response_conversation_history would
+    then fail and fall through to prepending prior history, doubling the
+    stored transcript every turn.
+
+    _transcript_mode="full" (set by _run_agent) marks the agent's
+    authoritative full transcript so the builder stores it verbatim even
+    when repair has rewritten the prefix."""
+
+    @pytest.mark.asyncio
+    async def test_repaired_consecutive_user_messages_stored_once(self, adapter):
+        """When the agent's result contains a transcript where repair has
+        merged consecutive user messages, the stored history must equal the
+        repaired transcript, not prior + current_user + repaired_transcript."""
+        repaired_transcript = [
+            {"role": "user", "content": "first message\n\nsecond message"},
+            {"role": "assistant", "content": "got both"},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "got both",
+                        "messages": list(repaired_transcript),
+                        "_transcript_mode": "full",
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "second message"},
+                )
+
+            assert resp.status == 200
+            resp_data = await resp.json()
+            stored = adapter._response_store.get(resp_data["id"])
+            stored_history = stored["conversation_history"]
+            # Must equal the repaired transcript exactly, not duplicated
+            assert stored_history == repaired_transcript
+            assert stored_history.count(repaired_transcript[0]) == 1
+
+    @pytest.mark.asyncio
+    async def test_repaired_transcript_does_not_double_on_chain(self, adapter):
+        """Two consecutive turns where repair merges user messages must
+        not cause exponential history growth."""
+        first_transcript = [
+            {"role": "user", "content": "first\n\nsecond"},
+            {"role": "assistant", "content": "reply 1"},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            # Turn 1
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "reply 1",
+                        "messages": list(first_transcript),
+                        "_transcript_mode": "full",
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp1 = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "second"},
+                )
+
+            assert resp1.status == 200
+            resp1_data = await resp1.json()
+            stored1 = adapter._response_store.get(resp1_data["id"])
+            assert stored1["conversation_history"] == first_transcript
+            assert len(stored1["conversation_history"]) == 2
+
+            # Turn 2: chains from turn 1
+            second_transcript = first_transcript + [
+                {"role": "user", "content": "third\n\nfourth"},
+                {"role": "assistant", "content": "reply 2"},
+            ]
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "reply 2",
+                        "messages": list(second_transcript),
+                        "_transcript_mode": "full",
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp2 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "fourth",
+                        "previous_response_id": resp1_data["id"],
+                    },
+                )
+
+            assert resp2.status == 200
+            resp2_data = await resp2.json()
+            stored2 = adapter._response_store.get(resp2_data["id"])
+            # Must be exactly second_transcript (4 msgs), not doubled (8 msgs)
+            assert stored2["conversation_history"] == second_transcript
+            assert len(stored2["conversation_history"]) == 4
+
+
+class TestRunAgentTranscriptMode:
+    """Unit tests for the _transcript_mode annotation applied by _run_agent."""
+
+    @pytest.mark.asyncio
+    async def test_run_agent_sets_transcript_mode_full_for_message_list(self, adapter):
+        """AIAgent returns a full transcript as result["messages"]; _run_agent
+        must mark it so _build_response_conversation_history trusts it."""
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {
+            "final_response": "ok",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "ok"},
+            ],
+        }
+        mock_agent.session_prompt_tokens = 1
+        mock_agent.session_completion_tokens = 2
+        mock_agent.session_total_tokens = 3
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            result, _ = await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-123",
+            )
+
+        assert result.get("_transcript_mode") == "full"


### PR DESCRIPTION
## What does this PR do?

Fixes a storage-side duplication bug in `/v1/responses` when `previous_response_id` chaining is used together with `repair_message_sequence`. The stored `conversation_history` doubles on every chained turn because the repaired transcript no longer matches the exact prefix expected by `_response_messages_turn_start_index`.

## Root cause

`AIAgent.run_conversation` returns the authoritative full transcript in `result["messages"]`. Before each LLM call, `repair_message_sequence_with_cursor` may merge adjacent user/assistant messages in place. The merged transcript no longer shares an exact prefix with the loaded `conversation_history`, so `_response_messages_turn_start_index` returns `0` and `_build_response_conversation_history` falls through to:

```python
full_history = prior
full_history.append(current_user)
full_history.extend(agent_messages)
```

Because `agent_messages` already contains the full transcript, this concatenation doubles the stored history every chained turn.

## Fix

- In `_run_agent`: when `result["messages"]` is a list, set `result["_transcript_mode"] = "full"`.
- In `_build_response_conversation_history`: after the exact-prefix heuristic fails, check `result.get("_transcript_mode") == "full"` and return `agent_messages` verbatim.

The existing `_compressed` flag and exact-prefix detection are kept as fallbacks for mocks, legacy adapters, and delta-shaped returns.

## Related Issue

Fixes #68257

Complements #69306 (compression-triggered prefix misses via `_compressed`) and relates to #70695 (tolerant semantic turn-start detection).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`
  - `_run_agent` annotates `result["_transcript_mode"] = "full"` when the agent returns a message list.
  - `_build_response_conversation_history` trusts the explicit mode and returns the full transcript directly.
- `tests/gateway/test_api_server.py`
  - `TestRepairedTranscriptDuplication`: two regression tests covering a repaired transcript stored once and chained turns without exponential growth.
  - `TestRunAgentTranscriptMode`: unit test verifying `_run_agent` sets `_transcript_mode="full"`.

## How to Test

```bash
python -m pytest tests/gateway/test_api_server.py::TestRepairedTranscriptDuplication tests/gateway/test_api_server.py::TestRunAgentTranscriptMode -q
```
