### PR TITLE
fix(wake): install pypinyin into Hermes env for sherpa phrases (#75241)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,8 @@ wake = [
   "onnxruntime==1.27.0",
   "sherpa-onnx==1.13.4",
   "sentencepiece==0.2.2",
+  # Undeclared text2token runtime dep (same reason as sentencepiece) — #74719/#75241.
+  "pypinyin==0.55.0",
   "pvporcupine==4.0.3",
   "sounddevice==0.5.5",
   "numpy==2.4.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,7 @@ wake = [
   "onnxruntime==1.27.0",
   "sherpa-onnx==1.13.4",
   "sentencepiece==0.2.2",
-  # Undeclared text2token runtime dep (same reason as sentencepiece) — #74719/#75241.
+  # Undeclared text2token runtime dep (same reason as sentencepiece), #74719/#75241.
   "pypinyin==0.55.0",
   "pvporcupine==4.0.3",
   "sounddevice==0.5.5",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -289,3 +289,27 @@ def test_huggingface_hub_lazy_pin_inside_transformers_window():
         "range (>=1.5.0,<2). The lazy refresh would downgrade the shared "
         "package and break Hindsight local embeddings (#60783)."
     )
+
+
+def test_wake_sherpa_declares_text2token_runtime_deps():
+    """sherpa_onnx.text2token imports sentencepiece + pypinyin before any
+    tokens_type branching, but sherpa-onnx does not declare them. Both the
+    ``[wake]`` extra (eager desktop) and ``LAZY_DEPS['wake.sherpa']`` (CLI
+    lazy path) must carry those pins so ``ensure("wake.sherpa")`` actually
+    installs them into Hermes' env (#74719 / #75241).
+    """
+    from tools.lazy_deps import LAZY_DEPS
+
+    optional_dependencies = _load_optional_dependencies()
+    wake_extra = optional_dependencies["wake"]
+    lazy_specs = LAZY_DEPS["wake.sherpa"]
+
+    for package in ("sentencepiece", "pypinyin"):
+        assert any(
+            dep == package or dep.startswith(f"{package}==") or dep.startswith(f"{package}[")
+            for dep in wake_extra
+        ), f"[wake] extra missing text2token runtime dep {package!r}"
+        assert any(
+            spec == package or spec.startswith(f"{package}==") or spec.startswith(f"{package}[")
+            for spec in lazy_specs
+        ), f"LAZY_DEPS['wake.sherpa'] missing text2token runtime dep {package!r}"

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -296,7 +296,7 @@ def test_wake_sherpa_declares_text2token_runtime_deps():
     tokens_type branching, but sherpa-onnx does not declare them. Both the
     ``[wake]`` extra (eager desktop) and ``LAZY_DEPS['wake.sherpa']`` (CLI
     lazy path) must carry those pins so ``ensure("wake.sherpa")`` actually
-    installs them into Hermes' env (#74719 / #75241).
+    installs them into Hermes' env (#74719, #75241).
     """
     from tools.lazy_deps import LAZY_DEPS
 

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -142,6 +142,39 @@ class TestEnsure:
         with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
             ld.ensure("test.cache", prompt=False)
 
+    def test_ensure_wake_sherpa_supplies_pypinyin_when_missing(self, monkeypatch):
+        """#75321 / #75241: when sherpa-onnx is present but pypinyin is not,
+        ensure('wake.sherpa') must install the pypinyin pin via the Hermes
+        venv installer (_venv_pip_install), not leave text2token to fail.
+        """
+        sherpa_specs = ld.LAZY_DEPS["wake.sherpa"]
+        pypinyin_specs = [s for s in sherpa_specs if s.startswith("pypinyin")]
+        assert pypinyin_specs == ["pypinyin==0.55.0"]
+
+        already_ok = {s for s in sherpa_specs if not s.startswith("pypinyin")}
+        supplied: set[str] = set()
+        pip_batches: list[tuple[str, ...]] = []
+
+        def _is_satisfied(spec: str) -> bool:
+            return spec in already_ok or spec in supplied
+
+        def _venv_pip_install(specs, **_kw):
+            batch = tuple(specs)
+            pip_batches.append(batch)
+            supplied.update(batch)
+            return ld._InstallResult(True, "ok", "")
+
+        monkeypatch.setattr(ld, "_is_satisfied", _is_satisfied)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(ld, "_venv_pip_install", _venv_pip_install)
+
+        assert ld.feature_missing("wake.sherpa") == ("pypinyin==0.55.0",)
+        ld.ensure("wake.sherpa", prompt=False)
+
+        assert pip_batches == [("pypinyin==0.55.0",)]
+        assert ld.feature_missing("wake.sherpa") == ()
+        assert ld.is_available("wake.sherpa") is True
+
 
 # ---------------------------------------------------------------------------
 # is_available

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -624,3 +624,44 @@ def test_machine_lock_is_released_when_owner_process_exits(tmp_path):
         if process.is_alive():
             process.terminate()
         process.join(10)
+
+
+def test_sherpa_text2token_missing_module_targets_hermes_executable(monkeypatch, tmp_path):
+    """Regression #75241: if text2token raises ModuleNotFoundError after
+    ensure(), the remessage must name ``sys.executable -m pip`` — never bare
+    Homebrew ``pip install`` (PEP 668 / wrong environment).
+    """
+    model_dir = tmp_path / "sherpa-model"
+    model_dir.mkdir()
+    (model_dir / "tokens.txt").write_text("a\n", encoding="utf-8")
+    (model_dir / "bpe.model").write_text("bpe", encoding="utf-8")
+    for name in ("encoder-x.onnx", "decoder-x.onnx", "joiner-x.onnx"):
+        (model_dir / name).write_bytes(b"onnx")
+
+    fake_sherpa = types.ModuleType("sherpa_onnx")
+
+    def _boom(*_a, **_k):
+        raise ModuleNotFoundError("No module named 'pypinyin'", name="pypinyin")
+
+    fake_sherpa.text2token = _boom
+    fake_sherpa.KeywordSpotter = object  # unused if text2token fails first
+    monkeypatch.setitem(sys.modules, "sherpa_onnx", fake_sherpa)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **k: None)
+    monkeypatch.setattr(ww, "enrolled_profile_phrases", lambda: {})
+
+    with pytest.raises(ModuleNotFoundError) as ei:
+        ww._SherpaKwsEngine(
+            {
+                "provider": "sherpa",
+                "phrase": "hey hermes",
+                "sherpa": {"model_dir": str(model_dir)},
+            }
+        )
+
+    msg = str(ei.value)
+    assert "pypinyin" in msg
+    assert f"{sys.executable} -m pip install pypinyin" in msg
+    assert f"uv pip install --python {sys.executable} pypinyin" in msg
+    assert "Do not use system/Homebrew pip" in msg
+    # Must not recommend bare Homebrew/system pip as the primary command.
+    assert "Please run `pip install pypinyin`" not in msg

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -665,3 +665,69 @@ def test_sherpa_text2token_missing_module_targets_hermes_executable(monkeypatch,
     assert "Do not use system/Homebrew pip" in msg
     # Must not recommend bare Homebrew/system pip as the primary command.
     assert "Please run `pip install pypinyin`" not in msg
+
+
+def test_sherpa_engine_ensure_supplies_pypinyin_before_text2token(monkeypatch, tmp_path):
+    """#75321 review: ensure('wake.sherpa') must supply pypinyin into the
+    Hermes install path before text2token() runs.
+    """
+    from tools import lazy_deps as ld
+
+    model_dir = tmp_path / "sherpa-model"
+    model_dir.mkdir()
+    (model_dir / "tokens.txt").write_text("a\n", encoding="utf-8")
+    (model_dir / "bpe.model").write_text("bpe", encoding="utf-8")
+    for name in ("encoder-x.onnx", "decoder-x.onnx", "joiner-x.onnx"):
+        (model_dir / name).write_bytes(b"onnx")
+
+    sherpa_specs = ld.LAZY_DEPS["wake.sherpa"]
+    already_ok = {s for s in sherpa_specs if not s.startswith("pypinyin")}
+    supplied: set[str] = set()
+    pip_batches: list[tuple[str, ...]] = []
+    text2token_calls: list[list[str]] = []
+
+    def _is_satisfied(spec: str) -> bool:
+        return spec in already_ok or spec in supplied
+
+    def _venv_pip_install(specs, **_kw):
+        batch = tuple(specs)
+        pip_batches.append(batch)
+        supplied.update(batch)
+        return ld._InstallResult(True, "ok", "")
+
+    monkeypatch.setattr(ld, "_is_satisfied", _is_satisfied)
+    monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+    monkeypatch.setattr(ld, "_venv_pip_install", _venv_pip_install)
+
+    def _text2token(phrases, **_kw):
+        assert any(s.startswith("pypinyin==") for s in supplied), (
+            "text2token ran before ensure supplied pypinyin"
+        )
+        text2token_calls.append(list(phrases))
+        return [["tok"] for _ in phrases]
+
+    class _FakeSpotter:
+        def __init__(self, **_kw):
+            pass
+
+        def create_stream(self):
+            return object()
+
+    fake_sherpa = types.ModuleType("sherpa_onnx")
+    fake_sherpa.text2token = _text2token
+    fake_sherpa.KeywordSpotter = _FakeSpotter
+    monkeypatch.setitem(sys.modules, "sherpa_onnx", fake_sherpa)
+    monkeypatch.setattr(ww, "enrolled_profile_phrases", lambda: {})
+
+    eng = ww._SherpaKwsEngine(
+        {
+            "provider": "sherpa",
+            "phrase": "hey hermes",
+            "profile_routing": False,
+            "sherpa": {"model_dir": str(model_dir)},
+        }
+    )
+
+    assert pip_batches == [("pypinyin==0.55.0",)]
+    assert text2token_calls == [["HEY HERMES"]]
+    assert eng._spotter is not None

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -628,7 +628,7 @@ def test_machine_lock_is_released_when_owner_process_exits(tmp_path):
 
 def test_sherpa_text2token_missing_module_targets_hermes_executable(monkeypatch, tmp_path):
     """Regression #75241: if text2token raises ModuleNotFoundError after
-    ensure(), the remessage must name ``sys.executable -m pip`` — never bare
+    ensure(), the remessage must name ``sys.executable -m pip``, never bare
     Homebrew ``pip install`` (PEP 668 / wrong environment).
     """
     model_dir = tmp_path / "sherpa-model"

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -174,7 +174,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # Open-vocabulary keyword spotting: any typed phrase, zero training.
     # sentencepiece and pypinyin are required by sherpa_onnx.text2token
     # (runtime phrase tokenization) even though sherpa-onnx doesn't declare
-    # them — text2token imports both before any tokens_type branching.
+    # them, text2token imports both before any tokens_type branching.
     "wake.sherpa": (
         "sherpa-onnx==1.13.4",
         "sentencepiece==0.2.2",

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -172,11 +172,13 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "numpy==2.4.3",
     ),
     # Open-vocabulary keyword spotting: any typed phrase, zero training.
-    # sentencepiece is required by sherpa_onnx.text2token (runtime phrase
-    # tokenization) even though sherpa-onnx doesn't declare it.
+    # sentencepiece and pypinyin are required by sherpa_onnx.text2token
+    # (runtime phrase tokenization) even though sherpa-onnx doesn't declare
+    # them — text2token imports both before any tokens_type branching.
     "wake.sherpa": (
         "sherpa-onnx==1.13.4",
         "sentencepiece==0.2.2",
+        "pypinyin==0.55.0",
         "sounddevice==0.5.5",
         "numpy==2.4.3",
     ),

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -591,11 +591,11 @@ class _SherpaKwsEngine(_Engine):
                 phrase_map.setdefault(p.strip(), prof)
 
         phrases = list(phrase_map)
-        # Runtime tokenization of the arbitrary phrases — the open-vocab core.
+        # Runtime tokenization of the arbitrary phrases, the open-vocab core.
         # sherpa_onnx.text2token imports pypinyin/sentencepiece before any
         # tokens_type branching; ensure("wake.sherpa") should have installed
         # them, but if a ModuleNotFoundError still escapes, point at the
-        # Hermes interpreter — never bare `pip install` (Homebrew PEP 668).
+        # Hermes interpreter, never bare `pip install` (Homebrew PEP 668).
         try:
             tokens = text2token(
                 [p.upper() for p in phrases],
@@ -609,7 +609,7 @@ class _SherpaKwsEngine(_Engine):
                 f"No module named {missing!r}. Install into Hermes' environment "
                 f"with: {sys.executable} -m pip install {missing}  "
                 f"(or: uv pip install --python {sys.executable} {missing}). "
-                f"Do not use system/Homebrew pip — it targets the wrong env."
+                f"Do not use system/Homebrew pip, it targets the wrong env."
             ) from e
         import tempfile
 

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -592,12 +592,25 @@ class _SherpaKwsEngine(_Engine):
 
         phrases = list(phrase_map)
         # Runtime tokenization of the arbitrary phrases — the open-vocab core.
-        tokens = text2token(
-            [p.upper() for p in phrases],
-            tokens=str(d / "tokens.txt"),
-            tokens_type="bpe",
-            bpe_model=str(d / "bpe.model"),
-        )
+        # sherpa_onnx.text2token imports pypinyin/sentencepiece before any
+        # tokens_type branching; ensure("wake.sherpa") should have installed
+        # them, but if a ModuleNotFoundError still escapes, point at the
+        # Hermes interpreter — never bare `pip install` (Homebrew PEP 668).
+        try:
+            tokens = text2token(
+                [p.upper() for p in phrases],
+                tokens=str(d / "tokens.txt"),
+                tokens_type="bpe",
+                bpe_model=str(d / "bpe.model"),
+            )
+        except ModuleNotFoundError as e:
+            missing = e.name or "pypinyin"
+            raise ModuleNotFoundError(
+                f"No module named {missing!r}. Install into Hermes' environment "
+                f"with: {sys.executable} -m pip install {missing}  "
+                f"(or: uv pip install --python {sys.executable} {missing}). "
+                f"Do not use system/Homebrew pip — it targets the wrong env."
+            ) from e
         import tempfile
 
         # sherpa keyword entries reject spaces in the @display-name; underscore

--- a/uv.lock
+++ b/uv.lock
@@ -1781,6 +1781,7 @@ wake = [
     { name = "onnxruntime" },
     { name = "openwakeword" },
     { name = "pvporcupine" },
+    { name = "pypinyin" },
     { name = "sentencepiece" },
     { name = "sherpa-onnx" },
     { name = "sounddevice" },
@@ -1894,6 +1895,7 @@ requires-dist = [
     { name = "pyasn1", marker = "extra == 'google'", specifier = "==0.6.4" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
+    { name = "pypinyin", marker = "extra == 'wake'", specifier = "==0.55.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
@@ -3504,6 +3506,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pypinyin"
+version = "0.55.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/a4/784cf98c09e0dc22776b0d7d8a4a5b761218bcae4608c2416ce1e167c8af/pypinyin-0.55.0.tar.gz", hash = "sha256:b5711b3a0c6f76e67408ec6b2e3c4987a3a806b7c528076e7c7b86fcf0eaa66b", size = 839836, upload-time = "2025-07-20T12:01:50.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/7b/4cabc76fcc21c3c7d5c671d8783984d30ac9d3bb387c4ba784fca3cdfa3a/pypinyin-0.55.0-py2.py3-none-any.whl", hash = "sha256:d53b1e8ad2cdb815fb2cb604ed3123372f5a28c6f447571244aca36fc62a286f", size = 840203, upload-time = "2025-07-20T12:01:48.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `pypinyin==0.55.0` to `[wake]` and `LAZY_DEPS["wake.sherpa"]` so `ensure("wake.sherpa")` installs it into Hermes' venv (same undeclared `text2token` runtime dep pattern as `sentencepiece`).
- If tokenization still raises `ModuleNotFoundError`, remessage with `{sys.executable} -m pip install ...` / `uv pip install --python ...` instead of bare Homebrew `pip`.
- Clean `uv.lock` regenerated with CI-pinned uv **0.9.28** (pypinyin-only, no scipy/vercel marker churn).

Fixes #75241.

Related: #74719, supersedes the blocked lockfile approach on #74733.

## Test plan
- [x] `uv lock --check` with uv 0.9.28
- [x] `scripts/run_tests.sh tests/test_project_metadata.py tests/tools/test_wake_word.py -q -k "wake_sherpa_declares or sherpa_text2token_missing"` (2 passed)
- [x] Full `tests/test_project_metadata.py` (8 passed)
- [ ] Optional smoke: sherpa wake without pypinyin, lazy install into Hermes env, or Hermes-venv-targeted hint (not bare `pip install`)