### PR TITLE
fix(agent): port nudge-counter reset to unified tool-execution middleware

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -473,13 +473,24 @@ def _run_agent_tool_execution_middleware(
             )
             return result
 
-        if function_name == "memory":
-            agent._turns_since_memory = 0
-        elif function_name == "skill_manage":
-            agent._iters_since_skill = 0
-
         _advance_start_order(_begin)
-        return execute(final_args)
+        _dispatch_result = execute(final_args)
+        # Reset nudge counters only on a non-blocked, non-error result.
+        # This dispatch path only reaches here when NOT blocked (the block
+        # check above returns early), but a call that executes and then
+        # fails must not reset the nudge either -- only genuine success
+        # does. Checked post-execution rather than before execute() (as an
+        # earlier revision of this fix did, prior to Relay centralizing
+        # concurrent and sequential dispatch into this shared middleware)
+        # so an execution error is correctly accounted for (issue #38863).
+        if function_name in ("memory", "skill_manage"):
+            _reset_is_error, _ = _detect_tool_failure(function_name, _dispatch_result)
+            if not _reset_is_error:
+                if function_name == "memory":
+                    agent._turns_since_memory = 0
+                else:
+                    agent._iters_since_skill = 0
+        return _dispatch_result
 
     def _hermes_pipeline(relay_args: dict[str, Any]) -> Any:
         request_result = apply_tool_request_middleware(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1628,6 +1628,188 @@ class TestRetryAfterCap:
 class TestConcurrentToolExecution:
     """Tests for _execute_tool_calls_concurrent and dispatch logic."""
 
+    # -- Nudge counter reset (issue #38863) --------------------------------
+    #
+    # The shared _run_agent_tool_execution_middleware() (used by BOTH
+    # concurrent and sequential dispatch since Relay centralized them)
+    # used to reset _turns_since_memory / _iters_since_skill right after
+    # the blocked-early-return check but BEFORE execute(final_args) ran.
+    # A call that then executed and returned an error still silently
+    # cleared the nudge, so the agent never got reminded to actually use
+    # memory/skills again. The reset now happens post-execution, gated on
+    # not blocked (the dispatch path only reaches the reset line at all
+    # when not blocked) and not is_error (review of #73440).
+
+    def test_concurrent_blocked_memory_does_not_reset_counter(self, agent, monkeypatch):
+        agent._turns_since_memory = 5
+        tc = _mock_tool_call(name="memory", arguments='{"action":"add","target":"memory","content":"x"}', call_id="m1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: "Blocked",
+        )
+        with patch("tools.memory_tool.memory_tool", side_effect=AssertionError("should not run")):
+            agent._execute_tool_calls_concurrent(mock_msg, [], "task-1")
+
+        assert agent._turns_since_memory == 5
+
+    def test_concurrent_blocked_skill_manage_does_not_reset_counter(self, agent, monkeypatch):
+        agent._iters_since_skill = 3
+        tc = _mock_tool_call(name="skill_manage", arguments='{"action":"list"}', call_id="s1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: "Blocked",
+        )
+        with patch("tools.skill_manager_tool.skill_manage", side_effect=AssertionError("should not run")):
+            agent._execute_tool_calls_concurrent(mock_msg, [], "task-1")
+
+        assert agent._iters_since_skill == 3
+
+    def test_concurrent_successful_memory_resets_counter(self, agent, monkeypatch):
+        agent._turns_since_memory = 5
+        tc = _mock_tool_call(name="memory", arguments='{"action":"add","target":"memory","content":"x"}', call_id="m2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+        with patch("tools.memory_tool.memory_tool", return_value='{"status": "saved"}'):
+            agent._execute_tool_calls_concurrent(mock_msg, [], "task-1")
+
+        assert agent._turns_since_memory == 0
+
+    def test_concurrent_successful_skill_manage_resets_counter(self, agent, monkeypatch):
+        agent._iters_since_skill = 3
+        tc = _mock_tool_call(name="skill_manage", arguments='{"action":"list"}', call_id="s2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+        with patch("tools.skill_manager_tool.skill_manage", return_value='{"skills": []}'):
+            agent._execute_tool_calls_concurrent(mock_msg, [], "task-1")
+
+        assert agent._iters_since_skill == 0
+
+    def test_concurrent_error_memory_does_not_reset_counter(self, agent, monkeypatch):
+        """An executed-but-failed memory call must not reset the counter
+        either -- only a genuine success does."""
+        agent._turns_since_memory = 5
+        tc = _mock_tool_call(name="memory", arguments='{"action":"add","target":"memory","content":"x"}', call_id="m3")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+        with patch("tools.memory_tool.memory_tool", return_value='{"error": "disk full"}'):
+            agent._execute_tool_calls_concurrent(mock_msg, [], "task-1")
+
+        assert agent._turns_since_memory == 5
+
+    def test_concurrent_error_skill_manage_does_not_reset_counter(self, agent, monkeypatch):
+        """Same error-result regression for skill_manage."""
+        agent._iters_since_skill = 3
+        tc = _mock_tool_call(name="skill_manage", arguments='{"action":"list"}', call_id="s3")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+        with patch("tools.skill_manager_tool.skill_manage", return_value='{"error": "not found"}'):
+            agent._execute_tool_calls_concurrent(mock_msg, [], "task-1")
+
+        assert agent._iters_since_skill == 3
+
+    # -- Sequential path: memory + skill_manage, blocked/success/error -----
+    # The review specifically flagged that only memory had sequential
+    # coverage despite the stated matrix -- added the missing
+    # skill_manage success/error sequential cases below.
+
+    def test_sequential_error_memory_does_not_reset_counter(self, agent, monkeypatch):
+        agent._turns_since_memory = 5
+        tc = _mock_tool_call(name="memory", arguments='{"action":"add","target":"memory","content":"x"}', call_id="m4")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+        with patch("tools.memory_tool.memory_tool", return_value='{"error": "disk full"}'):
+            agent._execute_tool_calls_sequential(mock_msg, [], "task-1")
+
+        assert agent._turns_since_memory == 5
+
+    def test_sequential_successful_memory_resets_counter(self, agent, monkeypatch):
+        agent._turns_since_memory = 5
+        tc = _mock_tool_call(name="memory", arguments='{"action":"add","target":"memory","content":"x"}', call_id="m5")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+        with patch("tools.memory_tool.memory_tool", return_value='{"status": "saved"}'):
+            agent._execute_tool_calls_sequential(mock_msg, [], "task-1")
+
+        assert agent._turns_since_memory == 0
+
+    def test_sequential_blocked_memory_does_not_reset_counter(self, agent, monkeypatch):
+        agent._turns_since_memory = 5
+        tc = _mock_tool_call(name="memory", arguments='{"action":"add","target":"memory","content":"x"}', call_id="m6")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: "Blocked",
+        )
+        with patch("tools.memory_tool.memory_tool", side_effect=AssertionError("should not run")):
+            agent._execute_tool_calls_sequential(mock_msg, [], "task-1")
+
+        assert agent._turns_since_memory == 5
+
+    def test_sequential_successful_skill_manage_resets_counter(self, agent, monkeypatch):
+        """Requested in review: sequential coverage previously existed
+        only for memory, not skill_manage."""
+        agent._iters_since_skill = 3
+        tc = _mock_tool_call(name="skill_manage", arguments='{"action":"list"}', call_id="s4")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+        with patch("tools.skill_manager_tool.skill_manage", return_value='{"skills": []}'):
+            agent._execute_tool_calls_sequential(mock_msg, [], "task-1")
+
+        assert agent._iters_since_skill == 0
+
+    def test_sequential_error_skill_manage_does_not_reset_counter(self, agent, monkeypatch):
+        """Requested in review: sequential error-result coverage for
+        skill_manage (previously only memory had it)."""
+        agent._iters_since_skill = 3
+        tc = _mock_tool_call(name="skill_manage", arguments='{"action":"list"}', call_id="s5")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: None,
+        )
+        with patch("tools.skill_manager_tool.skill_manage", return_value='{"error": "not found"}'):
+            agent._execute_tool_calls_sequential(mock_msg, [], "task-1")
+
+        assert agent._iters_since_skill == 3
+
+    def test_sequential_blocked_skill_manage_does_not_reset_counter(self, agent, monkeypatch):
+        """Requested in review: sequential blocked-call coverage for
+        skill_manage (previously only memory had it)."""
+        agent._iters_since_skill = 3
+        tc = _mock_tool_call(name="skill_manage", arguments='{"action":"list"}', call_id="s6")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *args, **kwargs: "Blocked",
+        )
+        with patch("tools.skill_manager_tool.skill_manage", side_effect=AssertionError("should not run")):
+            agent._execute_tool_calls_sequential(mock_msg, [], "task-1")
+
+        assert agent._iters_since_skill == 3
+
     def test_single_tool_uses_sequential_path(self, agent):
         """Single tool call should use sequential path, not concurrent."""
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")


### PR DESCRIPTION
## Context

Supersedes #73440 per @teknium1's review.

## Problem

Relay's centralization commit unified concurrent and sequential dispatch into a single shared `_run_agent_tool_execution_middleware()`. The submitted fix targeted the pre-unification location, no longer operative -- current main resets the nudge counters right after the blocked-early-return check but BEFORE `execute(final_args)` runs, so an execution error still silently cleared the nudge.

## Fix

Ported into the actual shared path: capture `execute()`'s return value, check it with the existing `_detect_tool_failure()`, and only reset when the call was not blocked and did not error.

Also added the two missing sequential `skill_manage` cases the review flagged -- the prior port's sequential coverage was memory-only despite the stated matrix.

## Verification

13/13 pass in the nudge-counter test set (6 concurrent + 6 sequential + 1 pre-existing); 39/39 across two test classes (no regression).