### PR TITLE
fix(desktop): stop pin-sync pull from reverting the user's own pin click

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -129,6 +129,33 @@ describe('watchSessionPins remote pull', () => {
     expect($pinnedSessionIds.get()).not.toContain('gone')
   })
 
+  it('keeps a fresh local pin when the row already carries pinned=false', async () => {
+    // Regression: the running backend returns `pinned` on every row, so the
+    // reconcile fired by the user's own click used to read the pre-click
+    // server value back as "gone" and instantly revert the pin.
+    $sessions.set([row('fresh', { pinned: false })])
+    await flush()
+
+    $pinnedSessionIds.set(['fresh'])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toContain('fresh')
+    expect(patch).toHaveBeenCalledWith('fresh', true, undefined)
+  })
+
+  it('keeps a fresh local unpin when the row still carries pinned=true', async () => {
+    $sessions.set([row('established', { pinned: true })])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('established')
+    patch.mockClear()
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('established')
+    expect(patch).toHaveBeenCalledWith('established', false, undefined)
+  })
+
   it('leaves the local set alone when the backend omits the flag', async () => {
     $pinnedSessionIds.set(['legacy'])
     // No `pinned` key at all — a runtime predating the column.

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -93,13 +93,23 @@ function pullRemotePins(): void {
   }
 }
 
-function reconcile(): void {
+// Why the pull is gated on `source`: a reconcile triggered by OUR OWN pin-set
+// change runs before the mirroring PATCH has even been issued, so every server
+// row still carries the pre-click value. Consulting rows at that moment reads
+// our own not-yet-pushed intent back as "the server says it's gone" and
+// instantly reverts the user's click (pin: row.pinned=false → unpin; unpin:
+// row.pinned=true → re-pin). The pull exists to adopt truth that arrives with
+// a session-list refresh (or at boot) — a local pin-set change carries no new
+// server information, so there is nothing to pull.
+function reconcile(source: 'boot' | 'pins' | 'sessions' = 'boot'): void {
   // Config/session REST is only reachable through the Electron bridge.
   if (!window.hermesDesktop) {
     return
   }
 
-  pullRemotePins()
+  if (source !== 'pins') {
+    pullRemotePins()
+  }
 
   const current = new Set($pinnedSessionIds.get())
 
@@ -139,8 +149,10 @@ function reconcile(): void {
 }
 
 // Sync once, then re-sync on pin-set and session-list changes. Call once per app.
+// The pin-set listener tags its origin so reconcile skips the pull pass — see
+// the note above reconcile().
 export function watchSessionPins(): void {
-  reconcile()
-  $pinnedSessionIds.listen(reconcile)
-  $sessions.listen(reconcile)
+  reconcile('boot')
+  $pinnedSessionIds.listen(() => reconcile('pins'))
+  $sessions.listen(() => reconcile('sessions'))
 }


### PR DESCRIPTION
## Summary

Sidebar pinning in the Desktop app could never stick against a current backend: clicking **Pin** (or Unpin) looked like a no-op. The session never moved to the Pinned section, and the pin was silently reverted within milliseconds.

## Root cause

`watchSessionPins()` in `apps/desktop/src/store/session-pin-sync.ts` runs `reconcile()` on every trigger — including changes to `$pinnedSessionIds` itself. `reconcile()` unconditionally starts with `pullRemotePins()`, which treats server rows as authoritative and drops local pins the server reports as unpinned.

But a reconcile triggered by the user's own click fires **before the mirroring PATCH has even been issued**, so every session row still carries the pre-click value:

- **Pin**: local set gains the id → reconcile → pull sees `row.pinned === false` → "server says it's gone" → `unpinSession()` reverts the click. The PATCH is never sent.
- **Unpin**: local set loses the id → reconcile → pull sees `row.pinned === true` → `pinSession()` re-adds it.

Backends that omit the `pinned` flag on session rows are unaffected (the pull skips `undefined`), which is why the existing tests — all using rows *without* the flag — passed while the feature was broken in production, where the list endpoint returns `pinned` on every row.

Verified live: after a pin click, localStorage's `hermes.desktop.pinnedSessions` is written and immediately deleted, no PATCH reaches `/api/sessions/{id}`, and `sessions.pinned` in state.db stays 0.

## Fix

Gate the pull pass on the reconcile source:

- session-list refresh / boot → pull (that's where new server truth arrives)
- local pin-set change → push only (a local click carries no new server information, so there is nothing to pull)

`.listen(() => reconcile('pins'))` vs `$sessions.listen(() => reconcile('sessions'))`; the push/mirror logic is unchanged, including the in-flight `unconfirmed` guard for stale list pages.

## Tests

Two regression tests reproducing the production shape (rows that carry the flag):

- `keeps a fresh local pin when the row already carries pinned=false` — failed before the fix (`expected [] to include 'a'`), passes after
- `keeps a fresh local unpin when the row still carries pinned=true`

Full suite: `npx vitest run src/store/session-pin-sync.test.ts` → 13/13 green (11 pre-existing + 2 new), no behavior change for cross-app pin adoption, stale-page races, or legacy backends without the column.