### PR TITLE
fix(cli): parse provider:model syntax in both -m/--model (interactive) and -z/--oneshot

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4362,6 +4362,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # through MoA instead of hitting the real provider with an unknown
         # model (#56828). A ``moa:`` prefix wins over an explicit ``--provider``.
         _moa_provider_override, self.model = _normalize_moa_model(self.model)
+        # A model string can also carry a provider:model (or the
+        # custom:<name>:<model> triple form for a named custom provider) --
+        # the SAME syntax the interactive /model command already parses via
+        # parse_model_input(). The -m/--model CLI flag never applied that
+        # split at all: the compound string was passed straight through as
+        # the model, provider stayed unset, and provider resolution fell
+        # back to the configured DEFAULT provider -- so `-m
+        # "custom:local-vllm:my-model"` silently sent the prompt to
+        # whatever cloud provider was configured as default, not the local
+        # endpoint the user named (issue #73943). Only applies when
+        # --provider wasn't explicitly passed, matching the moa: prefix
+        # precedent above (an explicit --provider flag still wins).
+        _model_provider_override: Optional[str] = None
+        if not provider and not _moa_provider_override:
+            from hermes_cli.models import parse_model_input
+            _split_provider, _split_model = parse_model_input(self.model, "")
+            if _split_provider:
+                _model_provider_override = _split_provider
+                self.model = _split_model
         # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
         _env_mt = os.environ.get("HERMES_MAX_TOKENS")
         if _env_mt:
@@ -4399,6 +4418,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.requested_provider = (
             _moa_provider_override
             or provider
+            or _model_provider_override
             or CLI_CONFIG["model"].get("provider")
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -339,6 +339,27 @@ def _run_agent(
     env_model = os.getenv("HERMES_INFERENCE_MODEL", "").strip()
     effective_model = (model or "").strip() or env_model or cfg_model
 
+    # A model string can also carry a provider:model (or the
+    # custom:<name>:<model> triple form for a named custom provider) -- the
+    # same syntax the interactive /model command and the HermesCLI
+    # -m/--model path (cli.py) already parse via parse_model_input(). The
+    # oneshot (-z/--oneshot) path bypasses HermesCLI entirely and sent the
+    # compound string straight through detect_provider_for_model() /
+    # resolve_runtime_provider() unsplit -- so `hermes -z -m
+    # "custom:local-vllm:my-model" "prompt"` silently sent the prompt to
+    # the default provider instead of the named local endpoint (review of
+    # #74214, sibling gap to the HermesCLI fix). Only applies when
+    # --provider wasn't explicitly passed, matching that fix's precedence
+    # rule (an explicit --provider flag still wins).
+    _oneshot_provider_override: Optional[str] = None
+    if not (provider or "").strip() and effective_model:
+        from hermes_cli.models import parse_model_input
+
+        _split_provider, _split_model = parse_model_input(effective_model, "")
+        if _split_provider:
+            _oneshot_provider_override = _split_provider
+            effective_model = _split_model
+
     # Resolve effective provider: explicit arg → (auto-detect from model if
     # model was explicit) → env / config (handled inside resolve_runtime_provider).
     #
@@ -347,7 +368,7 @@ def _run_agent(
     # session.  Without this, resolve_runtime_provider() would fall back to
     # the user's configured default provider, which may not host the model
     # the caller just asked for.
-    effective_provider = (provider or "").strip() or None
+    effective_provider = (provider or "").strip() or _oneshot_provider_override or None
     explicit_base_url_from_alias: Optional[str] = None
     if effective_provider is None and (model or env_model):
         # Only auto-detect when the model was explicitly requested via arg or

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -593,3 +593,145 @@ def test_custom_endpoint_key_env_is_a_valid_posix_name_for_ip_endpoints():
         assert _ENV_VAR_NAME_RE.match(custom_endpoint_key_env(identity)), identity
 
 
+
+class TestCliInitParsesCompoundModelProviderString:
+    """Regression tests for issue #73943: `-m "custom:name:model"` (and the
+    plain `provider:model` form) was passed straight through as an unsplit
+    model string. requested_provider stayed at its default/config value, so
+    a user selecting a local custom endpoint had their prompt sent to
+    whatever cloud provider was configured as default instead -- a real
+    data-egress bug, not just a UX papercut. The interactive /model command
+    already parsed this via parse_model_input(); -m/--model never did.
+    """
+
+    def test_named_custom_provider_triple_syntax_splits_correctly(self, monkeypatch):
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(
+            model="custom:jetson-vllm:nemotron-nano-30b", compact=True, max_turns=1
+        )
+
+        assert shell.requested_provider == "custom:jetson-vllm", (
+            "The named custom provider must be extracted from the compound "
+            "model string, not silently dropped to the default provider"
+        )
+        assert shell.model == "nemotron-nano-30b"
+
+    def test_provider_colon_model_syntax_splits_correctly(self, monkeypatch):
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(model="nous:hermes-3", compact=True, max_turns=1)
+
+        assert shell.requested_provider == "nous"
+        assert shell.model == "hermes-3"
+
+    def test_explicit_provider_flag_wins_over_embedded_provider(self, monkeypatch):
+        """--provider must take precedence over any provider: prefix in the
+        model string -- mirrors the moa: precedence test above, and
+        prevents this fix from surprising a user who passes both."""
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(
+            model="custom:jetson-vllm:nemotron-nano-30b",
+            provider="deepseek",
+            compact=True,
+            max_turns=1,
+        )
+
+        assert shell.requested_provider == "deepseek"
+        # The model string is left unsplit when an explicit --provider wins,
+        # matching existing behavior for any other provider-prefixed string.
+        assert shell.model == "custom:jetson-vllm:nemotron-nano-30b"
+
+    def test_plain_model_name_without_provider_prefix_unaffected(self, monkeypatch):
+        """A normal model name (no colon, or a colon that isn't a known
+        provider prefix) must not be touched -- this fix must not regress
+        the common case."""
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(
+            model="anthropic/claude-3.5-sonnet:beta", compact=True, max_turns=1
+        )
+
+        assert shell.model == "anthropic/claude-3.5-sonnet:beta"
+        assert shell.requested_provider == "auto"
+
+    def test_moa_prefix_still_wins_over_provider_colon_split(self, monkeypatch):
+        """moa: precedence (#56828) must not regress: since 'moa' isn't a
+        registered provider name recognized by parse_model_input in the
+        same way, the moa branch runs first and this fix's split must not
+        fire on an already-moa-normalized model string."""
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(model="moa:strategy", compact=True, max_turns=1)
+
+        assert shell.requested_provider == "moa"
+        assert shell.model == "strategy"
+
+    def test_end_to_end_resolves_to_named_custom_providers_own_base_url(self, monkeypatch):
+        """The actual reported symptom: verify the split provider string
+        reaches resolve_runtime_provider() correctly, rather than the
+        pre-fix behavior where the compound string was passed as the
+        model and no provider override was ever derived."""
+        cli = _import_cli()
+        config_copy = dict(cli.CLI_CONFIG)
+        model_copy = dict(config_copy.get("model", {}))
+        model_copy["provider"] = None
+        config_copy["model"] = model_copy
+        monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+        shell = cli.HermesCLI(
+            model="custom:jetson-vllm:nemotron-nano-30b", compact=True, max_turns=1
+        )
+
+        captured = {}
+
+        def _fake_resolve_runtime_provider(**kwargs):
+            captured.update(kwargs)
+            return {
+                "provider": "custom", "api_mode": "chat_completions",
+                "base_url": "http://192.168.1.149:8000/v1",
+                "api_key": "EMPTY", "source": "test",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            _fake_resolve_runtime_provider,
+        )
+        shell._ensure_runtime_credentials()
+
+        assert captured.get("requested") == "custom:jetson-vllm", (
+            f"resolve_runtime_provider must receive the split provider "
+            f"name, not the compound string or the default: {captured}"
+        )

--- a/tests/hermes_cli/test_oneshot_provider_routing.py
+++ b/tests/hermes_cli/test_oneshot_provider_routing.py
@@ -1,0 +1,111 @@
+"""Regression tests for issue #74214's sibling gap: the oneshot
+(-z/--oneshot) path bypasses HermesCLI entirely, so it needs its own
+provider:model / custom:<name>:<model> parsing applied before provider
+detection and runtime resolution -- otherwise the compound string reached
+resolve_runtime_provider() unsplit, silently sending the prompt to the
+default provider instead of the named custom endpoint.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+class _StopAtResolve(Exception):
+    """Raised by the mocked resolve_runtime_provider() to short-circuit
+    _run_agent() right after the call we want to inspect, before it
+    reaches agent construction (which needs much heavier mocking that's
+    irrelevant to what this fix changes)."""
+
+
+def _capture_resolve_call(monkeypatch):
+    captured = {}
+
+    def _fake_resolve(**kwargs):
+        captured.update(kwargs)
+        raise _StopAtResolve()
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _fake_resolve
+    )
+    return captured
+
+
+class TestOneshotProviderModelRouting:
+    def test_custom_provider_triple_syntax_supplies_split_requested_and_model(
+        self, monkeypatch, tmp_path
+    ):
+        """The exact case from review: custom:<name>:<model> must supply
+        requested='custom:<name>' and the stripped target model to the
+        resolver, not the compound string."""
+        from hermes_cli.oneshot import _run_agent
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda *a, **kw: {"model": {}},
+        )
+        captured = _capture_resolve_call(monkeypatch)
+
+        with pytest.raises(_StopAtResolve):
+            _run_agent(
+                "prompt", model="custom:jetson-vllm:nemotron-nano-30b",
+            )
+
+        assert captured.get("requested") == "custom:jetson-vllm", captured
+        assert captured.get("target_model") == "nemotron-nano-30b", captured
+
+    def test_explicit_provider_flag_wins_over_embedded_provider(
+        self, monkeypatch, tmp_path
+    ):
+        """--provider must take precedence over a provider: prefix in the
+        model string, matching the HermesCLI (-m/--model) fix's
+        precedence rule."""
+        from hermes_cli.oneshot import _run_agent
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda *a, **kw: {"model": {}},
+        )
+        captured = _capture_resolve_call(monkeypatch)
+
+        with pytest.raises(_StopAtResolve):
+            _run_agent(
+                "prompt",
+                model="custom:jetson-vllm:nemotron-nano-30b",
+                provider="deepseek",
+            )
+
+        assert captured.get("requested") == "deepseek", captured
+        # The model string is left unsplit when an explicit --provider wins.
+        assert captured.get("target_model") == "custom:jetson-vllm:nemotron-nano-30b", captured
+
+    def test_plain_model_without_provider_prefix_unaffected(
+        self, monkeypatch, tmp_path
+    ):
+        """A normal model name (no colon, or a colon that isn't a known
+        provider prefix) must not be touched -- this fix must not regress
+        the common case, including the existing detect_provider_for_model
+        auto-detection path."""
+        from hermes_cli.oneshot import _run_agent
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda *a, **kw: {"model": {}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: None,
+        )
+        captured = _capture_resolve_call(monkeypatch)
+
+        with pytest.raises(_StopAtResolve):
+            _run_agent("prompt", model="claude-sonnet-4.5")
+
+        assert captured.get("target_model") == "claude-sonnet-4.5", captured

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -186,7 +186,15 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.models",
-        mod("hermes_cli.models", detect_provider_for_model=lambda *_args, **_kwargs: None),
+        mod(
+            "hermes_cli.models",
+            detect_provider_for_model=lambda *_args, **_kwargs: None,
+            # Added for hermes_cli.oneshot._run_agent's provider:model
+            # split (review of #75311, sibling gap to #74214's HermesCLI
+            # fix). Safe passthrough: no provider prefix in this test's
+            # model name ("m"), so no split should occur.
+            parse_model_input=lambda raw, current_provider: ("", raw),
+        ),
     )
     monkeypatch.setitem(
         sys.modules,


### PR DESCRIPTION
## Context

Follow-up per @teknium1's review. This PR's scope has expanded: it originally only covered the oneshot path and claimed to supersede #74214, but #74214 was closed without merging -- so the interactive `HermesCLI` (`-m/--model`) fix it contained was never actually applied to main. This PR now carries BOTH fixes.

## Problems fixed

1. **Test fixture breakage.** The new `parse_model_input` import in `oneshot.py` broke an existing isolated-module test fixture in `test_tui_resume_flow.py` (CI failure: `ImportError: cannot import name 'parse_model_input'`). Fixed by adding the missing stub.
2. **Interactive path never actually fixed.** `cli.py`'s `HermesCLI.__init__` still forwarded a compound `-m` value unsplit. Carried the original interactive-path fix forward from the pre-split branch, along with its regression tests.

## Verification

6/6 pass in the new interactive-path test class; 27/27 across all four affected/related test files (no regression). The previously CI-failing `test_oneshot_wires_session_db_for_recall` now passes.