### PR TITLE
fix(desktop): include POSIX sane PATH entries during in-app update rebuild

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,7 +35,7 @@ import { classifyActiveRuntime } from './active-runtime-state'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
-import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
+import { buildDesktopBackendEnv, buildDesktopBackendPath, normalizeHermesHomeRoot } from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import {
   canImportHermesCli,
@@ -2970,7 +2970,7 @@ async function applyUpdates(opts = {}) {
       env: {
         ...process.env,
         HERMES_HOME,
-        PATH: pathWithHermesManagedNode(venvBin)
+        PATH: buildDesktopBackendPath({ hermesHome: HERMES_HOME, venvRoot: path.join(updateRoot, 'venv') })
       },
       detached: true,
       stdio: 'ignore'
@@ -3045,7 +3045,7 @@ async function handOffWindowsBootstrapRecovery(reason) {
     env: {
       ...process.env,
       HERMES_HOME,
-      PATH: pathWithHermesManagedNode(venvBin)
+      PATH: buildDesktopBackendPath({ hermesHome: HERMES_HOME, venvRoot: path.join(updateRoot, 'venv') })
     },
     detached: true,
     stdio: 'ignore'
@@ -3255,7 +3255,13 @@ async function applyUpdatesPosixInApp(opts: any) {
   const env: Record<string, string> = {
     HERMES_HOME,
     PYTHONUNBUFFERED: '1',
-    PATH: pathWithHermesManagedNode(path.join(updateRoot, 'venv', 'bin'))
+    // GUI-launched macOS apps inherit a Finder/Dock-sanitized PATH
+    // (/usr/bin:/bin:/usr/sbin:/sbin) that misses Homebrew (/opt/homebrew/bin)
+    // and user-installed CLIs — yet `hermes desktop --build-only` needs npm on
+    // PATH to rebuild the desktop shell. buildDesktopBackendPath adds the
+    // hermes-managed Node dir, venv/bin, the caller's PATH, and the sane
+    // POSIX fallback surface (incl. Homebrew), de-duplicated.
+    PATH: buildDesktopBackendPath({ hermesHome: HERMES_HOME, venvRoot: path.join(updateRoot, 'venv') })
   }
 
   // `hermes update` reaps stale `hermes serve` backends (a code update

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2970,7 +2970,7 @@ async function applyUpdates(opts = {}) {
       env: {
         ...process.env,
         HERMES_HOME,
-        PATH: buildDesktopBackendPath({ hermesHome: HERMES_HOME, venvRoot: path.join(updateRoot, 'venv') })
+        PATH: pathWithHermesManagedNode(venvBin)
       },
       detached: true,
       stdio: 'ignore'
@@ -3045,7 +3045,7 @@ async function handOffWindowsBootstrapRecovery(reason) {
     env: {
       ...process.env,
       HERMES_HOME,
-      PATH: buildDesktopBackendPath({ hermesHome: HERMES_HOME, venvRoot: path.join(updateRoot, 'venv') })
+      PATH: pathWithHermesManagedNode(venvBin)
     },
     detached: true,
     stdio: 'ignore'


### PR DESCRIPTION
## Summary
Fixes an issue where GUI-launched macOS desktop app updates fail during the rebuild stage (`hermes desktop --build-only`) with:
`Desktop GUI requires Node.js/npm, but npm was not found on PATH.`

## Cause
On macOS, applications launched from Finder/Dock/launchd inherit a sanitized environment `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes `/opt/homebrew/bin` and `/usr/local/bin` where Node.js/npm and other user CLIs typically reside.
When `applyUpdatesPosixInApp()` spawned `hermes desktop --build-only`, `pathWithHermesManagedNode()` constructed `PATH` as `[~/.hermes/node/bin, venv/bin, process.env.PATH]`. If `~/.hermes/node/bin` did not exist, the resulting `PATH` lacked `npm`.

## Fix
Replace `pathWithHermesManagedNode()` calls during update spawns with `buildDesktopBackendPath()`, which incorporates `POSIX_SANE_PATH_ENTRIES` (including `/opt/homebrew/bin` and `/usr/local/bin`) to ensure `npm` and node binaries are visible to the update rebuild process.

## Testing
- Verified `buildDesktopBackendPath()` resolves `/opt/homebrew/bin` under sanitized GUI `PATH`.
- Ran `npx vitest run` in `apps/desktop`: 4029 passed (including `backend-env.test.ts`).
- Rebuilt desktop app via `hermes desktop --build-only --force-build` successfully.