### PR TITLE
closed: superseded private-gateway cache experiment

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1860,6 +1860,11 @@ def anthropic_prompt_cache_policy(
     gateway implements the Anthropic cache_control contract
     (MiniMax, Zhipu GLM, LiteLLM's Anthropic proxy mode all do).
 
+    IBM ICA Next serves Claude models through an OpenAI-compatible
+    ``chat_completions`` endpoint while still forwarding Anthropic-style
+    ``cache_control`` markers.  That route uses the OpenAI-wire envelope
+    layout, not the native Anthropic Messages layout.
+
     Qwen / Alibaba-family models on OpenCode, OpenCode Go, and direct
     Alibaba (DashScope) also honour Anthropic-style ``cache_control``
     markers on OpenAI-wire chat completions. Upstream pi-mono #3392 /
@@ -1931,6 +1936,10 @@ def anthropic_prompt_cache_policy(
     # OpenAI-wire envelope cache_control semantics. Treat it as an
     # OpenRouter-equivalent endpoint for caching layout purposes.
     is_nous_portal = "nousresearch" in eff_base_url.lower()
+    is_ica_next = (
+        provider_lower == "ica-next"
+        or base_url_host_matches(eff_base_url, "api.nextgen-beta.ica.ibm.com")
+    )
     is_anthropic_wire = eff_api_mode == "anthropic_messages"
     is_native_anthropic = (
         is_anthropic_wire
@@ -1948,6 +1957,16 @@ def anthropic_prompt_cache_policy(
         and (is_claude or is_kimi)
         and not is_anthropic_wire
     ):
+        return True, False
+    # IBM ICA Next exposes Claude models over an OpenAI-compatible
+    # chat-completions endpoint, but empirical API responses report real
+    # Anthropic cache writes/reads when envelope-layout cache_control markers
+    # are present (cache_creation_input_tokens/cache_read_input_tokens). Without
+    # this branch, Hermes sends no markers for provider=ica-next and every
+    # multi-turn Claude request reprocesses the full conversation prefix. Keep
+    # this Claude-gated: non-Claude ICA models (Gemini/GPT/etc.) use their own
+    # server-side caching semantics and should not receive Anthropic markers.
+    if is_ica_next and is_claude and not is_anthropic_wire:
         return True, False
     # Nous Portal Qwen (e.g. qwen3.6-plus) takes the same envelope-layout
     # cache_control path as Portal Claude. Portal proxies to OpenRouter

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -663,6 +663,62 @@ class TestInit:
             )
             assert a._use_prompt_caching is True
 
+    def test_prompt_caching_claude_ica_next(self):
+        """Claude model via ICA Next should enable OpenAI-wire prompt caching."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="ica-next",
+                model="claude-opus-5",
+                base_url="https://api.nextgen-beta.ica.ibm.com/ica/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert getattr(a, "_use_prompt_caching") is True
+            assert getattr(a, "_use_native_cache_layout") is False
+
+    def test_prompt_caching_claude_ica_next_by_host(self):
+        """ICA Next host detection covers custom-provider aliases."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="custom",
+                model="claude-sonnet-5",
+                base_url="https://api.nextgen-beta.ica.ibm.com/ica/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert getattr(a, "_use_prompt_caching") is True
+            assert getattr(a, "_use_native_cache_layout") is False
+
+    def test_prompt_caching_non_claude_ica_next(self):
+        """ICA Next cache_control opt-in is Claude-only."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                provider="ica-next",
+                model="gemini-3.6-flash",
+                base_url="https://api.nextgen-beta.ica.ibm.com/ica/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert getattr(a, "_use_prompt_caching") is False
+
     def test_prompt_caching_non_claude(self):
         """Non-Claude model should disable prompt caching."""
         with (

--- a/tests/test_base_url_hostname.py
+++ b/tests/test_base_url_hostname.py
@@ -52,6 +52,10 @@ class TestBaseUrlHostMatchesExact:
     def test_exact_domain_matches(self):
         assert base_url_host_matches("https://openrouter.ai/api/v1", "openrouter.ai") is True
         assert base_url_host_matches("https://moonshot.ai", "moonshot.ai") is True
+        assert base_url_host_matches(
+            "https://api.nextgen-beta.ica.ibm.com/ica/v1",
+            "api.nextgen-beta.ica.ibm.com",
+        ) is True
 
     def test_subdomain_matches(self):
         # A subdomain of the registered domain should match — needed for

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -456,7 +456,15 @@ The marker is applied differently based on content type:
 
 Prompt caching is automatically enabled when:
 - The model is an Anthropic Claude model (detected by model name)
-- The provider supports `cache_control` (native Anthropic API or OpenRouter)
+- The provider supports `cache_control` (native Anthropic API, OpenRouter,
+  Nous Portal/OpenRouter-compatible routes, or IBM ICA Next Claude routes)
+
+IBM ICA Next (`provider: ica-next`, host `api.nextgen-beta.ica.ibm.com`) serves
+Claude models through an OpenAI-compatible `chat_completions` endpoint, but it
+still honors Anthropic `cache_control` markers. Hermes therefore uses the
+OpenAI-wire/envelope marker layout for ICA Claude models (`native_layout=False`).
+Live verification should show `cache_creation_input_tokens` on the first request
+with a stable prefix and `cache_read_input_tokens` on subsequent requests.
 
 ```yaml
 # config.yaml — TTL is configurable (must be "5m" or "1h")


### PR DESCRIPTION
Closed by author request.

This experiment was superseded by a generic config-driven approach for custom
OpenAI-compatible Claude gateways that support Anthropic-style `cache_control`
markers on the envelope layout. No provider-specific endpoint details are
intended to be part of the public PR history.
