### PR TITLE
fix(ui-tui): skip DEC 2026 markers on the main-screen write path

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -1134,7 +1134,12 @@ export default class Ink {
     const { bytes: writeBytes, backpressure } = writeDiffToTerminal(
       this.terminal,
       optimized,
-      this.altScreenActive && !SYNC_OUTPUT_SUPPORTED,
+      // Gate on the capability alone, not on the screen mode: a terminal that
+      // can't honor DEC 2026 gains nothing from BSU/ESU on the main screen
+      // either, and under a multiplexer the markers show up as repeated or
+      // garbled scrollback frames. This mirrors the capability the diff
+      // generator is already given above.
+      !SYNC_OUTPUT_SUPPORTED,
       trackDrain
         ? () => {
             // Callback fires once Node has flushed the chunk to the OS.
@@ -2430,7 +2435,10 @@ export default class Ink {
     // Non-TTY environments don't handle erasing ansi escapes well, so it's better to
     // only render last frame of non-static output
     const diff = this.log.renderPreviousOutput_DEPRECATED(this.frontFrame)
-    writeDiffToTerminal(this.terminal, optimize(diff))
+    // Same capability gate as the main render path — this final unmount frame
+    // lands in the visible scrollback, so it must not emit markers the
+    // terminal can't honor.
+    writeDiffToTerminal(this.terminal, optimize(diff), !SYNC_OUTPUT_SUPPORTED)
 
     // Clean up terminal modes synchronously before process exit.
     // React's componentWillUnmount won't run in time when process.exit() is called,

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
@@ -1,6 +1,10 @@
+import { Writable } from 'node:stream'
+
 import { describe, expect, it } from 'vitest'
 
-import { needsAltScreenResizeScrollbackClear } from './terminal.js'
+import type { Diff } from './frame.js'
+import { isSynchronizedOutputSupported, needsAltScreenResizeScrollbackClear, writeDiffToTerminal } from './terminal.js'
+import { BSU, ESU } from './termio/dec.js'
 
 describe('terminal resize quirks', () => {
   it('uses a deeper alt-screen resize clear for Apple Terminal', () => {
@@ -11,5 +15,100 @@ describe('terminal resize quirks', () => {
   it('keeps the normal resize repaint path for modern terminals', () => {
     expect(needsAltScreenResizeScrollbackClear({ TERM_PROGRAM: 'vscode' })).toBe(false)
     expect(needsAltScreenResizeScrollbackClear({ TERM_PROGRAM: 'iTerm.app' })).toBe(false)
+  })
+})
+
+describe('synchronized output detection', () => {
+  it('does not trust an outer terminal DEC 2026 capability under a multiplexer', () => {
+    // Zellij sets ZELLIJ to the session index — "0" for the first session — so
+    // the guard keys on presence, not truthiness of the value.
+    expect(isSynchronizedOutputSupported({ TERM_PROGRAM: 'WezTerm', ZELLIJ: '0' })).toBe(false)
+    expect(isSynchronizedOutputSupported({ TERM_PROGRAM: 'WezTerm', ZELLIJ: '1' })).toBe(false)
+    expect(isSynchronizedOutputSupported({ TERM_PROGRAM: 'WezTerm', TMUX: '/tmp/tmux-1/default,1,0' })).toBe(false)
+    expect(isSynchronizedOutputSupported({ STY: '4242.pts-0.host', TERM_PROGRAM: 'WezTerm' })).toBe(false)
+  })
+
+  it('still reports support for a DEC 2026 terminal with no multiplexer', () => {
+    expect(isSynchronizedOutputSupported({ TERM_PROGRAM: 'WezTerm' })).toBe(true)
+    expect(isSynchronizedOutputSupported({ TERM_PROGRAM: 'iTerm.app' })).toBe(true)
+    expect(isSynchronizedOutputSupported({ TERM: 'xterm-kitty' })).toBe(true)
+  })
+
+  it('reports no support for an unknown terminal', () => {
+    expect(isSynchronizedOutputSupported({ TERM: 'xterm-256color' })).toBe(false)
+  })
+
+  it('reads the injected env only, never the ambient process env', () => {
+    // Guards the injection itself: every branch must consult `env`, so an
+    // empty record is "unknown terminal" regardless of the host environment.
+    expect(isSynchronizedOutputSupported({})).toBe(false)
+  })
+})
+
+/** Captures everything written to a Terminal's stdout so a frame can be asserted on. */
+const captureTerminal = () => {
+  const chunks: string[] = []
+
+  const sink = () =>
+    new Writable({
+      write(chunk: Buffer | string, _encoding, callback) {
+        chunks.push(String(chunk))
+        callback()
+      }
+    })
+
+  return { frame: () => chunks.join(''), terminal: { stderr: sink(), stdout: sink() } }
+}
+
+describe('writeDiffToTerminal synchronized-output markers', () => {
+  const diff: Diff = [{ content: 'hello', type: 'stdout' }]
+
+  it('omits BSU/ESU from the emitted frame when markers are skipped', () => {
+    const { frame, terminal } = captureTerminal()
+
+    writeDiffToTerminal(terminal, diff, true)
+
+    const emitted = frame()
+
+    expect(emitted).toContain('hello')
+    expect(emitted).not.toContain(BSU)
+    expect(emitted).not.toContain(ESU)
+  })
+
+  it('wraps the emitted frame in BSU/ESU when the terminal supports DEC 2026', () => {
+    const { frame, terminal } = captureTerminal()
+
+    writeDiffToTerminal(terminal, diff, false)
+
+    const emitted = frame()
+
+    expect(emitted.startsWith(BSU)).toBe(true)
+    expect(emitted.endsWith(ESU)).toBe(true)
+    expect(emitted).toContain('hello')
+  })
+
+  it('emits no markers on a main-screen frame under a multiplexer', () => {
+    // The reported bug (#66490): the main-screen renderer passed
+    // `altScreenActive && !supported`, which is always false off the alt
+    // screen, so BSU/ESU reached Zellij on every frame. The renderer now gates
+    // on the capability alone; both flags are computed here exactly as
+    // ink.tsx computes them, so the emitted frames show the regression.
+    const altScreenActive = false
+    const syncSupported = isSynchronizedOutputSupported({ TERM_PROGRAM: 'WezTerm', ZELLIJ: '0' })
+
+    expect(syncSupported).toBe(false)
+
+    const fixed = captureTerminal()
+
+    writeDiffToTerminal(fixed.terminal, diff, !syncSupported)
+
+    expect(fixed.frame()).toBe('hello')
+
+    // Counterexample: the previous gate on this same main-screen frame.
+    const previous = captureTerminal()
+
+    writeDiffToTerminal(previous.terminal, diff, altScreenActive && !syncSupported)
+
+    expect(previous.frame()).toBe(`${BSU}hello${ESU}`)
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.ts
@@ -67,16 +67,20 @@ export function isProgressReportingAvailable(): boolean {
  * Checks if the terminal supports DEC mode 2026 (synchronized output).
  * When supported, BSU/ESU sequences prevent visible flicker during redraws.
  */
-export function isSynchronizedOutputSupported(): boolean {
-  // tmux parses and proxies every byte but doesn't implement DEC 2026.
-  // BSU/ESU pass through to the outer terminal but tmux has already
-  // broken atomicity by chunking. Skip to save 16 bytes/frame + parser work.
-  if (process.env.TMUX) {
+export function isSynchronizedOutputSupported(env: NodeJS.ProcessEnv = process.env): boolean {
+  // Terminal multiplexers parse and proxy every byte but don't implement
+  // DEC 2026. BSU/ESU pass through to the outer terminal, but the multiplexer
+  // has already broken atomicity by chunking — so the outer terminal's
+  // capability must not be trusted through one. Skip to save 16 bytes/frame
+  // + parser work. Same multiplexer set as termio/osc.ts (TMUX/STY), plus
+  // Zellij, which sets ZELLIJ to the session index ("0" for the first
+  // session) — so all three guard on presence, not value.
+  if (env.TMUX || env.STY || env.ZELLIJ) {
     return false
   }
 
-  const termProgram = process.env.TERM_PROGRAM
-  const term = process.env.TERM
+  const termProgram = env.TERM_PROGRAM
+  const term = env.TERM
 
   // Modern terminals with known DEC 2026 support
   if (
@@ -92,7 +96,7 @@ export function isSynchronizedOutputSupported(): boolean {
   }
 
   // kitty sets TERM=xterm-kitty or KITTY_WINDOW_ID
-  if (term?.includes('kitty') || process.env.KITTY_WINDOW_ID) {
+  if (term?.includes('kitty') || env.KITTY_WINDOW_ID) {
     return true
   }
 
@@ -112,17 +116,17 @@ export function isSynchronizedOutputSupported(): boolean {
   }
 
   // Zed uses the alacritty_terminal crate which supports DEC 2026
-  if (process.env.ZED_TERM) {
+  if (env.ZED_TERM) {
     return true
   }
 
   // Windows Terminal
-  if (process.env.WT_SESSION) {
+  if (env.WT_SESSION) {
     return true
   }
 
   // VTE-based terminals (GNOME Terminal, Tilix, etc.) since VTE 0.68
-  const vteVersion = process.env.VTE_VERSION
+  const vteVersion = env.VTE_VERSION
 
   if (vteVersion) {
     const version = parseInt(vteVersion, 10)
@@ -346,9 +350,11 @@ export function writeDiffToTerminal(
     return { bytes: 0, backpressure: false }
   }
 
-  // BSU/ESU wrapping is opt-out to keep main-screen behavior unchanged.
-  // Callers pass skipSyncMarkers=true when the terminal doesn't support
-  // DEC 2026 (e.g. tmux) AND the cost matters (high-frequency alt-screen).
+  // BSU/ESU wrapping is opt-out. Callers pass skipSyncMarkers=true whenever
+  // the terminal can't honor DEC 2026 (a multiplexer such as tmux, screen or
+  // Zellij), on the main screen as well as the alt screen — an unsupported
+  // terminal gains no atomicity from the markers and may render them as
+  // repeated or garbled frames in the visible scrollback.
   const useSync = !skipSyncMarkers
 
   // Buffer all writes into a single string to avoid multiple write calls


### PR DESCRIPTION
## What does this PR do?

Stops the TUI emitting DEC 2026 synchronized-output markers (BSU/ESU) on terminals that can't honor them, on the **main screen** as well as the alt screen.

`isSynchronizedOutputSupported()` exists precisely to detect that case, but the main-screen write path never consulted it:

- `ink.tsx` passed `this.altScreenActive && !SYNC_OUTPUT_SUPPORTED` as `skipSyncMarkers`. Off the alt screen `altScreenActive` is `false`, so the flag was **always** `false` and `writeDiffToTerminal` wrapped every main-screen frame in BSU/ESU.
- The diff *generator* one call earlier is already handed `SYNC_OUTPUT_SUPPORTED`. So the generator honored the capability while the write path ignored it — the two disagreed.
- The unmount path called `writeDiffToTerminal(...)` with no flag at all, and that final frame also lands in the visible scrollback.

Under a multiplexer the passed-through markers surface as repeated/garbled frames in the scrollback (#66490, reported under Zellij). **This is visible rendering corruption of the scrollback, not data loss** — the reporter confirms the stored conversation is intact.

The detector also only recognized tmux. It now takes an injectable env — mirroring `needsAltScreenResizeScrollbackClear` in the same file — and rejects the multiplexer set this repo already uses in `termio/osc.ts` (`TMUX || STY`) plus `ZELLIJ`, so GNU screen is covered as well as Zellij.

Behavior changes in exactly one quadrant — **main screen + unsupported terminal**. Supported terminals keep their flicker protection on both screens, and alt-screen behavior is unchanged.

## Related Issue

Fixes #66490

Supersedes #66538

#66538 identified the same root cause and its detector work is carried forward here (credit to @brian717 for the `ZELLIJ` diagnosis and the injectable-env approach). It has been unattended since 2026-07-17. It changes only the detector — the review on it asked for the write-path gating and an emitted-frame regression test, and the triage comment on #66490 likewise records it as `partial` because *"it does not update the main-screen write path that still emits BSU/ESU markers when synchronized output is unsupported."* This PR is that superset: detector + both write sites + frame-level tests. Happy to close this in favour of #66538 if it is revived and widened instead.

### Root-cause site coverage

Every site that shares this root cause is included:

| Site | Before | After |
| --- | --- | --- |
| `ink.tsx` main render write | `altScreenActive && !SYNC_OUTPUT_SUPPORTED` (never true on main screen) | `!SYNC_OUTPUT_SUPPORTED` |
| `ink.tsx` unmount write | no flag passed (always wrapped) | `!SYNC_OUTPUT_SUPPORTED` |
| `terminal.ts` detector | `process.env.TMUX` only | `env.TMUX \|\| env.STY \|\| env.ZELLIJ`, injectable |

`writeDiffToTerminal` is the only BSU/ESU emitter in the package (`terminal.ts`), and those are its only two non-test call sites.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/packages/hermes-ink/src/ink/terminal.ts`
  - `isSynchronizedOutputSupported()` takes `env: NodeJS.ProcessEnv = process.env` and rejects `TMUX || STY || ZELLIJ`. All remaining branches read `env` rather than `process.env`, so the injected value is honored end to end.
  - Updated the now-stale `useSync` contract comment, which documented the exact behavior being corrected ("opt-out to keep main-screen behavior unchanged").
- `ui-tui/packages/hermes-ink/src/ink/ink.tsx`
  - Main render write and unmount write both gate on `!SYNC_OUTPUT_SUPPORTED`.
- `ui-tui/packages/hermes-ink/src/ink/terminal.test.ts`
  - Detection cases for `ZELLIJ` (`"0"` and `"1"` — Zellij sets the session index, so the guard keys on presence), `STY`, `TMUX`, plus no-multiplexer terminals that must still report support, and a case pinning that the injected env alone is read.
  - **Emitted-frame regression tests**: `writeDiffToTerminal` is driven against a capturing `Writable` and the emitted bytes are asserted directly — BSU/ESU absent when markers are skipped, present when not, and absent on a main-screen frame under Zellij with the flag computed the way the renderer computes it. That last test also pins the previous gate as a counterexample, so the emitted frames show the regression.

## How to Test

1. `cd ui-tui && npx vitest run packages/hermes-ink/src/ink/terminal.test.ts` — 9 passing.
2. Red-before / green-after, verified in both directions:
   - Revert the `terminal.ts` multiplexer hunk (back to `env.TMUX` only) → 2 fail, 7 pass: the `ZELLIJ`/`STY` detection case and the main-screen emission case both go red. Restore → 9 pass.
   - The `ink.tsx` call sites are one-line flag expressions and are not reachable from a unit test — `hermes-ink` has no renderer harness, so reverting that hunk alone leaves the suite green. The emitted-frame tests cover the behavior the flag selects, and the counterexample assertion pins what the old expression produced on the same frame.
3. Manually, inside Zellij (or `screen`): run the TUI on the main screen and confirm the scrollback no longer shows repeated/garbled frames. `ZELLIJ=0 hermes` reproduces the detector path without a real multiplexer.
4. Full `ui-tui` suite: `npx vitest run` — 133 files, 1455 passed, 1 skipped, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- N/A — TypeScript change; ran the ui-tui vitest suite instead (1455 passed, 1 skipped, 0 failed) -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Node 22

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- updated the stale useSync contract comment -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- env-var reads only; the Windows Terminal branch is unchanged and now reads the injected env -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
