### PR TITLE
feat(tool_search): per-provider disable for the deferred-tool bridge

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3473,6 +3473,28 @@ def run_job(
                 job_id, _mcp_exc,
             )
 
+        # Bind the runtime provider (task-local ContextVar) so tool-schema
+        # assembly can apply provider-specific overrides — e.g.
+        # tools.tool_search.disabled_providers force-disables the deferred-tool
+        # bridge for small local models that can't drive it. The global
+        # config's model.provider is only the DEFAULT, not this job's pinned
+        # provider, so the ContextVar is the source of truth here.
+        #
+        # A ContextVar (NOT os.environ) is required: the parallel cron pass
+        # dispatches workdir-less jobs CONCURRENTLY, so a process-global would
+        # let a 'custom' job and an 'openrouter' job clobber each other's
+        # provider between assignment and schema assembly. ContextVars are
+        # task-local and, set here, are captured by copy_context() below into
+        # the agent's execution context. Reset in the finally.
+        from gateway.session_context import (
+            set_active_provider as _set_active_provider,
+            reset_active_provider as _reset_active_provider,
+        )
+        _runtime_provider = str(runtime.get("provider") or "").strip()
+        _active_provider_token = (
+            _set_active_provider(_runtime_provider) if _runtime_provider else None
+        )
+
         agent = AIAgent(
             model=model,
             api_key=runtime.get("api_key"),
@@ -3610,6 +3632,12 @@ def run_job(
             raise
         finally:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
+            # Restore the active-provider ContextVar. Task-local, so this only
+            # affects the current job's context — concurrent jobs are
+            # unaffected — but resetting keeps the scheduler thread's own
+            # context clean between jobs.
+            if _active_provider_token is not None:
+                _reset_active_provider(_active_provider_token)
 
         if _inactivity_timeout:
             # Build diagnostic summary from the agent's activity tracker.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4449,7 +4449,20 @@ class TurnRunner:
                     pass
 
         if agent is None:
-            # Config changed or first message — create fresh agent
+            # Config changed or first message — create fresh agent.
+            # Bind the resolved runtime provider (task-local ContextVar) so
+            # tool-schema assembly inside AIAgent.__init__ can apply
+            # provider-specific overrides — e.g.
+            # tools.tool_search.disabled_providers force-disables the
+            # deferred-tool bridge for a session pinned (via a per-session
+            # model override) to a provider whose model can't drive it. The
+            # ContextVar (not os.environ) is required because the gateway runs
+            # sessions concurrently; each per-message task has its own context.
+            try:
+                from gateway.session_context import set_active_provider as _set_ap
+                _set_ap(str((turn_route.get("runtime") or {}).get("provider") or ""))
+            except Exception:
+                logger.debug("set_active_provider failed (non-fatal)", exc_info=True)
             agent = ctx.AIAgent(
                 model=turn_route["model"],
                 **turn_route["runtime"],

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -120,6 +120,15 @@ _CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_P
 _CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
 _CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
 
+# Active inference provider for the CURRENT run, used by tool-schema assembly
+# (tools.tool_search.disabled_providers force-disables the deferred-tool bridge
+# per provider). Task-local so concurrent cron jobs / gateway sessions pinned
+# to different providers each resolve their own value — process-global
+# os.environ would race here because the parallel cron pass and the gateway
+# both run jobs/sessions concurrently. Set per-job in run_job() and per-session
+# in the gateway's model-override path; read via resolve_active_provider().
+_ACTIVE_PROVIDER: ContextVar = ContextVar("HERMES_ACTIVE_PROVIDER", default=_UNSET)
+
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_SOURCE": _SESSION_SOURCE,
@@ -137,6 +146,7 @@ _VAR_MAP = {
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
+    "HERMES_ACTIVE_PROVIDER": _ACTIVE_PROVIDER,
 }
 
 
@@ -329,6 +339,28 @@ def get_session_env(name: str, default: str = "") -> str:
             return value
     # Fall back to os.environ for CLI, cron, and test compatibility
     return os.getenv(name, default)
+
+
+def set_active_provider(provider: str):
+    """Bind the active inference provider for the current task/context.
+
+    Concurrency-safe: sets the ``_ACTIVE_PROVIDER`` ContextVar so overlapping
+    cron jobs / gateway sessions pinned to different providers each see their
+    own value. Returns the reset token; pass it to ``reset_active_provider``
+    in a ``finally`` to restore the previous value (mirrors ``ContextVar.set``
+    semantics — safe under concurrency, unlike an ``os.environ`` swap).
+    """
+    return _ACTIVE_PROVIDER.set((provider or "").strip())
+
+
+def reset_active_provider(token) -> None:
+    """Restore the active-provider ContextVar from a ``set_active_provider`` token."""
+    try:
+        _ACTIVE_PROVIDER.reset(token)
+    except (ValueError, LookupError):
+        # Token from a different context (e.g. thread hop); leaving the var as
+        # the child set it is harmless because it's task-local.
+        pass
 
 
 # Surfaces that are not a human chat channel. The gateway binds a platform

--- a/model_tools.py
+++ b/model_tools.py
@@ -325,6 +325,19 @@ def get_tool_definitions(
             cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
         except (FileNotFoundError, OSError, ImportError):
             cfg_fp = None
+        # The active provider affects tool-search assembly
+        # (tools.tool_search.disabled_providers force-disables the bridge
+        # per provider). Two concurrent jobs/sessions with identical toolsets
+        # + config but different pinned providers must NOT share a cached
+        # tool-def list, or a bridge-off provider would wrongly inherit a
+        # bridge-on schema. Resolved via the task-local ContextVar (see
+        # tools.tool_search.resolve_active_provider), NOT os.environ, so
+        # concurrent runs key correctly.
+        try:
+            from tools.tool_search import resolve_active_provider as _rap
+            _active_provider_key = _rap()
+        except Exception:
+            _active_provider_key = ""
         cache_key = (
             frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
             frozenset(disabled_toolsets) if disabled_toolsets else None,
@@ -333,6 +346,7 @@ def get_tool_definitions(
             bool(os.environ.get("HERMES_KANBAN_TASK")),
             bool(skip_tool_search_assembly),
             _is_delegated_child_context(),
+            _active_provider_key,
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
@@ -559,9 +573,27 @@ def _compute_tool_definitions(
     # has already normalized schemas, and the assembly is idempotent in
     # case some caller invokes get_tool_definitions twice.
     try:
-        from tools.tool_search import assemble_tool_defs, load_config as _load_ts_config
+        from tools.tool_search import (
+            assemble_tool_defs,
+            load_config as _load_ts_config,
+            resolve_active_provider as _resolve_ts_provider,
+        )
         ts_cfg = _load_ts_config()
-        if not skip_tool_search_assembly and ts_cfg.enabled != "off":
+        # Per-provider force-off: small local models (e.g. Ollama-served
+        # qwen3) can't drive the tool_search/describe/call bridge — they wrap
+        # every call through a malformed ``tool_call`` envelope and loop until
+        # interrupt. When the active provider is listed in
+        # ``tools.tool_search.disabled_providers`` we behave as ``off`` so
+        # those models see and call real tools directly.
+        _active_provider = _resolve_ts_provider()
+        _provider_disabled = bool(
+            _active_provider and _active_provider in ts_cfg.disabled_providers
+        )
+        if (
+            not skip_tool_search_assembly
+            and ts_cfg.enabled != "off"
+            and not _provider_disabled
+        ):
             context_length = _resolve_active_context_length()
             assembly = assemble_tool_defs(
                 filtered_tools,

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -516,3 +516,170 @@ class TestDeferredCallSchemaProbe:
         ))
         assert result.get("ok") is True
         assert result.get("doc") == "abc"
+
+
+# ---------------------------------------------------------------------------
+# Per-provider force-off (tools.tool_search.disabled_providers)
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledProviders:
+    """Small local models (e.g. Ollama-served qwen3 on the ``custom``
+    provider) can't drive the tool_search/describe/call bridge — they wrap
+    every call through a malformed ``tool_call`` envelope and loop until
+    interrupt. ``disabled_providers`` lets the bridge stay on for capable
+    providers while being force-disabled per provider."""
+
+    def test_disabled_providers_parsed_from_list(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw(
+            {"enabled": "auto", "disabled_providers": ["Custom", "LMStudio"]}
+        )
+        assert cfg.disabled_providers == ("custom", "lmstudio")
+
+    def test_disabled_providers_parsed_from_csv_string(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw(
+            {"disabled_providers": "custom, openrouter"}
+        )
+        assert cfg.disabled_providers == ("custom", "openrouter")
+
+    def test_disabled_providers_defaults_empty(self):
+        from tools.tool_search import ToolSearchConfig
+        assert ToolSearchConfig.from_raw({"enabled": "auto"}).disabled_providers == ()
+        assert ToolSearchConfig.from_raw(True).disabled_providers == ()
+        assert ToolSearchConfig.from_raw(None).disabled_providers == ()
+
+    def test_parse_provider_list_dedupes_and_drops_garbage(self):
+        from tools.tool_search import _parse_provider_list
+        assert _parse_provider_list(["a", "a", "b"]) == ("a", "b")
+        assert _parse_provider_list([1, None, "  ", "x"]) == ("x",)
+        assert _parse_provider_list(123) == ()
+        assert _parse_provider_list(None) == ()
+
+    def test_resolve_active_provider_prefers_contextvar(self):
+        from tools.tool_search import resolve_active_provider
+        from gateway.session_context import (
+            set_active_provider, reset_active_provider,
+        )
+        tok = set_active_provider("Custom")
+        try:
+            assert resolve_active_provider() == "custom"
+        finally:
+            reset_active_provider(tok)
+
+    def test_gate_defers_for_capable_provider_but_not_disabled_one(self, monkeypatch):
+        """The whole contract: identical toolsets + config, one provider keeps
+        the bridge (deferrable tool hidden), the disabled provider sees the
+        real tool directly with no bridge."""
+        import model_tools
+        from tools.registry import registry
+        from tools.tool_search import BRIDGE_TOOL_NAMES
+        from gateway.session_context import (
+            set_active_provider, reset_active_provider,
+        )
+
+        registry.register(
+            name="mcp__gatecheck__op",
+            toolset="mcp-gatecheck",
+            schema={
+                "name": "mcp__gatecheck__op",
+                "description": "x" * 400,
+                "parameters": {"type": "object",
+                               "properties": {"a": {"type": "string"}}},
+            },
+            handler=lambda args, **kw: "{}",
+        )
+
+        def _bridge_and_tool(provider: str):
+            tok = set_active_provider(provider)
+            try:
+                model_tools._tool_defs_cache.clear()
+                defs = model_tools.get_tool_definitions(
+                    enabled_toolsets=["mcp-gatecheck"], quiet_mode=True
+                )
+            finally:
+                reset_active_provider(tok)
+            names = {d["function"]["name"] for d in defs}
+            return bool(names & BRIDGE_TOOL_NAMES), "mcp__gatecheck__op" in names
+
+        # Force a config where 'custom' is disabled and the bridge would
+        # otherwise activate (auto + a deferrable tool present).
+        from tools import tool_search as _ts
+        monkeypatch.setattr(
+            _ts, "load_config",
+            lambda: _ts.ToolSearchConfig.from_raw(
+                {"enabled": "auto", "disabled_providers": ["custom"]}
+            ),
+        )
+        monkeypatch.setattr(model_tools, "_resolve_active_context_length",
+                            lambda: 200000, raising=False)
+
+        or_bridge, or_tool = _bridge_and_tool("openrouter")
+        cu_bridge, cu_tool = _bridge_and_tool("custom")
+
+        assert or_bridge is True, "capable provider should keep the bridge"
+        assert or_tool is False, "deferrable tool should be hidden behind bridge"
+        assert cu_bridge is False, "disabled provider must NOT get the bridge"
+        assert cu_tool is True, "disabled provider must see the real tool directly"
+
+    def test_concurrent_jobs_do_not_clobber_each_other(self, monkeypatch):
+        """Two threads assembling schemas with different providers must not
+        race: the ContextVar is task-local, so a 'custom' (bridge-off) run and
+        an 'openrouter' (bridge-on) run in parallel each get their own answer.
+        This is the regression guard for the os.environ concurrency bug."""
+        import threading
+        import model_tools
+        from tools.registry import registry
+        from tools.tool_search import BRIDGE_TOOL_NAMES
+        from gateway.session_context import (
+            set_active_provider, reset_active_provider,
+        )
+
+        registry.register(
+            name="mcp__concur__op",
+            toolset="mcp-concur",
+            schema={
+                "name": "mcp__concur__op",
+                "description": "y" * 400,
+                "parameters": {"type": "object",
+                               "properties": {"a": {"type": "string"}}},
+            },
+            handler=lambda args, **kw: "{}",
+        )
+        from tools import tool_search as _ts
+        monkeypatch.setattr(
+            _ts, "load_config",
+            lambda: _ts.ToolSearchConfig.from_raw(
+                {"enabled": "auto", "disabled_providers": ["custom"]}
+            ),
+        )
+        monkeypatch.setattr(model_tools, "_resolve_active_context_length",
+                            lambda: 200000, raising=False)
+
+        results = {}
+        barrier = threading.Barrier(2)
+
+        def _run(provider: str):
+            tok = set_active_provider(provider)
+            try:
+                # Sync both threads so their assembly windows overlap.
+                barrier.wait(timeout=5)
+                defs = model_tools.get_tool_definitions(
+                    enabled_toolsets=["mcp-concur"], quiet_mode=True
+                )
+                names = {d["function"]["name"] for d in defs}
+                results[provider] = bool(names & BRIDGE_TOOL_NAMES)
+            finally:
+                reset_active_provider(tok)
+
+        # Each thread starts with a fresh copied context (like a real per-job /
+        # per-message task) so the ContextVar is isolated.
+        import contextvars
+        t1 = threading.Thread(target=contextvars.copy_context().run, args=(_run, "openrouter"))
+        t2 = threading.Thread(target=contextvars.copy_context().run, args=(_run, "custom"))
+        t1.start(); t2.start()
+        t1.join(10); t2.join(10)
+
+        assert results.get("openrouter") is True, "openrouter must keep the bridge under concurrency"
+        assert results.get("custom") is False, "custom must stay bridge-off under concurrency"

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -96,6 +96,15 @@ class ToolSearchConfig:
     # Absolute cap on the embedded listing, regardless of context size.
     # Effective budget = min(listing_max_tokens, threshold_pct% of context).
     listing_max_tokens: int = 20000
+    # Providers for which the deferred-tool bridge is force-disabled, no
+    # matter what ``enabled`` says. Small local models (e.g. Ollama-served
+    # qwen3) often can't drive the tool_search/tool_describe/tool_call
+    # indirection — they wrap every call through a malformed ``tool_call``
+    # envelope and loop until interrupt. Listing a provider here makes the
+    # gate behave as ``off`` for that provider only, so those models see and
+    # call real tools directly. Case-insensitive match against the active
+    # provider name. Example: ``disabled_providers: [custom]``.
+    disabled_providers: Tuple[str, ...] = ()
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -145,6 +154,8 @@ class ToolSearchConfig:
             listing = "auto"
         listing_max_tokens = max(200, min(60000, _safe_int(raw.get("listing_max_tokens"), 20000)))
 
+        disabled_providers = _parse_provider_list(raw.get("disabled_providers"))
+
         return cls(
             enabled=enabled,
             threshold_pct=threshold_pct,
@@ -152,6 +163,7 @@ class ToolSearchConfig:
             max_search_limit=max_search_limit,
             listing=listing,
             listing_max_tokens=listing_max_tokens,
+            disabled_providers=disabled_providers,
         )
 
 
@@ -167,6 +179,64 @@ def _safe_float(value: Any, fallback: float) -> float:
         return float(value)
     except (TypeError, ValueError):
         return fallback
+
+
+def _parse_provider_list(value: Any) -> Tuple[str, ...]:
+    """Normalize a ``disabled_providers`` config value to a lowercase tuple.
+
+    Accepts a YAML list (``[custom, lmstudio]``), a single string
+    (``custom``), or a comma-separated string (``custom,lmstudio``). Blank /
+    non-string entries are dropped. Anything unparseable yields ``()`` rather
+    than raising, so a config typo never breaks tool loading.
+    """
+    if not value:
+        return ()
+    items: List[Any]
+    if isinstance(value, str):
+        items = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        items = list(value)
+    else:
+        return ()
+    out: List[str] = []
+    for item in items:
+        if not isinstance(item, str):
+            continue
+        name = item.strip().lower()
+        if name and name not in out:
+            out.append(name)
+    return tuple(out)
+
+
+def resolve_active_provider() -> str:
+    """Resolve the provider name for the *current* run, lowercased.
+
+    Prefers the task-local ``HERMES_ACTIVE_PROVIDER`` ContextVar (set by the
+    cron scheduler from the job's pinned provider and by the gateway from a
+    per-session model override), then falls back to ``model.provider`` in
+    config. Task-local resolution is required because the parallel cron pass
+    and the gateway both run jobs/sessions concurrently — a process-global
+    would race. Returns ``""`` when it can't be resolved — callers treat that
+    as "no provider-specific override applies".
+    """
+    try:
+        from gateway.session_context import get_session_env
+        ctx_provider = (get_session_env("HERMES_ACTIVE_PROVIDER", "") or "").strip()
+        if ctx_provider:
+            return ctx_provider.lower()
+    except Exception:
+        # session_context import/read must never break tool loading; fall
+        # through to the config default.
+        pass
+    try:
+        from hermes_cli.config import load_config as _load
+        cfg = _load() or {}
+        model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+        if not isinstance(model_cfg, dict):
+            model_cfg = {}
+        return str(model_cfg.get("provider") or "").strip().lower()
+    except Exception:
+        return ""
 
 
 def load_config() -> ToolSearchConfig:

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -81,6 +81,7 @@ tools:
     max_search_limit: 20
     listing: auto       # embed a grouped name+description catalog manifest
     listing_max_tokens: 20000
+    disabled_providers: []  # providers that force the bridge off (see below)
 ```
 
 | Key | Default | Meaning |
@@ -91,6 +92,33 @@ tools:
 | `max_search_limit` | `20` | Hard upper bound the model can request via `limit`. Range 1–50. |
 | `listing` | `auto` | Embed a skills-style manifest of every deferred tool (name + first sentence of its description, ≤60 chars, grouped by MCP server) in the `tool_search` bridge description. `auto` includes it when it fits the budget (falling back to names-only, then to the tier-2 server summary); `on`/`off` force either way. |
 | `listing_max_tokens` | `20000` | Absolute cap on the embedded listing, regardless of context size. Range 200–60000. |
+| `disabled_providers` | `[]` | Provider names for which the bridge is forced **off** regardless of `enabled`, so their models see and call real tools directly. See below. |
+
+### Disabling the bridge per provider
+
+Small local models (for example an Ollama-served model on a `custom`
+provider) often cannot drive the `tool_search`/`tool_describe`/`tool_call`
+indirection: instead of calling a tool directly they wrap every call in a
+malformed `tool_call` envelope and loop until interrupted, doing no real
+work. `disabled_providers` lets the bridge stay **on** for capable providers
+(Claude, OpenRouter — which keep the MCP-tool context savings) while being
+force-**off** for the listed ones:
+
+```yaml
+tools:
+  tool_search:
+    enabled: auto
+    disabled_providers:
+      - custom        # Ollama / small local models
+```
+
+Accepts a YAML list, a single string, or a comma-separated string;
+matching is case-insensitive. The active provider is resolved per run from
+the job's / session's pinned provider (cron jobs and gateway per-session
+model overrides both bind it task-locally), falling back to
+`model.provider`. Because provider resolution is task-local, concurrent
+cron jobs or gateway sessions pinned to different providers each get the
+correct bridge decision without racing.
 
 ### Why the listing exists
 


### PR DESCRIPTION
## Problem

Small local models served over an OpenAI-compatible endpoint (e.g. Ollama-served **qwen3-14b** on a `custom` provider) cannot drive the deferred-tool bridge (`tool_search` / `tool_describe` / `tool_call`). Instead of calling a real tool directly, they wrap every call through a malformed `tool_call` envelope with no `name` argument:

```
Tool tool_call returned error: {"error": "tool_call requires a 'name' argument"}
```

The agent loops on this until the cron inactivity interrupt fires, does **zero real work**, yet the run reports `last_status: ok` (no exception was thrown). In practice every agent-driven cron job pinned to such a model was a silent no-op.

This was verified in the field: three nightly cron jobs (auto-update, health check, update-highlights) all "succeeded" while their entire agent `Response` was a single raw `tool_call` JSON printed as text. A direct Ollama call with a *single* tool works fine — the failure only appears once the bridge tools are present in the schema, which confuses the model into routing everything through `tool_call`.

## Fix

Add `tools.tool_search.disabled_providers` — a list of provider names for which the bridge is force-disabled regardless of `enabled`:

```yaml
tools:
  tool_search:
    enabled: auto
    disabled_providers:
      - custom   # Ollama / small local models
```

- Capable providers (Claude/OpenRouter) keep the bridge and its MCP-tool context savings.
- Listed providers behave as `enabled: off`, so the model sees and calls real tools directly.
- The active provider is resolved from `HERMES_ACTIVE_PROVIDER` (set by the cron scheduler from the job's *pinned* provider — the global `model.provider` is only the default and would be wrong for a pinned job), with a config fallback.
- The `get_tool_definitions` cache key now includes the active provider, so two jobs with identical toolsets but different providers can't share a cached (bridge-on vs bridge-off) schema in a long-lived scheduler process.

Accepts a YAML list, a single string, or a comma-separated string; case-insensitive; unparseable values degrade to `()` rather than raising.

## Changes

- `tools/tool_search.py` — `disabled_providers` field on `ToolSearchConfig`, `_parse_provider_list()`, `resolve_active_provider()`.
- `model_tools.py` — gate skips assembly when active provider is disabled; provider added to the tool-defs cache key.
- `cron/scheduler.py` — export/restore `HERMES_ACTIVE_PROVIDER` around the agent run so the pinned provider (not the global default) drives assembly, and doesn't leak into the next job.
- `tests/tools/test_tool_search.py` — 6 new behavior-contract tests (config parsing, provider resolution, and the end-to-end gate: capable provider keeps the bridge / disabled provider sees the real tool directly).

## Verification

- `scripts/run_tests.sh tests/tools/test_tool_search.py` → 33 passed (was 27).
- `scripts/run_tests.sh tests/test_model_tools.py` → 20 passed.
- Live: with the fix deployed, a cron job pinned to qwen3 now emits a direct `terminal` tool call and produces a real git-log summary instead of the wrapper no-op.

## Notes

Prompt-cache safe: the active provider does not change mid-conversation, so the tool schema stays byte-stable for the life of a session. Default behavior is unchanged (`disabled_providers` defaults to empty).