### PR TITLE
fix(hindsight): avoid Windows daemon console popup

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -124,6 +124,82 @@ def _export_port_health_grace_timeout(config: dict[str, Any]) -> None:
     os.environ.setdefault(_PORT_HEALTH_GRACE_ENV, repr(seconds))
 
 
+def _pe_subsystem(executable: "Path") -> int | None:
+    """Return a Windows PE subsystem value, or None when it can't be read."""
+    try:
+        data = executable.read_bytes()
+        pe_offset = int.from_bytes(data[0x3C:0x40], "little")
+        optional_header = pe_offset + 24
+        # Subsystem is at offset 68 from the optional header start for both
+        # PE32 and PE32+ executables.
+        return int.from_bytes(data[optional_header + 68:optional_header + 70], "little")
+    except Exception:
+        return None
+
+
+def _windows_gui_pythonw(preferred_dir: "Path" | None = None) -> str | None:
+    """Find a real GUI-subsystem pythonw.exe for Hindsight daemon launch."""
+    if sys.platform != "win32":
+        return None
+
+    from pathlib import Path
+
+    candidates: list[Path] = []
+    if preferred_dir is not None:
+        candidates.append(Path(preferred_dir) / "pythonw.exe")
+    base_executable = getattr(sys, "_base_executable", None)
+    if base_executable:
+        candidates.append(Path(base_executable).with_name("pythonw.exe"))
+    candidates.append(Path(sys.base_prefix) / "pythonw.exe")
+    candidates.append(Path(sys.executable).with_name("pythonw.exe"))
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except Exception:
+            resolved = candidate
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if candidate.exists() and _pe_subsystem(candidate) == 2:
+            return str(candidate)
+    return None
+
+
+def _patch_hindsight_windows_daemon_launcher() -> None:
+    """Patch Hindsight's Windows daemon launcher to avoid terminal popups.
+
+    Some Windows virtual environments ship a ``Scripts/pythonw.exe`` launcher
+    whose PE subsystem is still console (3). Hindsight upstream trusts the
+    filename and launches the daemon through it; with Windows Terminal as the
+    default console host that creates a visible tab titled with the pythonw.exe
+    path. Patch the manager in-process so new HindsightEmbedded clients prefer
+    the base runtime's real GUI-subsystem pythonw.exe (subsystem 2).
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        module = importlib.import_module("hindsight_embed.daemon_embed_manager")
+        manager_cls = getattr(module, "DaemonEmbedManager", None)
+    except Exception:
+        return
+    if manager_cls is None:
+        return
+
+    current = getattr(manager_cls, "_windows_gui_interpreter", None)
+    if getattr(current, "_hermes_verified_gui_pythonw", False):
+        return
+
+    def _verified_windows_gui_interpreter(preferred_dir=None):
+        from pathlib import Path
+
+        return _windows_gui_pythonw(Path(preferred_dir) if preferred_dir is not None else None)
+
+    _verified_windows_gui_interpreter._hermes_verified_gui_pythonw = True
+    manager_cls._windows_gui_interpreter = staticmethod(_verified_windows_gui_interpreter)
+
+
 def _check_local_runtime() -> tuple[bool, str | None]:
     """Return whether local embedded Hindsight imports cleanly.
 
@@ -143,6 +219,7 @@ def _check_local_runtime() -> tuple[bool, str | None]:
     try:
         importlib.import_module("hindsight")
         importlib.import_module("hindsight_embed.daemon_embed_manager")
+        _patch_hindsight_windows_daemon_launcher()
         importlib.import_module("sentence_transformers")
         return True, None
     except Exception as exc:
@@ -1038,6 +1115,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     pass
                 except Exception as _e:
                     raise ImportError(str(_e))
+                _patch_hindsight_windows_daemon_launcher()
                 from hindsight import HindsightEmbedded
                 HindsightEmbedded.__del__ = lambda self: None
                 llm_provider = self._config.get("llm_provider", "")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -22,6 +22,7 @@ from plugins.memory.hindsight import (
     RECALL_SCHEMA,
     REFLECT_SCHEMA,
     RETAIN_SCHEMA,
+    _patch_hindsight_windows_daemon_launcher,
     _load_config,
     _load_simple_env,
     _build_embedded_profile_env,
@@ -29,6 +30,7 @@ from plugins.memory.hindsight import (
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _windows_gui_pythonw,
 )
 
 
@@ -149,6 +151,63 @@ def _assert_cloud_client_lazy_installed_before_import(tmp_path, monkeypatch, mod
         "timeout": 120.0,
         "api_key": "test-key",
     }
+
+
+def test_windows_gui_pythonw_rejects_console_subsystem_launcher(tmp_path, monkeypatch):
+    scripts_dir = tmp_path / "venv" / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    console_pythonw = scripts_dir / "pythonw.exe"
+    gui_pythonw = tmp_path / "runtime" / "pythonw.exe"
+    gui_pythonw.parent.mkdir()
+
+    console_pythonw.write_bytes(_minimal_pe(subsystem=3))
+    gui_pythonw.write_bytes(_minimal_pe(subsystem=2))
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sys, "base_prefix", str(gui_pythonw.parent))
+    monkeypatch.setattr(sys, "executable", str(scripts_dir / "python.exe"))
+    monkeypatch.setattr(sys, "_base_executable", str(gui_pythonw.with_name("python.exe")), raising=False)
+
+    assert _windows_gui_pythonw(scripts_dir) == str(gui_pythonw)
+
+
+def test_patch_hindsight_windows_daemon_launcher_prefers_real_gui_pythonw(tmp_path, monkeypatch):
+    scripts_dir = tmp_path / "venv" / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    console_pythonw = scripts_dir / "pythonw.exe"
+    gui_pythonw = tmp_path / "runtime" / "pythonw.exe"
+    gui_pythonw.parent.mkdir()
+
+    console_pythonw.write_bytes(_minimal_pe(subsystem=3))
+    gui_pythonw.write_bytes(_minimal_pe(subsystem=2))
+
+    class FakeManager:
+        @staticmethod
+        def _windows_gui_interpreter(preferred_dir=None):
+            return str(console_pythonw)
+
+    monkeypatch.setitem(sys.modules, "hindsight_embed.daemon_embed_manager", SimpleNamespace(DaemonEmbedManager=FakeManager))
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sys, "base_prefix", str(gui_pythonw.parent))
+    monkeypatch.setattr(sys, "executable", str(scripts_dir / "python.exe"))
+    monkeypatch.setattr(sys, "_base_executable", str(gui_pythonw.with_name("python.exe")), raising=False)
+
+    _patch_hindsight_windows_daemon_launcher()
+
+    assert FakeManager._windows_gui_interpreter(scripts_dir) == str(gui_pythonw)
+
+
+def _minimal_pe(*, subsystem: int) -> bytes:
+    """Return enough PE header bytes for the plugin's subsystem parser."""
+    data = bytearray(256)
+    data[0:2] = b"MZ"
+    pe_offset = 0x80
+    data[0x3C:0x40] = pe_offset.to_bytes(4, "little")
+    data[pe_offset:pe_offset + 4] = b"PE\0\0"
+    optional_header = pe_offset + 24
+    data[optional_header:optional_header + 2] = (0x20B).to_bytes(2, "little")
+    data[optional_header + 68:optional_header + 70] = subsystem.to_bytes(2, "little")
+    return bytes(data)
 
 
 class _FakeSessionDB:
@@ -337,6 +396,7 @@ class TestConfig:
 
         monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
         monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+        monkeypatch.setattr("tools.lazy_deps.ensure", lambda *args, **kwargs: None)
 
         p = HindsightMemoryProvider()
         p._mode = "local_embedded"


### PR DESCRIPTION
## Summary
- Avoid Hindsight's Windows daemon launch path using a console-subsystem `pythonw.exe`
- Verify the selected `pythonw.exe` is a real GUI-subsystem executable before patching Hindsight's daemon manager
- Add regression coverage for rejecting console-subsystem launchers

## Test Plan
- [x] `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py -q`
- [x] Manual provider-path validation: Hindsight daemon starts through the patched `HindsightMemoryProvider._get_client()` path without a new visible terminal-like window
