### PR TITLE
fix(buzz): harden hosted gateway integration

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -23,17 +23,19 @@ Configuration in config.yaml::
             home_channel: ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
             poll_interval: 4           # seconds between poll sweeps
             cli_path: ""               # path to the buzz binary (default: PATH, then ~/bin/buzz)
-            credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
+            credentials_file: ""       # JSON file holding the nsec (fallback for
+                                       #   BUZZ_PRIVATE_KEY) and, optionally, the
+                                       #   NIP-OA auth_tag (fallback for BUZZ_AUTH_TAG)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
 
 Or via environment variables (overrides config.yaml):
     BUZZ_RELAY_URL, BUZZ_CHANNELS, BUZZ_HOME_CHANNEL, BUZZ_POLL_INTERVAL,
     BUZZ_CLI_PATH, BUZZ_CREDENTIALS_FILE, BUZZ_ALLOWED_USERS,
-    BUZZ_ALLOW_ALL_USERS
+    BUZZ_ALLOW_ALL_USERS, BUZZ_AUTH_TAG
 
 The only secret is BUZZ_PRIVATE_KEY (nsec or hex) — it belongs in
-``~/.hermes/.env``.  It is passed to the CLI via the subprocess
-environment and is never logged.
+``~/.hermes/.env``.  It, and the optional NIP-OA BUZZ_AUTH_TAG, are passed
+to the CLI via the subprocess environment and are never logged.
 """
 
 import asyncio
@@ -46,7 +48,7 @@ import time
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
@@ -83,9 +85,37 @@ _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
 
-# Where to look for a credentials JSON (keys: nsec / private_key_hex) when
-# BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
+# Where to look for a credentials JSON (keys: nsec / private_key_hex /
+# auth_tag) when BUZZ_PRIVATE_KEY / BUZZ_AUTH_TAG are not set.  Module-level
+# so tests can point it at a tmpdir.
 _DEFAULT_CREDENTIALS_DIR = Path("~/.config/buzz").expanduser()
+
+# The only non-BUZZ_* parent environment variables the buzz CLI subprocess
+# inherits (when set): enough to find the binary, a home/temp directory, a
+# locale, and the system trust store for its TLS connection to the relay.
+# The second block is the Windows spelling of exactly those runtime facts —
+# a process spawned there without SystemRoot/USERPROFILE/TEMP has no system
+# directory, home, or temp dir at all.  Every name here is a path/locale
+# setting, never a credential.  See _cli_environment().
+_CLI_SAFE_ENV_KEYS = frozenset({
+    "PATH",
+    "HOME",
+    "USER",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "COMSPEC",
+    "PATHEXT",
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "TEMP",
+    "TMP",
+})
 
 
 def _load_nostr_auth():
@@ -221,14 +251,18 @@ def _resolve_cli_path(configured: str = "") -> str:
     return str(fallback) if fallback.is_file() else ""
 
 
-def _resolve_private_key(extra: Optional[dict] = None) -> str:
-    """Resolve the Nostr private key: env first, then a credentials JSON.
+def _credentials_documents(extra: Optional[dict] = None):
+    """Yield the parsed credentials JSON objects, in selection order.
 
-    NEVER log the return value.
+    One candidate list serves every credential a file can carry (private key,
+    NIP-OA auth tag): the configured path (BUZZ_CREDENTIALS_FILE or
+    ``credentials_file``, ``~`` expanded), else the auto-discovered
+    ``~/.config/buzz/*credentials*.json``.  A configured file is therefore the
+    single source for both; with auto-discovery each credential takes the
+    first candidate that provides it.  Unreadable, malformed, or non-object
+    files are skipped silently — their contents are never logged or surfaced
+    in an error.
     """
-    key = os.getenv("BUZZ_PRIVATE_KEY", "").strip()
-    if key:
-        return key
     configured = os.getenv("BUZZ_CREDENTIALS_FILE", "").strip() or (extra or {}).get("credentials_file", "")
     if configured:
         candidates = [Path(configured).expanduser()]
@@ -242,13 +276,70 @@ def _resolve_private_key(extra: Optional[dict] = None) -> str:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             continue
-        if not isinstance(data, dict):
-            continue
+        if isinstance(data, dict):
+            yield data
+
+
+def _resolve_private_key(extra: Optional[dict] = None) -> str:
+    """Resolve the Nostr private key: env first, then a credentials JSON.
+
+    NEVER log the return value.
+    """
+    key = os.getenv("BUZZ_PRIVATE_KEY", "").strip()
+    if key:
+        return key
+    for data in _credentials_documents(extra):
         for field in ("nsec", "private_key_hex", "private_key"):
             value = data.get(field)
             if isinstance(value, str) and value.strip():
                 return value.strip()
     return ""
+
+
+def _resolve_auth_tag(extra: Optional[dict] = None) -> str:
+    """Resolve the NIP-OA owner-attestation auth tag JSON.
+
+    Same precedence as the private key: a non-empty BUZZ_AUTH_TAG, else the
+    ``auth_tag`` field of the selected credentials JSON.  Only a non-blank
+    string value counts; anything else resolves to "" so a malformed file
+    degrades to "no attestation" instead of breaking the handshake with a
+    value the signer cannot use.  NEVER log the return value.
+    """
+    tag = os.getenv("BUZZ_AUTH_TAG", "").strip()
+    if tag:
+        return tag
+    for data in _credentials_documents(extra):
+        value = data.get("auth_tag")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _cli_environment(*, relay_url: str, private_key: str, auth_tag: str) -> Dict[str, str]:
+    """Build the environment the buzz CLI subprocess runs with.
+
+    The CLI gets a deliberately narrow slice of this process's environment
+    rather than a copy of all of it: the runtime keys in
+    ``_CLI_SAFE_ENV_KEYS`` that are actually set, plus the parent's own
+    ``BUZZ_*`` settings (relay/channel/transport config a user exported).
+    Everything else — other providers' API keys, Hermes internals — never
+    reaches a subprocess that talks to a third-party relay.
+
+    The call's own relay URL and credentials are layered on top, so a
+    resolved value always wins over an inherited one.  NEVER log the result.
+    """
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key in _CLI_SAFE_ENV_KEYS or key.startswith("BUZZ_")
+    }
+    env["BUZZ_RELAY_URL"] = relay_url
+    env["BUZZ_PRIVATE_KEY"] = private_key
+    # Only export a resolved tag; an empty one must not clobber whatever the
+    # parent environment already provides.
+    if auth_tag:
+        env["BUZZ_AUTH_TAG"] = auth_tag
+    return env
 
 
 async def _exec_buzz(
@@ -257,18 +348,19 @@ async def _exec_buzz(
     *,
     relay_url: str,
     private_key: str,
+    auth_tag: str = "",
     input_text: Optional[str] = None,
     timeout: float = _CLI_TIMEOUT,
 ) -> Tuple[int, str, str]:
     """Run the buzz CLI with an argument list (never a shell) and return
     ``(returncode, stdout, stderr)``.
 
-    The private key travels via the subprocess environment only — it never
-    appears in argv, so process listings and error logs stay clean.
+    The private key and the NIP-OA auth tag travel via the subprocess
+    environment only — they never appear in argv, so process listings and
+    error logs stay clean.  That environment is a narrow allowlist rather
+    than a copy of this process's (see _cli_environment).
     """
-    env = os.environ.copy()
-    env["BUZZ_RELAY_URL"] = relay_url
-    env["BUZZ_PRIVATE_KEY"] = private_key
+    env = _cli_environment(relay_url=relay_url, private_key=private_key, auth_tag=auth_tag)
     proc = await asyncio.create_subprocess_exec(
         cli_path,
         *args,
@@ -307,6 +399,25 @@ def _cli_error_message(stderr: str, returncode: int) -> str:
     except ValueError:
         pass
     return text or f"buzz CLI failed with exit code {returncode}"
+
+
+def _membership_conversation_id(event: dict) -> Optional[str]:
+    """The conversation a kind-44100 membership event names.
+
+    Buzz identifies a conversation with an ``h`` tag — the same tag its chat
+    messages carry and its subscriptions filter on.  Returns None when the
+    event names no conversation, or names more than one: neither is a shape
+    the relay is known to emit, and DM classification fails closed on both.
+    """
+    tags = event.get("tags")
+    if not isinstance(tags, list):
+        return None
+    ids = {
+        str(tag[1]).strip()
+        for tag in tags
+        if isinstance(tag, (list, tuple)) and len(tag) > 1 and tag[0] == "h" and str(tag[1]).strip()
+    }
+    return ids.pop() if len(ids) == 1 else None
 
 
 def _parse_json_list(stdout: str) -> List[dict]:
@@ -387,10 +498,12 @@ class BuzzAdapter(BasePlatformAdapter):
             if isinstance(entry, str) and (normalized := _normalize_user_ref(entry))
         }
 
-        # Secret — resolved lazily (never at import/registration time and
-        # never logged).  connect() re-resolves it to fail fast with a clear
-        # error when it is missing.
+        # Secrets — resolved lazily (never at import/registration time and
+        # never logged).  connect() re-resolves them to fail fast with a clear
+        # error when the key is missing.  The auth tag is optional and shares
+        # the private key's resolution, so one credentials file serves both.
         self._private_key: str = ""
+        self._auth_tag: str = ""
 
         # Identity — filled in by connect() from ``buzz users get``
         self._self_pubkey: str = ""
@@ -419,14 +532,21 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── buzz-cli plumbing ─────────────────────────────────────────────────
 
+    def _resolve_credentials(self) -> None:
+        """Resolve the private key and the NIP-OA auth tag together, off the
+        same credentials-file selection.  Never logged."""
+        self._private_key = _resolve_private_key(self._extra)
+        self._auth_tag = _resolve_auth_tag(self._extra)
+
     async def _run_cli(self, args: List[str], *, input_text: Optional[str] = None) -> Tuple[int, str, str]:
         if not self._private_key:
-            self._private_key = _resolve_private_key(self._extra)
+            self._resolve_credentials()
         return await _exec_buzz(
             self.cli_path,
             args,
             relay_url=self.relay_url,
             private_key=self._private_key,
+            auth_tag=self._auth_tag,
             input_text=input_text,
         )
 
@@ -442,7 +562,7 @@ class BuzzAdapter(BasePlatformAdapter):
             logger.error("Buzz: buzz CLI binary not found (set BUZZ_CLI_PATH or put 'buzz' on PATH)")
             self._set_fatal_error("cli_missing", "buzz CLI binary not found", retryable=False)
             return False
-        self._private_key = _resolve_private_key(self._extra)
+        self._resolve_credentials()
         if not self._private_key:
             logger.error("Buzz: no private key (set BUZZ_PRIVATE_KEY or a credentials file)")
             self._set_fatal_error("config_missing", "BUZZ_PRIVATE_KEY must be set", retryable=False)
@@ -738,8 +858,9 @@ class BuzzAdapter(BasePlatformAdapter):
 
     async def _authenticate_websocket(self, websocket) -> None:
         """NIP-42: wait for the relay's AUTH challenge, answer with a signed
-        kind-22242 event (plus the optional NIP-OA owner-attestation tag from
-        BUZZ_AUTH_TAG), and wait for the OK acknowledgment."""
+        kind-22242 event (plus the optional NIP-OA owner-attestation tag
+        resolved from BUZZ_AUTH_TAG or the credentials file), and wait for the
+        OK acknowledgment."""
         build_auth_event = _load_nostr_auth().build_auth_event
 
         raw = await asyncio.wait_for(websocket.recv(), timeout=_WS_AUTH_TIMEOUT)
@@ -750,7 +871,7 @@ class BuzzAdapter(BasePlatformAdapter):
             private_key=self._private_key,
             challenge=str(message[1]),
             relay_url=self._websocket_url(),
-            auth_tag_json=os.getenv("BUZZ_AUTH_TAG", ""),
+            auth_tag_json=self._auth_tag,
         )
         await websocket.send(json.dumps(["AUTH", event], separators=(",", ":")))
         while True:
@@ -800,10 +921,17 @@ class BuzzAdapter(BasePlatformAdapter):
 
     async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
         """A membership event p-tagged to us: rediscover conversations and
-        subscribe to any new ones (fresh DMs dispatch from their beginning)."""
+        subscribe to any new ones (fresh DMs dispatch from their beginning).
+
+        The frame arrived on the NIP-42-authenticated subscription filtered
+        to ``#p`` = our own pubkey, so it is addressed to this agent; the
+        conversation it names is passed to _discover_dms as the only
+        candidate for immediate DM classification (see "DM classification"
+        below for what the event does and does not prove).
+        """
         self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
         before = set(self._channel_state)
-        await self._discover_dms(seed=False)
+        await self._discover_dms(seed=False, membership_id=_membership_conversation_id(event))
         for channel_id in self._channel_state:
             if channel_id in before:
                 continue
@@ -921,7 +1049,7 @@ class BuzzAdapter(BasePlatformAdapter):
             self._maybe_latch_dm(channel_id, state, event)
         self._trim_seen(state)
 
-    async def _discover_dms(self, *, seed: bool) -> None:
+    async def _discover_dms(self, *, seed: bool, membership_id: Optional[str] = None) -> None:
         """Watch DM conversations.  New ones found mid-run dispatch from their
         beginning (a fresh conversation has no history worth suppressing);
         ones present at startup are seeded like channels.
@@ -933,6 +1061,13 @@ class BuzzAdapter(BasePlatformAdapter):
         finds are watched as ``group`` and latch to ``dm`` via p-tag
         detection (_is_direct_message_event) rather than trusting the name
         alone to unlock the mention-free DM path.
+
+        ``membership_id`` is set ONLY by _handle_membership_event — the one
+        conversation a kind-44100 membership event addressed to us named.  If
+        that exact conversation's metadata is DM-shaped, it is classified
+        ``dm`` right away, because some hosted relays never p-tag the messages
+        inside a DM (see _is_hosted_dm_metadata).  Every other find stays
+        ``group``.
         """
         code, out, _err = await self._run_cli(["dms", "list"])
         if code == 0:
@@ -955,12 +1090,22 @@ class BuzzAdapter(BasePlatformAdapter):
                 continue
             self._channel_meta[ch_id] = ch
             self._channel_names.setdefault(ch_id, str(ch.get("name") or ch_id))
-            if ch_id in self._channel_state or not self._may_reclassify_as_dm(ch_id):
+            hosted_dm = ch_id == membership_id and self._is_hosted_dm_metadata(ch_id)
+            if ch_id in self._channel_state:
+                # Already watched (startup seeding or an earlier sweep saw it
+                # before the membership event arrived): the same two facts
+                # still classify it, they just cannot create the state entry.
+                if hosted_dm:
+                    self._latch_hosted_dm(ch_id, self._channel_state[ch_id])
+                continue
+            if not self._may_reclassify_as_dm(ch_id):
                 continue
             if seed:
                 await self._seed_channel(ch_id, chat_type="group")
             else:
                 self._channel_state[ch_id] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+            if hosted_dm:
+                self._latch_hosted_dm(ch_id, self._channel_state[ch_id])
 
     async def _poll_channel(self, channel_id: str) -> None:
         state = self._channel_state.get(channel_id)
@@ -1059,6 +1204,33 @@ class BuzzAdapter(BasePlatformAdapter):
     # "DM" with an empty description.  Nothing is lost while unlatched: a
     # DM message that DOES mention us dispatches through the mention gate
     # anyway, so the latch flips exactly on the first message that needs it.
+    #
+    # One relay shape defeats the p-tag latch entirely: on some hosted relays
+    # the other party's kind-9 messages inside a DM carry ONLY
+    # ["h", <dm id>] — no p-tag ever arrives, so an un-mentioned DM stays
+    # stuck behind the channel mention gate forever.  For those,
+    # classification comes from the discovery path instead, and it takes two
+    # independent facts:
+    #
+    #   * a kind-44100 membership event, delivered on the NIP-42-authenticated
+    #     subscription filtered ``#p`` = our own pubkey, NAMES the conversation
+    #     (one ``h`` tag).  This is what the event contributes: it is addressed
+    #     to us and it points at exactly one conversation.  It is not proof of
+    #     membership on its own — the event is signed by whoever published it,
+    #     not by us — so it never classifies anything by itself;
+    #   * that same conversation is present in OUR OWN authenticated
+    #     ``channels list`` with the hosted-DM shape (name "DM", no
+    #     description, untyped, not operator-configured).  The listing is the
+    #     membership evidence: the relay only lists conversations this
+    #     identity belongs to.
+    #
+    # Both together classify a DM; neither half does so alone, and everything
+    # else fails closed — an event naming no conversation (or several) promotes
+    # nothing, an unauthenticated poll sweep or startup listing never promotes
+    # anything, and a typed / described / configured channel is excluded.
+    # A real channel that is genuinely named "DM", untyped and undescribed
+    # remains indistinguishable from a materialized DM by design; the operator
+    # can pin it via the configured `channels` list.
 
     def _may_reclassify_as_dm(self, channel_id: str) -> bool:
         """True when the conversation's metadata does not rule out a DM.
@@ -1074,6 +1246,44 @@ class BuzzAdapter(BasePlatformAdapter):
         name = str(meta.get("name") or "").strip()
         description = str(meta.get("description") or "").strip()
         return name == "DM" and not description
+
+    def _is_hosted_dm_metadata(self, channel_id: str) -> bool:
+        """True when ``channels list`` describes this conversation as a
+        relay-materialized DM rather than a community channel.
+
+        Stricter than _may_reclassify_as_dm, because this is the predicate
+        that (together with an authenticated membership event) unlocks the
+        mention-free DM path outright instead of merely allowing a p-tagged
+        message to do it:  the entry must match the observed hosted-DM shape
+        exactly — named "DM", no description, and no channel_type field at
+        all (the relay types real channels and leaves materialized DMs
+        untyped) — and must not be a channel the operator asked to watch.
+        Any other channel_type value, known or not, fails closed.
+        """
+        meta = self._channel_meta.get(channel_id)
+        if not isinstance(meta, dict) or channel_id in self.channels:
+            return False
+        name = str(meta.get("name") or "").strip()
+        description = str(meta.get("description") or "").strip()
+        channel_type = str(meta.get("channel_type") or "").strip()
+        return name == "DM" and not description and not channel_type
+
+    def _latch_hosted_dm(self, channel_id: str, state: dict) -> None:
+        """Classify a watched conversation as a DM once a membership event
+        named it and its ``channels list`` entry has the hosted-DM shape.
+
+        Applies whether the conversation was discovered in the same pass or
+        was already being watched as ``group`` (startup seeding, or a poll
+        sweep that ran before the membership event arrived) — the two facts
+        that classify it do not depend on when it was first seen.
+        """
+        if state["chat_type"] == "dm":
+            return
+        state["chat_type"] = "dm"
+        logger.info(
+            "Buzz: conversation %s classified as DM (membership event + DM-shaped listing)",
+            channel_id,
+        )
 
     def _is_direct_message_event(self, channel_id: str, event: dict) -> bool:
         """True when ``event`` is shaped like a direct message to us: a chat
@@ -1338,7 +1548,7 @@ async def _standalone_send(
     message: str,
     *,
     thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    media_files: Optional[List[Union[str, Tuple[str, bool]]]] = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """One-shot send without a live adapter (out-of-process cron delivery).
@@ -1350,6 +1560,7 @@ async def _standalone_send(
     extra = getattr(pconfig, "extra", {}) or {}
     relay = (os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")).strip()
     private_key = _resolve_private_key(extra)
+    auth_tag = _resolve_auth_tag(extra)
     cli_path = _resolve_cli_path(
         os.getenv("BUZZ_CLI_PATH", "").strip() or str(extra.get("cli_path", "") or "")
     )
@@ -1364,11 +1575,24 @@ async def _standalone_send(
     args = ["messages", "send", "--channel", target, "--content", "-"]
     if thread_id:
         args += ["--reply-to", str(thread_id)]
-    for path in media_files or []:
+    for entry in media_files or []:
+        # Both out-of-process callers (cron/scheduler.py and
+        # tools/send_message_tool.py) build media_files with the core
+        # (path, is_voice) contract — BasePlatformAdapter.extract_media +
+        # filter_media_delivery_paths.  Buzz attaches every file the same
+        # way, so only the path is used; stringifying the pair itself would
+        # hand the CLI an unopenable path.  A bare string is still accepted
+        # for callers that never adopted the pair contract.
+        path = entry[0] if isinstance(entry, (list, tuple)) else entry
         args += ["--file", str(path)]
     try:
         code, out, err = await _exec_buzz(
-            cli_path, args, relay_url=relay, private_key=private_key, input_text=message
+            cli_path,
+            args,
+            relay_url=relay,
+            private_key=private_key,
+            auth_tag=auth_tag,
+            input_text=message,
         )
     except asyncio.CancelledError:
         raise

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -19,6 +19,8 @@ npub_to_hex = _buzz_mod.npub_to_hex
 _normalize_user_ref = _buzz_mod._normalize_user_ref
 _cli_error_message = _buzz_mod._cli_error_message
 _resolve_private_key = _buzz_mod._resolve_private_key
+_resolve_auth_tag = _buzz_mod._resolve_auth_tag
+_exec_buzz = _buzz_mod._exec_buzz
 check_requirements = _buzz_mod.check_requirements
 validate_config = _buzz_mod.validate_config
 register = _buzz_mod.register
@@ -34,6 +36,9 @@ CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
 # [] for it (#68871) while `channels list` shows it as name "DM", empty
 # description, indistinguishable from a channel except via message p-tags.
 DM_CHANNEL = "6468cc16-a114-4f23-8b8c-02c1655cbf6b"
+# A second hosted-relay DM: same empty `dms list`, but its kind-9 messages
+# carry only ["h", <dm id>] — no p-tag for the latch to key off.
+HOSTED_DM = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
 
 _ENV_VARS = (
     "BUZZ_RELAY_URL",
@@ -45,7 +50,13 @@ _ENV_VARS = (
     "BUZZ_POLL_INTERVAL",
     "BUZZ_CLI_PATH",
     "BUZZ_CREDENTIALS_FILE",
+    "BUZZ_AUTH_TAG",
 )
+
+# Obviously-fake NIP-OA auth tags (four-string ["auth", …] shape). Never use
+# real credentials in tests.
+FAKE_FILE_AUTH_TAG = json.dumps(["auth", "f" * 64, "", "1" * 128])
+FAKE_ENV_AUTH_TAG = json.dumps(["auth", "e" * 64, "", "2" * 128])
 
 
 @pytest.fixture(autouse=True)
@@ -381,6 +392,274 @@ class TestDmClassification:
         assert a._may_reclassify_as_dm(CHANNEL) is False
 
 
+# ── Hosted-relay DMs discovered by kind-44100 membership events ──────────
+#
+# Second flavour of #68871, seen on hosted community relays:
+# `dms list` is empty, the DM only shows up in `channels list` as
+# name "DM"/empty description/no channel_type, AND the owner's kind-9
+# messages carry nothing but ["h", <dm id>] — no p-tag at all.  The p-tag
+# latch can never fire for those, so classification has to come from the
+# authenticated kind-44100 membership event that put the conversation in
+# front of us in the first place.
+
+
+class _RecordingWebSocket:
+    """Captures the frames the adapter sends; no relay round-trip."""
+
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, raw):
+        self.sent.append(json.loads(raw))
+
+
+def _membership_event(*, conversation=None, created_at=5000, pubkey=OTHER_PUBKEY):
+    """A kind-44100 channel-membership event p-tagged to us, as delivered on
+    the authenticated (NIP-42) membership subscription."""
+    tags = [["p", SELF_PUBKEY]]
+    if conversation:
+        tags.append(["h", conversation])
+    return {
+        "id": "m1",
+        "pubkey": pubkey,
+        "kind": 44100,
+        "created_at": created_at,
+        "content": "",
+        "tags": tags,
+    }
+
+
+def _h_only_event(event_id, channel, *, content="here's a test message",
+                  pubkey=OTHER_PUBKEY, created_at=5001):
+    """Owner message exactly as the hosted relay emits it inside a DM:
+    kind 9 with a single ["h", <dm id>] tag and no p-tag."""
+    return {
+        "id": event_id,
+        "pubkey": pubkey,
+        "content": content,
+        "created_at": created_at,
+        "kind": 9,
+        "tags": [["h", channel]],
+    }
+
+
+class TestHostedDmMembershipDiscovery:
+
+    def _adapter(self, extra=None):
+        a = _make_adapter(extra)
+        a._dispatched = []
+
+        async def capture(**kwargs):
+            a._dispatched.append(kwargs)
+
+        a._dispatch_message = capture
+        a._message_handler = AsyncMock()
+        return a
+
+    def _cli(self, *channel_entries):
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])          # hosted relay: always empty
+        cli.script("channels", "list", list(channel_entries))
+        return cli
+
+    @pytest.mark.asyncio
+    async def test_membership_discovered_dm_dispatches_h_only_message(self):
+        """The reported bug end to end: `dms list` empty, DM-shaped fallback
+        metadata, discovery driven by an authenticated membership event, then
+        a kind-9 owner message with no p-tag — it must route as a DM."""
+        a = self._adapter()
+        a._run_cli = self._cli(
+            {"channel_id": HOSTED_DM, "name": "DM", "description": ""},
+            {"channel_id": CHANNEL, "name": "general",
+             "description": "General conversation and community updates."},
+        )
+        websocket = _RecordingWebSocket()
+        subscriptions = {}
+
+        await a._handle_membership_event(
+            websocket, subscriptions, _membership_event(conversation=HOSTED_DM)
+        )
+
+        # The new conversation is watched and subscribed to over the WS.
+        assert a._channel_state[HOSTED_DM]["chat_type"] == "dm"
+        assert HOSTED_DM in subscriptions.values()
+        assert [f[2]["#h"] for f in websocket.sent if f[0] == "REQ"] == [[HOSTED_DM]]
+        # The real channel is neither watched nor reclassified.
+        assert CHANNEL not in a._channel_state
+
+        await a._handle_event(
+            HOSTED_DM, a._channel_state[HOSTED_DM], _h_only_event("e1", HOSTED_DM)
+        )
+        assert [d["message_id"] for d in a._dispatched] == ["e1"]
+        assert a._dispatched[0]["chat_type"] == "dm"
+
+    @pytest.mark.asyncio
+    async def test_real_channel_named_dm_is_not_reclassified(self):
+        """Negative: a real channel that merely calls itself "DM" must not
+        become a DM or escape the mention gate, even when it shows up in the
+        same authenticated membership pass."""
+        a = self._adapter()
+        a._run_cli = self._cli(
+            # Real channels carry a channel_type; relay-materialized DMs don't.
+            {"channel_id": CHANNEL, "name": "DM", "description": "",
+             "channel_type": "channel"},
+        )
+        await a._handle_membership_event(
+            _RecordingWebSocket(), {}, _membership_event(conversation=CHANNEL)
+        )
+
+        assert a._channel_state[CHANNEL]["chat_type"] == "group"
+        await a._handle_event(
+            CHANNEL, a._channel_state[CHANNEL], _h_only_event("e1", CHANNEL)
+        )
+        assert a._dispatched == []
+        # Still reachable the normal way — the mention gate, not a mute.
+        await a._handle_event(
+            CHANNEL, a._channel_state[CHANNEL],
+            _h_only_event("e2", CHANNEL, content="@Chip ping", created_at=5002),
+        )
+        assert [d["chat_type"] for d in a._dispatched] == ["group"]
+
+    @pytest.mark.asyncio
+    async def test_configured_channel_named_dm_is_not_reclassified(self):
+        """A conversation the operator explicitly configured as a watched
+        channel stays a channel, whatever it is named."""
+        a = self._adapter({"channels": [CHANNEL]})
+        a._run_cli = self._cli({"channel_id": CHANNEL, "name": "DM", "description": ""})
+        await a._handle_membership_event(
+            _RecordingWebSocket(), {}, _membership_event(conversation=CHANNEL)
+        )
+        assert a._channel_state[CHANNEL]["chat_type"] == "group"
+
+    @pytest.mark.asyncio
+    async def test_membership_event_only_promotes_the_conversation_it_names(self):
+        """A membership event naming one conversation must not promote some
+        other DM-shaped entry that happens to appear in the same listing."""
+        other_dm = "11111111-2222-3333-4444-555555555555"
+        a = self._adapter()
+        a._run_cli = self._cli(
+            {"channel_id": HOSTED_DM, "name": "DM", "description": ""},
+            {"channel_id": other_dm, "name": "DM", "description": ""},
+        )
+        await a._handle_membership_event(
+            _RecordingWebSocket(), {}, _membership_event(conversation=HOSTED_DM)
+        )
+        assert a._channel_state[HOSTED_DM]["chat_type"] == "dm"
+        assert a._channel_state[other_dm]["chat_type"] == "group"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("conversations", [[], [HOSTED_DM, CHANNEL]])
+    async def test_membership_event_that_names_no_single_conversation_promotes_nothing(
+        self, conversations
+    ):
+        """Fail closed on shapes the relay is not known to emit: an event
+        naming no conversation — or several — promotes none of them, however
+        DM-shaped the listing looks."""
+        a = self._adapter()
+        a._run_cli = self._cli(
+            {"channel_id": HOSTED_DM, "name": "DM", "description": ""},
+            {"channel_id": CHANNEL, "name": "DM", "description": ""},
+        )
+        event = _membership_event()
+        event["tags"] += [["h", c] for c in conversations]
+
+        await a._handle_membership_event(_RecordingWebSocket(), {}, event)
+
+        assert a._channel_state[HOSTED_DM]["chat_type"] == "group"
+        assert a._channel_state[CHANNEL]["chat_type"] == "group"
+        await a._handle_event(
+            HOSTED_DM, a._channel_state[HOSTED_DM], _h_only_event("e1", HOSTED_DM)
+        )
+        assert a._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_typed_conversation_named_dm_is_not_reclassified(self):
+        """A ``channels list`` entry that carries any channel_type at all is
+        not the untyped hosted-DM shape, so it stays a channel."""
+        a = self._adapter()
+        a._run_cli = self._cli(
+            {"channel_id": HOSTED_DM, "name": "DM", "description": "", "channel_type": "dm"},
+        )
+        await a._handle_membership_event(
+            _RecordingWebSocket(), {}, _membership_event(conversation=HOSTED_DM)
+        )
+        assert a._channel_state[HOSTED_DM]["chat_type"] == "group"
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_discovery_keeps_group_classification(self):
+        """Without a membership event (startup seeding / poll sweeps), the
+        fallback listing alone never unlocks the DM path — name "DM" is not
+        evidence on its own."""
+        a = self._adapter()
+        a._run_cli = self._cli({"channel_id": HOSTED_DM, "name": "DM", "description": ""})
+        await a._discover_dms(seed=False)
+        assert a._channel_state[HOSTED_DM]["chat_type"] == "group"
+        await a._handle_event(
+            HOSTED_DM, a._channel_state[HOSTED_DM], _h_only_event("e1", HOSTED_DM)
+        )
+        assert a._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_allowlist_still_gates_membership_discovered_dm(self):
+        """DM classification must not bypass the adapter allow-list."""
+        a = self._adapter()
+        a._allowed_pubkeys = {"b" * 64}
+        a._run_cli = self._cli({"channel_id": HOSTED_DM, "name": "DM", "description": ""})
+        await a._handle_membership_event(
+            _RecordingWebSocket(), {}, _membership_event(conversation=HOSTED_DM)
+        )
+        assert a._channel_state[HOSTED_DM]["chat_type"] == "dm"
+        await a._handle_event(
+            HOSTED_DM, a._channel_state[HOSTED_DM], _h_only_event("e1", HOSTED_DM)
+        )
+        assert a._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_membership_event_classifies_already_watched_hosted_dm(self):
+        """A DM that already existed at gateway start is watched as ``group``
+        by startup seeding, so it is not a *new* find when the membership
+        event lands.  The same two facts still classify it — otherwise every
+        pre-existing hosted DM stays behind the mention gate until the
+        conversation is recreated."""
+        a = self._adapter()
+        a._run_cli = self._cli({"channel_id": HOSTED_DM, "name": "DM", "description": ""})
+        await a._discover_dms(seed=False)          # startup/poll discovery
+        assert a._channel_state[HOSTED_DM]["chat_type"] == "group"
+
+        await a._handle_membership_event(
+            _RecordingWebSocket(), {}, _membership_event(conversation=HOSTED_DM)
+        )
+        assert a._channel_state[HOSTED_DM]["chat_type"] == "dm"
+        await a._handle_event(
+            HOSTED_DM, a._channel_state[HOSTED_DM], _h_only_event("e1", HOSTED_DM)
+        )
+        assert [d["chat_type"] for d in a._dispatched] == ["dm"]
+
+    @pytest.mark.asyncio
+    async def test_membership_event_leaves_already_watched_channel_alone(self):
+        """The same promotion must not reach a watched real channel that a
+        membership event happens to name."""
+        a = self._adapter()
+        a._run_cli = self._cli(
+            {"channel_id": CHANNEL, "name": "general",
+             "description": "General conversation and community updates."},
+        )
+        a._channel_meta[CHANNEL] = {
+            "channel_id": CHANNEL, "name": "general",
+            "description": "General conversation and community updates.",
+        }
+        a._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+
+        await a._handle_membership_event(
+            _RecordingWebSocket(), {}, _membership_event(conversation=CHANNEL)
+        )
+        assert a._channel_state[CHANNEL]["chat_type"] == "group"
+        await a._handle_event(
+            CHANNEL, a._channel_state[CHANNEL], _h_only_event("e1", CHANNEL)
+        )
+        assert a._dispatched == []
+
+
 # ── Sending ───────────────────────────────────────────────────────────────
 
 
@@ -482,6 +761,370 @@ class TestCredentialResolution:
         assert _resolve_private_key() == "nsec1fromfile"
 
 
+class TestAuthTagResolution:
+    """The NIP-OA auth tag resolves like the private key: env, then the same
+    credentials JSON (configured or auto-discovered).  A hosted relay that
+    requires NIP-OA attestation rejects the NIP-42 handshake with
+    relay_membership_required when the tag sitting in the credentials file
+    never reaches the auth event."""
+
+    def test_env_auth_tag_wins_over_credentials_file(self, monkeypatch, tmp_path):
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(
+            json.dumps({"nsec": "nsec1fromfile", "auth_tag": FAKE_FILE_AUTH_TAG}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+        monkeypatch.setenv("BUZZ_AUTH_TAG", FAKE_ENV_AUTH_TAG)
+        assert _resolve_auth_tag() == FAKE_ENV_AUTH_TAG
+
+    def test_blank_env_auth_tag_falls_back_to_file(self, monkeypatch, tmp_path):
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(
+            json.dumps({"nsec": "nsec1fromfile", "auth_tag": f"  {FAKE_FILE_AUTH_TAG}  "}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+        monkeypatch.setenv("BUZZ_AUTH_TAG", "   ")
+        assert _resolve_auth_tag() == FAKE_FILE_AUTH_TAG
+
+    def test_one_credentials_file_serves_key_and_tag(self, monkeypatch, tmp_path):
+        """The documented credentials_file config selects a single source for
+        both the nsec and the auth tag."""
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(
+            json.dumps({"nsec": "nsec1fromfile", "auth_tag": FAKE_FILE_AUTH_TAG}),
+            encoding="utf-8",
+        )
+        extra = {"credentials_file": str(creds)}
+        assert _resolve_private_key(extra) == "nsec1fromfile"
+        assert _resolve_auth_tag(extra) == FAKE_FILE_AUTH_TAG
+
+    def test_auto_discovered_credentials_file(self, monkeypatch, tmp_path):
+        creds_dir = tmp_path / "buzz-config"
+        creds_dir.mkdir()
+        (creds_dir / "hermes_credentials.json").write_text(
+            json.dumps({"nsec": "nsec1discovered", "auth_tag": FAKE_FILE_AUTH_TAG}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", creds_dir)
+        assert _resolve_private_key() == "nsec1discovered"
+        assert _resolve_auth_tag() == FAKE_FILE_AUTH_TAG
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            json.dumps({"nsec": "nsec1fromfile"}),          # field absent
+            json.dumps({"auth_tag": ["auth", "f" * 64]}),   # non-string value
+            json.dumps({"auth_tag": "   "}),                # blank string
+            json.dumps(["not", "a", "dict"]),               # non-dict document
+            "{not json at all",                             # malformed
+        ],
+    )
+    def test_unusable_auth_tag_resolves_empty(self, monkeypatch, tmp_path, payload):
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(payload, encoding="utf-8")
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+        assert _resolve_auth_tag() == ""
+
+    def test_unreadable_credentials_file_resolves_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(tmp_path / "does-not-exist.json"))
+        assert _resolve_auth_tag() == ""
+
+
+@pytest.fixture
+def spawned(monkeypatch):
+    """Capture the env of the subprocess ``_exec_buzz`` would spawn."""
+    captured = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        async def communicate(self, data=None):
+            return b"[]", b""
+
+    async def fake_spawn(cli_path, *args, **kwargs):
+        captured.update(cli_path=cli_path, args=list(args), env=kwargs.get("env") or {})
+        return _FakeProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_spawn)
+    return captured
+
+
+class TestAuthTagReachesCli:
+    """Every buzz CLI subprocess must inherit the resolved auth tag, so hosted
+    relays accept the CLI's own NIP-42 handshake."""
+
+    @pytest.mark.asyncio
+    async def test_exec_buzz_exports_auth_tag(self, spawned):
+        await _exec_buzz(
+            "/fake/buzz", ["users", "get"],
+            relay_url="https://r", private_key="nsec1x", auth_tag=FAKE_FILE_AUTH_TAG,
+        )
+        assert spawned["env"]["BUZZ_AUTH_TAG"] == FAKE_FILE_AUTH_TAG
+        assert spawned["env"]["BUZZ_RELAY_URL"] == "https://r"
+        assert spawned["env"]["BUZZ_PRIVATE_KEY"] == "nsec1x"
+        # Credentials travel by env only — never argv.
+        assert all(FAKE_FILE_AUTH_TAG not in str(a) for a in spawned["args"])
+        assert all("nsec1x" not in str(a) for a in spawned["args"])
+
+    @pytest.mark.asyncio
+    async def test_exec_buzz_leaves_auth_tag_unset_when_empty(self, monkeypatch, spawned):
+        monkeypatch.delenv("BUZZ_AUTH_TAG", raising=False)
+        await _exec_buzz(
+            "/fake/buzz", ["users", "get"], relay_url="https://r", private_key="nsec1x",
+        )
+        assert "BUZZ_AUTH_TAG" not in spawned["env"]
+
+    @pytest.mark.asyncio
+    async def test_exec_buzz_never_clobbers_inherited_auth_tag(self, monkeypatch, spawned):
+        """An unresolved tag must leave whatever the parent process exports
+        alone rather than blanking it out."""
+        monkeypatch.setenv("BUZZ_AUTH_TAG", FAKE_ENV_AUTH_TAG)
+        await _exec_buzz(
+            "/fake/buzz", ["users", "get"], relay_url="https://r", private_key="nsec1x",
+        )
+        assert spawned["env"]["BUZZ_AUTH_TAG"] == FAKE_ENV_AUTH_TAG
+
+    @pytest.mark.asyncio
+    async def test_run_cli_forwards_credentials_file_auth_tag(self, monkeypatch, tmp_path):
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(
+            json.dumps({"nsec": "nsec1fromfile", "auth_tag": FAKE_FILE_AUTH_TAG}),
+            encoding="utf-8",
+        )
+        from gateway.config import PlatformConfig
+
+        adapter = BuzzAdapter(PlatformConfig(
+            enabled=True,
+            extra={"relay_url": "https://test.relay", "credentials_file": str(creds)},
+        ))
+        captured = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="",
+                            input_text=None, timeout=30.0):
+            captured.update(private_key=private_key, auth_tag=auth_tag)
+            return 0, "[]", ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        await adapter._run_cli(["users", "get"])
+        assert captured == {"private_key": "nsec1fromfile", "auth_tag": FAKE_FILE_AUTH_TAG}
+
+
+class TestCliSubprocessEnvironment:
+    """The buzz CLI is a third-party binary talking to a third-party relay, so
+    it is spawned with a narrow allowlist (``_CLI_SAFE_ENV_KEYS`` + the
+    parent's own ``BUZZ_*`` settings) instead of a copy of this process's
+    environment — no other provider's key or Hermes internal goes with it.
+    Fake values only; nothing here is a real credential."""
+
+    # Sentinels: a secret-shaped non-BUZZ name, plus a plain unrelated one.
+    FAKE_FOREIGN_SECRET = "sk-fake-not-a-real-key-0000"
+    FAKE_UNRELATED = "hermes-internal-sentinel"
+
+    def _set_parent_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OPENAI_API_KEY", self.FAKE_FOREIGN_SECRET)
+        monkeypatch.setenv("HERMES_HOME", self.FAKE_UNRELATED)
+        monkeypatch.setenv("AWS_SESSION_TOKEN", self.FAKE_FOREIGN_SECRET)
+        monkeypatch.setenv("LANG", "C.UTF-8")
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("SSL_CERT_FILE", str(tmp_path / "ca.pem"))
+        monkeypatch.setenv("PATH", "/fake/bin")
+        monkeypatch.delenv("LC_ALL", raising=False)
+        # Unrelated BUZZ_* settings a user exported for the CLI itself.
+        monkeypatch.setenv("BUZZ_TRANSPORT", "poll")
+        monkeypatch.setenv("BUZZ_CHANNELS", CHANNEL)
+
+    @pytest.mark.asyncio
+    async def test_foreign_environment_does_not_reach_the_cli(
+        self, monkeypatch, tmp_path, spawned
+    ):
+        """Unrelated parent variables — including secret-shaped ones — are not
+        handed to the buzz subprocess, by name or by value."""
+        self._set_parent_env(monkeypatch, tmp_path)
+        await _exec_buzz(
+            "/fake/buzz", ["users", "get"],
+            relay_url="https://r", private_key="nsec1x", auth_tag=FAKE_FILE_AUTH_TAG,
+        )
+        env = spawned["env"]
+
+        assert "OPENAI_API_KEY" not in env
+        assert "HERMES_HOME" not in env
+        assert "AWS_SESSION_TOKEN" not in env
+        assert self.FAKE_FOREIGN_SECRET not in env.values()
+        assert self.FAKE_UNRELATED not in env.values()
+        # Nothing outside the allowlist / BUZZ_* namespace survives at all.
+        assert all(
+            k in _buzz_mod._CLI_SAFE_ENV_KEYS or k.startswith("BUZZ_") for k in env
+        ), sorted(env)
+
+    @pytest.mark.asyncio
+    async def test_runtime_keys_and_buzz_settings_are_preserved(
+        self, monkeypatch, tmp_path, spawned
+    ):
+        """The CLI still needs to find its binary, a temp dir, a locale and the
+        trust store — and the user's own BUZZ_* settings."""
+        self._set_parent_env(monkeypatch, tmp_path)
+        await _exec_buzz(
+            "/fake/buzz", ["users", "get"], relay_url="https://r", private_key="nsec1x",
+        )
+        env = spawned["env"]
+
+        assert env["PATH"] == "/fake/bin"
+        assert env["LANG"] == "C.UTF-8"
+        assert env["TMPDIR"] == str(tmp_path)
+        assert env["SSL_CERT_FILE"] == str(tmp_path / "ca.pem")
+        assert env["BUZZ_TRANSPORT"] == "poll"
+        assert env["BUZZ_CHANNELS"] == CHANNEL
+        # Allowlisted keys the parent does not set are not invented.
+        assert "LC_ALL" not in env
+
+    @pytest.mark.asyncio
+    async def test_windows_runtime_keys_reach_the_cli(self, monkeypatch, tmp_path, spawned):
+        """The Windows spelling of the same runtime facts is inherited too: a
+        CLI spawned on Windows without SystemRoot / USERPROFILE / TEMP has no
+        system directory, home or temp dir at all.  Foreign variables stay
+        filtered out either way."""
+        self._set_parent_env(monkeypatch, tmp_path)
+        monkeypatch.setenv("SYSTEMROOT", r"C:\Windows")
+        monkeypatch.setenv("USERPROFILE", r"C:\Users\agent")
+        monkeypatch.setenv("TEMP", r"C:\Users\agent\AppData\Local\Temp")
+        monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT")
+
+        await _exec_buzz(
+            "/fake/buzz", ["users", "get"], relay_url="https://r", private_key="nsec1x",
+        )
+        env = spawned["env"]
+
+        assert env["SYSTEMROOT"] == r"C:\Windows"
+        assert env["USERPROFILE"] == r"C:\Users\agent"
+        assert env["TEMP"] == r"C:\Users\agent\AppData\Local\Temp"
+        assert env["PATHEXT"] == ".COM;.EXE;.BAT"
+        assert "OPENAI_API_KEY" not in env
+        assert self.FAKE_FOREIGN_SECRET not in env.values()
+
+    @pytest.mark.asyncio
+    async def test_call_specific_values_override_inherited_ones(
+        self, monkeypatch, tmp_path, spawned
+    ):
+        """A resolved relay/key/tag always wins over whatever the parent
+        exported — the adapter's config, not the ambient shell, decides."""
+        self._set_parent_env(monkeypatch, tmp_path)
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://inherited.relay")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1inherited")
+        monkeypatch.setenv("BUZZ_AUTH_TAG", FAKE_ENV_AUTH_TAG)
+
+        await _exec_buzz(
+            "/fake/buzz", ["users", "get"],
+            relay_url="https://resolved.relay", private_key="nsec1resolved",
+            auth_tag=FAKE_FILE_AUTH_TAG,
+        )
+        env = spawned["env"]
+
+        assert env["BUZZ_RELAY_URL"] == "https://resolved.relay"
+        assert env["BUZZ_PRIVATE_KEY"] == "nsec1resolved"
+        assert env["BUZZ_AUTH_TAG"] == FAKE_FILE_AUTH_TAG
+        # Credentials travel by env only — never argv (see also
+        # test_exec_buzz_never_clobbers_inherited_auth_tag for the empty-tag
+        # half of this contract).
+        assert all("nsec1resolved" not in str(a) for a in spawned["args"])
+        assert all(FAKE_FILE_AUTH_TAG not in str(a) for a in spawned["args"])
+
+    @pytest.mark.asyncio
+    async def test_inherited_auth_tag_survives_the_allowlist(
+        self, monkeypatch, tmp_path, spawned
+    ):
+        """An unresolved tag leaves the inherited one in place: the allowlist
+        filters foreign variables, it does not drop BUZZ_* credentials."""
+        self._set_parent_env(monkeypatch, tmp_path)
+        monkeypatch.setenv("BUZZ_AUTH_TAG", FAKE_ENV_AUTH_TAG)
+        await _exec_buzz(
+            "/fake/buzz", ["users", "get"], relay_url="https://r", private_key="nsec1x",
+        )
+        assert spawned["env"]["BUZZ_AUTH_TAG"] == FAKE_ENV_AUTH_TAG
+
+
+class TestAuthTagReachesWebSocket:
+    """The NIP-42 handshake must sign the resolved auth tag — reading only the
+    parent environment loses a tag that lives in the credentials file, which
+    hosted relays answer with 403 relay_membership_required."""
+
+    class _FakeWebSocket:
+        """Replays a NIP-42 handshake: AUTH challenge, then OK for the reply."""
+
+        def __init__(self):
+            self.sent = []
+
+        async def recv(self):
+            if self.sent:
+                return json.dumps(["OK", self.sent[0][1]["id"], True, "authenticated"])
+            return json.dumps(["AUTH", "relay-challenge"])
+
+        async def send(self, raw):
+            self.sent.append(json.loads(raw))
+
+    @pytest.mark.asyncio
+    async def test_auth_event_carries_credentials_file_auth_tag(self, monkeypatch, tmp_path):
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(
+            json.dumps({"nsec": "nsec1fromfile", "auth_tag": FAKE_FILE_AUTH_TAG}),
+            encoding="utf-8",
+        )
+        from gateway.config import PlatformConfig
+
+        adapter = BuzzAdapter(PlatformConfig(
+            enabled=True,
+            extra={"relay_url": "https://test.relay", "credentials_file": str(creds)},
+        ))
+
+        signed = {}
+
+        def fake_build_auth_event(*, private_key, challenge, relay_url, auth_tag_json=""):
+            signed.update(private_key=private_key, auth_tag_json=auth_tag_json)
+            return {"id": "evt-auth", "kind": 22242}
+
+        monkeypatch.setattr(
+            _buzz_mod, "_load_nostr_auth",
+            lambda: MagicMock(build_auth_event=fake_build_auth_event),
+        )
+
+        async def fake_exec(cli_path, args, **kwargs):
+            return 0, "[]", ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        # The adapter lifecycle resolves credentials before the WS starts.
+        await adapter._run_cli(["users", "get"])
+
+        await adapter._authenticate_websocket(self._FakeWebSocket())
+        assert signed == {"private_key": "nsec1fromfile", "auth_tag_json": FAKE_FILE_AUTH_TAG}
+
+    @pytest.mark.asyncio
+    async def test_malformed_file_auth_tag_fails_the_handshake_without_leaking(
+        self, monkeypatch, tmp_path
+    ):
+        """A credentials file whose auth_tag is a non-blank but unusable
+        string must fail the handshake the same way a bad BUZZ_AUTH_TAG does
+        — the WS loop treats that as a disconnect and `auto` transport falls
+        back to polling — and the rejected value must not reach the error."""
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(
+            json.dumps({"private_key_hex": "00" * 31 + "03", "auth_tag": "not-json-at-all"}),
+            encoding="utf-8",
+        )
+        from gateway.config import PlatformConfig
+
+        adapter = BuzzAdapter(PlatformConfig(
+            enabled=True,
+            extra={"relay_url": "https://test.relay", "credentials_file": str(creds)},
+        ))
+        adapter._resolve_credentials()
+        assert adapter._auth_tag == "not-json-at-all"
+
+        with pytest.raises(ValueError) as excinfo:
+            await adapter._authenticate_websocket(self._FakeWebSocket())
+        assert "not-json-at-all" not in str(excinfo.value)
+
+
 # ── Env enablement / registration / standalone send ──────────────────────
 
 
@@ -524,7 +1167,8 @@ class TestStandaloneSend:
 
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="",
+                            input_text=None, timeout=30.0):
             captured.update(cli_path=cli_path, args=args, relay_url=relay_url, input_text=input_text)
             return 0, json.dumps({"accepted": True, "event_id": "evt-cron", "message": ""}), ""
 
@@ -536,5 +1180,93 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_forwards_credentials_file_auth_tag(self, monkeypatch, tmp_path):
+        """Out-of-process cron sends resolve the auth tag the same way the
+        live adapter does."""
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(
+            json.dumps({"nsec": "nsec1fromfile", "auth_tag": FAKE_FILE_AUTH_TAG}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+
+        captured = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="",
+                            input_text=None, timeout=30.0):
+            captured.update(private_key=private_key, auth_tag=auth_tag, args=args)
+            return 0, json.dumps({"accepted": True, "event_id": "evt-cron"}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(PlatformConfig(enabled=True, extra={}), CHANNEL, "cron says hi")
+        assert result == {"success": True, "message_id": "evt-cron"}
+        assert captured["private_key"] == "nsec1fromfile"
+        assert captured["auth_tag"] == FAKE_FILE_AUTH_TAG
+        assert all(FAKE_FILE_AUTH_TAG not in str(a) for a in captured["args"])
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_passes_only_paths_from_media_tuples(self, monkeypatch, tmp_path):
+        """``cron/scheduler.py`` and ``send_message_tool`` hand media over as
+        ``(path, is_voice)`` pairs (``BasePlatformAdapter.extract_media`` /
+        ``filter_media_delivery_paths``). Each ``--file`` argument must be the
+        resolved path alone — a stringified pair is an unopenable path to the
+        buzz CLI. A JSON-round-tripped pair (list) and a bare string from
+        callers that never adopted the pair contract keep working."""
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        report = tmp_path / "report.txt"
+        voice = tmp_path / "voice.ogg"
+        chart = tmp_path / "chart.png"
+        legacy = tmp_path / "legacy.pdf"
+        for f in (report, voice, chart, legacy):
+            f.write_text("x", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+
+        captured = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="",
+                            input_text=None, timeout=30.0):
+            captured.update(args=args, input_text=input_text)
+            return 0, json.dumps({"accepted": True, "event_id": "evt-media"}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            "here are the files",
+            thread_id="evt-parent",
+            media_files=[
+                (str(report), False),
+                (str(voice), True),
+                [str(chart), False],
+                str(legacy),
+            ],
+        )
+
+        assert result == {"success": True, "message_id": "evt-media"}
+        args = captured["args"]
+        assert [args[i + 1] for i, a in enumerate(args) if a == "--file"] == [
+            str(report), str(voice), str(chart), str(legacy),
+        ]
+        # Ordinary text still rides on stdin, and the reply target on argv.
+        assert captured["input_text"] == "here are the files"
+        assert args[args.index("--reply-to") + 1] == "evt-parent"
+        # Neither the key nor the is_voice flag leaks into argv.
+        assert all("nsec1x" not in str(a) for a in args)
+        assert all("False" not in str(a) and "True" not in str(a) for a in args)
 
 

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -105,6 +105,66 @@ class _FakeWebSocket:
 
 
 @pytest.mark.asyncio
+async def test_membership_subscription_is_authenticated_and_self_addressed():
+    """Live DM discovery rides a kind-44100 subscription opened after NIP-42
+    auth and filtered to events p-tagged to our own pubkey — the
+    self-addressed half of hosted-DM classification, which only takes effect
+    together with a DM-shaped `channels list` entry (see
+    `_is_hosted_dm_metadata`)."""
+    adapter = _make_adapter()
+    adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 100, "seen": {}}
+    websocket = _FakeWebSocket()
+
+    subscriptions = await adapter._subscribe_websocket(websocket)
+
+    membership_sub = _buzz_mod._WS_MEMBERSHIP_SUB_ID
+    assert subscriptions[membership_sub] is None  # not a per-channel sub
+    assert subscriptions["hermes-buzz-0"] == CHANNEL
+    frames = {f[1]: f[2] for f in websocket.sent if f[0] == "REQ"}
+    assert frames[membership_sub]["kinds"] == [_buzz_mod._WS_MEMBERSHIP_KIND]
+    assert frames[membership_sub]["#p"] == [SELF_PUBKEY]
+    assert frames["hermes-buzz-0"]["#h"] == [CHANNEL]
+
+
+@pytest.mark.asyncio
+async def test_membership_event_routes_hosted_dm_through_websocket_flow():
+    """End to end on the WS transport: `dms list` empty, DM-shaped fallback
+    metadata, a kind-44100 membership event, then a kind-9 owner message
+    carrying only an h-tag — it dispatches as a DM."""
+    hosted_dm = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+    adapter = _make_adapter()
+    dispatched = []
+
+    async def capture(**kwargs):
+        dispatched.append(kwargs)
+
+    adapter._dispatch_message = capture
+
+    async def fake_cli(args, *, input_text=None):
+        if args[:2] == ["channels", "list"]:
+            return 0, json.dumps([{"channel_id": hosted_dm, "name": "DM", "description": ""}]), ""
+        return 0, "[]", ""
+
+    adapter._run_cli = fake_cli
+
+    websocket = _FakeWebSocket()
+    subscriptions = {}
+    await adapter._handle_membership_event(websocket, subscriptions, {
+        "id": "m1", "kind": _buzz_mod._WS_MEMBERSHIP_KIND, "created_at": int(time.time()),
+        "pubkey": "a" * 64, "content": "",
+        "tags": [["p", SELF_PUBKEY], ["h", hosted_dm]],
+    })
+    assert hosted_dm in subscriptions.values()
+
+    state = adapter._channel_state[hosted_dm]
+    await adapter._handle_event(hosted_dm, state, {
+        "id": "e1", "kind": 9, "pubkey": "a" * 64, "created_at": int(time.time()),
+        "content": "here's a test message", "tags": [["h", hosted_dm]],
+    })
+    assert [d["chat_type"] for d in dispatched] == ["dm"]
+
+
+@pytest.mark.asyncio
 async def test_websocket_auth_raises_on_rejection():
     adapter = _make_adapter()
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -704,7 +704,7 @@ Connect Hermes to [Photon](https://photon.codes/) / Spectrum (iMessage and other
 | `BUZZ_ALLOW_ALL_USERS` | Allow any community member to talk to the agent (`true`/`false`) |
 | `BUZZ_TRANSPORT` | Inbound transport: `auto` (WebSocket w/ poll fallback, default), `websocket`, or `poll` |
 | `BUZZ_POLL_INTERVAL` | Seconds between inbound poll sweeps (default: `4`) |
-| `BUZZ_AUTH_TAG` | Optional NIP-OA owner-attestation auth tag JSON for NIP-42 WebSocket auth |
+| `BUZZ_AUTH_TAG` | Optional NIP-OA owner-attestation auth tag JSON for relay auth (WebSocket handshake and buzz CLI); falls back to `auth_tag` in the credentials file |
 | `BUZZ_CLI_PATH` | Path to the buzz CLI binary (default: `buzz` on PATH, then `~/bin/buzz`) |
 
 ### Microsoft Teams (adapter)

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -4,7 +4,7 @@ The Buzz adapter connects Hermes to a [Buzz](https://github.com/block/buzz) comm
 
 Buzz renders markdown, so agent replies keep their formatting. Images are delivered as uploads (local files) or links (URLs). Replies can thread onto an existing message via its event id.
 
-Inbound messages arrive over a persistent NIP-42-authenticated Nostr WebSocket subscription by default (near-instant delivery), with automatic fallback to CLI polling when the WebSocket can't be established. Outbound messages always go through the `buzz` CLI. Control it with `transport` / `BUZZ_TRANSPORT`: `auto` (default), `websocket` (require WS, fail otherwise), or `poll`. If your relay membership uses NIP-OA owner attestation, set `BUZZ_AUTH_TAG` to the four-string auth tag JSON.
+Inbound messages arrive over a persistent NIP-42-authenticated Nostr WebSocket subscription by default (near-instant delivery), with automatic fallback to CLI polling when the WebSocket can't be established. Outbound messages always go through the `buzz` CLI. Control it with `transport` / `BUZZ_TRANSPORT`: `auto` (default), `websocket` (require WS, fail otherwise), or `poll`. If your relay membership uses NIP-OA owner attestation, set `BUZZ_AUTH_TAG` to the four-string auth tag JSON, or put it in the `credentials_file` as `auth_tag` alongside the nsec.
 
 > Run `hermes gateway setup` and pick **Buzz** for a guided walk-through.
 
@@ -33,6 +33,7 @@ gateway:
         poll_interval: 4           # seconds between inbound poll sweeps
         cli_path: ""               # buzz binary (default: PATH, then ~/bin/buzz)
         credentials_file: ""       # JSON file with the nsec (BUZZ_PRIVATE_KEY fallback)
+                                   #   and optional auth_tag (BUZZ_AUTH_TAG fallback)
         allowed_users: []          # empty = allow all; hex pubkeys or npubs
 ```
 
@@ -77,7 +78,7 @@ gateway:
         home_channel: ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
         poll_interval: 4                  # seconds between inbound poll sweeps (default 4 — balances latency vs. relay load)
         cli_path: ""                      # buzz binary (default: PATH, then ~/bin/buzz)
-        credentials_file: ""              # JSON file with the nsec (BUZZ_PRIVATE_KEY fallback)
+        credentials_file: ""              # JSON file with the nsec (BUZZ_PRIVATE_KEY fallback) and optional auth_tag (BUZZ_AUTH_TAG fallback)
         allowed_users: []                 # empty = allow all if allow_all_users is true; otherwise restrict to listed npubs/hex pubkeys
         require_mention: true             # in channels: only respond when addressed (@name, npub, or hex pubkey); DMs always dispatch regardless
         allow_all_users: false            # set true for community mode (everyone can chat, only owner is admin); false for private mode (only allowed_users)


### PR DESCRIPTION
Fixes hosted Buzz relay authentication and messaging edge cases discovered during a real Hermes/Buzz deployment.

- loads auth tags from credentials files without exposing them
- classifies hosted membership DMs safely
- normalises standalone Buzz media payloads
- restricts Buzz subprocess environments to safe runtime and BUZZ_* keys
- adds focused/adjacent regression coverage and updates docs

Verified by a separate Claude Code review/fix pass plus the repository runner, lint, syntax and diff checks. No live credentials or relay-specific identifiers are included.