### PR TITLE
fix(cli): Docker cleanup config propagation

### DIFF
--- a/tests/tools/test_docker_config_propagation.py
+++ b/tests/tools/test_docker_config_propagation.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock, patch
+
+
+def test_file_and_execute_code_creation_honor_persist_settings():
+    """Every Docker creation path forwards the reuse and orphan-reaper flags."""
+    import tools.code_execution_tool as code_execution_tool
+    import tools.file_tools as file_tools
+    import tools.terminal_tool as terminal_tool
+
+    config = {
+        "env_type": "docker",
+        "docker_image": "python:3.11",
+        "cwd": "/workspace",
+        "timeout": 30,
+        "container_persistent": True,
+        "docker_persist_across_processes": False,
+        "docker_orphan_reaper": False,
+    }
+    created_env = MagicMock()
+
+    with (
+        patch.object(terminal_tool, "_active_environments", {}),
+        patch.object(terminal_tool, "_last_activity", {}),
+        patch.object(terminal_tool, "_creation_locks", {}),
+        patch.object(terminal_tool, "_task_env_overrides", {}),
+        patch.object(terminal_tool, "_get_env_config", return_value=config),
+        patch.object(terminal_tool, "_create_environment", return_value=created_env) as create_env,
+        patch.object(terminal_tool, "_start_cleanup_thread"),
+        patch.object(file_tools, "_file_ops_cache", {}),
+    ):
+        file_tools._get_file_ops("file-tool-task")
+        assert create_env.call_args.kwargs["container_config"]["docker_persist_across_processes"] is False
+        assert create_env.call_args.kwargs["container_config"]["docker_orphan_reaper"] is False
+
+        create_env.reset_mock()
+        # The terminal backend deliberately collapses ordinary task IDs into
+        # one shared container. Clear the first entry to exercise the separate
+        # process-level creation path used by execute_code.
+        terminal_tool._active_environments.clear()
+        code_execution_tool._get_or_create_env("execute-code-task")
+        assert create_env.call_args.kwargs["container_config"]["docker_persist_across_processes"] is False
+        assert create_env.call_args.kwargs["container_config"]["docker_orphan_reaper"] is False

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -777,6 +777,8 @@ def _get_or_create_env(task_id: str):
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_network": config.get("docker_network", True),
+                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
             }
 
         ssh_config = None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -92,7 +92,8 @@ def _truncate_to_char_budget(content: str, max_chars: int) -> tuple[str, int, bo
     (forcing the model to guess a smaller ``limit`` and burn a round-trip
     returning nothing), this trims the content to the last *complete line*
     that fits within ``max_chars`` and reports how many lines were kept so
-    the caller can offer a ``next_offset`` continuation.
+    the caller can offer a `
+ext_offset`` continuation.
 
     ``content`` is the gutter-rendered text (``LINE_NUM|CONTENT`` joined by
     ``\\n``). Individual lines are already clamped to ``get_max_line_length()``
@@ -1054,6 +1055,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "docker_forward_env": config.get("docker_forward_env", []),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                     "docker_network": config.get("docker_network", True),
+                    "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                    "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
                 }
 
             ssh_config = None
@@ -1281,7 +1284,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             # Instead of rejecting the whole read — which forces the model to
             # guess a smaller `limit` and wastes a round-trip returning nothing
             # — trim to the last complete line that fits and offer a
-            # `next_offset` so the model can paginate forward. This rescues the
+            # 
+ext_offset` so the model can paginate forward. This rescues the
             # "few but very long lines" case (logs, wide CSVs, minified data)
             # that sails past the line-count `limit` but blows the char budget.
             total_lines = result_dict.get("total_lines", "unknown")


### PR DESCRIPTION
Fixes #75291

## What changed
- Forward `docker_persist_across_processes` from file-tool and `execute_code` Docker creation paths.
- Forward `docker_orphan_reaper` through the same paths.
- Add regression coverage for both entry points.

## Root cause
Both paths built a partial `container_config`. The missing settings fell back to `terminal_tool` defaults, so an explicit `docker_persist_across_processes: false` was silently treated as `true`, leaving the container running and reusable.

## Validation
- `venv\\Scripts\\python.exe -m pytest tests/tools/test_docker_config_propagation.py tests/tools/test_docker_orphan_reaper_integration.py -q`
- Result: `7 passed`