### PR TITLE
fix(delegation): add stale watchdog to inline API calls

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -561,17 +561,24 @@ def direct_api_call(agent, api_kwargs: dict):
     Used when ``should_use_direct_api_call`` is True (cron turns and
     delegated children). Skips the interrupt worker (whose only job is
     interactive-interrupt responsiveness, which these contexts do not have)
-    so the nested-pool deadlock (#62151, #60203) cannot occur. Because the
-    request runs in-flight normally, the per-request OpenAI client's own httpx
-    timeout (provider ``request_timeout_seconds`` / ``HERMES_API_TIMEOUT``) bounds
-    a genuinely hung provider — the same bound interactive calls already rely on.
+    so the nested-pool deadlock (#62151, #60203) cannot occur. A request-local
+    timer preserves the non-streaming stale-timeout policy without adding the
+    worker layer back: it aborts the active socket from its timer thread while
+    the request itself remains inline.
     """
     _check_stale_giveup(agent)
     agent._touch_activity("waiting for non-streaming API response")
-    request_client_holder = {"client": None}
+    request_state = {
+        "client": None,
+        "done": False,
+        "stale": False,
+        "cancelled": False,
+    }
     request_client_lock = threading.Lock()
+    request_done = threading.Event()
+    stale_timeout = float(agent._compute_non_stream_stale_timeout(api_kwargs))
 
-    def _abort_active_request(reason: str) -> None:
+    def _abort_active_request(reason: str) -> bool:
         """Abort the inline request from a watchdog/interrupt thread."""
         # Abort while still holding the holder lock: the instant it is
         # released, the inline finally may pop + cache the client for reuse
@@ -580,9 +587,77 @@ def direct_api_call(agent, api_kwargs: dict):
         # (same atomicity contract as _close_request_client_once in the
         # interruptible variants; the abort itself never blocks).
         with request_client_lock:
-            request_client = request_client_holder["client"]
+            if request_state["done"]:
+                return False
+            if reason == "stale_call_kill" and request_state["cancelled"]:
+                return False
+            if reason != "stale_call_kill":
+                # A user interrupt/redirect that wins this lock owns the
+                # request outcome. Do not let a later timer misclassify the
+                # cancelled call as provider staleness and advance the
+                # cross-turn circuit breaker.
+                request_state["cancelled"] = True
+            newly_stale = reason == "stale_call_kill" and not request_state["stale"]
+            if newly_stale:
+                request_state["stale"] = True
+                # Advance the shared circuit breaker before releasing the
+                # request-state lock. The inline owner can unwind as soon as
+                # the socket abort lands; deferring this until afterward
+                # could let a fast retry succeed/reset first and then have
+                # this older timer incorrectly restore the stale streak.
+                _bump_stale_streak(agent)
+            request_client = request_state["client"]
             if request_client is not None:
-                agent._abort_request_openai_client(request_client, reason=reason)
+                try:
+                    agent._abort_request_openai_client(request_client, reason=reason)
+                except Exception:
+                    logger.debug(
+                        "Inline request abort failed (%s)", reason, exc_info=True
+                    )
+            return newly_stale
+
+    def _on_stale_timeout() -> None:
+        if not _abort_active_request("stale_call_kill"):
+            return
+        logger.warning(
+            "Inline non-streaming API call stale after %.0fs. model=%s. "
+            "Killing connection.",
+            stale_timeout,
+            api_kwargs.get("model", "unknown"),
+        )
+        try:
+            agent._buffer_status(
+                f"⚠️ No response from provider for {int(stale_timeout)}s "
+                f"(inline non-streaming, model: "
+                f"{api_kwargs.get('model', 'unknown')}). Aborting call."
+            )
+        except Exception:
+            logger.debug("Inline stale status buffering failed", exc_info=True)
+        agent._touch_activity(
+            f"stale inline non-streaming call killed after {int(stale_timeout)}s"
+        )
+
+        # A stranger-thread abort can race the tiny window after client
+        # registration but before the SDK opens its socket. In that case the
+        # first shutdown finds nothing and the request could otherwise start
+        # after this one-shot timer was spent. Keep enforcing the stale
+        # transition until the inline owner exits; the request-state lock
+        # makes every retry inert before the client can be reused.
+        def _enforce_stale_abort() -> None:
+            retry_delay = 0.1
+            while not request_done.wait(retry_delay):
+                _abort_active_request("stale_call_kill")
+                # Retry quickly across the registration/socket-open race, then
+                # back off so an undiscoverable socket cannot amplify one hang
+                # into thousands of warnings and client-graph traversals.
+                retry_delay = min(retry_delay * 2, 30.0)
+
+        enforcement_thread = threading.Thread(
+            target=_enforce_stale_abort,
+            name="hermes-inline-stale-abort",
+            daemon=True,
+        )
+        enforcement_thread.start()
 
     def _make_client(reason: str, kind: str = "openai"):
         # direct_api_call only runs for OpenAI-wire chat_completions cron
@@ -590,10 +665,38 @@ def direct_api_call(agent, api_kwargs: dict):
         # the dispatch — the only caller that passes kind — is never reached
         # here; the ``kind`` parameter exists purely for signature parity.
         client = agent._create_request_openai_client(reason=reason, api_kwargs=api_kwargs)
+        stale_before_dispatch = False
         with request_client_lock:
-            request_client_holder["client"] = client
+            request_state["client"] = client
+            if request_state["stale"]:
+                stale_before_dispatch = True
+                try:
+                    agent._abort_request_openai_client(
+                        client, reason="stale_call_kill"
+                    )
+                except Exception:
+                    logger.debug(
+                        "Inline request abort after late client registration failed",
+                        exc_info=True,
+                    )
+        if stale_before_dispatch:
+            # The timer may expire while client construction is in progress.
+            # A stranger-thread socket abort can find zero sockets at that
+            # point; handing the client to dispatch would then let create()
+            # open a brand-new socket after the only watchdog fired.
+            raise TimeoutError(
+                "Inline non-streaming API call timed out after "
+                f"{int(stale_timeout)}s before request dispatch "
+                f"(threshold: {int(stale_timeout)}s)"
+            )
         agent._active_request_abort = _abort_active_request
         return client
+
+    stale_timer = None
+    if math.isfinite(stale_timeout):
+        stale_timer = threading.Timer(max(0.0, stale_timeout), _on_stale_timeout)
+        stale_timer.daemon = True
+        stale_timer.start()
 
     # Only a clean return may report the reuse reason (request_complete):
     # after an error or interrupt the wire client is really closed so the
@@ -610,15 +713,29 @@ def direct_api_call(agent, api_kwargs: dict):
     else:
         if getattr(agent, "_interrupt_requested", False):
             raise InterruptedError("Agent interrupted during API call")
+        with request_client_lock:
+            stale = request_state["stale"]
+            request_state["done"] = True
+        if stale:
+            raise TimeoutError(
+                "Inline non-streaming API call timed out after "
+                f"{int(stale_timeout)}s with no response "
+                f"(threshold: {int(stale_timeout)}s)"
+            )
         _reset_stale_streak(agent)
         succeeded = True
         return response
     finally:
+        with request_client_lock:
+            request_state["done"] = True
+        request_done.set()
+        if stale_timer is not None:
+            stale_timer.cancel()
         if getattr(agent, "_active_request_abort", None) is _abort_active_request:
             agent._active_request_abort = None
         with request_client_lock:
-            request_client = request_client_holder["client"]
-            request_client_holder["client"] = None
+            request_client = request_state["client"]
+            request_state["client"] = None
         if request_client is not None:
             agent._close_request_openai_client(
                 request_client,

--- a/contributors/emails/diamantejc87@gmail.com
+++ b/contributors/emails/diamantejc87@gmail.com
@@ -1,0 +1,1 @@
+Zeraphim

--- a/tests/agent/test_cron_inline_api_call_62151.py
+++ b/tests/agent/test_cron_inline_api_call_62151.py
@@ -36,6 +36,7 @@ def _make_agent(*, platform="cron"):
     agent._interrupt_requested = False
     agent._consecutive_stale_streams = 0
     agent._touch_activity = MagicMock()
+    agent._compute_non_stream_stale_timeout.return_value = float("inf")
     agent._close_request_openai_client = MagicMock()
     return agent
 
@@ -98,5 +99,4 @@ def test_direct_api_call_interrupt_aborts_active_client_and_raises():
     assert not worker.is_alive()
     assert isinstance(result.get("exception"), InterruptedError)
     assert agent._active_request_abort is None
-
 

--- a/tests/agent/test_direct_api_call_stale_watchdog_75222.py
+++ b/tests/agent/test_direct_api_call_stale_watchdog_75222.py
@@ -1,0 +1,321 @@
+"""Regression coverage for the inline stale watchdog (#75222)."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.chat_completion_helpers import direct_api_call, interruptible_api_call
+
+
+def _make_agent(*, stale_timeout=0.03):
+    agent = SimpleNamespace(
+        platform="subagent",
+        api_mode="chat_completions",
+        provider="openrouter",
+        model="test/model",
+        _interrupt_requested=False,
+        _consecutive_stale_streams=0,
+        _active_request_abort=None,
+        _touch_activity=MagicMock(),
+        _buffer_status=MagicMock(),
+        _abort_request_openai_client=MagicMock(),
+        _close_request_openai_client=MagicMock(),
+        _compute_non_stream_stale_timeout=MagicMock(return_value=stale_timeout),
+    )
+    return agent
+
+
+def test_delegated_inline_call_stale_abort_preserves_transport_error_then_recovers():
+    """The stale policy applies without moving delegated dispatch off-thread."""
+    agent = _make_agent()
+    request_released = threading.Event()
+    request_thread_ids = []
+    caller_thread_id = threading.get_ident()
+
+    stale_client = MagicMock()
+
+    def _stale_request(**_kwargs):
+        request_thread_ids.append(threading.get_ident())
+        assert request_released.wait(timeout=2)
+        raise RuntimeError("socket closed by watchdog")
+
+    stale_client.chat.completions.create.side_effect = _stale_request
+    healthy_client = MagicMock()
+    healthy_response = SimpleNamespace(id="healthy")
+    healthy_client.chat.completions.create.return_value = healthy_response
+    agent._create_request_openai_client = MagicMock(
+        side_effect=[stale_client, healthy_client]
+    )
+
+    def _abort(client, *, reason):
+        assert client is stale_client
+        assert reason == "stale_call_kill"
+        request_released.set()
+
+    agent._abort_request_openai_client.side_effect = _abort
+
+    with pytest.raises(RuntimeError, match="socket closed by watchdog"):
+        interruptible_api_call(agent, {"model": "test/model", "messages": []})
+
+    assert request_thread_ids == [caller_thread_id]
+    assert agent._consecutive_stale_streams == 1
+    agent._close_request_openai_client.assert_called_once_with(
+        stale_client, reason="request_error_cleanup"
+    )
+
+    agent._compute_non_stream_stale_timeout.return_value = 1.0
+    response = interruptible_api_call(
+        agent, {"model": "test/model", "messages": []}
+    )
+
+    assert response is healthy_response
+    assert agent._consecutive_stale_streams == 0
+    assert agent._close_request_openai_client.call_args_list[-1].kwargs == {
+        "reason": "request_complete"
+    }
+
+
+def test_late_timer_callback_cannot_abort_reused_client():
+    """A callback from a completed request is inert during the next request."""
+
+    class CapturedTimer:
+        instances = []
+
+        def __init__(self, interval, function):
+            self.interval = interval
+            self.function = function
+            self.daemon = False
+            self.cancelled = False
+            self.instances.append(self)
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            self.cancelled = True
+
+    agent = _make_agent(stale_timeout=1.0)
+    reused_client = MagicMock()
+    second_started = threading.Event()
+    release_second = threading.Event()
+    calls = {"count": 0}
+
+    def _request(**_kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return SimpleNamespace(id="first")
+        second_started.set()
+        assert release_second.wait(timeout=2)
+        return SimpleNamespace(id="second")
+
+    reused_client.chat.completions.create.side_effect = _request
+    agent._create_request_openai_client = MagicMock(return_value=reused_client)
+
+    with patch(
+        "agent.chat_completion_helpers.threading.Timer", CapturedTimer
+    ):
+        first = direct_api_call(agent, {"model": "test/model", "messages": []})
+        result = {}
+        worker = threading.Thread(
+            target=lambda: result.setdefault(
+                "response",
+                direct_api_call(agent, {"model": "test/model", "messages": []}),
+            )
+        )
+        worker.start()
+        assert second_started.wait(timeout=1)
+
+        CapturedTimer.instances[0].function()
+        agent._abort_request_openai_client.assert_not_called()
+
+        release_second.set()
+        worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert first.id == "first"
+    assert result["response"].id == "second"
+    assert CapturedTimer.instances[0].cancelled is True
+
+
+def test_timer_firing_before_client_registration_aborts_late_client():
+    """A stale client factory must not dispatch after its watchdog was spent."""
+
+    class ImmediateTimer:
+        def __init__(self, _interval, function):
+            self.function = function
+            self.daemon = False
+
+        def start(self):
+            self.function()
+
+        def cancel(self):
+            return None
+
+    agent = _make_agent(stale_timeout=0.0)
+    client = MagicMock()
+    client.chat.completions.create.return_value = SimpleNamespace(id="too-late")
+    agent._create_request_openai_client = MagicMock(return_value=client)
+
+    with patch("agent.chat_completion_helpers.threading.Timer", ImmediateTimer):
+        with pytest.raises(TimeoutError, match="timed out"):
+            direct_api_call(agent, {"model": "test/model", "messages": []})
+
+    agent._abort_request_openai_client.assert_called_once_with(
+        client, reason="stale_call_kill"
+    )
+    agent._close_request_openai_client.assert_called_once_with(
+        client, reason="request_error_cleanup"
+    )
+    client.chat.completions.create.assert_not_called()
+    assert agent._consecutive_stale_streams == 1
+
+
+def test_stale_abort_is_reenforced_across_registration_to_dispatch_race():
+    """A pre-socket abort is retried after dispatch starts opening the socket."""
+
+    class CapturedTimer:
+        instance = None
+
+        def __init__(self, _interval, function):
+            self.function = function
+            self.daemon = False
+            CapturedTimer.instance = self
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            return None
+
+    before_create = threading.Event()
+    allow_create_lookup = threading.Event()
+    request_released = threading.Event()
+    abort_count = {"value": 0}
+
+    def _request(**_kwargs):
+        assert request_released.wait(timeout=2)
+        raise RuntimeError("socket closed by reenforced watchdog")
+
+    class Completions:
+        @property
+        def create(self):
+            # _make_client has returned, but the SDK request has not started:
+            # model a timer firing during the final attribute lookup.
+            before_create.set()
+            assert allow_create_lookup.wait(timeout=2)
+            return _request
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=Completions()))
+    agent = _make_agent(stale_timeout=1.0)
+    agent._create_request_openai_client = MagicMock(return_value=client)
+
+    def _abort(_client, *, reason):
+        assert reason == "stale_call_kill"
+        abort_count["value"] += 1
+        if abort_count["value"] >= 2:
+            request_released.set()
+
+    agent._abort_request_openai_client.side_effect = _abort
+    result = {}
+
+    with patch("agent.chat_completion_helpers.threading.Timer", CapturedTimer):
+        worker = threading.Thread(
+            target=lambda: result.setdefault(
+                "exception",
+                pytest.raises(
+                    RuntimeError,
+                    direct_api_call,
+                    agent,
+                    {"model": "test/model", "messages": []},
+                ).value,
+            )
+        )
+        worker.start()
+        assert before_create.wait(timeout=1)
+
+        CapturedTimer.instance.function()
+        allow_create_lookup.set()
+        worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert "reenforced watchdog" in str(result["exception"])
+    assert abort_count["value"] >= 2
+    assert agent._consecutive_stale_streams == 1
+
+
+def test_interrupt_winning_before_timer_does_not_count_as_stale():
+    """A cancelled request must not poison the provider stale circuit breaker."""
+
+    class CapturedTimer:
+        instance = None
+
+        def __init__(self, _interval, function):
+            self.function = function
+            self.daemon = False
+            self.cancelled = False
+            CapturedTimer.instance = self
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            self.cancelled = True
+
+    agent = _make_agent(stale_timeout=1.0)
+    request_started = threading.Event()
+    release_request = threading.Event()
+    client = MagicMock()
+
+    def _request(**_kwargs):
+        request_started.set()
+        assert release_request.wait(timeout=2)
+        raise RuntimeError("socket closed by interrupt")
+
+    client.chat.completions.create.side_effect = _request
+    agent._create_request_openai_client = MagicMock(return_value=client)
+    result = {}
+
+    with patch("agent.chat_completion_helpers.threading.Timer", CapturedTimer):
+        worker = threading.Thread(
+            target=lambda: result.setdefault(
+                "exception",
+                pytest.raises(
+                    InterruptedError,
+                    direct_api_call,
+                    agent,
+                    {"model": "test/model", "messages": []},
+                ).value,
+            )
+        )
+        worker.start()
+        assert request_started.wait(timeout=1)
+
+        agent._interrupt_requested = True
+        agent._active_request_abort("interrupt_abort")
+        CapturedTimer.instance.function()
+        release_request.set()
+        worker.join(timeout=2)
+
+    assert not worker.is_alive()
+    assert isinstance(result["exception"], InterruptedError)
+    agent._abort_request_openai_client.assert_called_once_with(
+        client, reason="interrupt_abort"
+    )
+    agent._buffer_status.assert_not_called()
+    assert agent._consecutive_stale_streams == 0
+
+
+def test_infinite_stale_timeout_disables_inline_timer():
+    agent = _make_agent(stale_timeout=float("inf"))
+    client = MagicMock()
+    response = SimpleNamespace(id="local")
+    client.chat.completions.create.return_value = response
+    agent._create_request_openai_client = MagicMock(return_value=client)
+
+    with patch(
+        "agent.chat_completion_helpers.threading.Timer",
+        side_effect=AssertionError("timer must stay disabled"),
+    ):
+        assert direct_api_call(agent, {"model": "test/model", "messages": []}) is response

--- a/tests/cron/test_cron_direct_api_call_62151.py
+++ b/tests/cron/test_cron_direct_api_call_62151.py
@@ -24,6 +24,7 @@ def _make_agent(*, platform="cron"):
     agent.provider = "openrouter"
     agent._interrupt_requested = False
     agent._touch_activity = MagicMock()
+    agent._compute_non_stream_stale_timeout.return_value = float("inf")
     agent._create_request_openai_client = MagicMock()
     agent._close_request_openai_client = MagicMock()
     return agent


### PR DESCRIPTION
## What does this PR do?

Adds a request-local stale watchdog to inline OpenAI-compatible API calls used by cron turns and delegated children. The request remains on the calling thread, preserving the nested-worker deadlock fixes from #62151 and #60203, while stalled providers are now aborted using the existing non-streaming stale-timeout policy.

## Related Issue

Fixes #75222

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Apply `_compute_non_stream_stale_timeout()` to `direct_api_call()`.
- Abort stale request-local sockets with backed-off enforcement across client-registration races.
- Preserve interrupt/redirect ownership and prevent cancelled calls from advancing the stale circuit breaker.
- Prevent late watchdog callbacks from aborting reused clients.
- Add regression coverage for stale abort, recovery, cancellation, client reuse, pre-dispatch races, and infinite timeouts.

## How to Test

1. Run the focused request-lifecycle and stale-timeout suite.
2. Confirm all 31 tests pass.
3. Run Ruff, Python compilation, and `git diff --check`.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only related changes
- [ ] I've run the full `pytest tests/ -q` suite
- [x] I've added tests for my changes
- [x] I've tested on macOS
- [x] Documentation changes are N/A
- [x] Config changes are N/A
- [x] Architecture/workflow documentation changes are N/A
- [x] I've considered cross-platform impact
- [x] Tool schema changes are N/A

## Screenshots / Logs

Not applicable; this changes internal request lifecycle behavior.
