### PR TITLE
fix(web): recognize Brave in subscription feature detection

### DIFF
--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -460,6 +460,7 @@ def get_nous_subscription_features(
         direct_exa = False
         direct_parallel = False
         direct_tavily = False
+        direct_searxng = False
         direct_brave = False
     if image_use_gateway:
         direct_fal = False

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -428,6 +428,7 @@ def get_nous_subscription_features(
     direct_parallel = bool(get_env_value("PARALLEL_API_KEY"))
     direct_tavily = bool(get_env_value("TAVILY_API_KEY"))
     direct_searxng = bool(get_env_value("SEARXNG_URL"))
+    direct_brave = bool(get_env_value("BRAVE_SEARCH_API_KEY"))
     direct_fal = fal_key_is_configured()
     direct_fal_video = direct_fal  # same FAL_KEY; separate var so use_gateway is independent
     direct_openai_tts = bool(resolve_openai_audio_api_key())
@@ -459,6 +460,7 @@ def get_nous_subscription_features(
         direct_exa = False
         direct_parallel = False
         direct_tavily = False
+        direct_brave = False
     if image_use_gateway:
         direct_fal = False
     if video_use_gateway:
@@ -535,6 +537,7 @@ def get_nous_subscription_features(
             or (web_backend == "parallel" and direct_parallel)
             or (web_backend == "tavily" and direct_tavily)
             or (web_backend == "searxng" and direct_searxng)
+            or (web_backend == "brave-free" and direct_brave)
             # Per-capability overrides: search_backend or extract_backend may be set
             # without web.backend (using the new split config from #20061)
             or (web_search_backend == "searxng" and direct_searxng)
@@ -542,10 +545,17 @@ def get_nous_subscription_features(
             or (web_search_backend == "firecrawl" and direct_firecrawl)
             or (web_search_backend == "parallel" and direct_parallel)
             or (web_search_backend == "tavily" and direct_tavily)
+            or (web_search_backend == "brave-free" and direct_brave)
         )
     )
     web_available = bool(
-        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng
+        managed_web_available
+        or direct_exa
+        or direct_firecrawl
+        or direct_parallel
+        or direct_tavily
+        or direct_searxng
+        or direct_brave
     )
 
     image_managed = image_tool_enabled and managed_image_available and not direct_fal

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -298,6 +298,7 @@ def _web_feature(web_cfg: Dict[str, object], tool_enabled: bool, managed: bool, 
         "tavily": (_any_env("TAVILY_API_KEY") or "tavily" in {backend, search_backend, extract_backend}) and not web_gw,
         "perplexity": _any_env("PERPLEXITY_API_KEY") and not web_gw,
         "searxng": _any_env("SEARXNG_URL"),
+        "brave-free": _any_env("BRAVE_SEARCH_API_KEY") and not web_gw,
     }
     web_managed = backend == "firecrawl" and managed and not direct_firecrawl
     active = web_managed or direct.get(backend) or direct.get(search_backend) or (extract_backend in ("tavily", "perplexity") and direct[extract_backend])

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -297,7 +297,7 @@ def _web_feature(web_cfg: Dict[str, object], tool_enabled: bool, managed: bool, 
         "parallel": _any_env("PARALLEL_API_KEY") and not web_gw,
         "tavily": (_any_env("TAVILY_API_KEY") or "tavily" in {backend, search_backend, extract_backend}) and not web_gw,
         "perplexity": _any_env("PERPLEXITY_API_KEY") and not web_gw,
-        "searxng": _any_env("SEARXNG_URL"),
+        "searxng": _any_env("SEARXNG_URL") and not web_gw,
         "brave-free": _any_env("BRAVE_SEARCH_API_KEY") and not web_gw,
     }
     web_managed = backend == "firecrawl" and managed and not direct_firecrawl

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -55,6 +55,29 @@ def test_get_nous_subscription_features_recognizes_direct_exa_backend(monkeypatc
     assert features.web.current_provider == "exa"
 
 
+def test_get_nous_subscription_features_recognizes_direct_brave_backend(monkeypatch):
+    env = {"BRAVE_SEARCH_API_KEY": "brave-test"}
+
+    monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "web")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+
+    features = ns.get_nous_subscription_features(
+        {"web": {"backend": "brave-free"}}
+    )
+
+    assert features.web.available is True
+    assert features.web.active is True
+    assert features.web.managed_by_nous is False
+    assert features.web.direct_override is True
+    assert features.web.current_provider == "brave-free"
+
+
 
 
 def _stub_browser_probes(monkeypatch, *, has_agent_browser, chromium, lightpanda=False):

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -78,6 +78,73 @@ def test_get_nous_subscription_features_recognizes_direct_brave_backend(monkeypa
     assert features.web.current_provider == "brave-free"
 
 
+def test_get_nous_subscription_features_recognizes_direct_brave_search_backend(
+    monkeypatch,
+):
+    env = {"BRAVE_SEARCH_API_KEY": "brave-test"}
+
+    monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "web")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+
+    features = ns.get_nous_subscription_features(
+        {"web": {"search_backend": "brave-free"}}
+    )
+
+    assert features.web.available is True
+    assert features.web.active is True
+    assert features.web.managed_by_nous is False
+    assert features.web.direct_override is True
+    assert features.web.current_provider == "brave-free"
+
+
+def test_web_use_gateway_suppresses_direct_brave_override(monkeypatch):
+    env = {"BRAVE_SEARCH_API_KEY": "brave-test"}
+
+    monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "web")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+
+    features = ns.get_nous_subscription_features(
+        {"web": {"backend": "brave-free", "use_gateway": True}}
+    )
+
+    assert features.web.available is False
+    assert features.web.active is False
+    assert features.web.direct_override is False
+
+
+def test_web_use_gateway_suppresses_direct_searxng_override(monkeypatch):
+    env = {"SEARXNG_URL": "https://search.example.test"}
+
+    monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda: _account(logged_in=False)
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "web")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+
+    features = ns.get_nous_subscription_features(
+        {"web": {"backend": "searxng", "use_gateway": True}}
+    )
+
+    assert features.web.available is False
+    assert features.web.active is False
+    assert features.web.direct_override is False
+
+
 
 
 def _stub_browser_probes(monkeypatch, *, has_agent_browser, chromium, lightpanda=False):

--- a/tests/hermes_cli/test_nous_subscription_web.py
+++ b/tests/hermes_cli/test_nous_subscription_web.py
@@ -1,0 +1,74 @@
+"""Web feature status follows direct credentials and explicit gateway selection."""
+
+import json
+
+import pytest
+
+from hermes_cli import nous_subscription as ns
+from hermes_cli.nous_account import NousPortalAccountInfo
+
+
+@pytest.fixture
+def web_profile(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for name in ("BRAVE_SEARCH_API_KEY", "SEARXNG_URL"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+
+    def configure(web, *, credentials="", enabled=True, gateway_ready=False):
+        (tmp_path / ".env").write_text(credentials, encoding="utf-8")
+        (tmp_path / "config.yaml").write_text(
+            json.dumps({
+                "web": web,
+                "platform_toolsets": {"cli": ["web"] if enabled else ["file"]},
+            }),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            ns, "get_nous_portal_account_info",
+            lambda: NousPortalAccountInfo(
+                logged_in=gateway_ready, source="jwt" if gateway_ready else "none",
+                fresh=False, paid_service_access=gateway_ready,
+            ),
+        )
+        monkeypatch.setattr(ns, "is_managed_tool_gateway_ready", lambda backend: gateway_ready)
+        # Real config, credential and toolset loaders; only remote/account and
+        # unrelated local browser probes are stubbed.
+        return ns.get_nous_subscription_features().web
+
+    return configure
+
+
+@pytest.mark.parametrize("selection_key", ["backend", "search_backend"])
+@pytest.mark.parametrize("has_key", [False, True])
+@pytest.mark.parametrize("enabled", [False, True])
+def test_direct_brave_status_tracks_credentials_and_toolset(web_profile, selection_key, has_key, enabled):
+    web = web_profile(
+        {selection_key: "brave-free"},
+        credentials="BRAVE_SEARCH_API_KEY=brave-test\n" if has_key else "",
+        enabled=enabled,
+    )
+    assert web.available is has_key
+    assert web.active is (has_key and enabled)
+    assert web.direct_override is (has_key and enabled)
+    assert web.managed_by_nous is False
+    assert web.current_provider == "brave-free"
+    assert web.explicit_configured is True
+
+
+@pytest.mark.parametrize("backend,credentials", [
+    ("brave-free", "BRAVE_SEARCH_API_KEY=brave-test\n"),
+    ("searxng", "SEARXNG_URL=https://search.example.test\n"),
+])
+@pytest.mark.parametrize("gateway_ready", [False, True])
+@pytest.mark.parametrize("legacy", [False, True])
+def test_gateway_selection_suppresses_direct_search_credentials(web_profile, backend, credentials, gateway_ready, legacy):
+    selection = {"backend": "nous", "search_backend": backend}
+    if legacy:
+        selection = {"backend": backend, "search_backend": backend, "use_gateway": True}
+    web = web_profile(selection, credentials=credentials, gateway_ready=gateway_ready)
+    assert web.available is gateway_ready
+    assert web.active is gateway_ready
+    assert web.managed_by_nous is gateway_ready
+    assert web.direct_override is False
+    assert web.current_provider == "firecrawl"


### PR DESCRIPTION
## Related Issue

No dedicated issue found. Brave Search support was added in #21337, but the subscription feature detector did not include it.

## Summary

A configured `brave-free` backend already works at runtime, but `get_nous_subscription_features()` ignored `BRAVE_SEARCH_API_KEY`. As a result, setup could warn that web search was unavailable even while Brave searches succeeded.

This PR aligns Brave with the existing direct-provider detection used for Exa, Parallel, Tavily, Firecrawl, and SearXNG.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Documentation
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Test Improvement

## Changes

- detect a direct Brave credential in subscription feature discovery
- suppress that direct override when `web.use_gateway` explicitly selects managed routing
- recognize Brave for both the shared `web.backend` and split `web.search_backend` configuration paths
- preserve `web.use_gateway` precedence for direct SearXNG credentials as well
- add focused regression tests for the Brave backend, split search backend, Brave gateway precedence, and SearXNG gateway precedence paths

## How to Test

```bash
HERMES_PYTHON=/path/to/dev-venv/bin/python \
  scripts/run_tests.sh tests/hermes_cli/test_nous_subscription.py

/path/to/dev-venv/bin/ruff check \
  hermes_cli/nous_subscription.py \
  tests/hermes_cli/test_nous_subscription.py
```

A manual feature-state smoke test with an isolated `HERMES_HOME`, a placeholder Brave credential, and `web.backend: brave-free` returned:

```text
available=True
active=True
direct_override=True
provider=brave-free
```

## Why This Approach

The runtime already treats `brave-free` as a native direct search backend. Keeping the fix in the feature detector is the smallest change and avoids modifying provider selection or request behavior. It also preserves the existing `web.use_gateway` precedence.

## Verification

- initial regression test failed before the production change with `web.available == False`
- review-follow-up RED: the SearXNG gateway-precedence test failed because the direct credential remained active; the two new Brave coverage cases already passed
- canonical focused suite: `9 passed, 0 failed`
- Ruff, `py_compile`, and `git diff --check`: passed
- canonical full-suite attempt produced 49 failures in 17 unrelated test files; the exact same 49 failures were reproduced on a clean `origin/main` worktree in the same environment (primarily unavailable optional SDKs with lazy installs disabled)
- GitHub CI passed on the review-follow-up head, including all eight Python test slices, Python e2e, Ruff/ty, Desktop Playwright E2E, supply-chain checks, and both amd64/arm64 Docker builds

## Checklist

- [x] I have read and followed the project's contribution guidelines
- [x] My code follows the project's style conventions
- [x] I have added tests that prove the fix
- [x] The focused test suite passes locally
- [ ] The complete existing test suite passes locally (see baseline-equivalent failures above)
- [x] I have not included secrets or credentials
- [x] This change is backward compatible

## Platform Tested

- Linux x86_64 development checkout based on current `origin/main`
- Original runtime reproduction and post-fix smoke test: Debian 13 ARM64, Hermes v0.19.0
