### PR TITLE
fix(auth): open /device for Nous Portal login instead of manage-subscription

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5010,6 +5010,91 @@ def _request_device_code(
     return data
 
 
+def _path_is_manage_subscription(url: str) -> bool:
+    """Return True when *url*'s path is the Portal plan/subscribe page."""
+    try:
+        path = (urlparse(url).path or "").rstrip("/").lower()
+    except Exception:
+        return "manage-subscription" in (url or "").lower()
+    return path.endswith("/manage-subscription")
+
+
+def _path_is_device_approval(url: str) -> bool:
+    """Return True when *url*'s path is the Portal device-approval page."""
+    try:
+        path = (urlparse(url).path or "").rstrip("/").lower()
+    except Exception:
+        return False
+    return path.endswith("/device")
+
+
+def _append_user_code_query(url: str, user_code: str) -> str:
+    """Ensure *url* carries ``user_code`` (leave existing code params alone)."""
+    if not user_code or not url:
+        return url
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query, keep_blank_values=True)
+    if "user_code" in qs or "code" in qs:
+        return url
+    sep = "&" if parsed.query else "?"
+    return f"{url}{sep}user_code={user_code}"
+
+
+def _resolve_nous_device_verification_url(
+    device_data: Dict[str, Any],
+    portal_base_url: str,
+) -> Tuple[str, bool]:
+    """Choose the browser URL for Nous device authorization.
+
+    Portal has been returning ``manage-subscription?user_code=…`` as
+    ``verification_uri_complete``. That page is a plan picker without a
+    device-approval UI, so users get stuck on CAPTCHA/login and the CLI
+    times out (#20605, #47950). Prefer the RFC-style ``/device`` page that
+    Hermes's own fixtures and docs expect.
+
+    Returns ``(url, rewritten)`` where *rewritten* is True when we replaced
+    a manage-subscription link with ``/device``.
+    """
+    user_code = str(device_data.get("user_code") or "").strip()
+    complete = str(device_data.get("verification_uri_complete") or "").strip()
+    base = str(device_data.get("verification_uri") or "").strip()
+    portal = (portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
+    fallback = (
+        f"{portal}/device?user_code={user_code}" if user_code else f"{portal}/device"
+    )
+
+    if base and _path_is_device_approval(base):
+        return _append_user_code_query(base, user_code), _path_is_manage_subscription(
+            complete
+        )
+
+    if complete and not _path_is_manage_subscription(complete):
+        return complete, False
+
+    if complete and _path_is_manage_subscription(complete) and user_code:
+        return fallback, True
+
+    if complete:
+        return complete, False
+    if base:
+        return _append_user_code_query(base, user_code), False
+    return fallback, bool(user_code)
+
+
+def _nous_device_auth_timeout_message(portal_base_url: str) -> str:
+    """Actionable timeout text for Nous device-code login failures."""
+    portal = (portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
+    return (
+        "Timed out waiting for device authorization.\n"
+        "  Portal sign-in is required before the device code can be approved.\n"
+        "  If the browser showed a CAPTCHA / 'You did not pass CAPTCHA' error,\n"
+        "  finish signing in at the Portal in a normal browser tab, then retry:\n"
+        "    hermes portal\n"
+        f"  Device approval page: {portal}/device\n"
+        f"  Portal login: {portal}/login"
+    )
+
+
 def _poll_for_token(
     client: httpx.Client,
     portal_base_url: str,
@@ -8534,7 +8619,9 @@ def _nous_device_code_login(
             scope=scope,
         )
 
-        verification_url = str(device_data["verification_uri_complete"])
+        verification_url, rewritten = _resolve_nous_device_verification_url(
+            device_data, portal_base_url
+        )
         user_code = str(device_data["user_code"])
         expires_in = int(device_data["expires_in"])
         interval = int(device_data["interval"])
@@ -8543,6 +8630,11 @@ def _nous_device_code_login(
         print("To continue:")
         print(f"  1. Open: {verification_url}")
         print(f"  2. If prompted, enter code: {user_code}")
+        if rewritten:
+            print(
+                "  (Using /device approval URL — Portal's manage-subscription "
+                "link has no device-approval UI)"
+            )
 
         if open_browser:
             opened = webbrowser.open(verification_url)
@@ -8564,14 +8656,19 @@ def _nous_device_code_login(
         effective_interval = max(1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
         print(f"Waiting for approval (polling every {effective_interval}s)...")
 
-        token_data = _poll_for_token(
-            client=client,
-            portal_base_url=portal_base_url,
-            client_id=client_id,
-            device_code=str(device_data["device_code"]),
-            expires_in=expires_in,
-            poll_interval=interval,
-        )
+        try:
+            token_data = _poll_for_token(
+                client=client,
+                portal_base_url=portal_base_url,
+                client_id=client_id,
+                device_code=str(device_data["device_code"]),
+                expires_in=expires_in,
+                poll_interval=interval,
+            )
+        except TimeoutError as exc:
+            raise TimeoutError(
+                _nous_device_auth_timeout_message(portal_base_url)
+            ) from exc
 
     now = datetime.now(timezone.utc)
     token_expires_in = _coerce_ttl_seconds(token_data.get("expires_in", 0))

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10161,8 +10161,9 @@ async def _start_device_code_flow(
     """
     if provider_id == "nous":
         from hermes_cli.auth import (
-            _request_device_code,
             PROVIDER_REGISTRY,
+            _request_device_code,
+            _resolve_nous_device_verification_url,
         )
         import httpx
         pconfig = PROVIDER_REGISTRY["nous"]
@@ -10192,6 +10193,9 @@ async def _start_device_code_flow(
         device_data, effective_scope = await asyncio.get_running_loop().run_in_executor(
             None, _do_nous_device_request
         )
+        verification_url, _rewritten = _resolve_nous_device_verification_url(
+            device_data, portal_base_url
+        )
         sid, sess = _new_oauth_session("nous", "device_code", profile=profile)
         sess["device_code"] = str(device_data["device_code"])
         sess["interval"] = int(device_data["interval"])
@@ -10206,7 +10210,7 @@ async def _start_device_code_flow(
             "session_id": sid,
             "flow": "device_code",
             "user_code": str(device_data["user_code"]),
-            "verification_url": str(device_data["verification_uri_complete"]),
+            "verification_url": verification_url,
             "expires_in": int(device_data["expires_in"]),
             "poll_interval": int(device_data["interval"]),
         }

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -1064,3 +1064,136 @@ class TestStalePortalBaseUrlMigration:
 
         auth_mod.resolve_nous_runtime_credentials()
         assert refresh_calls == [auth_mod.DEFAULT_NOUS_PORTAL_URL]
+
+
+# =============================================================================
+# Device verification URL — prefer /device over manage-subscription (#20605)
+# =============================================================================
+
+
+class TestResolveNousDeviceVerificationUrl:
+    """Portal sometimes returns manage-subscription as verification_uri_complete."""
+
+    def test_rewrites_manage_subscription_complete_uri(self):
+        from hermes_cli.auth import _resolve_nous_device_verification_url
+
+        url, rewritten = _resolve_nous_device_verification_url(
+            {
+                "user_code": "SMCL-97YT",
+                "verification_uri": (
+                    "https://portal.nousresearch.com/manage-subscription"
+                ),
+                "verification_uri_complete": (
+                    "https://portal.nousresearch.com/manage-subscription"
+                    "?user_code=SMCL-97YT"
+                ),
+            },
+            "https://portal.nousresearch.com",
+        )
+
+        assert rewritten is True
+        assert url == (
+            "https://portal.nousresearch.com/device?user_code=SMCL-97YT"
+        )
+
+    def test_prefers_device_verification_uri_over_manage_subscription_complete(self):
+        from hermes_cli.auth import _resolve_nous_device_verification_url
+
+        url, rewritten = _resolve_nous_device_verification_url(
+            {
+                "user_code": "ABCD-1234",
+                "verification_uri": "https://portal.example.com/device",
+                "verification_uri_complete": (
+                    "https://portal.example.com/manage-subscription"
+                    "?user_code=ABCD-1234"
+                ),
+            },
+            "https://portal.example.com",
+        )
+
+        assert rewritten is True
+        assert url == "https://portal.example.com/device?user_code=ABCD-1234"
+
+    def test_keeps_healthy_device_complete_uri(self):
+        from hermes_cli.auth import _resolve_nous_device_verification_url
+
+        url, rewritten = _resolve_nous_device_verification_url(
+            {
+                "user_code": "NOUS-1234",
+                "verification_uri": "https://portal.nousresearch.com/device",
+                "verification_uri_complete": (
+                    "https://portal.nousresearch.com/device?user_code=NOUS-1234"
+                ),
+            },
+            "https://portal.nousresearch.com",
+        )
+
+        assert rewritten is False
+        assert url == (
+            "https://portal.nousresearch.com/device?user_code=NOUS-1234"
+        )
+
+    def test_timeout_message_mentions_captcha_and_retry(self):
+        from hermes_cli.auth import _nous_device_auth_timeout_message
+
+        msg = _nous_device_auth_timeout_message("https://portal.nousresearch.com")
+        assert "CAPTCHA" in msg
+        assert "hermes portal" in msg
+        assert "https://portal.nousresearch.com/device" in msg
+        assert "https://portal.nousresearch.com/login" in msg
+
+
+def test_nous_device_code_login_opens_rewritten_device_url(monkeypatch):
+    """CLI must open /device even when Portal returns manage-subscription."""
+    import hermes_cli.auth as auth_mod
+
+    opened = []
+    printed = []
+
+    monkeypatch.setattr(
+        auth_mod,
+        "_request_device_code",
+        lambda **kwargs: {
+            "device_code": "device",
+            "user_code": "SMCL-97YT",
+            "verification_uri": (
+                "https://portal.nousresearch.com/manage-subscription"
+            ),
+            "verification_uri_complete": (
+                "https://portal.nousresearch.com/manage-subscription"
+                "?user_code=SMCL-97YT"
+            ),
+            "expires_in": 600,
+            "interval": 1,
+        },
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "_poll_for_token",
+        lambda **kwargs: {
+            "access_token": _invoke_jwt(seconds=3600),
+            "refresh_token": "refresh-token",
+            "expires_in": 900,
+            "scope": auth_mod.DEFAULT_NOUS_SCOPE,
+        },
+    )
+    monkeypatch.setattr(
+        auth_mod,
+        "refresh_nous_oauth_from_state",
+        lambda state, **kwargs: state,
+    )
+    monkeypatch.setattr(auth_mod.webbrowser, "open", lambda url: opened.append(url) or True)
+    monkeypatch.setattr("builtins.print", lambda *a, **k: printed.append(" ".join(str(x) for x in a)))
+
+    auth_mod._nous_device_code_login(
+        portal_base_url="https://portal.nousresearch.com",
+        inference_base_url="https://inference.example.com/v1",
+        open_browser=True,
+        timeout_seconds=1,
+    )
+
+    assert opened == [
+        "https://portal.nousresearch.com/device?user_code=SMCL-97YT"
+    ]
+    assert any("/device?user_code=SMCL-97YT" in line for line in printed)
+    assert any("manage-subscription" in line for line in printed)

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -55,6 +55,47 @@ def _fake_nous_device_data():
     }
 
 
+def test_nous_dashboard_login_rewrites_manage_subscription_verification_url():
+    """Dashboard must surface /device when Portal returns manage-subscription."""
+    import hermes_cli.web_server as ws
+
+    broken = {
+        "device_code": "device-code",
+        "user_code": "SMCL-97YT",
+        "verification_uri": "https://portal.nousresearch.com/manage-subscription",
+        "verification_uri_complete": (
+            "https://portal.nousresearch.com/manage-subscription"
+            "?user_code=SMCL-97YT"
+        ),
+        "expires_in": 600,
+        "interval": 5,
+    }
+    before_sessions = set(ws._oauth_sessions)
+    with patch(
+        "hermes_cli.auth._request_device_code",
+        return_value=broken,
+    ), patch(
+        "hermes_cli.web_server._nous_poller",
+        return_value=None,
+    ):
+        resp = client.post(
+            "/api/providers/oauth/nous/start",
+            headers=HEADERS,
+        )
+
+    try:
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["flow"] == "device_code"
+        assert body["user_code"] == "SMCL-97YT"
+        assert body["verification_url"] == (
+            "https://portal.nousresearch.com/device?user_code=SMCL-97YT"
+        )
+    finally:
+        for sid in set(ws._oauth_sessions) - before_sessions:
+            ws._oauth_sessions.pop(sid, None)
+
+
 def _invoke_scope_refusal():
     request = httpx.Request("POST", "https://portal.nousresearch.com/oauth/device/code")
     response = httpx.Response(


### PR DESCRIPTION
## Summary
- Prefer the Portal `/device?user_code=…` approval page when OAuth returns `manage-subscription?user_code=…`, which is a plan picker with no device-approval UI
- Apply the same rewrite in CLI login and dashboard OAuth start
- On device-auth timeout, print CAPTCHA-aware retry guidance (`hermes portal`, Portal login/device URLs)

Fixes #20605

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_auth_nous_provider.py tests/hermes_cli/test_web_oauth_dispatch.py -q`
- [ ] Run `hermes portal` / `hermes setup --portal` and confirm the printed + browser URL is `/device?user_code=…` even if the Portal API still returns manage-subscription
- [ ] Complete approval on `/device` and confirm login succeeds
- [ ] If CAPTCHA still blocks Portal sign-in itself, confirm the timeout message points at retry/`hermes portal` instead of a bare timeout