### PR TITLE
feat(api): bind run approvals to exact identities

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -812,7 +812,14 @@ def init_agent(
     agent.provider_data_collection = provider_data_collection
     agent.openrouter_min_coding_score = openrouter_min_coding_score
 
-    # Store toolset filtering options
+    # Store the authoritative toolset selection, not a mixed caller input.
+    # Exact composites must remain authority boundaries for later refresh and
+    # delegated-child narrowing paths as well as initial schema assembly.
+    if enabled_toolsets is not None:
+        from toolsets import authoritative_toolset_selection
+        enabled_toolsets = authoritative_toolset_selection(
+            list(enabled_toolsets)
+        )
     agent.enabled_toolsets = enabled_toolsets
     agent.disabled_toolsets = disabled_toolsets
     

--- a/cli.py
+++ b/cli.py
@@ -4191,6 +4191,23 @@ class _VoiceInputMessage:
         return self.text
 
 
+def _merge_reload_mcp_toolsets(enabled_toolsets, connected_servers):
+    """Return the safe enabled-toolset override for an MCP reload."""
+    if not enabled_toolsets or "all" in enabled_toolsets or "*" in enabled_toolsets:
+        return None
+    from toolsets import (
+        authoritative_toolset_selection,
+        has_exact_toolset_selection,
+    )
+    merged = authoritative_toolset_selection(list(enabled_toolsets))
+    if has_exact_toolset_selection(merged):
+        return merged
+    for name in sorted(connected_servers):
+        if name not in merged:
+            merged.append(name)
+    return merged
+
+
 class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     """
     Interactive CLI for the Hermes Agent.
@@ -11483,14 +11500,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # user pinned `all`/`*`, which already includes everything) so a
                 # freshly-added server isn't filtered out. Mirrors startup, where
                 # MCP server names are part of enabled_toolsets (see __init__).
-                enabled_override = None
                 et = self.enabled_toolsets
-                if et and "all" not in et and "*" not in et:
-                    merged = list(et)
-                    for _name in sorted(connected_servers):
-                        if _name not in merged:
-                            merged.append(_name)
-                    enabled_override = merged
+                enabled_override = _merge_reload_mcp_toolsets(
+                    et, connected_servers
+                )
                 refresh_agent_mcp_tools(
                     self.agent,
                     enabled_override=enabled_override,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -195,7 +195,14 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
         add nothing further (the user named exactly the servers they want)
       * otherwise -> union in every globally-enabled MCP server
     """
-    result = [t for t in per_job if t != "no_mcp"]
+    from toolsets import (
+        authoritative_toolset_selection,
+        has_exact_toolset_selection,
+    )
+    stripped = [t for t in per_job if t != "no_mcp"]
+    result = authoritative_toolset_selection(stripped)
+    if result != stripped or has_exact_toolset_selection(result):
+        return result
     if "no_mcp" in per_job:
         return result
     # lazy import: avoid heavy hermes_cli import at cron module load (matches

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -69,9 +69,14 @@ _api_request_profile: ContextVar[Optional[str]] = ContextVar(
 )
 
 def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> list[str]:
-    if smart_denied:
-        return ["once", "deny"]
-    return ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
+    """Choices supported by the identity-bound /v1/runs approval protocol.
+
+    Backend approval capabilities may include session or permanent grants for
+    interactive gateway clients, but this endpoint's resolver and advertised
+    contract intentionally accept only one-shot approval or denial.
+    """
+    del smart_denied, allow_permanent
+    return ["once", "deny"]
 
 
 try:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1845,6 +1845,11 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/runs/{run_id}", self._handle_get_run),
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
             ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
+            (
+                "POST",
+                "/v1/runs/{run_id}/approvals/{approval_id}",
+                self._handle_identity_bound_run_approval,
+            ),
             ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run),
         ]
         if _CRON_AVAILABLE:
@@ -2861,6 +2866,14 @@ class APIServerAdapter(BasePlatformAdapter):
                     "explicit split-runtime mode is enabled."
                 ),
             },
+            "protocols": {
+                "run_approval_identity_binding": {
+                    "version": 1,
+                    "method": "POST",
+                    "path": "/v1/runs/{run_id}/approvals/{approval_id}",
+                    "choices": ["once", "deny"],
+                },
+            },
             "features": {
                 "chat_completions": True,
                 "chat_completions_streaming": True,
@@ -2871,6 +2884,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
+                "run_approval_identity_binding": True,
                 "tool_progress_events": True,
                 "approval_events": True,
                 "session_resources": True,
@@ -2900,6 +2914,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
+                "run_approval_identity": {
+                    "method": "POST",
+                    "path": "/v1/runs/{run_id}/approvals/{approval_id}",
+                },
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
                 "skills": {"method": "GET", "path": "/v1/skills"},
                 "toolsets": {"method": "GET", "path": "/v1/toolsets"},
@@ -6080,6 +6098,41 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return _callback
 
+    def _schedule_run_approval_request(
+        self,
+        run_id: str,
+        loop: "asyncio.AbstractEventLoop",
+        queue: "asyncio.Queue[Optional[Dict]]",
+        approval_data: Dict[str, Any],
+    ) -> None:
+        """Serialize approval request status and SSE publication on the run loop."""
+        event = dict(approval_data or {})
+        if "command" in event:
+            from gateway.run import _redact_approval_command
+
+            event["command"] = _redact_approval_command(event.get("command"))
+        event.update({
+            "event": "approval.request",
+            "run_id": run_id,
+            "timestamp": time.time(),
+            "choices": _approval_event_choices(
+                smart_denied=bool(event.get("smart_denied")),
+                allow_permanent=event.get("allow_permanent") is not False,
+            ),
+        })
+
+        def _publish() -> None:
+            if self._run_streams.get(run_id) is not queue:
+                return
+            self._set_run_status(
+                run_id,
+                "waiting_for_approval",
+                last_event="approval.request",
+            )
+            queue.put_nowait(event)
+
+        loop.call_soon_threadsafe(_publish)
+
     @_admit_api_agent_request
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
@@ -6248,31 +6301,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents[run_id] = agent
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
-                    event = dict(approval_data or {})
-                    # Redact credentials from the command before it enters the
-                    # SSE/API event stream — same egress bug as #48456, second
-                    # transport: API/desktop clients would otherwise receive the
-                    # raw command Tirith flagged. Reuse the gateway seam.
-                    if "command" in event:
-                        from gateway.run import _redact_approval_command
-
-                        event["command"] = _redact_approval_command(event.get("command"))
-                    event.update({
-                        "event": "approval.request",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "choices": _approval_event_choices(
-                            smart_denied=bool(event.get("smart_denied")),
-                            allow_permanent=event.get("allow_permanent") is not False,
-                        ),
-                    })
-                    self._set_run_status(
-                        run_id,
-                        "waiting_for_approval",
-                        last_event="approval.request",
-                    )
                     try:
-                        loop.call_soon_threadsafe(q.put_nowait, event)
+                        self._schedule_run_approval_request(
+                            run_id,
+                            loop,
+                            q,
+                            approval_data,
+                        )
                     except Exception:
                         pass
 
@@ -6544,6 +6579,118 @@ class APIServerAdapter(BasePlatformAdapter):
         return response
 
 
+    async def _handle_identity_bound_run_approval(
+        self,
+        request: "web.Request",
+    ) -> "web.Response":
+        """Resolve one exact approval through a legacy-incompatible route."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        run_id = request.match_info["run_id"]
+        if self._run_statuses.get(run_id) is None:
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
+
+        approval_id = request.match_info.get("approval_id", "")
+        if re.fullmatch(r"[0-9a-f]{32}", approval_id) is None:
+            return web.json_response(
+                _openai_error(
+                    "Invalid approval_id; expected 32 lowercase hexadecimal characters",
+                    code="invalid_approval_id",
+                ),
+                status=400,
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if not isinstance(body, dict) or set(body) != {"choice"}:
+            return web.json_response(
+                _openai_error(
+                    "Identity-bound approval accepts only a choice field",
+                    code="invalid_identity_approval_request",
+                ),
+                status=400,
+            )
+        choice = body.get("choice")
+        if choice not in {"once", "deny"}:
+            return web.json_response(
+                _openai_error(
+                    "Identity-bound approval choice must be once or deny",
+                    code="invalid_identity_approval_choice",
+                ),
+                status=400,
+            )
+
+        approval_session_key = self._run_approval_sessions.get(run_id)
+        if not approval_session_key:
+            return web.json_response(
+                _openai_error(
+                    f"Run has no active approval session: {run_id}",
+                    code="approval_not_active",
+                ),
+                status=409,
+            )
+
+        try:
+            from tools.approval import resolve_gateway_approval_identity
+
+            result = resolve_gateway_approval_identity(
+                approval_session_key,
+                choice,
+                approval_id,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[api_server] identity approval resolution failed for run %s",
+                run_id,
+            )
+            return web.json_response(_openai_error(str(exc)), status=500)
+
+        if result.resolved != 1:
+            return web.json_response(
+                _openai_error(
+                    f"Run has no matching pending approval: {run_id}",
+                    code="approval_not_pending",
+                ),
+                status=409,
+            )
+
+        self._set_run_status(
+            run_id,
+            "waiting_for_approval" if result.pending else "running",
+            last_event="approval.responded",
+        )
+        response_event = {
+            "event": "approval.responded",
+            "run_id": run_id,
+            "timestamp": time.time(),
+            "choice": choice,
+            "approval_id": approval_id,
+            "resolved": result.resolved,
+            "pending": result.pending,
+        }
+        q = self._run_streams.get(run_id)
+        if q is not None:
+            try:
+                q.put_nowait(response_event)
+            except Exception:
+                pass
+
+        return web.json_response({
+            "object": "hermes.run.approval_response",
+            "run_id": run_id,
+            "choice": choice,
+            "approval_id": approval_id,
+            "resolved": result.resolved,
+            "pending": result.pending,
+        })
+
     async def _handle_run_approval(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/approval — resolve a pending run approval."""
         auth_err = self._check_auth(request)
@@ -6576,6 +6723,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        if "approval_id" in body:
+            return web.json_response(
+                _openai_error(
+                    "approval_id requires the versioned identity-bound route",
+                    code="identity_requires_versioned_route",
+                ),
+                status=400,
+            )
+
         approval_session_key = self._run_approval_sessions.get(run_id)
         if not approval_session_key:
             return web.json_response(
@@ -6591,13 +6747,14 @@ class APIServerAdapter(BasePlatformAdapter):
             or _coerce_request_bool(body.get("resolve_all"), default=False)
         )
         try:
-            from tools.approval import resolve_gateway_approval
+            from tools.approval import has_blocking_approval, resolve_gateway_approval
 
             resolved = resolve_gateway_approval(
                 approval_session_key,
                 choice,
                 resolve_all=resolve_all,
             )
+            pending = has_blocking_approval(approval_session_key)
         except Exception as exc:
             logger.exception("[api_server] approval resolution failed for run %s", run_id)
             return web.json_response(_openai_error(str(exc)), status=500)
@@ -6611,7 +6768,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=409,
             )
 
-        self._set_run_status(run_id, "running", last_event="approval.responded")
+        self._set_run_status(
+            run_id,
+            "waiting_for_approval" if pending else "running",
+            last_event="approval.responded",
+        )
         q = self._run_streams.get(run_id)
         if q is not None:
             try:
@@ -6621,6 +6782,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": time.time(),
                     "choice": choice,
                     "resolved": resolved,
+                    "pending": pending,
                 })
             except Exception:
                 pass
@@ -6630,6 +6792,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "run_id": run_id,
             "choice": choice,
             "resolved": resolved,
+            "pending": pending,
         })
 
     async def _handle_stop_run(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2848,6 +2848,8 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        from tools.approval import get_run_approval_policy
+
         return web.json_response({
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
@@ -2865,6 +2867,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     "tools execute on the API-server host unless a future "
                     "explicit split-runtime mode is enabled."
                 ),
+            },
+            "security": {
+                "run_approval_policy": get_run_approval_policy(),
             },
             "protocols": {
                 "run_approval_identity_binding": {

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1165,6 +1165,17 @@ class _ProviderAuthResolutionError(RuntimeError):
     """
 
 
+def _configured_disabled_toolsets(config: Dict[str, Any]) -> List[str]:
+    """Return validated global toolset denials for API runtime and attestation."""
+    agent_config = config.get("agent")
+    if not isinstance(agent_config, dict):
+        return []
+    raw = agent_config.get("disabled_toolsets")
+    if not isinstance(raw, (list, tuple, set)):
+        return []
+    return list(dict.fromkeys(str(name) for name in raw if str(name)))
+
+
 class APIServerAdapter(BasePlatformAdapter):
     """
     OpenAI-compatible HTTP API server adapter.
@@ -2633,6 +2644,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        disabled_toolsets = _configured_disabled_toolsets(user_config)
 
         max_iterations = _current_max_iterations()
 
@@ -2653,6 +2665,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "verbose_logging": False,
             "ephemeral_system_prompt": ephemeral_system_prompt or None,
             "enabled_toolsets": enabled_toolsets,
+            "disabled_toolsets": disabled_toolsets,
             "session_id": session_id,
             "platform": "api_server",
             "stream_delta_callback": stream_delta_callback,
@@ -2990,7 +3003,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 _get_platform_tools,
                 _toolset_has_keys,
             )
-            from toolsets import resolve_toolset
+            from toolsets import get_toolset, resolve_toolset
 
             config = load_config()
             enabled_toolsets = _get_platform_tools(
@@ -2998,13 +3011,52 @@ class APIServerAdapter(BasePlatformAdapter):
                 "api_server",
                 include_default_mcp_servers=False,
             )
+            disabled_toolsets = _configured_disabled_toolsets(config)
+            catalog = list(_get_effective_configurable_toolsets())
+            from model_tools import get_tool_definitions
+            effective_runtime_tools = {
+                tool["function"]["name"]
+                for tool in get_tool_definitions(
+                    enabled_toolsets=sorted(enabled_toolsets),
+                    disabled_toolsets=disabled_toolsets,
+                    quiet_mode=True,
+                )
+            }
+            catalog_names = {name for name, _, _ in catalog}
+            platform_config = config.get("platform_toolsets")
+            configured_rows = (
+                platform_config.get("api_server", [])
+                if isinstance(platform_config, dict)
+                else []
+            )
+            configured_exact_names = {
+                str(name)
+                for name in configured_rows
+                if isinstance(name, str)
+                and (get_toolset(name, include_registry=False) or {}).get("exact")
+            }
+            for name in sorted(
+                (enabled_toolsets | configured_exact_names) - catalog_names
+            ):
+                definition = get_toolset(name, include_registry=False)
+                if not definition or not definition.get("exact"):
+                    continue
+                catalog.append((
+                    name,
+                    name,
+                    str(definition.get("description") or "Exact static toolset"),
+                ))
+
             data: List[Dict[str, Any]] = []
-            for name, label, desc in _get_effective_configurable_toolsets():
+            for name, label, desc in catalog:
                 try:
                     tools = sorted(set(resolve_toolset(name)))
                 except Exception:
                     tools = []
                 is_enabled = name in enabled_toolsets
+                definition = get_toolset(name, include_registry=False)
+                if is_enabled and definition and definition.get("exact"):
+                    tools = sorted(set(tools) & effective_runtime_tools)
                 data.append({
                     "name": name,
                     "label": label,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2222,6 +2222,20 @@ def _get_platform_tools(
     # Normalise to str so downstream sorted() never mixes types.
     toolset_names = [str(ts) for ts in toolset_names]
 
+    # An explicitly selected exact toolset is an authored allowlist, so it is
+    # authoritative for the platform. Fail closed on mixed configuration by
+    # ignoring ordinary categories, recently shipped toolsets, plugins, and
+    # default MCP servers rather than allowing any of them to widen the agent
+    # schema. Multiple exact toolsets may be intentionally unioned.
+    exact_toolsets = {
+        ts for ts in toolset_names
+        if bool((TOOLSETS.get(ts) or {}).get("exact"))
+    }
+    if exact_toolsets:
+        agent_cfg = config.get("agent") or {}
+        disabled = {str(ts) for ts in (agent_cfg.get("disabled_toolsets") or [])}
+        return exact_toolsets - disabled
+
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     plugin_ts_keys = _get_plugin_toolset_keys()
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}

--- a/model_tools.py
+++ b/model_tools.py
@@ -364,6 +364,56 @@ def get_tool_definitions(
     return result
 
 
+def resolve_disabled_tool_names(
+    disabled_toolsets: Optional[List[str]],
+    *,
+    quiet_mode: bool = True,
+) -> set[str]:
+    """Resolve denials with the same shared-core preservation as runtime."""
+    tools_to_remove: set[str] = set()
+    for toolset_name in disabled_toolsets or []:
+        if validate_toolset(toolset_name):
+            from toolsets import bundle_non_core_tools, get_toolset
+            if toolset_name.startswith("hermes-") or (
+                get_toolset(toolset_name) or {}
+            ).get("posture"):
+                resolved = sorted(bundle_non_core_tools(toolset_name))
+                if (
+                    not quiet_mode
+                    and toolset_name.startswith("hermes-")
+                    and toolset_name not in _WARNED_DISABLED_BUNDLES
+                ):
+                    _WARNED_DISABLED_BUNDLES.add(toolset_name)
+                    logger.info(
+                        "agent.disabled_toolsets contains platform-bundle "
+                        "name '%s'; core tools are preserved and only its "
+                        "platform-specific tools (%s) are removed. Bundle "
+                        "names usually belong in `toolsets:`, not "
+                        "`disabled_toolsets` (#33924).",
+                        toolset_name,
+                        ", ".join(resolved) if resolved else "none",
+                    )
+            else:
+                resolved = resolve_toolset(toolset_name)
+            tools_to_remove.update(resolved)
+            if not quiet_mode:
+                print(
+                    f"🚫 Disabled toolset '{toolset_name}': "
+                    f"{', '.join(resolved) if resolved else 'no tools'}"
+                )
+        elif toolset_name in _LEGACY_TOOLSET_MAP:
+            legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
+            tools_to_remove.update(legacy_tools)
+            if not quiet_mode:
+                print(
+                    f"🚫 Disabled legacy toolset '{toolset_name}': "
+                    f"{', '.join(legacy_tools)}"
+                )
+        elif not quiet_mode:
+            print(f"⚠️  Unknown toolset: {toolset_name}")
+    return tools_to_remove
+
+
 def _compute_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
@@ -375,11 +425,21 @@ def _compute_tool_definitions(
     tools_to_include: set = set()
 
     if enabled_toolsets is not None:
-        effective_enabled_toolsets = list(enabled_toolsets)
+        from toolsets import (
+            authoritative_toolset_selection,
+            has_exact_toolset_selection,
+        )
+        effective_enabled_toolsets = authoritative_toolset_selection(
+            list(enabled_toolsets)
+        )
+        has_exact_toolset = has_exact_toolset_selection(
+            effective_enabled_toolsets
+        )
         if (
             os.environ.get("HERMES_KANBAN_TASK")
             and not _is_delegated_child_context()
             and "kanban" not in effective_enabled_toolsets
+            and not has_exact_toolset
         ):
             # Dispatcher-spawned workers are scoped by HERMES_KANBAN_TASK and
             # must always receive the lifecycle handoff tools. Assignee
@@ -411,43 +471,12 @@ def _compute_tool_definitions(
     # is enabled, any tools belonging to a disabled toolset are strictly
     # stripped out. See issue #17309.
     if disabled_toolsets:
-        for toolset_name in disabled_toolsets:
-            if validate_toolset(toolset_name):
-                from toolsets import bundle_non_core_tools, get_toolset
-                if toolset_name.startswith("hermes-") or (get_toolset(toolset_name) or {}).get("posture"):
-                    # Platform bundles (hermes-*) include _HERMES_CORE_TOOLS, and
-                    # posture toolsets (`posture: True`, e.g. `coding`) re-list
-                    # those same core tools without owning them, so subtracting
-                    # the whole toolset would strip core tools shared by other
-                    # enabled toolsets and empty the tool list (#33924, #57315).
-                    # Subtract only the non-core delta; keep core.
-                    to_remove = bundle_non_core_tools(toolset_name)
-                    tools_to_include.difference_update(to_remove)
-                    resolved = sorted(to_remove)
-                    if (not quiet_mode and toolset_name.startswith("hermes-")
-                            and toolset_name not in _WARNED_DISABLED_BUNDLES):
-                        _WARNED_DISABLED_BUNDLES.add(toolset_name)
-                        logger.info(
-                            "agent.disabled_toolsets contains platform-bundle "
-                            "name '%s'; core tools are preserved and only its "
-                            "platform-specific tools (%s) are removed. Bundle "
-                            "names usually belong in `toolsets:`, not "
-                            "`disabled_toolsets` (#33924).",
-                            toolset_name,
-                            ", ".join(resolved) if resolved else "none",
-                        )
-                else:
-                    resolved = resolve_toolset(toolset_name)
-                    tools_to_include.difference_update(resolved)
-                if not quiet_mode:
-                    print(f"🚫 Disabled toolset '{toolset_name}': {', '.join(resolved) if resolved else 'no tools'}")
-            elif toolset_name in _LEGACY_TOOLSET_MAP:
-                legacy_tools = _LEGACY_TOOLSET_MAP[toolset_name]
-                tools_to_include.difference_update(legacy_tools)
-                if not quiet_mode:
-                    print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
-            elif not quiet_mode:
-                print(f"⚠️  Unknown toolset: {toolset_name}")
+        tools_to_include.difference_update(
+            resolve_disabled_tool_names(
+                disabled_toolsets,
+                quiet_mode=quiet_mode,
+            )
+        )
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/tests/cli/test_cli_mcp_config_watch.py
+++ b/tests/cli/test_cli_mcp_config_watch.py
@@ -31,6 +31,15 @@ def _make_cli(tmp_path, mcp_servers=None, extra_config=None):
 
 class TestMCPConfigWatch:
 
+    def test_reload_merge_preserves_exact_toolset(self):
+        from cli import _merge_reload_mcp_toolsets
+
+        result = _merge_reload_mcp_toolsets(
+            ["restricted-command", "terminal"],
+            {"github", "playwright"},
+        )
+        assert result == ["restricted-command"]
+
 
 
     def test_new_mcp_server_triggers_reload(self, tmp_path):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -47,6 +47,12 @@ class TestPerJobToolsetMcpMerge:
         assert result == ["web"]
         assert not (set(result) & self._enabled_names())
 
+    def test_exact_toolset_blocks_mcp_merge(self):
+        result = _merge_mcp_into_per_job_toolsets(
+            ["restricted-command", "web"], self.CFG
+        )
+        assert result == ["restricted-command"]
+
 
     def test_resolver_empty_per_job_falls_through_to_platform(self):
         # No per-job list -> must delegate to _get_platform_tools (the platform

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -153,6 +153,12 @@ class TestIdempotencyCache:
 
 
 class TestAdapterInit:
+    def test_malformed_disabled_toolsets_scalar_is_rejected(self):
+        from gateway.platforms.api_server import _configured_disabled_toolsets
+
+        assert _configured_disabled_toolsets({"agent": {"disabled_toolsets": "delegation"}}) == []
+        assert _configured_disabled_toolsets({"agent": {"disabled_toolsets": ["delegation", "delegation"]}}) == ["delegation"]
+
     def test_default_config(self):
         config = PlatformConfig(enabled=True)
         adapter = APIServerAdapter(config)
@@ -198,7 +204,10 @@ class TestAdapterInit:
         monkeypatch.setattr(
             "gateway.run._load_gateway_config",
             lambda: {
-                "agent": {"reasoning_effort": "xhigh"},
+                "agent": {
+                    "reasoning_effort": "xhigh",
+                    "disabled_toolsets": ["delegation"],
+                },
                 "checkpoints": {
                     "enabled": True,
                     "max_snapshots": 7,
@@ -225,6 +234,7 @@ class TestAdapterInit:
         assert captured["checkpoint_max_snapshots"] == 7
         assert captured["checkpoint_max_total_size_mb"] == 321
         assert captured["checkpoint_max_file_size_mb"] == 4
+        assert captured["disabled_toolsets"] == ["delegation"]
 
 
 # ---------------------------------------------------------------------------
@@ -735,6 +745,147 @@ class TestToolsetsEndpoint:
                 assert by_name["web"]["enabled"] is False
                 assert by_name["web"]["tools"] == ["web_search"]
                 assert by_name["default"]["configured"] is True
+
+    @pytest.mark.asyncio
+    async def test_toolsets_reports_configured_exact_static_toolset(self, adapter):
+        config = {
+            "platform_toolsets": {"api_server": ["restricted-command"]},
+            "agent": {"disabled_toolsets": ["delegation"]},
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/toolsets")
+                assert resp.status == 200
+                data = await resp.json()
+
+        by_name = {toolset["name"]: toolset for toolset in data["data"]}
+        restricted = by_name["restricted-command"]
+        assert restricted["enabled"] is True
+        from model_tools import get_tool_definitions
+        expected = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(
+                enabled_toolsets=["restricted-command"],
+                disabled_toolsets=["delegation"],
+                quiet_mode=True,
+            )
+        }
+        assert set(restricted["tools"]) == expected
+        assert "delegate_task" not in restricted["tools"]
+
+    @pytest.mark.asyncio
+    async def test_toolsets_exact_static_posture_denial_preserves_core(self, adapter):
+        config = {
+            "platform_toolsets": {"api_server": ["restricted-command"]},
+            "agent": {"disabled_toolsets": ["coding"]},
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/toolsets")
+                assert resp.status == 200
+                data = await resp.json()
+        restricted = {ts["name"]: ts for ts in data["data"]}["restricted-command"]
+        assert restricted["enabled"] is True
+        from model_tools import get_tool_definitions
+        expected = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(
+                enabled_toolsets=["restricted-command"],
+                disabled_toolsets=["coding"],
+                quiet_mode=True,
+            )
+        }
+        assert set(restricted["tools"]) == expected
+        assert "terminal" in restricted["tools"]
+
+    @pytest.mark.asyncio
+    async def test_toolsets_reports_configured_exact_static_denial(self, adapter):
+        config = {
+            "platform_toolsets": {"api_server": ["restricted-command"]},
+            "agent": {"disabled_toolsets": ["restricted-command"]},
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/toolsets")
+                assert resp.status == 200
+                data = await resp.json()
+        restricted = {ts["name"]: ts for ts in data["data"]}["restricted-command"]
+        assert restricted["enabled"] is False
+        assert restricted["configured"] is True
+
+    @pytest.mark.asyncio
+    async def test_toolsets_exact_static_uses_runtime_availability_projection(self, adapter):
+        config = {"platform_toolsets": {"api_server": ["restricted-command"]}}
+        runtime_tools = [
+            {"type": "function", "function": {"name": "terminal"}},
+            {"type": "function", "function": {"name": "todo"}},
+        ]
+        events = []
+
+        def discover_catalog():
+            events.append("catalog")
+            return []
+
+        def project_runtime(**kwargs):
+            assert events == ["catalog"]
+            return runtime_tools
+
+        with patch("hermes_cli.config.load_config", return_value=config), patch(
+            "hermes_cli.tools_config._get_effective_configurable_toolsets",
+            side_effect=discover_catalog,
+        ), patch(
+            "model_tools.get_tool_definitions",
+            side_effect=project_runtime,
+        ) as projected:
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/toolsets")
+                assert resp.status == 200
+                data = await resp.json()
+        restricted = {ts["name"]: ts for ts in data["data"]}["restricted-command"]
+        assert restricted["tools"] == ["terminal", "todo"]
+        projected.assert_called_once_with(
+            enabled_toolsets=["restricted-command"],
+            disabled_toolsets=[],
+            quiet_mode=True,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "raw_disabled",
+        (["delegation"], ["coding"], ["hermes-cli"], "delegation"),
+    )
+    async def test_toolsets_exact_static_matches_runtime_projection(
+        self, adapter, raw_disabled
+    ):
+        from model_tools import get_tool_definitions
+
+        config = {
+            "platform_toolsets": {"api_server": ["restricted-command"]},
+            "agent": {"disabled_toolsets": raw_disabled},
+        }
+        valid_disabled = raw_disabled if isinstance(raw_disabled, list) else []
+        expected = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(
+                enabled_toolsets=["restricted-command"],
+                disabled_toolsets=valid_disabled,
+                quiet_mode=True,
+            )
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/toolsets")
+                assert resp.status == 200
+                data = await resp.json()
+        restricted = {ts["name"]: ts for ts in data["data"]}["restricted-command"]
+        assert restricted["enabled"] is True
+        assert set(restricted["tools"]) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -648,6 +648,28 @@ class TestCapabilitiesEndpoint:
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
 
+    @pytest.mark.asyncio
+    async def test_capabilities_attests_run_approval_policy(self, adapter):
+        expected = {
+            "version": 1,
+            "mode": "manual",
+            "frozen_yolo": False,
+            "session_yolo_count": 0,
+            "session_approved_count": 0,
+            "permanent_approved_count": 0,
+            "subagent_auto_approve": False,
+        }
+        with patch(
+            "tools.approval.get_run_approval_policy",
+            return_value=expected,
+        ):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/capabilities")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["security"]["run_approval_policy"] == expected
+
 
 # ---------------------------------------------------------------------------
 # /v1/skills and /v1/toolsets endpoints

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -35,13 +35,13 @@ from tools import approval as approval_mod
 @pytest.mark.parametrize(
     ("smart_denied", "allow_permanent", "expected"),
     [
-        (False, True, ["once", "session", "always", "deny"]),
-        (False, False, ["once", "session", "deny"]),
+        (False, True, ["once", "deny"]),
+        (False, False, ["once", "deny"]),
         (True, True, ["once", "deny"]),
         (True, False, ["once", "deny"]),
     ],
 )
-def test_approval_event_choices_follow_backend_capabilities(
+def test_identity_bound_run_approval_event_choices_never_widen(
     smart_denied, allow_permanent, expected
 ):
     assert _approval_event_choices(

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -69,6 +69,10 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_post(
+        "/v1/runs/{run_id}/approvals/{approval_id}",
+        adapter._handle_identity_bound_run_approval,
+    )
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
 
@@ -303,6 +307,16 @@ class TestRunStatus:
 
 
 class TestRunEvents:
+    def test_route_table_advertises_legacy_incompatible_identity_endpoint(self, adapter):
+        routes = {
+            (method, path)
+            for method, path, _handler in adapter._http_route_table()
+        }
+        assert (
+            "POST",
+            "/v1/runs/{run_id}/approvals/{approval_id}",
+        ) in routes
+
     @pytest.mark.asyncio
     async def test_events_stream_returns_completed(self, adapter):
         """Events stream should receive run.completed when agent finishes."""
@@ -331,6 +345,209 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+
+    @pytest.mark.asyncio
+    async def test_identity_bound_approval_resolves_exact_entry_and_echoes_id(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_identity_exact"
+        session_key = "run_identity_exact"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_approval"}
+        adapter._run_approval_sessions[run_id] = session_key
+        adapter._run_streams[run_id] = asyncio.Queue()
+        first = approval_mod._ApprovalEntry({"command": "first"})
+        second = approval_mod._ApprovalEntry({"command": "second"})
+        with approval_mod._lock:
+            approval_mod._gateway_queues[session_key] = [first, second]
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approvals/{second.approval_id}",
+                json={"choice": "once"},
+            )
+            body = await response.json()
+
+        assert response.status == 200
+        assert body["approval_id"] == second.approval_id
+        assert body["resolved"] == 1
+        assert body["pending"] is True
+        assert adapter._run_statuses[run_id]["status"] == "waiting_for_approval"
+        responded_event = adapter._run_streams[run_id].get_nowait()
+        assert responded_event["event"] == "approval.responded"
+        assert responded_event["approval_id"] == second.approval_id
+        assert responded_event["pending"] is True
+        assert second.result == "once"
+        assert second.event.is_set()
+        assert not first.event.is_set()
+        with approval_mod._lock:
+            assert approval_mod._gateway_queues[session_key] == [first]
+
+    @pytest.mark.asyncio
+    async def test_wrong_identity_returns_conflict_without_resolving(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_identity_wrong"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_approval"}
+        adapter._run_approval_sessions[run_id] = run_id
+        entry = approval_mod._ApprovalEntry({"command": "only"})
+        with approval_mod._lock:
+            approval_mod._gateway_queues[run_id] = [entry]
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approvals/{'0' * 32}",
+                json={"choice": "once"},
+            )
+            body = await response.json()
+
+        assert response.status == 409
+        assert body["error"]["code"] == "approval_not_pending"
+        assert not entry.event.is_set()
+        with approval_mod._lock:
+            assert approval_mod._gateway_queues[run_id] == [entry]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("approval_id", ["short", "A" * 32, "g" * 32, "0" * 33])
+    async def test_malformed_approval_identity_is_rejected(self, adapter, approval_id):
+        app = _create_runs_app(adapter)
+        run_id = "run_identity_malformed"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_approval"}
+        adapter._run_approval_sessions[run_id] = run_id
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approvals/{approval_id}",
+                json={"choice": "once"},
+            )
+            body = await response.json()
+
+        assert response.status == 400
+        assert body["error"]["code"] == "invalid_approval_id"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("choice", ["approve", "session", "always"])
+    async def test_identity_route_rejects_aliases_and_persistent_scope(self, adapter, choice):
+        app = _create_runs_app(adapter)
+        run_id = "run_identity_all"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_approval"}
+        adapter._run_approval_sessions[run_id] = run_id
+        entry = approval_mod._ApprovalEntry({"command": "only"})
+        with approval_mod._lock:
+            approval_mod._gateway_queues[run_id] = [entry]
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approvals/{entry.approval_id}",
+                json={"choice": choice},
+            )
+            body = await response.json()
+
+        assert response.status == 400
+        assert body["error"]["code"] == "invalid_identity_approval_choice"
+        assert not entry.event.is_set()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("extra", [{"all": True}, {"resolve_all": True}, {"approval_id": "0" * 32}])
+    async def test_identity_route_rejects_bulk_and_ambiguous_fields(self, adapter, extra):
+        app = _create_runs_app(adapter)
+        run_id = "run_identity_scope"
+        adapter._run_statuses[run_id] = {"run_id": run_id, "status": "waiting_for_approval"}
+        adapter._run_approval_sessions[run_id] = run_id
+        entry = approval_mod._ApprovalEntry({"command": "only"})
+        with approval_mod._lock:
+            approval_mod._gateway_queues[run_id] = [entry]
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approvals/{entry.approval_id}",
+                json={"choice": "once", **extra},
+            )
+            body = await response.json()
+
+        assert response.status == 400
+        assert body["error"]["code"] == "invalid_identity_approval_request"
+        assert not entry.event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_legacy_route_rejects_body_identity_without_mutation(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run_legacy_body_identity"
+        adapter._run_statuses[run_id] = {
+            "run_id": run_id,
+            "status": "waiting_for_approval",
+        }
+        adapter._run_approval_sessions[run_id] = run_id
+        entry = approval_mod._ApprovalEntry({"command": "only"})
+        with approval_mod._lock:
+            approval_mod._gateway_queues[run_id] = [entry]
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={"choice": "once", "approval_id": entry.approval_id},
+            )
+            body = await response.json()
+
+        assert response.status == 400
+        assert body["error"]["code"] == "identity_requires_versioned_route"
+        assert not entry.event.is_set()
+        with approval_mod._lock:
+            assert approval_mod._gateway_queues[run_id] == [entry]
+
+    @pytest.mark.asyncio
+    async def test_new_approval_publication_after_resolution_wins_status_race(
+        self,
+        adapter,
+        monkeypatch,
+    ):
+        app = _create_runs_app(adapter)
+        run_id = "run_identity_status_race"
+        adapter._run_statuses[run_id] = {
+            "run_id": run_id,
+            "status": "waiting_for_approval",
+        }
+        adapter._run_approval_sessions[run_id] = run_id
+        adapter._run_streams[run_id] = asyncio.Queue()
+        resolved_entry = approval_mod._ApprovalEntry({"command": "first"})
+        with approval_mod._lock:
+            approval_mod._gateway_queues[run_id] = [resolved_entry]
+
+        loop = asyncio.get_running_loop()
+        original_resolve = approval_mod.resolve_gateway_approval_identity
+
+        def resolve_then_enqueue(session_key, choice, approval_id):
+            result = original_resolve(session_key, choice, approval_id)
+            successor = approval_mod._ApprovalEntry({"command": "second"})
+            with approval_mod._lock:
+                approval_mod._gateway_queues[session_key] = [successor]
+            adapter._schedule_run_approval_request(
+                run_id,
+                loop,
+                adapter._run_streams[run_id],
+                successor.data,
+            )
+            return result
+
+        monkeypatch.setattr(
+            approval_mod,
+            "resolve_gateway_approval_identity",
+            resolve_then_enqueue,
+        )
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approvals/{resolved_entry.approval_id}",
+                json={"choice": "once"},
+            )
+            body = await response.json()
+            await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert body["pending"] is False
+        assert adapter._run_statuses[run_id]["status"] == "waiting_for_approval"
+        events = [adapter._run_streams[run_id].get_nowait() for _ in range(2)]
+        assert [event["event"] for event in events] == [
+            "approval.responded",
+            "approval.request",
+        ]
 
     @pytest.mark.asyncio
     async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -156,6 +156,173 @@ class TestBlockingGatewayApproval:
         assert not e2.event.is_set()
         assert len(_gateway_queues[session_key]) == 1
 
+    def test_entries_receive_unique_identity_exposed_to_notification(self):
+        """Every queued request exposes a stable identity before notification."""
+        from tools.approval import (
+            _await_gateway_decision,
+            _gateway_queues,
+            _lock,
+            resolve_gateway_approval,
+        )
+
+        session_key = "test-identity-notify"
+        notified = []
+        result = {}
+
+        def wait_for_decision():
+            result.update(_await_gateway_decision(
+                session_key,
+                notified.append,
+                {"command": "rm -rf /identity", "description": "identity"},
+            ))
+
+        thread = threading.Thread(target=wait_for_decision, daemon=True)
+        thread.start()
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not notified:
+            time.sleep(0.01)
+
+        assert len(notified) == 1
+        approval_id = notified[0]["approval_id"]
+        assert isinstance(approval_id, str)
+        assert len(approval_id) == 32
+        with _lock:
+            entry = _gateway_queues[session_key][0]
+            assert entry.approval_id == approval_id
+            assert entry.data["approval_id"] == approval_id
+
+        assert resolve_gateway_approval(
+            session_key,
+            "deny",
+            approval_id=approval_id,
+        ) == 1
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+        assert result["choice"] == "deny"
+
+    def test_identity_resolution_selects_exact_non_fifo_entry(self):
+        from tools.approval import _ApprovalEntry, _gateway_queues, resolve_gateway_approval
+
+        session_key = "test-exact-non-fifo"
+        first = _ApprovalEntry({"command": "first", "approval_id": "0" * 32})
+        second = _ApprovalEntry({"command": "second"})
+        assert first.approval_id != "0" * 32
+        assert first.approval_id != second.approval_id
+        _gateway_queues[session_key] = [first, second]
+
+        assert resolve_gateway_approval(
+            session_key,
+            "once",
+            approval_id=second.approval_id,
+        ) == 1
+        assert second.event.is_set()
+        assert second.result == "once"
+        assert not first.event.is_set()
+        assert _gateway_queues[session_key] == [first]
+
+    def test_identity_resolution_returns_atomic_pending_snapshot(self):
+        from tools.approval import (
+            _ApprovalEntry,
+            _gateway_queues,
+            resolve_gateway_approval_identity,
+        )
+
+        session_key = "test-identity-atomic-result"
+        first = _ApprovalEntry({"command": "first"})
+        second = _ApprovalEntry({"command": "second"})
+        _gateway_queues[session_key] = [first, second]
+
+        result = resolve_gateway_approval_identity(
+            session_key,
+            "once",
+            second.approval_id,
+        )
+
+        assert result.resolved == 1
+        assert result.pending is True
+        assert _gateway_queues[session_key] == [first]
+        assert second.result == "once"
+        assert second.event.is_set()
+
+    def test_wrong_identity_and_replay_do_not_mutate_queue(self):
+        from tools.approval import _ApprovalEntry, _gateway_queues, resolve_gateway_approval
+
+        session_key = "test-identity-replay"
+        entry = _ApprovalEntry({"command": "only"})
+        _gateway_queues[session_key] = [entry]
+
+        assert resolve_gateway_approval(
+            session_key,
+            "once",
+            approval_id="0" * 32,
+        ) == 0
+        assert _gateway_queues[session_key] == [entry]
+        assert not entry.event.is_set()
+
+        assert resolve_gateway_approval(
+            session_key,
+            "deny",
+            approval_id=entry.approval_id,
+        ) == 1
+        assert resolve_gateway_approval(
+            session_key,
+            "once",
+            approval_id=entry.approval_id,
+        ) == 0
+        assert session_key not in _gateway_queues
+
+    def test_duplicate_identity_fails_closed_without_mutating_queue(self):
+        from tools.approval import _ApprovalEntry, _gateway_queues, resolve_gateway_approval
+
+        session_key = "test-identity-collision"
+        first = _ApprovalEntry({"command": "first"})
+        second = _ApprovalEntry({"command": "second"})
+        second.approval_id = first.approval_id
+        second.data["approval_id"] = first.approval_id
+        _gateway_queues[session_key] = [first, second]
+
+        assert resolve_gateway_approval(
+            session_key,
+            "once",
+            approval_id=first.approval_id,
+        ) == 0
+        assert _gateway_queues[session_key] == [first, second]
+        assert not first.event.is_set()
+        assert not second.event.is_set()
+
+    def test_unregister_signals_all_entries(self):
+        """unregister_gateway_notify signals all waiting entries to prevent hangs."""
+        from tools.approval import (
+            register_gateway_notify, unregister_gateway_notify,
+            _ApprovalEntry, _gateway_queues,
+        )
+        session_key = "test-cleanup"
+        register_gateway_notify(session_key, lambda d: None)
+
+        e1 = _ApprovalEntry({"command": "cmd1"})
+        e2 = _ApprovalEntry({"command": "cmd2"})
+        _gateway_queues[session_key] = [e1, e2]
+
+        unregister_gateway_notify(session_key)
+        assert e1.event.is_set()
+        assert e2.event.is_set()
+
+    def test_clear_session_denies_and_signals_all_entries(self):
+        """clear_session must wake blocked entries during boundary cleanup."""
+        from tools.approval import clear_session, _ApprovalEntry, _gateway_queues
+
+        session_key = "test-boundary-cleanup"
+        e1 = _ApprovalEntry({"command": "cmd1"})
+        e2 = _ApprovalEntry({"command": "cmd2"})
+        _gateway_queues[session_key] = [e1, e2]
+
+        clear_session(session_key)
+
+        assert e1.event.is_set()
+        assert e2.event.is_set()
+        assert e1.result == "deny"
+        assert e2.result == "deny"
+        assert session_key not in _gateway_queues
 
 # ------------------------------------------------------------------
 # /approve command

--- a/tests/gateway/test_restricted_command_toolset.py
+++ b/tests/gateway/test_restricted_command_toolset.py
@@ -16,8 +16,6 @@ APPROVED_COMMAND_TOOLS = {
     "write_file",
     "patch",
     "search_files",
-    "web_search",
-    "web_extract",
     "vision_analyze",
     "delegate_task",
     "todo",

--- a/tests/gateway/test_restricted_command_toolset.py
+++ b/tests/gateway/test_restricted_command_toolset.py
@@ -1,0 +1,272 @@
+"""Exact static command-tool contracts for API-server agents."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from hermes_cli.tools_config import _get_platform_tools
+from model_tools import _clear_tool_defs_cache
+from tools.registry import registry
+
+
+APPROVED_COMMAND_TOOLS = {
+    "terminal",
+    "process",
+    "read_file",
+    "write_file",
+    "patch",
+    "search_files",
+    "web_search",
+    "web_extract",
+    "vision_analyze",
+    "delegate_task",
+    "todo",
+}
+
+
+def _tool_names(agent) -> set[str]:
+    return {tool["function"]["name"] for tool in agent.tools}
+
+
+def _make_agent(
+    enabled_toolsets: list[str],
+    disabled_toolsets: list[str] | None = None,
+):
+    from run_agent import AIAgent
+
+    return AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        provider="openrouter",
+        model="test/model",
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets or [],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+def _register_toolset_extension(name: str, toolset: str) -> None:
+    registry.register(
+        name=name,
+        toolset=toolset,
+        schema={
+            "name": name,
+            "description": "Dynamically registered toolset extension for testing.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda args, **kwargs: "{}",
+    )
+    _clear_tool_defs_cache()
+
+
+def _register_terminal_extension(name: str) -> None:
+    _register_toolset_extension(name, "terminal")
+
+
+def test_restricted_command_platform_selection_is_exact_and_registry_stable(monkeypatch):
+    # This contract tests membership, not host credential availability. Model a
+    # correctly configured command agent so every approved schema is exposable.
+    monkeypatch.setattr("tools.registry._check_fn_cached", lambda check_fn: True)
+    config = {
+        "platform_toolsets": {
+            # A static exact toolset is authoritative: unrelated entries must
+            # not widen an API-server agent if config is merged incorrectly.
+            "api_server": ["restricted-command", "terminal"],
+        }
+    }
+    extension_name = f"test_dynamic_terminal_{uuid4().hex}"
+
+    try:
+        enabled_before = sorted(_get_platform_tools(config, "api_server"))
+        agent_before = _make_agent(enabled_before)
+
+        _register_terminal_extension(extension_name)
+
+        enabled_after = sorted(_get_platform_tools(config, "api_server"))
+        agent_after = _make_agent(enabled_after)
+
+        assert enabled_before == ["restricted-command"]
+        assert enabled_after == enabled_before
+        assert _tool_names(agent_before) == APPROVED_COMMAND_TOOLS
+        assert _tool_names(agent_after) == APPROVED_COMMAND_TOOLS
+        assert extension_name not in getattr(agent_after, "valid_tool_names")
+    finally:
+        registry.deregister(extension_name)
+        _clear_tool_defs_cache()
+
+
+def test_restricted_command_delegated_leaf_inherits_only_allowed_child_surface(monkeypatch):
+    from tools.delegate_tool import _build_child_agent
+
+    monkeypatch.setattr("tools.registry._check_fn_cached", lambda check_fn: True)
+    extension_name = f"test_dynamic_terminal_{uuid4().hex}"
+    parent = _make_agent(["restricted-command"])
+
+    try:
+        _register_terminal_extension(extension_name)
+        child = _build_child_agent(
+            task_index=0,
+            goal="Inspect the requested files",
+            context=None,
+            toolsets=None,
+            model=None,
+            max_iterations=3,
+            task_count=1,
+            parent_agent=parent,
+            role="leaf",
+        )
+
+        # Leaf children inherit the exact parent surface, minus delegate_task
+        # (children cannot recursively delegate unless explicitly orchestrators).
+        assert getattr(child, "enabled_toolsets") == ["restricted-command"]
+        assert _tool_names(child) == _tool_names(parent) - {"delegate_task"}
+        assert extension_name not in getattr(child, "valid_tool_names")
+    finally:
+        registry.deregister(extension_name)
+        _clear_tool_defs_cache()
+
+
+def test_restricted_command_parent_cannot_be_downgraded_to_registry_category(monkeypatch):
+    from tools.delegate_tool import _build_child_agent, _expand_parent_toolsets
+
+    monkeypatch.setattr("tools.registry._check_fn_cached", lambda check_fn: True)
+    extension_name = f"test_dynamic_terminal_{uuid4().hex}"
+    parent = _make_agent(["restricted-command"])
+
+    try:
+        _register_terminal_extension(extension_name)
+        assert _expand_parent_toolsets({"restricted-command"}) == {"restricted-command"}
+        child = _build_child_agent(
+            task_index=0,
+            goal="Run a terminal command",
+            context=None,
+            toolsets=["terminal"],
+            model=None,
+            max_iterations=3,
+            task_count=1,
+            parent_agent=parent,
+            role="leaf",
+        )
+        assert getattr(child, "enabled_toolsets") == []
+        assert _tool_names(child) == set()
+        assert extension_name not in getattr(child, "valid_tool_names")
+    finally:
+        registry.deregister(extension_name)
+        _clear_tool_defs_cache()
+
+
+def test_restricted_command_ignores_implicit_kanban_widening(monkeypatch):
+    monkeypatch.setattr("tools.registry._check_fn_cached", lambda check_fn: True)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "exact-toolset-probe")
+    _clear_tool_defs_cache()
+    agent = _make_agent(["restricted-command"])
+    assert _tool_names(agent) == APPROVED_COMMAND_TOOLS
+
+
+def test_restricted_command_dominates_direct_mixed_selection(monkeypatch):
+    monkeypatch.setattr("tools.registry._check_fn_cached", lambda check_fn: True)
+    extension_name = f"test_dynamic_terminal_{uuid4().hex}"
+    try:
+        _register_terminal_extension(extension_name)
+        agent = _make_agent(["restricted-command", "terminal"])
+        assert getattr(agent, "enabled_toolsets") == ["restricted-command"]
+        assert _tool_names(agent) == APPROVED_COMMAND_TOOLS
+        assert extension_name not in getattr(agent, "valid_tool_names")
+
+        from tools.delegate_tool import _build_child_agent
+        child = _build_child_agent(
+            task_index=0,
+            goal="Run a terminal command",
+            context=None,
+            toolsets=["terminal"],
+            model=None,
+            max_iterations=3,
+            task_count=1,
+            parent_agent=agent,
+            role="leaf",
+        )
+        assert getattr(child, "enabled_toolsets") == []
+        assert _tool_names(child) == set()
+    finally:
+        registry.deregister(extension_name)
+        _clear_tool_defs_cache()
+
+
+def test_restricted_command_normalizes_mixed_refresh_override(monkeypatch):
+    from tools.mcp_tool import refresh_agent_mcp_tools
+
+    monkeypatch.setattr("tools.registry._check_fn_cached", lambda check_fn: True)
+    extension_name = f"test_dynamic_terminal_{uuid4().hex}"
+    agent = _make_agent(["restricted-command"])
+    try:
+        _register_terminal_extension(extension_name)
+        refresh_agent_mcp_tools(
+            agent,
+            enabled_override=["restricted-command", "terminal"],
+            quiet_mode=True,
+        )
+        assert getattr(agent, "enabled_toolsets") == ["restricted-command"]
+        assert _tool_names(agent) == APPROVED_COMMAND_TOOLS
+        assert extension_name not in getattr(agent, "valid_tool_names")
+    finally:
+        registry.deregister(extension_name)
+        _clear_tool_defs_cache()
+
+
+def test_restricted_command_orchestrator_preserves_exact_parent_boundary(monkeypatch):
+    from tools.delegate_tool import _build_child_agent
+
+    monkeypatch.setattr("tools.registry._check_fn_cached", lambda check_fn: True)
+    monkeypatch.setattr("tools.delegate_tool._get_orchestrator_enabled", lambda: True)
+    monkeypatch.setattr("tools.delegate_tool._get_max_spawn_depth", lambda: 2)
+    extension_name = f"test_dynamic_delegation_{uuid4().hex}"
+    parent = _make_agent(["restricted-command"])
+    try:
+        _register_toolset_extension(extension_name, "delegation")
+        child = _build_child_agent(
+            task_index=0,
+            goal="Coordinate a bounded child task",
+            context=None,
+            toolsets=["terminal"],
+            model=None,
+            max_iterations=3,
+            task_count=1,
+            parent_agent=parent,
+            role="orchestrator",
+        )
+        assert getattr(child, "enabled_toolsets") == ["restricted-command"]
+        assert _tool_names(child) <= _tool_names(parent)
+        assert "delegate_task" in _tool_names(child)
+        assert extension_name not in getattr(child, "valid_tool_names")
+    finally:
+        registry.deregister(extension_name)
+        _clear_tool_defs_cache()
+
+
+def test_restricted_command_orchestrator_inherits_parent_delegation_denial(monkeypatch):
+    from tools.delegate_tool import _build_child_agent
+
+    monkeypatch.setattr("tools.registry._check_fn_cached", lambda check_fn: True)
+    monkeypatch.setattr("tools.delegate_tool._get_orchestrator_enabled", lambda: True)
+    monkeypatch.setattr("tools.delegate_tool._get_max_spawn_depth", lambda: 2)
+    parent = _make_agent(
+        ["restricted-command"],
+        disabled_toolsets=["delegation"],
+    )
+    child = _build_child_agent(
+        task_index=0,
+        goal="Coordinate without exceeding the parent's authority",
+        context=None,
+        toolsets=["terminal"],
+        model=None,
+        max_iterations=3,
+        task_count=1,
+        parent_agent=parent,
+        role="orchestrator",
+    )
+    assert getattr(child, "enabled_toolsets") == ["restricted-command"]
+    assert "delegate_task" not in _tool_names(parent)
+    assert "delegate_task" not in _tool_names(child)
+    assert _tool_names(child) <= _tool_names(parent)

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -68,6 +68,17 @@ async def test_capabilities_advertises_session_control_surface(adapter):
     assert features["memory_write_api"] is False
     assert features["skills_api"] is True
     assert features["realtime_voice"] is False
+    assert features["run_approval_identity_binding"] is True
+    assert data["protocols"]["run_approval_identity_binding"] == {
+        "version": 1,
+        "method": "POST",
+        "path": "/v1/runs/{run_id}/approvals/{approval_id}",
+        "choices": ["once", "deny"],
+    }
+    assert data["endpoints"]["run_approval_identity"] == {
+        "method": "POST",
+        "path": "/v1/runs/{run_id}/approvals/{approval_id}",
+    }
     assert data["endpoints"]["sessions"] == {"method": "GET", "path": "/api/sessions"}
     assert data["endpoints"]["session_chat_stream"] == {
         "method": "POST",

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -24,6 +24,72 @@ from tools.approval import (
 )
 
 
+def test_run_approval_policy_reports_exact_bypass_posture(monkeypatch):
+    from tools import approval as approval_module
+
+    monkeypatch.setattr(
+        approval_module,
+        "_load_run_approval_security_config",
+        lambda: {
+            "approvals": {"mode": "manual"},
+            "delegation": {"subagent_auto_approve": False},
+        },
+    )
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+    with approval_module._lock:
+        approval_module._session_yolo.clear()
+        approval_module._session_approved.clear()
+        approval_module._permanent_approved.clear()
+        approval_module._session_yolo.add("session-yolo")
+        approval_module._session_approved["session-approved"] = {"rm"}
+        approval_module._permanent_approved.add("git_push")
+
+    try:
+        assert approval_module.get_run_approval_policy() == {
+            "version": 1,
+            "mode": "manual",
+            "frozen_yolo": False,
+            "session_yolo_count": 1,
+            "session_approved_count": 1,
+            "permanent_approved_count": 1,
+            "subagent_auto_approve": False,
+        }
+    finally:
+        with approval_module._lock:
+            approval_module._session_yolo.clear()
+            approval_module._session_approved.clear()
+            approval_module._permanent_approved.clear()
+
+
+def test_run_approval_policy_fails_when_config_is_unreadable(monkeypatch):
+    from tools import approval as approval_module
+
+    def fail_config_load():
+        raise OSError("config unavailable")
+
+    monkeypatch.setattr(
+        approval_module,
+        "_load_run_approval_security_config",
+        fail_config_load,
+    )
+
+    with pytest.raises(OSError, match="config unavailable"):
+        approval_module.get_run_approval_policy()
+
+
+def test_run_approval_policy_rejects_non_object_policy_blocks(monkeypatch):
+    from tools import approval as approval_module
+
+    monkeypatch.setattr(
+        approval_module,
+        "_load_run_approval_security_config",
+        lambda: {"approvals": "manual", "delegation": {}},
+    )
+
+    with pytest.raises(RuntimeError, match="must be objects"):
+        approval_module.get_run_approval_policy()
+
+
 class TestApprovalModeParsing:
     def test_normalization_table(self):
         # Unquoted YAML `off`/`on` arrive as booleans; unknown/empty fall back

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -191,6 +191,7 @@ class TestProviderEnvBlocklist:
     def test_tool_and_gateway_vars_are_stripped(self):
         """Tool and gateway secrets/config must not leak into subprocess env."""
         leaked_vars = {
+            "API_SERVER_KEY": "api-server-control-plane-secret",
             "TELEGRAM_BOT_TOKEN": "bot-token",
             "TELEGRAM_HOME_CHANNEL": "12345",
             "DISCORD_HOME_CHANNEL": "67890",

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -15,12 +15,14 @@ import hashlib
 import logging
 import os
 import re
+import secrets
 import shlex
 import sys
 import tempfile
 import threading
 import time
 import unicodedata
+from dataclasses import dataclass
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -2154,11 +2156,13 @@ def _denial_breaker_addendum(session_key: str) -> str:
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = ("approval_id", "event", "data", "result", "reason")
 
     def __init__(self, data: dict):
+        self.approval_id = secrets.token_hex(16)
         self.event = threading.Event()
-        self.data = data          # command, description, pattern_keys, …
+        self.data = dict(data)    # command, description, pattern_keys, …
+        self.data["approval_id"] = self.approval_id
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
@@ -2195,15 +2199,53 @@ def unregister_gateway_notify(session_key: str) -> None:
         entry.event.set()
 
 
+@dataclass(frozen=True)
+class ApprovalResolutionResult:
+    """Atomic result of resolving one exact gateway approval identity."""
+
+    resolved: int
+    pending: bool
+
+
+def resolve_gateway_approval_identity(
+    session_key: str,
+    choice: str,
+    approval_id: str,
+    reason: Optional[str] = None,
+) -> ApprovalResolutionResult:
+    """Resolve exactly one identity and snapshot remaining work under one lock."""
+    with _lock:
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return ApprovalResolutionResult(resolved=0, pending=False)
+        matching_indexes = [
+            index
+            for index, entry in enumerate(queue)
+            if entry.approval_id == approval_id
+        ]
+        if len(matching_indexes) != 1:
+            return ApprovalResolutionResult(resolved=0, pending=bool(queue))
+        entry = queue.pop(matching_indexes[0])
+        pending = bool(queue)
+        if not pending:
+            _gateway_queues.pop(session_key, None)
+        entry.result = choice
+        if reason:
+            entry.reason = reason
+        entry.event.set()
+        return ApprovalResolutionResult(resolved=1, pending=pending)
+
+
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             approval_id: Optional[str] = None) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
-    When *resolve_all* is True every pending approval in the session is
-    resolved at once (``/approve all``).  Otherwise only the oldest one
-    is resolved (FIFO).
+    When *approval_id* is provided, only that exact pending entry is resolved.
+    Otherwise, *resolve_all* resolves every pending approval in the session and
+    the default behavior resolves only the oldest entry (FIFO).
 
     *reason* is an optional free-text explanation attached to an explicit
     deny (``/deny <reason>``).  It is relayed back to the agent in the
@@ -2215,7 +2257,16 @@ def resolve_gateway_approval(session_key: str, choice: str,
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
-        if resolve_all:
+        if approval_id is not None:
+            matching_indexes = [
+                index
+                for index, entry in enumerate(queue)
+                if entry.approval_id == approval_id
+            ]
+            if len(matching_indexes) != 1:
+                return 0
+            targets = [queue.pop(matching_indexes[0])]
+        elif resolve_all:
             targets = list(queue)
             queue.clear()
         else:
@@ -3268,6 +3319,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     all_keys = approval_data.get("pattern_keys", [primary_key])
 
     entry = _ApprovalEntry(approval_data)
+    approval_data = entry.data
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2696,6 +2696,51 @@ def is_approval_bypass_active() -> bool:
     )
 
 
+def _load_run_approval_security_config() -> dict:
+    """Strictly load config for the externally attested approval posture.
+
+    Unlike the interactive approval helpers, this path must not silently
+    substitute defaults when config loading fails.  A caller that cannot read
+    the policy cannot truthfully attest it and must fail closed.
+    """
+    from hermes_cli.config import load_config
+
+    config = load_config()
+    if not isinstance(config, dict):
+        raise RuntimeError("Hermes config did not decode to an object")
+    return config
+
+
+def get_run_approval_policy() -> dict:
+    """Return the exact approval-bypass posture advertised to Runs clients."""
+    config = _load_run_approval_security_config()
+    approvals = config.get("approvals", {}) or {}
+    delegation = config.get("delegation", {}) or {}
+    if not isinstance(approvals, dict) or not isinstance(delegation, dict):
+        raise RuntimeError("Hermes approval policy blocks must be objects")
+
+    mode = _normalize_approval_mode(approvals.get("mode", "manual"))
+    subagent_auto_approve = is_truthy_value(
+        delegation.get("subagent_auto_approve", False)
+    )
+    with _lock:
+        session_yolo_count = len(_session_yolo)
+        session_approved_count = sum(
+            1 for patterns in _session_approved.values() if patterns
+        )
+        permanent_approved_count = len(_permanent_approved)
+
+    return {
+        "version": 1,
+        "mode": mode,
+        "frozen_yolo": bool(_YOLO_MODE_FROZEN),
+        "session_yolo_count": session_yolo_count,
+        "session_approved_count": session_approved_count,
+        "permanent_approved_count": permanent_approved_count,
+        "subagent_auto_approve": subagent_auto_approve,
+    }
+
+
 def _get_approval_timeout() -> int:
     """Read the approval timeout from config. Defaults to 300 seconds.
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -679,6 +679,12 @@ def _expand_parent_toolsets(parent_toolsets: set) -> set:
     the names of any individual toolsets whose tools are a *subset* of the
     parent's available tools.  The original parent toolset names are preserved.
     """
+    # Exact composites are authority boundaries, not convenience bundles.
+    # Expanding one into ordinary category names would let a narrowed child
+    # replace the exact surface with a registry-widenable category.
+    if any(bool((TOOLSETS.get(name) or {}).get("exact")) for name in parent_toolsets):
+        return set(parent_toolsets)
+
     parent_tool_names: set = set()
     for ts_name in parent_toolsets:
         ts_def = TOOLSETS.get(ts_name)
@@ -1294,9 +1300,13 @@ def _build_child_agent(
         inherited_disabled = [str(name) for name in raw_parent_disabled]
     else:
         inherited_disabled = []
-    if effective_role == "orchestrator":
+    from toolsets import has_exact_toolset_selection
+    parent_selection = sorted(parent_toolsets)
+    parent_has_exact_boundary = has_exact_toolset_selection(parent_selection)
+    if effective_role == "orchestrator" and not parent_has_exact_boundary:
         # Role grants delegate_task explicitly, matching the unconditional
-        # delegation toolset re-add below.
+        # ordinary delegation toolset re-add below. Exact parents retain every
+        # inherited denial so a child cannot exceed the parent's runtime set.
         inherited_disabled = [
             name for name in inherited_disabled if name != "delegation"
         ]
@@ -1306,12 +1316,18 @@ def _build_child_agent(
         )
     )
 
-    # Orchestrators retain the 'delegation' toolset that _strip_blocked_tools
-    # removed.  The re-add is unconditional on parent-toolset membership because
-    # orchestrator capability is granted by role, not inherited — see the
-    # test_intersection_preserves_delegation_bound test for the design rationale.
-    if effective_role == "orchestrator" and "delegation" not in child_toolsets:
-        child_toolsets.append("delegation")
+    # Ordinary orchestrators retain the 'delegation' toolset that
+    # _strip_blocked_tools removed. Exact parents already carry delegate_task
+    # inside their authored boundary, so preserve that exact selection instead
+    # of converting the child to registry-widenable ordinary delegation.
+    if effective_role == "orchestrator":
+        from toolsets import authoritative_toolset_selection
+        if parent_has_exact_boundary:
+            child_toolsets = authoritative_toolset_selection(parent_selection)
+        elif "delegation" not in child_toolsets:
+            # For ordinary parents, orchestrator capability remains role-granted
+            # rather than inherited; preserve the historical behavior.
+            child_toolsets.append("delegation")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
     child_prompt = _build_child_system_prompt(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6367,11 +6367,15 @@ def refresh_agent_mcp_tools(
     if enabled_override is not None or disabled_override is not None:
         enabled = enabled_override if enabled_override is not None else getattr(agent, "enabled_toolsets", None)
         disabled = disabled_override if disabled_override is not None else getattr(agent, "disabled_toolsets", None)
-        agent.enabled_toolsets = enabled
-        agent.disabled_toolsets = disabled
     else:
         enabled = getattr(agent, "enabled_toolsets", None)
         disabled = getattr(agent, "disabled_toolsets", None)
+
+    if enabled is not None:
+        from toolsets import authoritative_toolset_selection
+        enabled = authoritative_toolset_selection(list(enabled))
+    agent.enabled_toolsets = enabled
+    agent.disabled_toolsets = disabled
 
     # Capture the registry generation this rebuild is derived from BEFORE the
     # (potentially slow) get_tool_definitions call. Used at publish time to

--- a/toolsets.py
+++ b/toolsets.py
@@ -283,7 +283,6 @@ TOOLSETS = {
         "tools": [
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
-            "web_search", "web_extract",
             "vision_analyze", "delegate_task", "todo",
         ],
         "includes": [],

--- a/toolsets.py
+++ b/toolsets.py
@@ -275,6 +275,23 @@ TOOLSETS = {
         "includes": []
     },
 
+    "restricted-command": {
+        "description": (
+            "Exact static command-agent surface for tightly scoped API and "
+            "delegated execution"
+        ),
+        "tools": [
+            "terminal", "process",
+            "read_file", "write_file", "patch", "search_files",
+            "web_search", "web_extract",
+            "vision_analyze", "delegate_task", "todo",
+        ],
+        "includes": [],
+        # Exact toolsets are authored allowlists. Registry/plugin additions to
+        # a shared category (for example ``terminal``) must never widen them.
+        "exact": True,
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 
@@ -622,7 +639,8 @@ def get_toolset(name: str, *, include_registry: bool = True) -> Optional[Dict[st
     Args:
         name (str): Name of the toolset
         include_registry (bool): When True (default), merge in tools that
-            plugins/overlays registered into this toolset via the registry.
+            plugins/overlays registered into this toolset via the registry,
+            except for definitions marked ``exact`` (authored allowlists).
             When False, return only the static ``TOOLSETS`` definition (the
             composite-authored view). Platform reverse-mapping in
             ``_get_platform_tools`` uses False so that a tool registered into a
@@ -638,7 +656,7 @@ def get_toolset(name: str, *, include_registry: bool = True) -> Optional[Dict[st
     """
     toolset = TOOLSETS.get(name)
 
-    if not include_registry:
+    if not include_registry or (toolset and toolset.get("exact")):
         # Static view only: return the built-in definition (copying the nested
         # tools/includes lists so callers can't mutate TOOLSETS), or None for
         # registry/MCP-only toolsets that have no static counterpart.
@@ -653,8 +671,7 @@ def get_toolset(name: str, *, include_registry: bool = True) -> Optional[Dict[st
     try:
         from tools.registry import registry
     except Exception:
-        return toolset if toolset else None
-
+        return toolset
     if toolset:
         merged_tools = sorted(
             set(toolset.get("tools", []))
@@ -686,6 +703,28 @@ def get_toolset(name: str, *, include_registry: bool = True) -> Optional[Dict[st
         "tools": registry.get_tool_names_for_toolset(registry_toolset),
         "includes": [],
     }
+
+
+def has_exact_toolset_selection(names: List[str]) -> bool:
+    """Return whether a requested toolset list contains an exact boundary."""
+    return any(bool((TOOLSETS.get(name) or {}).get("exact")) for name in names)
+
+
+def authoritative_toolset_selection(names: List[str]) -> List[str]:
+    """Keep only exact entries when a selection contains an exact toolset.
+
+    Exact toolsets are authority boundaries, not composable convenience
+    bundles. Ordinary entries alongside one must never widen model assembly,
+    MCP refresh, cron jobs, or any other direct enabled-toolset consumer.
+    Lists without an exact entry retain their historical ordering and content.
+    """
+    requested = list(names)
+    if not has_exact_toolset_selection(requested):
+        return requested
+    return [
+        name for name in requested
+        if bool((TOOLSETS.get(name) or {}).get("exact"))
+    ]
 
 
 def bundle_non_core_tools(toolset_name: str) -> Set[str]:
@@ -727,11 +766,12 @@ def resolve_toolset(name: str, visited: Set[str] = None, *, include_registry: bo
         name (str): Name of the toolset to resolve
         visited (Set[str]): Set of already visited toolsets (for cycle detection)
         include_registry (bool): When True (default), include tools that
-            plugins/overlays registered into a toolset. When False, resolve only
-            the static ``TOOLSETS`` definition (includes are still resolved, but
-            statically). Platform reverse-mapping uses False so a registry-added
-            tool cannot drop the whole toolset from inference (see #49622 and
-            ``_get_platform_tools``).
+            plugins/overlays registered into a toolset. Definitions marked
+            ``exact`` always resolve statically, including their include graph.
+            When False, resolve only the static ``TOOLSETS`` definition
+            (includes are still resolved, but statically). Platform reverse-
+            mapping uses False so a registry-added tool cannot drop the whole
+            toolset from inference (see #49622 and ``_get_platform_tools``).
 
     Returns:
         List[str]: List of all tool names in the toolset
@@ -785,6 +825,11 @@ def resolve_toolset(name: str, visited: Set[str] = None, *, include_registry: bo
 
         return []
 
+    # Exact toolsets are static through their full include graph, not merely
+    # at the root. This keeps future exact composites from being widened by a
+    # registry addition to one of their included categories.
+    child_include_registry = include_registry and not toolset.get("exact", False)
+
     # Collect direct tools
     tools = set(toolset.get("tools", []))
 
@@ -792,7 +837,11 @@ def resolve_toolset(name: str, visited: Set[str] = None, *, include_registry: bo
     # sibling includes so diamond dependencies are only resolved once and
     # cycle warnings don't fire multiple times for the same cycle.
     for included_name in toolset.get("includes", []):
-        included_tools = resolve_toolset(included_name, visited, include_registry=include_registry)
+        included_tools = resolve_toolset(
+            included_name,
+            visited,
+            include_registry=child_include_registry,
+        )
         tools.update(included_tools)
 
     return sorted(tools)

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -102,6 +102,41 @@ GET  /health, /health/detailed
 
 Setup, headers (`X-Hermes-Session-Id`, `X-Hermes-Session-Key`), and frontend wiring: [API Server](../user-guide/features/api-server).
 
+### Identity-bound run approvals
+
+Clients that present an affirmative approval action must fetch authenticated
+`GET /v1/capabilities` and require all of the following:
+
+- `features.run_approval_identity_binding == true`;
+- `protocols.run_approval_identity_binding.version == 1`;
+- method `POST` and path `/v1/runs/{run_id}/approvals/{approval_id}`;
+- exact choices `["once", "deny"]`.
+
+Each `approval.request` SSE event carries a random 32-character lowercase
+hexadecimal `approval_id`. Resolve only the request the user reviewed through
+the versioned, legacy-incompatible route:
+
+```http
+POST /v1/runs/{run_id}/approvals/0123456789abcdef0123456789abcdef
+Content-Type: application/json
+
+{"choice":"once"}
+```
+
+The identity route resolves exactly one matching pending queue entry and echoes
+`approval_id` in both the HTTP response and the `approval.responded` event.
+Unknown or replayed identities return `409` without changing the queue. Malformed
+identities return `400`. The body must contain only `choice`, whose value must
+be exactly `once` or `deny`; aliases, `session`, `always`, `all`, `resolve_all`,
+and body-supplied identities are rejected before mutation. The returned
+`resolved` count and `pending` state are captured atomically with queue removal.
+
+The legacy `POST /v1/runs/{run_id}/approval` endpoint retains FIFO/resolve-all
+behavior for backward compatibility. New external UIs must never use that route
+for affirmative approval because older servers can ignore unknown fields and
+resolve a different FIFO entry. A versioned response with `pending: true` leaves
+the run in `waiting_for_approval` when another entry remains queued.
+
 ### Model catalog surfaces
 
 The OpenAI-compatible API intentionally keeps `GET /v1/models` minimal: it is


### PR DESCRIPTION
## Summary
- add authenticated capability discovery for identity-bound run approvals
- add legacy-incompatible `POST /v1/runs/{run_id}/approvals/{approval_id}` with canonical server-owned identities
- resolve exactly one pending approval under lock and return atomic `resolved`/`pending` state
- serialize approval status/event publication to prevent stale `running` updates from overwriting a newer approval wait
- reject identity fields on the legacy FIFO route to prevent downgrade/field-ignore mutation

## Security contract
- canonical approval IDs are exactly 32 lowercase hexadecimal characters
- request body is exactly `{ "choice": "once" | "deny" }`
- no session, permanent, bulk, alias, or body-supplied identity semantics
- response and SSE event echo exact run, approval identity, choice, resolved count, and pending state
- bearer authentication is required for both capability discovery and mutation

## Verification
- 65 changed-area approval/run/session tests passed
- 92 general API tests passed
- Ruff passed
- diff hygiene passed
- independent exact-byte security review: PASS, no unresolved High/Medium findings
- reviewed staged binary diff SHA-256: `3570dda6e2747780ec138a177f9369a1b50574dd412a690b465ba267251d1a31`

The installed/shared Hermes runtime was not modified or enabled.