### PR TITLE
feat(cli): add width-safe streaming Markdown rendering

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1380,6 +1380,16 @@ display:
   #   false: Wait for the full response before rendering
   streaming: true
 
+  # Assistant Markdown handling in the classic CLI.
+  #   render: Render headings, emphasis, tables, and syntax-highlighted fences
+  #   strip:  Remove Markdown markers and print plain text (default)
+  #   raw:    Preserve Markdown markers without terminal styling
+  # Toggle render/strip at runtime with /markdown (alias /md).
+  final_response_markdown: strip
+
+  # Pygments style for fenced code blocks. Empty selects a skin-aware default.
+  code_theme: ""
+
   # Show [HH:MM] timestamps on user input and assistant response labels.
   # timestamps: false
 

--- a/cli.py
+++ b/cli.py
@@ -6754,7 +6754,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 )
             rendered = self._md_stream_processor.feed_line(line)
             if rendered is not None:
-                _cprint(f"{_STREAM_PAD}{rendered}")
+                for rendered_line in rendered.split("\n"):
+                    _cprint(f"{_STREAM_PAD}{rendered_line}")
 
         def _flush_table_buf() -> None:
             buf = self._stream_table_buf
@@ -6886,7 +6887,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     )
                 rendered = self._md_stream_processor.feed_line(self._stream_buf)
                 if rendered is not None:
-                    _cprint(f"{_STREAM_PAD}{rendered}")
+                    for rendered_line in rendered.split("\n"):
+                        _cprint(f"{_STREAM_PAD}{rendered_line}")
             else:
                 line = _strip_markdown_syntax(self._stream_buf) if _mode == "strip" else self._stream_buf
                 _cprint(f"{_STREAM_PAD}{_tc}{line}{_RST}" if _tc else f"{_STREAM_PAD}{line}")
@@ -6895,7 +6897,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if _mode == "render" and getattr(self, "_md_stream_processor", None) is not None:
             tail = self._md_stream_processor.flush()
             if tail:
-                _cprint(f"{_STREAM_PAD}{tail}")
+                for rendered_line in tail.split("\n"):
+                    _cprint(f"{_STREAM_PAD}{rendered_line}")
             self._md_stream_processor = None
 
         # Close the response box

--- a/cli.py
+++ b/cli.py
@@ -2949,7 +2949,11 @@ def _terminal_width_for_streaming() -> int:
     return max(20, cols - len(_STREAM_PAD) - 2)
 
 
-def _render_final_assistant_content(text: str, mode: str = "render"):
+def _render_final_assistant_content(
+    text: str,
+    mode: str = "render",
+    code_theme: str = "monokai",
+):
     """Render final assistant content as markdown, stripped text, or raw text."""
     from rich.markdown import Markdown
 
@@ -2984,7 +2988,7 @@ def _render_final_assistant_content(text: str, mode: str = "render"):
     plain = _rich_text_from_ansi(text or "").plain
     plain = _preserve_windows_dot_segments_for_markdown(plain)
     plain = realign_markdown_tables(plain, panel_width)
-    return Markdown(plain)
+    return Markdown(plain, code_theme=code_theme)
 
 
 _OUTPUT_HISTORY_ENABLED = True
@@ -14138,15 +14142,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     pass
                 else:
                     _chat_console = ChatConsole()
-                    if self.final_response_markdown == "render":
-                        from hermes_cli.markdown_stream import render_markdown_rich
-
-                        content = render_markdown_rich(response, pygments_theme=self._pygments_theme)
-                    else:
-                        content = _render_final_assistant_content(
-                            response,
-                            mode=self.final_response_markdown,
-                        )
+                    content = _render_final_assistant_content(
+                        response,
+                        mode=self.final_response_markdown,
+                        code_theme=self._pygments_theme,
+                    )
                     _chat_console.print(Panel(
                         content,
                         title=f"[{_resp_color} bold]{label}[/]",

--- a/cli.py
+++ b/cli.py
@@ -2521,11 +2521,28 @@ def _hex_to_ansi(hex_color: str, *, bold: bool = False) -> str:
         b = int(hex_color[5:7], 16)
         prefix = "1;" if bold else ""
         return f"\033[{prefix}38;2;{r};{g};{b}m"
-    except (ValueError, IndexError):
+    except (ValueError, IndexError, TypeError):
         return _ACCENT_ANSI_DEFAULT if bold else "\033[38;2;184;134;11m"
 
 
-# ────────────────────────────────────────────────────────────────────────
+def _hex_to_truecolor(hex_str: str, layer: str = "fg") -> str:
+    """Convert '#RRGGBB' to '38;2;R;G;B' (fg) or '48;2;R;G;B' (bg).
+
+    Return an empty string for malformed or non-string input so skin YAML
+    mistakes degrade instead of crashing the streaming hot path.
+    """
+    if not isinstance(hex_str, str) or len(hex_str) != 7 or not hex_str.startswith("#"):
+        return ""
+    try:
+        r = int(hex_str[1:3], 16)
+        g = int(hex_str[3:5], 16)
+        b = int(hex_str[5:7], 16)
+    except (ValueError, TypeError):
+        return ""
+    prefix = "38" if layer == "fg" else "48"
+    return f"{prefix};2;{r};{g};{b}"
+
+
 # Light/dark terminal mode detection.
 #
 # Mirrors ui-tui/src/theme.ts detectLightMode().  Used to decide whether
@@ -4300,6 +4317,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Inline diff previews for write actions (display.inline_diffs in config.yaml)
         self._inline_diffs_enabled = CLI_CONFIG["display"].get("inline_diffs", True)
+
+        # Markdown rendering uses the existing display.final_response_markdown
+        # mode (render | strip | raw); avoid a second conflicting on/off flag.
+        self._pygments_theme = self._resolve_pygments_theme()
+        self._md_stream_processor = None
 
         # Per-turn accounting (display.turn_summary / display.spinner_token_flow).
         # Both are CLI-only, display-only chrome. The collector rides the
@@ -6423,6 +6445,30 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(text)}[/]")
 
+    def _resolve_pygments_theme(self) -> str:
+        """Pick a Pygments theme that matches the active skin."""
+        explicit = CLI_CONFIG["display"].get("code_theme", "")
+        if explicit:
+            return str(explicit)
+        try:
+            from hermes_cli.skin_engine import get_active_skin
+
+            skin = get_active_skin()
+            if skin.code_theme:
+                return skin.code_theme
+            skin_theme_map = {
+                "default": "monokai",
+                "ares": "monokai",
+                "mono": "friendly_grayscale",
+                "slate": "nord",
+                "poseidon": "nord",
+                "sisyphus": "friendly_grayscale",
+                "charizard": "monokai",
+            }
+            return skin_theme_map.get(skin.name, "monokai")
+        except Exception:
+            return "monokai"
+
     def _stream_reasoning_delta(self, text: str) -> None:
         """Stream reasoning/thinking tokens into a dim box above the response.
 
@@ -6650,18 +6696,30 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 _skin = get_active_skin()
                 label = _skin.get_branding("response_label", "⚕ Hermes")
                 _text_hex = _skin.get_color("banner_text", "#FFF8DC")
+                _code_fg_hex = _skin.get_color(
+                    "code_inline_fg",
+                    _skin.get_color("banner_accent", ""),
+                )
+                _code_bg_hex = _skin.get_color("code_inline_bg", "")
             except Exception:
                 label = "⚕ Hermes"
                 _text_hex = "#FFF8DC"
+                _code_fg_hex = ""
+                _code_bg_hex = ""
             # Build a true-color ANSI escape for the response text color
             # so streamed content matches the Rich Panel appearance.
-            try:
-                _r = int(_text_hex[1:3], 16)
-                _g = int(_text_hex[3:5], 16)
-                _b = int(_text_hex[5:7], 16)
-                self._stream_text_ansi = f"\033[38;2;{_r};{_g};{_b}m"
-            except (ValueError, IndexError):
-                self._stream_text_ansi = ""
+            _body_inner = _hex_to_truecolor(_text_hex, "fg")
+            self._stream_text_ansi = f"\033[{_body_inner}m" if _body_inner else ""
+            _code_fg_part = _hex_to_truecolor(_code_fg_hex, "fg") if _code_fg_hex else ""
+            _code_bg_part = _hex_to_truecolor(_code_bg_hex, "bg") if _code_bg_hex else ""
+            _code_parts = ["1"]
+            if _code_fg_part:
+                _code_parts.append(_code_fg_part)
+            if _code_bg_part:
+                _code_parts.append(_code_bg_part)
+            self._stream_inline_code_ansi = (
+                f"\033[{';'.join(_code_parts)}m" if len(_code_parts) > 1 else ""
+            )
             if self.show_timestamps:
                 label = f"{label} {datetime.now().strftime(getattr(self, 'timestamp_format', '%H:%M'))}"
             w = self._scrollback_box_width()
@@ -6672,9 +6730,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Emit complete lines, keep partial remainder in buffer
         _tc = getattr(self, "_stream_text_ansi", "")
+        _ic = getattr(self, "_stream_inline_code_ansi", "")
+
+        def _markdown_render_enabled() -> bool:
+            return self.final_response_markdown == "render"
 
         def _emit_one(printed_line: str) -> None:
             _cprint(f"{_STREAM_PAD}{_tc}{printed_line}{_RST}" if _tc else f"{_STREAM_PAD}{printed_line}")
+
+        def _emit_markdown_line(line: str) -> None:
+            if getattr(self, "_md_stream_processor", None) is None:
+                from hermes_cli.markdown_stream import MarkdownStreamProcessor
+
+                self._md_stream_processor = MarkdownStreamProcessor(
+                    base_ansi=_tc,
+                    pygments_theme=self._pygments_theme,
+                    inline_code_ansi=_ic,
+                )
+            rendered = self._md_stream_processor.feed_line(line)
+            if rendered is not None:
+                _cprint(f"{_STREAM_PAD}{rendered}")
 
         def _flush_table_buf() -> None:
             buf = self._stream_table_buf
@@ -6696,6 +6771,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         while "\n" in self._stream_buf:
             line, self._stream_buf = self._stream_buf.split("\n", 1)
+
+            if _markdown_render_enabled():
+                _emit_markdown_line(line)
+                continue
 
             # Hold table-shaped lines in a side-buffer so we can re-pad
             # the whole block once it ends.  Streaming line-by-line, we
@@ -6736,6 +6815,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             and not self._in_stream_table
             and not self._stream_buf.lstrip().startswith("|")
             and len(self._stream_buf) >= 80
+            and not _markdown_render_enabled()
         ):
             preview = self._stream_buf[-int(_STREAM_PARTIAL_PREVIEW_LEN):]
             cut = preview.find(" ")
@@ -6761,6 +6841,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._close_reasoning_box()
 
         _tc = getattr(self, "_stream_text_ansi", "")
+        _mode = getattr(self, "final_response_markdown", "strip")
 
         # If the stream buffer has a trailing partial line that looks like
         # a table row, fold it into the table buffer so the whole block
@@ -6781,16 +6862,35 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             joined = "\n".join(self._stream_table_buf)
             self._stream_table_buf = []
             self._in_stream_table = False
-            if self.final_response_markdown == "strip":
+            if _mode == "strip":
                 joined = _strip_markdown_syntax(joined)
             block = realign_markdown_tables(joined, _terminal_width_for_streaming())
             for ln in block.split("\n"):
                 _cprint(f"{_STREAM_PAD}{_tc}{ln}{_RST}" if _tc else f"{_STREAM_PAD}{ln}")
 
         if self._stream_buf:
-            line = _strip_markdown_syntax(self._stream_buf) if self.final_response_markdown == "strip" else self._stream_buf
-            _cprint(f"{_STREAM_PAD}{_tc}{line}{_RST}" if _tc else f"{_STREAM_PAD}{line}")
+            if _mode == "render":
+                if getattr(self, "_md_stream_processor", None) is None:
+                    from hermes_cli.markdown_stream import MarkdownStreamProcessor
+
+                    self._md_stream_processor = MarkdownStreamProcessor(
+                        base_ansi=_tc,
+                        pygments_theme=self._pygments_theme,
+                        inline_code_ansi=getattr(self, "_stream_inline_code_ansi", ""),
+                    )
+                rendered = self._md_stream_processor.feed_line(self._stream_buf)
+                if rendered is not None:
+                    _cprint(f"{_STREAM_PAD}{rendered}")
+            else:
+                line = _strip_markdown_syntax(self._stream_buf) if _mode == "strip" else self._stream_buf
+                _cprint(f"{_STREAM_PAD}{_tc}{line}{_RST}" if _tc else f"{_STREAM_PAD}{line}")
             self._stream_buf = ""
+
+        if _mode == "render" and getattr(self, "_md_stream_processor", None) is not None:
+            tail = self._md_stream_processor.flush()
+            if tail:
+                _cprint(f"{_STREAM_PAD}{tail}")
+            self._md_stream_processor = None
 
         # Close the response box
         if self._stream_box_opened:
@@ -6803,6 +6903,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._stream_started = False
         self._stream_box_opened = False
         self._stream_text_ansi = ""
+        self._stream_inline_code_ansi = ""
         self._stream_prefilt = ""
         self._in_reasoning_block = False
         self._stream_last_was_newline = True
@@ -6810,6 +6911,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._reasoning_buf = ""
         self._reasoning_preview_buf = ""
         self._deferred_content = ""
+        self._md_stream_processor = None
         self._stream_table_buf = []
         self._in_stream_table = False
 
@@ -9863,6 +9965,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._handle_approvals_command(cmd_original)
         elif canonical == "reasoning":
             self._handle_reasoning_command(cmd_original)
+        elif canonical == "markdown":
+            enabled = self.final_response_markdown != "render"
+            self.final_response_markdown = "render" if enabled else "strip"
+            state = "ON" if enabled else "OFF"
+            save_config_value("display.final_response_markdown", self.final_response_markdown)
+            _cprint(f"  Markdown rendering: {state}")
         elif canonical == "fast":
             self._handle_fast_command(cmd_original)
         elif canonical == "compress":
@@ -14028,8 +14136,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     pass
                 else:
                     _chat_console = ChatConsole()
+                    if self.final_response_markdown == "render":
+                        from hermes_cli.markdown_stream import render_markdown_rich
+
+                        content = render_markdown_rich(response, pygments_theme=self._pygments_theme)
+                    else:
+                        content = _render_final_assistant_content(
+                            response,
+                            mode=self.final_response_markdown,
+                        )
                     _chat_console.print(Panel(
-                        _render_final_assistant_content(response, mode=self.final_response_markdown),
+                        content,
                         title=f"[{_resp_color} bold]{label}[/]",
                         title_align="left",
                         border_style=_resp_color,

--- a/cli.py
+++ b/cli.py
@@ -6746,6 +6746,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     base_ansi=_tc,
                     pygments_theme=self._pygments_theme,
                     inline_code_ansi=_ic,
+                    max_width=_terminal_width_for_streaming(),
                 )
             rendered = self._md_stream_processor.feed_line(line)
             if rendered is not None:
@@ -6877,6 +6878,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         base_ansi=_tc,
                         pygments_theme=self._pygments_theme,
                         inline_code_ansi=getattr(self, "_stream_inline_code_ansi", ""),
+                        max_width=_terminal_width_for_streaming(),
                     )
                 rendered = self._md_stream_processor.feed_line(self._stream_buf)
                 if rendered is not None:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1970,7 +1970,11 @@ class CLICommandsMixin:
 
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(
-                        _render_final_assistant_content(response, mode=self.final_response_markdown),
+                        _render_final_assistant_content(
+                            response,
+                            mode=getattr(self, "final_response_markdown", "strip"),
+                            code_theme=getattr(self, "_pygments_theme", "monokai"),
+                        ),
                         title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
                         title_align="left",
                         border_style=_resp_color,

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -220,6 +220,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide|full|clamp] [--global]",
                subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra", "show", "hide", "on", "off", "full", "clamp", "--global")),
+    CommandDef("markdown", "Toggle markdown rendering on/off", "Configuration",
+               aliases=("md",), cli_only=True),
     CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
                args_hint="[normal|fast|status] [--global]",
                subcommands=("normal", "fast", "status", "on", "off", "--global")),

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1031,6 +1031,7 @@ DEFAULT_CONFIG = {
         "timestamps": False,      # Show timestamp on user and assistant labels
         "timestamp_format": "%H:%M",  # strftime format for timestamps (e.g. "%b-%d %H:%M")
         "final_response_markdown": "strip",  # render | strip | raw
+        "code_theme": "",          # Pygments theme for code blocks (empty = auto from skin)
         # Preserve recent classic CLI output across Ctrl+L, /redraw, and
         # terminal resize full-screen clears. Disable if a terminal emulator
         # behaves badly with replayed scrollback.

--- a/hermes_cli/markdown_stream.py
+++ b/hermes_cli/markdown_stream.py
@@ -1,0 +1,457 @@
+"""Streaming and non-streaming Markdown rendering for the Hermes CLI.
+
+Provides:
+- ``MarkdownStreamProcessor``: stateful line-by-line markdown-to-ANSI
+  transformer for the streaming display path.
+- ``render_markdown_rich``: one-shot Rich Markdown renderable for the
+  non-streaming Panel path.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# ANSI escape helpers
+# ---------------------------------------------------------------------------
+
+_RST = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_ITALIC = "\033[3m"
+_UNDERLINE = "\033[4m"
+_STRIKETHROUGH = "\033[9m"
+_BOLD_ITALIC = "\033[1;3m"
+
+# Sentinel Unicode chars (private-use area) for escaped markdown characters.
+# These are substituted *before* regex transforms and restored *after*.
+_ESC_STAR = "\ue000"
+_ESC_UNDER = "\ue001"
+_ESC_TILDE = "\ue002"
+_ESC_BACKTICK = "\ue003"
+
+_ESCAPE_MAP = {
+    r"\*": _ESC_STAR,
+    r"\_": _ESC_UNDER,
+    r"\~": _ESC_TILDE,
+    r"\`": _ESC_BACKTICK,
+}
+_RESTORE_MAP = {v: k[1] for k, v in _ESCAPE_MAP.items()}  # sentinel -> literal char
+
+
+# ---------------------------------------------------------------------------
+# Inline markdown regex transforms
+# ---------------------------------------------------------------------------
+
+_RE_HEADER = re.compile(r"^(#{1,6})\s+(.+)$")
+_RE_HR = re.compile(r"^[\s]*[-*_]{3,}[\s]*$")
+_RE_INLINE_CODE = re.compile(r"(?<!`)`(?!`)([^`]+)`(?!`)")
+_RE_BOLD_ITALIC = re.compile(r"\*{3}(\S(?:.*?\S)?)\*{3}")
+_RE_BOLD_STAR = re.compile(r"\*{2}(\S(?:.*?\S)?)\*{2}")
+_RE_BOLD_UNDER = re.compile(r"__(\S(?:.*?\S)?)__")
+_RE_ITALIC_STAR = re.compile(r"(?<!\w)\*(\S(?:.*?\S)?)\*(?!\w)")
+_RE_ITALIC_UNDER = re.compile(r"(?<!\w)_(\S(?:.*?\S)?)_(?!\w)")
+_RE_STRIKETHROUGH = re.compile(r"~~(\S(?:.*?\S)?)~~")
+_RE_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_RE_BLOCKQUOTE = re.compile(r"^(\s*>\s?)(.*)$")
+_RE_UL_MARKER = re.compile(r"^(\s*)([-*+])\s")
+_RE_OL_MARKER = re.compile(r"^(\s*)(\d+\.)\s")
+
+# Pipe-table row: starts and ends with | (after stripping), has at least one
+# inner |.  Also matches separator rows like |---|---|.
+_TABLE_ROW_RE = re.compile(r"^\s*\|.*\|.*$")
+_TABLE_SEP_RE = re.compile(r"^\s*\|[\s:?-]+(\|[\s:?-]+)+\|\s*$")
+
+
+def _strip_inline_markers(text: str) -> str:
+    """Remove inline markdown markers (**bold**, *italic*, `code`, ~~strike~~).
+
+    Used for headers and table cells where the surrounding context already
+    provides styling — we just need to remove the raw marker characters.
+    """
+    text = _RE_BOLD_ITALIC.sub(r"\1", text)
+    text = _RE_BOLD_STAR.sub(r"\1", text)
+    text = _RE_BOLD_UNDER.sub(r"\1", text)
+    text = _RE_ITALIC_STAR.sub(r"\1", text)
+    text = _RE_ITALIC_UNDER.sub(r"\1", text)
+    text = _RE_STRIKETHROUGH.sub(r"\1", text)
+    text = _RE_INLINE_CODE.sub(r"\1", text)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# MarkdownStreamProcessor
+# ---------------------------------------------------------------------------
+
+class MarkdownStreamProcessor:
+    """Stateful line-by-line markdown-to-ANSI transformer for streaming output.
+
+    Designed to sit between ``_emit_stream_text``'s line buffer and ``_cprint``.
+    Processes one complete line at a time.  The caller handles line buffering
+    (which ``_emit_stream_text`` already does).
+
+    Two states:
+        NORMAL     – apply inline markdown regex transforms
+        CODE_BLOCK – highlight each line with Pygments
+    """
+
+    def __init__(
+        self,
+        base_ansi: str = "",
+        pygments_theme: str = "monokai",
+        inline_code_ansi: str = "",
+    ):
+        """
+        Args:
+            base_ansi: Base text color ANSI escape (from skin's banner_text).
+                       Applied after every reset to restore the "default" color.
+            pygments_theme: Pygments style name for code blocks.
+            inline_code_ansi: Complete ANSI escape to apply to inline ``code``
+                       spans (e.g. bold + optional fg + optional bg resolved
+                       from the skin). When empty, inline code falls back to
+                       plain bold.
+        """
+        self._base = base_ansi
+        self._rst = _RST
+        self._theme = pygments_theme
+        self._inline_code_ansi = inline_code_ansi
+
+        # State
+        self._in_code_block = False
+        self._code_lang = ""
+        self._code_lines: list[str] = []
+        self._lexer = None
+        self._formatter = None
+        self._md_fence_depth = 0  # depth of skipped ```markdown/```md fences
+        self._table_rows: list[str] = []  # buffered pipe-table rows
+
+    # -- public API ---------------------------------------------------------
+
+    def feed_line(self, line: str) -> Optional[str]:
+        """Process one complete line and return ANSI-formatted output.
+
+        Returns ``None`` when the line is buffered (e.g. table rows) and
+        should NOT be printed.  The caller must skip ``_cprint`` for ``None``.
+        """
+        stripped = line.lstrip()
+
+        # -- Table buffering ---------------------------------------------------
+        # Pipe-table rows are buffered until a non-table line arrives, then
+        # the whole table is rendered at once (needs all rows for column widths).
+        if not self._in_code_block and _TABLE_ROW_RE.match(line):
+            self._table_rows.append(line)
+            return None  # suppress — will be emitted when the table ends
+
+        # If we were buffering a table and this line is NOT a table row,
+        # flush the table first, then process this line normally.
+        table_output = ""
+        if self._table_rows:
+            table_output = self._render_table()
+            self._table_rows.clear()
+
+        # -- Fence detection: ``` at start of line (after optional whitespace) --
+        # Only match lines that are JUST a fence: ```lang or ``` alone.
+        # Reject lines like "```text``` more stuff" or ```` (4+ backticks).
+        if stripped.startswith("```") and not stripped.startswith("````"):
+            _fence_rest = stripped[3:].strip()
+            _is_fence = (not _fence_rest                          # bare ```
+                         or re.match(r"^[a-zA-Z0-9_+-]+$", _fence_rest))  # ```lang
+
+            if _is_fence:
+                if self._in_code_block:
+                    # Closing fence
+                    self._exit_code_block()
+                    return self._render_fence_footer()
+
+                # Opening fence — extract language
+                lang = _fence_rest or ""
+
+                # Skip ```markdown / ```md fences — LLMs often wrap entire
+                # responses in these.  Render the inner content as normal
+                # markdown instead of treating it as a code block.
+                if lang.lower() in ("markdown", "md"):
+                    self._md_fence_depth += 1
+                    return table_output or ""
+
+                # Bare ``` in NORMAL mode: if we previously skipped a
+                # ```markdown opener, this is its matching closer — skip it.
+                if not lang and self._md_fence_depth > 0:
+                    self._md_fence_depth -= 1
+                    return table_output or ""
+
+                self._enter_code_block(lang)
+                fence = self._render_fence_header(lang)
+                return f"{table_output}\n{fence}" if table_output else fence
+
+        if self._in_code_block:
+            self._code_lines.append(line)
+            return self._highlight_code_line(line)
+
+        result = self._apply_inline_markdown(line)
+        return f"{table_output}\n{result}" if table_output else result
+
+    def flush(self) -> Optional[str]:
+        """Finalize state.  Returns any pending output (table, code block)."""
+        parts = []
+        if self._table_rows:
+            parts.append(self._render_table())
+            self._table_rows.clear()
+        if self._in_code_block:
+            self._exit_code_block()
+            parts.append(self._render_fence_footer())
+        return "\n".join(parts) if parts else None
+
+    def reset(self):
+        """Reset all state for a new response."""
+        self._in_code_block = False
+        self._code_lang = ""
+        self._code_lines.clear()
+        self._lexer = None
+        self._formatter = None
+        self._md_fence_depth = 0
+        self._table_rows.clear()
+
+    # -- code block internals -----------------------------------------------
+
+    def _enter_code_block(self, lang: str):
+        self._in_code_block = True
+        self._code_lang = lang or "text"
+        self._code_lines.clear()
+        self._lexer = None
+        self._formatter = None
+
+    def _exit_code_block(self):
+        self._in_code_block = False
+        self._code_lang = ""
+        self._code_lines.clear()
+        self._lexer = None
+        self._formatter = None
+
+    def _get_lexer(self):
+        if self._lexer is None:
+            from pygments.lexers import get_lexer_by_name, TextLexer
+            try:
+                self._lexer = get_lexer_by_name(self._code_lang, stripall=False)
+            except Exception:
+                self._lexer = TextLexer()
+        return self._lexer
+
+    def _get_formatter(self):
+        if self._formatter is None:
+            from pygments.formatters import TerminalTrueColorFormatter
+            self._formatter = TerminalTrueColorFormatter(style=self._theme)
+        return self._formatter
+
+    def _highlight_code_line(self, line: str) -> str:
+        from pygments import highlight as _pyg_highlight
+        lexer = self._get_lexer()
+        formatter = self._get_formatter()
+        # Highlight the single line; Pygments adds a trailing newline — strip it
+        result = _pyg_highlight(line + "\n", lexer, formatter).rstrip("\n")
+        return f"  {result}{self._rst}"
+
+    def _render_fence_header(self, lang: str) -> str:
+        w = shutil.get_terminal_size((80, 24)).columns
+        label = f" {lang} " if lang else ""
+        fill = max(w - 6 - len(label), 3)
+        return f"{_DIM}  ┌───{self._rst}{_DIM}{_BOLD}{label}{self._rst}{_DIM}{'─' * fill}{self._rst}"
+
+    def _render_fence_footer(self) -> str:
+        w = shutil.get_terminal_size((80, 24)).columns
+        fill = max(w - 4, 3)
+        return f"{_DIM}  └{'─' * fill}{self._rst}"
+
+    # -- table internals ----------------------------------------------------
+
+    def _render_table(self) -> str:
+        """Render buffered pipe-table rows as a box-drawing table."""
+        base = self._base
+        rst = self._rst
+
+        # Parse rows into cells
+        parsed: list[list[str]] = []
+        sep_indices: set[int] = set()
+        for i, raw in enumerate(self._table_rows):
+            row = raw.strip()
+            # Strip leading/trailing pipes and split
+            if row.startswith("|"):
+                row = row[1:]
+            if row.endswith("|"):
+                row = row[:-1]
+            cells = [_strip_inline_markers(c.strip()) for c in row.split("|")]
+            parsed.append(cells)
+            if _TABLE_SEP_RE.match(self._table_rows[i]):
+                sep_indices.add(i)
+
+        if not parsed:
+            return ""
+
+        # Compute column widths using terminal-aware width (handles emoji,
+        # CJK characters, etc. that occupy 2 cells in the terminal).
+        try:
+            from wcwidth import wcswidth
+            def _display_width(s: str) -> int:
+                w = wcswidth(s)
+                return w if w >= 0 else len(s)
+        except ImportError:
+            _display_width = len
+
+        n_cols = max(len(r) for r in parsed)
+        col_widths = [0] * n_cols
+        for i, row in enumerate(parsed):
+            if i in sep_indices:
+                continue  # don't let separator dashes inflate widths
+            for j, cell in enumerate(row):
+                if j < n_cols:
+                    col_widths[j] = max(col_widths[j], _display_width(cell))
+
+        # Ensure minimum width of 3 per column
+        col_widths = [max(w, 3) for w in col_widths]
+
+        def _pad_cell(val: str, target_width: int) -> str:
+            """Pad a cell value to target_width using display-aware spacing."""
+            current = _display_width(val)
+            pad = max(target_width - current, 0)
+            return val + " " * pad
+
+        def _border(left: str, mid: str, right: str, fill: str = "─") -> str:
+            segs = [fill * (w + 2) for w in col_widths]
+            return f"{_DIM}{left}{mid.join(segs)}{right}{rst}"
+
+        lines = []
+        lines.append(_border("  ┌", "┬", "┐"))
+
+        for i, row in enumerate(parsed):
+            if i in sep_indices:
+                # Render separator as a mid-border
+                lines.append(_border("  ├", "┼", "┤"))
+            else:
+                # Bold the header row (row 0, if followed by a separator)
+                is_header = (i == 0 and 1 in sep_indices)
+                cell_strs = []
+                for j in range(n_cols):
+                    val = row[j] if j < len(row) else ""
+                    padded = _pad_cell(val, col_widths[j])
+                    cell_strs.append(
+                        f" {_BOLD if is_header else ''}{base}{padded}{rst} "
+                    )
+                inner = f"{_DIM}│{rst}".join(cell_strs)
+                lines.append(f"  {_DIM}│{rst}{inner}{_DIM}│{rst}")
+
+        lines.append(_border("  └", "┴", "┘"))
+        return "\n".join(lines)
+
+    # -- inline markdown internals ------------------------------------------
+
+    def _apply_inline_markdown(self, line: str) -> str:
+        base = self._base
+        rst = self._rst
+
+        # 1. Escape backslash-escaped markdown characters
+        for esc_seq, sentinel in _ESCAPE_MAP.items():
+            line = line.replace(esc_seq, sentinel)
+
+        # 2. Full-line patterns (header, HR) — if matched, apply inline
+        #    formatting to the header text (strip bold/italic/code markers).
+        m = _RE_HEADER.match(line)
+        if m:
+            level = len(m.group(1))
+            text = m.group(2)
+            text = _strip_inline_markers(text)
+            if level == 1:
+                line = f"{_BOLD}{_UNDERLINE}{text}{rst}{base}"
+            elif level == 2:
+                line = f"{_BOLD}{text}{rst}{base}"
+            else:
+                line = f"{_BOLD}{_DIM}{text}{rst}{base}"
+            # Restore escaped chars and return early
+            for sentinel, literal in _RESTORE_MAP.items():
+                line = line.replace(sentinel, literal)
+            return f"{base}{line}{rst}" if base else line
+
+        if _RE_HR.match(line):
+            w = shutil.get_terminal_size((80, 24)).columns
+            line = f"{_DIM}{'─' * min(w - 4, 40)}{rst}{base}"
+            for sentinel, literal in _RESTORE_MAP.items():
+                line = line.replace(sentinel, literal)
+            return f"{base}{line}{rst}" if base else line
+
+        # 3. Protect inline code FIRST — extract `code` spans, replace with
+        #    sentinels so bold/italic regexes don't eat their content.
+        _code_spans: list[str] = []
+        _CODE_SENTINEL = "\ue010"
+
+        def _protect_code(m):
+            idx = len(_code_spans)
+            code_esc = self._inline_code_ansi or _BOLD
+            _code_spans.append(f"{code_esc}{m.group(1)}{rst}{base}")
+            return f"{_CODE_SENTINEL}{idx}{_CODE_SENTINEL}"
+
+        line = _RE_INLINE_CODE.sub(_protect_code, line)
+
+        # 4. Links
+        line = _RE_LINK.sub(
+            lambda m: f"{_UNDERLINE}{m.group(1)}{rst}{_DIM} ({m.group(2)}){rst}{base}",
+            line,
+        )
+
+        # 5. Bold+italic, bold, italic, strikethrough
+        line = _RE_BOLD_ITALIC.sub(lambda m: f"{_BOLD_ITALIC}{m.group(1)}{rst}{base}", line)
+        line = _RE_BOLD_STAR.sub(lambda m: f"{_BOLD}{m.group(1)}{rst}{base}", line)
+        line = _RE_BOLD_UNDER.sub(lambda m: f"{_BOLD}{m.group(1)}{rst}{base}", line)
+        line = _RE_ITALIC_STAR.sub(lambda m: f"{_ITALIC}{m.group(1)}{rst}{base}", line)
+        line = _RE_ITALIC_UNDER.sub(lambda m: f"{_ITALIC}{m.group(1)}{rst}{base}", line)
+        line = _RE_STRIKETHROUGH.sub(lambda m: f"{_STRIKETHROUGH}{m.group(1)}{rst}{base}", line)
+
+        # 6. Blockquote (full-line, but after inline transforms for content)
+        m = _RE_BLOCKQUOTE.match(line)
+        if m:
+            text = m.group(2)
+            line = f"{_DIM}  │ {_ITALIC}{text}{rst}{base}"
+
+        # 7. List markers
+        m = _RE_UL_MARKER.match(line)
+        if m:
+            indent = m.group(1)
+            rest = line[m.end():]
+            line = f"{indent}  • {rest}"
+        else:
+            m = _RE_OL_MARKER.match(line)
+            if m:
+                indent = m.group(1)
+                num = m.group(2)
+                rest = line[m.end():]
+                line = f"{indent}  {_DIM}{num}{rst}{base} {rest}"
+
+        # 8. Restore inline code sentinels
+        for i, rendered in enumerate(_code_spans):
+            line = line.replace(f"{_CODE_SENTINEL}{i}{_CODE_SENTINEL}", rendered)
+
+        # 9. Restore escaped characters
+        for sentinel, literal in _RESTORE_MAP.items():
+            line = line.replace(sentinel, literal)
+
+        # Apply base color wrapping
+        if base:
+            return f"{base}{line}{rst}"
+        return line
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming helper
+# ---------------------------------------------------------------------------
+
+def render_markdown_rich(text: str, pygments_theme: str = "monokai"):
+    """Return a Rich Markdown renderable for the non-streaming Panel path.
+
+    Args:
+        text: Complete LLM response text (plain markdown).
+        pygments_theme: Pygments style name for fenced code blocks.
+
+    Returns:
+        A ``rich.markdown.Markdown`` instance suitable for ``Panel(content)``.
+    """
+    from rich.markdown import Markdown
+    return Markdown(text, code_theme=pygments_theme)

--- a/hermes_cli/markdown_stream.py
+++ b/hermes_cli/markdown_stream.py
@@ -1,10 +1,7 @@
-"""Streaming and non-streaming Markdown rendering for the Hermes CLI.
+"""Streaming Markdown rendering for the Hermes CLI.
 
-Provides:
-- ``MarkdownStreamProcessor``: stateful line-by-line markdown-to-ANSI
-  transformer for the streaming display path.
-- ``render_markdown_rich``: one-shot Rich Markdown renderable for the
-  non-streaming Panel path.
+Provides ``MarkdownStreamProcessor``, a stateful line-by-line
+Markdown-to-ANSI transformer for the streaming display path.
 """
 
 from __future__ import annotations
@@ -280,9 +277,32 @@ class MarkdownStreamProcessor:
     # -- table internals ----------------------------------------------------
 
     def _render_table(self) -> str:
-        """Render buffered pipe-table rows as a box-drawing table."""
+        """Render buffered pipe-table rows without exceeding caller width."""
         base = self._base
         rst = self._rst
+
+        # Reuse the CLI's established narrow-table decision before drawing
+        # the richer box. Its horizontal representation is two cells narrower
+        # than our indented box, so reserve those cells in the budget. If it
+        # selects the vertical fallback, preserve that width-safe layout.
+        if self._max_width is not None:
+            from agent.markdown_tables import is_table_divider, realign_markdown_tables
+
+            budget = max(int(self._max_width) - 2, 1)
+            aligned = realign_markdown_tables("\n".join(self._table_rows), budget)
+            aligned_lines = aligned.splitlines()
+            stays_horizontal = len(aligned_lines) > 1 and is_table_divider(aligned_lines[1])
+            if not stays_horizontal:
+                rendered_lines = []
+                for line in aligned_lines:
+                    plain = _strip_inline_markers(line)
+                    if plain and set(plain) == {"─"}:
+                        rendered_lines.append(f"{_DIM}{plain}{rst}")
+                    elif base:
+                        rendered_lines.append(f"{base}{plain}{rst}")
+                    else:
+                        rendered_lines.append(plain)
+                return "\n".join(rendered_lines)
 
         # Parse rows into cells
         parsed: list[list[str]] = []
@@ -451,21 +471,3 @@ class MarkdownStreamProcessor:
         if base:
             return f"{base}{line}{rst}"
         return line
-
-
-# ---------------------------------------------------------------------------
-# Non-streaming helper
-# ---------------------------------------------------------------------------
-
-def render_markdown_rich(text: str, pygments_theme: str = "monokai"):
-    """Return a Rich Markdown renderable for the non-streaming Panel path.
-
-    Args:
-        text: Complete LLM response text (plain markdown).
-        pygments_theme: Pygments style name for fenced code blocks.
-
-    Returns:
-        A ``rich.markdown.Markdown`` instance suitable for ``Panel(content)``.
-    """
-    from rich.markdown import Markdown
-    return Markdown(text, code_theme=pygments_theme)

--- a/hermes_cli/markdown_stream.py
+++ b/hermes_cli/markdown_stream.py
@@ -102,6 +102,7 @@ class MarkdownStreamProcessor:
         base_ansi: str = "",
         pygments_theme: str = "monokai",
         inline_code_ansi: str = "",
+        max_width: Optional[int] = None,
     ):
         """
         Args:
@@ -112,11 +113,15 @@ class MarkdownStreamProcessor:
                        spans (e.g. bold + optional fg + optional bg resolved
                        from the skin). When empty, inline code falls back to
                        plain bold.
+            max_width: Maximum visible cells available to rendered output.
+                       The caller should subtract any indentation it prepends.
+                       When omitted, use the terminal width for compatibility.
         """
         self._base = base_ansi
         self._rst = _RST
         self._theme = pygments_theme
         self._inline_code_ansi = inline_code_ansi
+        self._max_width = max_width
 
         # State
         self._in_code_block = False
@@ -253,13 +258,22 @@ class MarkdownStreamProcessor:
         return f"  {result}{self._rst}"
 
     def _render_fence_header(self, lang: str) -> str:
-        w = shutil.get_terminal_size((80, 24)).columns
+        w = self._max_width
+        if w is None:
+            w = shutil.get_terminal_size((80, 24)).columns
+        w = max(int(w), 10)
         label = f" {lang} " if lang else ""
+        # Keep at least three border cells after the label. Fence languages are
+        # ASCII-only by parser contract, so len() is also their display width.
+        label = label[:max(w - 9, 0)]
         fill = max(w - 6 - len(label), 3)
         return f"{_DIM}  ┌───{self._rst}{_DIM}{_BOLD}{label}{self._rst}{_DIM}{'─' * fill}{self._rst}"
 
     def _render_fence_footer(self) -> str:
-        w = shutil.get_terminal_size((80, 24)).columns
+        w = self._max_width
+        if w is None:
+            w = shutil.get_terminal_size((80, 24)).columns
+        w = max(int(w), 10)
         fill = max(w - 4, 3)
         return f"{_DIM}  └{'─' * fill}{self._rst}"
 

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -173,6 +173,7 @@ class SkinConfig:
     branding: Dict[str, str] = field(default_factory=dict)
     tool_prefix: str = "┊"
     tool_emojis: Dict[str, str] = field(default_factory=dict)  # per-tool emoji overrides
+    code_theme: str = ""  # Pygments theme for code blocks (empty = auto)
     banner_logo: str = ""    # Rich-markup ASCII art logo (replaces HERMES_AGENT_LOGO)
     banner_hero: str = ""    # Rich-markup hero art (replaces HERMES_CADUCEUS)
 
@@ -853,6 +854,7 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
         branding=branding,
         tool_prefix=data.get("tool_prefix", default.get("tool_prefix", "┊")),
         tool_emojis=emoji_overrides,
+        code_theme=data.get("code_theme", ""),
         banner_logo=data.get("banner_logo", ""),
         banner_hero=data.get("banner_hero", ""),
     )

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -191,6 +191,8 @@ class TestCliApprovalUi:
         prompt_toolkit.
         """
         cli = _make_background_cli_stub()
+        cli.final_response_markdown = "render"
+        cli._pygments_theme = "friendly"
         seen = {}
 
         class FakeAgent:
@@ -215,6 +217,11 @@ class TestCliApprovalUi:
 
         with patch.object(cli_module, "AIAgent", FakeAgent), \
              patch.object(cli_module, "_cprint"), \
+             patch.object(
+                 cli_module,
+                 "_render_final_assistant_content",
+                 return_value="rendered",
+             ) as render_final, \
              patch.object(cli_module, "ChatConsole") as chat_console:
             chat_console.return_value.print = MagicMock()
             cli._handle_background_command("/btw check weather")
@@ -229,6 +236,11 @@ class TestCliApprovalUi:
         assert seen["approval"].__func__ is HermesCLI._approval_callback
         assert seen["sudo"].__self__ is cli
         assert seen["sudo"].__func__ is HermesCLI._sudo_password_callback
+        render_final.assert_called_once_with(
+            "done",
+            mode="render",
+            code_theme="friendly",
+        )
         assert not cli._background_tasks
 
 

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -22,6 +22,21 @@ def test_final_assistant_content_uses_markdown_renderable():
     assert "two" in output
 
 
+def test_final_assistant_content_uses_requested_code_theme():
+    renderable = _render_final_assistant_content(
+        "```python\nprint('hi')\n```",
+        code_theme="friendly",
+    )
+
+    assert isinstance(renderable, Markdown)
+    assert renderable.code_theme == "friendly"
+
+
+def test_final_assistant_content_preserves_windows_dot_segments():
+    path = r"C:\repo\.ai\settings.yaml"
+    renderable = _render_final_assistant_content(path)
+
+    assert path in _render_to_text(renderable)
 
 
 def test_final_assistant_content_keeps_non_path_markdown_escapes():

--- a/tests/cli/test_hex_to_truecolor.py
+++ b/tests/cli/test_hex_to_truecolor.py
@@ -1,0 +1,108 @@
+"""Unit tests for the _hex_to_truecolor helper in cli.py.
+
+Guards against the TypeError edge case where a user's skin YAML has a
+non-string color value (e.g. ``banner_text: 12345``) which would crash
+the streaming hot path if the helper attempted to slice the raw int.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from cli import _hex_to_truecolor
+
+
+class TestValidInputs:
+    def test_valid_rrggbb_fg(self):
+        assert _hex_to_truecolor("#FFD700", "fg") == "38;2;255;215;0"
+
+    def test_valid_rrggbb_bg(self):
+        assert _hex_to_truecolor("#FFD700", "bg") == "48;2;255;215;0"
+
+    def test_default_layer_is_fg(self):
+        assert _hex_to_truecolor("#FFD700") == "38;2;255;215;0"
+
+    def test_lowercase_valid(self):
+        assert _hex_to_truecolor("#aabbcc", "fg") == "38;2;170;187;204"
+
+    def test_mixed_case(self):
+        assert _hex_to_truecolor("#AaBbCc", "fg") == "38;2;170;187;204"
+
+    def test_black(self):
+        assert _hex_to_truecolor("#000000", "fg") == "38;2;0;0;0"
+
+    def test_white(self):
+        assert _hex_to_truecolor("#FFFFFF", "bg") == "48;2;255;255;255"
+
+
+class TestMalformedInputs:
+    def test_empty_string(self):
+        assert _hex_to_truecolor("", "fg") == ""
+
+    def test_none(self):
+        # Non-string input must not raise TypeError — this is the
+        # regression guard for the original bug.
+        assert _hex_to_truecolor(None, "fg") == ""  # type: ignore[arg-type]
+
+    def test_integer(self):
+        # Exact footgun from the code-review comment: a user's skin
+        # YAML with ``banner_text: 12345`` should degrade gracefully,
+        # not crash with TypeError inside the streaming hot path.
+        assert _hex_to_truecolor(12345, "fg") == ""  # type: ignore[arg-type]
+
+    def test_short_form(self):
+        # #ABC style — unsupported by the helper, should degrade.
+        assert _hex_to_truecolor("#ABC", "fg") == ""
+
+    def test_garbage_word(self):
+        assert _hex_to_truecolor("red", "fg") == ""
+
+    def test_missing_hash_prefix_but_valid_hex(self):
+        # Without the leading '#', slicing [1:3][3:5][5:7] off a 6-char
+        # string leaves the final component empty → ValueError → "".
+        assert _hex_to_truecolor("FFD700", "fg") == ""
+
+    def test_too_short(self):
+        assert _hex_to_truecolor("#FFD70", "fg") == ""
+
+    def test_non_hex_chars(self):
+        assert _hex_to_truecolor("#ZZZZZZ", "fg") == ""
+
+    def test_list_input(self):
+        assert _hex_to_truecolor([1, 2, 3], "fg") == ""  # type: ignore[arg-type]
+
+    def test_dict_input(self):
+        assert _hex_to_truecolor({"r": 1}, "fg") == ""  # type: ignore[arg-type]
+
+
+class TestLayerSelection:
+    def test_bg_layer_uses_48(self):
+        out = _hex_to_truecolor("#102030", "bg")
+        assert out.startswith("48;2;")
+
+    def test_fg_layer_uses_38(self):
+        out = _hex_to_truecolor("#102030", "fg")
+        assert out.startswith("38;2;")
+
+    def test_unknown_layer_defaults_to_bg(self):
+        # Current contract: anything other than "fg" becomes the bg code.
+        # This guards the behavior so callers know what they get.
+        out = _hex_to_truecolor("#102030", "something-else")
+        assert out.startswith("48;2;")
+
+
+@pytest.mark.parametrize(
+    "hex_str,expected",
+    [
+        ("#000000", "38;2;0;0;0"),
+        ("#FF0000", "38;2;255;0;0"),
+        ("#00FF00", "38;2;0;255;0"),
+        ("#0000FF", "38;2;0;0;255"),
+        ("#808080", "38;2;128;128;128"),
+    ],
+)
+def test_valid_fg_parametrized(hex_str, expected):
+    assert _hex_to_truecolor(hex_str, "fg") == expected

--- a/tests/cli/test_markdown_command.py
+++ b/tests/cli/test_markdown_command.py
@@ -1,0 +1,42 @@
+"""Classic CLI /markdown command tests."""
+
+from unittest.mock import patch
+
+
+def _stub(mode: str):
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pending_resume_sessions = None
+    cli.final_response_markdown = mode
+    return cli
+
+
+def test_markdown_command_enables_render_mode():
+    import cli as climod
+
+    cli = _stub("strip")
+    with (
+        patch.object(climod, "_cprint") as printed,
+        patch.object(climod, "save_config_value") as saved,
+    ):
+        assert cli.process_command("/markdown") is True
+
+    assert cli.final_response_markdown == "render"
+    saved.assert_called_once_with("display.final_response_markdown", "render")
+    assert "ON" in str(printed.call_args)
+
+
+def test_md_alias_disables_render_mode_to_strip():
+    import cli as climod
+
+    cli = _stub("render")
+    with (
+        patch.object(climod, "_cprint") as printed,
+        patch.object(climod, "save_config_value") as saved,
+    ):
+        assert cli.process_command("/md") is True
+
+    assert cli.final_response_markdown == "strip"
+    saved.assert_called_once_with("display.final_response_markdown", "strip")
+    assert "OFF" in str(printed.call_args)

--- a/tests/cli/test_stream_flush_left.py
+++ b/tests/cli/test_stream_flush_left.py
@@ -83,3 +83,24 @@ def test_markdown_fence_uses_width_remaining_after_stream_pad(cli_stub, monkeypa
     ]
     assert len(fence_lines) == 2
     assert all(len(line) <= 32 for line in fence_lines)
+
+
+def test_multiline_markdown_table_emits_one_flush_left_row_per_call(cli_stub, monkeypatch):
+    import cli as climod
+
+    cli, emitted = cli_stub
+    cli.final_response_markdown = "render"
+    cli._pygments_theme = "monokai"
+    monkeypatch.setattr(climod, "_terminal_width_for_streaming", lambda: 32)
+
+    cli._stream_delta(
+        "| Name | Description |\n"
+        "| --- | --- |\n"
+        "| Hermes | A deliberately long description that cannot fit |\n"
+        "\n"
+    )
+
+    table_lines = [line for line in emitted if "Name:" in line or "Description:" in line]
+    assert table_lines
+    assert all(not line.startswith(" ") for line in table_lines)
+    assert all("\n" not in line for line in table_lines)

--- a/tests/cli/test_stream_flush_left.py
+++ b/tests/cli/test_stream_flush_left.py
@@ -62,3 +62,24 @@ def test_intentional_markdown_indentation_is_preserved(cli_stub):
     plain = [_strip_ansi(e) for e in emitted]
     assert any(line == "- item" for line in plain)
     assert any(line == "  - nested item" for line in plain)
+
+
+def test_markdown_fence_uses_width_remaining_after_stream_pad(cli_stub, monkeypatch):
+    import cli as climod
+
+    cli, emitted = cli_stub
+    cli.final_response_markdown = "render"
+    cli._pygments_theme = "monokai"
+    monkeypatch.setattr(climod, "_STREAM_PAD", "    ")
+    monkeypatch.setattr(climod, "_terminal_width_for_streaming", lambda: 28)
+
+    cli._stream_delta("```python\nprint('hi')\n```\n")
+    cli._flush_stream()
+
+    fence_lines = [
+        _strip_ansi(line)
+        for line in emitted
+        if "┌" in _strip_ansi(line) or "└" in _strip_ansi(line)
+    ]
+    assert len(fence_lines) == 2
+    assert all(len(line) <= 32 for line in fence_lines)

--- a/tests/test_markdown_stream.py
+++ b/tests/test_markdown_stream.py
@@ -347,6 +347,25 @@ class TestCodeBlockBasic:
         assert _strip_ansi(code).startswith("  ")
         p.feed_line("```")
 
+    def test_labelled_fence_respects_caller_width(self):
+        p = MarkdownStreamProcessor(max_width=32)
+
+        header = _strip_ansi(p.feed_line("```python"))
+        footer = _strip_ansi(p.feed_line("```"))
+
+        assert len(header) <= 32
+        assert len(footer) <= 32
+        assert " python " in header
+
+    def test_bare_fence_respects_caller_width(self):
+        p = MarkdownStreamProcessor(max_width=20)
+
+        header = _strip_ansi(p.feed_line("```"))
+        footer = _strip_ansi(p.feed_line("```"))
+
+        assert len(header) <= 20
+        assert len(footer) <= 20
+
 
 class TestMultipleCodeBlocks:
     def test_two_blocks_with_normal_text(self):

--- a/tests/test_markdown_stream.py
+++ b/tests/test_markdown_stream.py
@@ -1,0 +1,722 @@
+"""Tests for hermes_cli.markdown_stream — streaming & non-streaming markdown rendering."""
+
+import re
+import pytest
+
+from hermes_cli.markdown_stream import MarkdownStreamProcessor, render_markdown_rich
+
+# Helpers
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+def _has_ansi(text: str, code: str) -> bool:
+    """Check if a specific ANSI escape code appears in text."""
+    return f"\033[{code}m" in text
+
+
+# =========================================================================
+# Inline markdown transforms (NORMAL mode)
+# =========================================================================
+
+class TestInlineBold:
+    def test_bold_double_star(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("Hello **world**")
+        assert _has_ansi(out, "1")  # bold
+        assert "world" in _strip_ansi(out)
+
+    def test_bold_double_under(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("Hello __world__")
+        assert _has_ansi(out, "1")
+        assert "world" in _strip_ansi(out)
+
+    def test_bold_mid_sentence(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("some **bold** text here")
+        plain = _strip_ansi(out)
+        assert "bold" in plain
+        assert "some" in plain
+        assert "text here" in plain
+
+
+class TestInlineItalic:
+    def test_italic_star(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("Hello *world*")
+        assert _has_ansi(out, "3")  # italic
+        assert "world" in _strip_ansi(out)
+
+    def test_italic_under(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("Hello _world_")
+        assert _has_ansi(out, "3")
+
+
+class TestInlineBoldItalic:
+    def test_bold_italic(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("***both***")
+        assert _has_ansi(out, "1;3")  # bold+italic
+        assert "both" in _strip_ansi(out)
+
+
+class TestInlineStrikethrough:
+    def test_strikethrough(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("~~removed~~")
+        assert _has_ansi(out, "9")  # strikethrough
+        assert "removed" in _strip_ansi(out)
+
+
+class TestInlineCode:
+    def test_inline_code(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("Use `foo()` here")
+        # Default processor uses plain bold (no skin-supplied fg/bg).
+        assert _has_ansi(out, "1")  # bold
+        assert "foo()" in _strip_ansi(out)
+
+    def test_inline_code_no_match_triple_backtick(self):
+        """Triple backticks should NOT be treated as inline code."""
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("```python")
+        plain = _strip_ansi(out)
+        # Should be a fence header, not inline code formatting
+        assert "python" in plain
+
+
+class TestHeaders:
+    def test_h1(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("# Title")
+        assert _has_ansi(out, "1")  # bold
+        assert _has_ansi(out, "4")  # underline (h1 specific)
+        assert "Title" in _strip_ansi(out)
+
+    def test_h2(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("## Subtitle")
+        assert _has_ansi(out, "1")
+        assert "Subtitle" in _strip_ansi(out)
+
+    def test_h3(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("### Section")
+        assert _has_ansi(out, "1")
+        assert "Section" in _strip_ansi(out)
+
+    def test_h4(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("#### Subsection")
+        assert "Subsection" in _strip_ansi(out)
+
+    def test_h5(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("##### Deep Section")
+        assert _has_ansi(out, "1")
+        assert "Deep Section" in _strip_ansi(out)
+        assert "#" not in _strip_ansi(out)
+
+    def test_h6(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("###### Deepest")
+        assert "Deepest" in _strip_ansi(out)
+        assert "#" not in _strip_ansi(out)
+
+    def test_header_strips_inline_bold(self):
+        """Bold markers inside headers should be stripped, not shown literally."""
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("### 1. **set_context.sh - Bug**")
+        plain = _strip_ansi(out)
+        assert "set_context.sh - Bug" in plain
+        assert "**" not in plain
+
+    def test_header_strips_inline_code(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("## Using `foo()` in production")
+        plain = _strip_ansi(out)
+        assert "foo()" in plain
+        assert "`" not in plain
+
+    def test_header_strips_mixed_inline(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("# **Bold** and *italic* and `code`")
+        plain = _strip_ansi(out)
+        assert "Bold and italic and code" in plain
+        assert "**" not in plain
+        assert "*" not in plain
+        assert "`" not in plain
+
+
+class TestBlockquote:
+    def test_blockquote(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("> quoted text")
+        assert _has_ansi(out, "3")  # italic
+        assert "│" in _strip_ansi(out)
+        assert "quoted text" in _strip_ansi(out)
+
+
+class TestListMarkers:
+    def test_unordered_dash(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("- item one")
+        assert "•" in _strip_ansi(out)
+        assert "item one" in _strip_ansi(out)
+
+    def test_unordered_star(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("* item two")
+        assert "•" in _strip_ansi(out)
+
+    def test_unordered_plus(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("+ item three")
+        assert "•" in _strip_ansi(out)
+
+    def test_ordered_list(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("1. first")
+        plain = _strip_ansi(out)
+        assert "1." in plain
+        assert "first" in plain
+
+    def test_indented_list(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("  - nested")
+        assert "•" in _strip_ansi(out)
+        assert "nested" in _strip_ansi(out)
+
+
+class TestLinks:
+    def test_link(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("See [docs](https://example.com) for info")
+        plain = _strip_ansi(out)
+        assert "docs" in plain
+        assert "https://example.com" in plain
+        assert _has_ansi(out, "4")  # underline
+
+
+class TestHorizontalRule:
+    def test_dashes(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("---")
+        assert "─" in _strip_ansi(out)
+
+    def test_stars(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("***")
+        # Could be hr or bold-italic marker; with nothing between, hr wins
+        # because the full-line regex matches first
+        assert "─" in _strip_ansi(out)
+
+
+class TestRobustness:
+    """Edge cases that caused corruption in adversarial markdown."""
+
+    def test_unmatched_bold_passthrough(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("some **unmatched bold")
+        assert "**unmatched" in _strip_ansi(out)
+
+    def test_unmatched_italic_passthrough(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("some *unmatched italic")
+        assert "*unmatched" in _strip_ansi(out)
+
+    def test_triple_backticks_mid_text_not_fence(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("Use ```python to start code")
+        plain = _strip_ansi(out)
+        assert "```python" in plain
+        assert "┌" not in plain  # NOT a fence header
+
+    def test_inline_code_protected_from_bold(self):
+        """Bold markers inside inline code should not be interpreted."""
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("Run `**not bold**` here")
+        plain = _strip_ansi(out)
+        assert "**not bold**" in plain
+
+    def test_mixed_unmatched_markers(self):
+        """Multiple unmatched markers shouldn't cascade."""
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("text ** more _ stuff ~~ end")
+        plain = _strip_ansi(out)
+        assert "**" in plain
+        assert "_" in plain
+        assert "~~" in plain
+
+
+class TestEscapedCharacters:
+    def test_escaped_star(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("\\*not bold\\*")
+        plain = _strip_ansi(out)
+        assert "*not bold*" in plain
+        # Should NOT have bold ANSI (only the base color, if any)
+        assert "\033[1m" not in out or "\033[1;" not in out
+
+    def test_escaped_backtick(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("Use \\`backtick\\` literally")
+        plain = _strip_ansi(out)
+        assert "`backtick`" in plain
+
+
+class TestEmptyAndPlainLines:
+    def test_empty_line(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("")
+        assert _strip_ansi(out) == ""
+
+    def test_plain_text(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("Just plain text, no markdown.")
+        assert "Just plain text, no markdown." in _strip_ansi(out)
+
+
+class TestBaseAnsi:
+    def test_base_color_applied(self):
+        base = "\033[38;2;255;248;220m"
+        p = MarkdownStreamProcessor(base_ansi=base)
+        out = p.feed_line("Hello")
+        assert out.startswith(base)
+
+    def test_no_base_color(self):
+        p = MarkdownStreamProcessor(base_ansi="")
+        out = p.feed_line("Hello")
+        assert "Hello" in _strip_ansi(out)
+
+
+# =========================================================================
+# Code block handling (CODE_BLOCK mode)
+# =========================================================================
+
+class TestCodeBlockBasic:
+    def test_open_close_cycle(self):
+        p = MarkdownStreamProcessor()
+        header = p.feed_line("```python")
+        assert "python" in _strip_ansi(header)
+        assert "┌" in _strip_ansi(header)
+
+        code = p.feed_line("print('hello')")
+        # Should have Pygments highlighting (some ANSI in there)
+        assert "print" in _strip_ansi(code)
+
+        footer = p.feed_line("```")
+        assert "└" in _strip_ansi(footer)
+
+    def test_code_not_inline_formatted(self):
+        """Lines inside code block should NOT get inline markdown transforms."""
+        p = MarkdownStreamProcessor()
+        p.feed_line("```python")
+        code_out = p.feed_line("x = **kwargs")
+        plain = _strip_ansi(code_out)
+        # **kwargs should be literal, not bolded
+        assert "**kwargs" in plain
+        p.feed_line("```")
+
+    def test_no_language_fence(self):
+        p = MarkdownStreamProcessor()
+        header = p.feed_line("```")
+        assert "┌" in _strip_ansi(header)
+        # No language label, just the fence line
+        code = p.feed_line("some text")
+        assert "some text" in _strip_ansi(code)
+        footer = p.feed_line("```")
+        assert "└" in _strip_ansi(footer)
+
+    def test_unknown_language_no_crash(self):
+        p = MarkdownStreamProcessor()
+        header = p.feed_line("```brainfuck")
+        assert "brainfuck" in _strip_ansi(header)
+        code = p.feed_line("++++++++[>++++[>++>+++>+++>+<<<<-]")
+        assert _strip_ansi(code).strip()  # Something was emitted
+        p.feed_line("```")
+
+    def test_code_lines_indented(self):
+        """Code lines should be indented with 2 spaces."""
+        p = MarkdownStreamProcessor()
+        p.feed_line("```python")
+        code = p.feed_line("x = 1")
+        assert _strip_ansi(code).startswith("  ")
+        p.feed_line("```")
+
+
+class TestMultipleCodeBlocks:
+    def test_two_blocks_with_normal_text(self):
+        p = MarkdownStreamProcessor()
+        # First block
+        h1 = p.feed_line("```python")
+        assert "┌" in _strip_ansi(h1)
+        p.feed_line("x = 1")
+        f1 = p.feed_line("```")
+        assert "└" in _strip_ansi(f1)
+
+        # Normal text between
+        normal = p.feed_line("Some **bold** text")
+        assert _has_ansi(normal, "1")  # bold applied
+
+        # Second block
+        h2 = p.feed_line("```javascript")
+        assert "javascript" in _strip_ansi(h2)
+        p.feed_line("const x = 1;")
+        f2 = p.feed_line("```")
+        assert "└" in _strip_ansi(f2)
+
+
+class TestTableRendering:
+    """Pipe tables should be buffered and rendered with box-drawing borders."""
+
+    def test_basic_table(self):
+        p = MarkdownStreamProcessor()
+        # Table rows return None while buffering (suppressed from output)
+        assert p.feed_line("| Name | Role |") is None
+        assert p.feed_line("|------|------|") is None
+        assert p.feed_line("| Alice | Dev |") is None
+        # Non-table line flushes the table
+        out = p.feed_line("After table")
+        plain = _strip_ansi(out)
+        assert "┌" in plain
+        assert "┘" in plain
+        assert "Alice" in plain
+        assert "Dev" in plain
+        assert "After table" in plain
+
+    def test_table_has_header_bold(self):
+        p = MarkdownStreamProcessor()
+        p.feed_line("| H1 | H2 |")
+        p.feed_line("|-----|-----|")
+        p.feed_line("| a | b |")
+        out = p.feed_line("")
+        # Header row should be bold
+        assert _has_ansi(out, "1")
+
+    def test_table_flush(self):
+        """Table at end of stream is flushed properly."""
+        p = MarkdownStreamProcessor()
+        p.feed_line("| X | Y |")
+        p.feed_line("|---|---|")
+        p.feed_line("| 1 | 2 |")
+        tail = p.flush()
+        assert tail is not None
+        plain = _strip_ansi(tail)
+        assert "┌" in plain
+        assert "┘" in plain
+        assert "1" in plain
+
+    def test_table_separator_not_hr(self):
+        """Table separator rows should NOT become horizontal rules."""
+        p = MarkdownStreamProcessor()
+        p.feed_line("| A | B |")
+        p.feed_line("|-----|-----|")
+        p.feed_line("| x | y |")
+        out = p.feed_line("done")
+        plain = _strip_ansi(out)
+        # Should have table box chars, and ├ for the separator
+        assert "├" in plain
+        assert "┼" in plain
+
+    def test_table_column_alignment(self):
+        """Columns should be padded to uniform width."""
+        p = MarkdownStreamProcessor()
+        p.feed_line("| Short | LongerColumn |")
+        p.feed_line("|-------|--------------|")
+        p.feed_line("| a | b |")
+        out = p.feed_line("")
+        plain = _strip_ansi(out)
+        # "Short" and "a" should be padded to same width
+        lines = plain.split("\n")
+        # Find data rows (contain │)
+        data_lines = [l for l in lines if "│" in l and "─" not in l]
+        assert len(data_lines) >= 2
+
+    def test_table_strips_inline_markers(self):
+        """Bold/italic/code markers in cells should be stripped."""
+        p = MarkdownStreamProcessor()
+        p.feed_line("| **Feature** | **Winner** |")
+        p.feed_line("|---|---|")
+        p.feed_line("| **Model Class** | **Qwen** |")
+        out = p.feed_line("done")
+        plain = _strip_ansi(out)
+        assert "Feature" in plain
+        assert "Winner" in plain
+        assert "Model Class" in plain
+        assert "Qwen" in plain
+        assert "**" not in plain
+
+    def test_reset_clears_table(self):
+        p = MarkdownStreamProcessor()
+        p.feed_line("| A | B |")
+        assert len(p._table_rows) == 1
+        p.reset()
+        assert len(p._table_rows) == 0
+
+
+class TestMarkdownFenceSkip:
+    """LLMs often wrap responses in ```markdown ... ```. These fences should
+    be transparent — content inside renders as normal markdown."""
+
+    def test_markdown_fence_skipped(self):
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("```markdown")
+        assert out == ""  # fence line suppressed
+        # Content should be rendered as normal markdown, not code
+        header = p.feed_line("# Hello")
+        assert _has_ansi(header, "1")  # bold header
+        assert "Hello" in _strip_ansi(header)
+        # Closing fence also suppressed
+        close = p.feed_line("```")
+        assert close == ""
+
+    def test_md_fence_skipped(self):
+        p = MarkdownStreamProcessor()
+        assert p.feed_line("```md") == ""
+        out = p.feed_line("**bold**")
+        assert _has_ansi(out, "1")
+        assert p.feed_line("```") == ""
+
+    def test_nested_code_inside_markdown_fence(self):
+        """Inner ```python blocks should still be highlighted as code."""
+        p = MarkdownStreamProcessor()
+        p.feed_line("```markdown")  # skipped
+
+        # Normal markdown
+        h = p.feed_line("## Title")
+        assert _has_ansi(h, "1")
+
+        # Inner code block works normally
+        header = p.feed_line("```python")
+        assert "┌" in _strip_ansi(header)
+        assert "python" in _strip_ansi(header)
+        code = p.feed_line("x = 1")
+        assert "x" in _strip_ansi(code)
+        footer = p.feed_line("```")
+        assert "└" in _strip_ansi(footer)
+
+        # Back to normal markdown
+        bold = p.feed_line("**done**")
+        assert _has_ansi(bold, "1")
+
+        # Outer closing fence suppressed
+        assert p.feed_line("```") == ""
+        assert p.flush() is None
+
+    def test_full_llm_markdown_response(self):
+        """Simulate an LLM wrapping its entire response in ```markdown."""
+        p = MarkdownStreamProcessor()
+        lines = [
+            "```markdown",
+            "# Welcome",
+            "",
+            "---",
+            "",
+            "- Item one",
+            "- Item two",
+            "",
+            "```python",
+            "print('hello')",
+            "```",
+            "",
+            "*End of demo*",
+            "```",
+        ]
+        outputs = [p.feed_line(l) for l in lines]
+
+        # ```markdown skipped
+        assert outputs[0] == ""
+        # # Welcome → rendered as header
+        assert _has_ansi(outputs[1], "1")
+        assert "Welcome" in _strip_ansi(outputs[1])
+        # --- → HR
+        assert "─" in _strip_ansi(outputs[3])
+        # - Item one → bullet
+        assert "•" in _strip_ansi(outputs[5])
+        # ```python → code fence header
+        assert "┌" in _strip_ansi(outputs[8])
+        # print('hello') → code
+        assert "print" in _strip_ansi(outputs[9])
+        # ``` → code fence footer
+        assert "└" in _strip_ansi(outputs[10])
+        # *End of demo* → italic
+        assert _has_ansi(outputs[12], "3")
+        # Closing ``` → skipped
+        assert outputs[13] == ""
+        assert p.flush() is None
+
+    def test_reset_clears_md_fence_depth(self):
+        p = MarkdownStreamProcessor()
+        p.feed_line("```markdown")
+        assert p._md_fence_depth == 1
+        p.reset()
+        assert p._md_fence_depth == 0
+
+
+class TestUnclosedCodeBlock:
+    def test_flush_closes_block(self):
+        p = MarkdownStreamProcessor()
+        p.feed_line("```python")
+        p.feed_line("x = 1")
+        p.feed_line("y = 2")
+        # Stream ends without closing fence
+        tail = p.flush()
+        assert tail is not None
+        assert "└" in _strip_ansi(tail)
+
+    def test_flush_when_no_open_block(self):
+        p = MarkdownStreamProcessor()
+        p.feed_line("Normal text")
+        tail = p.flush()
+        assert tail is None
+
+
+class TestReset:
+    def test_reset_mid_code_block(self):
+        p = MarkdownStreamProcessor()
+        p.feed_line("```python")
+        p.feed_line("x = 1")
+        p.reset()
+        # After reset, should be back in NORMAL mode
+        out = p.feed_line("**bold again**")
+        assert _has_ansi(out, "1")  # bold
+        # flush should have nothing
+        assert p.flush() is None
+
+    def test_reset_clears_all_state(self):
+        p = MarkdownStreamProcessor()
+        p.feed_line("```python")
+        p.feed_line("code")
+        p.reset()
+        assert not p._in_code_block
+        assert p._code_lang == ""
+        assert len(p._code_lines) == 0
+        assert p._lexer is None
+        assert p._formatter is None
+
+
+# =========================================================================
+# Streaming simulation (multi-line sequences)
+# =========================================================================
+
+class TestStreamingSequence:
+    def test_typical_response(self):
+        """Simulate a typical LLM response with mixed content."""
+        p = MarkdownStreamProcessor()
+        lines = [
+            "Here's an example:",
+            "",
+            "```python",
+            "def hello():",
+            '    print("Hello, world!")',
+            "```",
+            "",
+            "This uses the **print** function.",
+        ]
+        outputs = [p.feed_line(line) for line in lines]
+
+        # Line 0: normal text
+        assert "Here's an example:" in _strip_ansi(outputs[0])
+        # Line 2: fence header
+        assert "┌" in _strip_ansi(outputs[2])
+        # Lines 3-4: code (indented)
+        assert "def" in _strip_ansi(outputs[3])
+        assert "print" in _strip_ansi(outputs[4])
+        # Line 5: fence footer
+        assert "└" in _strip_ansi(outputs[5])
+        # Line 7: bold
+        assert _has_ansi(outputs[7], "1")
+        assert "print" in _strip_ansi(outputs[7])
+
+        # No open block at end
+        assert p.flush() is None
+
+
+# =========================================================================
+# Non-streaming helper
+# =========================================================================
+
+class TestRenderMarkdownRich:
+    def test_returns_rich_markdown(self):
+        from rich.markdown import Markdown
+        result = render_markdown_rich("# Hello\n\nWorld")
+        assert isinstance(result, Markdown)
+
+    def test_custom_theme(self):
+        result = render_markdown_rich("```python\nx=1\n```", pygments_theme="nord")
+        from rich.markdown import Markdown
+        assert isinstance(result, Markdown)
+
+
+# =========================================================================
+# Inline code ANSI is resolved from the skin (not hardcoded)
+# =========================================================================
+
+class TestInlineCodeAnsi:
+    """The inline code escape must be injected via the ``inline_code_ansi``
+    constructor kwarg — never hardcoded cyan-bold-on-black. This keeps the
+    streaming renderer skinnable (see plan: skin-inline-code)."""
+
+    # A handful of representative inline-code inputs to exercise the code
+    # path across: vanilla, with-bold-around-it, with-brackets, multiple
+    # spans, and inside a list.
+    _INLINE_CODE_INPUTS = [
+        "Use `foo()` here",
+        "See `bar` and `baz` on the line",
+        "- list item with `code`",
+        "**bold** then `code` then *italic*",
+        "Call `obj.method(arg)` now",
+    ]
+
+    def test_default_inline_code_is_bold_only(self):
+        """With no inline_code_ansi passed, inline code is wrapped in plain
+        bold — no foreground color, no background color."""
+        p = MarkdownStreamProcessor()
+        out = p.feed_line("Use `foo()` here")
+        # Plain bold present
+        assert "\033[1m" in out
+        # No 38;2;R;G;B foreground sequence around the code span
+        assert "38;2;" not in out
+        # No background sequence of any form (256-color 48;5 or true-color
+        # 48;2 or indexed 40-47)
+        assert "48;2;" not in out
+        assert "\033[40m" not in out
+        # Content still present
+        assert "foo()" in _strip_ansi(out)
+
+    def test_custom_inline_code_ansi_applied(self):
+        """A sentinel escape passed via inline_code_ansi must appear verbatim
+        around each inline code span."""
+        sentinel = "\033[1;38;2;255;191;0m"  # bold + amber fg
+        p = MarkdownStreamProcessor(inline_code_ansi=sentinel)
+        out = p.feed_line("Use `foo()` here")
+        assert sentinel in out
+        assert "foo()" in _strip_ansi(out)
+
+    def test_inline_code_no_hardcoded_black_bg(self):
+        """Regression guard: \\033[40m (indexed black bg) must never appear
+        in default-processor output across a representative set of inline
+        code inputs. The entire bug the plan fixes is 'hardcoded black bg'
+        — locking this in prevents regression."""
+        p = MarkdownStreamProcessor()
+        for text in self._INLINE_CODE_INPUTS:
+            out = p.feed_line(text)
+            assert "\033[40m" not in out, (
+                f"Unexpected hardcoded black bg in output for {text!r}: {out!r}"
+            )
+            # Belt-and-braces: the legacy combined escape must also be gone.
+            assert "\033[1;36;40m" not in out
+
+    def test_inline_code_bg_from_skin(self):
+        """When the skin supplies bg + fg (bold + 38;2;R;G;B + 48;2;R;G;B),
+        the whole escape must land verbatim around each code span."""
+        # bold + banner_accent-ish fg + panel-tint bg
+        sentinel = "\033[1;38;2;44;94;160;48;2;232;237;243m"
+        p = MarkdownStreamProcessor(inline_code_ansi=sentinel)
+        out = p.feed_line("Use `foo()` here")
+        assert sentinel in out
+        assert "foo()" in _strip_ansi(out)

--- a/tests/test_markdown_stream.py
+++ b/tests/test_markdown_stream.py
@@ -3,7 +3,7 @@
 import re
 import pytest
 
-from hermes_cli.markdown_stream import MarkdownStreamProcessor, render_markdown_rich
+from hermes_cli.markdown_stream import MarkdownStreamProcessor
 
 # Helpers
 _ANSI_RE = re.compile(r"\033\[[0-9;]*m")
@@ -455,6 +455,21 @@ class TestTableRendering:
         data_lines = [l for l in lines if "│" in l and "─" not in l]
         assert len(data_lines) >= 2
 
+    def test_wide_table_falls_back_within_caller_width(self):
+        p = MarkdownStreamProcessor(max_width=32)
+        p.feed_line("| Name | Description |")
+        p.feed_line("| --- | --- |")
+        p.feed_line("| Hermes | A deliberately long description that cannot fit |")
+
+        tail = p.flush()
+        assert tail is not None
+        plain = _strip_ansi(tail)
+
+        assert "Name:" in plain
+        assert "Description:" in plain
+        assert "┌" not in plain
+        assert all(len(line) <= 32 for line in plain.splitlines())
+
     def test_table_strips_inline_markers(self):
         """Bold/italic/code markers in cells should be stripped."""
         p = MarkdownStreamProcessor()
@@ -653,22 +668,6 @@ class TestStreamingSequence:
 
         # No open block at end
         assert p.flush() is None
-
-
-# =========================================================================
-# Non-streaming helper
-# =========================================================================
-
-class TestRenderMarkdownRich:
-    def test_returns_rich_markdown(self):
-        from rich.markdown import Markdown
-        result = render_markdown_rich("# Hello\n\nWorld")
-        assert isinstance(result, Markdown)
-
-    def test_custom_theme(self):
-        result = render_markdown_rich("```python\nx=1\n```", pygments_theme="nord")
-        from rich.markdown import Markdown
-        assert isinstance(result, Markdown)
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Revives Pascal Comte's closed streaming-renderer PR #5617 on current `main`, then fixes width-accounting and compatibility gaps found while validating it in the classic Python/prompt_toolkit CLI.

The streaming path now:

- renders headings, emphasis, links, lists, blockquotes, inline code, and fenced code as lines arrive
- syntax-highlights fenced code with skin-aware Pygments themes
- keeps fenced-code chrome inside the width supplied by the caller
- keeps wide streamed tables inside that same budget by reusing the existing vertical key-value fallback
- uses the existing `display.final_response_markdown` setting as the single `render` / `strip` / `raw` source of truth
- adds `/markdown` (`/md`) as a render/strip toggle

The concrete width bug reproduced in a 140-column tmux pane: the inner `python` fence consumed the full terminal width, then caller indentation was prepended, wrapping its final border cells onto another row. `MarkdownStreamProcessor` now receives and honors the caller's actual content width.

### Provenance and overlap

This is explicitly a superseding revival of closed PR #5617, not a claim that the renderer is new work. The feature commit preserves Pascal Comte's authorship.

It is adapted to current `main` rather than restoring the old branch verbatim:

- `DEFAULT_CONFIG` now lives in `hermes_cli/config_defaults.py`
- current `main` already owns completed-response rendering through `_render_final_assistant_content()` and `display.final_response_markdown`; this PR retains that path and its table/Windows-path normalization rather than adding a second completed-response renderer
- streamed wide tables reuse `agent.markdown_tables.realign_markdown_tables()` and its existing vertical fallback
- current streaming output is flush-left, while regression coverage also protects callers that prepend indentation

There is substantial overlap in this feature area. I reviewed #16691, #12836, #5084, #4513, and #1986:

- #16691 improves the current print/scroll Markdown path but explicitly does not add a standalone streaming renderer or `/markdown` toggle
- #12836 overlaps final and streaming Markdown rendering, but uses a different implementation and does not cover the caller-width fence/table regressions addressed here
- #5084 and #4513 are broader/stacked rich-output efforts

This PR does not attempt the managed-buffer navigation or broad TUI refactor described by #684. Its scope is the classic CLI's existing line-buffer/scrollback streaming path.

## Related Issue

Phase-1 streaming Markdown work for #684.

Supersedes/revives #5617; related to #16691, #12836, #5084, #4513, and #1986.

## Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `hermes_cli/markdown_stream.py`: stateful streaming Markdown-to-ANSI renderer, syntax highlighting, width-aware fences, and width-safe table fallback
- `cli.py`: integrate the processor into the existing stream path; retain the established completed-response normalization path; emit every row of multi-line table fallbacks through the caller's indentation/flush-left path; add `/markdown`
- `hermes_cli/cli_commands_mixin.py`: keep background-task final Markdown on the same active Pygments theme as foreground responses
- `hermes_cli/config_defaults.py`: optional `display.code_theme`
- `hermes_cli/commands.py`: register `/markdown` and `/md`
- `hermes_cli/skin_engine.py`: expose an optional per-skin code theme
- `cli-config.yaml.example`: document Markdown modes and code-theme selection
- tests: renderer behavior, malformed input, tables, fences, syntax highlighting, command persistence, caller padding, final-render normalization/theme, and defensive skin-color conversion

## How to Test

```bash
ulimit -n 4096
uv run --extra dev pytest \
  tests/test_markdown_stream.py \
  tests/cli/test_cli_markdown_rendering.py \
  tests/cli/test_stream_flush_left.py \
  tests/cli/test_stream_delta_think_tag.py \
  tests/cli/test_markdown_command.py \
  tests/cli/test_hex_to_truecolor.py \
  tests/cli/test_cli_approval_ui.py::TestCliApprovalUi::test_background_task_registers_thread_local_approval_callbacks -q

uv run --extra dev ruff check \
  cli.py hermes_cli/markdown_stream.py \
  hermes_cli/cli_commands_mixin.py \
  tests/test_markdown_stream.py \
  tests/cli/test_cli_markdown_rendering.py \
  tests/cli/test_stream_flush_left.py \
  tests/cli/test_markdown_command.py \
  tests/cli/test_cli_approval_ui.py
```

Verified on macOS 15.7.7:

```text
136 passed in 3.25s
ruff: All checks passed
```

Broader classic-CLI result:

```text
835 passed, 1 skipped, 3 failed in 87.92s
```

The three failures are the existing OSC-52 `/copy` mock expectations in `tests/cli/test_cli_copy_command.py`; all three reproduce unchanged on a detached clean `origin/main` worktree (`3 failed, 2 passed`).

Live 140-column tmux validation after the fix showed the labelled inner fence at 138 visible cells and its footer at 137, with no detached/wrapped border row. A wide table switched to vertical fallback with every row retaining the caller's output alignment. Syntax highlighting remained active.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commits follow Conventional Commits
- [x] I searched existing PRs and documented the overlap/provenance above
- [x] The PR contains only streaming-Markdown integration and correctness work
- [ ] I've run `pytest tests/ -q` and all tests pass — three unrelated baseline `/copy` failures are documented above
- [x] I've added regression tests
- [x] I've tested on macOS 15.7.7 under tmux

### Documentation & Housekeeping

- [x] Relevant docs/docstrings are updated
- [x] `cli-config.yaml.example` is updated
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform width and Windows path behavior were considered and tested
- [x] Tool descriptions/schemas are N/A

## Screenshots / Logs

Manual tmux/ANSI validation confirmed heading/bold styling, themed inline-code colors, distinct Pygments token colors, and no inner-fence wrapping at 140 columns. A separate 72-column live run rendered an over-wide Markdown table through the vertical fallback (`Name: Hermes`, wrapped `Description:` value); its longest captured row was exactly 72 cells and the disposable session was cleaned up.

