### PR TITLE
feat(curator): surface near-duplicate skills in audit and status

### DIFF
--- a/contributors/emails/ehrktm090@gmail.com
+++ b/contributors/emails/ehrktm090@gmail.com
@@ -1,0 +1,2 @@
+younnieCutler
+# PR for #67582

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -65,6 +65,27 @@ def _print_unmanaged_summary() -> None:
     )
 
 
+def _print_registry_health() -> None:
+    """Summarize near-duplicate pressure without making the user diff directories.
+
+    Kept to counts here: the scan is lexical and its candidates need the
+    per-pair evidence to be judged, which is what `hermes curator audit` prints.
+    """
+    from tools import skills_duplicate_audit
+
+    try:
+        stats = skills_duplicate_audit.summarize(skills_duplicate_audit.scan_duplicates())
+    except Exception:
+        return
+    if not stats.get("possible_duplicate_pairs"):
+        return
+    print("\nregistry health:")
+    print(f"  possible duplicate pairs  {stats['possible_duplicate_pairs']}")
+    print(f"  high confidence           {stats['high_confidence_pairs']}")
+    print(f"  medium confidence         {stats['medium_confidence_pairs']}")
+    print("  run `hermes curator audit` for the per-pair evidence")
+
+
 def _cmd_status(args) -> int:
     from agent import curator
     from tools import skill_usage
@@ -115,6 +136,9 @@ def _cmd_status(args) -> int:
     if not rows:
         print("\nno curator-managed skills")
         _print_unmanaged_summary()
+        # Duplicates live on disk, not in the usage record, so an unmanaged-only
+        # library still accumulates them.
+        _print_registry_health()
         return 0
 
     by_state = {"active": [], "stale": [], "archived": []}
@@ -143,6 +167,7 @@ def _cmd_status(args) -> int:
 
     # Surface the curation blind spot on the managed path too.
     _print_unmanaged_summary()
+    _print_registry_health()
 
     # Show top 5 least-recently-active skills. Views and edits are activity too:
     # curator should not report a skill as "never used" right after skill_view()
@@ -613,6 +638,30 @@ def _cmd_list_archived(args) -> int:
     return 0
 
 
+def _cmd_audit(args) -> int:
+    """Report near-duplicate skill candidates. Read-only.
+
+    Deterministic and local: no model call, no network, and nothing is written
+    to the skill library. The output is a shortlist for a human, not a merge
+    plan — see tools/skills_duplicate_audit.py for what the signals mean.
+    """
+    import json as _json
+    from tools import skills_duplicate_audit
+
+    candidates = skills_duplicate_audit.scan_duplicates()
+
+    if getattr(args, "json", False):
+        payload = {
+            "summary": skills_duplicate_audit.summarize(candidates),
+            "candidates": [c._asdict() for c in candidates],
+        }
+        print(_json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+
+    print(skills_duplicate_audit.format_duplicate_report(candidates))
+    return 0
+
+
 def _cmd_usage(args) -> int:
     """Show usage telemetry for ALL skills, with provenance.
 
@@ -688,6 +737,16 @@ def register_cli(parent: argparse.ArgumentParser) -> None:
 
     p_status = subs.add_parser("status", help="Show curator status and skill stats")
     p_status.set_defaults(func=_cmd_status)
+
+    p_audit = subs.add_parser(
+        "audit",
+        help="Report near-duplicate skill candidates (read-only, no LLM)",
+    )
+    p_audit.add_argument(
+        "--json", action="store_true",
+        help="Emit the full report as JSON instead of a table",
+    )
+    p_audit.set_defaults(func=_cmd_audit)
 
     p_usage = subs.add_parser(
         "usage",

--- a/tests/hermes_cli/test_curator_audit.py
+++ b/tests/hermes_cli/test_curator_audit.py
@@ -1,0 +1,138 @@
+"""Tests for `hermes curator audit` and the status registry-health block."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+
+import hermes_cli.curator as curator_cli
+from tools.skills_duplicate_audit import DuplicateCandidate
+
+_CANDIDATES = [
+    DuplicateCandidate(
+        name_a="ai-voice-cloning",
+        name_b="cosyvoice2-voice-cloning",
+        confidence="high",
+        signals=("identical normalized body hash",),
+        ownership_a="agent",
+        ownership_b="agent",
+    ),
+    DuplicateCandidate(
+        name_a="git-commit-helper",
+        name_b="commit-message-generator",
+        confidence="medium",
+        signals=("similar descriptions (0.91)",),
+        ownership_a="agent",
+        ownership_b="hub",
+    ),
+]
+
+
+def _run(handler, **kwargs) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = handler(SimpleNamespace(**kwargs))
+    assert rc == 0
+    return buf.getvalue()
+
+
+def test_audit_subcommand_is_registered():
+    """A handler nobody can dispatch to is dead code."""
+    parser = argparse.ArgumentParser(prog="hermes curator")
+    curator_cli.register_cli(parser)
+
+    args = parser.parse_args(["audit"])
+    assert args.func is curator_cli._cmd_audit
+    assert args.json is False
+
+    assert parser.parse_args(["audit", "--json"]).json is True
+
+
+def test_audit_prints_pairs_with_evidence(monkeypatch):
+    """Every pair carries its signals and both origins — without the evidence the
+    reader cannot tell a real duplicate from a shared template."""
+    from tools import skills_duplicate_audit
+
+    monkeypatch.setattr(skills_duplicate_audit, "scan_duplicates", lambda: _CANDIDATES)
+
+    out = _run(curator_cli._cmd_audit, json=False)
+
+    assert "ai-voice-cloning <-> cosyvoice2-voice-cloning" in out
+    assert "identical normalized body hash" in out
+    assert "High confidence" in out
+    assert "Medium confidence" in out
+    assert "hub" in out
+    assert "not merge decisions" in out
+
+
+def test_audit_json_round_trips(monkeypatch):
+    from tools import skills_duplicate_audit
+
+    monkeypatch.setattr(skills_duplicate_audit, "scan_duplicates", lambda: _CANDIDATES)
+
+    payload = json.loads(_run(curator_cli._cmd_audit, json=True))
+
+    assert payload["summary"] == {
+        "possible_duplicate_pairs": 2,
+        "high_confidence_pairs": 1,
+        "medium_confidence_pairs": 1,
+    }
+    assert payload["candidates"][0]["name_a"] == "ai-voice-cloning"
+    assert payload["candidates"][0]["signals"] == ["identical normalized body hash"]
+
+
+def test_audit_reports_clean_registry(monkeypatch):
+    from tools import skills_duplicate_audit
+
+    monkeypatch.setattr(skills_duplicate_audit, "scan_duplicates", lambda: [])
+
+    assert "None found" in _run(curator_cli._cmd_audit, json=False)
+
+
+def test_registry_health_block_lists_counts(monkeypatch):
+    from tools import skills_duplicate_audit
+
+    monkeypatch.setattr(skills_duplicate_audit, "scan_duplicates", lambda: _CANDIDATES)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        curator_cli._print_registry_health()
+    out = buf.getvalue()
+
+    assert "registry health" in out
+    assert "possible duplicate pairs  2" in out
+    assert "curator audit" in out
+
+
+def test_registry_health_stays_silent_when_clean(monkeypatch):
+    """Status is already dense. A registry with nothing to report should add no
+    lines at all."""
+    from tools import skills_duplicate_audit
+
+    monkeypatch.setattr(skills_duplicate_audit, "scan_duplicates", lambda: [])
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        curator_cli._print_registry_health()
+
+    assert buf.getvalue() == ""
+
+
+def test_registry_health_survives_a_broken_scan(monkeypatch):
+    """`status` reports curator state; a duplicate-scan failure is not a reason to
+    deny the user the rest of it."""
+    from tools import skills_duplicate_audit
+
+    def _boom():
+        raise OSError("skills directory vanished")
+
+    monkeypatch.setattr(skills_duplicate_audit, "scan_duplicates", _boom)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        curator_cli._print_registry_health()
+
+    assert buf.getvalue() == ""

--- a/tests/tools/test_skills_duplicate_audit.py
+++ b/tests/tools/test_skills_duplicate_audit.py
@@ -1,0 +1,240 @@
+"""Tests for tools.skills_duplicate_audit — read-only near-duplicate scanner."""
+
+import hashlib
+
+from tools.skills_duplicate_audit import (
+    format_duplicate_report,
+    scan_duplicates,
+    summarize,
+)
+
+# Long enough to clear the minimum-body guard, distinct enough that two skills
+# using it are genuinely the same skill twice.
+VOICE_BODY = (
+    "## When to Use\n"
+    "Clone a speaker's voice from a short reference sample for dubbing work.\n"
+    "## Reference Audio\n"
+    "Supply at least ten seconds of clean speech with no background music.\n"
+    "## Procedure\n"
+    "Upload the reference clip, then synthesize the target text with the model.\n"
+)
+
+
+def _write_skill(root, name, description, body, frontmatter=True):
+    d = root / name
+    d.mkdir(parents=True)
+    if frontmatter:
+        content = f"---\nname: {name}\ndescription: {description}\n---\n{body}"
+    else:
+        content = body
+    (d / "SKILL.md").write_text(content, encoding="utf-8")
+    return d
+
+
+def _pairs(candidates):
+    return {(c.name_a, c.name_b) for c in candidates}
+
+
+def test_exact_duplicate_under_different_names(tmp_path):
+    """The issue's real case: same content, name varied just enough to slip past
+    the same-name overwrite guard."""
+    _write_skill(tmp_path, "ai-voice-cloning", "Clone a voice", VOICE_BODY)
+    _write_skill(tmp_path, "cosyvoice2-voice-cloning", "Clone a voice", VOICE_BODY)
+
+    candidates = scan_duplicates([tmp_path])
+
+    assert len(candidates) == 1
+    assert candidates[0].confidence == "high"
+    assert "identical normalized body hash" in candidates[0].signals
+
+
+def test_similar_names_different_behavior_is_not_reported(tmp_path):
+    """Sibling skills share a name prefix and the mandated section scaffold but do
+    opposite things. Reporting these is how the audit loses a user's trust."""
+    _write_skill(
+        tmp_path, "aws-s3-upload", "Upload files to an S3 bucket",
+        "## When to Use\nPushing build artifacts to object storage for release.\n"
+        "## Procedure\nRun the sync command against the destination prefix.\n",
+    )
+    _write_skill(
+        tmp_path, "aws-s3-delete", "Delete objects from an S3 bucket",
+        "## When to Use\nRemoving objects and every historical version of them.\n"
+        "## Procedure\nRestore from a versioned snapshot if this was a mistake.\n",
+    )
+
+    assert scan_duplicates([tmp_path]) == []
+
+
+def test_matching_descriptions_with_different_bodies_is_medium(tmp_path):
+    """Same advertised purpose, different actual content — worth a look, not a
+    merge."""
+    _write_skill(
+        tmp_path, "git-commit-helper", "Write a conventional commit message",
+        "## Conventional Commits\nPrefix the subject with the change type.\n"
+        "## Scope Selection\nName the package the change actually touches.\n",
+    )
+    _write_skill(
+        tmp_path, "commit-message-generator", "Write a conventional commit message",
+        "## Draft From Diff\nSummarize the staged hunks into one subject line.\n"
+        "## Length Budget\nKeep the subject under seventy-two characters total.\n",
+    )
+
+    candidates = scan_duplicates([tmp_path])
+
+    assert len(candidates) == 1
+    assert candidates[0].confidence == "medium"
+    assert any("similar descriptions" in s for s in candidates[0].signals)
+
+
+def test_malformed_and_missing_frontmatter_do_not_crash(tmp_path):
+    """A skill with no frontmatter falls back to its directory name; broken YAML
+    must not take the whole scan down with it."""
+    _write_skill(tmp_path, "no-frontmatter", "", VOICE_BODY, frontmatter=False)
+    d = tmp_path / "broken-yaml"
+    d.mkdir()
+    (d / "SKILL.md").write_text(
+        "---\nname: [unclosed\ndescription: \"also broken\n---\n" + VOICE_BODY,
+        encoding="utf-8",
+    )
+
+    candidates = scan_duplicates([tmp_path])
+
+    names = {c.name_a for c in candidates} | {c.name_b for c in candidates}
+    assert "no-frontmatter" in names
+    assert all(isinstance(c.confidence, str) for c in candidates)
+
+
+def test_ordering_is_deterministic(tmp_path):
+    """Output gets diffed between runs, so identical input must produce an
+    identical report — high confidence first, then alphabetical."""
+    _write_skill(tmp_path, "zebra-voice", "Clone a voice", VOICE_BODY)
+    _write_skill(tmp_path, "alpha-voice", "Clone a voice", VOICE_BODY)
+    _write_skill(
+        tmp_path, "mid-notes", "Take structured notes",
+        "## Capture\nWrite down decisions and their stated rationale.\n"
+        "## Review\nRe-read the captured notes before the next meeting.\n",
+    )
+    _write_skill(
+        tmp_path, "mid-notes-two", "Take structured notes",
+        "## Inbox\nCollect loose thoughts before they are lost entirely.\n"
+        "## Triage\nPromote anything still relevant a full day later on.\n",
+    )
+
+    first = scan_duplicates([tmp_path])
+    second = scan_duplicates([tmp_path])
+
+    assert first == second
+    assert [c.confidence for c in first] == sorted(
+        (c.confidence for c in first), key=lambda c: 0 if c == "high" else 1
+    )
+    assert ("alpha-voice", "zebra-voice") in _pairs(first)
+
+
+def test_archived_skills_are_not_scanned(tmp_path):
+    """Archived skills sit under .archive/ awaiting restore. Reporting one as a
+    duplicate of its own live replacement would be noise."""
+    _write_skill(tmp_path, "ai-voice-cloning", "Clone a voice", VOICE_BODY)
+    _write_skill(tmp_path / ".archive", "ai-voice-cloning-old", "Clone a voice", VOICE_BODY)
+
+    assert scan_duplicates([tmp_path]) == []
+
+
+def test_ownership_is_reported_for_both_sides(tmp_path):
+    """Whether a candidate is even actionable depends on where each skill came
+    from — a hub-installed or protected skill is not the curator's to merge."""
+    _write_skill(tmp_path, "ai-voice-cloning", "Clone a voice", VOICE_BODY)
+    _write_skill(tmp_path, "cosyvoice2-voice-cloning", "Clone a voice", VOICE_BODY)
+
+    candidate = scan_duplicates([tmp_path])[0]
+
+    assert candidate.ownership_a
+    assert candidate.ownership_b
+
+
+def test_empty_registry(tmp_path):
+    assert scan_duplicates([tmp_path]) == []
+    assert summarize([]) == {
+        "possible_duplicate_pairs": 0,
+        "high_confidence_pairs": 0,
+        "medium_confidence_pairs": 0,
+    }
+    assert "None found" in format_duplicate_report([])
+
+
+def test_scan_never_mutates_the_skill_library(tmp_path):
+    """The whole premise of this layer is that it is safe to run. Prove it: every
+    file byte-identical, no files added or removed."""
+    _write_skill(tmp_path, "ai-voice-cloning", "Clone a voice", VOICE_BODY)
+    _write_skill(tmp_path, "cosyvoice2-voice-cloning", "Clone a voice", VOICE_BODY)
+
+    def snapshot():
+        return {
+            str(p.relative_to(tmp_path)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in sorted(tmp_path.rglob("*"))
+            if p.is_file()
+        }
+
+    before = snapshot()
+    scan_duplicates([tmp_path])
+    assert snapshot() == before
+
+
+def test_registry_boilerplate_headings_are_discounted(tmp_path):
+    """Skill families invent their own templates. Once a heading is everywhere in
+    the registry it stops identifying anything, whatever template produced it."""
+    def templated(unique_prose):
+        # Same section skeleton every time; the prose underneath is what differs.
+        return (
+            f"## Working With This Skill\n{unique_prose[0]}\n"
+            f"## For Beginners\n{unique_prose[1]}\n"
+            f"## Reference Files\n{unique_prose[2]}\n"
+        )
+
+    family = {
+        "axolotl": (
+            "YAML-recipe trainer for supervised fine-tuning",
+            (
+                "Configure the YAML recipe before launching any training run.",
+                "Begin from the LoRA example recipe shipped in the examples tree.",
+                "Dataset format notes and recipe fields are documented separately.",
+            ),
+        ),
+        "unsloth": (
+            "Kernel-accelerated low-rank adapters on a single GPU",
+            (
+                "Patch the model with the accelerated kernels at import time.",
+                "Start from the free notebook covering a four-bit adapter run.",
+                "Kernel compatibility per architecture is listed in its own file.",
+            ),
+        ),
+        "pytorch-fsdp": (
+            "Shard very large models across many ranks",
+            (
+                "Shard optimizer state across ranks before the first forward pass.",
+                "Read the sharding-strategy primer to pick a wrapping policy.",
+                "Checkpoint layout and resharding rules are described elsewhere.",
+            ),
+        ),
+    }
+    for name, (description, prose) in family.items():
+        _write_skill(tmp_path, name, description, templated(prose))
+
+    # Enough other skills carrying the same template that it reads as common.
+    fillers = [
+        "Render invoices", "Rotate database credentials", "Summarize podcasts",
+        "Diff terraform plans", "Crop product photos", "Chase overdue tickets",
+        "Publish release notes", "Tail production logs", "Seed demo fixtures",
+    ]
+    for i, desc in enumerate(fillers):
+        _write_skill(
+            tmp_path, f"filler-{i}", desc,
+            templated((f"Step {i} alpha detail.", f"Step {i} beta detail.",
+                       f"Step {i} gamma detail.")),
+        )
+
+    candidates = scan_duplicates([tmp_path])
+
+    # The family shares nothing but the template, so it must not surface.
+    assert ("axolotl", "unsloth") not in _pairs(candidates)
+    assert ("axolotl", "pytorch-fsdp") not in _pairs(candidates)
+    assert ("pytorch-fsdp", "unsloth") not in _pairs(candidates)

--- a/tests/tools/test_skills_duplicate_audit.py
+++ b/tests/tools/test_skills_duplicate_audit.py
@@ -179,6 +179,37 @@ def test_scan_never_mutates_the_skill_library(tmp_path):
     assert snapshot() == before
 
 
+def test_default_scan_classifies_external_dirs_as_external(tmp_path, monkeypatch):
+    """`skills.external_dirs` entries are read-only and externally owned, but
+    `skill_usage.provenance()` classifies purely by name against the hub and
+    bundled manifests — it has no notion of "external" at all. A skill that
+    exists only in an external directory must not inherit whatever provenance
+    an unrelated same-named manifest entry would produce; the discovered path
+    has to settle it. Exercises the *default* scan (no explicit skills_dirs),
+    since that's the path skill_usage.get_all_skills_dirs() feeds in
+    production."""
+    import agent.skill_utils as skill_utils
+
+    local_root = tmp_path / "local"
+    external_root = tmp_path / "external"
+    local_root.mkdir()
+    external_root.mkdir()
+
+    _write_skill(local_root, "ai-voice-cloning", "Clone a voice", VOICE_BODY)
+    _write_skill(external_root, "cosyvoice2-voice-cloning", "Clone a voice", VOICE_BODY)
+
+    monkeypatch.setattr(skill_utils, "get_all_skills_dirs", lambda: [local_root, external_root])
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [external_root])
+
+    candidates = scan_duplicates()  # default scan — no explicit skills_dirs
+
+    assert len(candidates) == 1
+    ownership = {candidates[0].name_a: candidates[0].ownership_a,
+                 candidates[0].name_b: candidates[0].ownership_b}
+    assert ownership["cosyvoice2-voice-cloning"] == "external, read-only"
+    assert ownership["ai-voice-cloning"] != "external, read-only"
+
+
 def test_registry_boilerplate_headings_are_discounted(tmp_path):
     """Skill families invent their own templates. Once a heading is everywhere in
     the registry it stops identifying anything, whatever template produced it."""

--- a/tools/skills_duplicate_audit.py
+++ b/tools/skills_duplicate_audit.py
@@ -1,0 +1,326 @@
+"""
+Deterministic near-duplicate candidate audit for skills — opt-in diagnostic,
+not a merge decision.
+
+The curator's consolidation pass is LLM-driven and opt-in (``curator.consolidate``,
+default false), so most registries accumulate near-identical skills that nothing
+ever collapses. This module answers a narrower and much cheaper question with no
+model call and no external dependencies: *which skill pairs look alike enough
+that a human should look?*
+
+It reports **candidates**, never verdicts. Every signal here is lexical, so two
+skills can share their name shape and every heading and still do genuinely
+different things — the report exists to point a human at a short list, not to
+authorize a merge. Nothing in this module writes to the skill library.
+
+Pairs are reported on their own and never chained into groups: if A resembles B
+and B resembles C, that does not make A and C duplicates, and collapsing them
+into one cluster is how a "cleanup" silently deletes an unrelated skill.
+
+CLI: ``hermes curator audit``
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from collections import Counter
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Dict, Iterable, List, NamedTuple, Optional, Sequence, Set, Tuple
+
+
+class DuplicateCandidate(NamedTuple):
+    """One pair of skills that look alike, with the evidence for saying so."""
+
+    name_a: str
+    name_b: str
+    confidence: str  # "high" | "medium"
+    signals: Tuple[str, ...]
+    ownership_a: str
+    ownership_b: str
+
+
+# Lexical thresholds. Deliberately conservative: a missed duplicate costs a line
+# of registry bloat, a false one costs a user's trust in the whole report.
+_NAME_OVERLAP_HIGH = 0.5
+_HEADING_OVERLAP_HIGH = 0.6
+_DESC_SIMILARITY_MIN = 0.85
+
+# Bodies shorter than this are too small to carry a meaningful hash match — a
+# registry full of stub skills would otherwise report every stub against every
+# other one.
+_MIN_BODY_CHARS = 40
+
+_CONFIDENCE_ORDER = {"high": 0, "medium": 1}
+
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$", re.MULTILINE)
+_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+_WS_RE = re.compile(r"\s+", re.UNICODE)
+
+# Headings only mean something when they distinguish. Two layers strip the ones
+# that don't:
+#
+# 1. CONTRIBUTING.md prescribes an exact section scaffold for SKILL.md, so a
+#    well-authored skill is *expected* to carry these. An early version of this
+#    scanner paired a voice-cloning skill with an S3 upload skill on
+#    "When to Use / Procedure / Pitfalls" alone.
+# 2. Skill families invent their own templates that no fixed list can predict —
+#    the bundled fine-tuning skills share ten headings ("Working with this
+#    skill", "For beginners", …) while doing entirely different things. So any
+#    heading common across the registry is discounted too, whatever its origin.
+_SCAFFOLD_HEADINGS = frozenset(
+    {
+        "when to use",
+        "prerequisites",
+        "how to run",
+        "quick reference",
+        "procedure",
+        "pitfalls",
+        "verification",
+        "overview",
+        "usage",
+        "examples",
+        "notes",
+    }
+)
+
+# A heading carried by this fraction of the registry is boilerplate, not
+# identity. Below _MIN_CORPUS_FOR_DF skills there is nothing to estimate from,
+# so only the fixed scaffold above applies.
+_BOILERPLATE_DF_RATIO = 0.15
+_MIN_CORPUS_FOR_DF = 8
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, drop punctuation, collapse whitespace.
+
+    Mirrors the normalization already used for near-duplicate transcript
+    detection in the gateway, so "Git Commit Helper" and "git-commit_helper"
+    compare equal.
+    """
+    if not text:
+        return ""
+    return _WS_RE.sub(" ", _PUNCT_RE.sub(" ", text.lower())).strip()
+
+
+def _name_tokens(name: str) -> Set[str]:
+    """Token set for a skill name: ``ai-voice-cloning`` -> {ai, voice, cloning}."""
+    return {tok for tok in _normalize(name.replace("-", " ").replace("_", " ")).split() if tok}
+
+
+def _headings(body: str) -> Set[str]:
+    """Distinctive normalized heading texts, used as a structural fingerprint.
+
+    Template scaffold headings are dropped — see ``_SCAFFOLD_HEADINGS``.
+    """
+    found = {_normalize(h) for h in _HEADING_RE.findall(body)}
+    return {norm for norm in found if norm and norm not in _SCAFFOLD_HEADINGS}
+
+
+def _body_digest(body: str) -> str:
+    """SHA-256 of the normalized body, or "" when the body is too short to judge."""
+    norm = _normalize(body)
+    if len(norm) < _MIN_BODY_CHARS:
+        return ""
+    return hashlib.sha256(norm.encode("utf-8")).hexdigest()
+
+
+def _jaccard(a: Set[str], b: Set[str]) -> float:
+    """Set overlap. Two empty sets share nothing, so they score 0, not 1."""
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _ratio(a: str, b: str) -> float:
+    if not a or not b:
+        return 0.0
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _ownership(skill_name: str) -> str:
+    """Human-facing origin label, with a note when the skill can't be curated."""
+    try:
+        from tools import skill_usage
+
+        label = skill_usage.provenance(skill_name)
+        if skill_usage.is_protected_builtin(skill_name):
+            return f"{label}, protected"
+        return label
+    except Exception:
+        # Usage state is optional context for the report, never a prerequisite
+        # for producing it.
+        return "unknown"
+
+
+def _load_skills(skills_dirs: Optional[Sequence[Path]] = None) -> List[Dict[str, object]]:
+    """Read every active SKILL.md into the fields the comparison needs.
+
+    Archived skills live under ``.archive/`` and support directories hold
+    progressive-disclosure data, not active skills; both are already excluded by
+    ``iter_skill_index_files``, so restoring an archived skill is what brings it
+    back into the audit.
+    """
+    from agent.skill_utils import (
+        get_all_skills_dirs,
+        iter_skill_index_files,
+        parse_frontmatter,
+    )
+
+    roots: Iterable[Path] = skills_dirs if skills_dirs is not None else get_all_skills_dirs()
+
+    skills: List[Dict[str, object]] = []
+    seen: Set[str] = set()
+    for root in roots:
+        root = Path(root)
+        if not root.is_dir():
+            continue
+        for index_file in iter_skill_index_files(root, "SKILL.md"):
+            try:
+                content = index_file.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            frontmatter, body = parse_frontmatter(content)
+            raw_name = frontmatter.get("name") if isinstance(frontmatter, dict) else None
+            name = str(raw_name).strip() if raw_name else index_file.parent.name
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            description = ""
+            if isinstance(frontmatter, dict):
+                description = str(frontmatter.get("description") or "")
+            skills.append(
+                {
+                    "name": name,
+                    "tokens": _name_tokens(name),
+                    "headings": _headings(body),
+                    "digest": _body_digest(body),
+                    "description": _normalize(description),
+                }
+            )
+    skills.sort(key=lambda s: str(s["name"]))
+    return skills
+
+
+def _boilerplate_headings(skills: Sequence[Dict[str, object]]) -> Set[str]:
+    """Headings so common in this registry that they say nothing about a skill."""
+    if len(skills) < _MIN_CORPUS_FOR_DF:
+        return set()
+    counts: Counter = Counter()
+    for skill in skills:
+        counts.update(skill["headings"])  # type: ignore[arg-type]
+    cutoff = max(2, math.ceil(_BOILERPLATE_DF_RATIO * len(skills)))
+    return {heading for heading, count in counts.items() if count >= cutoff}
+
+
+def _compare(a: Dict[str, object], b: Dict[str, object]) -> Optional[Tuple[str, Tuple[str, ...]]]:
+    """Judge one pair. Returns (confidence, signals) or None when not a candidate."""
+    signals: List[str] = []
+
+    digest_a, digest_b = str(a["digest"]), str(b["digest"])
+    identical_body = bool(digest_a) and digest_a == digest_b
+    if identical_body:
+        signals.append("identical normalized body hash")
+
+    name_overlap = _jaccard(a["tokens"], b["tokens"])  # type: ignore[arg-type]
+    heading_overlap = _jaccard(a["distinctive"], b["distinctive"])  # type: ignore[arg-type]
+    desc_similarity = _ratio(str(a["description"]), str(b["description"]))
+
+    if name_overlap >= _NAME_OVERLAP_HIGH:
+        signals.append(f"high normalized-name overlap ({name_overlap:.2f})")
+    if heading_overlap >= _HEADING_OVERLAP_HIGH:
+        signals.append(f"matching document headings ({heading_overlap:.2f})")
+    if desc_similarity >= _DESC_SIMILARITY_MIN:
+        signals.append(f"similar descriptions ({desc_similarity:.2f})")
+
+    # A shared name shape on its own is not evidence: `aws-s3-upload` and
+    # `aws-s3-delete` are siblings, not duplicates. Require the content to agree
+    # before a pair is worth a human's attention at all.
+    content_agrees = (
+        identical_body
+        or heading_overlap >= _HEADING_OVERLAP_HIGH
+        or desc_similarity >= _DESC_SIMILARITY_MIN
+    )
+    if not content_agrees:
+        return None
+
+    if identical_body or (
+        name_overlap >= _NAME_OVERLAP_HIGH and heading_overlap >= _HEADING_OVERLAP_HIGH
+    ):
+        return "high", tuple(signals)
+    return "medium", tuple(signals)
+
+
+def scan_duplicates(
+    skills_dirs: Optional[Sequence[Path]] = None,
+) -> List[DuplicateCandidate]:
+    """Report skill pairs that look like near-duplicates.
+
+    Read-only. Pass *skills_dirs* to scan specific roots; the default is every
+    configured skills directory. Ordering is deterministic (highest confidence
+    first, then alphabetical) so the output can be diffed between runs.
+    """
+    skills = _load_skills(skills_dirs)
+
+    boilerplate = _boilerplate_headings(skills)
+    for skill in skills:
+        skill["distinctive"] = skill["headings"] - boilerplate  # type: ignore[operator]
+
+    candidates: List[DuplicateCandidate] = []
+    for i, left in enumerate(skills):
+        for right in skills[i + 1 :]:
+            verdict = _compare(left, right)
+            if verdict is None:
+                continue
+            confidence, signals = verdict
+            name_a, name_b = str(left["name"]), str(right["name"])
+            candidates.append(
+                DuplicateCandidate(
+                    name_a=name_a,
+                    name_b=name_b,
+                    confidence=confidence,
+                    signals=signals,
+                    ownership_a=_ownership(name_a),
+                    ownership_b=_ownership(name_b),
+                )
+            )
+
+    candidates.sort(key=lambda c: (_CONFIDENCE_ORDER.get(c.confidence, 9), c.name_a, c.name_b))
+    return candidates
+
+
+def summarize(candidates: Sequence[DuplicateCandidate]) -> Dict[str, int]:
+    """Counts for the ``hermes curator status`` health block."""
+    return {
+        "possible_duplicate_pairs": len(candidates),
+        "high_confidence_pairs": sum(1 for c in candidates if c.confidence == "high"),
+        "medium_confidence_pairs": sum(1 for c in candidates if c.confidence == "medium"),
+    }
+
+
+def format_duplicate_report(candidates: Sequence[DuplicateCandidate]) -> str:
+    """Plain-text report grouped by confidence."""
+    if not candidates:
+        return "Duplicate candidates:\n  None found."
+
+    lines = ["Duplicate candidates:"]
+    for label in ("high", "medium"):
+        bucket = [c for c in candidates if c.confidence == label]
+        if not bucket:
+            continue
+        lines.append("")
+        lines.append(f"  {label.capitalize()} confidence ({len(bucket)}):")
+        for cand in bucket:
+            lines.append("")
+            lines.append(f"    {cand.name_a} <-> {cand.name_b}")
+            lines.append("      Signals:")
+            for signal in cand.signals:
+                lines.append(f"        - {signal}")
+            lines.append("      Ownership:")
+            lines.append(f"        - {cand.name_a}: {cand.ownership_a}")
+            lines.append(f"        - {cand.name_b}: {cand.ownership_b}")
+    lines.append("")
+    lines.append("  Note: lexical candidates for human review, not merge decisions.")
+    return "\n".join(lines)

--- a/tools/skills_duplicate_audit.py
+++ b/tools/skills_duplicate_audit.py
@@ -140,8 +140,25 @@ def _ratio(a: str, b: str) -> float:
     return SequenceMatcher(None, a, b).ratio()
 
 
-def _ownership(skill_name: str) -> str:
-    """Human-facing origin label, with a note when the skill can't be curated."""
+def _ownership(skill_name: str, skill_path: Path) -> str:
+    """Human-facing origin label, with a note when the skill can't be curated.
+
+    Path is checked before name: ``skills.external_dirs`` entries are
+    externally owned and read-only, but ``skill_usage.provenance()`` has no
+    concept of "external" — it classifies purely by name against the hub and
+    bundled manifests. A skill discovered only in an external directory can
+    share its name with an unrelated hub or bundled entry, in which case
+    naming-only classification reports the wrong origin for the file this
+    scan actually read. Checking the discovered path first avoids that.
+    """
+    try:
+        from agent.skill_utils import is_external_skill_path
+
+        if is_external_skill_path(skill_path):
+            return "external, read-only"
+    except Exception:
+        pass
+
     try:
         from tools import skill_usage
 
@@ -194,6 +211,7 @@ def _load_skills(skills_dirs: Optional[Sequence[Path]] = None) -> List[Dict[str,
             skills.append(
                 {
                     "name": name,
+                    "path": index_file.parent,
                     "tokens": _name_tokens(name),
                     "headings": _headings(body),
                     "digest": _body_digest(body),
@@ -282,8 +300,8 @@ def scan_duplicates(
                     name_b=name_b,
                     confidence=confidence,
                     signals=signals,
-                    ownership_a=_ownership(name_a),
-                    ownership_b=_ownership(name_b),
+                    ownership_a=_ownership(name_a, Path(str(left["path"]))),
+                    ownership_b=_ownership(name_b, Path(str(right["path"]))),
                 )
             )
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1223,6 +1223,8 @@ The curator is an auxiliary-model background task that periodically reviews agen
 | Subcommand | Description |
 |------------|-------------|
 | `status` | Show curator status and skill stats |
+| `audit` | Report near-duplicate skill candidates (read-only, no LLM, no mutations) |
+| `audit --json` | Emit the duplicate report as JSON |
 | `run` | Trigger a curator review now (blocks until the LLM pass finishes) |
 | `run --background` | Start the LLM pass in a background thread and return immediately |
 | `run --dry-run` | Preview only — produce the review report with no mutations |

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -92,6 +92,8 @@ Earlier releases used a one-off `curator.auxiliary.{provider,model}` block. That
 
 ```bash
 hermes curator status         # last run, counts, pinned list, LRU top 5
+hermes curator audit          # report near-duplicate skill candidates (read-only)
+hermes curator audit --json   # same report as JSON
 hermes curator run            # trigger a run now (blocks until done). Prune-only unless curator.consolidate: true
 hermes curator run --consolidate # force the LLM consolidation pass on for this run, overriding the config default
 hermes curator run --background  # fire-and-forget: start the run in a background thread
@@ -113,6 +115,50 @@ hermes curator list-archived    # list skills currently in ~/.hermes/skills/.arc
 hermes curator archive <skill>  # manually archive a single skill now
 hermes curator prune [--days N] # bulk-archive agent-created skills idle >= N days (default 90)
 ```
+
+## Duplicate audit
+
+The consolidation pass is LLM-driven and off by default, so a registry can quietly
+accumulate skills that do the same thing under different names. `hermes curator audit`
+answers that narrower question locally — no model call, no network, and nothing is
+written to the skill library:
+
+```bash
+hermes curator audit
+```
+
+```text
+Duplicate candidates:
+
+  High confidence (1):
+
+    ai-voice-cloning <-> cosyvoice2-voice-cloning
+      Signals:
+        - identical normalized body hash
+        - high normalized-name overlap (0.67)
+      Ownership:
+        - ai-voice-cloning: agent
+        - cosyvoice2-voice-cloning: agent
+
+  Note: lexical candidates for human review, not merge decisions.
+```
+
+`hermes curator status` prints just the counts, so bloat shows up without you having to
+diff directories by hand.
+
+The signals are lexical: matching names, distinctive headings, descriptions, and a hash
+of the normalized body. Headings that are common across your registry — the SKILL.md
+section scaffold, or a template a family of skills shares — are discounted, because a
+heading everyone has identifies no one. Two skills can still share all of that and do
+different things, which is why the output is a shortlist for you to read rather than a
+merge plan. Nothing is merged or archived on the strength of this report; use
+`hermes curator archive <skill>` once you've decided.
+
+Pairs are reported on their own and never chained into clusters. If A resembles B and B
+resembles C, that does not make A and C duplicates — collapsing them into one group is
+how a cleanup quietly removes an unrelated skill.
+
+Archived skills are not scanned; restoring one brings it back into the audit.
 
 ## Backups and rollback
 


### PR DESCRIPTION
## What does this PR do?

Adds a read-only near-duplicate audit for the skill registry — Phase 1 of the plan I proposed in #67582.

The curator's consolidation pass is LLM-driven and opt-in (`curator.consolidate`, default `false`), so most registries have nothing that ever collapses two skills doing the same job under different names. The only existing guard catches an exact name collision, which a slightly-renamed variant walks straight past.

This answers the narrower question locally: **which skill pairs look alike enough that a human should look?** No model call, no network, no new dependencies, and nothing is written to the skill library.

```
$ hermes curator audit

Duplicate candidates:

  High confidence (1):

    ai-voice-cloning <-> cosyvoice2-voice-cloning
      Signals:
        - identical normalized body hash
        - high normalized-name overlap (0.67)
      Ownership:
        - ai-voice-cloning: agent
        - cosyvoice2-voice-cloning: agent

  Note: lexical candidates for human review, not merge decisions.
```

`hermes curator status` gains a counts-only "registry health" block so bloat shows up without diffing directories by hand.

### Why the signals are shaped this way

The signals are lexical — name tokens, distinctive headings, descriptions, and a hash of the normalized body — so the output is deliberately a shortlist, not a merge plan. Two things stop it crying wolf, both found by running it against this repo's own bundled skills:

1. **CONTRIBUTING.md prescribes a section scaffold for SKILL.md**, so counting those headings makes every compliant skill resemble every other one. An earlier revision paired a voice-cloning skill with an S3 upload skill on `When to Use / Procedure / Pitfalls` alone.
2. **Skill families invent templates no fixed list can anticipate** — the bundled fine-tuning skills share ten headings while doing different things. So any heading common across the registry is discounted too, whatever produced it.

Pairs are reported on their own and never chained into clusters. If A resembles B and B resembles C, that does not make A and C duplicates — collapsing that group is how a cleanup quietly removes an unrelated skill. (Same reasoning as the pair-only grouping in #68737.)

Measured on this repo's 111 bundled skills: **1.4s, zero high-confidence pairs, 3 medium** — it does not fire indiscriminately on a curated set.

This deliberately does **not** depend on #71110's new `origin` field; ownership is read through the existing `provenance()` so the two can land in either order.

## Related Issue

Refs #67582

Phase 1 of three. This PR is read-only by design — the pre-create similarity gate and the active dedupe pass from that issue are follow-ups, and both want this module as their shared detector rather than a second implementation.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/skills_duplicate_audit.py` — new. `scan_duplicates()` / `format_duplicate_report()` / `summarize()`, mirroring the shape of the existing opt-in diagnostic in `tools/skills_ast_audit.py`. Reuses `iter_skill_index_files`, `parse_frontmatter`, and `skill_usage.provenance` rather than re-deriving any of it.
- `hermes_cli/curator.py` — adds `_cmd_audit` (with `--json`, following the `curator usage` pattern), registers the `audit` subcommand, and adds `_print_registry_health()` to `status` on both the managed and no-managed-skills paths.
- `tests/tools/test_skills_duplicate_audit.py`, `tests/hermes_cli/test_curator_audit.py` — new.
- `website/docs/reference/cli-commands.md`, `website/docs/user-guide/features/curator.md` — document the subcommand.
- `contributors/emails/ehrktm090@gmail.com` — attribution mapping for `contributor-check`.

## How to Test

1. `hermes curator audit` — prints candidate pairs with their evidence, or `None found`.
2. `hermes curator audit --json` — same report as JSON (`summary` + `candidates`).
3. `hermes curator status` — shows the `registry health` block when candidates exist, and stays silent when there are none.
4. Confirm it is genuinely read-only: hash `~/.hermes/skills/` before and after a run; `test_scan_never_mutates_the_skill_library` asserts exactly this.

```bash
python -m pytest tests/tools/test_skills_duplicate_audit.py tests/hermes_cli/test_curator_audit.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate — nothing currently addresses skill duplicate detection
- [x] My PR contains **only** changes related to this feature
- [x] I've run the tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

Note on scope of the test run: the full suite needs the `all`/`dev` extras, which don't install cleanly in my environment (`httpx` and friends are missing, and 181 test modules fail to import for that reason on a clean checkout). I ran every curator- and skill-related module that collects — **81 passed**:

```
tests/agent/test_curator_activity.py  tests/agent/test_curator_backup.py
tests/agent/test_curator_classification.py  tests/agent/test_curator_reports.py
tests/hermes_cli/test_curator_archive_prune.py  tests/hermes_cli/test_curator_audit.py
tests/hermes_cli/test_curator_recent_run_notice.py  tests/hermes_cli/test_curator_run.py
tests/hermes_cli/test_curator_status.py  tests/hermes_cli/test_curator_usage.py
tests/hermes_cli/test_skills_subparser.py  tests/tools/test_skill_usage.py
tests/tools/test_skill_provenance.py  tests/tools/test_skills_duplicate_audit.py
tests/tools/test_skills_ast_audit.py
```

Three failures elsewhere (`test_curator.py::test_review_fork_*`, `test_skill_utils.py::test_absolute_via_symlink_*`) reproduce identically on a clean checkout with my changes stashed, so they are pre-existing and untouched by this PR. The last is a missing `import pytest` in that test module, which only surfaces on Windows where the symlink guard fires.

Also ran `python scripts/check-windows-footguns.py --all` (clean) and verified every file read in the new code passes `encoding=` for `PLW1514`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (CLI reference + curator user guide)
- [x] `cli-config.yaml.example` — N/A, no config keys added
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — all paths go through `pathlib`, no shell-outs, no OS branches
- [x] Tool descriptions/schemas — N/A, no tool behavior changed
