### PR TITLE
fix(state): reap finished-thread WAL read connections at runtime (#75269)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1797,11 +1797,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # read-only connections so they never queue behind writer flushes on
         # self._lock. See _read_ctx().
         self._read_local = threading.local()
-        # Strong set of all live read connections across all threads.  We
-        # hold a reference so short-lived reader threads' connections are
-        # not GC'd without close() — that would leak tracked fds in
-        # _live_connections.  close() drains this set.
-        self._read_conns: "set[sqlite3.Connection]" = set()
+        # Live read connections keyed by their owning thread.  We hold a
+        # strong reference so short-lived reader threads' connections are not
+        # GC'd without close() — that would leak tracked fds in
+        # _live_connections.  Connections whose owner thread has exited are
+        # reaped at runtime by _reap_dead_read_conns() (see #75269); close()
+        # drains whatever remains.
+        self._read_conns: "dict[sqlite3.Connection, threading.Thread]" = {}
         self._read_conns_lock = threading.Lock()
         # Set when close() begins.  _get_read_conn checks this under the
         # lock so a reader that finishes opening after the drain finds the
@@ -2031,6 +2033,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 f"file:{self.db_path}?mode=ro",
                 tracking_path=self.db_path,
                 uri=True,
+                # close()/_reap_dead_read_conns() drain worker-created
+                # connections from a different thread after the worker exits,
+                # so the default check_same_thread=True guard would raise
+                # ProgrammingError on close and leave the fd open (#75269).
+                # Matches the writer + cross-profile read-only connections.
+                check_same_thread=False,
                 timeout=5.0,
                 isolation_level=None,
             )
@@ -2048,7 +2056,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     conn.close()
                     self._read_local.failed = True
                     return None
-                self._read_conns.add(conn)
+                # Reap connections left behind by worker threads that have
+                # since exited, so descriptor usage stays bounded by live
+                # reader concurrency rather than the historical worker count.
+                self._reap_dead_read_conns()
+                self._read_conns[conn] = threading.current_thread()
         except sqlite3.Error:
             # Mark this thread failed so we don't retry the open on every
             # query; the locked writer connection still serves reads.
@@ -2057,6 +2069,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return None
         self._read_local.conn = conn
         return conn
+
+    def _reap_dead_read_conns(self) -> None:
+        """Close read connections whose owning thread has exited.
+
+        Caller must hold ``_read_conns_lock``.  A finished worker thread can
+        no longer use its connection — its ``threading.local()`` slot is gone
+        and no query is in flight — so it is safe to close and drop it here
+        instead of waiting for ``close()``.  Without this a long-lived
+        SessionDB accumulated one WAL fd per worker that ever read, eventually
+        exhausting RLIMIT_NOFILE (#75269).  Read connections are opened with
+        ``check_same_thread=False`` precisely so this cross-thread close works.
+        """
+        dead = [c for c, owner in self._read_conns.items() if not owner.is_alive()]
+        for c in dead:
+            try:
+                c.close()
+            except Exception:
+                pass
+            self._read_conns.pop(c, None)
 
     @contextmanager
     def _read_ctx(self):
@@ -2522,10 +2553,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Close all read-only connections across all threads.  Per-thread
         # connections live in threading.local() and would otherwise be GC'd
         # without calling close(), leaking tracked fds in _live_connections.
-        # The strong set holds references so short-lived reader threads'
-        # connections survive until close() drains them.  Setting the closed
-        # flag under the lock prevents a reader from registering a new
-        # connection after the drain.
+        # _read_conns holds references so short-lived reader threads'
+        # connections survive until they are reaped (finished thread) or
+        # drained here.  Setting the closed flag under the lock prevents a
+        # reader from registering a new connection after the drain.
         with self._read_conns_lock:
             self._read_conns_closed = True
             read_conns = list(self._read_conns)

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -129,3 +129,156 @@ def test_anchored_view_and_around_use_read_path(db):
         assert done["view"]["window"]
     finally:
         db._lock.release()
+
+
+# ── #75269: finished-thread read connections must be reaped at runtime ──
+#
+# These tests force ``_wal_active = True`` so the per-thread read path runs
+# regardless of whether the linked SQLite build actually enables WAL (some
+# runtimes fall back to journal_mode=DELETE). The reaping contract is
+# platform-independent: it only depends on the connection lifecycle, not on
+# WAL semantics, so forcing the flag exercises the real production path.
+
+
+def _force_read_path(d):
+    """Activate the per-thread read-only split on runtimes where WAL is off."""
+    d._wal_active = True
+
+
+def test_finished_read_threads_do_not_accumulate_conns(tmp_path):
+    """A long-lived SessionDB must not retain a read conn per historical worker.
+
+    Reproduces #75269: sequential worker threads each open one read connection
+    and exit. Without runtime reaping the strong ``_read_conns`` set grows
+    without bound; with reaping it stays bounded by live reader concurrency.
+    """
+    import gc
+
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+
+        def read_once():
+            assert d._get_read_conn() is not None
+
+        for _ in range(40):
+            w = threading.Thread(target=read_once)
+            w.start()
+            w.join(timeout=10)
+            assert not w.is_alive()
+
+        gc.collect()
+        retained = len(d._read_conns)
+        assert retained < 12, (
+            f"finished worker threads retained {retained} read connections; "
+            "descriptor usage must be bounded by live reader concurrency (#75269)"
+        )
+    finally:
+        d.close()
+
+
+def test_reaped_connection_is_actually_closed(tmp_path):
+    """A connection whose owning thread exited must be closed on reap."""
+    import sqlite3 as _sqlite3
+
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+
+        holder = {}
+
+        def worker_open():
+            holder["conn"] = d._get_read_conn()
+
+        w = threading.Thread(target=worker_open)
+        w.start(); w.join(timeout=10)
+        assert not w.is_alive()
+        victim = holder["conn"]
+        assert victim is not None
+
+        # Trigger a reap by registering another connection from a fresh thread.
+        def worker_reap():
+            assert d._get_read_conn() is not None
+
+        r = threading.Thread(target=worker_reap)
+        r.start(); r.join(timeout=10)
+        assert not r.is_alive()
+
+        assert victim not in d._read_conns, "dead-thread connection was not reaped"
+        with pytest.raises(_sqlite3.ProgrammingError):
+            victim.execute("SELECT 1")
+    finally:
+        d.close()
+
+
+def test_live_thread_connection_not_reaped(tmp_path):
+    """A connection whose owner thread is still alive must survive a reap."""
+    import threading as _t
+
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+
+        ready = _t.Event()
+        release = _t.Event()
+        live_conn = {}
+
+        def hold():
+            live_conn["c"] = d._get_read_conn()
+            ready.set()
+            release.wait(timeout=10)
+
+        keeper = _t.Thread(target=hold)
+        keeper.start()
+        assert ready.wait(timeout=10)
+        conn = live_conn["c"]
+        assert conn is not None
+
+        # Register from other threads, which triggers reaping sweeps.
+        for _ in range(5):
+            w = _t.Thread(target=lambda: d._get_read_conn())
+            w.start(); w.join(timeout=10)
+
+        assert keeper.is_alive(), "live reader thread died unexpectedly"
+        assert conn in d._read_conns, "live-thread connection was wrongly reaped"
+
+        release.set()
+        keeper.join(timeout=10)
+    finally:
+        d.close()
+
+
+def test_reaping_is_thread_safe_under_concurrency(tmp_path):
+    """Concurrent readers + reaping must not raise."""
+    import time
+
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d.create_session(session_id="s1", source="cli", model="m")
+        _force_read_path(d)
+        d.append_message("s1", role="user", content="concurrency smoke")
+
+        errors = []
+
+        def reader():
+            try:
+                for _ in range(20):
+                    d.get_session("s1")
+                    d._get_read_conn()  # may register + reap
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(8)]
+        for i, t in enumerate(threads):
+            t.start()
+            if i % 2:  # stagger so threads exit at different times
+                time.sleep(0.001)
+        for t in threads:
+            t.join(timeout=20)
+        assert not errors, f"concurrent read/reap raised: {errors!r}"
+        assert not any(t.is_alive() for t in threads)
+    finally:
+        d.close()


### PR DESCRIPTION
## Summary

Fixes #75269.

A long-lived shared `SessionDB` retained one read-only SQLite WAL connection for every worker thread that ever used the read path. `_get_read_conn()` cached the connection in `threading.local()` but also added it to the strong `_read_conns` set, which was drained only by `SessionDB.close()`. In a long-lived gateway, `close()` may not run for days, so descriptor usage grew with the *historical* worker count rather than current reader concurrency — eventually exhausting `RLIMIT_NOFILE` (`EMFILE`).

## Root cause

`_read_conns` was a strong `set` with no runtime reaping. The unbounded retention was introduced when tracked readers were added in `f228e145ba`.

## Fix

1. **Track the owning thread per connection**: `_read_conns` is now `dict[Connection, Thread]` instead of `set`.
2. **Reap at runtime**: `_reap_dead_read_conns()` closes and drops connections whose owner thread has exited (`not thread.is_alive()`), invoked lazily when a new connection registers (under the existing `_read_conns_lock`).
3. **Allow cross-thread close**: read connections now open with `check_same_thread=False` (matching the writer and cross-profile read-only connections), so the reaper can close a finished worker's connection from a different thread. These are SELECT-only, autocommit, no Python callbacks — safe for serialized SQLite.

`close()` still drains whatever remains; `list(dict)` yields connection keys and `.clear()` works on the dict.

## Why not close-on-every-`_read_ctx`?

The issue body notes this avoids the leak but adds ~20× overhead for `get_session()` and ~10× for `search_messages()` in local benchmarks.

## Relationship to #74304

#74304 (jmeadlock, OPEN) is complementary: it adds `check_same_thread=False` for **shutdown-time** cross-thread drain. It does not add runtime reaping, so descriptor growth still accumulates before `close()`. This PR is a superset — it includes `check_same_thread=False` (same line) **and** adds lifetime reaping.

## Test plan

4 new regression tests in `tests/test_session_db_read_path_split.py`:
- `test_finished_read_threads_do_not_accumulate_conns` — 40 sequential worker threads, asserts retained < 12 (**RED on main**: 40 retained; **GREEN** with fix)
- `test_reaped_connection_is_actually_closed` — dead-thread connection closed on reap, `execute` raises `ProgrammingError` (**RED→GREEN**)
- `test_live_thread_connection_not_reaped` — a live reader thread's connection survives reap sweeps (guard)
- `test_reaping_is_thread_safe_under_concurrency` — 8 concurrent readers + interleaved reaps, no errors (guard)

Tests force `_wal_active=True` to exercise the per-thread read path on runtimes where WAL falls back to DELETE mode; the reaping contract is platform-independent.

```
tests/test_session_db_read_path_split.py — 7 passed, 4 skipped (WAL-runtime)
tests/hermes_state/ + test_web_server_sessiondb_eventloop.py — 42 passed, 4 skipped
ruff check — All checks passed!
```

Auto-published by Moonsong via Path B automated pipeline.