### PR TITLE
fix: arm failure cooldown on interrupted codex app-server compaction (#75364)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2427,6 +2427,27 @@ def _compress_context_via_codex_app_server(
             existing_prompt = agent._build_system_prompt(system_message)
         return messages, existing_prompt
 
+    # Honor the compressor-owned failure cooldown so a previous interrupted
+    # compaction does not retry every turn.  ``force=True`` (explicit
+    # ``/compress``) bypasses the cooldown.
+    if not force:
+        compressor = getattr(agent, "context_compressor", None)
+        if compressor is not None:
+            _refresh_persisted_compression_guards(compressor)
+            cd = compressor.get_active_compression_failure_cooldown()
+            if cd:
+                logger.info(
+                    "codex app-server compaction skipped: failure cooldown "
+                    "active (session=%s remaining=%.0fs error=%s)",
+                    getattr(agent, "session_id", None) or "none",
+                    cd["remaining_seconds"],
+                    cd.get("error"),
+                )
+                existing_prompt = getattr(agent, "_cached_system_prompt", None)
+                if not existing_prompt:
+                    existing_prompt = agent._build_system_prompt(system_message)
+                return messages, existing_prompt
+
     codex_session = getattr(agent, "_codex_session", None)
     if codex_session is None:
         logger.info(
@@ -2490,6 +2511,14 @@ def _compress_context_via_codex_app_server(
             )
         except Exception:
             pass
+        # Arm the failure cooldown so the next turn does not retry immediately.
+        # Transcript returned unchanged → still above threshold; without a
+        # brake the compaction loop repeats every turn.
+        _cc = getattr(agent, "context_compressor", None)
+        if _cc is not None:
+            _rec = getattr(_cc, "_record_compression_failure_cooldown", None)
+            if callable(_rec):
+                _rec(600, str(result.error or "interrupted"))
         existing_prompt = getattr(agent, "_cached_system_prompt", None)
         if not existing_prompt:
             existing_prompt = agent._build_system_prompt(system_message)


### PR DESCRIPTION
fix: arm failure cooldown on interrupted codex app-server compaction (#75364)

When codex app-server compaction returns interrupted or error,
_compress_context_via_codex_app_server returned the transcript unchanged
without arming any failure brake. Since the session was still above
threshold, every subsequent turn retried compaction immediately — creating
an infinite retry loop that could last for hours.

Every other compression path records either a failure cooldown or an
ineffective-compression strike. The codex path did neither because it
dispatches before the cooldown guard block in compress_context.

Two changes:
1. On entry: check the compressor-owned failure cooldown before
   dispatching (honoring the same guard the Hermes summarizer path uses).
   force=True bypasses so explicit /compress is never braked.
2. On failure exit: record _record_compression_failure_cooldown(600s)
   on the context compressor so the next turn respects the cooldown.

Fixes #75364


## Changes

1. **Cooldown check on entry**: Before dispatching to `compact_thread()`, check `get_active_compression_failure_cooldown()` on the context compressor. If a cooldown is active, return early with the existing prompt. `force=True` bypasses so explicit `/compress` is never braked.

2. **Cooldown recording on failure**: When the codex compaction returns `interrupted` or `error`, call `_record_compression_failure_cooldown(600s)` on the context compressor so subsequent turns respect the cooldown.

## Test plan
- [x] Existing compression anti-thrash tests pass
- [x] Existing compression interrupt protection tests pass
- [x] Syntax validated

Fixes #75364