### PR TITLE
fix(serve): allow /api/ws query-token auth for desktop wsUrl compat

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -388,7 +388,7 @@ def _has_valid_session_token(request: Request) -> bool:
 # Routes that may also authenticate via a ``?token=`` query param, for download
 # links opened by the OS shell or a new browser tab where the session header
 # can't be set. Kept narrow — same query-token tradeoff as the /api/pty WS.
-_QUERY_TOKEN_API_PATHS: frozenset[str] = frozenset({"/api/files/download"})
+_QUERY_TOKEN_API_PATHS: frozenset[str] = frozenset({"/api/files/download", "/api/ws"})
 
 
 def _has_valid_query_token(request: Request, path: str) -> bool:


### PR DESCRIPTION
## Problem

Since the recent auth refactor (0.19.1, commit b1858f33a1), the desktop app connects to the backend WebSocket at `ws://127.0.0.1:{port}/api/ws?token=***`. However, the new `_QUERY_TOKEN_API_PATHS` whitelist only contains `/api/files/download`, so the `/api/ws` handshake is rejected with **HTTP 403** by `auth_middleware` — the desktop UI shows "Could not connect to Hermes gateway".

## Root cause

`auth_middleware` (web_server.py:636) requires a valid session token on all `/api/` routes. For WebSocket endpoints opened by the Electron renderer, a query-string token is the only viable transport (browser WebSocket API cannot set custom headers). The `_QUERY_TOKEN_API_PATHS` whitelist gate keeps `/api/ws` out, so every desktop WS connect attempt fails before the WS handler's own auth can run.

## Fix

Add `/api/ws` to `_QUERY_TOKEN_API_PATHS`. The WS endpoint already validates the query token itself via `_ws_auth_ok`, so this only lets the handshake through to the endpoint's own auth check — no security regression.

Verified: with this one-line change, desktop WS handshake with `?token=` returns `101 Switching Protocols`; without token still returns 403.

## Notes

- Backend: `hermes_cli/web_server.py` — one-line whitelist addition
- Desktop-side evidence: UI stuck on "Could not connect to Hermes gateway" until this path is permitted
