### PR TITLE
docs(sessions): correct compression-lineage and snapshot-growth claims, transplant to config_defaults.py

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2575,6 +2575,19 @@ DEFAULT_CONFIG = {
         # no consumer outside their own overwrite guard and accumulated
         # GBs of disk on heavy users.  Opt in only if you have an external
         # tool that consumes the JSON files directly.
+        # Note: this snapshot's message count is noncanonical. Default
+        # in-place compression (compression.in_place: true) rewrites the
+        # live history to fewer messages under the SAME session_id, but
+        # the writer's own truncation guard then refuses to overwrite the
+        # existing (larger) snapshot -- so the file typically freezes at
+        # its pre-compaction size rather than staying in sync. Only
+        # rotation mode (in_place: false) or /branch forks a new
+        # session_id (and /branch copies the parent's loaded transcript
+        # into it, so that file isn't empty either). There is no single
+        # API that reconstructs a full branch+compression lineage --
+        # SessionDB.get_compression_lineage/export_session_lineage only
+        # traverse rotation-mode compression ancestors, not branch parents
+        # (issue #2229).
         "write_json_snapshots": False,
         # Search-index (FTS) storage optimization — the compact v23 layout
         # that drops duplicate content copies and stops trigram-indexing tool

--- a/run_agent.py
+++ b/run_agent.py
@@ -2854,6 +2854,34 @@ class AIAgent:
         tags).  The truncation guard ("don't overwrite a larger log with
         fewer messages") is preserved so resume + branch don't clobber a
         fuller existing snapshot.
+
+        Scope and message-count caveats -- this snapshot's count is
+        noncanonical, not a reliable proxy for "how much history exists":
+
+        - Compression defaults to ``compression.in_place: true``
+          (``agent/conversation_compression.py``), which REWRITES the live
+          message list to a smaller compacted set under the SAME
+          session_id. Because this writer re-derives ``session_{sid}.json``
+          from ``self.session_id`` on every call, and the truncation guard
+          above refuses to overwrite an existing larger snapshot with
+          fewer messages, the file typically just stops being updated at
+          its pre-compaction size rather than "keeping up" with the live
+          (now-smaller) history -- the opposite of continuing to grow.
+          Only the opt-out rotation mode (``compression.in_place: false``)
+          forks a new child session_id, starting a fresh snapshot file.
+        - ``/branch`` (``gateway/slash_commands.py::_handle_branch_command``)
+          always creates a new child session_id and copies the parent's
+          loaded transcript into it before the branch continues, so a
+          branched snapshot starts as a copy, not empty.
+        - Don't use ``SessionDB.get_compression_lineage`` /
+          ``export_session_lineage`` to explain a branch child's snapshot:
+          those only traverse ROTATION-MODE COMPRESSION ancestors --
+          ``get_compression_lineage()`` returns just the requested ID
+          for a branch-child row (``hermes_state.py``) rather than
+          walking into the branch's parent chain. There is no single API
+          that reconstructs a full branch+compression lineage; state.db
+          per-session_id reads and this snapshot are both scoped to one
+          session_id's own rows either way (issue #2229).
         """
         if not getattr(self, "_session_json_enabled", False):
             return


### PR DESCRIPTION
## Context

Supersedes #73436 per @teknium1's review -- two remaining inaccuracies in the prior correction.

## Fixes

1. `SessionDB.get_compression_lineage()` does not traverse branch chains -- it returns only the requested session_id for a branch-child row. Corrected the docstring to state there is no single API that reconstructs a full branch+compression lineage, and that these readers are scoped to rotation-mode compression ancestors only.
2. The snapshot does not reliably "keep accumulating" through in-place compaction -- the truncation guard actively prevents the file from being updated to a smaller post-compaction message count, so it typically freezes at its pre-compaction size instead. Corrected to describe this noncanonical, count-agnostic behavior.

Also transplanted the corrected note to `hermes_cli/config_defaults.py`, which now owns the setting (the prior extraction commit moved it out of `hermes_cli/config.py`).

## Verification

No behavior change; comment-only. 2/2 existing session-log tests pass.