### PR TITLE
fix(gateway): proactive session lock heal via done_callback to prevent permanent deadlock

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4923,6 +4923,27 @@ class BasePlatformAdapter(ABC):
         done = getattr(task, "done", None)
         return bool(done and done())
 
+    def _make_session_lock_heal_callback(self, session_key: str, owner_task: "asyncio.Task[None]"):
+        """Build a done-callback that proactively heals a stale session lock.
+
+        This is the proactive counterpart to the reactive ``_heal_stale_session_lock``:
+        when the owner task exits (for any reason — success, error, or cancellation),
+        the callback heals the session lock so the adapter never ends up in a permanent
+        deadlock state where ``_active_sessions[session_key]`` is held but nothing is
+        actually processing.
+
+        The identity check (``self._session_tasks.get(key) is completed_task``) prevents
+        cross-contamination: if a newer task has taken over the session, the callback
+        for the old task is a no-op.
+        """
+
+        def _heal_lock_on_done(completed_task: "asyncio.Task[None]") -> None:
+            if self._session_tasks.get(session_key) is not owner_task:
+                return  # replaced by a newer task; not our job to clean up
+            self._heal_stale_session_lock(session_key)
+
+        return _heal_lock_on_done
+
     def _heal_stale_session_lock(self, session_key: str) -> bool:
         """Clear a stale session lock if the owner task is already gone.
 
@@ -4980,6 +5001,7 @@ class BasePlatformAdapter(ABC):
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
             task.add_done_callback(self._expected_cancelled_tasks.discard)
+            task.add_done_callback(self._make_session_lock_heal_callback(session_key, task))
         return True
 
     async def cancel_session_processing(

--- a/tests/gateway/test_session_lock_heal_done_callback.py
+++ b/tests/gateway/test_session_lock_heal_done_callback.py
@@ -1,0 +1,213 @@
+"""Regression tests for issue #75280 — stale session lock causes permanent
+gateway deadlock because _heal_stale_session_lock only fires reactively on
+inbound message.
+
+The fix adds a done_callback in _start_session_processing that proactively
+heals the session lock when the owner task exits, regardless of exit reason
+(success, error, or cancellation).
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False):
+        pass  # type: ignore[return-value]
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, text, **kwargs):
+        pass  # type: ignore[return-value]
+
+    async def get_chat_info(self, chat_id):
+        return {}  # type: ignore[return-value]
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="test-token")
+    adapter = _StubAdapter(config, Platform.TELEGRAM)
+    adapter._busy_text_mode = ""
+    adapter.sent_responses = []  # type: ignore[attr-defined]
+
+    async def _mock_send_retry(chat_id, content, **kwargs):
+        adapter.sent_responses.append(content)  # type: ignore[attr-defined]
+
+    adapter._send_with_retry = _mock_send_retry  # type: ignore[attr-defined]
+    return adapter
+
+
+def _session_key(chat_id="12345"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"
+    )
+    return build_session_key(source)
+
+
+# ===========================================================================
+# Tests: proactive session-lock heal via done_callback
+# ===========================================================================
+
+
+class TestProactiveSessionLockHeal:
+    """Verify that the done_callback installed by _start_session_processing
+    proactively heals the session lock when the owner task exits."""
+
+    @pytest.mark.asyncio
+    async def test_heal_callback_heals_on_task_success(self):
+        """When the owner task completes successfully, the done_callback heals
+        the session lock without waiting for an inbound message."""
+        adapter = _make_adapter()
+        sk = _session_key()
+
+        guard = asyncio.Event()
+        adapter._active_sessions[sk] = guard
+
+        async def _ok():
+            return None
+
+        task = asyncio.create_task(_ok())
+        adapter._session_tasks[sk] = task
+        adapter._background_tasks.add(task)
+        task.add_done_callback(adapter._background_tasks.discard)
+        task.add_done_callback(adapter._make_session_lock_heal_callback(sk, task))
+
+        await task
+
+        # After the callback fires, the lock should be healed.
+        assert sk not in adapter._active_sessions, (
+            "session lock should be healed after task completion"
+        )
+        assert sk not in adapter._session_tasks, (
+            "_session_tasks entry should be removed after heal"
+        )
+
+    @pytest.mark.asyncio
+    async def test_heal_callback_heals_on_task_error(self):
+        """When the owner task raises an error, the done_callback still heals
+        the session lock (the bug scenario from #75280)."""
+        adapter = _make_adapter()
+        sk = _session_key()
+
+        guard = asyncio.Event()
+        adapter._active_sessions[sk] = guard
+
+        async def _fail():
+            raise RuntimeError("relay scope corruption")
+
+        task = asyncio.create_task(_fail())
+        adapter._session_tasks[sk] = task
+        adapter._background_tasks.add(task)
+        task.add_done_callback(adapter._background_tasks.discard)
+        task.add_done_callback(adapter._make_session_lock_heal_callback(sk, task))
+
+        with pytest.raises(RuntimeError, match="relay scope corruption"):
+            await task
+
+        # Lock must be healed even though the task errored.
+        assert sk not in adapter._active_sessions, (
+            "session lock should be healed even when task raises an error"
+        )
+        assert sk not in adapter._session_tasks
+
+    @pytest.mark.asyncio
+    async def test_heal_callback_noop_when_task_replaced(self):
+        """If a newer task has taken over the session, the old task's callback
+        is a no-op — prevents cross-contamination."""
+        adapter = _make_adapter()
+        sk = _session_key()
+
+        guard_a = asyncio.Event()
+        adapter._active_sessions[sk] = guard_a
+
+        async def _ok_a():
+            return None
+
+        async def _ok_b():
+            await asyncio.sleep(10)  # long-running "newer" task
+            return None
+
+        task_a = asyncio.create_task(_ok_a())
+        task_b = asyncio.create_task(_ok_b())
+
+        # Wait for task_a to complete.
+        await task_a
+
+        # Simulate: task_b replaced task_a as the session owner.
+        adapter._session_tasks[sk] = task_b
+        adapter._active_sessions[sk] = guard_a
+
+        task_a.add_done_callback(adapter._make_session_lock_heal_callback(sk, task_a))
+
+        # task_a's callback should NOT heal because task_b owns the session now.
+        assert sk in adapter._active_sessions, (
+            "old callback should not heal when a newer task owns the session"
+        )
+        assert adapter._session_tasks[sk] is task_b
+
+        # Clean up task_b.
+        task_b.cancel()
+        try:
+            await task_b
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_heal_callback_clears_pending_messages(self):
+        """When the done_callback heals, it also clears pending messages for
+        that session (matching _heal_stale_session_lock behavior)."""
+        adapter = _make_adapter()
+        sk = _session_key()
+
+        guard = asyncio.Event()
+        adapter._active_sessions[sk] = guard
+        fake_event = asyncio.Event()
+        adapter._pending_messages[sk] = fake_event
+
+        async def _ok():
+            return None
+
+        task = asyncio.create_task(_ok())
+        adapter._session_tasks[sk] = task
+        adapter._background_tasks.add(task)
+        task.add_done_callback(adapter._background_tasks.discard)
+        task.add_done_callback(adapter._make_session_lock_heal_callback(sk, task))
+
+        await task
+
+        assert sk not in adapter._pending_messages, (
+            "pending messages should be cleared on heal"
+        )
+
+    @pytest.mark.asyncio
+    async def test_heal_callback_noop_when_no_task_entry(self):
+        """If _session_tasks has no entry for the key, the callback is a no-op
+        (the _heal_stale_session_lock already handles this)."""
+        adapter = _make_adapter()
+        sk = _session_key()
+
+        guard = asyncio.Event()
+        adapter._active_sessions[sk] = guard
+        # No _session_tasks entry.
+
+        async def _ok():
+            return None
+
+        task = asyncio.create_task(_ok())
+        task.add_done_callback(adapter._make_session_lock_heal_callback(sk, task))
+
+        await task
+
+        # Should NOT raise; _heal_stale_session_lock returns False when no task entry.
+        assert sk in adapter._active_sessions


### PR DESCRIPTION
## Background

Fixes #75280: When a background skill-save turn errors out, the session lock is never released, causing a **permanent gateway deadlock** until manual process restart. Telegram messages completely stop processing (~1x/day on affected instances).

## Root Cause

When the background message processing task exits due to an error or cancellation, the `_active_sessions[session_key]` entry remains. The existing `_heal_stale_session_lock()` only fires **reactively** when a new inbound message arrives. If the PTB updater is dead (no new messages), the heal never fires → circular deadlock.

`_start_session_processing()` already attaches `done_callback`s for tracking set cleanup, but none of them heal the session lock.

## Fix

1. Added `_make_session_lock_heal_callback()` method that builds a done_callback
2. In `_start_session_processing()`, install this callback on every task
3. When the task exits (success, error, or cancellation), the callback proactively calls `_heal_stale_session_lock()` to clean up the session lock
4. Identity verification (checks if `_session_tasks[key]` is still the original task) prevents cross-contamination when a newer task has taken over

## Verification

- Code changes verified locally
- Follows AGENTS.md contribution guidelines
- No breaking changes
- 5 new regression tests (success/error/task-replacement/pending-clear/no-task-entry scenarios)
- Existing 15 split-brain tests all pass

Closes #75280