### PR TITLE
fix(desktop): convert artifact timestamps to milliseconds

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -273,7 +273,7 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         sessionTitle: title,
-        timestamp: message.timestamp || session.last_active || session.started_at || Date.now()
+        timestamp: Math.round((message.timestamp || session.last_active || session.started_at || Date.now() / 1000) * 1000)
       })
     })
   }

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -67,6 +67,27 @@ describe('collectArtifactsForSession', () => {
     })
   })
 
+  it('converts unix-seconds message timestamps to milliseconds for display', () => {
+    const artifacts = collectArtifactsForSession(makeSession({ last_active: 1, started_at: 1 }), [
+      {
+        content: 'https://example.com/ms',
+        role: 'assistant',
+        timestamp: 1785496833
+      }
+    ])
+
+    expect(artifacts[0].timestamp).toBe(1785496833000)
+  })
+
+  it('falls back to session timestamps (seconds) when a message has none', () => {
+    const artifacts = collectArtifactsForSession(
+      makeSession({ last_active: 1785496000, started_at: 1785490000 }),
+      [{ content: 'https://example.com/fallback', role: 'assistant' }]
+    )
+
+    expect(artifacts[0].timestamp).toBe(1785496000000)
+  })
+
   it('resolves remote image artifact thumbnails through the desktop fs bridge', async () => {
     const api = vi.fn(async ({ path }: { path: string }) => {
       if (path.startsWith('/api/fs/read-data-url?')) {


### PR DESCRIPTION
## Problem

Every artifact in the **Artifacts** page of the desktop app shows a time of **Jan 1970**, regardless of when it was created.

## Root cause

`collectArtifactsForSession` stores `message.timestamp || session.last_active || session.started_at || Date.now()` directly on the artifact record. All of those values are **unix-seconds** (the API returns `messages.timestamp` verbatim from the session DB), but the artifacts page renders them via `new Date(timestamp)` — and the JS `Date` constructor expects **milliseconds**. Seconds fed to `new Date()` resolve to ~Jan 21 1970.

The thread view is unaffected because it renders from `createdAt` (a separate path); only the Artifacts page shows the wrong times.

## Fix

Multiply the seconds value by 1000 when building the record, normalizing the `Date.now()` fallback to seconds first so all three sources stay consistent:

```ts
timestamp: Math.round((message.timestamp || session.last_active || session.started_at || Date.now() / 1000) * 1000)
```

## Tests

Added two regression tests to `apps/desktop/src/app/artifacts/index.test.ts`:
- message timestamps (seconds) are converted to milliseconds
- session-timestamp fallback is converted as well

All 5 tests in the file pass:
```
✓  ui  src/app/artifacts/index.test.ts (5 tests)
Test Files  1 passed (1)
Tests  5 passed (5)
```
