### PR TITLE
fix(install): accept update handoff from the parent pid

### DIFF
--- a/hermes_cli/update_lock.py
+++ b/hermes_cli/update_lock.py
@@ -36,6 +36,14 @@ The updater therefore exports :data:`HANDOFF_PID_ENV` naming its own pid, and
 ``acquire`` treats a live holder matching that pid as the lock we are already
 running under. The env var alone grants nothing: the pid must also be the
 live marker owner, so a stale or forged value cannot bypass the lock.
+
+For resilience against updater binaries built *before* that env existed (which
+still write the marker and spawn ``hermes update`` as a direct child but never
+set the env), ``acquire`` ALSO treats a live holder whose pid is our direct
+parent (``os.getppid()``) as our orchestrator. This breaks the otherwise
+unwinnable chicken-and-egg on macOS drag-installs, where the in-app update
+keeps relaunching the same old binary and deadlocks against its own parent's
+lock on every attempt — see issue #75278.
 """
 
 from __future__ import annotations
@@ -202,14 +210,38 @@ class UpdateLock:
     def acquire(self) -> bool:
         """Claim the lock. Returns False (and sets ``holder``) if it's taken.
 
-        A live holder whose pid matches :data:`HANDOFF_PID_ENV` is our own
-        orchestrating parent (the Tauri updater spawning `hermes update` as a
-        stage): we run under ITS claim rather than refusing or re-writing the
-        marker, and ``release`` leaves the parent's marker untouched.
+        A live holder is our own orchestrating parent in two cases, and we run
+        under ITS claim rather than refusing or re-writing the marker (and
+        ``release`` leaves the parent's marker untouched):
+
+        * its pid is named in :data:`HANDOFF_PID_ENV` — set by the current Tauri
+          updater (``update_child_env`` in
+          ``apps/bootstrap-installer/src-tauri/src/update.rs``); or
+        * it is our direct parent process (``os.getppid()``).
+
+        The second case is the chicken-and-egg breaker for #75278. A
+        ``hermes-setup --update`` binary BUILT BEFORE the handoff env existed
+        still writes the in-progress marker and spawns ``hermes update`` as a
+        direct child, but never sets ``HERMES_UPDATE_HANDOFF_PID``. The new
+        Python ``hermes update`` would then refuse its own parent's lock with
+        the concurrent-update exit code, the GUI maps that to "Hermes is still
+        running", and — because the updater is relaunched from that same (old)
+        binary on every retry — no number of retries can ever succeed. macOS
+        drag-installs in particular ship that older binary, so every in-app
+        update there is permanently broken until the binary itself is rebuilt,
+        which the deadlocked update can never do. Recognizing the parent as the
+        orchestrator via ``os.getppid()`` makes the handoff work with BOTH old
+        and new updater binaries, on every platform, with no binary bump
+        required.
+
+        In both cases the pid/pid alone grants nothing: the holder must also be
+        the *live* marker owner, so a stale value, a reused pid, or a forged env
+        cannot bypass the lock, and a dashboard-spawned ``hermes update`` (no
+        handoff env, no updater parent) is still refused exactly as before.
         """
         existing = read_live_update(path=self.path)
         if existing is not None:
-            if existing.pid == _handoff_pid():
+            if existing.pid == _handoff_pid() or existing.pid == os.getppid():
                 return True
             self.holder = existing
             return False

--- a/tests/hermes_cli/test_update_lock.py
+++ b/tests/hermes_cli/test_update_lock.py
@@ -17,7 +17,10 @@ disk.
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 import time
+from pathlib import Path
 
 import pytest
 
@@ -223,4 +226,69 @@ class TestHandoffFromOrchestratingUpdater:
         lock = UpdateLock(path=marker)
         assert lock.acquire() is True
         assert lock.acquired is True
+        assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == os.getpid()
+
+    def test_handoff_via_parent_pid_when_env_unset(self, marker, monkeypatch):
+        """Older updater binaries never set HERMES_UPDATE_HANDOFF_PID, but they
+        spawn ``hermes update`` as a direct child whose parent owns the marker.
+
+        The child must recognize that parent through its real parent pid and run
+        under the existing claim — otherwise a GUI update deadlocks forever
+        (#75278): the in-app updater keeps relaunching the same old binary, and
+        every attempt refuses its own parent's lock with the concurrent-update
+        exit code.
+        """
+        # The orchestrating updater (our parent) owns the marker; no handoff env.
+        monkeypatch.setattr(os, "getppid", lambda: os.getpid())
+        monkeypatch.delenv(HANDOFF_PID_ENV, raising=False)
+        marker.write_text(f"{os.getpid()}\n{int(time.time())}\n", encoding="utf-8")
+
+        lock = UpdateLock(path=marker)
+        assert lock.acquire() is True
+        assert lock.acquired is False, "the parent's claim is not ours to own"
+
+        lock.release()
+        assert marker.exists(), "the parent still needs its marker after our stage ends"
+        assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == os.getpid()
+
+    def test_handoff_via_real_parent_pid_end_to_end(self, tmp_path, monkeypatch):
+        """End-to-end reproduction of #75278 against an older updater binary.
+
+        A real child process is launched with NO HERMES_UPDATE_HANDOFF_PID in
+        its environment, while its actual parent holds the marker. The child's
+        real ``os.getppid()`` equals the live marker owner, so it must acquire
+        the lock via the parent-pid fallback. Without that fallback the child
+        exits 2 ("Hermes is still running") and the macOS in-app update is
+        permanently broken.
+        """
+        marker = tmp_path / ".hermes-update-in-progress"
+        # Parent (this process) holds the marker, exactly like hermes-setup --update.
+        marker.write_text(f"{os.getpid()}\n{int(time.time())}\n", encoding="utf-8")
+
+        child_script = (
+            "import os\n"
+            "from pathlib import Path\n"
+            "from hermes_cli.update_lock import UpdateLock, describe_holder\n"
+            "lock = UpdateLock(path=Path(os.environ['MARKER']))\n"
+            "ok = lock.acquire()\n"
+            "print('ACQUIRED' if ok else 'REFUSED')\n"
+            "if not ok:\n"
+            "    print(describe_holder(lock.holder))\n"
+        )
+        env = dict(os.environ)
+        env.pop(HANDOFF_PID_ENV, None)
+        env["MARKER"] = str(marker)
+        repo_root = Path(__file__).resolve().parents[2]
+        env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+
+        result = subprocess.run(
+            [sys.executable, "-c", child_script],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ACQUIRED" in result.stdout, result.stdout + result.stderr
+        # The child must NOT have taken ownership: the parent's marker is intact.
         assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == os.getpid()


### PR DESCRIPTION
## What changed and why

The cross-process update lock (#50238) made the `.hermes-update-in-progress` marker mutually exclusive across every update entrypoint, and the handoff in 8c76fe19f lets the Tauri updater's `hermes update` child run under the lock its parent already holds by naming the parent pid in `HERMES_UPDATE_HANDOFF_PID`.

That env var is only exported by updater binaries built **after** 8c76fe19f. A `hermes-setup --update` binary built **before** it still writes the marker and spawns `hermes update` as a direct child, but never sets `HERMES_UPDATE_HANDOFF_PID`. The new Python `hermes update` then refuses its own parent's lock with exit 2 ("Hermes is still running"), the GUI maps that to a dead-end failure screen, and because every retry relaunches the *same old binary* the update can never succeed — a chicken-and-egg that permanently breaks in-app updates on macOS drag-installs (issue #75278, and the same root cause as #74531 / #74942 / #74836).

This change makes `UpdateLock.acquire()` also accept a handoff when the live marker owner is its **direct parent process** (`os.getppid()`). The handoff now works whether or not `HERMES_UPDATE_HANDOFF_PID` is present, on every platform, with no binary bump required. The pid must still be the *live* marker owner, so a stale pid, a reused pid, or a forged env value cannot bypass the lock — a dashboard-spawned `hermes update` (no handoff env, no updater parent) is still refused exactly as before.

## How to test

1. `pytest tests/hermes_cli/test_update_lock.py -v` — all pass, including the two new regression tests:
   - `test_handoff_via_parent_pid_when_env_unset` — unit test of the parent-pid fallback.
   - `test_handoff_via_real_parent_pid_end_to_end` — real child process whose parent owns the marker, with **no** `HERMES_UPDATE_HANDOFF_PID` in its environment, must acquire (reproduces #75278 against an older-binary scenario).
2. Manual reproduction of the bug: launch `hermes update` as a child of a process that holds the marker, without setting `HERMES_UPDATE_HANDOFF_PID`. Before the fix it exits 2; after the fix it proceeds under the parent's claim.
3. Regression guard: a terminal `hermes update` while a foreign updater holds the marker is still refused (env/pid alone grants nothing).

## Platforms tested

- macOS (Darwin) — the reported failure platform; verified the parent-pid handoff resolves the deadlock.
- Logic is platform-agnostic (uses `os.getppid()`, available on macOS/Linux/Windows); no platform-specific branches added.

## Related issues

Fixes #75278. Same root cause as #74531, #74942, #74836.