### PR TITLE
chore: map jordan.mymail@gmail.com -> lxman in contributor directory

### DIFF
--- a/contributors/emails/jordan.mymail@gmail.com
+++ b/contributors/emails/jordan.mymail@gmail.com
@@ -1,0 +1,2 @@
+lxman
+# PR #74522 salvage (per-turn micro-compaction)


### PR DESCRIPTION
## Summary
Maps `jordan.mymail@gmail.com` -> `lxman` in `contributors/emails/`.

Attribution prerequisite for the #74522 salvage (per-turn micro-compaction): the contributor audit requires every commit-author email on `main` to resolve to a GitHub login, and the salvage cherry-picks @lxman's 11 commits with authorship preserved.

## Validation
`python -c "import release; release.AUTHOR_MAP['jordan.mymail@gmail.com']"` -> `lxman`
