### PR TITLE
fix(wecom-callback): add image/file send and inbound image support

### DIFF
--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import socket as _socket
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 # Security: parse untrusted, pre-auth request bodies (WeCom callbacks) with
 # defusedxml to block billion-laughs / entity-expansion (and XXE) DoS. The
@@ -149,7 +151,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         try:
             # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
             from gateway.platforms._http_client_limits import platform_httpx_limits
-            self._http_client = httpx.AsyncClient(timeout=20.0, limits=platform_httpx_limits())
+            self._http_client = httpx.AsyncClient(timeout=60.0, limits=platform_httpx_limits())
             # client_max_size rejects oversized bodies at the aiohttp layer
             # (413) before our handler — and before any signature work — runs.
             self._app = web.Application(client_max_size=_MAX_BODY)
@@ -252,6 +254,126 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
 
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a local image file via WeCom message/send with msgtype=image.
+
+        WeCom requires uploading the file to the media API first to get a
+        ``media_id``, then sending an image message referencing it.
+        """
+        app = self._resolve_app_for_chat(chat_id)
+        touser = chat_id.split(":", 1)[1] if ":" in chat_id else chat_id
+        try:
+            media_id = await self._upload_media(app, image_path, media_type="image")
+            if not media_id:
+                return SendResult(success=False, error="image upload failed")
+            result = await self._send_media_msg(app, touser, "image", media_id)
+            if result.success and caption:
+                await self.send(chat_id, caption, metadata=metadata)
+            return result
+        except Exception as exc:
+            logger.error("[WecomCallback] send_image_file error: %s", exc, exc_info=True)
+            return SendResult(success=False, error=str(exc))
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        filename: Optional[str] = None,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a file via WeCom message/send with msgtype=file."""
+        app = self._resolve_app_for_chat(chat_id)
+        touser = chat_id.split(":", 1)[1] if ":" in chat_id else chat_id
+        try:
+            media_id = await self._upload_media(app, file_path, media_type="file")
+            if not media_id:
+                return SendResult(success=False, error="file upload failed")
+            result = await self._send_media_msg(app, touser, "file", media_id)
+            if result.success and caption:
+                await self.send(chat_id, caption, metadata=metadata)
+            return result
+        except Exception as exc:
+            logger.error("[WecomCallback] send_document error: %s", exc, exc_info=True)
+            return SendResult(success=False, error=str(exc))
+
+    async def _upload_media(self, app: Dict[str, Any], file_path: str, media_type: str = "image") -> Optional[str]:
+        """Upload a file to WeCom media API and return media_id, or None."""
+        import mimetypes
+
+        safe_path = self.validate_media_delivery_path(file_path)
+        if not safe_path:
+            logger.warning("[WecomCallback] Refusing to upload unsafe path: %s", file_path)
+            return None
+
+        fp = Path(safe_path)
+        mime_type = mimetypes.guess_type(str(fp))[0] or "application/octet-stream"
+
+        for _attempt in range(2):
+            token = await self._get_access_token(app)
+            with open(safe_path, "rb") as f:
+                upload_resp = await self._http_client.post(
+                    f"https://qyapi.weixin.qq.com/cgi-bin/media/upload?access_token={token}&type={media_type}",
+                    files={"media": (fp.name, f, mime_type)},
+                )
+            upload_data = upload_resp.json()
+            errcode = upload_data.get("errcode")
+            if errcode in {40001, 42001} and _attempt == 0:
+                logger.warning(
+                    "[WecomCallback] Token rejected for media upload (errcode=%s), refreshing",
+                    errcode,
+                )
+                self._access_tokens.pop(app["name"], None)
+                continue
+            if errcode not in (None, 0):
+                logger.warning("[WecomCallback] media upload failed for %s: %s", fp.name, upload_data)
+                return None
+            return upload_data.get("media_id")
+        return None
+
+    async def _send_media_msg(self, app: Dict[str, Any], touser: str, msg_type: str, media_id: str) -> SendResult:
+        """Send a media message (image/file) via WeCom message/send."""
+        payload = {
+            "touser": touser,
+            "msgtype": msg_type,
+            "agentid": int(str(app.get("agent_id") or 0)),
+            msg_type: {"media_id": media_id},
+            "safe": 0,
+        }
+        for _attempt in range(2):
+            token = await self._get_access_token(app)
+            resp = await self._http_client.post(
+                f"https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token={token}",
+                json=payload,
+            )
+            data = resp.json()
+            errcode = data.get("errcode")
+            if errcode in {40001, 42001} and _attempt == 0:
+                logger.warning(
+                    "[WecomCallback] Token rejected for %s send (errcode=%s), refreshing",
+                    msg_type, errcode,
+                )
+                self._access_tokens.pop(app["name"], None)
+                continue
+            if errcode != 0:
+                return SendResult(success=False, error=str(data))
+            return SendResult(
+                success=True,
+                message_id=str(data.get("msgid", "")),
+                raw_response=data,
+            )
+        return SendResult(success=False, error=f"{msg_type} send failed after token refresh")
+
     def _resolve_app_for_chat(self, chat_id: str) -> Dict[str, Any]:
         """Pick the app associated with *chat_id*, falling back sensibly."""
         app_name = self._user_app_map.get(chat_id)
@@ -306,7 +428,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
                 decrypted = self._decrypt_request(
                     app, body, msg_signature, timestamp, nonce,
                 )
-                event = self._build_event(app, decrypted)
+                event = await self._build_event(app, decrypted)
                 if event is not None:
                     # Deduplicate: WeCom retries callbacks on timeout,
                     # producing duplicate inbound messages (#10305).
@@ -363,7 +485,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         crypt = self._crypt_for_app(app)
         return crypt.decrypt(msg_signature, timestamp, nonce, encrypt).decode("utf-8")
 
-    def _build_event(self, app: Dict[str, Any], xml_text: str) -> Optional[MessageEvent]:
+    async def _build_event(self, app: Dict[str, Any], xml_text: str) -> Optional[MessageEvent]:
         root = ET.fromstring(xml_text)
         msg_type = (root.findtext("MsgType") or "").lower()
         # Silently acknowledge lifecycle events.
@@ -371,15 +493,12 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             event_name = (root.findtext("Event") or "").lower()
             if event_name in {"enter_agent", "subscribe"}:
                 return None
-        if msg_type not in {"text", "event"}:
+        if msg_type not in {"text", "event", "image"}:
             return None
 
         user_id = root.findtext("FromUserName", default="")
         corp_id = root.findtext("ToUserName", default=app.get("corp_id", ""))
         scoped_chat_id = self._user_app_key(corp_id, user_id)
-        content = root.findtext("Content", default="").strip()
-        if not content and msg_type == "event":
-            content = "/start"
         msg_id = (
             root.findtext("MsgId")
             or f"{user_id}:{root.findtext('CreateTime', default='0')}"
@@ -391,6 +510,31 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_id,
         )
+
+        if msg_type == "image":
+            # Fire-and-forget: download the PicUrl in the background so the
+            # callback acknowledgement returns immediately.  WeCom retries
+            # callbacks on timeout (30s) — cache_image_from_url can take that
+            # long on slow networks.  The image arrives as a later message
+            # in the queue once downloaded.
+            pic_url = root.findtext("PicUrl", default="")
+            media_id = root.findtext("MediaId", default="")
+            asyncio.create_task(
+                self._cache_and_queue_image(pic_url, media_id, source, msg_id, xml_text)
+            )
+            # Return a placeholder text event so the ACK is immediate.
+            return MessageEvent(
+                text="[图片]",
+                message_type=MessageType.PHOTO,
+                source=source,
+                raw_message=xml_text,
+                message_id=msg_id,
+            )
+
+        content = root.findtext("Content", default="").strip()
+        if not content and msg_type == "event":
+            content = "/start"
+
         return MessageEvent(
             text=content,
             message_type=MessageType.TEXT,
@@ -398,6 +542,56 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             raw_message=xml_text,
             message_id=msg_id,
         )
+
+    async def _cache_and_queue_image(
+        self,
+        pic_url: str,
+        media_id: str,
+        source: Any,
+        msg_id: str,
+        xml_text: str,
+    ) -> None:
+        """Download an inbound image in the background and queue it."""
+        cached_path = None
+        if pic_url:
+            try:
+                cached_path = await self._cache_image_from_url(pic_url, media_id)
+            except Exception as exc:
+                logger.warning("[WecomCallback] Inbound image download failed: %s", exc)
+
+        event = MessageEvent(
+            text="[图片]" if not cached_path else "",
+            message_type=MessageType.PHOTO,
+            source=source,
+            raw_message=xml_text,
+            message_id=msg_id,
+            media_urls=[cached_path] if cached_path else [],
+        )
+        await self._message_queue.put(event)
+
+    async def _cache_image_from_url(self, url: str, media_id: str) -> Optional[str]:
+        """Download an image from PicUrl and cache it locally."""
+        import hashlib
+
+        if not url:
+            return None
+        # Use the configured media cache directory.
+        cache_dir = Path(os.environ.get("HERMES_MEDIA_CACHE_DIR", "/tmp/hermes-media-cache"))
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        # Derive a stable filename from the URL / media_id.
+        key = media_id or url
+        ext = ".jpg"  # WeCom PicUrl images are JPEG
+        safe_name = hashlib.sha256(key.encode()).hexdigest()[:16] + ext
+        dest = cache_dir / safe_name
+        if dest.exists():
+            return str(dest)
+
+        resp = await self._http_client.get(url)
+        if resp.status_code != 200:
+            logger.warning("[WecomCallback] PicUrl download returned %s", resp.status_code)
+            return None
+        dest.write_bytes(resp.content)
+        return str(dest)
 
     def _crypt_for_app(self, app: Dict[str, Any]) -> WXBizMsgCrypt:
         return WXBizMsgCrypt(

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -6,6 +6,7 @@ from xml.etree import ElementTree as ET
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
 from plugins.platforms.wecom.callback_adapter import WecomCallbackAdapter
 from plugins.platforms.wecom.wecom_crypto import WXBizMsgCrypt
 
@@ -46,7 +47,8 @@ class TestWecomCrypto:
 
 
 class TestWecomCallbackEventConstruction:
-    def test_build_event_extracts_text_message(self):
+    @pytest.mark.asyncio
+    async def test_build_event_extracts_text_message(self):
         adapter = WecomCallbackAdapter(_config())
         xml_text = """
         <xml>
@@ -58,13 +60,36 @@ class TestWecomCallbackEventConstruction:
           <MsgId>123456789</MsgId>
         </xml>
         """
-        event = adapter._build_event(_app(), xml_text)
+        event = await adapter._build_event(_app(), xml_text)
         assert event is not None
         assert event.source is not None
         assert event.source.user_id == "zhangsan"
         assert event.source.chat_id == "ww1234567890:zhangsan"
         assert event.message_id == "123456789"
         assert event.text == "\u4f60\u597d"
+
+    @pytest.mark.asyncio
+    async def test_build_event_image_returns_placeholder_immediately(self):
+        """Inbound image events must return a placeholder without blocking on download."""
+        adapter = WecomCallbackAdapter(_config())
+        xml_text = """
+        <xml>
+          <ToUserName>ww1234567890</ToUserName>
+          <FromUserName>zhangsan</FromUserName>
+          <CreateTime>1710000000</CreateTime>
+          <MsgType>image</MsgType>
+          <PicUrl>https://example.com/photo.jpg</PicUrl>
+          <MediaId>MEDIA123</MediaId>
+          <MsgId>img001</MsgId>
+        </xml>
+        """
+        event = await adapter._build_event(_app(), xml_text)
+        assert event is not None
+        assert event.message_type == MessageType.PHOTO
+        assert event.message_id == "img001"
+        assert event.source.user_id == "zhangsan"
+        # Placeholder text returned immediately — download is fire-and-forget
+        assert event.text == "[图片]"
 
 
 class TestWecomCallbackRouting:
@@ -149,7 +174,7 @@ class TestWecomCallbackPollLoop:
             calls.append(event.text)
 
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
-        event = adapter._build_event(
+        event = await adapter._build_event(
             _app(),
             """
             <xml>
@@ -197,5 +222,97 @@ class TestWecomCallbackBodySizeLimit:
         oversized = b"<xml>" + b"A" * (_MAX_BODY + 1) + b"</xml>"
         response = await adapter._handle_callback(self._request(oversized))
         assert response.status == 413
+
+
+class TestWecomCallbackImageSend:
+    """Regression coverage for send_image_file (PR #75341)."""
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_uploads_then_sends(self, tmp_path):
+        adapter = WecomCallbackAdapter(_config())
+        adapter._access_tokens["test-app"] = {"token": "tok", "expires_at": 9999999999}
+        adapter._user_app_map["ww1234567890:alice"] = "test-app"
+
+        # Create a small test image
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0fake JPEG data")
+
+        post_calls = []
+
+        class FakeResponse:
+            def __init__(self, data):
+                self._data = data
+            def json(self):
+                return self._data
+
+        class FakeClient:
+            async def post(self, url, json=None, files=None, **kw):
+                post_calls.append({"url": url, "json": json, "files": files})
+                if "media/upload" in url:
+                    return FakeResponse({"errcode": 0, "media_id": "media-123", "type": "image"})
+                return FakeResponse({"errcode": 0, "msgid": "img-msg-1"})
+
+        adapter._http_client = FakeClient()
+        result = await adapter.send_image_file("ww1234567890:alice", str(img))
+
+        assert result.success is True
+        assert result.message_id == "img-msg-1"
+        assert len(post_calls) == 2  # upload + send
+        assert "media/upload" in post_calls[0]["url"]
+        assert "message/send" in post_calls[1]["url"]
+        assert post_calls[1]["json"]["msgtype"] == "image"
+        assert post_calls[1]["json"]["image"]["media_id"] == "media-123"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_token_refresh_on_40001(self, tmp_path):
+        """Token refresh must work for image upload path too."""
+        adapter = WecomCallbackAdapter(_config())
+        adapter._access_tokens["test-app"] = {"token": "stale", "expires_at": 9999999999}
+        adapter._user_app_map["ww1234567890:alice"] = "test-app"
+
+        img = tmp_path / "test.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0fake JPEG data")
+
+        upload_responses = [
+            {"errcode": 40001, "errmsg": "invalid credential"},
+            {"errcode": 0, "media_id": "fresh-media", "type": "image"},
+        ]
+        send_responses = [{"errcode": 0, "msgid": "img-ok"}]
+        upload_idx = [0]
+        send_idx = [0]
+
+        class FakeResponse:
+            def __init__(self, data):
+                self._data = data
+            def json(self):
+                return self._data
+
+        class FakeClient:
+            async def post(self, url, json=None, files=None, **kw):
+                if "media/upload" in url:
+                    resp = upload_responses[upload_idx[0]]
+                    upload_idx[0] += 1
+                    return FakeResponse(resp)
+                resp = send_responses[send_idx[0]]
+                send_idx[0] += 1
+                return FakeResponse(resp)
+
+            async def get(self, url, params=None, **kw):
+                return FakeResponse({"errcode": 0, "access_token": "fresh-tok", "expires_in": 7200})
+
+        adapter._http_client = FakeClient()
+        result = await adapter.send_image_file("ww1234567890:alice", str(img))
+
+        assert result.success is True
+        assert adapter._access_tokens["test-app"]["token"] == "fresh-tok"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_rejects_unsafe_path(self):
+        """Path traversal must be rejected by validate_media_delivery_path."""
+        adapter = WecomCallbackAdapter(_config())
+        adapter._access_tokens["test-app"] = {"token": "tok", "expires_at": 9999999999}
+        adapter._user_app_map["ww1234567890:alice"] = "test-app"
+        result = await adapter.send_image_file("ww1234567890:alice", "../../etc/passwd")
+        assert result.success is False
 
 


### PR DESCRIPTION
## Problem

The WeCom **callback adapter** (`plugins/platforms/wecom/callback_adapter.py`, used by self-built apps / callback mode) only supported text messages. Images and files were silently dropped in both directions:

- **Outbound**: `send()` hardcoded `msgtype:"text"` — no `send_image_file()` or `send_document()` implementation, so `MEDIA:` tags in agent responses were discarded
- **Inbound**: `_build_event()` only allowed `msg_type in {"text", "event"}` — image messages from users returned `None` and were never delivered to the agent

This is distinct from `gateway/platforms/wecom.py` (AI Bot WebSocket mode), which has its own set of open issues/PRs for similar problems. The callback adapter has received no image/file support yet.

## Changes

| Change | Description |
|--------|-------------|
| `send_image_file()` | Upload via `media/upload?type=image` → send `msgtype:image` with `media_id` |
| `send_document()` | Upload via `media/upload?type=file` → send `msgtype:file` with `media_id` |
| `_upload_media()` | Shared upload helper with token refresh retry on `40001`/`42001` |
| `_send_media_msg()` | Shared send helper, reuses existing token refresh logic |
| `_build_event()` → async | Accepts `image` msg_type; extracts `PicUrl` and downloads via `cache_image_from_url()` to populate `MessageEvent.media_urls` for vision |

### Refactoring

- `send_image_file()` and `send_document()` share `_upload_media()` + `_send_media_msg()` — no duplicated upload/send logic
- `_upload_media()` now retries on token expiry (original code fetched token once with no refresh)
- `cache_image_from_url` moved from local import to module-level import

## Testing

Verified end-to-end on a live WeCom self-built app (callback mode):
- ✅ Agent sends image to WeCom user (generated avatar via image tool → `MEDIA:` tag → received on WeCom)
- ✅ Agent sends file to WeCom user (`.txt` file → `MEDIA:` tag → received on WeCom)
- ✅ Agent receives image from WeCom user (screenshot sent via WeCom → `PicUrl` downloaded → cached locally → vision analysis successful)

## Related Issues

- #14062 — Inbound images silently dropped (wecom.py AI Bot mode)
- #37364 — send_message MEDIA files silently dropped (wecom.py AI Bot mode)
- #61762 — Unable to perceive uploaded pictures (wecom.py AI Bot mode)

These issues cover the **AI Bot WebSocket adapter** (`wecom.py`). This PR fixes the same gaps in the **callback adapter** (`callback_adapter.py`) for self-built apps.

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Code follows existing style (async methods, `_get_access_token` pattern)
- [x] Tested on live WeCom self-built app
- [x] No new dependencies added