### PR TITLE
fix(gateway): report host model in proxy-mode /new banner

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17419,14 +17419,104 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return self._format_session_info()
         return self._format_session_info()
 
+    def _probe_proxy_serving_identity(self) -> Optional[Dict[str, str]]:
+        """Ask the proxy host which model/provider it is currently serving.
+
+        Thin proxy gateways (``GATEWAY_PROXY_URL`` / ``gateway.proxy_url``)
+        often have no local ``model:`` block by design — the host runs
+        inference. The /new banner must report the *serving* identity, not
+        the container's empty config (#75238, same invariant as #59003).
+
+        Probes ``GET {proxy}/api/model/options`` (Bearer ``GATEWAY_PROXY_KEY``
+        when set). Prefers top-level ``model``/``provider``; falls back to the
+        ``providers[].is_current`` row. Returns ``None`` on any failure so the
+        caller can degrade honestly instead of guessing.
+        """
+        proxy_url = self._get_proxy_url()
+        if not proxy_url:
+            return None
+
+        import json
+        import urllib.request
+
+        url = f"{proxy_url.rstrip('/')}/api/model/options"
+        headers = {"Accept": "application/json"}
+        proxy_key = os.getenv("GATEWAY_PROXY_KEY", "").strip()
+        if proxy_key:
+            headers["Authorization"] = f"Bearer {proxy_key}"
+        req = urllib.request.Request(url, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=2.0) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+            payload = json.loads(raw)
+        except Exception:
+            logger.debug(
+                "proxy model-options probe failed for %s", proxy_url, exc_info=True,
+            )
+            return None
+        if not isinstance(payload, dict):
+            return None
+
+        model = str(payload.get("model") or "").strip()
+        provider = str(payload.get("provider") or "").strip()
+        if not model or not provider:
+            for row in payload.get("providers") or []:
+                if not isinstance(row, dict) or not row.get("is_current"):
+                    continue
+                if not provider:
+                    provider = str(row.get("slug") or row.get("name") or "").strip()
+                if not model:
+                    models = row.get("models") or []
+                    if models:
+                        model = str(models[0]).strip()
+                    current = row.get("current_model") or row.get("model")
+                    if current:
+                        model = str(current).strip()
+                break
+        if not model and not provider:
+            return None
+        return {
+            "model": model or "unknown",
+            "provider": provider or "unknown",
+        }
+
     def _format_session_info(self) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
+
+        In proxy mode the serving model lives on the host; local config is
+        often intentionally empty, so we probe the host instead of
+        advertising empty backticks + a hardcoded openrouter fallback (#75238).
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
+
+        # Proxy path first: never fall through to the local-config banner when
+        # GATEWAY_PROXY_URL is set — that path is known to be dishonest for
+        # thin containers (#75238).
+        try:
+            proxy_url = self._get_proxy_url()
+        except Exception:
+            proxy_url = None
+        if proxy_url:
+            host = None
+            try:
+                host = self._probe_proxy_serving_identity()
+            except Exception:
+                logger.debug("proxy serving-identity probe raised", exc_info=True)
+            if host:
+                return "\n".join([
+                    f"◆ Model: `{host['model']}`",
+                    f"◆ Provider: {host['provider']}",
+                    "◆ Context: managed by host",
+                ])
+            return "\n".join([
+                "◆ Model: `unknown`",
+                "◆ Provider: unknown (host unreachable — may be stale)",
+                "◆ Context: managed by host",
+            ])
 
         model = _resolve_gateway_model()
         config_context_length = None

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -102,3 +102,102 @@ class TestResetNoticeSessionInfo:
         assert "anthropic" in info
         assert "base-model" not in info
 
+
+class TestProxyModeSessionInfo:
+    """#75238: proxy-mode /new banner must report the host's serving model,
+    not the thin container's empty local config."""
+
+    def test_proxy_uses_host_identity(self, runner, tmp_path):
+        # Local config deliberately empty — the Matrix E2EE thin-container shape.
+        p1, p2, p3 = _patch_info(tmp_path, "gateway:\n  proxy_url: http://host.example:8642\n",
+                                  "",
+                                  {"provider": "", "base_url": "", "api_key": ""})
+        with p1, p2, p3, \
+             patch.object(GatewayRunner, "_get_proxy_url", return_value="http://host.example:8642"), \
+             patch.object(
+                 GatewayRunner,
+                 "_probe_proxy_serving_identity",
+                 return_value={"model": "gpt-5.6-sol", "provider": "openai-codex"},
+             ):
+            info = runner._format_session_info()
+        assert "gpt-5.6-sol" in info
+        assert "openai-codex" in info
+        assert "managed by host" in info
+        assert "openrouter" not in info.lower()
+        assert "model.context_length" not in info
+
+    def test_proxy_probe_failure_degrades_honestly(self, runner, tmp_path):
+        p1, p2, p3 = _patch_info(tmp_path, None, "", {"provider": "", "base_url": "", "api_key": ""})
+        with p1, p2, p3, \
+             patch.object(GatewayRunner, "_get_proxy_url", return_value="http://host.example:8642"), \
+             patch.object(GatewayRunner, "_probe_proxy_serving_identity", return_value=None):
+            info = runner._format_session_info()
+        assert "unknown" in info
+        assert "host unreachable" in info
+        assert "managed by host" in info
+        # Must not invent openrouter or a config-edit hint the host won't read.
+        assert "openrouter" not in info.lower()
+        assert "model.context_length" not in info
+
+    def test_probe_prefers_top_level_model_provider(self, runner, monkeypatch):
+        import io
+        import json
+
+        payload = {
+            "model": "host-model",
+            "provider": "host-provider",
+            "providers": [
+                {"slug": "other", "is_current": False, "models": ["x"]},
+                {"slug": "host-provider", "is_current": True, "models": ["host-model"]},
+            ],
+        }
+        body = json.dumps(payload).encode()
+
+        class _Resp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, timeout=None):
+            assert req.full_url.endswith("/api/model/options")
+            assert req.get_header("Authorization") == "Bearer secret-key"
+            r = _Resp(body)
+            r.status = 200
+            return r
+
+        monkeypatch.setenv("GATEWAY_PROXY_KEY", "secret-key")
+        with patch.object(GatewayRunner, "_get_proxy_url", return_value="http://host.example:8642"), \
+             patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            identity = runner._probe_proxy_serving_identity()
+        assert identity == {"model": "host-model", "provider": "host-provider"}
+
+    def test_probe_falls_back_to_is_current_row(self, runner, monkeypatch):
+        import io
+        import json
+
+        payload = {
+            "model": "",
+            "provider": "",
+            "providers": [
+                {"slug": "openai-codex", "is_current": True, "models": ["gpt-5.6-sol"]},
+            ],
+        }
+        body = json.dumps(payload).encode()
+
+        class _Resp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, timeout=None):
+            return _Resp(body)
+
+        with patch.object(GatewayRunner, "_get_proxy_url", return_value="http://host.example:8642"), \
+             patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            identity = runner._probe_proxy_serving_identity()
+        assert identity == {"model": "gpt-5.6-sol", "provider": "openai-codex"}
+


### PR DESCRIPTION
## Bug

In proxy mode (`GATEWAY_PROXY_URL`), `/new` and `/reset` print a session banner from the **local** container config. Thin Matrix E2EE containers intentionally have no `model:` block, so the banner showed:

```
◆ Model: ``
◆ Provider: openrouter
◆ Context: 256K tokens (default — set model.context_length in config to override)
```

while the host was serving something else (e.g. `gpt-5.6-sol` via `openai-codex`).

Fixes #75238

Same invariant as #59003: the banner must report the **serving** model.

## Fix

When `_get_proxy_url()` is set:

1. `GET {proxy}/api/model/options` with optional `GATEWAY_PROXY_KEY`
2. Prefer top-level `model` / `provider`
3. Fall back to the `providers[].is_current` row
4. On failure: `unknown` + `host unreachable — may be stale` (no openrouter guess)
5. Context line is `managed by host` — never tells users to edit a config the host ignores

Non-proxy path unchanged.

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_session_info.py` — 9 passed
- [x] ruff clean on touched files
- [ ] Upstream CI

## Risk

Low. Proxy-only branch; local banner path untouched. Probe timeout is 2s and only runs on `/new`/`/reset` info formatting (already off the event loop via `asyncio.to_thread` for the reset notice).
