### PR TITLE
fix(desktop): adopt late-registered plugin theme on startup

### DIFF
--- a/apps/desktop/src/themes/context.test.tsx
+++ b/apps/desktop/src/themes/context.test.tsx
@@ -1,8 +1,11 @@
 import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { registry } from '@/contrib/registry'
+
 import { __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
 import { ThemeProvider } from './context'
+import { THEMES_AREA } from './user-themes'
 
 // The live-authoring loop: Hermes writes/edits one skin file and every surface
 // repaints. An in-place edit keeps the NAME — only the palette moves.
@@ -66,5 +69,60 @@ describe('ThemeProvider ← backend skin sync', () => {
       ingestBackendSkin({ name: 'forest', colors: { background: '#001100', ui_text: '#66ff66' } }, { apply: false })
     )
     expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
+  })
+})
+
+// A contributed theme (plugin / registry-backed) only enters the registry AFTER
+// boot. The boot paint and the provider's initial state resolve the persisted
+// pick through `normalizeSkin`, which falls back to the default when the name
+// doesn't resolve yet — so a chosen contributed theme snaps back to the default
+// on every restart unless the provider re-reads the persisted pick once the
+// theme registers.
+describe('ThemeProvider ← late-registered contributed theme', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    __resetBackendSkinSync()
+  })
+
+  afterEach(cleanup)
+
+  it('adopts a persisted contributed theme once it registers (survives restart)', () => {
+    // The user previously picked the contributed theme — that choice is durable.
+    window.localStorage.setItem('hermes-desktop-theme-v2', 'liquid')
+
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    // Theme isn't registered yet, so boot fell back to the default (nous:
+    // foreground #17171A). The persisted pick must not be lost, only deferred.
+    expect(cssVar('--theme-foreground')).toBe('#17171A')
+
+    // The plugin loads and registers its theme. The registry version bumps and
+    // the provider must re-read the persisted 'liquid' and repaint it.
+    let dispose!: () => void
+    act(() => {
+      dispose = registry.register({
+        id: 'liquid',
+        area: THEMES_AREA,
+        data: {
+          name: 'liquid',
+          label: 'Liquid Glass',
+          colors: { background: '#0a1120', foreground: '#f2f5fa', primary: '#0a84ff', ring: '#0a84ff', midground: '#0a84ff' },
+          // darkColors present → getBaseColors returns `colors` verbatim in
+          // light mode (no synthesis), so the assertion reads the literal seed.
+          darkColors: { background: '#05080f', foreground: '#e8edf7', primary: '#0a84ff', ring: '#0a84ff', midground: '#0a84ff' }
+        }
+      })
+    })
+
+    try {
+      expect(cssVar('--theme-foreground')).toBe('#f2f5fa')
+      expect(cssVar('--theme-background-seed')).toBe('#0a1120')
+    } finally {
+      dispose()
+    }
   })
 })

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -351,6 +351,19 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setModeState(modePref.resolve(profileKey))
   }, [profileKey])
 
+  // A contributed theme (plugin / registry-backed) registers AFTER boot, so the
+  // persisted pick that the boot paint and the initial state fell back from may
+  // only resolve now. Re-read the persisted skin whenever the registry grows; if
+  // it now resolves to something we're not already showing, adopt it. This is
+  // what lets a late-registered contributed theme the user already chose survive
+  // a restart instead of snapping back to the default. The functional update
+  // preserves reference identity on the common no-op path so unrelated registry
+  // churn never re-renders the (expensive) themed tree.
+  useEffect(() => {
+    const persisted = skinPref.resolve(profileKey)
+    setThemeNameState(prev => (persisted === prev ? prev : persisted))
+  }, [registryVersion, profileKey])
+
   const systemDark = useMediaQuery('(prefers-color-scheme: dark)')
   const resolvedMode = resolveMode(mode, systemDark)
 


### PR DESCRIPTION
## Problem

Plugin-contributed themes (registered into the runtime registry after boot)
snap back to the default theme on every restart, even though the user's choice
is correctly persisted in localStorage.

**Root cause:** `ThemeProvider` initialises its React state once via `useState()`.
At that point the plugin theme hasn't registered yet, so `normalizeSkin()`
silently falls back to the default. Nothing re-reads the persisted choice
after the theme becomes available.

## Fix

Add a `useEffect` keyed on `registryVersion` that re-reads the persisted skin
whenever the registry grows. If the persisted name now resolves and differs from
what's currently shown, adopt it. The functional `setState` preserves reference
identity on the no-op path, so unrelated registry churn never re-renders the
themed tree.

Only affects contributed (plugin) themes — builtin and user-installed
(localStorage-synchronous) themes were never impacted.

## Testing

New test in `context.test.tsx` reproduces the exact race:
persist choice → render (falls back to default) → register theme → assert adopted.

Verified red-green: test fails without the fix, passes with it.
Full themes suite: 8 files / 67 tests green.