### PR TITLE
fix(desktop): allow updater handoff for gateway-only venv locks

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -196,9 +196,9 @@ import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
+import { canHandOffLockedUpdateToInstaller, listWindowsInstallVenvHolders } from './update-lock-handoff'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
-import { canHandOffLockedUpdateToInstaller, listWindowsInstallVenvHolders } from './update-lock-handoff'
 import {
   buildRelaunchScript,
   collectRelaunchArgs,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -198,6 +198,7 @@ import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
+import { canHandOffLockedUpdateToInstaller, listWindowsInstallVenvHolders } from './update-lock-handoff'
 import {
   buildRelaunchScript,
   collectRelaunchArgs,
@@ -2843,6 +2844,16 @@ async function releaseBackendLock(updateRoot, tag) {
   rememberLog(
     `[${tag}] venv shim still locked after 15s; aborting hand-off (something outside this app holds the venv)`
   )
+
+  const remainingHolders = listWindowsInstallVenvHolders(updateRoot)
+
+  if (canHandOffLockedUpdateToInstaller(updateRoot, remainingHolders)) {
+    rememberLog(
+      `[${tag}] venv shim still locked, but only same-install gateway process(es) remain; handing off so \`hermes update\` can pause/resume them safely`
+    )
+
+    return { unlocked: true }
+  }
 
   return { unlocked: false }
 }

--- a/apps/desktop/electron/update-lock-handoff.test.ts
+++ b/apps/desktop/electron/update-lock-handoff.test.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  canHandOffLockedUpdateToInstaller,
+  isSameInstallVenvHolder,
+  listWindowsInstallVenvHolders,
+  parseWindowsProcessList
+} from './update-lock-handoff'
+
+const UPDATE_ROOT = 'C:\\Users\\me\\.hermes\\hermes-agent'
+
+test('parseWindowsProcessList parses LIST-formatted WMIC output', () => {
+  const parsed = parseWindowsProcessList(
+    [
+      'CommandLine=C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run --replace',
+      'ExecutablePath=C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe',
+      'ProcessId=4242',
+      '',
+      'CommandLine=C:\\Windows\\System32\\notepad.exe',
+      'ExecutablePath=C:\\Windows\\System32\\notepad.exe',
+      'ProcessId=99',
+      ''
+    ].join('\n')
+  )
+
+  assert.deepEqual(parsed, [
+    {
+      commandLine:
+        'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run --replace',
+      executablePath: 'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe',
+      pid: 4242
+    },
+    {
+      commandLine: 'C:\\Windows\\System32\\notepad.exe',
+      executablePath: 'C:\\Windows\\System32\\notepad.exe',
+      pid: 99
+    }
+  ])
+})
+
+test('isSameInstallVenvHolder matches venv executables from the same install root', () => {
+  assert.equal(
+    isSameInstallVenvHolder(
+      {
+        commandLine: 'pythonw.exe -m hermes_cli.main gateway run --replace',
+        executablePath: 'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe',
+        pid: 4242
+      },
+      UPDATE_ROOT
+    ),
+    true
+  )
+})
+
+test('isSameInstallVenvHolder matches base interpreters that still target this install', () => {
+  assert.equal(
+    isSameInstallVenvHolder(
+      {
+        commandLine:
+          'C:\\Python313\\python.exe -m hermes_cli.main gateway run --replace --root C:\\Users\\me\\.hermes\\hermes-agent',
+        executablePath: 'C:\\Python313\\python.exe',
+        pid: 4242
+      },
+      UPDATE_ROOT
+    ),
+    true
+  )
+})
+
+test('canHandOffLockedUpdateToInstaller allows same-install gateways', () => {
+  assert.equal(
+    canHandOffLockedUpdateToInstaller(UPDATE_ROOT, [
+      {
+        commandLine:
+          'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run --replace',
+        executablePath: 'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe',
+        pid: 4242
+      }
+    ]),
+    true
+  )
+})
+
+test('canHandOffLockedUpdateToInstaller rejects same-install non-gateway holders', () => {
+  assert.equal(
+    canHandOffLockedUpdateToInstaller(UPDATE_ROOT, [
+      {
+        commandLine:
+          'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\python.exe -m hermes_cli.main serve --host 127.0.0.1',
+        executablePath: 'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\python.exe',
+        pid: 4242
+      }
+    ]),
+    false
+  )
+})
+
+test('listWindowsInstallVenvHolders filters to same-install venv holders and skips this process pid', () => {
+  const holders = listWindowsInstallVenvHolders(UPDATE_ROOT, () =>
+    [
+      'CommandLine=C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run --replace',
+      'ExecutablePath=C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe',
+      'ProcessId=4242',
+      '',
+      `CommandLine=${process.execPath}`,
+      `ExecutablePath=${process.execPath}`,
+      `ProcessId=${process.pid}`,
+      '',
+      'CommandLine=C:\\Windows\\System32\\notepad.exe',
+      'ExecutablePath=C:\\Windows\\System32\\notepad.exe',
+      'ProcessId=99',
+      ''
+    ].join('\n')
+  )
+
+  assert.deepEqual(holders, [
+    {
+      commandLine:
+        'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run --replace',
+      executablePath: 'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe',
+      pid: 4242
+    }
+  ])
+})
+
+test('listWindowsInstallVenvHolders falls back to PowerShell when wmic is unavailable', () => {
+  const calls: string[] = []
+  const holders = listWindowsInstallVenvHolders(UPDATE_ROOT, command => {
+    calls.push(command)
+    if (command === 'wmic') {
+      throw new Error('wmic missing')
+    }
+    return [
+      'CommandLine=C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run --replace',
+      'ExecutablePath=C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe',
+      'ProcessId=4242',
+      ''
+    ].join('\n')
+  })
+
+  assert.deepEqual(calls, ['wmic', 'powershell'])
+  assert.deepEqual(holders, [
+    {
+      commandLine:
+        'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run --replace',
+      executablePath: 'C:\\Users\\me\\.hermes\\hermes-agent\\venv\\Scripts\\pythonw.exe',
+      pid: 4242
+    }
+  ])
+})

--- a/apps/desktop/electron/update-lock-handoff.ts
+++ b/apps/desktop/electron/update-lock-handoff.ts
@@ -1,0 +1,141 @@
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+
+import { hiddenWindowsChildOptions } from './windows-child-options'
+
+export interface WindowsProcessEntry {
+  commandLine: string
+  executablePath: string
+  pid: number
+}
+
+type ProcessListRunner = (file: string, args: string[], options: unknown) => string
+
+function normalizeWindowsPathForCompare(value: string): string {
+  return path.win32.normalize(String(value || '')).replaceAll('/', '\\').toLowerCase()
+}
+
+export function isSameInstallVenvHolder(entry: Partial<WindowsProcessEntry>, updateRoot: string): boolean {
+  const commandLine = String(entry.commandLine || '')
+  const executablePath = String(entry.executablePath || '')
+  const commandLineLow = commandLine.toLowerCase().replaceAll('/', '\\')
+  const executableLow = executablePath.toLowerCase().replaceAll('/', '\\')
+  const normalizedRoot = normalizeWindowsPathForCompare(updateRoot)
+  const rootPrefix = `${normalizedRoot}\\`
+  const venvPrefix = `${rootPrefix}venv\\`
+
+  if (executableLow.startsWith(venvPrefix)) {
+    return true
+  }
+
+  if (commandLineLow.includes(venvPrefix)) {
+    return true
+  }
+
+  return commandLineLow.includes('hermes_cli.main') && commandLineLow.includes(normalizedRoot)
+}
+
+export function isGatewayRunCommand(commandLine: string): boolean {
+  return String(commandLine || '').toLowerCase().includes('gateway run')
+}
+
+export function canHandOffLockedUpdateToInstaller(
+  updateRoot: string,
+  entries: Array<Partial<WindowsProcessEntry>>
+): boolean {
+  const holders = entries.filter(entry => isSameInstallVenvHolder(entry, updateRoot))
+
+  return holders.length > 0 && holders.every(entry => isGatewayRunCommand(String(entry.commandLine || '')))
+}
+
+export function parseWindowsProcessList(text: string): WindowsProcessEntry[] {
+  const entries: WindowsProcessEntry[] = []
+  let current: Partial<WindowsProcessEntry> = {}
+
+  const flush = () => {
+    if (Number.isInteger(current.pid) && current.pid! > 0) {
+      entries.push({
+        commandLine: String(current.commandLine || ''),
+        executablePath: String(current.executablePath || ''),
+        pid: Number(current.pid)
+      })
+    }
+    current = {}
+  }
+
+  for (const rawLine of String(text || '').split(/\r?\n/)) {
+    const line = rawLine.trim()
+
+    if (!line) {
+      flush()
+      continue
+    }
+
+    if (line.startsWith('CommandLine=')) {
+      current.commandLine = line.slice('CommandLine='.length)
+      continue
+    }
+
+    if (line.startsWith('ExecutablePath=')) {
+      current.executablePath = line.slice('ExecutablePath='.length)
+      continue
+    }
+
+    if (line.startsWith('ProcessId=')) {
+      const pid = Number.parseInt(line.slice('ProcessId='.length), 10)
+
+      if (Number.isInteger(pid)) {
+        current.pid = pid
+      }
+    }
+  }
+
+  flush()
+  return entries
+}
+
+export function listWindowsInstallVenvHolders(
+  updateRoot: string,
+  run: ProcessListRunner = (file, args, options) => execFileSync(file, args, options as any)
+): WindowsProcessEntry[] {
+  const commands: Array<[string, string[]]> = [
+    ['wmic', ['process', 'get', 'ProcessId,ExecutablePath,CommandLine', '/FORMAT:LIST']],
+    [
+      'powershell',
+      [
+        '-NoProfile',
+        '-Command',
+        "Get-CimInstance Win32_Process | ForEach-Object { 'CommandLine=' + ($_.CommandLine -replace \"`r`n\",' ' -replace \"`n\",' '); 'ExecutablePath=' + $_.ExecutablePath; 'ProcessId=' + $_.ProcessId; '' }"
+      ]
+    ],
+    [
+      'pwsh',
+      [
+        '-NoProfile',
+        '-Command',
+        "Get-CimInstance Win32_Process | ForEach-Object { 'CommandLine=' + ($_.CommandLine -replace \"`r`n\",' ' -replace \"`n\",' '); 'ExecutablePath=' + $_.ExecutablePath; 'ProcessId=' + $_.ProcessId; '' }"
+      ]
+    ]
+  ]
+
+  for (const [command, args] of commands) {
+    try {
+      const stdout = run(
+        command,
+        args,
+        hiddenWindowsChildOptions({
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore']
+        })
+      )
+
+      return parseWindowsProcessList(stdout).filter(
+        entry => entry.pid !== process.pid && isSameInstallVenvHolder(entry, updateRoot)
+      )
+    } catch {
+      void 0
+    }
+  }
+
+  return []
+}


### PR DESCRIPTION
## Summary
- treat Windows update-lock timeouts as recoverable when the remaining same-install venv holders are only `gateway run` processes
- add a focused Windows process scanner with WMIC and PowerShell fallbacks to identify same-install holders safely
- add Electron tests for holder detection, gateway-only handoff decisions, and WMIC fallback behavior

## Problem
Issue #75334 describes a real dead-end in the Desktop self-update flow on Windows: the desktop preflight waits for the venv shim lock to disappear, but it only kills backends the desktop itself owns. If the remaining lock holder is a same-install `hermes gateway run` process, Desktop aborts the update even though `hermes update` already knows how to pause and resume Windows gateways safely.

## Fix
After the 15s Desktop-side unlock wait expires, this change inspects the remaining same-install venv holders. If they are all gateway processes, Desktop now hands off to the updater instead of aborting, letting the existing `hermes update` pause/resume logic finish the job. Non-gateway holders still block the update exactly as before.

## Testing
- `cd apps/desktop && npx vitest run --project electron electron/update-lock-handoff.test.ts electron/windows-child-options.test.ts`
- `cd apps/desktop && npx tsc -p tsconfig.electron.json --noEmit`

Closes #75334
