### PR TITLE
fix(desktop): keep fallback out of composer model

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -5,7 +5,16 @@ import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/c
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $desktopOnboarding } from '@/store/onboarding'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $currentBranch, $currentCwd, setCurrentBranch, setCurrentCwd } from '@/store/session'
+import {
+  $currentBranch,
+  $currentCwd,
+  $currentModel,
+  $currentProvider,
+  setCurrentBranch,
+  setCurrentCwd,
+  setCurrentModel,
+  setCurrentProvider
+} from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import {
@@ -86,19 +95,35 @@ describe('applyRuntimeInfo foreground scoping', () => {
   beforeEach(() => {
     setCurrentCwd('/main-repo')
     setCurrentBranch('main')
+    setCurrentModel('manual-model')
+    setCurrentProvider('manual-provider')
   })
 
   afterEach(() => {
     setCurrentCwd('')
     setCurrentBranch('')
+    setCurrentModel('')
+    setCurrentProvider('')
   })
 
-  it('publishes a foreground runtime into the composer atoms', () => {
-    const patch = applyRuntimeInfo({ branch: 'bb/feature', cwd: '/main-repo/worktree' })
+  it('publishes session-scoped runtime fields without replacing the sticky composer model', () => {
+    const patch = applyRuntimeInfo({
+      branch: 'bb/feature',
+      cwd: '/main-repo/worktree',
+      model: 'fallback-model',
+      provider: 'fallback-provider'
+    })
 
     expect($currentCwd.get()).toBe('/main-repo/worktree')
     expect($currentBranch.get()).toBe('bb/feature')
-    expect(patch).toMatchObject({ branch: 'bb/feature', cwd: '/main-repo/worktree' })
+    expect($currentModel.get()).toBe('manual-model')
+    expect($currentProvider.get()).toBe('manual-provider')
+    expect(patch).toMatchObject({
+      branch: 'bb/feature',
+      cwd: '/main-repo/worktree',
+      model: 'fallback-model',
+      provider: 'fallback-provider'
+    })
   })
 
   it('keeps a background runtime out of the composer atoms but still returns its patch', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -8,8 +8,12 @@ import { $activeGatewayProfile } from '@/store/profile'
 import {
   $currentBranch,
   $currentCwd,
+  $currentModel,
+  $currentProvider,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentModel,
+  setCurrentProvider,
   setSelectedStoredSessionId,
   workspaceCwdBelongsToSelectedSession
 } from '@/store/session'
@@ -94,19 +98,35 @@ describe('applyRuntimeInfo foreground scoping', () => {
   beforeEach(() => {
     setCurrentCwd('/main-repo')
     setCurrentBranch('main')
+    setCurrentModel('manual-model')
+    setCurrentProvider('manual-provider')
   })
 
   afterEach(() => {
     setCurrentCwd('')
     setCurrentBranch('')
+    setCurrentModel('')
+    setCurrentProvider('')
   })
 
-  it('publishes a foreground runtime into the composer atoms', () => {
-    const patch = applyRuntimeInfo({ branch: 'bb/feature', cwd: '/main-repo/worktree' })
+  it('publishes session-scoped runtime fields without replacing the sticky composer model', () => {
+    const patch = applyRuntimeInfo({
+      branch: 'bb/feature',
+      cwd: '/main-repo/worktree',
+      model: 'fallback-model',
+      provider: 'fallback-provider'
+    })
 
     expect($currentCwd.get()).toBe('/main-repo/worktree')
     expect($currentBranch.get()).toBe('bb/feature')
-    expect(patch).toMatchObject({ branch: 'bb/feature', cwd: '/main-repo/worktree' })
+    expect($currentModel.get()).toBe('manual-model')
+    expect($currentProvider.get()).toBe('manual-provider')
+    expect(patch).toMatchObject({
+      branch: 'bb/feature',
+      cwd: '/main-repo/worktree',
+      model: 'fallback-model',
+      provider: 'fallback-provider'
+    })
   })
 
   it('keeps a background runtime out of the composer atoms but still returns its patch', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -934,8 +934,9 @@ type SessionRuntimeStatePatch = Partial<
 interface ApplyRuntimeInfoOptions {
   /**
    * Whether this runtime belongs to the session the MAIN pane is showing.
-   * Foreground (the default) mirrors into the composer atoms every main-pane
-   * surface reads.
+   * Foreground (the default) mirrors session-scoped fields into the composer
+   * atoms every main-pane surface reads. Model/provider are deliberately kept
+   * out because those atoms represent the user's sticky selection.
    *
    * A tile or a background branch must pass `false`: it owns a different
    * worktree, and writing its cwd into `$currentCwd` re-pointed the main
@@ -947,17 +948,12 @@ interface ApplyRuntimeInfoOptions {
   foreground?: boolean
 }
 
-/** Mirror a session's runtime state into the composer atoms the MAIN pane
- *  renders from. Foreground sessions only — see ApplyRuntimeInfoOptions. */
+/** Mirror session-scoped runtime state into the composer atoms the MAIN pane
+ *  renders from. Foreground sessions only — see ApplyRuntimeInfoOptions.
+ *  Model/provider stay in the returned session patch: publishing a temporary
+ *  fallback pair into the persisted sticky atoms would make it the primary for
+ *  future sessions (#75320). */
 function publishRuntimeToComposer(state: SessionRuntimeStatePatch): void {
-  if (state.model !== undefined) {
-    setCurrentModel(state.model)
-  }
-
-  if (state.provider !== undefined) {
-    setCurrentProvider(state.provider)
-  }
-
   if (state.cwd !== undefined) {
     setCurrentCwd(state.cwd)
   }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -937,8 +937,9 @@ type SessionRuntimeStatePatch = Partial<
 interface ApplyRuntimeInfoOptions {
   /**
    * Whether this runtime belongs to the session the MAIN pane is showing.
-   * Foreground (the default) mirrors into the composer atoms every main-pane
-   * surface reads.
+   * Foreground (the default) mirrors session-scoped fields into the composer
+   * atoms every main-pane surface reads. Model/provider are deliberately kept
+   * out because those atoms represent the user's sticky selection.
    *
    * A tile or a background branch must pass `false`: it owns a different
    * worktree, and writing its cwd into `$currentCwd` re-pointed the main
@@ -950,17 +951,12 @@ interface ApplyRuntimeInfoOptions {
   foreground?: boolean
 }
 
-/** Mirror a session's runtime state into the composer atoms the MAIN pane
- *  renders from. Foreground sessions only — see ApplyRuntimeInfoOptions. */
+/** Mirror session-scoped runtime state into the composer atoms the MAIN pane
+ *  renders from. Foreground sessions only — see ApplyRuntimeInfoOptions.
+ *  Model/provider stay in the returned session patch: publishing a temporary
+ *  fallback pair into the persisted sticky atoms would make it the primary for
+ *  future sessions (#75320). */
 function publishRuntimeToComposer(state: SessionRuntimeStatePatch): void {
-  if (state.model !== undefined) {
-    setCurrentModel(state.model)
-  }
-
-  if (state.provider !== undefined) {
-    setCurrentProvider(state.provider)
-  }
-
   if (state.cwd !== undefined) {
     if (state.cwd) {
       // The runtime named a real folder for the session in the main pane, so

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -183,7 +183,9 @@ describe('useSessionStateCache — per-session turn timer', () => {
     expect($turnStartedAt.get()).toBeNull()
   })
 
-  it('mirrors the focused session model metadata when switching from a cached session', () => {
+  it('keeps the sticky composer model while mirroring other focused-session metadata', () => {
+    setCurrentModel('manual-model')
+    setCurrentProvider('manual-provider')
     let cache!: Cache
 
     const { rerender } = render(
@@ -206,7 +208,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
     })
 
     // Background metadata is cached but must not bleed into the visible statusbar.
-    expect($currentModel.get()).toBe('')
+    expect($currentModel.get()).toBe('manual-model')
     expect($currentReasoningEffort.get()).toBe('')
     expect($currentFastMode.get()).toBe(false)
 
@@ -219,14 +221,14 @@ describe('useSessionStateCache — per-session turn timer', () => {
       cache.syncSessionStateToView('bg-runtime', bgState!)
     })
 
-    expect($currentModel.get()).toBe('anthropic/claude-opus-4.8')
-    expect($currentProvider.get()).toBe('anthropic')
+    expect($currentModel.get()).toBe('manual-model')
+    expect($currentProvider.get()).toBe('manual-provider')
     expect($currentReasoningEffort.get()).toBe('high')
     expect($currentServiceTier.get()).toBe('priority')
     expect($currentFastMode.get()).toBe(true)
   })
 
-  it('clears stale model metadata when the newly focused session has no cached value', () => {
+  it('clears session-scoped metadata without clearing the sticky composer model', () => {
     setCurrentModel('previous-model')
     setCurrentProvider('previous-provider')
     setCurrentReasoningEffort('high')
@@ -252,8 +254,8 @@ describe('useSessionStateCache — per-session turn timer', () => {
       cache.syncSessionStateToView('bg-runtime', bgState!)
     })
 
-    expect($currentModel.get()).toBe('')
-    expect($currentProvider.get()).toBe('')
+    expect($currentModel.get()).toBe('previous-model')
+    expect($currentProvider.get()).toBe('previous-provider')
     expect($currentReasoningEffort.get()).toBe('')
     expect($currentServiceTier.get()).toBe('')
     expect($currentFastMode.get()).toBe(false)

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -12,9 +12,7 @@ import {
   $messages,
   setActiveSessionStoredIdRotation,
   setCurrentFastMode,
-  setCurrentModel,
   setCurrentPersonality,
-  setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setTurnStartedAt,
@@ -36,8 +34,12 @@ interface SessionStateCacheOptions {
 }
 
 function syncRuntimeMetadataToView(state: ClientSessionState) {
-  setCurrentModel(state.model ?? '')
-  setCurrentProvider(state.provider ?? '')
+  // Model/provider belong to the sticky composer selection, not the live
+  // session runtime. A fallback can change state.model/state.provider for one
+  // turn; copying that pair into the persisted composer atoms makes every new
+  // session inherit the fallback as its primary (#75320). The focused
+  // session's runtime pair remains available through ClientSessionState for
+  // display surfaces such as the model pill.
   setCurrentReasoningEffort(state.reasoningEffort ?? '')
   setCurrentServiceTier(state.serviceTier ?? '')
   setCurrentFastMode(state.fast ?? false)


### PR DESCRIPTION
Fixes #75320

## Summary
- keep live session `model` / `provider` metadata in per-session state instead of copying it into the persisted composer selection
- preserve the user's manual/default composer pair when a focused session temporarily runs on a fallback
- retain runtime model/provider in the returned session patch so session display surfaces continue to show the active runtime
- add regression coverage for both session-state-cache and `applyRuntimeInfo` paths

## Why
The Desktop composer model/provider atoms are persisted and reused as overrides for new sessions. Copying a temporary fallback runtime into those atoms made later sessions treat the fallback as their primary, defeating per-turn primary restoration.

## Validation
- `npm --prefix apps/desktop test -- --project ui src/app/session` — 394 passed
- `npm --prefix apps/desktop run typecheck`
- `npm exec eslint src/app/session/hooks/use-session-state-cache.ts src/app/session/hooks/use-session-state-cache.test.tsx src/app/session/hooks/use-session-actions/utils.ts src/app/session/hooks/use-session-actions/utils.test.ts`
- `git diff --check`
