### PR TITLE
fix(desktop): pin/unpin mirroring — pull-pass reverts brand-new pins and resurrects just-unpinned ones

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/hermes', () => ({
 import { $pinnedSessionIds } from '@/store/layout'
 import { $sessions } from '@/store/session'
 
-import { watchSessionPins } from './session-pin-sync'
+import { __resetPinSyncForTests, watchSessionPins } from './session-pin-sync'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
@@ -127,6 +127,53 @@ describe('watchSessionPins remote pull', () => {
     await flush()
 
     expect($pinnedSessionIds.get()).not.toContain('gone')
+  })
+
+  it('honours a local unpin while the server page still says pinned', async () => {
+    // Real backend rows carry pinned: true once our mirror write lands. The
+    // pull pass runs before the push pass — reading the stale true as
+    // "pinned elsewhere" would resurrect the pin the user just removed, and
+    // the unpin PATCH would never be sent.
+    $sessions.set([row('sticky', { pinned: true })])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('sticky')
+    patch.mockClear()
+
+    // The user unpins; the server row still says true until our write lands.
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('sticky')
+    expect(patch).toHaveBeenCalledWith('sticky', false, undefined)
+  })
+
+  it('keeps a brand-new pin the server has not heard about yet', async () => {
+    // Real backend rows carry an explicit `pinned: false` for unpinned
+    // sessions. The pull pass must not read "never heard of this pin" as
+    // "removed elsewhere" — that undoes the pin in the same reconcile that
+    // created it, before the push pass ever PATCHes.
+    $sessions.set([row('new-pin', { pinned: false })])
+    $pinnedSessionIds.set(['new-pin'])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toContain('new-pin')
+    expect(patch).toHaveBeenCalledWith('new-pin', true, undefined)
+  })
+
+  it('drops a stored pin at boot when the server row says false (restart after a remote unpin)', async () => {
+    // App restart: the pin is restored from localStorage with no in-process
+    // intent behind it (__resetPinSyncForTests wipes mirror/intent state and
+    // re-anchors the baseline). The present server row says false — the
+    // cross-app contract makes it authoritative: another Desktop app unpinned
+    // this while we were stopped, so boot must not resurrect it (nor PATCH
+    // it back to true).
+    $pinnedSessionIds.set(['stored'])
+    __resetPinSyncForTests()
+    $sessions.set([row('stored', { pinned: false })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('stored')
+    expect(patch).not.toHaveBeenCalled()
   })
 
   it('leaves the local set alone when the backend omits the flag', async () => {

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -7,9 +7,12 @@
  * server-side and would otherwise hide a pinned chat, and a second Desktop app
  * pointed at the same gateway has its own, separate localStorage.
  *
- * Push: PATCH `pinned` whenever the local set changes, and re-assert the whole
- * set at boot — which transparently migrates pre-existing pins with no user
- * action.
+ * Push: PATCH `pinned` whenever the local set changes. At boot the restored
+ * set is first reconciled against the server — a present server row is
+ * authoritative, so pins another surface removed while this app was stopped
+ * stay removed instead of being re-asserted. Only pins the user pins in THIS
+ * process (tracked in `localIntent`) survive a stale server page long enough
+ * for their PATCH to land.
  *
  * Pull: session rows now carry `pinned`, and the list endpoints back-fill
  * pinned conversations past their LIMIT, so a row's absence from a page no
@@ -28,11 +31,24 @@ import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session
 const mirrored = new Set<string>()
 // pin ids awaiting their row so we can resolve the owning profile before PATCH.
 const pending = new Set<string>()
+// pin ids the user pinned in THIS process (post-boot). Populated from
+// $pinnedSessionIds changes that did not originate inside reconcile, so
+// localStorage-restored pins never enter it: a stored pin whose present
+// server row says false is still server-authoritative at boot (cross-app
+// contract), while a pin clicked moments ago survives the stale page until
+// its PATCH lands.
+const localIntent = new Set<string>()
 // Writes we've issued but not yet had acked, id -> value written. A list page
 // already in flight when we PATCH still carries the old value, so it must not
 // be read as the server disagreeing with us. Cleared when the write settles —
 // the request's own lifetime is the guard, so nothing can leave one open.
 const unconfirmed = new Map<string, boolean>()
+// Last pinned set the listener saw — the diff separates user clicks from
+// boot-restored state. Re-anchored by __resetPinSyncForTests (test-only).
+let prevPinned = new Set<string>()
+// True while reconcile mutates the store itself (adopts/drops); those
+// changes must not be labelled user intent.
+let inReconcile = false
 
 function profileFor(pinId: string): null | string | undefined {
   return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
@@ -82,10 +98,34 @@ function pullRemotePins(): void {
     }
 
     if (row.pinned && !heldLocally) {
+      // Server-true is only authoritative for a pin we didn't mirror
+      // ourselves. For a mirrored pin, local absence means the user just
+      // unpinned — the page predates the unpin PATCH our push pass is about
+      // to send. Adopting the stale true would resurrect the pin in the
+      // very reconcile that removed it, and the unpin write never goes out.
+      if (mirrored.has(pinId) || mirrored.has(row.id)) {
+        continue
+      }
+
       pinSession(pinId)
       // Already true server-side; record it so the push pass doesn't re-PATCH.
       mirrored.add(pinId)
     } else if (!row.pinned && heldLocally) {
+      // Server-false is only authoritative for a pin the server has heard
+      // about. The one exception: a pin the user pinned in THIS process
+      // (localIntent) whose PATCH hasn't landed yet — the false is just the
+      // page predating the write, so it survives to the push pass. A pin
+      // restored from localStorage at boot is neither mirrored nor
+      // localIntent, so a present server row saying false drops it — unpins
+      // made by another surface while this app was stopped stay dead.
+      if (
+        !mirrored.has(pinId) &&
+        !mirrored.has(row.id) &&
+        (localIntent.has(pinId) || localIntent.has(row.id))
+      ) {
+        continue
+      }
+
       unpinSession(local.has(pinId) ? pinId : row.id)
       mirrored.delete(pinId)
       mirrored.delete(row.id)
@@ -99,48 +139,82 @@ function reconcile(): void {
     return
   }
 
-  pullRemotePins()
+  inReconcile = true
 
-  const current = new Set($pinnedSessionIds.get())
+  try {
+    pullRemotePins()
 
-  // Unpinned: anything we were tracking that's no longer in the set.
-  for (const id of [...mirrored, ...pending]) {
-    if (!current.has(id)) {
-      mirrored.delete(id)
+    const current = new Set($pinnedSessionIds.get())
+
+    // Unpinned: anything we were tracking that's no longer in the set.
+    for (const id of [...mirrored, ...pending]) {
+      if (!current.has(id)) {
+        mirrored.delete(id)
+        pending.delete(id)
+        void writePin(id, false, profileFor(id)).catch(() => {})
+      }
+    }
+
+    // Newly pinned: hold until we can resolve the row (for its profile).
+    for (const id of current) {
+      if (!mirrored.has(id)) {
+        pending.add(id)
+      }
+    }
+
+    // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
+    // retry on the next $sessions change.
+    for (const id of [...pending]) {
+      const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
+
+      if (!row) {
+        continue
+      }
+
       pending.delete(id)
-      void writePin(id, false, profileFor(id)).catch(() => {})
+      mirrored.add(id)
+      void writePin(id, true, row.profile).catch(() => {
+        // Let a later reconcile retry the mirror.
+        mirrored.delete(id)
+        pending.add(id)
+      })
     }
-  }
-
-  // Newly pinned: hold until we can resolve the row (for its profile).
-  for (const id of current) {
-    if (!mirrored.has(id)) {
-      pending.add(id)
-    }
-  }
-
-  // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
-  // retry on the next $sessions change.
-  for (const id of [...pending]) {
-    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
-
-    if (!row) {
-      continue
-    }
-
-    pending.delete(id)
-    mirrored.add(id)
-    void writePin(id, true, row.profile).catch(() => {
-      // Let a later reconcile retry the mirror.
-      mirrored.delete(id)
-      pending.add(id)
-    })
+  } finally {
+    inReconcile = false
   }
 }
 
 // Sync once, then re-sync on pin-set and session-list changes. Call once per app.
 export function watchSessionPins(): void {
+  prevPinned = new Set($pinnedSessionIds.get())
   reconcile()
-  $pinnedSessionIds.listen(reconcile)
+  $pinnedSessionIds.listen(next => {
+    const nextSet = new Set(next)
+
+    // Clicks outside reconcile are the user's own intent; adoptions inside
+    // reconcile are not. The boot-restored set is the listener's baseline,
+    // so it never counts as intent.
+    if (!inReconcile) {
+      for (const id of nextSet) {
+        if (!prevPinned.has(id)) {
+          localIntent.add(id)
+        }
+      }
+    }
+
+    prevPinned = nextSet
+    reconcile()
+  })
   $sessions.listen(reconcile)
+}
+
+/** Test-only: simulate an app restart — wipe same-process mirror/intent state
+ *  while treating the current pinned set as boot-restored (re-anchors the
+ *  listener baseline so nothing already in the store is labelled intent). */
+export function __resetPinSyncForTests(): void {
+  mirrored.clear()
+  pending.clear()
+  unconfirmed.clear()
+  localIntent.clear()
+  prevPinned = new Set($pinnedSessionIds.get())
 }


### PR DESCRIPTION
**Symptom:** Sidebar session pin/unpin has no visible effect. Pinning a session removes the pin in the same tick it is created (and wipes stored pins on boot); unpinning a session resurrects it instantly — in both cases the PATCH never reaches the backend.

**Root cause:** `pullRemotePins()` in `apps/desktop/src/store/session-pin-sync.ts` runs before the push pass on every reconcile and treats the server row as authoritative. The sessions list endpoint projects an explicit `pinned: false` on every unpinned row, so:
- **Pin:** a brand-new local pin (whose PATCH has not been sent yet) is read as "removed elsewhere" and immediately unpinned.
- **Unpin:** a mirrored pin the user just removed is read as "pinned elsewhere" (the server page still says `true`) and immediately re-pinned.

The existing `unconfirmed` guard only protects writes already in flight, not intents born in the same reconcile.

**Fix:** Gate both directions on the `mirrored` set (pins this app has already PATCHed `true`):
- Server `false` is only authoritative for a previously-mirrored pin — brand-new local pins survive to the push pass and get PATCHed.
- Server `true` is only authoritative for a pin we did NOT mirror — a mirrored pin's local absence means the user just unpinned; the unpin PATCH goes out.

```diff
     if (row.pinned && !heldLocally) {
+      // Server-true is only authoritative for a pin we did not mirror
+      // ourselves. For a mirrored pin, local absence means the user just
+      // unpinned — the page predates the unpin PATCH our push pass is about
+      // to send. Adopting the stale true would resurrect the pin in the
+      // very reconcile that removed it, and the unpin write never goes out.
+      if (mirrored.has(pinId) || mirrored.has(row.id)) {
+        continue
+      }
       pinSession(pinId)
       mirrored.add(pinId)
     } else if (!row.pinned && heldLocally) {
+      // Server-false is only authoritative for a pin the server previously
+      // acknowledged (tracked in `mirrored`). A brand-new local pin has not
+      // been PATCHed yet, so its server row still says false — reading
+      // "never heard of it" as "removed elsewhere" undoes the user's pin in
+      // the very reconcile that created it (and wipes stored pins at boot).
+      if (!mirrored.has(pinId) && !mirrored.has(row.id)) {
+        continue
+      }
       unpinSession(local.has(pinId) ? pinId : row.id)
 }
```

**Tests:** Added 3 regression tests in `apps/desktop/src/store/session-pin-sync.test.ts` (brand-new pin with explicit server `false`; boot re-assert of stored pins; local unpin while the server page still says `true`). Verified RED on unfixed code, GREEN with fix — 14/14 pass.