### PR TITLE
fix(display): don't read "error": null as a tool failure

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1264,6 +1264,31 @@ def _trim_error(msg: str) -> str:
     return msg
 
 
+_ERROR_KEY_RE = re.compile(r'"(?:error|failed)"\s*:')
+_ERROR_AS_VALUE_RE = re.compile(r':\s*"(?:error|failed)"')
+# JSON literals that mean "no error here". Anchored at the value position.
+_FALSY_VALUE_RE = re.compile(r'\s*(?:null|false|0|""|\[\]|\{\})\s*(?:[,}\]]|$)')
+
+
+def _has_error_signal(window: str, full: str) -> bool:
+    """Return True when *window* carries a genuine error marker.
+
+    *window* is the lowercased prefix actually scanned; *full* is the whole
+    lowercased result, used only to read a key's value when it straddles the
+    window boundary.
+
+    A plain ``'"error"' in text`` test is not enough: tools that report per
+    item — ``web_extract`` is the common one — emit ``"error": null`` on
+    *every successful* entry, so the substring is present exactly when
+    nothing went wrong. Only an error key with a non-falsy value, or the
+    literal string used as a value (``{"status": "error"}``), is a failure.
+    """
+    for match in _ERROR_KEY_RE.finditer(window):
+        if not _FALSY_VALUE_RE.match(full, match.end()):
+            return True
+    return bool(_ERROR_AS_VALUE_RE.search(window))
+
+
 def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
     """Inspect a tool result string for signs of failure.
 
@@ -1308,7 +1333,7 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     if not isinstance(result, str):
         return False, ""
     lower = result[:500].lower()
-    if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
+    if _has_error_signal(lower, result.lower()) or result.startswith("Error"):
         return True, " [error]"
 
     return False, ""

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -119,3 +119,62 @@ class TestGetCuteToolMessageFailureSuffix:
         line = get_cute_tool_message("web_search", {"query": "hi"}, 0.2, result=ok)
         assert "[" not in line.split("0.2s", 1)[1]
 
+
+
+class TestDetectToolFailureNullErrorField:
+    """Per-item ``"error": null`` must not read as a failure.
+
+    Regression guard: tools that report per item (web_extract, and any
+    multi-URL/multi-file tool) emit an explicit null error field on every
+    successful entry. A bare substring test flags those successes as
+    failures, so the agent sees "[error]" on a call that returned the
+    content it asked for.
+    """
+
+    def test_web_extract_success_with_null_error_not_flagged(self):
+        result = json.dumps({
+            "results": [{
+                "url": "https://example.com",
+                "title": "Example Domain",
+                "content": "Example Domain\n==============\n\nThis domain is "
+                           "for use in documentation examples.",
+                "error": None,
+            }]
+        }, indent=2)
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
+    def test_web_extract_real_error_still_flagged(self):
+        result = json.dumps({
+            "results": [{
+                "url": "https://example.com",
+                "title": "",
+                "content": "",
+                "error": "Blocked: URL targets a private or internal network address",
+            }]
+        }, indent=2)
+        assert _detect_tool_failure("web_extract", result) == (True, " [error]")
+
+    def test_mixed_batch_with_one_real_error_is_flagged(self):
+        result = json.dumps({
+            "results": [
+                {"url": "https://ok.example", "content": "fine", "error": None},
+                {"url": "https://bad.example", "content": "", "error": "timeout"},
+            ]
+        }, indent=2)
+        assert _detect_tool_failure("web_extract", result) == (True, " [error]")
+
+    def test_false_failed_flag_not_flagged(self):
+        result = json.dumps({"items": [{"name": "a", "failed": False}]})
+        assert _detect_tool_failure("some_tool", result) == (False, "")
+
+    def test_error_as_string_value_still_flagged(self):
+        # {"status": "error"} has no error *key*, but plainly reports one.
+        result = json.dumps({"status": "error", "detail": "upstream refused"})
+        assert _detect_tool_failure("some_tool", result) == (True, " [error]")
+
+    def test_null_error_beyond_scan_window_not_flagged(self):
+        # The key sits past the 500-char prefix that gets scanned; the value
+        # must still be read correctly rather than assumed truthy.
+        padding = "x" * 600
+        result = json.dumps({"content": padding, "error": None})
+        assert _detect_tool_failure("web_extract", result) == (False, "")


### PR DESCRIPTION
## What does this PR do?

`_detect_tool_failure()` reports successful tool calls as failures when the result contains an explicit null error field.

The structured-error check only inspects the top level of the payload. Results shaped `{"results": [...]}` fall through to the generic heuristic below it, which tests for the bare substring `"error"` in the first 500 characters:

```python
lower = result[:500].lower()
if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
    return True, " [error]"
```

Tools that report per item emit `"error": null` on *every successful* entry — so the substring is present precisely when nothing went wrong. `web_extract` is the common case. A successful single-URL extraction returns:

```json
{
  "results": [
    {
      "url": "https://example.com",
      "title": "Example Domain",
      "content": "Example Domain\n==============\n\nThis domain is for use in documentation examples.",
      "error": null
    }
  ]
}
```

The CLI renders `📄 fetch example.com [error]` and the log records `tool web_extract failed` — while the content was fetched correctly.

What makes this worth fixing rather than cosmetic: the agent sees the failure marker and acts on it. It retries a call that already returned its data, burns turns, or reports failure to the user. The symptom is also intermittent in a way that hides the cause — the error key only trips the heuristic when it lands inside the 500-character window, so short extractions are flagged while long ones pass.

The fix narrows the heuristic: an `"error"`/`"failed"` key counts as a failure only when its value is not an explicit falsy literal (`null`, `false`, `0`, `""`, `[]`, `{}`). Detection strength is preserved — a key with a real message still flags, and the literal used as a value (`{"status": "error"}`) is now matched explicitly, which the old substring test caught only incidentally. The value is read from the full result so a key sitting near the window boundary is not assumed truthy.

## Related Issue

No existing issue — I searched open and closed issues and PRs for `detect_tool_failure`, `web_extract error` and `tool failure detection` and found none.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/display.py` — added `_has_error_signal()` plus three module-level patterns (`_ERROR_KEY_RE`, `_ERROR_AS_VALUE_RE`, `_FALSY_VALUE_RE`); `_detect_tool_failure()` now calls it instead of the bare substring test.
- `tests/agent/test_display_tool_failure.py` — added `TestDetectToolFailureNullErrorField` with 6 cases.

## How to Test

Reproduce on `main` (no network needed):

```python
import json
from agent.display import _detect_tool_failure

ok = json.dumps({"results": [{"url": "https://example.com",
                              "content": "Example Domain",
                              "error": None}]}, indent=2)
print(_detect_tool_failure("web_extract", ok))
# main:       (True, ' [error]')   <- wrong
# this patch: (False, '')
```

Real errors must still be detected:

```python
bad = json.dumps({"results": [{"url": "https://example.com", "content": "",
                               "error": "Blocked: URL targets a private address"}]}, indent=2)
print(_detect_tool_failure("web_extract", bad))   # (True, ' [error]') on both
```

Verified end to end against a live `web_extract` call: the short extraction returns `(False, '')` and a blocked URL still returns `(True, ' [error]')`.

Test suite:

```bash
pytest tests/agent/test_display_tool_failure.py -q   # 17 passed
```

Reverting only `agent/display.py` makes exactly two of the new tests fail, which confirms they pin the bug rather than the implementation.

On `tests/agent/` this environment has 93 pre-existing failures unrelated to this change (missing optional test dependencies). The counts before and after are identical at 93, with 3269 → 3275 passing — the six added tests and nothing else.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(display):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` — see the note above on pre-existing failures
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helper) — no user-facing docs affected
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: pure-Python string/regex handling, no platform-specific behaviour
- [x] N/A — no tool behaviour or schema change; this only affects how results are classified for display and logging
