### PR TITLE
fix(agent): align iteration budget defaults and execute_code refund (#75097)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -455,7 +455,7 @@ def init_agent(
     command: str = None,
     args: list[str] | None = None,
     model: str = "",
-    max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
+    max_iterations: int = 500,  # Default tool-calling iterations
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     save_trajectories: bool = False,
@@ -528,7 +528,7 @@ def init_agent(
         requested_provider (str): Original provider identity before runtime canonicalization
         api_mode (str): API mode override: "chat_completions" or "codex_responses"
         model (str): Model name to use (default: "anthropic/claude-opus-4.6")
-        max_iterations (int): Maximum number of tool calling iterations (default: 90)
+        max_iterations (int): Maximum number of tool calling iterations (default: 500)
         enabled_toolsets (List[str]): Only enable tools from these toolsets (optional)
         disabled_toolsets (List[str]): Disable tools from these toolsets (optional)
         save_trajectories (bool): Whether to save conversation trajectories to JSONL files (default: False)
@@ -571,8 +571,8 @@ def init_agent(
 
     agent.model = model
     agent.max_iterations = max_iterations
-    # Shared iteration budget — parent creates, children inherit.
-    # Consumed by every LLM turn across parent + all subagents.
+    # Iteration budget for this agent.  Each subagent gets its own
+    # independent budget at delegation time (see delegate_tool.py).
     agent.iteration_budget = iteration_budget or IterationBudget(max_iterations)
     agent.save_trajectories = save_trajectories
     agent.verbose_logging = verbose_logging

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6153,6 +6153,8 @@ def run_conversation(
                 # cheap RPC-style calls that shouldn't eat the budget.
                 _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                 if _tc_names == {"execute_code"}:
+                    api_call_count -= 1
+                    agent._api_call_count = api_call_count
                     agent.iteration_budget.refund()
                 
                 # Use real token counts from the API response to decide

--- a/run_agent.py
+++ b/run_agent.py
@@ -440,7 +440,7 @@ class AIAgent:
         command: str = None,
         args: list[str] | None = None,
         model: str = "",
-        max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
+        max_iterations: int = 500,  # Default tool-calling iterations
         tool_delay: float = None,  # Deprecated: accepted for compatibility, ignored
         enabled_toolsets: List[str] = None,
         disabled_toolsets: List[str] = None,


### PR DESCRIPTION
## Summary

- Restore `max_iterations` default from 90 to 500 in `AIAgent.__init__()` and `init_agent()` to match `DEFAULT_CONFIG["agent"]["max_turns"]` and the Python-library documentation.
- Refund `api_call_count` alongside `IterationBudget` for execute_code-only iterations so the loop guard (`api_call_count < max_iterations`) reflects the actual remaining capacity.
- Update stale comments that still describe the old shared parent/subagent budget behavior.

## Root Cause

1. Commit `1b081e489` raised every hardcoded default to 500. An unrelated refactor (`ce9f6712f`) changed the constructor and `init_agent()` defaults back to 90 while removing `tool_delay`.

2. The conversation loop has two limiting counters (`api_call_count < max_iterations` AND `iteration_budget.remaining > 0`), but the execute_code refund at line 6156 only updated `IterationBudget` — not `api_call_count`. This meant a refunded iteration still consumed the hard loop cap.

3. Subagent budgets became independent in `68ab37e89` but the comments in `agent_init.py` were not updated.

## Changes

| File | Change |
|------|--------|
| `run_agent.py:443` | `max_iterations=90` → `max_iterations=500` |
| `agent/agent_init.py:458` | `max_iterations=90` → `max_iterations=500` |
| `agent/agent_init.py:531` | Docstring default 90 → 500 |
| `agent/agent_init.py:574-575` | Comment: independent budget per subagent |
| `agent/conversation_loop.py:6155-6156` | Add `api_call_count -= 1` + `_api_call_count` sync |

Fixes #75097