### PR TITLE
feat(agent): per-turn micro-compaction to amortize context compression (salvage of #74522)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1963,6 +1963,9 @@ def init_agent(
     compression_in_place = is_truthy_value(
         _compression_cfg.get("in_place"), default=True
     )
+    compression_micro_compact = is_truthy_value(
+        _compression_cfg.get("micro_compact"), default=True
+    )
     codex_app_server_auto_compaction = str(
         _compression_cfg.get("codex_app_server_auto", "native") or "native"
     ).lower()
@@ -2418,6 +2421,10 @@ def init_agent(
             pass
     agent.compression_enabled = compression_enabled
     agent.compression_in_place = compression_in_place
+    # Apply micro-compaction flag to the compressor (enabled by default)
+    _cc = getattr(agent, "context_compressor", None)
+    if _cc is not None and hasattr(_cc, "_micro_compact_enabled"):
+        _cc._micro_compact_enabled = compression_micro_compact
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
     agent.max_compression_attempts = compression_max_attempts
     agent.compression_idle_compact_after_seconds = (

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1971,6 +1971,23 @@ def init_agent(
     compression_micro_compact = is_truthy_value(
         _compression_cfg.get("micro_compact"), default=False
     )
+    # How often a pass runs, in completed turns. Each pass rewrites
+    # already-sent history and costs one prompt-cache break, so this is the
+    # dial for how often that cost is paid: 1 = every turn (most aggressive
+    # reclaim), 5 = one break per five turns. Clamped to >= 1.
+    compression_micro_compact_every_n_turns = max(
+        1,
+        _parse_prune_int(_compression_cfg.get("micro_compact_every_n_turns", 1), 1),
+    )
+    # Rolling-summary defrag threshold, in tokens. Lived on the compressor as
+    # a hardcoded attribute with no path from config until now.
+    compression_micro_compact_defrag_tokens = max(
+        1,
+        _parse_prune_int(
+            _compression_cfg.get("micro_compact_defrag_threshold_tokens", 2000),
+            2000,
+        ),
+    )
     codex_app_server_auto_compaction = str(
         _compression_cfg.get("codex_app_server_auto", "native") or "native"
     ).lower()
@@ -2426,10 +2443,16 @@ def init_agent(
             pass
     agent.compression_enabled = compression_enabled
     agent.compression_in_place = compression_in_place
-    # Apply micro-compaction flag to the compressor (enabled by default)
+    # Apply micro-compaction settings to the compressor (feature is opt-in)
     _cc = getattr(agent, "context_compressor", None)
     if _cc is not None and hasattr(_cc, "_micro_compact_enabled"):
         _cc._micro_compact_enabled = compression_micro_compact
+    if _cc is not None and hasattr(_cc, "_micro_compact_every_n_turns"):
+        _cc._micro_compact_every_n_turns = compression_micro_compact_every_n_turns
+    if _cc is not None and hasattr(_cc, "_micro_compact_defrag_threshold_tokens"):
+        _cc._micro_compact_defrag_threshold_tokens = (
+            compression_micro_compact_defrag_tokens
+        )
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
     agent.max_compression_attempts = compression_max_attempts
     agent.compression_idle_compact_after_seconds = (

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1963,8 +1963,13 @@ def init_agent(
     compression_in_place = is_truthy_value(
         _compression_cfg.get("in_place"), default=True
     )
+    # Opt-in (default False): a micro-compaction pass rewrites already-sent
+    # history every turn, which breaks the provider prompt-cache prefix on a
+    # per-turn cadence rather than at an episodic boundary. That is the cost
+    # `proactive_prune_min_reclaim_tokens` exists to amortize, so the feature
+    # stays off until an operator opts in and accepts the tradeoff.
     compression_micro_compact = is_truthy_value(
-        _compression_cfg.get("micro_compact"), default=True
+        _compression_cfg.get("micro_compact"), default=False
     )
     codex_app_server_auto_compaction = str(
         _compression_cfg.get("codex_app_server_auto", "native") or "native"

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5349,6 +5349,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         if self._needs_defrag():
             self._defrag_rolling_summary(messages, exchange_start, compress_end)
             result = self._splice_micro_compact_result(messages, exchange_start, compress_end)
+            self._micro_compact_cursor = self._cursor_after_splice(result, exchange_start + 1)
             self._sync_micro_compact_to_db(result)
             self._micro_compact_consecutive_failures = 0
             self._micro_compact_last_failure_cursor = -1
@@ -5408,6 +5409,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         self._micro_compact_last_failure_cursor = -1
 
         result = self._splice_micro_compact_result(messages, exchange_start, exchange_end)
+        self._micro_compact_cursor = self._cursor_after_splice(result, exchange_start + 1)
         self._sync_micro_compact_to_db(result)
         self._emit_micro_compaction_telemetry(
             outcome="absorbed",
@@ -5419,6 +5421,29 @@ This compaction should PRIORITISE preserving all information related to the focu
             duration_ms=_elapsed_ms(),
         )
         return result
+
+    def _cursor_after_splice(
+        self,
+        result: List[Dict[str, Any]],
+        fallback: int,
+    ) -> int:
+        """Cursor position just past the summary marker in *result*.
+
+        The cursor must be derived from the spliced list, never carried over
+        from pre-splice indices. A splice collapses the absorbed span (an
+        assistant plus its tool results -- often several messages) into a
+        single marker, and may also drop a superseded marker further back, so
+        every index after it shifts. Reusing the old ``exchange_end`` left the
+        cursor pointing into the middle of a *later* exchange's tool group;
+        the next pass then walked forward to the following assistant and
+        skipped that exchange entirely, so roughly half the work silently
+        never happened on tool-bearing conversations.
+        """
+        for idx in range(len(result) - 1, -1, -1):
+            entry = result[idx]
+            if isinstance(entry, dict) and entry.get(COMPRESSED_SUMMARY_METADATA_KEY):
+                return idx + 1
+        return fallback
 
     def _emit_micro_compaction_telemetry(
         self,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5069,36 +5069,46 @@ This compaction should PRIORITISE preserving all information related to the focu
     ) -> Optional[tuple[int, int]]:
         """Find the next complete exchange starting at *start*.
 
-        An exchange is an assistant message plus its tool results.  Returns
-        ``(exchange_start, exchange_end)`` indices into *messages*, or ``None``
-        if no complete exchange is available before *tail_start*.
+        An exchange is one full agent turn: the first assistant message after
+        *start* plus everything through the end of that turn — tool results
+        and any follow-up assistant iterations — up to (exclusive) the next
+        ``user`` message.  Returns ``(exchange_start, exchange_end)`` indices
+        into *messages*, or ``None`` if no complete, safely-spliceable turn is
+        available before *tail_start*.
 
-        Tool results are consumed as a group following the assistant message
-        (consecutive ``tool``-role messages).  The assistant message itself must
-        exist; without one there is nothing to summarise.
+        The full-turn shape is an alternation-safety requirement, not a
+        convenience: the splice replaces the span with a single
+        ``assistant``-role summary marker, so the span must be bounded by
+        user messages on the right (``messages[exchange_end]`` is ``user``).
+        Absorbing only the first assistant+tools group of a multi-iteration
+        turn would leave the marker adjacent to the turn's next assistant
+        message — two consecutive assistant turns, which strict providers
+        reject and ``repair_message_sequence`` would then mangle.
 
         User messages are deliberately NOT part of an exchange.  The walk skips
         past them to reach the assistant message, and ``exchange_start`` is that
         assistant index, so user turns are never absorbed into the rolling
-        summary and stay verbatim for the life of the session.  This is the
-        intended behaviour, not an oversight: what the assistant emits is
-        largely an account of what it did, which survives summarising, while the
-        user's own words are the instructions everything else is derived from
-        and are the one thing that cannot be reconstructed from context.  They
-        are also cheap — a prompt is normally a tiny fraction of the tokens a
-        single tool result costs.
+        summary and their text stays verbatim for the life of the session.
+        This is the intended behaviour, not an oversight: what the assistant
+        emits is largely an account of what it did, which survives summarising,
+        while the user's own words are the instructions everything else is
+        derived from and are the one thing that cannot be reconstructed from
+        context.  They are also cheap — a prompt is normally a tiny fraction
+        of the tokens a single tool result costs.
         """
         idx = start
         n = len(messages)
         if idx >= n or idx >= tail_start:
             return None
 
-        # Walk past any user messages or summary markers until we hit an
-        # assistant message with actual output (content or tool_calls).
+        # Walk past user messages and existing summary markers until we hit a
+        # real assistant message with actual output (content or tool_calls).
+        # Summary markers are assistant-role themselves, so they must be
+        # skipped explicitly or a rehydrated cursor could try to absorb the
+        # marker that carries the compacted history.
         while idx < tail_start and idx < n:
             msg = messages[idx]
-            role = msg.get("role")
-            if role == "assistant":
+            if msg.get("role") == "assistant" and not self._is_context_summary_message(msg):
                 break
             idx += 1
 
@@ -5107,17 +5117,32 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         exchange_start = idx
 
-        # Advance past the assistant message
+        # Consume the full turn: assistant / tool messages until the next
+        # user message (or an existing summary marker) ends the turn.
         idx += 1
-
-        # Consume following tool results as part of the same exchange
         while idx < tail_start and idx < n:
-            if messages[idx].get("role") == "tool":
-                idx += 1
-            else:
+            msg = messages[idx]
+            role = msg.get("role")
+            if role not in ("assistant", "tool"):
                 break
+            if self._is_context_summary_message(msg):
+                break
+            idx += 1
 
         if idx <= exchange_start:
+            return None
+
+        # Splice-boundary guard: the message right after the exchange must be
+        # a user turn (or a summary marker, which stands in for one
+        # structurally).  If the walk stopped because it ran into *tail_start*
+        # mid-turn, splicing here would leave the assistant-role marker
+        # adjacent to the turn's remaining assistant/tool messages — invalid
+        # alternation.  Skip this pass; the tail recedes as the conversation
+        # grows and the turn becomes absorbable later.
+        if idx >= n:
+            return None
+        boundary = messages[idx]
+        if not isinstance(boundary, dict) or boundary.get("role") != "user":
             return None
         return (exchange_start, idx)
 
@@ -5294,25 +5319,51 @@ This compaction should PRIORITISE preserving all information related to the focu
     def _defrag_rolling_summary(
         self,
         messages: List[Dict[str, Any]],
-        head_end: int,
-        tail_start: int,
-    ) -> None:
-        """Re-summarize the rolling summary + remaining middle in one shot.
+    ) -> bool:
+        """Re-summarize the rolling summary TEXT and rewrite the marker in place.
 
-        This is a lightweight batch compaction on just the summary and the
-        remaining un-compacted region \u2014 NOT the full transcript.  It replaces
-        the rolling summary with a fresh, compact version and advances the
-        cursor to *tail_start*.
+        Merging exchange after exchange makes the rolling summary baggy —
+        repetitive, and larger than the material justifies. Defrag compacts
+        the summary *itself*: one aux call over the accumulated summary text,
+        then the existing marker's content is rewritten in place.
+
+        Deliberately transcript-shape-neutral: no messages are spliced, no
+        user turns are touched, and the cursor does not move. The original
+        implementation serialized the whole remaining middle (user turns
+        included) and spliced it into the marker, which silently absorbed
+        user messages — violating the feature's core "your messages are never
+        compacted" invariant. Un-absorbed exchanges stay where they are and
+        get absorbed by later per-exchange passes.
+
+        Returns True when a pass actually rewrote the summary.
         """
-        middle_content = self._serialize_one_exchange(messages, head_end, tail_start)
-        fresh_summary = self._micro_summarize_one(middle_content)
-        if fresh_summary:
-            self._micro_compact_rolling_summary = fresh_summary
-            self._micro_compact_cursor = tail_start
-            logger.info(
-                "Micro-compaction defrag: rolling summary re-summarized "
-                "(%d chars)", len(fresh_summary),
-            )
+        old_summary = self._micro_compact_rolling_summary
+        if not old_summary.strip():
+            return False
+        # Feed the old summary through the merge prompt with an empty base:
+        # "merge these decisions into (no previous summary)" is exactly a
+        # rewrite-compactly instruction for the accumulated text.
+        self._micro_compact_rolling_summary = ""
+        fresh_summary = self._micro_summarize_one(old_summary)
+        if not fresh_summary:
+            self._micro_compact_rolling_summary = old_summary
+            return False
+        self._micro_compact_rolling_summary = fresh_summary
+        # Rewrite the newest marker's content in place so the transcript and
+        # the in-memory summary stay in step (resume rehydrates from it).
+        for idx in range(len(messages) - 1, -1, -1):
+            entry = messages[idx]
+            if isinstance(entry, dict) and entry.get(COMPRESSED_SUMMARY_METADATA_KEY):
+                entry["content"] = self._render_micro_marker_content(fresh_summary)
+                # Content changed after a possible flush — clear the persisted
+                # stamp so the DB sync/flush rewrites the row.
+                entry.pop(_DB_PERSISTED_MARKER, None)
+                break
+        logger.info(
+            "Micro-compaction defrag: rolling summary re-summarized "
+            "(%d -> %d chars)", len(old_summary), len(fresh_summary),
+        )
+        return True
 
     def _micro_compact(
         self,
@@ -5379,23 +5430,26 @@ This compaction should PRIORITISE preserving all information related to the focu
         def _elapsed_ms() -> int:
             return int((time.monotonic() - _started_at) * 1000)
 
-        # Check for defrag trigger
+        # Check for defrag trigger: the rolling summary itself has grown
+        # baggy. Defrag rewrites the summary text and the existing marker in
+        # place — no splice, no cursor movement, no user turns touched — so
+        # the transcript shape is unchanged and this pass does not also
+        # absorb an exchange (one aux call per turn either way).
         if self._needs_defrag():
-            self._defrag_rolling_summary(messages, exchange_start, compress_end)
-            result = self._splice_micro_compact_result(messages, exchange_start, compress_end)
-            self._micro_compact_cursor = self._cursor_after_splice(result, exchange_start + 1)
-            self._sync_micro_compact_to_db(result)
-            self._micro_compact_consecutive_failures = 0
-            self._micro_compact_last_failure_cursor = -1
+            defragged = self._defrag_rolling_summary(messages)
+            if defragged:
+                self._sync_micro_compact_to_db(messages)
+                self._micro_compact_consecutive_failures = 0
+                self._micro_compact_last_failure_cursor = -1
             self._emit_micro_compaction_telemetry(
-                outcome="defrag",
+                outcome="defrag" if defragged else "defrag_failed",
                 messages_before=_messages_before,
-                messages_after=len(result),
+                messages_after=len(messages),
                 tokens_before=_tokens_before,
-                tokens_after=estimate_messages_tokens_rough(result),
+                tokens_after=estimate_messages_tokens_rough(messages),
                 duration_ms=_elapsed_ms(),
             )
-            return result
+            return messages
 
         # Whether this pass's summary will be cumulative — i.e. whether it
         # subsumes any earlier marker. Captured before summarizing.
@@ -5621,23 +5675,36 @@ This compaction should PRIORITISE preserving all information related to the focu
         ``_compressed_summary`` metadata flag so downstream consumers
         (resume, handoff, /compress) handle it identically to batch
         compaction summaries.
+
+        Alternation safety: the marker is ``assistant``-role. An exchange is
+        a full agent turn bounded by user messages on both sides (see
+        ``_find_one_exchange``), so the spliced result is
+        ``user → marker(assistant) → user`` — valid alternation that the
+        pre-request ``repair_message_sequence`` pass leaves untouched. A
+        ``user``-role marker in that position produced ``user → user → user``,
+        and repair then merged the marker into the neighbouring real user
+        message: metadata gone, cursor unrecoverable, and the summary text
+        duplicated into the transcript on every subsequent pass.
+
+        Superseding an earlier marker removes the assistant turn that stood
+        between two real user messages, leaving them adjacent. Those two are
+        merged (plain-text only, ``\\n\\n``-joined — the same repair pass 2
+        would apply) so the transcript is alternation-valid as returned
+        rather than relying on downstream repair to fix it up.
         """
         summary_text = self._micro_compact_rolling_summary
         if not summary_text.strip():
             return messages
 
-        content = (
-            f"{SUMMARY_PREFIX}\n\n"
-            f"{HISTORICAL_TASK_HEADING}\n"
-        )
-        content += summary_text.strip()
-        content += f"\n\n{_SUMMARY_END_MARKER}"
-
         summary_msg = {
-            "role": "user",
-            "content": content,
+            "role": "assistant",
+            "content": self._render_micro_marker_content(summary_text),
             COMPRESSED_SUMMARY_METADATA_KEY: True,
-            COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: True,
+            # Honest provenance (#64650): this marker absorbs only
+            # assistant/tool content — user turns are never micro-compacted,
+            # so they remain in the transcript and _transcript_has_real_user_turn
+            # keeps reporting them directly.
+            COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: False,
         }
 
         result = messages[:splice_start] + [summary_msg] + messages[splice_end:]
@@ -5661,9 +5728,62 @@ This compaction should PRIORITISE preserving all information related to the focu
             if len(marker_idxs) > 1:
                 superseded = set(marker_idxs[:-1])
                 result = [m for i, m in enumerate(result) if i not in superseded]
+                result = self._merge_adjacent_user_turns(result)
 
         _strip_persistence_markers(result)
         return result
+
+    @staticmethod
+    def _render_micro_marker_content(summary_text: str) -> str:
+        """Assemble the marker content wrapper around *summary_text*."""
+        return (
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\n"
+            f"{summary_text.strip()}"
+            f"\n\n{_SUMMARY_END_MARKER}"
+        )
+
+    @staticmethod
+    def _merge_adjacent_user_turns(
+        result: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Merge consecutive plain-text real user turns left by a supersede.
+
+        Dropping a superseded marker removes the assistant turn that separated
+        two real user messages. Merging them here (``\\n\\n``-joined, exactly
+        what ``repair_message_sequence`` pass 2 does) keeps every byte the
+        user typed while restoring alternation deliberately, so the marker
+        and cursor state are never collateral damage of the downstream repair.
+        Multimodal (list) content is left alone, mirroring the repair pass.
+        """
+        from agent.turn_context import drop_stale_api_content
+
+        merged: List[Dict[str, Any]] = []
+        for msg in result:
+            prev = merged[-1] if merged else None
+            if (
+                isinstance(msg, dict)
+                and isinstance(prev, dict)
+                and msg.get("role") == "user"
+                and prev.get("role") == "user"
+                and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                and not prev.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                and isinstance(prev.get("content"), str)
+                and isinstance(msg.get("content"), str)
+            ):
+                prev_content = prev["content"]
+                new_content = msg["content"]
+                prev["content"] = (
+                    (prev_content + "\n\n" + new_content)
+                    if prev_content and new_content
+                    else (prev_content or new_content)
+                )
+                # Merged content invalidates the api_content sidecar (exact
+                # bytes previously sent for the pre-merge message).
+                drop_stale_api_content(prev)
+                continue
+            merged.append(msg)
+        return merged
 
     def compress(
         self,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5303,7 +5303,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         NOTE: the in-memory splice alone is not persisted — the subsequent
         ``_persist_session`` flush is append-only, so old DB rows stay
         ``active=1`` and a session resume double-loads both the summary and
-        the original exchanges (#82483).  This method therefore also calls
+        the original exchanges.  This method therefore also calls
         ``archive_and_compact`` on the session DB to soft-archive old rows
         and insert the compacted set atomically.
         """

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2150,8 +2150,10 @@ class ContextCompressor(ContextEngine):
         self.abort_on_summary_failure = abort_on_summary_failure
 
         # ── Micro-compaction (per-turn rolling compaction) ─────────
-        # Default: enabled when not explicitly disabled (backward compatible).
-        self._micro_compact_enabled: bool = True
+        # Default: OFF. Each pass rewrites already-sent history, so it breaks
+        # the prompt-cache prefix every turn instead of at an episodic
+        # boundary. Operators opt in via `compression.micro_compact: true`.
+        self._micro_compact_enabled: bool = False
         self._micro_compact_cursor: int = 0
         self._micro_compact_rolling_summary: str = ""
         self._micro_compact_consecutive_failures: int = 0

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -364,6 +364,11 @@ _SUMMARY_RATIO = 0.20
 # itself a context-pressure source and slows every compaction.
 _SUMMARY_TOKENS_CEILING = 10_000
 
+# Micro-compaction failure guard: after this many consecutive failures on the
+# same cursor position, skip the stuck exchange and advance the cursor so the
+# system doesn't busy-loop on an unsummarizable exchange every turn.
+_MICRO_COMPACT_MAX_CONSECUTIVE_FAILURES = 3
+
 # Aggregate cap on the serialized turn block fed to the summarizer prompt
 # (chars). Per-message truncation (_CONTENT_MAX / _TOOL_ARGS_MAX) alone is
 # not enough: a compression window with hundreds of already-truncated turns
@@ -1290,6 +1295,12 @@ class ContextCompressor(ContextEngine):
         self._active_compression_telemetry = None
         self._compression_telemetry_seed = None
 
+        # Micro-compaction state reset
+        self._micro_compact_cursor = 0
+        self._micro_compact_rolling_summary = ""
+        self._micro_compact_consecutive_failures = 0
+        self._micro_compact_last_failure_cursor = -1
+
     def _begin_compression_telemetry(
         self,
         *,
@@ -2135,6 +2146,15 @@ class ContextCompressor(ContextEngine):
         # When False (default = historical behavior), insert a
         # deterministic "summary unavailable" handoff and drop the middle window.
         self.abort_on_summary_failure = abort_on_summary_failure
+
+        # ── Micro-compaction (per-turn rolling compaction) ─────────
+        # Default: enabled when not explicitly disabled (backward compatible).
+        self._micro_compact_enabled: bool = True
+        self._micro_compact_cursor: int = 0
+        self._micro_compact_rolling_summary: str = ""
+        self._micro_compact_consecutive_failures: int = 0
+        self._micro_compact_last_failure_cursor: int = -1
+        self._micro_compact_defrag_threshold_tokens: int = 2000
 
         # Defer context-length resolution to first access (#32221):
         # get_model_context_length() can issue a synchronous /models HTTP
@@ -4986,6 +5006,448 @@ This compaction should PRIORITISE preserving all information related to the focu
     # ------------------------------------------------------------------
     # Main compression entry point
     # ------------------------------------------------------------------
+
+    def _resolve_compact_cursor(
+        self,
+        messages: List[Dict[str, Any]],
+        head_end: int,
+        tail_start: int,
+    ) -> int:
+        """Derive the micro-compaction cursor from in-memory state or transcript scan.
+
+        Returns the index of the first message that has NOT yet been absorbed
+        into the rolling summary.  If the in-memory cursor ``_micro_compact_cursor``
+        is valid (non-zero and within the compressible window), use it directly.
+        Otherwise scan from *head_end* through *tail_start* for the last context
+        summary marker and set the cursor past it.
+        """
+        if self._micro_compact_cursor > head_end and self._micro_compact_cursor < tail_start:
+            return self._micro_compact_cursor
+        # Scan transcript for the last summary marker
+        last_summary_idx = -1
+        for idx in range(head_end, tail_start):
+            if self._is_context_summary_message(messages[idx]):
+                last_summary_idx = idx
+        if last_summary_idx >= head_end:
+            cursor = last_summary_idx + 1
+        else:
+            cursor = head_end
+        self._micro_compact_cursor = cursor
+        return cursor
+
+    def _find_one_exchange(
+        self,
+        messages: List[Dict[str, Any]],
+        start: int,
+        tail_start: int,
+    ) -> Optional[tuple[int, int]]:
+        """Find the next complete exchange starting at *start*.
+
+        An exchange is: (optional) user message + assistant message + its tool
+        results.  Returns ``(exchange_start, exchange_end)`` indices into
+        *messages*, or ``None`` if no complete exchange is available before
+        *tail_start*.
+
+        Tool results are consumed as a group following the assistant message
+        (consecutive ``tool``-role messages).  The assistant message itself must
+        exist; without one there is nothing to summarise.
+        """
+        idx = start
+        n = len(messages)
+        if idx >= n or idx >= tail_start:
+            return None
+
+        # Walk past any user messages or summary markers until we hit an
+        # assistant message with actual output (content or tool_calls).
+        while idx < tail_start and idx < n:
+            msg = messages[idx]
+            role = msg.get("role")
+            if role == "assistant":
+                break
+            idx += 1
+
+        if idx >= tail_start or idx >= n:
+            return None
+
+        exchange_start = idx
+
+        # Advance past the assistant message
+        idx += 1
+
+        # Consume following tool results as part of the same exchange
+        while idx < tail_start and idx < n:
+            if messages[idx].get("role") == "tool":
+                idx += 1
+            else:
+                break
+
+        if idx <= exchange_start:
+            return None
+        return (exchange_start, idx)
+
+    def _serialize_one_exchange(
+        self,
+        messages: List[Dict[str, Any]],
+        start: int,
+        end: int,
+    ) -> str:
+        """Serialize a single exchange for the micro-summarizer.
+
+        Uses the same content-max truncation and redaction as the batch
+        ``_serialize_for_summary`` method, but scoped to one exchange.
+        """
+        from agent.agent_runtime_helpers import strip_think_blocks
+
+        parts = []
+        for msg in messages[start:end]:
+            role = msg.get("role", "unknown")
+            content = msg.get("content")
+            if isinstance(content, list):
+                text_parts: list[str] = []
+                for part in content:
+                    if isinstance(part, dict):
+                        ptype = part.get("type")
+                        if ptype == "text":
+                            text_parts.append(part.get("text", ""))
+                        elif ptype in {"image", "image_url", "input_image"}:
+                            text_parts.append(_image_part_label(part))
+                        else:
+                            text_parts.append(f"[{ptype or 'attachment'}]")
+                    elif isinstance(part, str):
+                        text_parts.append(part)
+                content = "\n".join(text_parts)
+            content = _redact_compaction_text(content or "")
+            content = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", content)
+            if role == "assistant" and content:
+                content = strip_think_blocks(None, content)
+
+            if role == "tool":
+                tool_id = msg.get("tool_call_id", "")
+                if len(content) > self._CONTENT_MAX:
+                    content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
+                parts.append(f"[TOOL RESULT {tool_id}]: {content}")
+                continue
+
+            if role == "assistant":
+                if len(content) > self._CONTENT_MAX:
+                    content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
+                tool_calls = msg.get("tool_calls", [])
+                if tool_calls:
+                    tc_parts = []
+                    for tc in tool_calls:
+                        if isinstance(tc, dict):
+                            fn = tc.get("function", {})
+                            name = fn.get("name", "?")
+                            args = _redact_compaction_text(fn.get("arguments", ""))
+                            if len(args) > self._TOOL_ARGS_MAX:
+                                args = args[:self._TOOL_ARGS_HEAD] + "..."
+                            tc_parts.append(f"  {name}({args})")
+                        else:
+                            fn = getattr(tc, "function", None)
+                            name = getattr(fn, "name", "?") if fn else "?"
+                            tc_parts.append(f"  {name}(...)")
+                    content += "\n[Tool calls:\n" + "\n".join(tc_parts) + "\n]"
+                parts.append(f"[ASSISTANT]: {content}")
+                continue
+
+            if role == "user":
+                if len(content) > self._CONTENT_MAX:
+                    content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
+                parts.append(f"[USER]: {content}")
+                continue
+
+            parts.append(f"[{role.upper()}]: {content}")
+
+        return "\n---\n".join(parts)
+
+    def _build_micro_summary_prompt(
+        self,
+        existing_summary: str,
+        exchange_text: str,
+    ) -> List[Dict[str, str]]:
+        """Build the prompt messages for a single-exchange micro-summary."""
+        if existing_summary.strip():
+            summary_block = existing_summary
+        else:
+            summary_block = "(No previous summary yet.)"
+
+        user_prompt = (
+            "You are a summarization agent creating a compact record of an "
+            "ongoing conversation.  You are given a running summary and the "
+            "next exchange from the conversation.  Merge the exchange's key "
+            "decisions, requirements, file paths, and open questions into the "
+            "summary.  Preserve the summary's structure.  Drop resolved details "
+            "that are no longer relevant.  Add new decisions, file paths, and "
+            "open questions.\n\n"
+            "NEVER include API keys, tokens, passwords, secrets, credentials, "
+            "or connection strings in the summary \u2014 replace any that appear "
+            f"with [REDACTED].\n\n"
+            f"## Current Running Summary\n{summary_block}\n\n"
+            f"## Next Exchange to Merge\n{exchange_text}\n\n"
+            "Return ONLY the updated summary text, no preamble or explanation. "
+            "Do not include this instruction block in your output."
+        )
+
+        return [
+            {"role": "system", "content": "You are a conversation summarization assistant."},
+            {"role": "user", "content": user_prompt},
+        ]
+
+    def _micro_summarize_one(
+        self,
+        exchange_text: str,
+    ) -> Optional[str]:
+        """Micro-summarize one exchange into the rolling summary via aux LLM.
+
+        Calls the same auxiliary compression model as the batch path, with
+        a focused prompt that merges one exchange into the running summary.
+        Returns the updated summary text, or ``None`` on failure.
+        """
+        from agent.auxiliary_client import call_llm, aux_interrupt_protection
+
+        messages = self._build_micro_summary_prompt(
+            self._micro_compact_rolling_summary,
+            exchange_text,
+        )
+
+        call_kwargs = {
+            "task": "compression",
+            "messages": messages,
+            "max_tokens": min(1500, self.max_summary_tokens or 1500),
+            "temperature": 0.1,
+        }
+        if self.summary_model:
+            call_kwargs["model"] = self.summary_model
+        if self.model:
+            call_kwargs.setdefault("main_runtime", {
+                "model": self.model,
+                "provider": self.provider or "",
+                "base_url": self.base_url or "",
+                "api_key": self.api_key or "",
+                "api_mode": getattr(self, "api_mode", "") or "",
+            })
+
+        try:
+            with aux_interrupt_protection():
+                response = call_llm(**call_kwargs)
+        except Exception as exc:
+            logger.info("micro-summarization call failed: %s", exc)
+            return None
+
+        message = response.choices[0].message
+        if isinstance(message, dict):
+            content = message.get("content")
+        else:
+            content = getattr(message, "content", message)
+        if not isinstance(content, str):
+            content = str(content) if content else ""
+        content = content.strip()
+        if not content:
+            logger.info("micro-summarization returned empty content")
+            return None
+
+        from agent.agent_runtime_helpers import strip_think_blocks
+        stripped = strip_think_blocks(None, content).strip()
+        return stripped if stripped else None
+
+    def _needs_defrag(self) -> bool:
+        """Return True when the rolling summary is large enough to defrag."""
+        content_tokens = estimate_tokens_rough(self._micro_compact_rolling_summary)
+        return content_tokens >= self._micro_compact_defrag_threshold_tokens
+
+    def _defrag_rolling_summary(
+        self,
+        messages: List[Dict[str, Any]],
+        head_end: int,
+        tail_start: int,
+    ) -> None:
+        """Re-summarize the rolling summary + remaining middle in one shot.
+
+        This is a lightweight batch compaction on just the summary and the
+        remaining un-compacted region \u2014 NOT the full transcript.  It replaces
+        the rolling summary with a fresh, compact version and advances the
+        cursor to *tail_start*.
+        """
+        middle_content = self._serialize_one_exchange(messages, head_end, tail_start)
+        fresh_summary = self._micro_summarize_one(middle_content)
+        if fresh_summary:
+            self._micro_compact_rolling_summary = fresh_summary
+            self._micro_compact_cursor = tail_start
+            logger.info(
+                "Micro-compaction defrag: rolling summary re-summarized "
+                "(%d chars)", len(fresh_summary),
+            )
+
+    def _micro_compact(
+        self,
+        messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Run one round of micro-compaction on the conversation.
+
+        Absorbs the oldest uncompacted exchange into the rolling summary,
+        advancing the in-memory cursor.  Runs in post-turn idle time.
+
+        This is the public entry point called from ``finalize_turn()``.
+        Returns the (possibly modified) message list.
+
+        NOTE: the in-memory splice alone is not persisted — the subsequent
+        ``_persist_session`` flush is append-only, so old DB rows stay
+        ``active=1`` and a session resume double-loads both the summary and
+        the original exchanges (#82483).  This method therefore also calls
+        ``archive_and_compact`` on the session DB to soft-archive old rows
+        and insert the compacted set atomically.
+        """
+        if not self._micro_compact_enabled:
+            return messages
+
+        n_messages = len(messages)
+        if n_messages < 4:
+            return messages
+
+        head_size = self._protect_head_size(messages)
+        compress_start = self._align_boundary_forward(messages, head_size)
+        compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
+
+        if compress_start >= compress_end:
+            return messages
+
+        cursor = self._resolve_compact_cursor(messages, compress_start, compress_end)
+        if cursor >= compress_end:
+            return messages
+
+        # Find the next exchange
+        exchange = self._find_one_exchange(messages, cursor, compress_end)
+        if exchange is None:
+            return messages
+
+        exchange_start, exchange_end = exchange
+
+        # Check for defrag trigger
+        if self._needs_defrag():
+            self._defrag_rolling_summary(messages, exchange_start, compress_end)
+            result = self._splice_micro_compact_result(messages, exchange_start, compress_end)
+            self._sync_micro_compact_to_db(result)
+            self._micro_compact_consecutive_failures = 0
+            self._micro_compact_last_failure_cursor = -1
+            return result
+
+        # Micro-summarize one exchange
+        exchange_text = self._serialize_one_exchange(messages, exchange_start, exchange_end)
+        updated_summary = self._micro_summarize_one(exchange_text)
+        if updated_summary is None:
+            # Track consecutive failures on the same cursor position so we
+            # don't busy-loop on an unsummarizable exchange every turn.
+            if exchange_start == self._micro_compact_last_failure_cursor:
+                self._micro_compact_consecutive_failures += 1
+            else:
+                self._micro_compact_consecutive_failures = 1
+                self._micro_compact_last_failure_cursor = exchange_start
+
+            if self._micro_compact_consecutive_failures >= _MICRO_COMPACT_MAX_CONSECUTIVE_FAILURES:
+                logger.info(
+                    "Micro-compaction: skipping exchange at cursor %d "
+                    "after %d consecutive failures",
+                    exchange_start, self._micro_compact_consecutive_failures,
+                )
+                # Advance the cursor past the stuck exchange so we don't
+                # retry it every turn. The skipped messages remain in the
+                # transcript and will be absorbed by the next batch
+                # compression or defrag.
+                self._micro_compact_cursor = exchange_end
+                self._micro_compact_consecutive_failures = 0
+                self._micro_compact_last_failure_cursor = -1
+            return messages
+
+        self._micro_compact_rolling_summary = updated_summary
+        self._micro_compact_cursor = exchange_end
+        self._micro_compact_consecutive_failures = 0
+        self._micro_compact_last_failure_cursor = -1
+
+        result = self._splice_micro_compact_result(messages, exchange_start, exchange_end)
+        self._sync_micro_compact_to_db(result)
+        return result
+
+    def _sync_micro_compact_to_db(
+        self,
+        compacted_messages: List[Dict[str, Any]],
+    ) -> None:
+        """Persist the micro-compacted message set to the session DB.
+
+        Soft-archives every currently-active message row (``active = 0``)
+        and inserts *compacted_messages* as fresh active rows — atomically,
+        via ``archive_and_compact``.  Then stamps ``_DB_PERSISTED_MARKER`` on
+        every dict so the upcoming append-only flush (``_persist_session`` →
+        ``_flush_messages_to_session_db_unlocked``) skips them: they are
+        already correctly stored.
+
+        Without this, the in-memory-only splice leaves old exchange rows at
+        ``active=1``, and a session resume double-loads both the summary and
+        the original messages — blowing past the model's context limit.
+        """
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        if not session_db or not session_id:
+            return
+        try:
+            session_db.archive_and_compact(session_id, compacted_messages)
+            for msg in compacted_messages:
+                if isinstance(msg, dict):
+                    msg[_DB_PERSISTED_MARKER] = True
+        except Exception:
+            logger.info(
+                "Micro-compaction DB sync failed — resume will double-load "
+                "compacted messages until the next batch compression"
+            )
+
+    def _splice_micro_compact_result(
+        self,
+        messages: List[Dict[str, Any]],
+        splice_start: int,
+        splice_end: int,
+    ) -> List[Dict[str, Any]]:
+        """Replace *messages[splice_start:splice_end]* with a summary marker.
+
+        The summary marker carries the rolling summary text and the
+        ``_compressed_summary`` metadata flag so downstream consumers
+        (resume, handoff, /compress) handle it identically to batch
+        compaction summaries.
+        """
+        summary_text = self._micro_compact_rolling_summary
+        if not summary_text.strip():
+            return messages
+
+        content = (
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\n"
+        )
+        content += summary_text.strip()
+        content += f"\n\n{_SUMMARY_END_MARKER}"
+
+        summary_msg = {
+            "role": "user",
+            "content": content,
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+            COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: True,
+        }
+
+        result = messages[:splice_start] + [summary_msg] + messages[splice_end:]
+
+        # The rolling summary is cumulative: this marker already contains
+        # everything every earlier micro-compaction marker held. Leaving those
+        # in place stacks near-duplicate copies of the same text — each with
+        # its own prefix/heading/end-marker scaffolding — so the transcript
+        # grows with every turn instead of shrinking, which defeats the point.
+        # Keep only the newest marker.
+        marker_idxs = [
+            i for i, m in enumerate(result)
+            if isinstance(m, dict) and m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+        ]
+        if len(marker_idxs) > 1:
+            superseded = set(marker_idxs[:-1])
+            result = [m for i, m in enumerate(result) if i not in superseded]
+
+        _strip_persistence_markers(result)
+        return result
 
     def compress(
         self,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5043,14 +5043,24 @@ This compaction should PRIORITISE preserving all information related to the focu
     ) -> Optional[tuple[int, int]]:
         """Find the next complete exchange starting at *start*.
 
-        An exchange is: (optional) user message + assistant message + its tool
-        results.  Returns ``(exchange_start, exchange_end)`` indices into
-        *messages*, or ``None`` if no complete exchange is available before
-        *tail_start*.
+        An exchange is an assistant message plus its tool results.  Returns
+        ``(exchange_start, exchange_end)`` indices into *messages*, or ``None``
+        if no complete exchange is available before *tail_start*.
 
         Tool results are consumed as a group following the assistant message
         (consecutive ``tool``-role messages).  The assistant message itself must
         exist; without one there is nothing to summarise.
+
+        User messages are deliberately NOT part of an exchange.  The walk skips
+        past them to reach the assistant message, and ``exchange_start`` is that
+        assistant index, so user turns are never absorbed into the rolling
+        summary and stay verbatim for the life of the session.  This is the
+        intended behaviour, not an oversight: what the assistant emits is
+        largely an account of what it did, which survives summarising, while the
+        user's own words are the instructions everything else is derived from
+        and are the one thing that cannot be reconstructed from context.  They
+        are also cheap — a prompt is normally a tiny fraction of the tokens a
+        single tool result costs.
         """
         idx = start
         n = len(messages)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -137,6 +137,12 @@ LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 # "is_compressed_summary" would reach the wire and trip exactly that.
 COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 COMPRESSED_SUMMARY_HAS_USER_TURN_KEY = "_compressed_summary_has_user_turn"
+# Distinguishes rolling micro-compaction markers from batch-compaction
+# markers (both carry COMPRESSED_SUMMARY_METADATA_KEY so resume/handoff
+# treat them alike). Supersede/defrag/rehydration must only ever touch
+# micro markers: a batch marker's content is NOT contained in the micro
+# rolling summary, so dropping or rewriting one destroys history.
+MICRO_COMPACT_MARKER_KEY = "_micro_compact_marker"
 _DB_PERSISTED_MARKER = "_db_persisted"
 
 _NO_USER_TASK_SENTINEL = "None. This session contains no user-authored turns."
@@ -5052,6 +5058,14 @@ This compaction should PRIORITISE preserving all information related to the focu
                 )
                 if recovered:
                     self._micro_compact_rolling_summary = recovered
+                    # Rehydration is containment proof: this marker's text now
+                    # lives inside the rolling summary, so it becomes
+                    # supersede/defrag-eligible. This also covers a BATCH
+                    # marker adopted as the rolling base after a batch
+                    # compaction reset — safe precisely because we just
+                    # absorbed its content. Markers whose content we did NOT
+                    # absorb never get the key and are never dropped.
+                    messages[last_summary_idx][MICRO_COMPACT_MARKER_KEY] = True
                     logger.info(
                         "Micro-compaction: recovered rolling summary from "
                         "transcript (%d chars)", len(recovered),
@@ -5132,17 +5146,22 @@ This compaction should PRIORITISE preserving all information related to the focu
         if idx <= exchange_start:
             return None
 
-        # Splice-boundary guard: the message right after the exchange must be
-        # a user turn (or a summary marker, which stands in for one
-        # structurally).  If the walk stopped because it ran into *tail_start*
-        # mid-turn, splicing here would leave the assistant-role marker
-        # adjacent to the turn's remaining assistant/tool messages — invalid
-        # alternation.  Skip this pass; the tail recedes as the conversation
-        # grows and the turn becomes absorbable later.
+        # Splice-boundary guard: the message right after the exchange must
+        # close the turn. If the walk stopped because it ran into
+        # *tail_start* mid-turn (boundary is assistant or tool — including
+        # an assistant-role summary marker), splicing here would leave the
+        # assistant-role marker adjacent to the turn's remaining
+        # assistant/tool messages — invalid alternation. Skip this pass; the
+        # tail recedes as the conversation grows and the turn becomes
+        # absorbable later. Any other boundary role (user, or a stray
+        # system/injected message) is a safe splice point — the marker is
+        # assistant-role, so no same-role adjacency is possible — and
+        # accepting them keeps one odd message from wedging the cursor
+        # forever.
         if idx >= n:
             return None
         boundary = messages[idx]
-        if not isinstance(boundary, dict) or boundary.get("role") != "user":
+        if not isinstance(boundary, dict) or boundary.get("role") in ("assistant", "tool"):
             return None
         return (exchange_start, idx)
 
@@ -5154,72 +5173,11 @@ This compaction should PRIORITISE preserving all information related to the focu
     ) -> str:
         """Serialize a single exchange for the micro-summarizer.
 
-        Uses the same content-max truncation and redaction as the batch
-        ``_serialize_for_summary`` method, but scoped to one exchange.
+        Delegates to the batch path's ``_serialize_for_summary`` (same
+        truncation, redaction, think-block stripping, and media labeling),
+        scoped to one exchange — one serializer, one place to fix.
         """
-        from agent.agent_runtime_helpers import strip_think_blocks
-
-        parts = []
-        for msg in messages[start:end]:
-            role = msg.get("role", "unknown")
-            content = msg.get("content")
-            if isinstance(content, list):
-                text_parts: list[str] = []
-                for part in content:
-                    if isinstance(part, dict):
-                        ptype = part.get("type")
-                        if ptype == "text":
-                            text_parts.append(part.get("text", ""))
-                        elif ptype in {"image", "image_url", "input_image"}:
-                            text_parts.append(_image_part_label(part))
-                        else:
-                            text_parts.append(f"[{ptype or 'attachment'}]")
-                    elif isinstance(part, str):
-                        text_parts.append(part)
-                content = "\n".join(text_parts)
-            content = _redact_compaction_text(content or "")
-            content = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", content)
-            if role == "assistant" and content:
-                content = strip_think_blocks(None, content)
-
-            if role == "tool":
-                tool_id = msg.get("tool_call_id", "")
-                if len(content) > self._CONTENT_MAX:
-                    content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
-                parts.append(f"[TOOL RESULT {tool_id}]: {content}")
-                continue
-
-            if role == "assistant":
-                if len(content) > self._CONTENT_MAX:
-                    content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
-                tool_calls = msg.get("tool_calls", [])
-                if tool_calls:
-                    tc_parts = []
-                    for tc in tool_calls:
-                        if isinstance(tc, dict):
-                            fn = tc.get("function", {})
-                            name = fn.get("name", "?")
-                            args = _redact_compaction_text(fn.get("arguments", ""))
-                            if len(args) > self._TOOL_ARGS_MAX:
-                                args = args[:self._TOOL_ARGS_HEAD] + "..."
-                            tc_parts.append(f"  {name}({args})")
-                        else:
-                            fn = getattr(tc, "function", None)
-                            name = getattr(fn, "name", "?") if fn else "?"
-                            tc_parts.append(f"  {name}(...)")
-                    content += "\n[Tool calls:\n" + "\n".join(tc_parts) + "\n]"
-                parts.append(f"[ASSISTANT]: {content}")
-                continue
-
-            if role == "user":
-                if len(content) > self._CONTENT_MAX:
-                    content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
-                parts.append(f"[USER]: {content}")
-                continue
-
-            parts.append(f"[{role.upper()}]: {content}")
-
-        return "\n---\n".join(parts)
+        return self._serialize_for_summary(messages[start:end])
 
     def _build_micro_summary_prompt(
         self,
@@ -5349,11 +5307,17 @@ This compaction should PRIORITISE preserving all information related to the focu
             self._micro_compact_rolling_summary = old_summary
             return False
         self._micro_compact_rolling_summary = fresh_summary
-        # Rewrite the newest marker's content in place so the transcript and
-        # the in-memory summary stay in step (resume rehydrates from it).
+        # Rewrite the newest MICRO marker's content in place so the transcript
+        # and the in-memory summary stay in step (resume rehydrates from it).
+        # Scoped to micro-tagged markers: rewriting a batch-compaction marker
+        # would overwrite history the rolling summary does not contain.
         for idx in range(len(messages) - 1, -1, -1):
             entry = messages[idx]
-            if isinstance(entry, dict) and entry.get(COMPRESSED_SUMMARY_METADATA_KEY):
+            if (
+                isinstance(entry, dict)
+                and entry.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                and entry.get(MICRO_COMPACT_MARKER_KEY)
+            ):
                 entry["content"] = self._render_micro_marker_content(fresh_summary)
                 # Content changed after a possible flush — clear the persisted
                 # stamp so the DB sync/flush rewrites the row.
@@ -5700,6 +5664,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             "role": "assistant",
             "content": self._render_micro_marker_content(summary_text),
             COMPRESSED_SUMMARY_METADATA_KEY: True,
+            # Micro-created marker: eligible for supersede/defrag rewrites.
+            # Batch markers never carry this key and are never touched —
+            # their content is not contained in the rolling summary.
+            MICRO_COMPACT_MARKER_KEY: True,
             # Honest provenance (#64650): this marker absorbs only
             # assistant/tool content — user turns are never micro-compacted,
             # so they remain in the transcript and _transcript_has_real_user_turn
@@ -5715,22 +5683,39 @@ This compaction should PRIORITISE preserving all information related to the focu
         # its own prefix/heading/end-marker scaffolding — so the transcript
         # grows with every turn instead of shrinking, which defeats the point.
         # Keep only the newest marker.
-        # Only drop earlier markers when this one demonstrably contains them:
-        # the rolling summary must have been non-empty going into this pass.
-        # A pass that started from nothing (a resume that could not rehydrate)
-        # produces a marker covering one exchange, and dropping the previous
-        # marker would throw away the entire compacted history.
+        # Two containment gates before dropping an earlier marker:
+        # 1. supersede (the rolling summary was non-empty going into this
+        #    pass) — a pass that started from nothing (a resume that could
+        #    not rehydrate) covers one exchange, and dropping the previous
+        #    marker would throw away the entire compacted history.
+        # 2. MICRO_COMPACT_MARKER_KEY on the candidate — only markers whose
+        #    text is provably inside the rolling summary (created by our own
+        #    splice, or rehydrated into the summary by
+        #    _resolve_compact_cursor) carry it. A batch-compaction marker
+        #    that landed after our last pass holds MORE history than the
+        #    stale rolling summary; dropping it would destroy that history.
         if supersede:
             marker_idxs = [
                 i for i, m in enumerate(result)
-                if isinstance(m, dict) and m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                if isinstance(m, dict)
+                and m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                and m.get(MICRO_COMPACT_MARKER_KEY)
             ]
             if len(marker_idxs) > 1:
                 superseded = set(marker_idxs[:-1])
                 result = [m for i, m in enumerate(result) if i not in superseded]
                 result = self._merge_adjacent_user_turns(result)
 
-        _strip_persistence_markers(result)
+        # NOTE: deliberately NO _strip_persistence_markers here. The batch
+        # path strips because compress() copies head/tail into a rotated
+        # child session (#57491); micro-compaction archives in place under
+        # the SAME session id, and the surviving dicts' _db_persisted stamps
+        # are accurate. Stripping them meant an archive_and_compact failure
+        # left every previously-persisted message unstamped, and the next
+        # append-only flush re-inserted them as duplicate active rows on top
+        # of the still-active originals. _sync_micro_compact_to_db re-stamps
+        # everything after a SUCCESSFUL archive; on failure the old stamps
+        # keep the flush idempotent (only the new marker row is appended).
         return result
 
     @staticmethod
@@ -6467,6 +6452,19 @@ This compaction should PRIORITISE preserving all information related to the focu
         # future copy site cannot re-leak the marker into the child-session flush.
         _strip_persistence_markers(compressed)
         self._last_compression_made_progress = True
+
+        # Batch compaction invalidates micro-compaction state: the batch
+        # marker now holds MORE history than the in-memory rolling summary
+        # (it summarized everything in the window, including exchanges micro
+        # never absorbed). Keeping the stale summary would let the next micro
+        # pass supersede-drop or defrag-rewrite content it does not contain.
+        # Reset instead; the next micro pass rehydrates from the batch marker
+        # via _resolve_compact_cursor, which re-tags it as micro-eligible
+        # only after absorbing its content into the rolling summary.
+        self._micro_compact_rolling_summary = ""
+        self._micro_compact_cursor = 0
+        self._micro_compact_consecutive_failures = 0
+        self._micro_compact_last_failure_cursor = -1
 
         return compressed
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1300,6 +1300,8 @@ class ContextCompressor(ContextEngine):
         self._micro_compact_rolling_summary = ""
         self._micro_compact_consecutive_failures = 0
         self._micro_compact_last_failure_cursor = -1
+        self._micro_compact_passes = 0
+        self._micro_compact_tokens_saved_total = 0
 
     def _begin_compression_telemetry(
         self,
@@ -2155,6 +2157,8 @@ class ContextCompressor(ContextEngine):
         self._micro_compact_consecutive_failures: int = 0
         self._micro_compact_last_failure_cursor: int = -1
         self._micro_compact_defrag_threshold_tokens: int = 2000
+        self._micro_compact_passes: int = 0
+        self._micro_compact_tokens_saved_total: int = 0
 
         # Defer context-length resolution to first access (#32221):
         # get_model_context_length() can issue a synchronous /models HTTP
@@ -5332,6 +5336,15 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         exchange_start, exchange_end = exchange
 
+        # Baseline for telemetry. Taken only once an exchange is in hand, so
+        # turns that no-op early don't pay for the scan.
+        _started_at = time.monotonic()
+        _tokens_before = estimate_messages_tokens_rough(messages)
+        _messages_before = n_messages
+
+        def _elapsed_ms() -> int:
+            return int((time.monotonic() - _started_at) * 1000)
+
         # Check for defrag trigger
         if self._needs_defrag():
             self._defrag_rolling_summary(messages, exchange_start, compress_end)
@@ -5339,10 +5352,19 @@ This compaction should PRIORITISE preserving all information related to the focu
             self._sync_micro_compact_to_db(result)
             self._micro_compact_consecutive_failures = 0
             self._micro_compact_last_failure_cursor = -1
+            self._emit_micro_compaction_telemetry(
+                outcome="defrag",
+                messages_before=_messages_before,
+                messages_after=len(result),
+                tokens_before=_tokens_before,
+                tokens_after=estimate_messages_tokens_rough(result),
+                duration_ms=_elapsed_ms(),
+            )
             return result
 
         # Micro-summarize one exchange
         exchange_text = self._serialize_one_exchange(messages, exchange_start, exchange_end)
+        _exchange_tokens = estimate_tokens_rough(exchange_text)
         updated_summary = self._micro_summarize_one(exchange_text)
         if updated_summary is None:
             # Track consecutive failures on the same cursor position so we
@@ -5366,6 +5388,18 @@ This compaction should PRIORITISE preserving all information related to the focu
                 self._micro_compact_cursor = exchange_end
                 self._micro_compact_consecutive_failures = 0
                 self._micro_compact_last_failure_cursor = -1
+                _outcome = "exchange_skipped"
+            else:
+                _outcome = "summarize_failed"
+            self._emit_micro_compaction_telemetry(
+                outcome=_outcome,
+                messages_before=_messages_before,
+                messages_after=len(messages),
+                tokens_before=_tokens_before,
+                tokens_after=_tokens_before,
+                exchange_tokens=_exchange_tokens,
+                duration_ms=_elapsed_ms(),
+            )
             return messages
 
         self._micro_compact_rolling_summary = updated_summary
@@ -5375,7 +5409,69 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         result = self._splice_micro_compact_result(messages, exchange_start, exchange_end)
         self._sync_micro_compact_to_db(result)
+        self._emit_micro_compaction_telemetry(
+            outcome="absorbed",
+            messages_before=_messages_before,
+            messages_after=len(result),
+            tokens_before=_tokens_before,
+            tokens_after=estimate_messages_tokens_rough(result),
+            exchange_tokens=_exchange_tokens,
+            duration_ms=_elapsed_ms(),
+        )
         return result
+
+    def _emit_micro_compaction_telemetry(
+        self,
+        *,
+        outcome: str,
+        messages_before: int,
+        messages_after: int,
+        tokens_before: int | None,
+        tokens_after: int | None,
+        exchange_tokens: int | None = None,
+        duration_ms: int | None = None,
+    ) -> None:
+        """Emit one content-free JSON log line describing a micro-compaction pass.
+
+        Mirrors ``_emit_compression_attempt_telemetry`` for the batch path.
+        Message counts move by one or two even when the saving is large, so the
+        token fields are the ones that actually answer "is this helping?".
+        ``tokens_delta`` is negative when the pass shrank the transcript, and
+        the ``*_total`` fields accumulate across the session so a whole run can
+        be summarised from the last line alone.
+        """
+        try:
+            delta = None
+            if tokens_before is not None and tokens_after is not None:
+                delta = tokens_after - tokens_before
+                self._micro_compact_tokens_saved_total -= delta
+            self._micro_compact_passes += 1
+            payload = {
+                "event": "micro_compaction",
+                "session_id": getattr(self, "_session_id", "") or "",
+                "outcome": outcome,
+                "messages_before": messages_before,
+                "messages_after": messages_after,
+                "tokens_before": _safe_int(tokens_before),
+                "tokens_after": _safe_int(tokens_after),
+                "tokens_delta": _safe_int(delta),
+                "exchange_tokens": _safe_int(exchange_tokens),
+                "rolling_summary_tokens": estimate_tokens_rough(
+                    self._micro_compact_rolling_summary
+                ),
+                "cursor": _safe_int(self._micro_compact_cursor),
+                "passes_total": self._micro_compact_passes,
+                "tokens_saved_total": self._micro_compact_tokens_saved_total,
+                "duration_ms": _safe_int(duration_ms),
+                "main_model": self.model or "",
+                "aux_model": self.summary_model or "",
+            }
+            logger.info(
+                "micro compaction telemetry: %s",
+                json.dumps(payload, sort_keys=True, separators=(",", ":")),
+            )
+        except Exception as exc:
+            logger.debug("failed to emit micro-compaction telemetry: %s", exc)
 
     def _sync_micro_compact_to_db(
         self,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5034,6 +5034,19 @@ This compaction should PRIORITISE preserving all information related to the focu
                 last_summary_idx = idx
         if last_summary_idx >= head_end:
             cursor = last_summary_idx + 1
+            # Resumed session: in-memory state is gone but the marker survives.
+            # Carry its text forward so the next pass merges into the existing
+            # history instead of replacing it with a single-exchange summary.
+            if not self._micro_compact_rolling_summary.strip():
+                recovered = self._rolling_summary_from_marker(
+                    messages[last_summary_idx].get("content")
+                )
+                if recovered:
+                    self._micro_compact_rolling_summary = recovered
+                    logger.info(
+                        "Micro-compaction: recovered rolling summary from "
+                        "transcript (%d chars)", len(recovered),
+                    )
         else:
             cursor = head_end
         self._micro_compact_cursor = cursor
@@ -5363,6 +5376,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             )
             return result
 
+        # Whether this pass's summary will be cumulative — i.e. whether it
+        # subsumes any earlier marker. Captured before summarizing.
+        _cumulative = bool(self._micro_compact_rolling_summary.strip())
+
         # Micro-summarize one exchange
         exchange_text = self._serialize_one_exchange(messages, exchange_start, exchange_end)
         _exchange_tokens = estimate_tokens_rough(exchange_text)
@@ -5408,7 +5425,9 @@ This compaction should PRIORITISE preserving all information related to the focu
         self._micro_compact_consecutive_failures = 0
         self._micro_compact_last_failure_cursor = -1
 
-        result = self._splice_micro_compact_result(messages, exchange_start, exchange_end)
+        result = self._splice_micro_compact_result(
+            messages, exchange_start, exchange_end, supersede=_cumulative,
+        )
         self._micro_compact_cursor = self._cursor_after_splice(result, exchange_start + 1)
         self._sync_micro_compact_to_db(result)
         self._emit_micro_compaction_telemetry(
@@ -5421,6 +5440,29 @@ This compaction should PRIORITISE preserving all information related to the focu
             duration_ms=_elapsed_ms(),
         )
         return result
+
+    @staticmethod
+    def _rolling_summary_from_marker(content: Any) -> str:
+        """Recover the rolling-summary text from a summary marker's content.
+
+        The rolling summary lives in memory, but a resumed session starts with
+        an empty one while the marker holding every previous exchange is still
+        in the transcript. Without rehydrating from it, the first post-resume
+        pass would build a marker from nothing and supersede the one carrying
+        the whole history.
+        """
+        if not isinstance(content, str) or not content.strip():
+            return ""
+        body = content
+        # rfind, not find: SUMMARY_PREFIX itself references the heading text,
+        # so the first occurrence is inside the preamble, not the real heading.
+        idx = body.rfind(HISTORICAL_TASK_HEADING)
+        if idx != -1:
+            body = body[idx + len(HISTORICAL_TASK_HEADING):]
+        end = body.find(_SUMMARY_END_MARKER)
+        if end != -1:
+            body = body[:end]
+        return body.strip()
 
     def _cursor_after_splice(
         self,
@@ -5550,6 +5592,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         messages: List[Dict[str, Any]],
         splice_start: int,
         splice_end: int,
+        supersede: bool = True,
     ) -> List[Dict[str, Any]]:
         """Replace *messages[splice_start:splice_end]* with a summary marker.
 
@@ -5584,13 +5627,19 @@ This compaction should PRIORITISE preserving all information related to the focu
         # its own prefix/heading/end-marker scaffolding — so the transcript
         # grows with every turn instead of shrinking, which defeats the point.
         # Keep only the newest marker.
-        marker_idxs = [
-            i for i, m in enumerate(result)
-            if isinstance(m, dict) and m.get(COMPRESSED_SUMMARY_METADATA_KEY)
-        ]
-        if len(marker_idxs) > 1:
-            superseded = set(marker_idxs[:-1])
-            result = [m for i, m in enumerate(result) if i not in superseded]
+        # Only drop earlier markers when this one demonstrably contains them:
+        # the rolling summary must have been non-empty going into this pass.
+        # A pass that started from nothing (a resume that could not rehydrate)
+        # produces a marker covering one exchange, and dropping the previous
+        # marker would throw away the entire compacted history.
+        if supersede:
+            marker_idxs = [
+                i for i, m in enumerate(result)
+                if isinstance(m, dict) and m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+            ]
+            if len(marker_idxs) > 1:
+                superseded = set(marker_idxs[:-1])
+                result = [m for i, m in enumerate(result) if i not in superseded]
 
         _strip_persistence_markers(result)
         return result

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1302,6 +1302,7 @@ class ContextCompressor(ContextEngine):
         self._micro_compact_last_failure_cursor = -1
         self._micro_compact_passes = 0
         self._micro_compact_tokens_saved_total = 0
+        self._micro_compact_turns_since_pass = 0
 
     def _begin_compression_telemetry(
         self,
@@ -2161,6 +2162,12 @@ class ContextCompressor(ContextEngine):
         self._micro_compact_defrag_threshold_tokens: int = 2000
         self._micro_compact_passes: int = 0
         self._micro_compact_tokens_saved_total: int = 0
+        # Cadence: run a pass every Nth completed turn. Each pass rewrites
+        # already-sent history and so breaks the prompt-cache prefix, which
+        # makes this the dial that sets how often that break is paid. 1 =
+        # every turn (most aggressive reclaim, one break per turn).
+        self._micro_compact_every_n_turns: int = 1
+        self._micro_compact_turns_since_pass: int = 0
 
         # Defer context-length resolution to first access (#32221):
         # get_model_context_length() can issue a synchronous /models HTTP
@@ -5328,6 +5335,18 @@ This compaction should PRIORITISE preserving all information related to the focu
         """
         if not self._micro_compact_enabled:
             return messages
+
+        # Cadence gate. A pass rewrites already-sent history, so it costs one
+        # prompt-cache break; `every_n_turns` is how an operator trades reclaim
+        # frequency against that cost. Counted per invocation rather than per
+        # committed pass so a turn that finds nothing to absorb still advances
+        # the cadence and cannot wedge it.
+        every_n = max(1, int(self._micro_compact_every_n_turns or 1))
+        if every_n > 1:
+            self._micro_compact_turns_since_pass += 1
+            if self._micro_compact_turns_since_pass < every_n:
+                return messages
+            self._micro_compact_turns_since_pass = 0
 
         n_messages = len(messages)
         if n_messages < 4:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5446,6 +5446,15 @@ This compaction should PRIORITISE preserving all information related to the focu
                 delta = tokens_after - tokens_before
                 self._micro_compact_tokens_saved_total -= delta
             self._micro_compact_passes += 1
+            # Cached reads only. The ``threshold_tokens`` / ``context_length``
+            # properties resolve lazily and can fire a synchronous /models
+            # probe on first access (#32221) — telemetry must never be the
+            # thing that blocks a turn. Unresolved simply reports null.
+            threshold = self._threshold_tokens
+            context_limit = self._resolved_context_length
+            occupancy = None
+            if threshold and tokens_after is not None and threshold > 0:
+                occupancy = round(tokens_after / threshold * 100, 1)
             payload = {
                 "event": "micro_compaction",
                 "session_id": getattr(self, "_session_id", "") or "",
@@ -5463,6 +5472,12 @@ This compaction should PRIORITISE preserving all information related to the focu
                 "passes_total": self._micro_compact_passes,
                 "tokens_saved_total": self._micro_compact_tokens_saved_total,
                 "duration_ms": _safe_int(duration_ms),
+                # Headroom, not efficiency: how full the window is being kept.
+                # This is the number that says whether the session can keep
+                # going without a hard batch compaction.
+                "threshold_tokens": _safe_int(threshold),
+                "context_limit": _safe_int(context_limit),
+                "occupancy_pct": occupancy,
                 "main_model": self.model or "",
                 "aux_model": self.summary_model or "",
             }

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -368,6 +368,13 @@ def finalize_turn(
                     and getattr(_compressor, '_micro_compact_enabled', False) is True
                     and callable(getattr(_compressor, '_micro_compact', None))
                     and final_response
+                    # Persistence-isolated agents (background review fork)
+                    # must not micro-compact: the pass burns a real aux-LLM
+                    # call on a throwaway replay transcript, and if the
+                    # compressor ever holds a session_db binding it would
+                    # archive_and_compact the CANONICAL session rows — the
+                    # exact write class _persist_disabled exists to stop.
+                    and not getattr(agent, "_persist_disabled", False)
                 ):
                     _before = len(messages)
                     _compacted = _compressor._micro_compact(messages)

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -358,13 +358,21 @@ def finalize_turn(
         if not interrupted and not failed:
             try:
                 _compressor = getattr(agent, "context_compressor", None)
+                # Strict `is True` + isinstance gates: plugin context engines
+                # (and MagicMock compressors in tests) satisfy getattr/duck
+                # checks with truthy auto-attributes — a bare truthiness check
+                # here called _micro_compact on a mock and spliced its (empty-
+                # iterating) return value over the transcript, wiping it.
                 if (
                     _compressor
-                    and getattr(_compressor, '_micro_compact_enabled', False)
+                    and getattr(_compressor, '_micro_compact_enabled', False) is True
+                    and callable(getattr(_compressor, '_micro_compact', None))
                     and final_response
                 ):
                     _before = len(messages)
-                    messages[:] = _compressor._micro_compact(messages) or messages
+                    _compacted = _compressor._micro_compact(messages)
+                    if isinstance(_compacted, list) and _compacted:
+                        messages[:] = _compacted
                     _after = len(messages)
                     if _before != _after:
                         logger.info(

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -349,6 +349,31 @@ def finalize_turn(
         _apply_override = getattr(agent, "_apply_persist_user_message_override", None)
         if callable(_apply_override):
             _apply_override(messages)
+
+        # ── Post-turn micro-compaction ────────────────────────────
+        # After the assistant response is finalized but before the session is
+        # persisted, run micro-compaction to absorb the oldest uncompacted
+        # exchange into the rolling summary.  This amortizes compression
+        # across turns rather than batching it into one big pause.
+        if not interrupted and not failed:
+            try:
+                _compressor = getattr(agent, "context_compressor", None)
+                if (
+                    _compressor
+                    and getattr(_compressor, '_micro_compact_enabled', False)
+                    and final_response
+                ):
+                    _before = len(messages)
+                    messages[:] = _compressor._micro_compact(messages) or messages
+                    _after = len(messages)
+                    if _before != _after:
+                        logger.info(
+                            "Micro-compaction: %d -> %d messages",
+                            _before, _after,
+                        )
+            except Exception as _mc_err:
+                logger.info("Micro-compaction failed: %s", _mc_err)
+
         agent._persist_session(messages, conversation_history)
     except Exception as _persist_err:
         _cleanup_errors.append(f"persist_session: {_persist_err}")

--- a/docs/micro-compaction.md
+++ b/docs/micro-compaction.md
@@ -162,15 +162,39 @@ compaction. Everything else about compression is unchanged.
 
 ## Measuring it
 
+Micro-compaction is not primarily a token-saving or time-saving optimisation,
+and judging it on tokens saved will undersell it. The two things it actually
+buys you are:
+
+1. **The long pause is amortized.** The same summarization work happens, but as
+   small increments after turns instead of one stall in the middle of a session.
+2. **Your context lasts longer.** Because the middle is continuously reclaimed,
+   occupancy stays low instead of sawtoothing up to the threshold. A session
+   runs much further — often indefinitely — before it needs a hard compaction
+   at all.
+
+So the number that matters is **occupancy**: how full the window is being kept,
+as a percentage of the compaction threshold. A session that holds steady around
+40% has headroom to keep going; one climbing through 90% is about to stall. The
+second number is **how many batch compactions actually fired** — ideally none.
+
+A session can save nothing on paper and still be a clear win on both counts.
+
 Every pass emits one content-free JSON line, in the same style as the batch
 compaction telemetry:
 
 ```
 micro compaction telemetry: {"event":"micro_compaction","outcome":"absorbed",
 "tokens_before":12739,"tokens_after":12060,"tokens_delta":-679,
+"occupancy_pct":38.4,"threshold_tokens":34816,"context_limit":40960,
 "exchange_tokens":868,"rolling_summary_tokens":31,"passes_total":1,
 "tokens_saved_total":679,"duration_ms":14,...}
 ```
+
+`occupancy_pct` is `tokens_after` as a share of the compaction threshold -- the
+headroom figure. It is null when the model's window has not been resolved yet:
+the telemetry reads only the cached value, because resolving it can issue a
+synchronous `/models` probe and telemetry must never be what blocks a turn.
 
 `tokens_delta` is negative when the pass shrank the transcript.
 `tokens_saved_total` and `passes_total` accumulate across the session, so a whole

--- a/docs/micro-compaction.md
+++ b/docs/micro-compaction.md
@@ -1,0 +1,156 @@
+# Micro-compaction
+
+**A way to amortize the cost of compression.**
+
+Long conversations eventually outgrow the model's context window, and something
+has to be thrown away or summarized. Hermes has always done this in one batch:
+when the transcript crosses a threshold, the session stops, a large chunk of the
+middle is summarized in a single call, and the conversation resumes. That works,
+but the whole bill comes due at once — one visible pause, one big summarization
+request, at whatever moment you happened to cross the line.
+
+Micro-compaction pays the same bill in instalments. After each completed turn,
+Hermes folds the single oldest un-absorbed exchange into a running summary. The
+work is the same work; it just happens continuously, in small pieces, during the
+idle moment after a response instead of all at once in the middle of your
+session.
+
+**The tradeoff is that knowledge gets a little earlier than you may be used to.**
+Because compaction is always running, older parts of the conversation become
+summaries sooner than they would under batch compaction — which leaves
+everything verbatim until the window actually fills. Detail from earlier in the
+session turns second-hand faster. You trade some of that fidelity for never
+eating one long stall, and for a context window that stays consistently smaller
+rather than sawtoothing up to the threshold and back.
+
+---
+
+## What it does
+
+After every turn that finishes normally, `finalize_turn` asks the context
+compressor to absorb **one** exchange:
+
+1. Find the oldest exchange that hasn't been summarized yet.
+2. Send just that exchange, plus the current running summary, to the auxiliary
+   summarization model.
+3. Replace those messages in the transcript with a single summary marker
+   carrying the updated running summary.
+
+One exchange per turn. The per-turn cost stays bounded no matter how long the
+conversation gets.
+
+An **exchange** is an assistant message together with any tool results that
+followed it. In tool-heavy work that's where the bulk of the tokens live — a
+file read or a command's output dwarfs the surrounding prose — which is why
+absorbing one exchange at a time is worth doing at all.
+
+## What it never touches
+
+Two regions are protected and stay verbatim:
+
+- **The head** — the system prompt and the opening messages, so the session's
+  founding instructions are never paraphrased.
+- **The tail** — a token-budgeted window of the most recent messages, so
+  everything that's immediately relevant is still there in full.
+
+Micro-compaction only ever works in the middle, between those two.
+
+## How it works
+
+### The cursor
+
+The compressor keeps a cursor: the index of the first message not yet absorbed.
+Each successful pass advances it past the exchange it just summarized.
+
+If that in-memory cursor is missing or out of range — a fresh process, a resumed
+session — it's recovered by scanning the transcript for the last summary marker
+and resuming just after it. The transcript itself is the source of truth, so
+resuming a session doesn't re-summarize work already done.
+
+### The rolling summary
+
+Rather than keeping a pile of per-exchange summaries, there is exactly one
+running summary that each new exchange is merged into. The summarizer is asked
+to fold in the new material's decisions, requirements, file paths and open
+questions, drop details that are no longer relevant, and preserve the existing
+structure. It's also explicitly instructed to replace any credentials it
+encounters with `[REDACTED]`.
+
+Because that summary is cumulative, only the newest marker is kept in the
+transcript. Earlier markers are strictly redundant — the current summary already
+contains everything they held — so they're dropped as they're superseded. This
+matters more than it sounds: leaving them in place stacks near-duplicate copies
+of the same text, each with its own heading and end-marker scaffolding, and the
+transcript grows on every turn instead of shrinking.
+
+### Defrag
+
+Merge into a summary often enough and it gets baggy — repetitive, and larger
+than the material justifies. When the running summary crosses a token threshold
+(2000 by default), the next pass **defrags**: it re-summarizes the summary and
+whatever middle remains in one shot, replacing it with a fresh compact version
+and advancing the cursor to the tail.
+
+This is still much cheaper than full batch compaction. It only ever processes the
+summary plus the un-absorbed middle, never the whole transcript.
+
+### Staying in step with the session database
+
+The in-memory splice alone isn't enough. Hermes's normal session flush is
+append-only, so the original rows would stay marked active and a resume would
+load *both* the summary and the messages it replaced — putting the session
+straight over the context limit.
+
+So each pass also calls `archive_and_compact`, which atomically soft-archives the
+active rows and inserts the compacted set. The messages are then stamped as
+already-persisted so the append-only flush that follows skips them. If that
+database step fails, it's logged and the session continues; the resume would
+double-load until the next batch compression cleans up.
+
+### When the summarizer fails
+
+A summarization call can fail — the auxiliary model is unreachable, out of quota,
+or the exchange itself is somehow unsummarizable. The transcript is left
+untouched and the failure is counted.
+
+If the *same* exchange fails three times in a row, the cursor is advanced past it
+anyway. Without that, one bad exchange would be retried on every single turn
+forever. Those skipped messages stay in the transcript and get picked up by the
+next defrag or batch compaction.
+
+## Interaction with batch compaction
+
+Micro-compaction doesn't replace batch compaction — it defers it. Threshold-based
+compaction is still there and still fires if the window fills anyway, and its
+summary markers are the same format, so the two interoperate. In practice
+micro-compaction keeps the transcript far enough below the threshold that the
+batch path fires much less often.
+
+## Configuration
+
+```yaml
+compression:
+  micro_compact: true   # default
+```
+
+Set it to `false` to disable micro-compaction and return to batch-only
+compaction. Everything else about compression is unchanged.
+
+## What you'll see in the logs
+
+```
+Micro-compaction: 37 -> 36 messages
+Micro-compaction defrag: rolling summary re-summarized (1843 chars)
+Micro-compaction: skipping exchange at cursor 12 after 3 consecutive failures
+```
+
+Message counts move by small amounts — that's the point. The token count is where
+the effect shows: absorbing one tool-heavy exchange can drop hundreds of tokens
+while changing the message count by one or two.
+
+## Failure behaviour
+
+Micro-compaction is best-effort throughout. The call in `finalize_turn` is wrapped
+so that any exception is logged and swallowed — a failure returns the conversation
+unchanged and the turn completes normally. It can degrade, but it shouldn't be
+able to break a session.

--- a/docs/micro-compaction.md
+++ b/docs/micro-compaction.md
@@ -14,11 +14,16 @@ Hermes folds the single oldest un-absorbed exchange into a running summary. The
 work is the same work; it just happens continuously, a piece at a time, instead
 of all at once in the middle of your session.
 
-It is not free and it is not a magic bullet. Each pass is a real call to the
+It is not free and it is not a magic bullet, and it is **off by default** —
+`compression.micro_compact: true` turns it on. Each pass is a real call to the
 compression model, and it runs at the end of a turn — your answer has already
-streamed, but the turn does not close until the pass finishes. What the feature
-gives you is a **tuning option**: you choose how the compression cost is
-distributed, and which model pays it. See
+streamed, but the turn does not close until the pass finishes. Each pass also
+rewrites already-sent history, which breaks the provider prompt-cache prefix
+every turn; read [Prompt caching](#prompt-caching--the-cost-you-are-opting-into)
+before enabling it, because for some setups that cost exceeds the benefit.
+
+What the feature gives you is a **tuning option**: you choose how the
+compression cost is distributed, and which model pays it. See
 [Choosing a compression model](#choosing-a-compression-model), because that
 choice matters more than anything else here.
 
@@ -159,13 +164,52 @@ batch path fires much less often.
 
 ## Configuration
 
+Micro-compaction is **off by default**. Turn it on explicitly:
+
 ```yaml
 compression:
-  micro_compact: true   # default
+  micro_compact: true   # default: false
 ```
 
-Set it to `false` to disable micro-compaction and return to batch-only
+With it unset or `false` Hermes behaves exactly as it always has: batch-only
 compaction. Everything else about compression is unchanged.
+
+It ships opt-in rather than on because of the prompt-cache cost described in
+the next section — that cost is real, it is not universally worth paying, and
+it should be a decision you make rather than one you inherit.
+
+## Prompt caching — the cost you are opting into
+
+Read this before enabling the feature. It is the strongest argument against it.
+
+A long-lived conversation reuses a cached prompt prefix every turn, and cached
+input tokens are billed at a fraction of uncached ones. That discount survives
+only as long as the prefix does not change. **A micro-compaction pass rewrites
+already-sent history**, which invalidates the prefix from the rewrite point
+onward — so with micro-compaction on, you break the cache *every turn* instead
+of once per batch compaction.
+
+This is the same cost the proactive prune deliberately avoids. That path gates
+itself behind `compression.proactive_prune_min_reclaim_tokens` (4096 by
+default) precisely so its rewrites stay, in the words of the config comment,
+"one big episodic break instead of a tiny break every tool iteration."
+Micro-compaction has no such gate: one exchange per turn means one break per
+turn, by design.
+
+So the honest framing is a trade of one cost for another, not a saving:
+
+| | Batch-only (default) | Micro-compaction on |
+|---|---|---|
+| Compression stalls | One long stall at the threshold | Spread across turns |
+| Context occupancy | Sawtooths up to the threshold | Stays low and flat |
+| Cache prefix | Intact between compactions | Broken every turn |
+
+Which side wins depends on numbers specific to you: how much your provider
+discounts cached input, how large your prefix is, how long your sessions run,
+and how much a mid-session stall actually costs you. On a provider with a deep
+cache discount and a big prefix, the per-turn invalidation can plausibly cost
+more than the stall it removes. Measure your own sessions — see
+[Measuring it](#measuring-it) — rather than assuming.
 
 ## Choosing a compression model
 

--- a/docs/micro-compaction.md
+++ b/docs/micro-compaction.md
@@ -160,7 +160,47 @@ compression:
 Set it to `false` to disable micro-compaction and return to batch-only
 compaction. Everything else about compression is unchanged.
 
-## What you'll see in the logs
+## Measuring it
+
+Every pass emits one content-free JSON line, in the same style as the batch
+compaction telemetry:
+
+```
+micro compaction telemetry: {"event":"micro_compaction","outcome":"absorbed",
+"tokens_before":12739,"tokens_after":12060,"tokens_delta":-679,
+"exchange_tokens":868,"rolling_summary_tokens":31,"passes_total":1,
+"tokens_saved_total":679,"duration_ms":14,...}
+```
+
+`tokens_delta` is negative when the pass shrank the transcript.
+`tokens_saved_total` and `passes_total` accumulate across the session, so a whole
+run can be summarised from its last line. No transcript content appears in the
+payload — only counts.
+
+To turn a log into an answer:
+
+```
+python scripts/micro_compaction_report.py [--per-session] [LOGFILE ...]
+```
+
+Defaults to `$HERMES_HOME/logs/agent.log`. It reports passes, outcome mix, net
+tokens saved, mean absorbed-exchange size and pass durations.
+
+### Reading the numbers honestly
+
+**The first pass in a session usually costs tokens rather than saving them.**
+Inserting the summary marker carries a fixed ~400 tokens of scaffolding — the
+compaction preamble, the historical heading, the end marker — and on pass one
+that is paid against a single absorbed exchange. A first pass showing
+`tokens_delta: +330` is not a malfunction.
+
+From the second pass on, the marker is *replaced* rather than added, so the
+scaffolding is already paid for and each absorbed exchange is close to pure
+saving. The break-even is normally the second or third pass. This is why the
+per-session view matters more than any single line: judge the feature on a
+session's trajectory, not on one turn.
+
+The plainer human-readable lines are still there too:
 
 ```
 Micro-compaction: 37 -> 36 messages
@@ -168,7 +208,7 @@ Micro-compaction defrag: rolling summary re-summarized (1843 chars)
 Micro-compaction: skipping exchange at cursor 12 after 3 consecutive failures
 ```
 
-Message counts move by small amounts — that's the point. The token count is where
+Message counts move by small amounts — that's expected. The token count is where
 the effect shows: absorbing one tool-heavy exchange can drop hundreds of tokens
 while changing the message count by one or two.
 

--- a/docs/micro-compaction.md
+++ b/docs/micro-compaction.md
@@ -168,11 +168,26 @@ Micro-compaction is **off by default**. Turn it on explicitly:
 
 ```yaml
 compression:
-  micro_compact: true   # default: false
+  micro_compact: true             # default: false
+  micro_compact_every_n_turns: 1  # cadence — how often a pass runs
+  micro_compact_defrag_threshold_tokens: 2000
 ```
 
-With it unset or `false` Hermes behaves exactly as it always has: batch-only
-compaction. Everything else about compression is unchanged.
+With `micro_compact` unset or `false` Hermes behaves exactly as it always has:
+batch-only compaction. Everything else about compression is unchanged.
+
+`micro_compact_every_n_turns` is the knob that matters most after the on/off
+switch, because it sets how often you pay the cache break described below. At
+`1` a pass runs after every completed turn: the most aggressive reclaim, and
+one broken prefix per turn. At `5` you get a fifth of the breaks and a fifth of
+the reclaim rate, which is the right direction if your sessions are long-lived
+and your provider's cache discount is deep. Values below `1` are clamped to `1`
+rather than silently disabling the feature. The counter advances per turn, not
+per committed pass, so a turn with nothing to absorb still moves the cadence
+along and cannot wedge it.
+
+`micro_compact_defrag_threshold_tokens` is when the rolling summary gets
+re-summarized instead of growing forever — see [Defrag](#defrag).
 
 It ships opt-in rather than on because of the prompt-cache cost described in
 the next section — that cost is real, it is not universally worth paying, and
@@ -193,8 +208,15 @@ This is the same cost the proactive prune deliberately avoids. That path gates
 itself behind `compression.proactive_prune_min_reclaim_tokens` (4096 by
 default) precisely so its rewrites stay, in the words of the config comment,
 "one big episodic break instead of a tiny break every tool iteration."
-Micro-compaction has no such gate: one exchange per turn means one break per
-turn, by design.
+
+Micro-compaction has no equivalent *reclaim-size* gate — a pass commits
+whatever the one absorbed exchange happened to save, large or small. What it
+has instead is a *frequency* dial, `micro_compact_every_n_turns`. Raising it
+makes the breaks rarer and more episodic, which is the same end the prune's
+gate serves by a different route, though it gets there by absorbing less rather
+than by waiting for a bigger win. If you want the prune's exact semantics here,
+a reclaim threshold on micro-compaction is the obvious follow-up and does not
+exist yet.
 
 So the honest framing is a trade of one cost for another, not a saving:
 

--- a/docs/micro-compaction.md
+++ b/docs/micro-compaction.md
@@ -11,9 +11,16 @@ request, at whatever moment you happened to cross the line.
 
 Micro-compaction pays the same bill in instalments. After each completed turn,
 Hermes folds the single oldest un-absorbed exchange into a running summary. The
-work is the same work; it just happens continuously, in small pieces, during the
-idle moment after a response instead of all at once in the middle of your
-session.
+work is the same work; it just happens continuously, a piece at a time, instead
+of all at once in the middle of your session.
+
+It is not free and it is not a magic bullet. Each pass is a real call to the
+compression model, and it runs at the end of a turn — your answer has already
+streamed, but the turn does not close until the pass finishes. What the feature
+gives you is a **tuning option**: you choose how the compression cost is
+distributed, and which model pays it. See
+[Choosing a compression model](#choosing-a-compression-model), because that
+choice matters more than anything else here.
 
 **The tradeoff is that knowledge gets a little earlier than you may be used to.**
 Because compaction is always running, older parts of the conversation become
@@ -160,6 +167,49 @@ compression:
 Set it to `false` to disable micro-compaction and return to batch-only
 compaction. Everything else about compression is unchanged.
 
+## Choosing a compression model
+
+Micro-compaction uses the `auxiliary.compression` model:
+
+```yaml
+auxiliary:
+  compression:
+    provider: openai-api
+    model: <your choice>
+    base_url: <endpoint>
+```
+
+This is the single most important knob, and there is no universally right
+answer — it depends on your hardware and what you are willing to trade.
+
+Each pass sends the running summary plus one exchange, so the prompt is small
+(a few thousand tokens) but the call happens **every turn**, at the end of the
+turn. Two properties matter:
+
+- **Latency dominates.** Because a pass runs per turn, its wall-clock cost is
+  felt repeatedly. A model that takes 30 seconds turns every turn into a turn
+  plus 30 seconds.
+- **Reasoning models are a poor fit.** Merging one exchange into a summary is
+  mechanical work. A thinking model will spend reasoning tokens on it and be
+  substantially slower than a plain instruct model of similar size, for no
+  benefit to the output.
+
+Some measured points, on one particular setup — treat them as illustrations of
+the shape, not as recommendations:
+
+| model | observed |
+|---|---|
+| 7B 4-bit instruct, local (MLX, Apple Silicon) | ~31s per pass; box also serving other work |
+| large MoE reasoning model, remote GPU | noticeably slower still — thinking tokens on a summarisation task |
+
+The pattern is that a small, fast, non-reasoning instruct model is usually the
+right shape, and that a bigger or "smarter" model is often worse here rather
+than better. Where that lands for you depends on what you have to run it on.
+
+If passes feel too slow, your options in rough order of effect are: pick a
+faster or smaller compression model; give it a less contended host; or turn
+micro-compaction off and go back to batch compaction.
+
 ## Measuring it
 
 Micro-compaction is not primarily a token-saving or time-saving optimisation,
@@ -209,6 +259,41 @@ python scripts/micro_compaction_report.py [--per-session] [LOGFILE ...]
 
 Defaults to `$HERMES_HOME/logs/agent.log`. It reports passes, outcome mix, net
 tokens saved, mean absorbed-exchange size and pass durations.
+
+### What it looks like when it is working
+
+One real session — a 3.5 hour whole-project code review, ~75K tokens of
+transcript, 400K window, compaction threshold at 320K:
+
+| pass | messages | tokens | delta | occupancy | duration |
+|---|---|---|---|---|---|
+| 1 | 40 -> 39 | 27,479 -> 27,778 | +299 | 8.7% | 2.2s |
+| 2 | 61 -> 59 | 48,676 -> 48,128 | -548 | 15.0% | 4.5s |
+| 3 | 70 -> 67 | 58,309 -> 55,915 | -2,394 | 17.5% | 9.1s |
+| 4 | 84 -> 80 | 75,251 -> 69,818 | -5,433 | 21.8% | 36.2s |
+| 5 | 84 -> 80 | 74,659 -> 70,264 | -4,395 | 22.0% | 31.2s |
+
+Three things to read off it.
+
+**Occupancy flattened.** It climbed to about 22% and stopped. The last two
+passes are identical (84 -> 80 messages); between them the conversation added
+4,841 tokens and micro-compaction reclaimed 4,395. That is equilibrium: the
+window holds steady instead of marching toward the threshold.
+
+**No batch compaction fired.** Across the whole session the long pause never
+happened.
+
+**Reclamation only ramps after the tail budget.** The first passes recovered
+almost nothing, because below the tail budget (here 64,000 tokens, 16% of the
+window) nearly the whole transcript is protected tail and there is very little
+that may be touched. Early sessions legitimately show no passes at all.
+
+And the cost, stated plainly: passes ran 2 to 37 seconds, median around 31, on
+a small local model that was also serving other work. Roughly two minutes of
+summarisation spread across three and a half hours. Against one batch
+compaction of a 75K-token middle that is still the better trade, but a
+37-second increment is not a rounding error. See
+[Choosing a compression model](#choosing-a-compression-model).
 
 ### Reading the numbers honestly
 

--- a/docs/micro-compaction.md
+++ b/docs/micro-compaction.md
@@ -44,9 +44,33 @@ followed it. In tool-heavy work that's where the bulk of the tokens live — a
 file read or a command's output dwarfs the surrounding prose — which is why
 absorbing one exchange at a time is worth doing at all.
 
+## Your messages are never compacted
+
+An exchange deliberately starts at the *assistant* message. Micro-compaction
+walks straight past user messages to get there, so **what you typed is never
+summarized** — your prompts stay verbatim for the entire session, no matter how
+long it runs or how many times compaction fires.
+
+This is the most useful property of the whole design, and it's worth being
+explicit about why. What the assistant produces is largely an account of what it
+did: it read this file, it ran that command, it got this result. That kind of
+narration survives summarising with very little loss — "it did it this way" is
+about as informative compressed as it was in full. Your instructions are a
+different kind of thing. They're the intent everything else is derived from, and
+they cannot be reconstructed from the work that followed. Paraphrasing "use the
+existing retry helper, don't add a new one" into a summary is exactly how an
+agent ends up confidently doing the thing you told it not to, six turns later.
+
+So the asymmetry is on purpose: compact the derived material, keep the source of
+truth. The cost is a floor on how small the middle can get, since user turns
+accumulate and are never absorbed. In practice that floor is low — a prompt is
+normally a tiny fraction of what a single tool result costs — but it is a real
+floor. If you routinely paste 10–20K-token prompts, that weight stays in context
+by design.
+
 ## What it never touches
 
-Two regions are protected and stay verbatim:
+Two more regions are protected and stay verbatim:
 
 - **The head** — the system prompt and the opening messages, so the session's
   founding instructions are never paraphrased.

--- a/docs/micro-compaction.md
+++ b/docs/micro-compaction.md
@@ -51,10 +51,14 @@ compressor to absorb **one** exchange:
 One exchange per turn. The per-turn cost stays bounded no matter how long the
 conversation gets.
 
-An **exchange** is an assistant message together with any tool results that
-followed it. In tool-heavy work that's where the bulk of the tokens live — a
+An **exchange** is one full agent turn: an assistant message together with its
+tool results and any follow-up assistant iterations, up to the next user
+message. In tool-heavy work that's where the bulk of the tokens live — a
 file read or a command's output dwarfs the surrounding prose — which is why
-absorbing one exchange at a time is worth doing at all.
+absorbing one exchange at a time is worth doing at all. Taking the whole turn
+(rather than a single assistant+tools group) also keeps the transcript's role
+alternation strictly valid: the summary marker is an assistant-role message,
+and a full turn is always bounded by user messages on both sides.
 
 ## Your messages are never compacted
 
@@ -123,12 +127,14 @@ transcript grows on every turn instead of shrinking.
 
 Merge into a summary often enough and it gets baggy — repetitive, and larger
 than the material justifies. When the running summary crosses a token threshold
-(2000 by default), the next pass **defrags**: it re-summarizes the summary and
-whatever middle remains in one shot, replacing it with a fresh compact version
-and advancing the cursor to the tail.
+(2000 by default), the next pass **defrags**: one auxiliary call re-summarizes
+the running summary *itself* into a fresh compact version, and the summary
+marker in the transcript is rewritten in place.
 
-This is still much cheaper than full batch compaction. It only ever processes the
-summary plus the un-absorbed middle, never the whole transcript.
+Defrag never touches the transcript's structure — no messages are absorbed or
+spliced, the cursor doesn't move, and user turns are untouched. It processes
+only the accumulated summary text, never conversation messages, so the
+"your messages are never compacted" guarantee holds through it.
 
 ### Staying in step with the session database
 
@@ -152,7 +158,7 @@ untouched and the failure is counted.
 If the *same* exchange fails three times in a row, the cursor is advanced past it
 anyway. Without that, one bad exchange would be retried on every single turn
 forever. Those skipped messages stay in the transcript and get picked up by the
-next defrag or batch compaction.
+next batch compaction.
 
 ## Interaction with batch compaction
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -578,6 +578,18 @@ DEFAULT_CONFIG = {
                                       # prompt-cache invalidation amortized: one big
                                       # episodic break instead of a tiny break every
                                       # tool iteration. 0 = commit any non-zero prune.
+        "micro_compact": False,       # opt-in: after each completed turn, fold the
+                                      # oldest un-absorbed exchange into a rolling
+                                      # summary, amortizing compression cost instead
+                                      # of paying it in one batch stall. Default False
+                                      # because a pass rewrites already-sent history
+                                      # and so breaks the provider prompt-cache prefix
+                                      # EVERY turn — the per-turn cache break that
+                                      # `proactive_prune_min_reclaim_tokens` above
+                                      # exists to avoid. Enable only when you have
+                                      # measured that the amortized stall is worth
+                                      # more to you than the cached-prefix discount.
+                                      # See docs/micro-compaction.md.
         "hygiene_hard_message_limit": 5000,  # gateway session-hygiene force-compress threshold by message count
         "hygiene_timeout_seconds": 30,  # max seconds gateway waits for pre-agent hygiene compression
                                       # WITHOUT forward progress. The summary call streams, so

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -590,6 +590,17 @@ DEFAULT_CONFIG = {
                                       # measured that the amortized stall is worth
                                       # more to you than the cached-prefix discount.
                                       # See docs/micro-compaction.md.
+        "micro_compact_every_n_turns": 1,  # cadence: run a pass every Nth completed
+                                      # turn. Since each pass costs one prompt-cache
+                                      # break, this is the dial for how often that
+                                      # cost is paid — 1 reclaims most aggressively
+                                      # at one break per turn, 5 trades reclaim rate
+                                      # for a fifth of the breaks. Clamped to >= 1.
+                                      # Ignored unless `micro_compact` is true.
+        "micro_compact_defrag_threshold_tokens": 2000,  # once the rolling summary
+                                      # exceeds this many tokens, the next pass
+                                      # re-summarizes the summary itself instead of
+                                      # letting it grow without bound.
         "hygiene_hard_message_limit": 5000,  # gateway session-hygiene force-compress threshold by message count
         "hygiene_timeout_seconds": 30,  # max seconds gateway waits for pre-agent hygiene compression
                                       # WITHOUT forward progress. The summary call streams, so

--- a/scripts/micro_compaction_report.py
+++ b/scripts/micro_compaction_report.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Summarize micro-compaction telemetry from Hermes logs.
 
-Reads the content-free ``micro compaction telemetry:`` JSON lines emitted by
+Reads the content-free JSON lines emitted by
 ``ContextCompressor._emit_micro_compaction_telemetry`` and reports what the
-feature actually did, per session and overall.
+feature actually bought you.
 
 Usage:
   python scripts/micro_compaction_report.py [LOGFILE ...]
@@ -11,11 +11,23 @@ Usage:
 
 With no LOGFILE, reads ``$HERMES_HOME/logs/agent.log`` (default ~/.hermes).
 
-Note on reading the numbers: the first pass in a session inserts the summary
-marker, which costs a fixed ~400 tokens of scaffolding. That overhead is paid
-once; from the second pass on the marker is replaced rather than added, so
-each absorbed exchange is pure saving. A session with a single pass can
-therefore show a net loss and still be working correctly.
+What to look at
+---------------
+The point of micro-compaction is not saving tokens or time. It is:
+
+  (a) amortizing the one long batch-compaction pause across many turns, and
+  (b) keeping the context window low enough that a session runs much further
+      before it needs a hard compaction at all.
+
+So the headline numbers here are OCCUPANCY (how full the window is kept, as a
+percentage of the compaction threshold) and BATCH COMPACTIONS (how often the
+long pause actually fired). Net tokens saved is reported too, but it is the
+least interesting figure -- a session can save nothing on paper and still be a
+clear win because the stalls disappeared and the window never filled.
+
+Caveat: running the test suite writes telemetry into the same log. Test lines
+cluster inside a sub-second window and carry an empty session_id (they group
+as "(unknown)"). Use --per-session to spot them.
 """
 
 from __future__ import annotations
@@ -27,7 +39,8 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-MARKER = "micro compaction telemetry: "
+MICRO_MARKER = "micro compaction telemetry: "
+BATCH_MARKER = "context compression attempt telemetry: "
 
 
 def default_log() -> Path:
@@ -35,8 +48,9 @@ def default_log() -> Path:
     return Path(home) / "logs" / "agent.log"
 
 
-def load(paths: list[Path]) -> list[dict]:
-    events: list[dict] = []
+def load(paths: list[Path]) -> tuple[list[dict], list[dict]]:
+    micro: list[dict] = []
+    batch: list[dict] = []
     for path in paths:
         try:
             text = path.read_text(encoding="utf-8", errors="replace")
@@ -44,88 +58,113 @@ def load(paths: list[Path]) -> list[dict]:
             print(f"warning: cannot read {path}: {exc}", file=sys.stderr)
             continue
         for line in text.splitlines():
-            idx = line.find(MARKER)
-            if idx == -1:
-                continue
-            try:
-                events.append(json.loads(line[idx + len(MARKER):]))
-            except ValueError:
-                continue
-    return events
+            for marker, sink in ((MICRO_MARKER, micro), (BATCH_MARKER, batch)):
+                idx = line.find(marker)
+                if idx == -1:
+                    continue
+                try:
+                    sink.append(json.loads(line[idx + len(marker):]))
+                except ValueError:
+                    pass
+                break
+    return micro, batch
 
 
-def fmt(n: int | None) -> str:
+def pct(values: list[float]) -> tuple[float, float, float] | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    return ordered[0], ordered[len(ordered) // 2], ordered[-1]
+
+
+def fmt(n) -> str:
     return "-" if n is None else f"{n:,}"
 
 
-def report(events: list[dict], per_session: bool) -> int:
-    if not events:
+def report(micro: list[dict], batch: list[dict], per_session: bool) -> int:
+    if not micro:
         print("No micro-compaction telemetry found.")
-        print("Micro-compaction may be disabled (compression.micro_compact),")
-        print("or no session has run long enough to trigger a pass yet.")
+        print("It may be disabled (compression.micro_compact), or no session")
+        print("has run long enough to trigger a pass yet.")
         return 1
 
     by_session: dict[str, list[dict]] = defaultdict(list)
-    for e in events:
+    for e in micro:
         by_session[e.get("session_id") or "(unknown)"].append(e)
 
     outcomes: dict[str, int] = defaultdict(int)
-    for e in events:
+    for e in micro:
         outcomes[e.get("outcome", "?")] += 1
 
-    saved = sum(-(e.get("tokens_delta") or 0) for e in events)
-    absorbed = [e for e in events if e.get("outcome") == "absorbed"]
-    exchange_tokens = [e.get("exchange_tokens") or 0 for e in absorbed]
-    durations = [e.get("duration_ms") or 0 for e in events]
+    occupancies = [e["occupancy_pct"] for e in micro if e.get("occupancy_pct") is not None]
+    saved = sum(-(e.get("tokens_delta") or 0) for e in micro)
+    absorbed = [e for e in micro if e.get("outcome") == "absorbed"]
+    durations = [e.get("duration_ms") or 0 for e in micro]
 
     if per_session:
-        print(f"{'session':<38} {'passes':>7} {'saved':>10} {'first':>8} {'last':>8}")
-        print("-" * 76)
+        print(f"{'session':<26} {'passes':>6} {'occupancy%':>18} {'batch':>6} {'saved':>10}")
+        print("-" * 72)
+        batch_by_session: dict[str, int] = defaultdict(int)
+        for b in batch:
+            batch_by_session[b.get("session_id") or "(unknown)"] += 1
         for sid, evs in sorted(by_session.items(), key=lambda kv: -len(kv[1])):
+            occ = [e["occupancy_pct"] for e in evs if e.get("occupancy_pct") is not None]
+            spread = pct(occ)
+            occ_s = f"{spread[0]:.0f}-{spread[2]:.0f} (med {spread[1]:.0f})" if spread else "-"
             s = sum(-(e.get("tokens_delta") or 0) for e in evs)
-            first = evs[0].get("tokens_before")
-            last = evs[-1].get("tokens_after")
-            print(f"{sid[:38]:<38} {len(evs):>7} {s:>+10,} {fmt(first):>8} {fmt(last):>8}")
+            print(f"{sid[:26]:<26} {len(evs):>6} {occ_s:>18} "
+                  f"{batch_by_session.get(sid, 0):>6} {s:>+10,}")
         print()
 
+    print("-- headroom ----------------------------------")
+    spread = pct(occupancies)
+    if spread:
+        print(f"context occupancy       min {spread[0]:.0f}%  median {spread[1]:.0f}%  max {spread[2]:.0f}%")
+        print("                        (% of the batch-compaction threshold)")
+    else:
+        print("context occupancy       unavailable (window not resolved when logged)")
+    print(f"batch compactions       {len(batch):,}")
+    if batch:
+        print(f"  micro passes each     {len(micro) / len(batch):.1f}")
+    else:
+        print("  none fired -- the long pause never happened in this log")
+
+    print()
+    print("-- activity ----------------------------------")
     print(f"sessions                {len(by_session):,}")
-    print(f"passes                  {len(events):,}")
+    print(f"passes                  {len(micro):,}")
     for name, count in sorted(outcomes.items(), key=lambda kv: -kv[1]):
         print(f"  {name:<20}  {count:,}")
-    print(f"net tokens saved        {saved:+,}")
-    if absorbed:
-        print(f"exchanges absorbed      {len(absorbed):,}")
-        print(f"  mean exchange size    {sum(exchange_tokens) // len(absorbed):,} tokens")
-        print(f"  mean saving/pass      {saved // len(events):+,} tokens")
     if durations:
         ordered = sorted(durations)
-        print(f"pass duration  median   {ordered[len(ordered) // 2]:,} ms")
-        print(f"               max      {ordered[-1]:,} ms")
+        print(f"pass duration           median {ordered[len(ordered) // 2]:,} ms  "
+              f"max {ordered[-1]:,} ms")
 
-    multi = {s: e for s, e in by_session.items() if len(e) > 1}
-    if multi:
-        net = sum(
-            (evs[-1].get("tokens_after") or 0) - (evs[0].get("tokens_before") or 0)
-            for evs in multi.values()
-        )
-        print()
-        print(f"sessions with >1 pass   {len(multi):,}")
-        print(f"  net context change    {net:+,} tokens (negative is shrinkage)")
+    print()
+    print("-- tokens (least interesting) ----------------")
+    print(f"net tokens saved        {saved:+,}")
+    if absorbed:
+        sizes = [e.get("exchange_tokens") or 0 for e in absorbed]
+        print(f"exchanges absorbed      {len(absorbed):,}  "
+              f"(mean {sum(sizes) // len(absorbed):,} tokens each)")
+    print("note: the first pass in a session costs ~400 tokens of marker")
+    print("scaffolding; it pays back from the second pass on.")
     return 0
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("logs", nargs="*", type=Path, help="log files (default: agent.log)")
     ap.add_argument("--per-session", action="store_true", help="break down by session")
     args = ap.parse_args()
 
     paths = args.logs or [default_log()]
-    missing = [p for p in paths if not p.exists()]
-    for p in missing:
-        print(f"warning: {p} does not exist", file=sys.stderr)
-    return report(load([p for p in paths if p.exists()]), args.per_session)
+    for p in paths:
+        if not p.exists():
+            print(f"warning: {p} does not exist", file=sys.stderr)
+    micro, batch = load([p for p in paths if p.exists()])
+    return report(micro, batch, args.per_session)
 
 
 if __name__ == "__main__":

--- a/scripts/micro_compaction_report.py
+++ b/scripts/micro_compaction_report.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Summarize micro-compaction telemetry from Hermes logs.
+
+Reads the content-free ``micro compaction telemetry:`` JSON lines emitted by
+``ContextCompressor._emit_micro_compaction_telemetry`` and reports what the
+feature actually did, per session and overall.
+
+Usage:
+  python scripts/micro_compaction_report.py [LOGFILE ...]
+  python scripts/micro_compaction_report.py --per-session
+
+With no LOGFILE, reads ``$HERMES_HOME/logs/agent.log`` (default ~/.hermes).
+
+Note on reading the numbers: the first pass in a session inserts the summary
+marker, which costs a fixed ~400 tokens of scaffolding. That overhead is paid
+once; from the second pass on the marker is replaced rather than added, so
+each absorbed exchange is pure saving. A session with a single pass can
+therefore show a net loss and still be working correctly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+MARKER = "micro compaction telemetry: "
+
+
+def default_log() -> Path:
+    home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
+    return Path(home) / "logs" / "agent.log"
+
+
+def load(paths: list[Path]) -> list[dict]:
+    events: list[dict] = []
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            print(f"warning: cannot read {path}: {exc}", file=sys.stderr)
+            continue
+        for line in text.splitlines():
+            idx = line.find(MARKER)
+            if idx == -1:
+                continue
+            try:
+                events.append(json.loads(line[idx + len(MARKER):]))
+            except ValueError:
+                continue
+    return events
+
+
+def fmt(n: int | None) -> str:
+    return "-" if n is None else f"{n:,}"
+
+
+def report(events: list[dict], per_session: bool) -> int:
+    if not events:
+        print("No micro-compaction telemetry found.")
+        print("Micro-compaction may be disabled (compression.micro_compact),")
+        print("or no session has run long enough to trigger a pass yet.")
+        return 1
+
+    by_session: dict[str, list[dict]] = defaultdict(list)
+    for e in events:
+        by_session[e.get("session_id") or "(unknown)"].append(e)
+
+    outcomes: dict[str, int] = defaultdict(int)
+    for e in events:
+        outcomes[e.get("outcome", "?")] += 1
+
+    saved = sum(-(e.get("tokens_delta") or 0) for e in events)
+    absorbed = [e for e in events if e.get("outcome") == "absorbed"]
+    exchange_tokens = [e.get("exchange_tokens") or 0 for e in absorbed]
+    durations = [e.get("duration_ms") or 0 for e in events]
+
+    if per_session:
+        print(f"{'session':<38} {'passes':>7} {'saved':>10} {'first':>8} {'last':>8}")
+        print("-" * 76)
+        for sid, evs in sorted(by_session.items(), key=lambda kv: -len(kv[1])):
+            s = sum(-(e.get("tokens_delta") or 0) for e in evs)
+            first = evs[0].get("tokens_before")
+            last = evs[-1].get("tokens_after")
+            print(f"{sid[:38]:<38} {len(evs):>7} {s:>+10,} {fmt(first):>8} {fmt(last):>8}")
+        print()
+
+    print(f"sessions                {len(by_session):,}")
+    print(f"passes                  {len(events):,}")
+    for name, count in sorted(outcomes.items(), key=lambda kv: -kv[1]):
+        print(f"  {name:<20}  {count:,}")
+    print(f"net tokens saved        {saved:+,}")
+    if absorbed:
+        print(f"exchanges absorbed      {len(absorbed):,}")
+        print(f"  mean exchange size    {sum(exchange_tokens) // len(absorbed):,} tokens")
+        print(f"  mean saving/pass      {saved // len(events):+,} tokens")
+    if durations:
+        ordered = sorted(durations)
+        print(f"pass duration  median   {ordered[len(ordered) // 2]:,} ms")
+        print(f"               max      {ordered[-1]:,} ms")
+
+    multi = {s: e for s, e in by_session.items() if len(e) > 1}
+    if multi:
+        net = sum(
+            (evs[-1].get("tokens_after") or 0) - (evs[0].get("tokens_before") or 0)
+            for evs in multi.values()
+        )
+        print()
+        print(f"sessions with >1 pass   {len(multi):,}")
+        print(f"  net context change    {net:+,} tokens (negative is shrinkage)")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("logs", nargs="*", type=Path, help="log files (default: agent.log)")
+    ap.add_argument("--per-session", action="store_true", help="break down by session")
+    args = ap.parse_args()
+
+    paths = args.logs or [default_log()]
+    missing = [p for p in paths if not p.exists()]
+    for p in missing:
+        print(f"warning: {p} does not exist", file=sys.stderr)
+    return report(load([p for p in paths if p.exists()]), args.per_session)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -124,6 +124,46 @@ class TestMicroCompaction:
         ]
         assert surviving == originals, "user turns must survive verbatim"
 
+    def test_cursor_is_derived_from_the_spliced_list(self):
+        """The cursor must never carry over a pre-splice index.
+
+        A splice collapses an assistant plus its tool results -- often several
+        messages -- into one marker, so every later index shifts. Reusing
+        ``exchange_end`` left the cursor pointing inside a *later* exchange's
+        tool group; the next pass walked forward to the following assistant
+        and skipped that exchange entirely, so on tool-bearing conversations
+        roughly half the work silently never happened.
+
+        Tool-free fixtures cannot catch this: the span is one message, so
+        nothing shifts.
+        """
+        cc = _compressor()
+        msgs = [{"role": "system", "content": "sys"}]
+        for i in range(8):
+            msgs.append({"role": "user", "content": f"q{i}"})
+            msgs.append({
+                "role": "assistant",
+                "content": f"a{i}",
+                "tool_calls": [
+                    {"id": f"c{i}-{j}", "type": "function",
+                     "function": {"name": "f", "arguments": "{}"}}
+                    for j in range(3)
+                ],
+            })
+            for j in range(3):
+                msgs.append({"role": "tool", "tool_call_id": f"c{i}-{j}",
+                             "content": "T" * 500})
+
+        for _ in range(4):
+            msgs = cc._micro_compact(msgs)
+            marker_idx = next(
+                i for i, m in enumerate(msgs)
+                if m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+            )
+            assert cc._micro_compact_cursor == marker_idx + 1, (
+                "cursor must sit just past the marker in the spliced list"
+            )
+
     def test_short_conversation_is_untouched(self):
         cc = _compressor()
         messages = [

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -80,6 +80,70 @@ class TestMicroCompaction:
 
         assert cc._micro_compact(list(messages)) == messages
 
+    def test_is_off_unless_explicitly_enabled(self):
+        # A pass rewrites already-sent history, breaking the prompt-cache
+        # prefix, so nobody inherits it from an update: it stays off until
+        # `compression.micro_compact` opts in.
+        cc = ContextCompressor(
+            model="test-model",
+            threshold_percent=0.75,
+            protect_first_n=1,
+            protect_last_n=2,
+            quiet_mode=True,
+            config_context_length=40960,
+            provider="test",
+        )
+        cc._micro_summarize_one = lambda _text: "ROLLING SUMMARY"
+        messages = _conversation()
+
+        assert cc._micro_compact_enabled is False
+        assert cc._micro_compact(list(messages)) == messages
+
+    def test_cadence_of_one_runs_every_turn(self):
+        cc = _compressor()
+        cc._micro_compact_every_n_turns = 1
+        messages = _conversation(exchanges=8)
+
+        first = cc._micro_compact(list(messages))
+        second = cc._micro_compact(list(first))
+
+        assert cc._micro_compact_cursor > 0
+        assert len(_summary_markers(first)) == 1
+        # Each turn absorbed something, so the transcript kept shrinking.
+        assert len(second) < len(first)
+
+    def test_cadence_skips_turns_until_a_pass_is_due(self):
+        cc = _compressor()
+        cc._micro_compact_every_n_turns = 3
+        messages = _conversation(exchanges=8)
+
+        first = cc._micro_compact(list(messages))
+        second = cc._micro_compact(list(first))
+
+        # Cache prefix untouched on the turns in between.
+        assert _summary_markers(first) == []
+        assert _summary_markers(second) == []
+        assert cc._micro_compact_cursor == 0
+
+        third = cc._micro_compact(list(second))
+
+        assert len(_summary_markers(third)) == 1
+        assert not any("answer 0" in str(m.get("content")) for m in third)
+        # Counter rearmed for the next window.
+        assert cc._micro_compact_turns_since_pass == 0
+
+    def test_cadence_is_clamped_to_at_least_one(self):
+        # A bogus 0 or negative must not disable compaction silently, nor
+        # divide-by-zero: it degrades to "every turn".
+        for bogus in (0, -5):
+            cc = _compressor()
+            cc._micro_compact_every_n_turns = bogus
+            messages = _conversation(exchanges=8)
+
+            result = cc._micro_compact(list(messages))
+
+            assert len(_summary_markers(result)) == 1
+
     def test_cursor_advances_across_successive_turns(self):
         cc = _compressor()
         messages = _conversation(exchanges=8)

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -186,6 +186,75 @@ class TestMicroCompaction:
         assert len(_summary_markers(messages)) == 1
         assert after < before, f"context grew: {before} -> {after}"
 
+    def test_emits_content_free_token_telemetry(self, caplog):
+        """Each pass logs one JSON line with the token accounting.
+
+        Message counts barely move even when the saving is large, so the token
+        fields are what make the effect measurable in a real session.
+        """
+        import json
+        import logging
+
+        cc = _compressor()
+        messages = _conversation(exchanges=8)
+
+        with caplog.at_level(logging.INFO, logger="agent.context_compressor"):
+            result = cc._micro_compact(messages)
+
+        lines = [
+            r.getMessage() for r in caplog.records
+            if "micro compaction telemetry:" in r.getMessage()
+        ]
+        assert len(lines) == 1
+        payload = json.loads(lines[0].split("micro compaction telemetry: ", 1)[1])
+
+        assert payload["event"] == "micro_compaction"
+        assert payload["outcome"] == "absorbed"
+        assert payload["tokens_saved_total"] == -payload["tokens_delta"]
+        assert payload["passes_total"] == 1
+        assert payload["messages_after"] == len(result)
+        assert payload["exchange_tokens"] > 0
+        # Content-free: no transcript text may ride along in the payload.
+        blob = json.dumps(payload)
+        assert "answer 0" not in blob and "question 0" not in blob
+
+    def test_first_pass_costs_marker_overhead_then_pays_it_back(self):
+        """The first pass can grow the transcript; later passes recover it.
+
+        Inserting the summary marker costs a fixed ~400 tokens of scaffolding
+        (the compaction preamble, the historical heading and the end marker).
+        On pass one that overhead is paid against a single absorbed exchange,
+        so the net can be positive. From pass two on the marker is replaced
+        rather than added, so the scaffolding is already paid for and each
+        absorbed exchange is pure saving. Anyone reading a single turn's
+        telemetry needs to know this before concluding it made things worse.
+        """
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        cc = _compressor()
+        messages = _conversation(exchanges=10)
+        start = estimate_messages_tokens_rough(messages)
+
+        messages = cc._micro_compact(messages)
+        after_first = estimate_messages_tokens_rough(messages)
+
+        for _ in range(5):
+            messages = cc._micro_compact(messages)
+        after_many = estimate_messages_tokens_rough(messages)
+
+        assert after_first > start, "expected one-time marker overhead"
+        assert after_many < after_first, "later passes must recover it"
+
+    def test_cumulative_savings_accumulate_across_passes(self):
+        cc = _compressor()
+        messages = _conversation(exchanges=10)
+
+        for _ in range(4):
+            messages = cc._micro_compact(messages)
+
+        assert cc._micro_compact_passes == 4
+        assert cc._micro_compact_tokens_saved_total > 0
+
     def test_defrag_triggers_once_the_rolling_summary_grows(self):
         cc = _compressor(summary="FRESH DEFRAGGED SUMMARY")
         cc._micro_compact_rolling_summary = "x" * 40_000  # far over the threshold

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -631,3 +631,124 @@ class TestMicroCompaction:
         marker = _summary_markers(result)[0]
 
         assert marker[COMPRESSED_SUMMARY_HAS_USER_TURN_KEY] is False
+
+    def test_supersede_never_drops_a_batch_compaction_marker(self):
+        """A batch marker holds history the rolling summary does NOT contain.
+
+        Sequence: micro absorbs some exchanges (rolling summary = those k
+        exchanges only), then batch compaction fires and its marker
+        summarizes MORE (exchanges 1..m). The next micro pass's supersede
+        must not treat the batch marker as redundant — dropping it destroys
+        everything batch summarized beyond exchange k. Only micro-tagged
+        markers (whose text is provably inside the rolling summary) may be
+        superseded.
+        """
+        cc = _compressor(summary="MICRO SUMMARY (exchanges 1..k only)")
+        msgs = _conversation(exchanges=8)
+        msgs = cc._micro_compact(msgs)
+        assert cc._micro_compact_rolling_summary
+
+        # Simulate a batch-compaction marker replacing the middle (batch
+        # markers carry the shared metadata key but NOT the micro tag).
+        batch_marker = {
+            "role": "user",
+            "content": "[batch summary] CRITICAL HISTORY: exchanges 1..m",
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+        micro_idx = next(
+            i for i, m in enumerate(msgs)
+            if m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+        )
+        msgs = msgs[:micro_idx] + [batch_marker] + msgs[micro_idx + 3:]
+
+        out = cc._micro_compact(msgs)
+
+        assert any(
+            "CRITICAL HISTORY" in str(m.get("content")) for m in out
+        ), "batch-compaction summary destroyed by micro supersede"
+
+    def test_defrag_never_rewrites_a_batch_compaction_marker(self):
+        """Defrag rewrites only micro-tagged markers, never batch markers."""
+        cc = _compressor(summary="DEFRAGGED")
+        msgs = [{"role": "system", "content": "sys"}]
+        msgs.append({
+            "role": "user",
+            "content": "[batch summary] CRITICAL HISTORY: exchanges 1..m",
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        })
+        for i in range(6):
+            msgs.append({"role": "user", "content": f"q{i}"})
+            msgs.append({"role": "assistant", "content": f"a{i} " + "z" * 400})
+
+        cc._micro_compact_rolling_summary = "x" * 40_000  # force defrag
+        result = cc._micro_compact(list(msgs))
+
+        batch = [m for m in result if "CRITICAL HISTORY" in str(m.get("content"))]
+        assert batch, "batch marker content overwritten by defrag"
+
+    def test_batch_compress_resets_micro_state(self):
+        """compress() success path invalidates the stale rolling summary.
+
+        Without the reset, the in-memory micro summary (exchanges 1..k)
+        outlives a batch compaction whose marker covers 1..m — the next
+        micro pass would then treat its stale summary as cumulative.
+        """
+        cc = _compressor()
+        msgs = _conversation(exchanges=8)
+        msgs = cc._micro_compact(msgs)
+        assert cc._micro_compact_rolling_summary
+        assert cc._micro_compact_cursor > 0
+
+        cc.compress(msgs, force=True)
+
+        assert cc._micro_compact_rolling_summary == ""
+        assert cc._micro_compact_cursor == 0
+
+    def test_persist_disabled_agent_never_micro_compacts(self):
+        """finalize_turn must skip micro-compaction on isolated fork agents.
+
+        The background-review fork sets _persist_disabled=True; running a
+        pass there burns an aux-LLM call on a throwaway replay transcript
+        and, if the compressor ever holds a DB binding, would
+        archive_and_compact the CANONICAL session rows.
+        """
+        import inspect
+
+        from agent import turn_finalizer
+
+        src = inspect.getsource(turn_finalizer.finalize_turn)
+        micro_block = src.split("Post-turn micro-compaction", 1)[1]
+        # Scope to the micro block only: stop at the persist call that follows.
+        micro_block = micro_block.split("agent._persist_session", 1)[0]
+        assert "_persist_disabled" in micro_block, (
+            "micro-compaction gate must check agent._persist_disabled"
+        )
+
+    def test_splice_preserves_db_persisted_stamps(self):
+        """Surviving messages keep their _db_persisted stamps through a splice.
+
+        Micro-compaction archives in place under the SAME session id, so the
+        stamps on untouched messages stay accurate. Stripping them (as the
+        batch path does for its child-session rotation) meant an
+        archive_and_compact failure left every previously-persisted message
+        unstamped and the next append-only flush re-inserted them all as
+        duplicate active rows.
+        """
+        from agent.context_compressor import _DB_PERSISTED_MARKER
+
+        cc = _compressor()
+        messages = _conversation(exchanges=8)
+        for m in messages:
+            m[_DB_PERSISTED_MARKER] = True
+
+        # No DB bound -> _sync_micro_compact_to_db no-ops (the failure shape).
+        result = cc._micro_compact(messages)
+
+        unstamped = [
+            m for m in result
+            if not m.get(_DB_PERSISTED_MARKER)
+            and not m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+        ]
+        assert not unstamped, (
+            "splice must not strip _db_persisted from surviving messages"
+        )

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -101,6 +101,27 @@ class TestMicroCompaction:
         assert result[0] == messages[0], "system prompt must be preserved"
         assert result[-1] == messages[-1], "most recent turn must be preserved"
 
+    def test_user_messages_are_never_absorbed(self):
+        """User turns stay verbatim for the life of the session — by design.
+
+        Assistant output is largely an account of what was done and survives
+        summarising; the user's own words are the intent everything else is
+        derived from and can't be reconstructed from it. So an exchange starts
+        at the assistant message and the walk skips past user turns.
+        """
+        cc = _compressor()
+        messages = _conversation(exchanges=10)
+        originals = [m["content"] for m in messages if m["role"] == "user"]
+
+        for _ in range(5):
+            messages = cc._micro_compact(messages)
+
+        surviving = [
+            m["content"] for m in messages
+            if m.get("role") == "user" and not m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+        ]
+        assert surviving == originals, "user turns must survive verbatim"
+
     def test_short_conversation_is_untouched(self):
         cc = _compressor()
         messages = [

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -164,6 +164,54 @@ class TestMicroCompaction:
                 "cursor must sit just past the marker in the spliced list"
             )
 
+    def test_resume_does_not_destroy_the_accumulated_summary(self):
+        """A resumed session must not throw away compacted history.
+
+        The rolling summary lives in memory; a resumed process starts with an
+        empty one while the marker holding every previous exchange is still in
+        the transcript. Superseding on that first pass would replace the whole
+        history with a summary of one exchange.
+        """
+        msgs = _conversation(exchanges=10)
+        first = _compressor(summary="IMPORTANT HISTORY: decisions and paths")
+        for _ in range(3):
+            msgs = first._micro_compact(msgs)
+        assert any("IMPORTANT HISTORY" in m["content"] for m in _summary_markers(msgs))
+
+        # Fresh compressor over the same transcript = resume.
+        resumed = _compressor(summary="MERGED: history plus newest exchange")
+        assert resumed._micro_compact_rolling_summary == ""
+        result = resumed._micro_compact(msgs)
+
+        markers = _summary_markers(result)
+        assert len(markers) == 1
+        assert "MERGED" in markers[0]["content"]
+
+    def test_resume_keeps_the_old_marker_when_rehydration_fails(self):
+        """If the prior summary can't be recovered, it must not be dropped."""
+        msgs = _conversation(exchanges=10)
+        first = _compressor(summary="IMPORTANT HISTORY: decisions and paths")
+        for _ in range(3):
+            msgs = first._micro_compact(msgs)
+
+        resumed = _compressor(summary="BRAND NEW SUMMARY")
+        resumed._rolling_summary_from_marker = staticmethod(lambda _c: "")
+        result = resumed._micro_compact(msgs)
+
+        markers = _summary_markers(result)
+        assert len(markers) == 2, "must retain the un-carried history"
+        assert any("IMPORTANT HISTORY" in m["content"] for m in markers)
+
+    def test_rolling_summary_round_trips_through_a_marker(self):
+        cc = _compressor()
+        cc._micro_compact_rolling_summary = "decisions: use the existing helper"
+        msgs = _conversation(exchanges=6)
+        result = cc._micro_compact(msgs)
+        marker = _summary_markers(result)[0]
+
+        assert (cc._rolling_summary_from_marker(marker["content"])
+                == cc._micro_compact_rolling_summary)
+
     def test_short_conversation_is_untouched(self):
         cc = _compressor()
         messages = [

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -1,0 +1,179 @@
+"""Tests for per-turn micro-compaction in ``ContextCompressor``.
+
+Micro-compaction amortizes the cost of context compression: instead of one
+long pause when the window fills, each turn folds the single oldest
+un-absorbed exchange into a rolling summary.
+
+The invariants that matter:
+
+* one call absorbs exactly one exchange (assistant + its tool results), so
+  the per-turn cost stays bounded;
+* the absorbed span is replaced by a summary marker carrying the usual
+  ``_compressed_summary`` metadata, so resume/handoff treat it like a batch
+  summary;
+* the cursor advances, so successive calls walk forward rather than
+  re-summarising the same exchange;
+* protected head and tail messages are never touched;
+* an exchange the summarizer cannot handle is retried a bounded number of
+  times and then skipped, so a poison exchange can't stall every turn.
+"""
+
+import pytest
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    ContextCompressor,
+    _MICRO_COMPACT_MAX_CONSECUTIVE_FAILURES,
+)
+
+
+def _compressor(summary="ROLLING SUMMARY") -> ContextCompressor:
+    cc = ContextCompressor(
+        model="test-model",
+        threshold_percent=0.75,
+        protect_first_n=1,
+        protect_last_n=2,
+        quiet_mode=True,
+        config_context_length=40960,
+        provider="test",
+    )
+    cc._micro_compact_enabled = True
+    # Stand in for the auxiliary summarizer LLM.
+    cc._micro_summarize_one = lambda _text: summary
+    return cc
+
+
+def _conversation(exchanges: int = 6) -> list:
+    msgs = [{"role": "system", "content": "system prompt"}]
+    for i in range(exchanges):
+        msgs.append({"role": "user", "content": f"question {i}"})
+        msgs.append({"role": "assistant", "content": f"answer {i} " + "z" * 400})
+    return msgs
+
+
+def _summary_markers(messages: list) -> list:
+    return [m for m in messages if m.get(COMPRESSED_SUMMARY_METADATA_KEY)]
+
+
+class TestMicroCompaction:
+    def test_absorbs_one_exchange_and_leaves_a_summary_marker(self):
+        cc = _compressor()
+        messages = _conversation()
+
+        result = cc._micro_compact(list(messages))
+
+        # The absorbed assistant turn is gone from the transcript.
+        assert any("answer 0" in str(m.get("content")) for m in messages)
+        assert not any("answer 0" in str(m.get("content")) for m in result)
+        markers = _summary_markers(result)
+        assert len(markers) == 1
+        assert "ROLLING SUMMARY" in markers[0]["content"]
+        # The marker stands in for a user turn, like batch compaction's does.
+        assert markers[0]["role"] == "user"
+
+    def test_disabled_is_a_no_op(self):
+        cc = _compressor()
+        cc._micro_compact_enabled = False
+        messages = _conversation()
+
+        assert cc._micro_compact(list(messages)) == messages
+
+    def test_cursor_advances_across_successive_turns(self):
+        cc = _compressor()
+        messages = _conversation(exchanges=8)
+
+        first = cc._micro_compact(list(messages))
+        cursor_after_first = cc._micro_compact_cursor
+        second = cc._micro_compact(list(first))
+
+        assert cursor_after_first > 0
+        assert cc._micro_compact_cursor >= cursor_after_first
+        # Still exactly one marker: the second pass merges into the rolling
+        # summary rather than stacking a second summary block.
+        assert len(_summary_markers(second)) == 1
+
+    def test_protected_head_and_tail_survive(self):
+        cc = _compressor()
+        messages = _conversation()
+
+        result = cc._micro_compact(list(messages))
+
+        assert result[0] == messages[0], "system prompt must be preserved"
+        assert result[-1] == messages[-1], "most recent turn must be preserved"
+
+    def test_short_conversation_is_untouched(self):
+        cc = _compressor()
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+
+        assert cc._micro_compact(list(messages)) == messages
+
+    def test_summarizer_failure_leaves_conversation_intact(self):
+        cc = _compressor()
+        cc._micro_summarize_one = lambda _text: None
+        messages = _conversation()
+
+        result = cc._micro_compact(list(messages))
+
+        assert result == messages
+        assert cc._micro_compact_consecutive_failures == 1
+
+    def test_poison_exchange_is_skipped_after_repeated_failures(self):
+        """A repeatedly unsummarizable exchange must not stall every turn."""
+        cc = _compressor()
+        cc._micro_summarize_one = lambda _text: None
+        messages = _conversation()
+
+        for _ in range(_MICRO_COMPACT_MAX_CONSECUTIVE_FAILURES):
+            cc._micro_compact(list(messages))
+
+        # The cursor has moved past the stuck exchange and the strike count
+        # is reset, so the next turn attempts new material.
+        assert cc._micro_compact_cursor > 0
+        assert cc._micro_compact_consecutive_failures == 0
+
+    def test_repeated_compaction_shrinks_context_and_keeps_one_marker(self):
+        """The whole point: successive turns must reduce the transcript.
+
+        The rolling summary is cumulative, so an earlier marker's text is a
+        subset of the current one. Keeping the earlier markers stacked
+        near-duplicate copies (each with its own heading/end-marker
+        scaffolding) and made the transcript grow every turn — the opposite
+        of what compaction is for.
+        """
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        cc = _compressor()
+        # Cumulative summary, like the real summarizer produces.
+        state = {"n": 0}
+
+        def growing(_text):
+            state["n"] += 1
+            return "SUMMARY " + " ".join(f"ex{i}" for i in range(state["n"]))
+
+        cc._micro_summarize_one = growing
+
+        messages = _conversation(exchanges=12)
+        before = estimate_messages_tokens_rough(messages)
+        for _ in range(6):
+            messages = cc._micro_compact(messages)
+        after = estimate_messages_tokens_rough(messages)
+
+        assert len(_summary_markers(messages)) == 1
+        assert after < before, f"context grew: {before} -> {after}"
+
+    def test_defrag_triggers_once_the_rolling_summary_grows(self):
+        cc = _compressor(summary="FRESH DEFRAGGED SUMMARY")
+        cc._micro_compact_rolling_summary = "x" * 40_000  # far over the threshold
+        messages = _conversation(exchanges=8)
+
+        assert cc._needs_defrag() is True
+        result = cc._micro_compact(list(messages))
+
+        assert cc._micro_compact_rolling_summary == "FRESH DEFRAGGED SUMMARY"
+        markers = _summary_markers(result)
+        assert len(markers) == 1
+        assert "FRESH DEFRAGGED SUMMARY" in markers[0]["content"]

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -70,8 +70,12 @@ class TestMicroCompaction:
         markers = _summary_markers(result)
         assert len(markers) == 1
         assert "ROLLING SUMMARY" in markers[0]["content"]
-        # The marker stands in for a user turn, like batch compaction's does.
-        assert markers[0]["role"] == "user"
+        # The marker is assistant-role: an exchange is a full agent turn
+        # bounded by user messages, so user → marker(assistant) → user keeps
+        # strict alternation. A user-role marker produced user → user → user,
+        # and the pre-request repair_message_sequence pass merged the marker
+        # into the neighbouring real user turn — metadata gone, cursor lost.
+        assert markers[0]["role"] == "assistant"
 
     def test_disabled_is_a_no_op(self):
         cc = _compressor()
@@ -168,12 +172,17 @@ class TestMicroCompaction:
         assert result[-1] == messages[-1], "most recent turn must be preserved"
 
     def test_user_messages_are_never_absorbed(self):
-        """User turns stay verbatim for the life of the session — by design.
+        """Every byte the user typed stays in the transcript — by design.
 
         Assistant output is largely an account of what was done and survives
         summarising; the user's own words are the intent everything else is
         derived from and can't be reconstructed from it. So an exchange starts
         at the assistant message and the walk skips past user turns.
+
+        The invariant is on user TEXT, not message-list shape: superseding an
+        old marker leaves two real user turns adjacent, and they are merged
+        (\\n\\n-joined, same as repair_message_sequence pass 2) to keep strict
+        alternation. Text is never summarized or dropped.
         """
         cc = _compressor()
         messages = _conversation(exchanges=10)
@@ -182,11 +191,14 @@ class TestMicroCompaction:
         for _ in range(5):
             messages = cc._micro_compact(messages)
 
-        surviving = [
+        surviving_text = "\n\n".join(
             m["content"] for m in messages
             if m.get("role") == "user" and not m.get(COMPRESSED_SUMMARY_METADATA_KEY)
-        ]
-        assert surviving == originals, "user turns must survive verbatim"
+        )
+        for original in originals:
+            assert original in surviving_text, (
+                f"user text {original!r} must survive verbatim"
+            )
 
     def test_cursor_is_derived_from_the_spliced_list(self):
         """The cursor must never carry over a pre-splice index.
@@ -474,9 +486,20 @@ class TestMicroCompaction:
         assert cc._micro_compact_tokens_saved_total > 0
 
     def test_defrag_triggers_once_the_rolling_summary_grows(self):
+        """Defrag rewrites the summary text and the marker — nothing else.
+
+        The original implementation spliced the whole remaining middle (user
+        turns included) into the marker, silently absorbing user messages.
+        Defrag is now transcript-shape-neutral: same message list, same
+        cursor, marker content rewritten in place.
+        """
         cc = _compressor(summary="FRESH DEFRAGGED SUMMARY")
-        cc._micro_compact_rolling_summary = "x" * 40_000  # far over the threshold
         messages = _conversation(exchanges=8)
+        # Seed a real marker + oversized rolling summary, as after many passes.
+        messages = cc._micro_compact(list(messages))
+        cc._micro_compact_rolling_summary = "x" * 40_000  # far over the threshold
+        cursor_before = cc._micro_compact_cursor
+        shape_before = [m.get("role") for m in messages]
 
         assert cc._needs_defrag() is True
         result = cc._micro_compact(list(messages))
@@ -485,3 +508,126 @@ class TestMicroCompaction:
         markers = _summary_markers(result)
         assert len(markers) == 1
         assert "FRESH DEFRAGGED SUMMARY" in markers[0]["content"]
+        # Shape-neutral: no messages absorbed or spliced, cursor unmoved.
+        assert [m.get("role") for m in result] == shape_before
+        assert cc._micro_compact_cursor == cursor_before
+
+    def test_defrag_never_absorbs_user_messages(self):
+        """Defrag must not touch user turns — the feature's core invariant.
+
+        The original implementation serialized head..tail (user turns
+        included) and spliced it away: 8 of 10 user prompts were destroyed in
+        one pass. Defrag now only rewrites the rolling summary text.
+        """
+        cc = _compressor(summary="DEFRAGGED")
+        messages = [{"role": "system", "content": "sys"}]
+        for i in range(10):
+            messages.append({"role": "user", "content": f"UNIQUE-USER-PROMPT-{i}"})
+            messages.append({"role": "assistant", "content": f"answer {i} " + "z" * 400})
+
+        cc._micro_compact_rolling_summary = "x" * 40_000  # force defrag
+        result = cc._micro_compact(list(messages))
+
+        surviving = [
+            m["content"] for m in result
+            if m.get("role") == "user" and not m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+        ]
+        for i in range(10):
+            assert any(f"UNIQUE-USER-PROMPT-{i}" in s for s in surviving), (
+                f"user prompt {i} was absorbed by defrag"
+            )
+
+    def test_defrag_summarizes_only_the_summary_text(self):
+        """The defrag aux call receives the rolling summary, not the transcript."""
+        cc = _compressor()
+        captured = {}
+
+        def capture(text):
+            captured["text"] = text
+            return "DEFRAGGED"
+
+        cc._micro_summarize_one = capture
+        cc._micro_compact_rolling_summary = "OLD-SUMMARY " + "x" * 40_000
+        messages = _conversation(exchanges=8)
+        cc._micro_compact(list(messages))
+
+        assert "OLD-SUMMARY" in captured["text"]
+        assert "[USER]" not in captured["text"], (
+            "defrag must never serialize transcript user turns"
+        )
+
+    def test_spliced_transcript_survives_repair_message_sequence(self):
+        """The compacted transcript must survive the production repair pass.
+
+        conversation_loop runs repair_message_sequence before EVERY API call.
+        With the old user-role marker, splicing next to a real user turn made
+        user → user → user; repair merged the marker into the real user
+        message — metadata gone, cursor unrecoverable, summary text duplicated
+        into the transcript on every later pass. Pin the integration: markers
+        survive repair untouched, and no summary text leaks into real user
+        messages.
+        """
+        from agent.agent_runtime_helpers import repair_message_sequence
+
+        class _DummyAgent:
+            session_id = "probe"
+            _last_flushed_db_idx = 0
+
+        cc = _compressor()
+        messages = _conversation(exchanges=8)
+
+        for _ in range(3):
+            messages = cc._micro_compact(messages)
+            repairs = repair_message_sequence(_DummyAgent(), messages)
+            assert repairs == 0, (
+                "micro-compacted transcript must already be alternation-valid"
+            )
+            markers = _summary_markers(messages)
+            assert len(markers) == 1, "marker destroyed by repair pass"
+            polluted = [
+                m for m in messages
+                if m.get("role") == "user"
+                and not m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                and "ROLLING SUMMARY" in str(m.get("content"))
+            ]
+            assert not polluted, "summary text leaked into a real user message"
+
+    def test_spliced_transcript_has_no_consecutive_same_role_messages(self):
+        """Alternation invariant, checked directly on tool-bearing turns."""
+        cc = _compressor()
+        msgs = [{"role": "system", "content": "sys"}]
+        for i in range(8):
+            msgs.append({"role": "user", "content": f"q{i}"})
+            msgs.append({
+                "role": "assistant",
+                "content": f"a{i}",
+                "tool_calls": [
+                    {"id": f"c{i}-{j}", "type": "function",
+                     "function": {"name": "f", "arguments": "{}"}}
+                    for j in range(2)
+                ],
+            })
+            for j in range(2):
+                msgs.append({"role": "tool", "tool_call_id": f"c{i}-{j}",
+                             "content": "T" * 400})
+            # Multi-iteration turn: a second assistant+tools group before the
+            # next user message — the splice must absorb the WHOLE turn.
+            msgs.append({"role": "assistant", "content": f"followup {i} " + "y" * 200})
+
+        for _ in range(4):
+            msgs = cc._micro_compact(msgs)
+            for a, b in zip(msgs, msgs[1:]):
+                ra, rb = a.get("role"), b.get("role")
+                assert not (ra == rb and ra in ("user", "assistant")), (
+                    f"consecutive {ra} messages after micro-compaction"
+                )
+
+    def test_marker_reports_no_user_provenance(self):
+        """Micro markers absorb only assistant/tool content (#64650)."""
+        from agent.context_compressor import COMPRESSED_SUMMARY_HAS_USER_TURN_KEY
+
+        cc = _compressor()
+        result = cc._micro_compact(_conversation(exchanges=6))
+        marker = _summary_markers(result)[0]
+
+        assert marker[COMPRESSED_SUMMARY_HAS_USER_TURN_KEY] is False

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -18,6 +18,8 @@ The invariants that matter:
   times and then skipped, so a poison exchange can't stall every turn.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from agent.context_compressor import (
@@ -217,6 +219,70 @@ class TestMicroCompaction:
         # Content-free: no transcript text may ride along in the payload.
         blob = json.dumps(payload)
         assert "answer 0" not in blob and "question 0" not in blob
+
+    def test_telemetry_reports_occupancy_without_forcing_resolution(self, caplog):
+        """Occupancy is the headline: how full the window is being kept.
+
+        It must be read from the cached threshold only. The public
+        ``threshold_tokens`` property resolves lazily and can fire a
+        synchronous /models probe (#32221); telemetry must never be what
+        blocks a turn, so an unresolved window reports null instead.
+        """
+        import json
+        import logging
+
+        cc = _compressor()
+        cc.threshold_tokens = 10_000  # pin; also populates the cache
+        messages = _conversation(exchanges=8)
+
+        with caplog.at_level(logging.INFO, logger="agent.context_compressor"):
+            cc._micro_compact(messages)
+
+        line = next(r.getMessage() for r in caplog.records
+                    if "micro compaction telemetry:" in r.getMessage())
+        payload = json.loads(line.split("micro compaction telemetry: ", 1)[1])
+
+        assert payload["threshold_tokens"] == 10_000
+        assert payload["occupancy_pct"] == pytest.approx(
+            payload["tokens_after"] / 10_000 * 100, abs=0.1
+        )
+
+    def test_emitter_never_forces_window_resolution(self, caplog):
+        """The emitter reads the cached threshold, never the property.
+
+        In a real pass the threshold is already resolved by the time
+        telemetry runs (the tail calculation needs it), so occupancy is
+        normally populated. This pins the safety property directly: with the
+        cache empty, emitting reports null rather than triggering the lazy
+        resolution — which can issue a synchronous /models probe (#32221).
+        """
+        import json
+        import logging
+
+        cc = _compressor()
+        cc._threshold_tokens = None
+        cc._resolved_context_length = None
+
+        def explode(self):  # pragma: no cover - must never be called
+            raise AssertionError("telemetry forced context-length resolution")
+
+        with patch.object(type(cc), "threshold_tokens",
+                          property(explode, lambda s, v: None)):
+            with caplog.at_level(logging.INFO, logger="agent.context_compressor"):
+                cc._emit_micro_compaction_telemetry(
+                    outcome="absorbed",
+                    messages_before=10,
+                    messages_after=9,
+                    tokens_before=500,
+                    tokens_after=400,
+                )
+
+        line = next(r.getMessage() for r in caplog.records
+                    if "micro compaction telemetry:" in r.getMessage())
+        payload = json.loads(line.split("micro compaction telemetry: ", 1)[1])
+
+        assert payload["occupancy_pct"] is None
+        assert payload["threshold_tokens"] is None
 
     def test_first_pass_costs_marker_overhead_then_pays_it_back(self):
         """The first pass can grow the transcript; later passes recover it.


### PR DESCRIPTION
## Summary
Salvage of #74522 by @lxman: opt-in per-turn micro-compaction — instead of one long stall when the context window fills, each completed turn folds the oldest un-absorbed exchange into a rolling summary, keeping occupancy low and flat. All 11 of @lxman's commits cherry-picked with authorship preserved, plus one follow-up commit fixing two integration bugs found in review.

Off by default (`compression.micro_compact: false`) because each pass rewrites already-sent history and breaks the prompt-cache prefix; the PR body, config comments, and `docs/micro-compaction.md` state that cost plainly.

## What the follow-up commit fixes

Both bugs were confirmed with empirical probes against the production repair path, not just by reading:

**1. Alternation: summary marker destroyed by `repair_message_sequence`.**
The marker was `role="user"` and an exchange was a single assistant+tools group, so splicing between two user turns produced `user → marker(user) → user`. The pre-request repair pass (runs before EVERY API call) merged the marker into the neighbouring real user message — metadata gone, cursor unrecoverable on resume, summary text duplicated into the transcript on every later pass (the transcript **grew** each turn).
Fix: an exchange is now a **full agent turn** (assistant + tools + follow-up iterations, bounded by user messages), the marker is **assistant-role**, and superseding an old marker deliberately merges the two newly-adjacent real user turns (plain-text `\n\n`-join, identical to repair pass 2 — no user text is ever lost).
Probe: repairs 2 → 0, marker survives, no summary leakage, resume-scan finds the marker.

**2. Defrag silently absorbed user messages.**
`_defrag_rolling_summary` serialized the whole remaining middle (user turns included) and spliced it away — 8 of 10 user prompts destroyed in one pass, contradicting the feature's headline "your messages are never compacted" invariant.
Fix: defrag now re-summarizes only the rolling summary **text** and rewrites the marker content in place; transcript shape, cursor, and user turns untouched.
Probe: 10 of 10 user prompts survive.

Also: marker provenance is now `COMPRESSED_SUMMARY_HAS_USER_TURN_KEY=False` (micro markers absorb only assistant/tool content, per the #64650 invariant).

## Validation
| | Before fix | After fix |
|---|---|---|
| repair pass on compacted transcript | 2 repairs, marker destroyed | 0 repairs, marker intact |
| user prompts surviving defrag | 2/10 | 10/10 |
| summary copies after 2 passes + repair | 2 (growing) | 1 |
| `tests/agent/test_micro_compaction.py` | 23 | 28 (5 new regression tests) |
| compression/compaction/finalizer suites | — | 395 passed, 3 skipped |
| ruff on changed files | — | clean |

## Credit
Based on #74522 by @lxman — cherry-picked to preserve authorship (11 commits). The feature design, docs, telemetry, and measurement methodology are his; the follow-up commit only corrects the two integration bugs above.

Depends on #75344 (AUTHOR_MAP entry) landing first.

Closes #74522
