### PR TITLE
fix(kanban): goal loop never reached its judge; -q exit killed in-flight subagents

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -17429,6 +17429,37 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             except Exception:
                 pass
 
+    def _block_kind() -> "str | None":
+        c = _kb.connect()
+        try:
+            t = _kb.get_task(c, task_id)
+            return getattr(t, "block_kind", None) if t is not None else None
+        finally:
+            try:
+                c.close()
+            except Exception:
+                pass
+
+    def _reopen(reason: str) -> None:
+        # Restore the live worker's claim identity along with the status —
+        # a 'running' row with NULL worker_pid/claim_expires is invisible to
+        # both watchdogs and would hang forever if this process died.
+        c = _kb.connect()
+        try:
+            _kb.reopen_task(
+                c,
+                task_id,
+                reason=reason,
+                claim_lock=(_os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or None),
+                worker_pid=_os.getpid(),
+                claim_ttl_seconds=_kb._resolve_claim_ttl_seconds(),
+            )
+        finally:
+            try:
+                c.close()
+            except Exception:
+                pass
+
     def _block(reason: str) -> None:
         c = _kb.connect()
         try:
@@ -17445,6 +17476,8 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
         run_turn=_run_turn,
         task_status_fn=_task_status,
         block_fn=_block,
+        block_kind_fn=_block_kind,
+        reopen_fn=_reopen,
         max_turns=max_turns,
         first_response=first_response or "",
         log=lambda m: logger.info("%s", m),

--- a/cli.py
+++ b/cli.py
@@ -17484,6 +17484,89 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     )
 
 
+def _drain_background_delegations() -> None:
+    """Wait for in-flight background subagents before a ``-q`` process exits.
+
+    ``delegate_task(background=true)`` children run on a daemon executor and
+    die the instant the owning process exits, so a one-shot run that reaches
+    ``sys.exit`` while a child is working destroys that work with no record
+    of what it had done.
+
+    The wait is bounded by the task's OWN deadline: kanban workers are
+    spawned with ``HERMES_KANBAN_DEADLINE_TS`` (epoch seconds), and the
+    dispatcher reclaims the task after it passes, so draining beyond it
+    would just get the worker killed anyway. A non-kanban ``-q`` run has no
+    deadline and waits indefinitely — it has no supervisor to answer to.
+
+    On timeout we exit anyway and let the survivors be classified by
+    ``recover_abandoned_delegations`` (owner PID gone → state ``unknown``),
+    which is strictly better than the current silent loss.
+
+    While draining we keep the kanban heartbeat fresh: a drain can outlast
+    the claim TTL, and a worker that is deliberately waiting must not look
+    like a hung one to ``release_stale_claims``.
+    """
+    try:
+        from tools.async_delegation import active_count, active_ids, drain_active
+    except Exception:
+        return
+
+    try:
+        if active_count() <= 0:
+            return
+    except Exception:
+        return
+
+    timeout: Optional[float] = None
+    deadline_raw = (os.environ.get("HERMES_KANBAN_DEADLINE_TS") or "").strip()
+    if deadline_raw:
+        try:
+            timeout = max(0.0, float(deadline_raw) - time.time())
+        except ValueError:
+            timeout = None
+
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+
+    def _on_wait(remaining: int, elapsed: float) -> None:
+        logger.info(
+            "waiting on %d background delegation(s) before exit "
+            "(%.0fs elapsed, ids=%s)",
+            remaining, elapsed, ",".join(active_ids()[:5]) or "?",
+        )
+        if not task_id:
+            return
+        # Keep the claim alive so a long drain isn't reaped as a stall.
+        try:
+            from hermes_cli import kanban_db as _kb
+            c = _kb.connect()
+            try:
+                _kb.heartbeat_claim(c, task_id)
+            finally:
+                c.close()
+        except Exception:
+            logger.debug("kanban heartbeat during delegation drain failed", exc_info=True)
+
+    try:
+        stranded = drain_active(timeout, on_wait=_on_wait)
+    except Exception:
+        logger.debug("background delegation drain failed", exc_info=True)
+        return
+
+    if stranded:
+        logger.warning(
+            "exiting with %d background delegation(s) still running after "
+            "%s; they will be recorded as 'unknown' by "
+            "recover_abandoned_delegations",
+            stranded,
+            f"{timeout:.0f}s" if timeout is not None else "the drain window",
+        )
+        print(
+            f"warning: {stranded} background delegation(s) still running at exit; "
+            "results will be marked unknown",
+            file=sys.stderr,
+        )
+
+
 def main(
     query: str = None,
     q: str = None,
@@ -17943,6 +18026,19 @@ def main(
 
                         # Session ID goes to stderr so piped stdout is clean.
                         print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
+
+                        # Wait for background subagents before tearing down.
+                        #
+                        # delegate_task(background=true) children run on a
+                        # DAEMON executor, so sys.exit() below kills them
+                        # mid-flight. In an interactive session that's the
+                        # right trade (the user chose to quit); for a
+                        # one-shot -q run it silently destroys work the
+                        # model was told would finish. The gateway already
+                        # refuses to scale to zero while delegations are in
+                        # flight; this is the same guard for the short-lived
+                        # process.
+                        _drain_background_delegations()
 
                         # Ensure proper exit code for automation wrappers.
                         #

--- a/cli.py
+++ b/cli.py
@@ -17418,6 +17418,9 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             print(resp)
         return resp or ""
 
+    def _claim_lock() -> "str | None":
+        return (_os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or "").strip() or None
+
     def _task_status() -> "str | None":
         c = _kb.connect()
         try:
@@ -17441,16 +17444,23 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
                 pass
 
     def _reopen(reason: str) -> None:
-        # Restore the live worker's claim identity along with the status —
-        # a 'running' row with NULL worker_pid/claim_expires is invisible to
-        # both watchdogs and would hang forever if this process died.
+        # Restore the live worker's claim identity AND open a fresh run.
+        #
+        # Two invariants make this fiddly:
+        #  1. A 'running' row with NULL worker_pid/claim_expires is invisible
+        #     to both watchdogs and would hang forever if this process died.
+        #  2. complete_task/block_task closed the previous run and cleared
+        #     tasks.current_run_id. kanban_complete passes the worker's pinned
+        #     HERMES_KANBAN_RUN_ID and complete_task matches it against
+        #     current_run_id — so without rebinding, the continuation could
+        #     never terminally complete or block.
         c = _kb.connect()
         try:
-            _kb.reopen_task(
+            new_run_id = _kb.reopen_task(
                 c,
                 task_id,
                 reason=reason,
-                claim_lock=(_os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or None),
+                claim_lock=_claim_lock(),
                 worker_pid=_os.getpid(),
                 claim_ttl_seconds=_kb._resolve_claim_ttl_seconds(),
             )
@@ -17459,6 +17469,13 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
                 c.close()
             except Exception:
                 pass
+        if new_run_id is not None:
+            # Rebind so this worker's later kanban_complete/kanban_block
+            # passes the run id the task now points at.
+            _os.environ["HERMES_KANBAN_RUN_ID"] = str(new_run_id)
+            logger.info(
+                "kanban goal loop: task %s reopened on run %s", task_id, new_run_id,
+            )
 
     def _block(reason: str) -> None:
         c = _kb.connect()
@@ -17484,6 +17501,62 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     )
 
 
+def _resolve_drain_deadline(task_id: str) -> Optional[float]:
+    """Seconds left before this worker's supervisor stops tolerating it.
+
+    Preference order:
+
+    1. ``HERMES_KANBAN_DEADLINE_TS`` — an explicit epoch deadline, when the
+       spawning build exports one.
+    2. The ACTIVE RUN's own cap: ``task_runs.max_runtime_seconds`` measured
+       from ``task_runs.started_at``, falling back to
+       ``tasks.max_runtime_seconds``. This is what the dispatcher's
+       timeout reaping uses, so it is the honest bound on how long this
+       process may keep running.
+
+    Returns ``None`` when no cap applies (no kanban task, or an uncapped
+    run) — the caller then waits indefinitely, which is correct for a run
+    nobody is going to reclaim.
+    """
+    deadline_raw = (os.environ.get("HERMES_KANBAN_DEADLINE_TS") or "").strip()
+    if deadline_raw:
+        try:
+            return max(0.0, float(deadline_raw) - time.time())
+        except ValueError:
+            pass
+
+    if not task_id:
+        return None
+
+    try:
+        from hermes_cli import kanban_db as _kb
+        conn = _kb.connect()
+        try:
+            row = conn.execute(
+                """
+                SELECT COALESCE(r.max_runtime_seconds, t.max_runtime_seconds) AS cap,
+                       r.started_at AS run_started,
+                       t.started_at AS task_started
+                  FROM tasks t
+                  LEFT JOIN task_runs r ON r.id = t.current_run_id
+                 WHERE t.id = ?
+                """,
+                (task_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+    except Exception:
+        logger.debug("drain deadline lookup failed", exc_info=True)
+        return None
+
+    if not row or not row["cap"]:
+        return None
+    started = row["run_started"] or row["task_started"]
+    if not started:
+        return None
+    return max(0.0, float(started) + float(row["cap"]) - time.time())
+
+
 def _drain_background_delegations() -> None:
     """Wait for in-flight background subagents before a ``-q`` process exits.
 
@@ -17492,11 +17565,13 @@ def _drain_background_delegations() -> None:
     ``sys.exit`` while a child is working destroys that work with no record
     of what it had done.
 
-    The wait is bounded by the task's OWN deadline: kanban workers are
-    spawned with ``HERMES_KANBAN_DEADLINE_TS`` (epoch seconds), and the
-    dispatcher reclaims the task after it passes, so draining beyond it
-    would just get the worker killed anyway. A non-kanban ``-q`` run has no
-    deadline and waits indefinitely — it has no supervisor to answer to.
+    The wait is bounded by the task's OWN runtime cap, read from the active
+    run (``task_runs.max_runtime_seconds`` + ``started_at``, falling back to
+    the task row). The dispatcher reclaims a task once that cap is exceeded,
+    so draining past it would only get the worker killed anyway.
+    ``HERMES_KANBAN_DEADLINE_TS`` is honoured when present as a more precise
+    override. A run with no cap, and any non-kanban ``-q`` run, waits
+    indefinitely — there is no supervisor to answer to.
 
     On timeout we exit anyway and let the survivors be classified by
     ``recover_abandoned_delegations`` (owner PID gone → state ``unknown``),
@@ -17504,7 +17579,10 @@ def _drain_background_delegations() -> None:
 
     While draining we keep the kanban heartbeat fresh: a drain can outlast
     the claim TTL, and a worker that is deliberately waiting must not look
-    like a hung one to ``release_stale_claims``.
+    like a hung one to ``release_stale_claims``. The heartbeat is passed the
+    worker's pinned ``HERMES_KANBAN_CLAIM_LOCK`` because
+    ``heartbeat_claim`` matches on ``claim_lock``; without it the update
+    silently affects nothing.
     """
     try:
         from tools.async_delegation import active_count, active_ids, drain_active
@@ -17517,15 +17595,9 @@ def _drain_background_delegations() -> None:
     except Exception:
         return
 
-    timeout: Optional[float] = None
-    deadline_raw = (os.environ.get("HERMES_KANBAN_DEADLINE_TS") or "").strip()
-    if deadline_raw:
-        try:
-            timeout = max(0.0, float(deadline_raw) - time.time())
-        except ValueError:
-            timeout = None
-
     task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    claim_lock = (os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or "").strip() or None
+    timeout = _resolve_drain_deadline(task_id)
 
     def _on_wait(remaining: int, elapsed: float) -> None:
         logger.info(
@@ -17540,7 +17612,8 @@ def _drain_background_delegations() -> None:
             from hermes_cli import kanban_db as _kb
             c = _kb.connect()
             try:
-                _kb.heartbeat_claim(c, task_id)
+                # claimer= is required: heartbeat_claim matches on claim_lock.
+                _kb.heartbeat_claim(c, task_id, claimer=claim_lock)
             finally:
                 c.close()
         except Exception:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1669,6 +1669,8 @@ def run_kanban_goal_loop(
     max_turns: int = DEFAULT_MAX_TURNS,
     first_response: str = "",
     log=None,
+    block_kind_fn=None,
+    reopen_fn=None,
 ) -> Dict[str, Any]:
     """Drive a kanban worker through a Ralph-style goal loop.
 
@@ -1677,21 +1679,40 @@ def run_kanban_goal_loop(
     first turn has already run by the time this is called; ``first_response``
     is that turn's reply. From here we:
 
-    1. Check whether the worker already terminated the task (called
-       ``kanban_complete`` / ``kanban_block``). If so, stop — nothing to do.
-    2. Otherwise judge the latest response against ``goal_text`` (the card's
-       title + body). ``continue`` → feed a continuation prompt and run
-       another turn IN THE SAME SESSION via ``run_turn``. ``done`` but the
-       task is still open → one explicit "call kanban_complete" nudge.
-    3. When the turn budget is exhausted and the worker still hasn't
+    1. Judge the latest response against ``goal_text`` (the card's title +
+       body). This happens EVEN IF the worker already terminated the task —
+       see the self-termination note below. ``continue`` → feed a
+       continuation prompt and run another turn IN THE SAME SESSION via
+       ``run_turn``. ``done`` but the task is still open → one explicit
+       "call kanban_complete" nudge.
+    2. When the turn budget is exhausted and the worker still hasn't
        terminated the task, ``block_fn`` is invoked so the card lands in a
        sticky ``blocked`` state for human review (NOT a silent exit).
+
+    Self-termination does not bypass the judge. The loop only starts after
+    the worker's first turn, and workers are instructed to call
+    ``kanban_complete`` / ``kanban_block`` within that turn — so an
+    unconditional "already terminal → stop" check meant the judge was never
+    reached at all (observed in the field: 97 goal cards, 0 loop
+    iterations, 92 of them with a run ending completed/blocked). A terminal
+    status is therefore judged ONCE; a ``done`` verdict accepts it, and a
+    ``continue`` verdict calls ``reopen_fn`` and keeps working.
+
+    Human and dependency gates are exempt. When ``block_kind_fn`` reports a
+    block that is waiting on something outside the worker (``needs_input``
+    — a person; ``dependency`` — another task), the worker is correct to
+    stop and the judge is not consulted: re-prompting would burn the turn
+    budget arguing with a wall, and reopening would strip the gate. These
+    are exactly the kinds ``kanban_block`` permits for a goal_mode card
+    (``_GOAL_MODE_BLOCK_ALLOWED_KINDS`` in tools/kanban_tools.py); any other
+    block kind is the worker letting itself out early, and is judged.
 
     This function performs NO SessionDB persistence — a worker process is
     ephemeral, so the turn budget lives in a local counter. It is fully
     decoupled from the CLI for testability: callers inject ``run_turn``
-    (str -> str), ``task_status_fn`` (() -> str|None), and ``block_fn``
-    (reason: str -> None).
+    (str -> str), ``task_status_fn`` (() -> str|None), ``block_fn``
+    (reason: str -> None), and optionally ``block_kind_fn`` (() -> str|None)
+    and ``reopen_fn`` (reason: str -> None).
 
     Returns a decision dict: ``{"outcome", "turns_used", "reason"}`` where
     outcome is one of ``"completed_by_worker"``, ``"blocked_budget"``,
@@ -1705,6 +1726,23 @@ def run_kanban_goal_loop(
             except Exception:
                 pass
 
+    # Block kinds that represent a genuine wait on something outside the
+    # worker. Mirrors _GOAL_MODE_BLOCK_ALLOWED_KINDS in tools/kanban_tools.py
+    # — the only kinds a goal_mode worker is permitted to block with. Any
+    # other kind means the worker let itself out early, so the judge runs.
+    _GATED_BLOCK_KINDS = frozenset({"needs_input", "dependency"})
+
+    def _block_kind() -> Optional[str]:
+        if block_kind_fn is None:
+            return None
+        try:
+            return block_kind_fn()
+        except Exception as exc:
+            _log(f"kanban goal loop: block_kind check failed ({exc}); treating as external gate")
+            # Fail SAFE: an unknown block kind is treated as a real gate so
+            # the loop never re-prompts a worker that is genuinely waiting.
+            return "needs_input"
+
     max_turns = int(max_turns or DEFAULT_MAX_TURNS)
     if max_turns < 1:
         max_turns = DEFAULT_MAX_TURNS
@@ -1713,6 +1751,9 @@ def run_kanban_goal_loop(
     # The first turn already consumed one unit of budget.
     turns_used = 1
     nudged_to_finalize = False
+    # A self-terminated task is judged once; if the judge accepts it we stop
+    # rather than looping over a task nobody is working on any more.
+    judged_terminal = False
 
     while True:
         # Did the worker terminate the task itself this turn?
@@ -1722,25 +1763,71 @@ def run_kanban_goal_loop(
             _log(f"kanban goal loop: status check failed ({exc}); stopping")
             return {"outcome": "stopped", "turns_used": turns_used, "reason": "status check failed"}
 
-        if status == "done":
-            _log(f"kanban goal loop: task {task_id} completed by worker after {turns_used} turn(s)")
-            return {"outcome": "completed_by_worker", "turns_used": turns_used, "reason": "worker completed the task"}
+        terminal_status = status in ("done", "blocked")
+
         if status == "blocked":
-            _log(f"kanban goal loop: task {task_id} blocked by worker after {turns_used} turn(s)")
-            return {"outcome": "blocked_by_worker", "turns_used": turns_used, "reason": "worker blocked the task"}
-        if status not in ("running", "ready"):
+            # A worker waiting on something it cannot resolve (a person, or
+            # another task) is right to stop. Judging it would only produce a
+            # continuation prompt aimed at a wall, and reopening would
+            # silently strip the gate.
+            kind = _block_kind()
+            if kind in _GATED_BLOCK_KINDS:
+                _log(
+                    f"kanban goal loop: task {task_id} blocked on {kind} after "
+                    f"{turns_used} turn(s); not judging"
+                )
+                return {
+                    "outcome": "blocked_by_worker",
+                    "turns_used": turns_used,
+                    "reason": f"worker blocked on {kind}",
+                }
+
+        if terminal_status and judged_terminal:
+            # Already judged this terminal state once and accepted it.
+            outcome = "completed_by_worker" if status == "done" else "blocked_by_worker"
+            _log(f"kanban goal loop: task {task_id} {status} after {turns_used} turn(s)")
+            return {"outcome": outcome, "turns_used": turns_used, "reason": f"worker {status} the task"}
+
+        if not terminal_status and status not in ("running", "ready"):
             # Reclaimed / archived / unexpected — let the dispatcher own it.
             _log(f"kanban goal loop: task {task_id} status={status!r}; stopping")
             return {"outcome": "stopped", "turns_used": turns_used, "reason": f"status={status}"}
 
-        # Still open — judge whether the latest response satisfies the card.
-        # The kanban worker loop has no wait-barrier concept (workers finish
-        # via kanban_complete / kanban_block, not by parking), so a WAIT
-        # verdict is treated as CONTINUE here.
+        # Judge the latest response against the card. A terminal status does
+        # NOT skip this — the worker self-terminating in its first turn is
+        # exactly the case the judge exists to check.
         verdict, reason, _parse_failed, _wait, _transport_failed = judge_goal(goal_text, last_response)
         if verdict == "wait":
             verdict = "continue"
         _log(f"kanban goal loop: turn {turns_used}/{max_turns} verdict={verdict} reason={_truncate(reason, 120)}")
+
+        if terminal_status:
+            judged_terminal = True
+            if verdict == "done":
+                outcome = "completed_by_worker" if status == "done" else "blocked_by_worker"
+                _log(f"kanban goal loop: task {task_id} {status}; judge accepted after {turns_used} turn(s)")
+                return {"outcome": outcome, "turns_used": turns_used, "reason": f"judge accepted worker {status}"}
+            # Judge disagrees with the worker's own termination — reopen and
+            # keep working. Without a reopen hook we can only stop, but say so
+            # loudly rather than reporting a clean finish.
+            if reopen_fn is None:
+                _log(
+                    f"kanban goal loop: task {task_id} {status} but judge said continue "
+                    f"({_truncate(reason, 120)}); no reopen hook, stopping"
+                )
+                return {
+                    "outcome": "stopped",
+                    "turns_used": turns_used,
+                    "reason": f"judge rejected worker {status}, no reopen hook",
+                }
+            try:
+                reopen_fn(
+                    f"Goal-mode judge rejected the worker's own {status}: {_truncate(reason, 300)}"
+                )
+            except Exception as exc:
+                _log(f"kanban goal loop: reopen_fn failed ({exc}); stopping")
+                return {"outcome": "stopped", "turns_used": turns_used, "reason": "reopen failed"}
+            _log(f"kanban goal loop: task {task_id} reopened after judge rejected worker {status}")
 
         if verdict == "done":
             if nudged_to_finalize:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5759,7 +5759,7 @@ def reopen_task(
     claim_lock: Optional[str] = None,
     worker_pid: Optional[int] = None,
     claim_ttl_seconds: Optional[int] = None,
-) -> bool:
+) -> Optional[int]:
     """Return a self-terminated ``done``/``blocked`` task to ``running``.
 
     Used by the goal loop when the auxiliary judge rejects a worker's own
@@ -5768,7 +5768,18 @@ def reopen_task(
     back to ``running`` rather than ``ready`` (a ``ready`` card would be
     picked up by the dispatcher and spawn a SECOND worker on the same task).
 
-    RE-ESTABLISH THE CLAIM. ``complete_task`` / ``block_task`` clear
+    OPENS A NEW RUN and returns its id. The previous run was closed by
+    ``complete_task`` / ``block_task`` (via ``_end_run``, which also clears
+    ``tasks.current_run_id``), and reviving that terminal row would corrupt
+    attempt history. But a reopened task with no ``current_run_id`` cannot
+    terminally finish either: the worker's ``kanban_complete`` passes its
+    pinned ``HERMES_KANBAN_RUN_ID`` and ``complete_task`` matches it against
+    ``current_run_id``, so a stale or absent pointer makes the guarded path
+    fail. Callers MUST rebind the worker's run id to the returned value
+    (the CLI goal loop re-exports ``HERMES_KANBAN_RUN_ID``), otherwise the
+    continuation can never complete or block.
+
+    RE-ESTABLISHES THE CLAIM. ``complete_task`` / ``block_task`` clear
     ``claim_lock``, ``claim_expires`` and ``worker_pid``. Both watchdogs are
     scoped to those columns — ``reap_crashed_workers`` selects
     ``status='running' AND worker_pid IS NOT NULL``, and
@@ -5776,15 +5787,19 @@ def reopen_task(
     NOT NULL``. A reopen that left them NULL would produce a card that is
     ``running`` yet invisible to every watchdog: if the worker then died,
     the task would hang in ``running`` forever with no recovery path. So
-    callers pass the live worker's own claim identity and it is restored.
+    callers pass the live worker's own claim identity and it is restored —
+    the same lock must be used for later ``heartbeat_claim`` calls, which
+    match on ``claim_lock``.
 
-    ``current_run_id`` is deliberately NOT restored — ``complete_task``
-    already closed that run row, and reviving a terminal run would corrupt
-    attempt history. ``block_recurrences`` is left alone for the same reason
-    ``unblock_task`` leaves it: the counter is loop protection.
+    ``block_recurrences`` is left alone for the same reason ``unblock_task``
+    leaves it: the counter is loop protection.
+
+    Returns the new run id, or ``None`` if the task was not in a terminal
+    state (nothing reopened).
     """
     now = int(time.time())
-    expires = now + int(claim_ttl_seconds) if claim_ttl_seconds else None
+    lock = claim_lock or _claimer_id()
+    expires = now + _resolve_claim_ttl_seconds(claim_ttl_seconds)
     with write_txn(conn):
         cur = conn.execute(
             """
@@ -5792,22 +5807,62 @@ def reopen_task(
                SET status       = 'running',
                    completed_at = NULL,
                    block_kind   = NULL,
-                   claim_lock   = COALESCE(?, claim_lock),
+                   claim_lock   = ?,
                    worker_pid   = COALESCE(?, worker_pid),
-                   claim_expires= COALESCE(?, claim_expires)
+                   claim_expires= ?
              WHERE id = ?
                AND status IN ('done', 'blocked')
             """,
-            (claim_lock, worker_pid, expires, task_id),
+            (lock, worker_pid, expires, task_id),
         )
         if cur.rowcount != 1:
-            return False
-        conn.execute(
-            "INSERT INTO task_events (task_id, kind, payload, created_at) "
-            "VALUES (?, 'status', ?, ?)",
-            (task_id, json.dumps({"status": "running", "reopened": True, "reason": reason}), now),
+            return None
+        trow = conn.execute(
+            "SELECT assignee, current_step_key, max_runtime_seconds "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        run_cur = conn.execute(
+            """
+            INSERT INTO task_runs (
+                task_id, profile, step_key, status,
+                claim_lock, claim_expires, max_runtime_seconds,
+                worker_pid, started_at
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?)
+            """,
+            (
+                task_id,
+                trow["assignee"] if trow else None,
+                trow["current_step_key"] if trow else None,
+                lock,
+                expires,
+                trow["max_runtime_seconds"] if trow else None,
+                worker_pid,
+                now,
+            ),
         )
-    return True
+        new_run_id = run_cur.lastrowid
+        if new_run_id is None:
+            raise RuntimeError(f"reopen_task: task_runs insert returned no rowid for {task_id}")
+        run_id = int(new_run_id)
+        conn.execute(
+            "UPDATE tasks SET current_run_id = ? WHERE id = ?",
+            (run_id, task_id),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+            "VALUES (?, ?, 'status', ?, ?)",
+            (
+                task_id,
+                run_id,
+                json.dumps({
+                    "status": "running", "reopened": True,
+                    "reason": reason, "run_id": run_id,
+                }),
+                now,
+            ),
+        )
+    return run_id
 
 
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5751,6 +5751,65 @@ def promote_task(
     return True, None
 
 
+def reopen_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    reason: str,
+    *,
+    claim_lock: Optional[str] = None,
+    worker_pid: Optional[int] = None,
+    claim_ttl_seconds: Optional[int] = None,
+) -> bool:
+    """Return a self-terminated ``done``/``blocked`` task to ``running``.
+
+    Used by the goal loop when the auxiliary judge rejects a worker's own
+    ``kanban_complete`` / ``kanban_block``: the worker process is still
+    alive and about to be handed a continuation prompt, so the card goes
+    back to ``running`` rather than ``ready`` (a ``ready`` card would be
+    picked up by the dispatcher and spawn a SECOND worker on the same task).
+
+    RE-ESTABLISH THE CLAIM. ``complete_task`` / ``block_task`` clear
+    ``claim_lock``, ``claim_expires`` and ``worker_pid``. Both watchdogs are
+    scoped to those columns — ``reap_crashed_workers`` selects
+    ``status='running' AND worker_pid IS NOT NULL``, and
+    ``release_stale_claims`` selects ``status='running' AND claim_expires IS
+    NOT NULL``. A reopen that left them NULL would produce a card that is
+    ``running`` yet invisible to every watchdog: if the worker then died,
+    the task would hang in ``running`` forever with no recovery path. So
+    callers pass the live worker's own claim identity and it is restored.
+
+    ``current_run_id`` is deliberately NOT restored — ``complete_task``
+    already closed that run row, and reviving a terminal run would corrupt
+    attempt history. ``block_recurrences`` is left alone for the same reason
+    ``unblock_task`` leaves it: the counter is loop protection.
+    """
+    now = int(time.time())
+    expires = now + int(claim_ttl_seconds) if claim_ttl_seconds else None
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status       = 'running',
+                   completed_at = NULL,
+                   block_kind   = NULL,
+                   claim_lock   = COALESCE(?, claim_lock),
+                   worker_pid   = COALESCE(?, worker_pid),
+                   claim_expires= COALESCE(?, claim_expires)
+             WHERE id = ?
+               AND status IN ('done', 'blocked')
+            """,
+            (claim_lock, worker_pid, expires, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'status', ?, ?)",
+            (task_id, json.dumps({"status": "running", "reopened": True, "reason": reason}), now),
+        )
+    return True
+
+
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """Transition ``blocked``/``scheduled`` -> ready or todo.
 

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -111,9 +111,18 @@ def _patch_judge(monkeypatch, verdicts):
     monkeypatch.setattr(goals, "judge_goal", _fake_judge)
 
 
-def test_loop_stops_when_worker_already_completed(monkeypatch):
-    # Worker called kanban_complete on its first turn — no judging needed.
-    _patch_judge(monkeypatch, ["continue"])  # should never be consulted
+def test_loop_judges_worker_completion_and_accepts_it(monkeypatch):
+    # Worker called kanban_complete on its first turn. The judge is STILL
+    # consulted once (that self-completion is exactly what it exists to
+    # check); a "done" verdict accepts it and no extra turn is run.
+    #
+    # This test previously asserted the opposite ("no judging needed") and
+    # encoded the reachability bug: because the loop only starts after the
+    # worker's first turn, and workers are told to terminate their own task
+    # in that turn, an unconditional terminal-status exit meant the judge
+    # was never reached — 97 goal cards in the field produced 0 loop
+    # iterations. See tests/hermes_cli/test_kanban_goal_reachability.py.
+    _patch_judge(monkeypatch, ["done"])
     turns = []
 
     res = goals.run_kanban_goal_loop(
@@ -125,7 +134,7 @@ def test_loop_stops_when_worker_already_completed(monkeypatch):
         first_response="done already",
     )
     assert res["outcome"] == "completed_by_worker"
-    assert turns == []  # no extra turns
+    assert turns == []  # accepted completion runs no further turns
 
 
 

--- a/tests/hermes_cli/test_kanban_goal_reachability.py
+++ b/tests/hermes_cli/test_kanban_goal_reachability.py
@@ -1,0 +1,248 @@
+"""Regression tests: the goal loop must actually reach its judge.
+
+Field evidence (2026-07): a board with 97 ``goal_mode=1`` cards logged 8
+judge calls and ZERO goal-loop iterations over seven weeks. The loop is
+invoked from cli.py AFTER the worker's first turn has already finished, and
+its first action is a status check that returns on ``done``/``blocked``.
+Workers are instructed to call ``kanban_complete`` / ``kanban_block`` during
+that first turn, so the status is already terminal and ``judge_goal`` is
+never consulted: 92 of 97 cards had a run ending completed/blocked.
+
+The judge itself was verified healthy (client resolves, 5.1s round trip,
+correct verdict), so this is purely a reachability defect.
+
+These tests encode the intended contract:
+
+1. A worker that self-completes in turn 1 is still judged once.
+2. A ``continue`` verdict reopens the task rather than accepting the
+   worker's own completion.
+3. A ``done`` verdict leaves the worker's completion alone.
+4. Human-gate blocks (``needs_input``) are NEVER second-guessed - the
+   worker is waiting on a person, and re-prompting it would burn turns
+   arguing with a wall.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import goals
+
+
+def _patch_judge(monkeypatch, verdicts):
+    seq = list(verdicts)
+    calls = []
+
+    def _fake_judge(goal, response, subgoals=None, background_processes=None, **_kw):
+        v = seq.pop(0) if seq else "done"
+        calls.append((goal, response, v))
+        return v, f"scripted:{v}", False, None, False
+
+    monkeypatch.setattr(goals, "judge_goal", _fake_judge)
+    return calls
+
+
+def test_self_completed_worker_is_still_judged(monkeypatch):
+    """Turn-1 kanban_complete must not bypass the judge."""
+    calls = _patch_judge(monkeypatch, ["done"])
+
+    goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="confirm root cause with two independent sources",
+        run_turn=lambda p: "x",
+        task_status_fn=lambda: "done",
+        block_fn=lambda r: pytest.fail("should not block on an accepted completion"),
+        first_response="Root cause found. Completing.",
+    )
+
+    assert len(calls) == 1, (
+        "worker self-completed in turn 1 and the judge was never consulted "
+        "- this is the reachability bug"
+    )
+
+
+def test_judge_continue_reopens_a_self_completed_task(monkeypatch):
+    """A premature self-completion is reopened and the worker keeps working."""
+    _patch_judge(monkeypatch, ["continue", "done"])
+    statuses = iter(["done", "running", "done"])
+    reopened = []
+    turns = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t2",
+        goal_text="ship it",
+        run_turn=lambda p: turns.append(p) or "kept going",
+        task_status_fn=lambda: next(statuses),
+        block_fn=lambda r: pytest.fail("should not block"),
+        reopen_fn=lambda reason: reopened.append(reason),
+        max_turns=10,
+        first_response="Probably fine. Completing.",
+    )
+
+    assert reopened, "judge said continue - the task must be reopened"
+    assert turns, "worker must be re-prompted after a continue verdict"
+    assert "not done yet" in turns[0]
+    assert res["outcome"] in ("completed_by_worker", "stopped")
+
+
+def test_judge_done_accepts_self_completion(monkeypatch):
+    """A legitimate completion is judged once and left alone."""
+    calls = _patch_judge(monkeypatch, ["done"])
+    reopened = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t3",
+        goal_text="task",
+        run_turn=lambda p: pytest.fail("no extra turn for an accepted completion"),
+        task_status_fn=lambda: "done",
+        block_fn=lambda r: pytest.fail("should not block"),
+        reopen_fn=lambda reason: reopened.append(reason),
+        first_response="Full evidence attached. Completing.",
+    )
+
+    assert len(calls) == 1
+    assert reopened == []
+    assert res["outcome"] == "completed_by_worker"
+
+
+def test_human_gate_block_is_never_judged(monkeypatch):
+    """needs_input blocks wait on a person - never re-prompt or reopen them."""
+    calls = _patch_judge(monkeypatch, ["continue"])
+    reopened = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t4",
+        goal_text="task",
+        run_turn=lambda p: pytest.fail("must not re-prompt a human-gated worker"),
+        task_status_fn=lambda: "blocked",
+        block_kind_fn=lambda: "needs_input",
+        block_fn=lambda r: None,
+        reopen_fn=lambda reason: reopened.append(reason),
+        first_response="Drafted the message. Blocking for approval.",
+    )
+
+    assert calls == [], "a human-gate block must not be sent to the judge"
+    assert reopened == []
+    assert res["outcome"] == "blocked_by_worker"
+
+
+def test_non_human_block_is_judged(monkeypatch):
+    """A self-declared block with no human gate still gets judged."""
+    calls = _patch_judge(monkeypatch, ["continue", "done"])
+    statuses = iter(["blocked", "running", "done"])
+    turns = []
+    reopened = []
+
+    goals.run_kanban_goal_loop(
+        task_id="t5",
+        goal_text="task",
+        run_turn=lambda p: turns.append(p) or "resumed",
+        task_status_fn=lambda: next(statuses),
+        block_kind_fn=lambda: None,
+        block_fn=lambda r: None,
+        reopen_fn=lambda reason: reopened.append(reason),
+        max_turns=10,
+        first_response="Giving up, blocking.",
+    )
+
+    assert len(calls) >= 1, "a non-human block must still be judged"
+    assert turns, "judge said continue - worker must be re-prompted"
+
+
+def test_dependency_block_is_never_judged(monkeypatch):
+    """dependency blocks wait on another task - same exemption as needs_input."""
+    calls = _patch_judge(monkeypatch, ["continue"])
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t7",
+        goal_text="task",
+        run_turn=lambda p: pytest.fail("must not re-prompt a dependency-gated worker"),
+        task_status_fn=lambda: "blocked",
+        block_kind_fn=lambda: "dependency",
+        block_fn=lambda r: None,
+        reopen_fn=lambda reason: pytest.fail("must not reopen a dependency gate"),
+        first_response="Waiting on parent task.",
+    )
+
+    assert calls == []
+    assert res["outcome"] == "blocked_by_worker"
+
+
+def test_unknown_block_kind_fails_safe(monkeypatch):
+    """A block_kind lookup that throws is treated as a human gate."""
+    calls = _patch_judge(monkeypatch, ["continue"])
+
+    def _boom():
+        raise RuntimeError("db unavailable")
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t6",
+        goal_text="task",
+        run_turn=lambda p: pytest.fail("must not re-prompt when block kind is unknown"),
+        task_status_fn=lambda: "blocked",
+        block_kind_fn=_boom,
+        block_fn=lambda r: None,
+        reopen_fn=lambda reason: pytest.fail("must not reopen when block kind is unknown"),
+        first_response="Blocked.",
+    )
+
+    assert calls == []
+    assert res["outcome"] == "blocked_by_worker"
+
+
+class TestReopenKeepsTaskWatchdogVisible:
+    """reopen_task must leave the card recoverable if the worker then dies.
+
+    ``complete_task`` / ``block_task`` NULL out claim_lock, worker_pid and
+    claim_expires. Both watchdogs are scoped to those columns
+    (``reap_crashed_workers``: running AND worker_pid IS NOT NULL;
+    ``release_stale_claims``: running AND claim_expires IS NOT NULL), so a
+    reopen that left them NULL would strand the task in ``running`` with no
+    recovery path.
+    """
+
+    def test_reopen_restores_claim_identity(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        from hermes_cli import kanban_db as kb
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        kb.init_db()
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="goal card", assignee="w", goal_mode=True)
+            kb.complete_task(conn, tid, result="premature", summary="s")
+            assert kb.get_task(conn, tid).status == "done"
+
+            ok = kb.reopen_task(
+                conn, tid, reason="judge rejected",
+                claim_lock="host:123", worker_pid=4242, claim_ttl_seconds=900,
+            )
+            assert ok
+
+            row = conn.execute(
+                "SELECT status, worker_pid, claim_lock, claim_expires, completed_at "
+                "FROM tasks WHERE id = ?", (tid,),
+            ).fetchone()
+
+        assert row["status"] == "running"
+        assert row["completed_at"] is None
+        assert row["worker_pid"] == 4242, "reap_crashed_workers would skip a NULL pid"
+        assert row["claim_lock"] == "host:123"
+        assert row["claim_expires"], "release_stale_claims would skip a NULL claim_expires"
+
+    def test_reopen_rejects_non_terminal_task(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        from hermes_cli import kanban_db as kb
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        kb.init_db()
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="open card", assignee="w")
+            assert kb.reopen_task(conn, tid, reason="x") is False

--- a/tests/hermes_cli/test_kanban_goal_reachability.py
+++ b/tests/hermes_cli/test_kanban_goal_reachability.py
@@ -216,15 +216,15 @@ class TestReopenKeepsTaskWatchdogVisible:
             kb.complete_task(conn, tid, result="premature", summary="s")
             assert kb.get_task(conn, tid).status == "done"
 
-            ok = kb.reopen_task(
+            run_id = kb.reopen_task(
                 conn, tid, reason="judge rejected",
                 claim_lock="host:123", worker_pid=4242, claim_ttl_seconds=900,
             )
-            assert ok
+            assert run_id is not None
 
             row = conn.execute(
-                "SELECT status, worker_pid, claim_lock, claim_expires, completed_at "
-                "FROM tasks WHERE id = ?", (tid,),
+                "SELECT status, worker_pid, claim_lock, claim_expires, completed_at, "
+                "current_run_id FROM tasks WHERE id = ?", (tid,),
             ).fetchone()
 
         assert row["status"] == "running"
@@ -232,6 +232,115 @@ class TestReopenKeepsTaskWatchdogVisible:
         assert row["worker_pid"] == 4242, "reap_crashed_workers would skip a NULL pid"
         assert row["claim_lock"] == "host:123"
         assert row["claim_expires"], "release_stale_claims would skip a NULL claim_expires"
+        assert row["current_run_id"] == run_id, (
+            "a reopened task with no live run cannot terminally complete: "
+            "complete_task matches the worker's pinned run id against current_run_id"
+        )
+
+    def test_full_complete_reopen_complete_lifecycle(self, tmp_path, monkeypatch):
+        """The guarded worker path must still work after a reopen.
+
+        kanban_complete passes the worker's pinned HERMES_KANBAN_RUN_ID and
+        complete_task requires it to equal tasks.current_run_id. If a reopen
+        leaves that pointer stale or NULL, the continuation can never
+        terminally complete or block through the guarded paths - it just
+        fails silently and the card hangs in running.
+        """
+        from pathlib import Path
+        from hermes_cli import kanban_db as kb
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        kb.init_db()
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="goal card", assignee="w", goal_mode=True)
+
+            # Claim it like the dispatcher does, so a real run row exists.
+            claimed = kb.claim_task(conn, tid, claimer="host:123")
+            assert claimed is not None
+            first_run = kb.get_task(conn, tid).current_run_id
+            assert first_run is not None, "claim must open a run"
+
+            # First attempt: worker completes with its own run id pinned.
+            assert kb.complete_task(
+                conn, tid, result="premature", summary="s",
+                expected_run_id=first_run,
+            ) is True
+
+            # Judge rejects it -> reopen onto a NEW run.
+            second_run = kb.reopen_task(
+                conn, tid, reason="judge rejected",
+                claim_lock="host:123", worker_pid=4242,
+            )
+            assert second_run is not None
+            assert second_run != first_run, "reopen must not revive the closed run"
+
+            # The stale run id must NOT be able to complete the task.
+            assert kb.complete_task(
+                conn, tid, result="stale", summary="s",
+                expected_run_id=first_run,
+            ) is False
+            assert kb.get_task(conn, tid).status == "running"
+
+            # The rebound run id must succeed.
+            assert kb.complete_task(
+                conn, tid, result="real work", summary="done properly",
+                expected_run_id=second_run,
+            ) is True
+            assert kb.get_task(conn, tid).status == "done"
+
+            runs = conn.execute(
+                "SELECT id, status, outcome FROM task_runs WHERE task_id = ? ORDER BY id",
+                (tid,),
+            ).fetchall()
+
+        assert len(runs) == 2, "each attempt keeps its own run row"
+        assert all(r["status"] != "running" for r in runs), "both runs closed"
+
+    def test_reopen_allows_block_after_reopen(self, tmp_path, monkeypatch):
+        """A reopened continuation must also be able to block for a human."""
+        from pathlib import Path
+        from hermes_cli import kanban_db as kb
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        kb.init_db()
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="goal card", assignee="w", goal_mode=True)
+            kb.complete_task(conn, tid, result="premature", summary="s")
+            new_run = kb.reopen_task(conn, tid, reason="judge rejected", worker_pid=4242)
+            assert new_run is not None
+
+            kb.block_task(conn, tid, reason="needs a human", kind="needs_input")
+            task = kb.get_task(conn, tid)
+
+        assert task.status == "blocked"
+        assert task.block_kind == "needs_input"
+
+    def test_reopen_heartbeat_uses_the_restored_lock(self, tmp_path, monkeypatch):
+        """heartbeat_claim matches on claim_lock - the drain must pass it."""
+        from pathlib import Path
+        from hermes_cli import kanban_db as kb
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        kb.init_db()
+
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="goal card", assignee="w", goal_mode=True)
+            kb.complete_task(conn, tid, result="x", summary="s")
+            kb.reopen_task(conn, tid, reason="r", claim_lock="host:999", worker_pid=1)
+
+            assert kb.heartbeat_claim(conn, tid, claimer="host:999") is True
+            assert kb.heartbeat_claim(conn, tid, claimer="wrong:lock") is False
 
     def test_reopen_rejects_non_terminal_task(self, tmp_path, monkeypatch):
         from pathlib import Path
@@ -245,4 +354,4 @@ class TestReopenKeepsTaskWatchdogVisible:
 
         with kb.connect() as conn:
             tid = kb.create_task(conn, title="open card", assignee="w")
-            assert kb.reopen_task(conn, tid, reason="x") is False
+            assert kb.reopen_task(conn, tid, reason="x") is None

--- a/tests/tools/test_async_delegation_drain.py
+++ b/tests/tools/test_async_delegation_drain.py
@@ -1,0 +1,113 @@
+"""The one-shot ``-q`` exit path must not kill in-flight background subagents.
+
+``delegate_task(background=true)`` children run on a DAEMON executor
+(tools/async_delegation._get_executor), so they are destroyed the instant the
+owning process exits. That is correct for an interactive session but wrong for
+a one-shot ``hermes chat -q`` run — notably a kanban worker, which reaches
+``sys.exit`` as soon as its final turn returns and silently loses whatever its
+subagents were doing.
+
+The gateway already refuses to scale to zero while ``active_count() > 0``
+(gateway/run.py). These tests cover the equivalent guard for the short-lived
+process: ``drain_active``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from tools import async_delegation as ad
+
+
+@pytest.fixture(autouse=True)
+def _clean_records():
+    ad._reset_for_tests()
+    yield
+    ad._reset_for_tests()
+
+
+def _fake_running(delegation_id: str, status: str = "running") -> None:
+    with ad._records_lock:
+        ad._records[delegation_id] = {"status": status}
+
+
+def _finish(delegation_id: str) -> None:
+    with ad._records_lock:
+        ad._records[delegation_id]["status"] = "completed"
+
+
+def test_drain_returns_immediately_when_nothing_running():
+    started = time.monotonic()
+    assert ad.drain_active(30) == 0
+    assert time.monotonic() - started < 1.0
+
+
+def test_drain_waits_for_an_in_flight_delegation():
+    _fake_running("deleg_aaa")
+
+    def _finish_soon():
+        time.sleep(0.3)
+        _finish("deleg_aaa")
+
+    threading.Thread(target=_finish_soon, daemon=True).start()
+
+    started = time.monotonic()
+    stranded = ad.drain_active(10, poll_interval=0.05)
+    elapsed = time.monotonic() - started
+
+    assert stranded == 0, "drain must wait until the child finishes"
+    assert elapsed >= 0.25, "drain returned before the child was done"
+
+
+def test_drain_reports_stranded_delegations_on_timeout():
+    """Timeout must report survivors, not pretend a clean drain."""
+    _fake_running("deleg_bbb")
+    _fake_running("deleg_ccc")
+
+    stranded = ad.drain_active(0.2, poll_interval=0.05)
+
+    assert stranded == 2, (
+        "a timed-out drain must return the count still running so the caller "
+        "can warn; these are then classified by recover_abandoned_delegations"
+    )
+
+
+def test_zero_timeout_does_not_block():
+    _fake_running("deleg_ddd")
+    started = time.monotonic()
+    assert ad.drain_active(0) == 1
+    assert time.monotonic() - started < 0.5
+
+
+def test_finalizing_counts_as_in_flight():
+    """A child mid-finalize still has a result to record - do not exit on it."""
+    _fake_running("deleg_eee", status="finalizing")
+    assert ad.drain_active(0.1, poll_interval=0.05) == 1
+
+
+def test_on_wait_receives_progress_and_failures_are_swallowed():
+    _fake_running("deleg_fff")
+    seen: list[int] = []
+
+    def _cb(remaining, elapsed):
+        seen.append(remaining)
+        raise RuntimeError("logging blew up")
+
+    stranded = ad.drain_active(0.2, poll_interval=0.05, on_wait=_cb)
+
+    assert stranded == 1
+    assert seen, "on_wait should have been called at least once"
+    assert all(n == 1 for n in seen)
+
+
+def test_active_ids_lists_in_flight_only():
+    _fake_running("deleg_ggg")
+    _fake_running("deleg_hhh", status="finalizing")
+    with ad._records_lock:
+        ad._records["deleg_done"] = {"status": "completed"}
+
+    ids = set(ad.active_ids())
+    assert ids == {"deleg_ggg", "deleg_hhh"}

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -571,6 +571,64 @@ def active_task_count() -> int:
         return total
 
 
+def active_ids() -> List[str]:
+    """Delegation ids currently running, for drain diagnostics."""
+    with _records_lock:
+        return [
+            did for did, r in _records.items()
+            if r.get("status") in {"running", "finalizing"}
+        ]
+
+
+def drain_active(
+    timeout: Optional[float],
+    *,
+    poll_interval: float = 2.0,
+    on_wait: Optional[Callable[[int, float], None]] = None,
+) -> int:
+    """Block until every in-flight async delegation finishes, or ``timeout``.
+
+    Background delegations run on a DAEMON executor (see ``_get_executor``),
+    so they are killed the instant the owning process exits. That is the
+    right trade for an interactive session — the user can quit — but a
+    one-shot ``hermes chat -q`` run (notably a kanban worker) reaches
+    ``sys.exit`` the moment its final turn returns and silently destroys
+    every child mid-flight. The gateway already refuses to scale to zero
+    while ``active_count() > 0``; this is the equivalent guard for the
+    short-lived process.
+
+    ``timeout=None`` waits indefinitely; ``timeout<=0`` returns immediately.
+    ``on_wait(remaining_count, elapsed)`` is invoked once per poll so the
+    caller can log progress.
+
+    Returns the number of delegations STILL running when we stopped waiting
+    (0 = fully drained). A non-zero return means the caller is about to
+    abandon them: on process exit they are picked up by
+    ``recover_abandoned_delegations`` and recorded as ``unknown`` rather
+    than vanishing without trace.
+    """
+    if timeout is not None and timeout <= 0:
+        return active_count()
+
+    started = time.monotonic()
+    while True:
+        remaining = active_count()
+        if remaining == 0:
+            return 0
+        elapsed = time.monotonic() - started
+        if timeout is not None and elapsed >= timeout:
+            return remaining
+        if on_wait is not None:
+            try:
+                on_wait(remaining, elapsed)
+            except Exception:  # noqa: BLE001 - never let logging break the drain
+                logger.debug("drain_active on_wait callback failed", exc_info=True)
+        sleep_for = poll_interval
+        if timeout is not None:
+            sleep_for = min(sleep_for, max(0.0, timeout - elapsed))
+        time.sleep(sleep_for)
+
+
 def _new_delegation_id() -> str:
     return f"deleg_{uuid.uuid4().hex[:8]}"
 


### PR DESCRIPTION
Two independent defects found while auditing why `--goal` cards on a production board were never enforced. Both are cases where a guard exists elsewhere in the codebase but is missing on one path.

Fixes the bug half of #73417.

---

## 1. The goal loop never reached its judge

A board with **97 `goal_mode=1` cards** logged **8 judge calls and 0 loop iterations** over seven weeks.

The judge was healthy the whole time — verified directly in the worker venv:

```
get_text_auxiliary_client("goal_judge")  -> OpenAI client, deepseek-v4-pro (not None)
judge_goal(deliberately_weak_response)   -> 5.1s, arity 5, verdict="continue" + correct reason
```

**Cause.** `run_kanban_goal_loop` opened with a status check that returned on `done`/`blocked`:

```python
while True:
    status = task_status_fn()
    if status == "done":    return {"outcome": "completed_by_worker", ...}
    if status == "blocked": return {"outcome": "blocked_by_worker", ...}
    ...
    verdict, reason, ... = judge_goal(goal_text, last_response)   # never reached
```

But the loop is invoked from `cli.py` **after** the worker's first turn has already completed, and worker skills instruct the model to call `kanban_complete` / `kanban_block` during that turn. So the status was already terminal and `judge_goal` was never called. On the board in question, **92 of 97** cards had a run ending completed/blocked. All 8 judge calls that did occur came from the separate `kanban_complete` gate, never the loop.

**Fix.** A terminal status is now judged **once**. `done` accepts the worker's completion and stops; `continue` reopens the card and keeps working.

Blocks waiting on something outside the worker (`needs_input`, `dependency` — exactly the kinds `_GOAL_MODE_BLOCK_ALLOWED_KINDS` permits for a goal_mode card) are exempt and never judged: re-prompting would argue with a wall, and reopening would strip a human gate. An unknown block kind fails safe to exempt.

**New `kanban_db.reopen_task`** restores the live worker's claim identity (`claim_lock` / `worker_pid` / `claim_expires`) along with the status. This matters more than it looks: `complete_task` and `block_task` NULL those columns, and both watchdogs are scoped to them — `reap_crashed_workers` selects `running AND worker_pid IS NOT NULL`, `release_stale_claims` selects `running AND claim_expires IS NOT NULL`. A reopen that left them NULL would produce a `running` card invisible to every watchdog, stuck forever if the worker then died. `current_run_id` is deliberately **not** revived (that run row is closed; reviving it would corrupt attempt history), and the card returns to `running` rather than `ready` so the dispatcher cannot spawn a second worker on it.

**Test note:** `test_loop_stops_when_worker_already_completed` asserted the buggy behaviour — its comment read *"no judging needed"*. It is rewritten to assert the judge runs once and accepts, with the field evidence in the docstring so it is not "restored" later.

---

## 2. `-q` runs exited on in-flight background subagents

`delegate_task(background=true)` children run on a **daemon** executor — deliberately, per `async_delegation.py`: *"NOT a `with ThreadPoolExecutor()` block, which would join on exit and defeat the whole point of async."* Daemon threads die instantly with the process.

That trade is right for an interactive session. It is wrong for a one-shot `hermes chat -q` run, which calls `sys.exit` the moment its final turn returns — killing every running child mid-flight. Kanban workers hit this constantly: the model dispatches subagents, reports, and the process tears down under them.

**Every other surface already guards this.** The gateway refuses to scale to zero while `active_count() > 0`, with a comment naming this exact failure (*"suspending mid-flight loses them"*); the API server checks it; the TUI reports it; `/stop` interrupts deliberately. The `-q` exit was the one path that just left. The loss was known, too — `recover_abandoned_delegations()` exists solely to label the wreckage afterwards (*"owner exited before recording a terminal result; outcome unknown"*).

**Fix.** Adds `async_delegation.drain_active(timeout)` + `active_ids()`, called from the `-q` exit path before `sys.exit`.

- **Bounded by the task's own deadline.** Kanban workers carry `HERMES_KANBAN_DEADLINE_TS` and the dispatcher reclaims the task once it passes, so draining beyond it would only get the worker killed anyway. A non-kanban `-q` run has no supervisor and waits indefinitely.
- **On timeout, exit anyway** and let `recover_abandoned_delegations` classify survivors as `unknown` — a recorded unknown beats a silent loss — plus a stderr warning with the count.
- **Heartbeats the kanban claim while draining.** A drain can outlast the claim TTL, and a deliberately-waiting worker must not look like a stalled one to `release_stale_claims`.

Verified by behaviour, not only unit tests: exit held 2.0s for a child finishing at 1.5s; a never-finishing child returned at the 3s task deadline with the warning and the record left for recovery; an already-expired deadline does not block at all.

---

## Testing

New: `tests/hermes_cli/test_kanban_goal_reachability.py` (turn-1 self-completion is still judged, `continue` reopens, `done` accepts, `needs_input`/`dependency` never judged, unknown block kind fails safe, `reopen_task` keeps the task watchdog-visible) and `tests/tools/test_async_delegation_drain.py` (waits for in-flight, reports stranded on timeout, zero-timeout non-blocking, `finalizing` counts as in-flight, `on_wait` failures swallowed).

Passing on this branch against `main`: goal-loop + delegation suites (39), kanban tools + kanban_db + scale-to-zero (62). Also verified pre-rebase on the development branch: 237 kanban_db, 250 kanban core/workflow/chain/diagnostics, 168 kanban plugin, 169 delegation/process/CLI-indicator.

## Not included

Two related items from #73417 remain open: the `judge_goal` 3-tuple/5-tuple unpack crash that fired after its own fix (`d401fd725`) — needs a stale-deploy check, and both handlers fail open to `done` so the gate silently disappears when it throws — and the board-scoped settings feature request.