### PR TITLE
fix(sessions): finalize abandoned lifecycle rows

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1337,9 +1337,57 @@ def _notify_single_query_session_finalize(cli, *, reason: str = "shutdown") -> N
         _single_query_finalize_attempted_session_ids.add(session_id)
 
 
+def _finalize_owned_cli_session_row(cli) -> None:
+    """Persist and end the SQLite row owned by a terminating CLI surface."""
+    agent = getattr(cli, "agent", None)
+    session_id = getattr(agent, "session_id", None) or getattr(cli, "session_id", None)
+    session_db = getattr(cli, "_session_db", None)
+    if not session_db or not session_id:
+        return
+
+    persist = getattr(cli, "_persist_active_session_before_close", None)
+    if callable(persist):
+        try:
+            persisted = persist()
+        except (Exception, KeyboardInterrupt) as exc:
+            # Never mark the row closed if the final transcript flush failed.
+            # Leaving it open is fail-closed: later recovery preserves the
+            # already-durable transcript and keeps the persistence failure
+            # visible instead of converting it into a clean terminal state.
+            warning = (
+                "Warning: final transcript persistence failed; session row was left open "
+                "for audited recovery."
+            )
+            logger.warning("Could not persist CLI session before close: %s", exc)
+            print(warning, file=sys.stderr)
+            return
+        if persisted is False:
+            warning = (
+                "Warning: final transcript persistence failed; session row was left open "
+                "for audited recovery."
+            )
+            logger.warning("CLI session persistence reported failure before close")
+            print(warning, file=sys.stderr)
+            return
+
+    try:
+        session_db.end_session(session_id, "cli_close")
+    except (Exception, KeyboardInterrupt) as exc:
+        logger.debug("Could not close CLI session in DB: %s", exc)
+
+    if not getattr(cli, "_delete_session_on_exit", False):
+        discard_empty = getattr(cli, "_discard_session_if_empty", None)
+        if callable(discard_empty):
+            try:
+                discard_empty(session_id)
+            except (Exception, KeyboardInterrupt) as exc:
+                logger.debug("Could not prune empty CLI session: %s", exc)
+
+
 def _finalize_single_query(cli) -> None:
     """Close one-shot CLI resources before releasing the active session lease."""
     try:
+        _finalize_owned_cli_session_row(cli)
         _notify_single_query_session_finalize(cli)
         _run_cleanup(notify_session_finalize=False)
     finally:
@@ -2148,6 +2196,32 @@ def _run_state_db_auto_maintenance(session_db) -> None:
             logger.debug("Orphan compression finalize skipped: %s", _finalize_exc)
 
         cfg = (_load_full_config().get("sessions") or {})
+
+        # Reconcile proven process-owned crashes before native retention. This
+        # is bounded and interval-gated in state_meta; failures are isolated so
+        # existing archive/prune maintenance still runs.
+        try:
+            from hermes_cli.active_sessions import recover_abandoned_session_rows
+
+            recovery = recover_abandoned_session_rows(
+                session_db,
+                apply=True,
+                older_than_seconds=86400.0,
+                limit=100,
+                respect_interval_seconds=(
+                    float(cfg.get("min_interval_hours", 24)) * 3600.0
+                ),
+            )
+            recovered_count = len(recovery.get("recovered_ids") or [])
+            if recovered_count:
+                logger.info(
+                    "Finalized %d proven abandoned CLI session(s)",
+                    recovered_count,
+                )
+        except Exception as _recovery_exc:
+            logger.warning(
+                "Abandoned-session recovery skipped: %s", _recovery_exc
+            )
 
         # Auto-archive (soft-hide stale sessions) is independent of the
         # destructive auto_prune sweep — run it first, before prune's early
@@ -4571,12 +4645,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     f"saved to disk and cannot be resumed later. Reason: {e}"
                 )
 
-        # Opportunistic state.db maintenance — runs at most once per
-        # min_interval_hours, tracked via state_meta in state.db itself so
-        # it's shared across all Hermes processes for this HERMES_HOME.
-        # Never blocks startup on failure.
-        _run_state_db_auto_maintenance(self._session_db)
-
         # Opportunistic shadow-repo cleanup — deletes orphan/stale
         # checkpoint repos under ~/.hermes/checkpoints/.  Opt-in via
         # checkpoints.auto_prune, idempotent via .last_prune marker.
@@ -4734,14 +4802,34 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             )
         except Exception as exc:
             logger.warning("Failed to claim active session slot: %s", exc)
-            return True
+            message = (
+                "Hermes could not register process ownership; refusing to start "
+                "without lifecycle safety evidence."
+            )
+            if stderr:
+                print(message, file=sys.stderr)
+            else:
+                self._console_print(f"[bold red]{message}[/]")
+            return False
         if message:
             if stderr:
                 print(message, file=sys.stderr)
             else:
                 self._console_print(f"[bold red]{message}[/]")
             return False
+        if lease is None:
+            message = "Hermes did not receive a process ownership lease; refusing to start."
+            if stderr:
+                print(message, file=sys.stderr)
+            else:
+                self._console_print(f"[bold red]{message}[/]")
+            return False
         self._active_session_lease = lease
+        # Owner registration must precede state maintenance. Recovery runs
+        # first inside that boundary, then normal archive/prune retention.
+        session_db = getattr(self, "_session_db", None)
+        if lease is not None and session_db is not None:
+            _run_state_db_auto_maintenance(session_db)
         try:
             atexit.register(self._release_active_session)
         except Exception:
@@ -14206,8 +14294,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             pass
 
-    def _persist_active_session_before_close(self):
-        """Best-effort SQLite/JSON flush before the CLI marks a session closed.
+    def _persist_active_session_before_close(self) -> bool:
+        """Flush SQLite/JSON state and report whether finalization is safe.
 
         ``run_conversation()`` normally persists at turn boundaries, but a
         terminal close/SIGHUP/SIGTERM can unwind the prompt_toolkit app while
@@ -14216,12 +14304,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         session_search, and state.db do not lose the interrupted turn.
         """
         agent = getattr(self, "agent", None)
-        if not agent or not hasattr(agent, "_persist_session"):
-            return
+        if not agent:
+            return True
+        if not hasattr(agent, "_persist_session"):
+            return False
 
         persist_lock = getattr(agent, "_session_persist_lock", None)
 
-        def _snapshot_and_persist() -> None:
+        def _snapshot_and_persist() -> bool:
             # This snapshot must share the staging lock with ``chat()``. Without
             # it, close can retain a mutable history baseline just before chat
             # appends its pending dict; the later flush then mistakes that dict
@@ -14231,7 +14321,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if not isinstance(messages, list):
                 messages = getattr(self, "conversation_history", None)
             if not isinstance(messages, list):
-                return
+                return False
             if isinstance(pending_cli_message, dict) and not any(
                 message is pending_cli_message for message in messages
             ):
@@ -14240,7 +14330,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # keeps any durable resumed prefix from being re-appended.
                 messages = [*messages, pending_cli_message]
             if not messages:
-                return
+                return True
 
             # A normal turn builds a new list that reuses the resumed-history dicts.
             # Keep that CLI history as the baseline so a signal between assigning
@@ -14273,23 +14363,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     _restore_or_build_system_prompt(agent, None, conversation_history)
                 except Exception:
                     logger.debug("Could not build system prompt during CLI close", exc_info=True)
-                    return
+                    return False
             if getattr(agent, "_cached_system_prompt", None) is None:
-                return
+                return False
 
             agent._ensure_db_session()
-            agent._persist_session(messages, conversation_history)
+            persisted = agent._persist_session(messages, conversation_history)
+            if persisted is False:
+                return False
             if getattr(agent, "session_id", None):
                 self.session_id = agent.session_id
+            return True
 
         try:
             if persist_lock is None:
-                _snapshot_and_persist()
-            else:
-                with persist_lock:
-                    _snapshot_and_persist()
+                return _snapshot_and_persist()
+            with persist_lock:
+                return _snapshot_and_persist()
         except (Exception, KeyboardInterrupt) as e:
             logger.debug("Could not persist active CLI session before close: %s", e)
+            return False
 
     def _print_exit_summary(self, clear_screen: bool = True):
         """Print session resume info on exit, similar to Claude Code.
@@ -17291,40 +17384,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             set_sudo_password_callback(None)
             set_approval_callback(None)
             set_secret_capture_callback(None)
-            # Flush any in-memory turn transcript before marking the session
-            # closed.  On SIGHUP/SIGTERM/window close the agent thread may not
-            # reach its normal run_conversation() persistence path before the
-            # daemon thread is reaped.
-            self._persist_active_session_before_close()
+            # Persist and close the SQLite row through the same idempotent owner
+            # boundary used by one-shot mode. Transcript persistence happens
+            # before end_session(); the first terminal reason still wins.
+            _finalize_owned_cli_session_row(self)
 
-            # Close session in SQLite
-            if hasattr(self, '_session_db') and self._session_db and self.agent:
+            # /exit --delete: also remove the current session's transcripts
+            # and SQLite history. Ported from google-gemini/gemini-cli#19332.
+            if (
+                getattr(self, '_delete_session_on_exit', False)
+                and self._session_db
+                and self.agent
+            ):
                 try:
-                    self._session_db.end_session(self.agent.session_id, "cli_close")
+                    from hermes_constants import get_hermes_home as _ghh
+                    _sessions_dir = _ghh() / "sessions"
+                    _sid = self.agent.session_id
+                    if self._session_db.delete_session(_sid, sessions_dir=_sessions_dir):
+                        _cprint(f"  {_DIM}✓ Session {_escape(_sid)} deleted{_RST}")
+                    else:
+                        _cprint(f"  {_DIM}✗ Session {_escape(_sid)} not found for deletion{_RST}")
                 except (Exception, KeyboardInterrupt) as e:
-                    logger.debug("Could not close session in DB: %s", e)
-                # Started-and-immediately-quit sessions never gained content;
-                # drop the empty row so /resume and `hermes sessions list`
-                # stay clean (gemini-cli#27770 port). No-op for resumed or
-                # titled sessions and anything with messages or children.
-                if not getattr(self, '_delete_session_on_exit', False):
-                    try:
-                        self._discard_session_if_empty(self.agent.session_id)
-                    except (Exception, KeyboardInterrupt) as e:
-                        logger.debug("Could not prune empty session: %s", e)
-                # /exit --delete: also remove the current session's transcripts
-                # and SQLite history. Ported from google-gemini/gemini-cli#19332.
-                if getattr(self, '_delete_session_on_exit', False):
-                    try:
-                        from hermes_constants import get_hermes_home as _ghh
-                        _sessions_dir = _ghh() / "sessions"
-                        _sid = self.agent.session_id
-                        if self._session_db.delete_session(_sid, sessions_dir=_sessions_dir):
-                            _cprint(f"  {_DIM}✓ Session {_escape(_sid)} deleted{_RST}")
-                        else:
-                            _cprint(f"  {_DIM}✗ Session {_escape(_sid)} not found for deletion{_RST}")
-                    except (Exception, KeyboardInterrupt) as e:
-                        logger.debug("Could not delete session on exit: %s", e)
+                    logger.debug("Could not delete session on exit: %s", e)
             # Plugin hook: on_session_end — safety net for interrupted exits.
             # run_conversation() already fires this per-turn on normal completion,
             # so only fire here if the agent was mid-turn (_agent_running) when

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Gateway developers and maintainers
 > **Source files:** `gateway/session.py` (~1444 lines), `gateway/run.py` (~16800 lines), `gateway/config.py`
-> **Last updated:** 2026-06-16
+> **Last updated:** 2026-07-31
 
 ## Overview
 
@@ -611,6 +611,71 @@ Session expiry watcher evicts agent when session finalizes
 When a session expires:
 1. `_cleanup_agent_resources(agent)` — shuts down memory provider, closes tool resources.
 2. `_evict_cached_agent(key)` — removes from `_agent_cache` so the agent can be GC'd.
+
+---
+
+## 9. Process-owned CLI row finalization and recovery
+
+CLI processes, gateway turns, and the first real TUI/Desktop turn register an
+owner lease in `~/.hermes/runtime/active_sessions.json` before running an agent.
+Registration remains active even when `max_concurrent_sessions` enforcement is
+disabled; the registry is also safety evidence for abandoned-row recovery. A
+registration exception or missing lease rejects the turn rather than running
+without ownership evidence. PID identity includes process start time to resist
+PID reuse.
+
+Normal interactive and `chat -q` shutdown persist the in-memory transcript, end
+the owned SQLite row, then release the owner lease. Empty untitled sessions are
+still deleted by the existing empty-session hygiene rule. Cron and delegated
+children retain their own existing owner/finalizer paths.
+
+Startup recovery is deliberately narrow and fail-closed:
+
+- only `source='cli'` rows from the always-on owner-lease era are eligible;
+- inactivity must exceed 24 hours (default);
+- a live owner lease excludes the row;
+- gateway metadata/routing, Telegram topic bindings, any handoff state,
+  compression locks, active delegations, live parent/child relationships,
+  pinned rows, and archived rows exclude the row;
+- ambiguous rows are reported with an explicit reason and left untouched;
+- recovery only sets `ended_at` and `end_reason='orphan_recovered'`; messages,
+  titles, metadata, and parent/child fields are not deleted or rewritten;
+- startup attempts are bounded by the configured maintenance interval and a
+  persistent last-attempt marker;
+- protected rows do not consume the recoverable-candidate batch limit, so an
+  old pinned, handed-off, delegated, routed, or otherwise protected row cannot
+  permanently starve a later proven orphan;
+- apply classification and update run in one SQLite write transaction while
+  holding the cross-process owner-registry lock; dry classification uses a read
+  connection and does not enter the write/checkpoint path.
+
+### Audit and manual apply
+
+The maintenance command is dry-run by default:
+
+```bash
+hermes sessions finalize-orphans
+hermes sessions finalize-orphans --json
+```
+
+It reports proven candidates and exclusion reasons without creating the lease
+epoch, creating/pruning the owner registry, entering the SQLite write/checkpoint
+path, or changing session rows. The audit copies a verified-stable main database
+to a temporary file and opens only that copy with immutable SQLite access, so
+the live database and WAL/SHM sidecars remain byte-identical. It rejects a
+non-empty WAL or rollback journal and also rejects any main-file or sidecar
+change observed while taking the snapshot rather than returning a potentially
+incomplete report. The temporary snapshot is removed on close. To request a
+write:
+
+```bash
+hermes sessions finalize-orphans --apply --yes
+```
+
+`--apply` requires `--yes`, always performs a fresh dry classification first,
+then reclassifies under the registry lock before changing any row. Use
+`--min-age-hours` and `--limit` to adjust the
+bounded scan. This command is not a transcript-deletion or database-repair tool.
 
 ---
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8141,7 +8141,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> tuple[Any, Optional[str]]:
         """Claim a cross-process active-session slot for a new gateway turn."""
         if self._is_session_running(session_key):
-            return None, None
+            return None, "A turn is already active for this session; please retry shortly."
         local_limit_message = self._active_session_limit_message(session_key)
         if local_limit_message is not None:
             return None, local_limit_message
@@ -8149,7 +8149,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from hermes_cli.active_sessions import try_acquire_active_session
 
             platform = source.platform.value if source and source.platform else "gateway"
-            return try_acquire_active_session(
+            lease, message = try_acquire_active_session(
                 session_id=session_key,
                 surface=f"gateway:{platform}",
                 config=getattr(self, "config", None),
@@ -8159,9 +8159,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "user_id": getattr(source, "user_id", "") or "",
                 },
             )
+            if lease is None and message is None:
+                message = (
+                    "Hermes could not register process ownership; refusing this turn "
+                    "without lifecycle safety evidence."
+                )
+            return lease, message
         except Exception as exc:
             logger.warning("Failed to claim active session slot: %s", exc)
-            return None, None
+            return (
+                None,
+                "Hermes could not register process ownership; refusing this turn "
+                "without lifecycle safety evidence.",
+            )
 
     @staticmethod
     def _agent_has_active_subagents(running_agent: Any) -> bool:

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import time
 import uuid
@@ -179,18 +180,44 @@ class _FileLock:
             self._fh = None
 
 
-def _read_entries(path: Path) -> list[dict[str, Any]]:
+def _read_entries(path: Path, *, strict: bool = False) -> list[dict[str, Any]]:
     try:
         with open(path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
     except FileNotFoundError:
         return []
-    except Exception:
+    except Exception as exc:
+        if strict:
+            raise RuntimeError(f"invalid active session registry: {path}") from exc
         logger.warning("Ignoring corrupt active session registry at %s", path)
         return []
     entries = data.get("entries") if isinstance(data, dict) else data
     if not isinstance(entries, list):
+        if strict:
+            raise RuntimeError(f"invalid active session registry: {path}")
         return []
+    if strict:
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise RuntimeError(f"invalid active session registry: {path}")
+            pid_raw = entry.get("pid")
+            process_start = _optional_float(entry.get("process_start_time"))
+            try:
+                pid = int(str(pid_raw))
+            except (TypeError, ValueError):
+                raise RuntimeError(
+                    f"invalid active session registry: {path}"
+                ) from None
+            if (
+                pid <= 0
+                or process_start is None
+                or process_start <= 0
+                or not isinstance(entry.get("lease_id"), str)
+                or not entry.get("lease_id")
+                or not isinstance(entry.get("session_id"), str)
+                or not entry.get("session_id")
+            ):
+                raise RuntimeError(f"invalid active session registry: {path}")
     return [entry for entry in entries if isinstance(entry, dict)]
 
 
@@ -217,7 +244,8 @@ def _optional_float(value: Any) -> Optional[float]:
     if value is None or value == "":
         return None
     try:
-        return float(value)
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else None
     except (TypeError, ValueError):
         return None
 
@@ -234,13 +262,16 @@ def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
 
         exists = bool(_pid_exists(pid_int))
     except Exception:
-        return False
+        # Owner liveness is a safety proof. If the process table cannot be
+        # inspected, retain the lease as potentially live rather than allowing
+        # recovery to finalize its session row.
+        return True
     if not exists:
         return False
     expected_start = _optional_float(process_start_time)
     if expected_start is None:
         return True
-    current_start = _process_start_time(pid_int)
+    current_start = _optional_float(_process_start_time(pid_int))
     if current_start is None:
         return True
     return abs(current_start - expected_start) < 0.001
@@ -277,26 +308,24 @@ def try_acquire_active_session(
 ) -> tuple[Optional[ActiveSessionLease], Optional[str]]:
     """Acquire an active-session slot.
 
-    Returns ``(lease, None)`` on success.  When the cap is disabled, the lease is
-    a no-op object so callers can unconditionally call ``release()``.
+    Returns ``(lease, None)`` on success. Owner identity is registered even
+    when the concurrency cap is disabled; only cap rejection is skipped.
     """
     max_sessions = resolve_max_concurrent_sessions(config)
     lease_id = uuid.uuid4().hex
-    if max_sessions is None:
-        return ActiveSessionLease(
-            lease_id=lease_id,
-            session_id=session_id,
-            surface=surface,
-            enabled=False,
-        ), None
 
     now = time.time()
+    process_start_time = _optional_float(_process_start_time(os.getpid()))
+    if process_start_time is None:
+        raise RuntimeError(
+            "active session owner identity unavailable: process start time missing"
+        )
     entry = {
         "lease_id": lease_id,
         "session_id": str(session_id),
         "surface": str(surface),
         "pid": os.getpid(),
-        "process_start_time": _process_start_time(os.getpid()),
+        "process_start_time": process_start_time,
         "started_at": now,
         "updated_at": now,
     }
@@ -307,13 +336,13 @@ def try_acquire_active_session(
 
     state_path = _state_path()
     with _FileLock(_lock_path()):
-        raw_entries = _read_entries(state_path)
+        raw_entries = _read_entries(state_path, strict=True)
         entries = _prune_dead(raw_entries)
         pruned = len(raw_entries) - len(entries)
         if pruned:
             logger.info("Pruned %d stale active session lease(s)", pruned)
         active_count = len(entries)
-        if active_count >= max_sessions:
+        if max_sessions is not None and active_count >= max_sessions:
             _write_entries(state_path, entries)
             logger.info(
                 "Active session limit reached: active=%d max=%d surface=%s",
@@ -338,7 +367,7 @@ def release_active_session(lease: ActiveSessionLease) -> None:
     state_path = _state_path()
     try:
         with _FileLock(_lock_path()):
-            entries = _prune_dead(_read_entries(state_path))
+            entries = _prune_dead(_read_entries(state_path, strict=True))
             kept = [
                 entry
                 for entry in entries
@@ -368,7 +397,7 @@ def transfer_active_session(
 
     state_path = _state_path()
     with _FileLock(_lock_path()):
-        entries = _prune_dead(_read_entries(state_path))
+        entries = _prune_dead(_read_entries(state_path, strict=True))
         updated = False
         for entry in entries:
             if str(entry.get("lease_id") or "") != lease.lease_id:
@@ -399,12 +428,11 @@ def release_orphaned_leases(live_lease_ids: set[str]) -> int:
     """
     pid = os.getpid()
     state_path = _state_path()
-    # With the cap disabled the registry is never written, so don't take a lock
-    # (or create its file) on the idle-reaper tick for the majority of installs.
+    # Avoid taking the lock (or creating it) when no registry exists yet.
     if not state_path.exists():
         return 0
     with _FileLock(_lock_path()):
-        entries = _prune_dead(_read_entries(state_path))
+        entries = _prune_dead(_read_entries(state_path, strict=True))
         kept = [
             entry
             for entry in entries
@@ -418,9 +446,82 @@ def release_orphaned_leases(live_lease_ids: set[str]) -> int:
 
 
 def active_session_registry_snapshot() -> list[dict[str, Any]]:
-    """Return the pruned active-session registry for diagnostics/tests."""
+    """Return a pruned active-session snapshot for diagnostics."""
     state_path = _state_path()
     with _FileLock(_lock_path()):
-        entries = _prune_dead(_read_entries(state_path))
+        entries = _prune_dead(_read_entries(state_path, strict=True))
         _write_entries(state_path, entries)
-        return entries
+        return [dict(entry) for entry in entries]
+
+
+def recover_abandoned_session_rows(
+    session_db: Any,
+    *,
+    apply: bool = True,
+    older_than_seconds: float = 86400,
+    limit: int = 100,
+    now: Optional[float] = None,
+    respect_interval_seconds: Optional[float] = None,
+) -> dict[str, Any]:
+    """Classify/recover rows using owner evidence; apply holds the registry lock."""
+    current_time = time.time() if now is None else float(now)
+    state_path = _state_path()
+
+    def _recover(entries: list[dict[str, Any]]) -> dict[str, Any]:
+        active_ids = {
+            str(entry.get("session_id"))
+            for entry in entries
+            if entry.get("session_id")
+        }
+        if apply and respect_interval_seconds is not None:
+            if not session_db.claim_lifecycle_recovery_attempt(
+                now=current_time,
+                interval_seconds=float(respect_interval_seconds),
+            ):
+                return {
+                    "candidate_ids": [],
+                    "recovered_ids": [],
+                    "excluded": {},
+                    "skipped": "interval",
+                }
+        if apply:
+            try:
+                epoch = session_db.get_or_create_lifecycle_recovery_epoch(
+                    now=current_time
+                )
+            except (TypeError, ValueError, RuntimeError):
+                return {
+                    "candidate_ids": [],
+                    "recovered_ids": [],
+                    "excluded": {},
+                    "skipped": "invalid_epoch",
+                }
+        else:
+            epoch = session_db.get_lifecycle_recovery_epoch()
+            if epoch is None:
+                # No always-on lease era has been established yet. Treat every
+                # existing row as legacy/unproven without writing marker state.
+                epoch = current_time
+        return session_db.recover_abandoned_sessions(
+            older_than_seconds=older_than_seconds,
+            active_session_ids=active_ids,
+            eligible_started_after=epoch,
+            source_allowlist=("cli",),
+            limit=limit,
+            now=current_time,
+            apply=apply,
+            report_legacy_exclusions=not apply,
+        )
+
+    if not apply:
+        # A preview is never mutation authority. Read the atomically replaced
+        # registry without taking/creating its lock, and reclassify under lock
+        # if the operator later requests apply.
+        return _recover(_prune_dead(_read_entries(state_path, strict=True)))
+
+    with _FileLock(_lock_path()):
+        raw_entries = _read_entries(state_path, strict=True)
+        entries = _prune_dead(raw_entries)
+        if len(entries) != len(raw_entries):
+            _write_entries(state_path, entries)
+        return _recover(entries)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12141,6 +12141,40 @@ def main():
 
     sessions_subparsers.add_parser("stats", help="Show session store statistics")
 
+    sessions_finalize_orphans = sessions_subparsers.add_parser(
+        "finalize-orphans",
+        help="Audit or finalize proven abandoned CLI session rows",
+        description=(
+            "Report old unended CLI rows using live process-owner and state "
+            "evidence. Default is read-only. --apply reclassifies under the "
+            "owner-registry lock, then only sets ended_at/end_reason; it never "
+            "deletes transcripts."
+        ),
+    )
+    sessions_finalize_orphans.add_argument(
+        "--apply",
+        action="store_true",
+        help="Finalize proven candidates; requires --yes (default: dry run)",
+    )
+    sessions_finalize_orphans.add_argument(
+        "--yes", "-y", action="store_true", help="Authorize metadata-only apply"
+    )
+    sessions_finalize_orphans.add_argument(
+        "--min-age-hours",
+        type=float,
+        default=24.0,
+        help="Minimum inactivity age in hours (default: 24)",
+    )
+    sessions_finalize_orphans.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum old unended rows to classify (default: 100)",
+    )
+    sessions_finalize_orphans.add_argument(
+        "--json", action="store_true", help="Print the full machine-readable report"
+    )
+
     sessions_rename = sessions_subparsers.add_parser(
         "rename", help="Set or change a session's title"
     )

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -224,13 +224,128 @@ def cmd_sessions(args, sessions_parser=None):
         print("  Do not install it. Review the JSON report for partial data or errors.")
         return 1
 
+    min_age_hours = 24.0
+    limit = 100
+    if action == "finalize-orphans":
+        min_age_hours = float(getattr(args, "min_age_hours", 24.0))
+        limit = int(getattr(args, "limit", 100))
+        if min_age_hours <= 0:
+            print("Error: --min-age-hours must be greater than zero.")
+            return 2
+        if limit <= 0:
+            print("Error: --limit must be greater than zero.")
+            return 2
+
     try:
         from hermes_state import SessionDB
 
-        db = SessionDB()
+        if action == "finalize-orphans":
+            db = SessionDB(read_only=True, immutable=True)
+        else:
+            db = SessionDB()
     except Exception as e:
         print(f"Error: Could not open session database: {e}")
-        return
+        return 1 if action == "finalize-orphans" else None
+
+    # Audit-first abandoned-row maintenance. Always classify read-only before
+    # any confirmation or apply; apply then reclassifies under the registry
+    # lock so stale preview evidence can never authorize a write.
+    if action == "finalize-orphans":
+        from collections import Counter as _Counter
+        from hermes_cli.active_sessions import recover_abandoned_session_rows
+
+        try:
+            dry_report = recover_abandoned_session_rows(
+                db,
+                apply=False,
+                older_than_seconds=min_age_hours * 3600.0,
+                limit=limit,
+            )
+        except Exception as e:
+            print(f"Error: Could not audit abandoned sessions: {e}")
+            db.close()
+            return 1
+        candidates = list(dry_report.get("candidate_ids") or [])
+        excluded = dict(dry_report.get("excluded") or {})
+        report = {
+            "mode": "dry_run",
+            "min_age_hours": min_age_hours,
+            "limit": limit,
+            **dry_report,
+        }
+
+        if not getattr(args, "apply", False):
+            if getattr(args, "json", False):
+                print(_json.dumps(report, indent=2, sort_keys=True))
+            else:
+                reason_counts = _Counter(
+                    reason
+                    for reasons in excluded.values()
+                    for reason in reasons
+                )
+                print("Dry run — no session rows were changed.")
+                print(f"  proven candidates: {len(candidates)}")
+                print(f"  excluded/ambiguous: {len(excluded)}")
+                for reason, count in sorted(reason_counts.items()):
+                    print(f"    {reason}: {count}")
+                if candidates:
+                    print("  candidate session IDs:")
+                    for session_id in candidates:
+                        print(f"    {session_id}")
+                print(
+                    "Use --apply --yes to reclassify and finalize proven candidates."
+                )
+            db.close()
+            return 0
+
+        if not getattr(args, "yes", False):
+            print("Error: --apply requires --yes after reviewing the dry-run report.")
+            db.close()
+            return 2
+
+        if not candidates:
+            report["mode"] = "apply"
+            report["apply_skipped"] = "no_proven_candidates"
+            if getattr(args, "json", False):
+                print(_json.dumps(report, indent=2, sort_keys=True))
+            else:
+                print("No proven abandoned session rows to finalize.")
+            db.close()
+            return 0
+
+        db.close()
+        try:
+            db = SessionDB()
+        except Exception as e:
+            print(f"Error: Could not reopen session database for apply: {e}")
+            return 1
+        try:
+            applied = recover_abandoned_session_rows(
+                db,
+                apply=True,
+                older_than_seconds=min_age_hours * 3600.0,
+                limit=limit,
+            )
+        except Exception as e:
+            print(f"Error: Could not finalize abandoned sessions: {e}")
+            db.close()
+            return 1
+        report = {
+            "mode": "apply",
+            "min_age_hours": min_age_hours,
+            "limit": limit,
+            "dry_run": dry_report,
+            "apply": applied,
+        }
+        if getattr(args, "json", False):
+            print(_json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(
+                f"Finalized {len(applied.get('recovered_ids') or [])} "
+                "proven abandoned session row(s); transcripts were preserved."
+            )
+        db.close()
+        return 0
 
     # Hide third-party tool sessions by default, but honour explicit --source
     _source = getattr(args, "source", None)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -16,15 +16,19 @@ Key design decisions:
 
 import asyncio
 import atexit
+import hashlib
 import json
 import logging
+import math
 import os
 import random
 import re
+import shutil
 import sqlite3
 import sys
 import threading
 import time
+import tempfile
 from collections import deque
 from contextlib import contextmanager
 from pathlib import Path
@@ -77,6 +81,71 @@ except ImportError:  # pragma: no cover - stripped/scaffold installs only
     psutil = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
+
+
+def _validated_lifecycle_timestamp(
+    value: Any, *, upper_bound: float
+) -> Optional[float]:
+    """Return a trustworthy lifecycle marker, or ``None`` when ambiguous."""
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(timestamp) or timestamp <= 0 or timestamp > upper_bound:
+        return None
+    return timestamp
+
+
+def _copy_file_for_immutable_audit(source: Path, destination: Path) -> None:
+    """Copy hook kept separate so concurrent-writer behavior is testable."""
+    shutil.copyfile(source, destination)
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sqlite_audit_source_state(path: Path) -> tuple[Any, ...]:
+    stat = path.stat()
+    sidecars = []
+    for suffix in ("-wal", "-shm", "-journal"):
+        sidecar = Path(f"{path}{suffix}")
+        if sidecar.exists():
+            sidecar_stat = sidecar.stat()
+            sidecars.append((suffix, sidecar_stat.st_size, sidecar_stat.st_mtime_ns))
+        else:
+            sidecars.append((suffix, None, None))
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, *sidecars)
+
+
+def _stable_immutable_audit_snapshot(source: Path) -> tuple[Path, Path]:
+    """Copy a quiescent SQLite main file, refusing any concurrent change."""
+    before = _sqlite_audit_source_state(source)
+    for suffix, size, _mtime in before[4:]:
+        if suffix in ("-wal", "-journal") and size:
+            label = "active WAL" if suffix == "-wal" else "active rollback journal"
+            raise RuntimeError(
+                f"read-only lifecycle audit refused: {label} contains uncheckpointed state"
+            )
+
+    snapshot_dir = Path(tempfile.mkdtemp(prefix="hermes-lifecycle-audit-"))
+    snapshot_path = snapshot_dir / "state.db"
+    try:
+        _copy_file_for_immutable_audit(source, snapshot_path)
+        after = _sqlite_audit_source_state(source)
+        if before != after or _file_sha256(source) != _file_sha256(snapshot_path):
+            raise RuntimeError(
+                "read-only lifecycle audit refused: database changed during immutable "
+                "audit snapshot"
+            )
+        return snapshot_dir, snapshot_path
+    except Exception:
+        shutil.rmtree(snapshot_dir, ignore_errors=True)
+        raise
 
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
 
@@ -1788,9 +1857,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     _IMPORT_MAX_SESSION_BYTES = 5 * 1024 * 1024
     _IMPORT_MAX_TOTAL_BYTES = 25 * 1024 * 1024
 
-    def __init__(self, db_path: Path = None, read_only: bool = False):
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        read_only: bool = False,
+        immutable: bool = False,
+    ):
         self.db_path = db_path or _default_db_path()
         self.read_only = read_only
+        self.immutable = immutable
+        self._immutable_snapshot_dir: Optional[Path] = None
+        self._immutable_snapshot_path: Optional[Path] = None
+        if immutable and not read_only:
+            raise ValueError("immutable SessionDB access requires read_only=True")
 
         self._lock = threading.Lock()
         # Read-path split (WAL only): recall/browse queries run on per-thread
@@ -1846,9 +1925,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # must already exist + be initialised (callers guard on
                 # db_path.exists()); a SELECT against an empty file raises and
                 # the caller degrades per-profile.
+                connect_path = self.db_path
+                if immutable:
+                    (
+                        self._immutable_snapshot_dir,
+                        self._immutable_snapshot_path,
+                    ) = _stable_immutable_audit_snapshot(self.db_path)
+                    connect_path = self._immutable_snapshot_path
+                immutable_query = "&immutable=1" if immutable else ""
                 self._conn = _connect_tracked_db(
-                    f"file:{self.db_path}?mode=ro",
-                    tracking_path=self.db_path,
+                    f"file:{connect_path}?mode=ro{immutable_query}",
+                    tracking_path=connect_path,
                     uri=True,
                     check_same_thread=False,
                     timeout=1.0,
@@ -2002,6 +2089,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # Tests that need to reset the state can call
             # ``hermes_state._set_last_init_error(None)`` explicitly.
             _set_last_init_error(f"{type(exc).__name__}: {exc}")
+            if self._immutable_snapshot_dir is not None:
+                shutil.rmtree(self._immutable_snapshot_dir, ignore_errors=True)
+                self._immutable_snapshot_dir = None
+                self._immutable_snapshot_path = None
             raise
 
     # ── Read-path split ──
@@ -2544,6 +2635,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     logger.debug("WAL checkpoint (TRUNCATE) at close failed: %s", exc)
                 self._conn.close()
                 self._conn = None
+        if self._immutable_snapshot_dir is not None:
+            shutil.rmtree(self._immutable_snapshot_dir, ignore_errors=True)
+            self._immutable_snapshot_dir = None
+            self._immutable_snapshot_path = None
 
     # ── Chunked FTS rebuild engine (v23 opt-in optimize) ──
     #
@@ -3230,6 +3325,365 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (time.time(), end_reason, session_id),
             )
         self._execute_write(_do)
+
+    def get_lifecycle_recovery_epoch(self) -> Optional[float]:
+        """Read the always-on owner-lease epoch without creating state."""
+        with self._read_ctx() as conn:
+            if conn is None:
+                return None
+            row = conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                ("session_lifecycle_owner_registry_epoch",),
+            ).fetchone()
+        if row is None:
+            return None
+        value = row["value"] if isinstance(row, sqlite3.Row) else row[0]
+        return _validated_lifecycle_timestamp(value, upper_bound=time.time())
+
+    def get_or_create_lifecycle_recovery_epoch(
+        self, *, now: Optional[float] = None
+    ) -> float:
+        """Return the first instant always-on process-owner leases were active."""
+        wall_time = time.time()
+        epoch = wall_time if now is None else float(now)
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                ("session_lifecycle_owner_registry_epoch",),
+            ).fetchone()
+            if row is None:
+                if _validated_lifecycle_timestamp(epoch, upper_bound=wall_time) is None:
+                    raise ValueError(
+                        "lifecycle recovery epoch must be a finite past timestamp"
+                    )
+                conn.execute(
+                    "INSERT INTO state_meta(key, value) VALUES (?, ?)",
+                    ("session_lifecycle_owner_registry_epoch", repr(epoch)),
+                )
+                return epoch
+            value = row["value"] if isinstance(row, sqlite3.Row) else row[0]
+            stored_epoch = _validated_lifecycle_timestamp(
+                value, upper_bound=time.time()
+            )
+            if stored_epoch is None:
+                raise RuntimeError("stored lifecycle recovery epoch is invalid")
+            return stored_epoch
+
+        return self._execute_write(_do)
+
+    def claim_lifecycle_recovery_attempt(
+        self,
+        *,
+        now: Optional[float] = None,
+        interval_seconds: float = 86400.0,
+    ) -> bool:
+        """Atomically claim the bounded startup-recovery interval."""
+        wall_time = time.time()
+        current_time = wall_time if now is None else float(now)
+        if _validated_lifecycle_timestamp(current_time, upper_bound=wall_time) is None:
+            return False
+        interval = float(interval_seconds)
+        if not math.isfinite(interval) or interval < 0:
+            return False
+        key = "session_lifecycle_recovery_last_attempt_at"
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?", (key,)
+            ).fetchone()
+            if row is not None:
+                value = row["value"] if isinstance(row, sqlite3.Row) else row[0]
+                last_attempt = _validated_lifecycle_timestamp(
+                    value, upper_bound=current_time
+                )
+                if last_attempt is None:
+                    # Unknown marker state is ambiguous: suppress unattended work.
+                    return False
+                if current_time - last_attempt < interval:
+                    return False
+            conn.execute(
+                "INSERT INTO state_meta(key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (key, repr(current_time)),
+            )
+            return True
+
+        return bool(self._execute_write(_do))
+
+    def recover_abandoned_sessions(
+        self,
+        *,
+        older_than_seconds: float = 86400,
+        active_session_ids: Optional[set[str]] = None,
+        eligible_started_after: Optional[float] = None,
+        source_allowlist: tuple[str, ...] = ("cli",),
+        limit: int = 100,
+        now: Optional[float] = None,
+        apply: bool = True,
+        report_legacy_exclusions: bool = True,
+    ) -> Dict[str, Any]:
+        """Mark proven abandoned process-owned sessions ended, deleting nothing."""
+        current_time = time.time() if now is None else float(now)
+        if not math.isfinite(current_time) or current_time <= 0:
+            return {
+                "candidate_ids": [],
+                "recovered_ids": [],
+                "excluded": {},
+                "skipped": "invalid_time",
+            }
+        if apply and active_session_ids is None:
+            return {
+                "candidate_ids": [],
+                "recovered_ids": [],
+                "excluded": {},
+                "skipped": "missing_active_session_snapshot",
+            }
+        if apply and eligible_started_after is None:
+            return {
+                "candidate_ids": [],
+                "recovered_ids": [],
+                "excluded": {},
+                "skipped": "missing_epoch",
+            }
+        if eligible_started_after is not None:
+            validated_epoch = _validated_lifecycle_timestamp(
+                eligible_started_after, upper_bound=current_time
+            )
+            if validated_epoch is None:
+                return {
+                    "candidate_ids": [],
+                    "recovered_ids": [],
+                    "excluded": {},
+                    "skipped": "invalid_epoch",
+                }
+            eligible_started_after = validated_epoch
+        cutoff = current_time - float(older_than_seconds)
+        active_ids = {str(value) for value in (active_session_ids or set())}
+        sources = tuple(str(value) for value in source_allowlist if str(value))
+        bounded_limit = max(1, min(int(limit), 1000))
+        if not sources:
+            return {"candidate_ids": [], "recovered_ids": [], "excluded": {}}
+
+        source_placeholders = ",".join("?" for _ in sources)
+
+        def _do(conn):
+            params: list[Any] = [*sources, cutoff]
+            epoch_clause = ""
+            if eligible_started_after is not None:
+                epoch_clause = " AND s.started_at >= ?"
+                params.append(float(eligible_started_after))
+            active_values = sorted(active_ids)
+            active_placeholders = ",".join("?" for _ in active_values)
+            active_reference_sql = (
+                f"id IN ({active_placeholders})" if active_values else "0"
+            )
+            topic_table_exists = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type = 'table' AND name = 'telegram_dm_topic_bindings'"
+            ).fetchone()
+            topic_reference_sql = (
+                "EXISTS(SELECT 1 FROM telegram_dm_topic_bindings t "
+                "WHERE t.session_id = s.id)"
+                if topic_table_exists
+                else "0"
+            )
+            delegation_columns = {
+                str(row["name"] if isinstance(row, sqlite3.Row) else row[1])
+                for row in conn.execute("PRAGMA table_info(async_delegations)")
+            }
+            delegation_origin_id_sql = (
+                " OR ad.origin_session_id = s.id"
+                if "origin_session_id" in delegation_columns
+                else ""
+            )
+            rows = conn.execute(
+                f"""
+                WITH classified AS (
+                SELECT s.id, s.started_at, s.session_key, s.user_id,
+                       s.chat_id, s.chat_type, s.thread_id, s.origin_json,
+                       s.archived, s.pinned, s.handoff_state,
+                       EXISTS(
+                           SELECT 1 FROM compression_locks cl
+                           WHERE cl.session_id = s.id AND cl.expires_at > ?
+                       ) AS compression_active,
+                       EXISTS(
+                           SELECT 1 FROM async_delegations ad
+                           WHERE (
+                                   ad.state IN ('pending', 'running', 'queued', 'finalizing')
+                                   OR ad.delivery_state = 'pending'
+                                 )
+                             AND (ad.origin_session = s.id
+                                  OR ad.origin_ui_session_id = s.id
+                                  OR ad.parent_session_id = s.id
+                                  {delegation_origin_id_sql})
+                       ) AS delegation_active,
+                       EXISTS(
+                           SELECT 1 FROM sessions parent
+                           WHERE parent.id = s.parent_session_id
+                             AND parent.ended_at IS NULL
+                       ) AS live_parent,
+                       EXISTS(
+                           SELECT 1 FROM sessions child
+                           WHERE child.parent_session_id = s.id
+                             AND child.ended_at IS NULL
+                       ) AS live_child,
+                       EXISTS(
+                           SELECT 1 FROM gateway_routing gr,
+                                        json_tree(gr.entry_json) route_value
+                           WHERE route_value.value = s.id
+                             AND route_value.key IN ('session_id', 'current_session_id')
+                       ) AS gateway_routing_reference,
+                       {topic_reference_sql} AS telegram_topic_binding
+                FROM sessions s
+                WHERE s.ended_at IS NULL
+                  AND s.source IN ({source_placeholders})
+                  AND COALESCE(
+                        (SELECT MAX(m.timestamp) FROM messages m
+                         WHERE m.session_id = s.id),
+                        s.started_at
+                      ) < ?
+                  {epoch_clause}
+                ), ranked AS (
+                    SELECT classified.*,
+                           (
+                               COALESCE(session_key, '') <> ''
+                               OR COALESCE(user_id, '') <> ''
+                               OR COALESCE(chat_id, '') <> ''
+                               OR COALESCE(chat_type, '') <> ''
+                               OR COALESCE(thread_id, '') <> ''
+                               OR COALESCE(origin_json, '') <> ''
+                               OR {active_reference_sql}
+                               OR pinned
+                               OR archived
+                               OR COALESCE(handoff_state, '') <> ''
+                               OR compression_active
+                               OR delegation_active
+                               OR live_parent
+                               OR live_child
+                               OR gateway_routing_reference
+                               OR telegram_topic_binding
+                           ) AS recovery_protected
+                    FROM classified
+                ), candidate_rows AS (
+                    SELECT * FROM ranked
+                    WHERE NOT recovery_protected
+                    ORDER BY started_at ASC, id ASC
+                    LIMIT ?
+                ), excluded_rows AS (
+                    SELECT * FROM ranked
+                    WHERE recovery_protected
+                    ORDER BY started_at ASC, id ASC
+                    LIMIT ?
+                )
+                SELECT * FROM candidate_rows
+                UNION ALL
+                SELECT * FROM excluded_rows
+                """,
+                [
+                    current_time,
+                    *params,
+                    *active_values,
+                    bounded_limit,
+                    bounded_limit,
+                ],
+            ).fetchall()
+            recovered_ids: list[str] = []
+            candidate_ids: list[str] = []
+            excluded: dict[str, list[str]] = {}
+            for row in rows:
+                session_id = str(row["id"] if isinstance(row, sqlite3.Row) else row[0])
+                if any(
+                    row[key]
+                    for key in (
+                        "session_key", "user_id", "chat_id", "chat_type",
+                        "thread_id", "origin_json",
+                    )
+                ):
+                    excluded[session_id] = ["gateway_owned"]
+                    continue
+                if session_id in active_ids:
+                    excluded[session_id] = ["active_lease"]
+                    continue
+                if row["pinned"]:
+                    excluded[session_id] = ["pinned"]
+                    continue
+                if row["archived"]:
+                    excluded[session_id] = ["archived"]
+                    continue
+                if row["handoff_state"]:
+                    reason = (
+                        "handoff_active"
+                        if row["handoff_state"] in ("pending", "running")
+                        else "handoff_related"
+                    )
+                    excluded[session_id] = [reason]
+                    continue
+                if row["compression_active"]:
+                    excluded[session_id] = ["compression_active"]
+                    continue
+                if row["delegation_active"]:
+                    excluded[session_id] = ["delegation_active"]
+                    continue
+                if row["live_parent"]:
+                    excluded[session_id] = ["live_parent"]
+                    continue
+                if row["live_child"]:
+                    excluded[session_id] = ["live_child"]
+                    continue
+                if row["gateway_routing_reference"]:
+                    excluded[session_id] = ["gateway_routing_reference"]
+                    continue
+                if row["telegram_topic_binding"]:
+                    excluded[session_id] = ["telegram_topic_binding"]
+                    continue
+                candidate_ids.append(session_id)
+                if not apply:
+                    continue
+                updated = conn.execute(
+                    "UPDATE sessions SET ended_at = ?, end_reason = 'orphan_recovered' "
+                    "WHERE id = ? AND ended_at IS NULL",
+                    (current_time, session_id),
+                )
+                if updated.rowcount == 1:
+                    recovered_ids.append(session_id)
+            if report_legacy_exclusions and eligible_started_after is not None:
+                legacy_rows = conn.execute(
+                    f"""
+                    SELECT s.id
+                    FROM sessions s
+                    WHERE s.ended_at IS NULL
+                      AND s.source IN ({source_placeholders})
+                      AND COALESCE(
+                            (SELECT MAX(m.timestamp) FROM messages m
+                             WHERE m.session_id = s.id),
+                            s.started_at
+                          ) < ?
+                      AND s.started_at < ?
+                    ORDER BY s.started_at ASC, s.id ASC
+                    LIMIT ?
+                    """,
+                    [*sources, cutoff, float(eligible_started_after), bounded_limit],
+                ).fetchall()
+                for legacy_row in legacy_rows:
+                    legacy_id = str(
+                        legacy_row["id"]
+                        if isinstance(legacy_row, sqlite3.Row)
+                        else legacy_row[0]
+                    )
+                    excluded[legacy_id] = ["before_recovery_epoch"]
+            return {
+                "candidate_ids": candidate_ids,
+                "recovered_ids": recovered_ids,
+                "excluded": excluded,
+            }
+
+        if apply:
+            return self._execute_write(_do)
+        with self._read_ctx() as conn:
+            if conn is None:
+                return {"candidate_ids": [], "recovered_ids": [], "excluded": {}}
+            return _do(conn)
 
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -1818,7 +1818,11 @@ class AIAgent:
                 if timestamp is not None:
                     msg["timestamp"] = timestamp
 
-    def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _persist_session(
+        self,
+        messages: List[Dict],
+        conversation_history: Optional[List[Dict]] = None,
+    ) -> bool:
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
@@ -1839,24 +1843,25 @@ class AIAgent:
 
         persist_lock = getattr(self, "_session_persist_lock", None)
 
-        def _persist_and_drain() -> None:
+        def _persist_and_drain() -> bool:
             self._drop_trailing_empty_response_scaffolding(messages)
             self._session_messages = messages
             self._save_session_log(messages)
-            self._flush_messages_to_session_db(messages, conversation_history)
+            if self._flush_messages_to_session_db(messages, conversation_history) is False:
+                return False
             # Drain async token-accounting deltas at every persist point (turn
             # finalize + error exits) so a crash after this line loses at most
             # the in-flight API call's delta. Cheap no-op when nothing queued.
             if self._session_db is not None:
                 self._session_db.flush_token_counts()
             note_turn_persisted(self)
+            return True
 
         if persist_lock is None:
-            _persist_and_drain()
-            return
+            return _persist_and_drain()
 
         with persist_lock:
-            _persist_and_drain()
+            return _persist_and_drain()
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.

--- a/tests/gateway/test_owner_registration_fail_closed.py
+++ b/tests/gateway/test_owner_registration_fail_closed.py
@@ -1,0 +1,97 @@
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_cli import active_sessions
+
+
+def _runner():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = {}
+    runner._is_session_running = lambda _key: False
+    runner._active_session_limit_message = lambda _key: None
+    return runner
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat",
+        user_id="user",
+    )
+
+
+def test_gateway_owner_registration_exception_rejects_turn(monkeypatch):
+    def fail_registration(**_kwargs):
+        raise OSError("registry unavailable")
+
+    monkeypatch.setattr(active_sessions, "try_acquire_active_session", fail_registration)
+
+    lease, message = _runner()._claim_active_session_slot("session", _source())
+
+    assert lease is None
+    assert message is not None
+    assert "ownership" in message.lower()
+
+
+def test_gateway_corrupt_owner_registry_rejects_turn(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    (runtime / "active_sessions.json").write_text("{corrupt", encoding="utf-8")
+
+    lease, message = _runner()._claim_active_session_slot("session", _source())
+
+    assert lease is None
+    assert message is not None
+    assert "ownership" in message.lower()
+
+
+def test_gateway_missing_process_start_identity_rejects_turn(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(active_sessions, "_process_start_time", lambda _pid: None)
+
+    lease, message = _runner()._claim_active_session_slot("session", _source())
+
+    assert lease is None
+    assert message is not None
+    assert "ownership" in message.lower()
+
+
+def test_gateway_registry_lock_failure_rejects_turn(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def fail_lock(_self):
+        raise OSError("lock unavailable")
+
+    monkeypatch.setattr(active_sessions._FileLock, "__enter__", fail_lock)
+
+    lease, message = _runner()._claim_active_session_slot("session", _source())
+
+    assert lease is None
+    assert message is not None
+    assert "ownership" in message.lower()
+
+
+def test_gateway_missing_owner_lease_rejects_turn(monkeypatch):
+    monkeypatch.setattr(
+        active_sessions,
+        "try_acquire_active_session",
+        lambda **_kwargs: (None, None),
+    )
+
+    lease, message = _runner()._claim_active_session_slot("session", _source())
+
+    assert lease is None
+    assert message is not None
+    assert "ownership" in message.lower()
+
+
+def test_gateway_running_race_rejects_duplicate_turn():
+    runner = _runner()
+    runner._is_session_running = lambda session_key: True
+
+    lease, message = runner._claim_active_session_slot("session", _source())
+
+    assert lease is None
+    assert message is not None
+    assert "already active" in message.lower()

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -1,4 +1,5 @@
 import logging
+import json
 import os
 import subprocess
 import sys
@@ -6,7 +7,29 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
+
 from hermes_cli import active_sessions
+
+
+def test_pid_liveness_probe_failure_is_treated_as_potentially_live(monkeypatch):
+    import gateway.status
+
+    def fail_probe(_pid):
+        raise OSError("process table unavailable")
+
+    monkeypatch.setattr(gateway.status, "_pid_exists", fail_probe)
+
+    assert active_sessions._pid_alive(12345, 100.0)
+
+
+def test_process_start_probe_non_finite_is_treated_as_potentially_live(monkeypatch):
+    import gateway.status
+
+    monkeypatch.setattr(gateway.status, "_pid_exists", lambda _pid: True)
+    monkeypatch.setattr(active_sessions, "_process_start_time", lambda _pid: float("nan"))
+
+    assert active_sessions._pid_alive(12345, 100.0)
 
 
 def test_resolve_max_concurrent_sessions_values(caplog):
@@ -44,6 +67,29 @@ def test_resolve_max_concurrent_sessions_values(caplog):
 
 
 
+
+
+def test_disabled_cap_still_registers_owner_identity_for_lifecycle_recovery(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="owned-session",
+        surface="cli",
+        config={"max_concurrent_sessions": 0},
+    )
+
+    assert message is None
+    assert lease is not None
+    entries = active_sessions.active_session_registry_snapshot()
+    assert len(entries) == 1
+    assert entries[0]["session_id"] == "owned-session"
+    assert entries[0]["pid"] == os.getpid()
+    assert entries[0]["process_start_time"] is not None
+
+    lease.release()
+    assert active_sessions.active_session_registry_snapshot() == []
 
 
 def test_cross_process_acquire_claims_only_one_last_slot(tmp_path, monkeypatch):
@@ -158,7 +204,15 @@ def test_release_orphaned_leases_reclaims_only_unowned_own_pid_entries(tmp_path,
     active_sessions._write_entries(
         active_sessions._state_path(),
         active_sessions._read_entries(active_sessions._state_path())
-        + [{"lease_id": "elsewhere", "session_id": "other", "surface": "cli", "pid": os.getpid() }],
+        + [
+            {
+                "lease_id": "elsewhere",
+                "session_id": "other",
+                "surface": "cli",
+                "pid": os.getpid(),
+                "process_start_time": active_sessions._process_start_time(os.getpid()),
+            }
+        ],
     )
 
     assert active_sessions.release_orphaned_leases({kept.lease_id, "elsewhere"}) == 1
@@ -167,3 +221,162 @@ def test_release_orphaned_leases_reclaims_only_unowned_own_pid_entries(tmp_path,
         for entry in active_sessions.active_session_registry_snapshot()
     ) == ["kept", "other"]
     assert orphan is not None
+
+
+def test_recovery_uses_locked_live_owner_snapshot(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    lease, error = active_sessions.try_acquire_active_session(
+        config={}, session_id="live-session", surface="cli"
+    )
+    assert error is None
+    assert lease is not None
+    captured = {}
+
+    class FakeSessionDB:
+        def get_lifecycle_recovery_epoch(self):
+            captured["read_epoch"] = True
+            return None
+
+        def get_or_create_lifecycle_recovery_epoch(self, *, now=None):
+            raise AssertionError("dry run must not create recovery epoch state")
+
+        def recover_abandoned_sessions(self, **kwargs):
+            captured.update(kwargs)
+            return {"candidate_ids": [], "recovered_ids": [], "excluded": {}}
+
+    try:
+        result = active_sessions.recover_abandoned_session_rows(
+            FakeSessionDB(), apply=False, now=456.0
+        )
+    finally:
+        lease.release()
+
+    assert result["recovered_ids"] == []
+    assert captured["read_epoch"] is True
+    assert captured["eligible_started_after"] == 456.0
+    assert captured["active_session_ids"] == {"live-session"}
+    assert captured["apply"] is False
+
+
+def test_recovery_fails_closed_on_corrupt_owner_registry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    registry = active_sessions._state_path()
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text("{not-json", encoding="utf-8")
+
+    class FakeSessionDB:
+        def get_or_create_lifecycle_recovery_epoch(self, *, now=None):
+            raise AssertionError("database must not be touched")
+
+        def recover_abandoned_sessions(self, **kwargs):
+            raise AssertionError("database must not be touched")
+
+    try:
+        active_sessions.recover_abandoned_session_rows(
+            FakeSessionDB(), apply=True, now=456.0
+        )
+    except RuntimeError as exc:
+        assert "active session registry" in str(exc)
+    else:
+        raise AssertionError("corrupt owner evidence must block recovery")
+
+    assert registry.read_text(encoding="utf-8") == "{not-json"
+
+
+def test_recovery_fails_closed_on_ambiguous_owner_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    state_dir = tmp_path / ".hermes" / "runtime"
+    state_dir.mkdir(parents=True)
+    registry = state_dir / "active_sessions.json"
+    registry.write_text('{"entries": [{}]}', encoding="utf-8")
+
+    class FakeDB:
+        def recover_abandoned_sessions(self, **kwargs):
+            raise AssertionError("ambiguous owner evidence must block classification")
+
+    with pytest.raises(RuntimeError, match="invalid active session registry"):
+        active_sessions.recover_abandoned_session_rows(
+            FakeDB(), apply=False, now=100.0
+        )
+
+    assert registry.read_text(encoding="utf-8") == '{"entries": [{}]}'
+
+
+@pytest.mark.parametrize("process_start_time", ["nan", "inf", "-inf"])
+def test_registry_rejects_non_finite_process_start_time(
+    tmp_path, process_start_time
+):
+    registry = tmp_path / "active_sessions.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "lease_id": "lease",
+                        "session_id": "session",
+                        "pid": 123,
+                        "process_start_time": process_start_time,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="invalid active session registry"):
+        active_sessions._read_entries(registry, strict=True)
+
+
+def test_startup_recovery_respects_claimed_interval(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    class FakeSessionDB:
+        def claim_lifecycle_recovery_attempt(self, *, now=None, interval_seconds=None):
+            assert now == 456.0
+            assert interval_seconds == 3600.0
+            return False
+
+        def get_or_create_lifecycle_recovery_epoch(self, *, now=None):
+            raise AssertionError("suppressed recovery must not continue")
+
+        def recover_abandoned_sessions(self, **kwargs):
+            raise AssertionError("suppressed recovery must not continue")
+
+    result = active_sessions.recover_abandoned_session_rows(
+        FakeSessionDB(),
+        apply=True,
+        now=456.0,
+        respect_interval_seconds=3600.0,
+    )
+
+    assert result == {
+        "candidate_ids": [],
+        "recovered_ids": [],
+        "excluded": {},
+        "skipped": "interval",
+    }
+
+
+def test_acquire_does_not_overwrite_corrupt_owner_registry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    registry = active_sessions._state_path()
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="active session registry"):
+        active_sessions.try_acquire_active_session(
+            session_id="new-session", surface="cli", config={}
+        )
+    assert registry.read_text(encoding="utf-8") == "{not-json"
+
+
+def test_acquire_requires_pid_reuse_resistant_owner_identity(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(active_sessions, "_process_start_time", lambda _pid: None)
+
+    with pytest.raises(RuntimeError, match="process start time missing"):
+        active_sessions.try_acquire_active_session(
+            session_id="unproven-owner", surface="cli", config={}
+        )
+
+    assert not (tmp_path / ".hermes" / "runtime" / "active_sessions.json").exists()

--- a/tests/hermes_cli/test_cli_active_session_limit.py
+++ b/tests/hermes_cli/test_cli_active_session_limit.py
@@ -1,4 +1,8 @@
+from typing import Any, cast
+
+import cli as cli_module
 from cli import HermesCLI
+from hermes_cli import active_sessions
 from hermes_cli.active_sessions import (
     active_session_registry_snapshot,
     try_acquire_active_session,
@@ -39,3 +43,71 @@ def test_cli_claim_active_session_respects_global_limit(tmp_path, monkeypatch):
     finally:
         held.release()
         cli._release_active_session()
+
+
+def test_cli_claim_runs_state_maintenance_after_owner_registration(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    cli = object.__new__(HermesCLI)
+    cli.session_id = "current-session"
+    cli.config = {}
+    cli._active_session_lease = None
+    cli._session_db = cast(Any, object())
+    calls = []
+    monkeypatch.setattr(
+        cli_module,
+        "_run_state_db_auto_maintenance",
+        lambda session_db: calls.append(
+            (
+                session_db,
+                [entry["session_id"] for entry in active_session_registry_snapshot()],
+            )
+        ),
+    )
+
+    try:
+        assert cli._claim_active_session("cli") is True
+    finally:
+        cli._release_active_session()
+
+    assert calls == [(cli._session_db, ["current-session"])]
+
+
+def test_cli_claim_fails_closed_when_owner_identity_cannot_be_registered(
+    monkeypatch,
+):
+    cli = object.__new__(HermesCLI)
+    cli.session_id = "unregistered-session"
+    cli.config = {}
+    cli._active_session_lease = None
+    printed = []
+    cli._console_print = lambda text: printed.append(text)
+
+    monkeypatch.setattr(
+        active_sessions,
+        "try_acquire_active_session",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("identity unavailable")),
+    )
+
+    assert cli._claim_active_session("cli") is False
+    assert cli._active_session_lease is None
+    assert len(printed) == 1
+    assert "could not register process ownership" in printed[0].lower()
+
+
+def test_cli_claim_rejects_missing_lease_without_error_message(monkeypatch):
+    cli = object.__new__(HermesCLI)
+    cli.session_id = "missing-lease"
+    cli.config = {}
+    cli._active_session_lease = None
+    printed = []
+    cli._console_print = lambda text: printed.append(text)
+    monkeypatch.setattr(
+        active_sessions,
+        "try_acquire_active_session",
+        lambda **_kwargs: (None, None),
+    )
+
+    assert cli._claim_active_session("cli") is False
+    assert "ownership lease" in printed[0].lower()

--- a/tests/hermes_cli/test_session_lifecycle_finalization.py
+++ b/tests/hermes_cli/test_session_lifecycle_finalization.py
@@ -1,0 +1,509 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from types import SimpleNamespace
+
+import pytest
+
+import cli as cli_mod
+from run_agent import AIAgent
+from hermes_cli.active_sessions import (
+    active_session_registry_snapshot,
+    recover_abandoned_session_rows,
+    try_acquire_active_session,
+)
+from hermes_state import SessionDB
+
+
+@pytest.fixture(autouse=True)
+def reset_single_query_finalize_state(monkeypatch):
+    monkeypatch.setattr(cli_mod, "_single_query_finalize_attempted_session_ids", set())
+    monkeypatch.setattr(cli_mod, "_cleanup_done", False)
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_single_query_finalization_closes_owned_row_without_losing_transcript(
+    session_db, monkeypatch
+):
+    session_id = "single-query"
+    session_db.create_session(session_id="parent-session", source="cli")
+    session_db.create_session(
+        session_id=session_id,
+        source="cli",
+        parent_session_id="parent-session",
+    )
+    session_db.set_session_title(session_id, "Lifecycle probe")
+    session_db.append_message(session_id, role="user", content="hello")
+    session_db.append_message(session_id, role="assistant", content="done")
+
+    released = []
+    fake_cli = SimpleNamespace(
+        _session_db=session_db,
+        session_id=session_id,
+        agent=SimpleNamespace(session_id=session_id, platform="cli"),
+        conversation_history=[],
+        _release_active_session=lambda: released.append(session_id),
+    )
+    monkeypatch.setattr(cli_mod, "_notify_single_query_session_finalize", lambda _cli: None)
+    monkeypatch.setattr(cli_mod, "_run_cleanup", lambda **_kwargs: None)
+
+    cli_mod._finalize_single_query(fake_cli)
+
+    row = session_db.get_session(session_id)
+    assert row["ended_at"] is not None
+    assert row["end_reason"] == "cli_close"
+    assert row["title"] == "Lifecycle probe"
+    assert row["parent_session_id"] == "parent-session"
+    assert [m["content"] for m in session_db.get_messages(session_id)] == ["hello", "done"]
+    assert released == [session_id]
+
+
+def test_interactive_normal_exit_persists_then_ends_and_releases_owner(
+    session_db, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    session_id = "interactive-normal"
+    session_db.create_session(session_id=session_id, source="cli")
+    session_db.set_session_title(session_id, "Interactive normal")
+    lease, error = try_acquire_active_session(
+        session_id=session_id, surface="cli", config={}
+    )
+    assert error is None and lease is not None
+
+    def persist():
+        session_db.append_message(session_id, role="user", content="interactive input")
+        session_db.append_message(session_id, role="assistant", content="interactive output")
+
+    fake_cli = SimpleNamespace(
+        _session_db=session_db,
+        session_id=session_id,
+        agent=SimpleNamespace(session_id=session_id, platform="cli"),
+        _persist_active_session_before_close=persist,
+        _release_active_session=lease.release,
+    )
+
+    try:
+        cli_mod._finalize_owned_cli_session_row(fake_cli)
+    finally:
+        fake_cli._release_active_session()
+
+    row = session_db.get_session(session_id)
+    assert row["ended_at"] is not None
+    assert row["end_reason"] == "cli_close"
+    assert row["title"] == "Interactive normal"
+    assert [message["content"] for message in session_db.get_messages(session_id)] == [
+        "interactive input",
+        "interactive output",
+    ]
+    assert active_session_registry_snapshot() == []
+
+
+def test_one_shot_provider_failure_still_finalizes_durable_user_turn(
+    session_db, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    session_id = "provider-failure"
+    session_db.create_session(session_id=session_id, source="cli")
+    lease, error = try_acquire_active_session(
+        session_id=session_id, surface="cli", config={}
+    )
+    assert error is None and lease is not None
+
+    fake_cli = SimpleNamespace(
+        _session_db=session_db,
+        session_id=session_id,
+        agent=SimpleNamespace(session_id=session_id, platform="cli"),
+        _persist_active_session_before_close=lambda: session_db.append_message(
+            session_id, role="user", content="failed request"
+        ),
+        _release_active_session=lease.release,
+    )
+    monkeypatch.setattr(cli_mod, "_notify_single_query_session_finalize", lambda _cli: None)
+    monkeypatch.setattr(cli_mod, "_run_cleanup", lambda **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        try:
+            raise RuntimeError("provider failed")
+        finally:
+            cli_mod._finalize_single_query(fake_cli)
+
+    row = session_db.get_session(session_id)
+    assert row["ended_at"] is not None
+    assert row["end_reason"] == "cli_close"
+    assert [message["content"] for message in session_db.get_messages(session_id)] == [
+        "failed request"
+    ]
+    assert active_session_registry_snapshot() == []
+
+
+def test_keyboard_interrupt_cleanup_finalizes_and_releases_owner(
+    session_db, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    session_id = "keyboard-interrupt"
+    session_db.create_session(session_id=session_id, source="cli")
+    lease, error = try_acquire_active_session(
+        session_id=session_id, surface="cli", config={}
+    )
+    assert error is None and lease is not None
+    fake_cli = SimpleNamespace(
+        _session_db=session_db,
+        session_id=session_id,
+        agent=SimpleNamespace(session_id=session_id, platform="cli"),
+        _persist_active_session_before_close=lambda: session_db.append_message(
+            session_id, role="user", content="interrupted input"
+        ),
+        _release_active_session=lease.release,
+    )
+    monkeypatch.setattr(cli_mod, "_notify_single_query_session_finalize", lambda _cli: None)
+    monkeypatch.setattr(cli_mod, "_run_cleanup", lambda **_kwargs: None)
+
+    with pytest.raises(KeyboardInterrupt):
+        try:
+            raise KeyboardInterrupt
+        finally:
+            cli_mod._finalize_single_query(fake_cli)
+
+    row = session_db.get_session(session_id)
+    assert row["ended_at"] is not None
+    assert row["end_reason"] == "cli_close"
+    assert active_session_registry_snapshot() == []
+
+
+@pytest.mark.parametrize(
+    "failure_stage",
+    ["snapshot", "system_prompt", "session_creation"],
+)
+def test_real_cli_pre_persist_failure_keeps_row_open_and_releases_lease(
+    session_db, tmp_path, monkeypatch, failure_stage
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    session_id = f"pre-persist-{failure_stage}"
+    session_db.create_session(session_id=session_id, source="cli")
+    lease, error = try_acquire_active_session(
+        session_id=session_id, surface="cli", config={}
+    )
+    assert error is None and lease is not None
+    discard_calls = []
+
+    if failure_stage == "snapshot":
+        class SnapshotFailureAgent:
+            platform = "cli"
+            _pending_cli_user_message = None
+            _cached_system_prompt = "system"
+            _session_persist_lock = None
+
+            def __init__(self, value):
+                self.session_id = value
+
+            @property
+            def _session_messages(self):
+                raise OSError("snapshot unavailable")
+
+            def _ensure_db_session(self):
+                raise AssertionError("snapshot failure must stop before session creation")
+
+            def _persist_session(self, _messages, _history):
+                raise AssertionError("snapshot failure must stop before persistence")
+
+        agent = SnapshotFailureAgent(session_id)
+    else:
+        def ensure_session():
+            if failure_stage == "session_creation":
+                raise OSError("session creation failed")
+
+        agent = SimpleNamespace(
+            session_id=session_id,
+            platform="cli",
+            _session_messages=[{"role": "user", "content": "not durable"}],
+            _pending_cli_user_message=None,
+            _cached_system_prompt=None if failure_stage == "system_prompt" else "system",
+            _session_persist_lock=None,
+            _ensure_db_session=ensure_session,
+            _persist_session=lambda _messages, _history: True,
+        )
+        if failure_stage == "system_prompt":
+            monkeypatch.setattr(
+                "agent.conversation_loop._restore_or_build_system_prompt",
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    OSError("system prompt unavailable")
+                ),
+            )
+
+    real_cli = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    real_cli.agent = agent
+    real_cli.session_id = session_id
+    real_cli._session_db = session_db
+    real_cli.conversation_history = []
+
+    def discard_empty(session_id):
+        discard_calls.append(session_id)
+        return False
+
+    real_cli._discard_session_if_empty = discard_empty
+    real_cli._release_active_session = lease.release
+    monkeypatch.setattr(cli_mod, "_notify_single_query_session_finalize", lambda _cli: None)
+    monkeypatch.setattr(cli_mod, "_run_cleanup", lambda **_kwargs: None)
+
+    cli_mod._finalize_single_query(real_cli)
+
+    row = session_db.get_session(session_id)
+    assert row is not None
+    assert row["ended_at"] is None
+    assert row["end_reason"] is None
+    assert discard_calls == []
+    assert active_session_registry_snapshot() == []
+
+
+def test_real_cli_empty_session_deletion_is_post_persistence_and_fail_closed(
+    session_db, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    for session_id in ("empty", "titled", "parent", "history"):
+        session_db.create_session(session_id=session_id, source="cli")
+    session_db.set_session_title("titled", "Keep titled")
+    session_db.create_session(
+        session_id="child", source="cli", parent_session_id="parent"
+    )
+
+    def finalize(session_id, history):
+        agent = SimpleNamespace(
+            session_id=session_id,
+            platform="cli",
+            _session_messages=[],
+            _pending_cli_user_message=None,
+            _cached_system_prompt="system",
+            _session_persist_lock=None,
+            _ensure_db_session=lambda: None,
+            _persist_session=lambda _messages, _history: True,
+        )
+        real_cli = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+        real_cli.agent = agent
+        real_cli.session_id = session_id
+        real_cli._session_db = session_db
+        real_cli.conversation_history = history
+        cli_mod._finalize_owned_cli_session_row(real_cli)
+
+    finalize("empty", [])
+    finalize("titled", [])
+    finalize("parent", [])
+    finalize("history", [{"role": "user", "content": "not yet durable"}])
+
+    assert session_db.get_session("empty") is None
+    for session_id in ("titled", "parent", "history"):
+        row = session_db.get_session(session_id)
+        assert row is not None
+        assert row["ended_at"] is not None
+        assert row["end_reason"] == "cli_close"
+    assert session_db.get_session("child") is not None
+
+
+def test_owned_row_stays_open_when_final_transcript_persist_fails(
+    session_db, monkeypatch, capsys
+):
+    session_id = "persist-failed"
+    session_db.create_session(session_id=session_id, source="cli")
+    discarded = []
+    released = []
+
+    def fail_persist():
+        raise OSError("disk full")
+
+    fake_cli = SimpleNamespace(
+        _session_db=session_db,
+        session_id=session_id,
+        agent=SimpleNamespace(session_id=session_id, platform="cli"),
+        conversation_history=[],
+        _persist_active_session_before_close=fail_persist,
+        _discard_session_if_empty=lambda value: discarded.append(value),
+        _release_active_session=lambda: released.append(session_id),
+    )
+    monkeypatch.setattr(cli_mod, "_notify_single_query_session_finalize", lambda _cli: None)
+    monkeypatch.setattr(cli_mod, "_run_cleanup", lambda **_kwargs: None)
+
+    cli_mod._finalize_single_query(fake_cli)
+
+    row = session_db.get_session(session_id)
+    assert row is not None
+    assert row["ended_at"] is None
+    assert row["end_reason"] is None
+    assert discarded == []
+    assert released == [session_id]
+    assert "left open" in capsys.readouterr().err
+
+
+def test_real_cli_persistence_failure_leaves_owned_row_open(session_db, capsys):
+    session_id = "real-persist-failure"
+    session_db.create_session(session_id=session_id, source="cli")
+
+    def fail_persist(_messages, _conversation_history):
+        raise OSError("disk full")
+
+    agent = SimpleNamespace(
+        session_id=session_id,
+        platform="cli",
+        _session_messages=[{"role": "user", "content": "not durable"}],
+        _pending_cli_user_message=None,
+        _cached_system_prompt="system",
+        _session_persist_lock=None,
+        _ensure_db_session=lambda: None,
+        _persist_session=fail_persist,
+    )
+    real_cli = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    real_cli.agent = agent
+    real_cli.session_id = session_id
+    real_cli._session_db = session_db
+    real_cli.conversation_history = []
+
+    cli_mod._finalize_owned_cli_session_row(real_cli)
+
+    row = session_db.get_session(session_id)
+    assert row["ended_at"] is None
+    assert session_db.get_messages(session_id) == []
+    assert "session row was left open" in capsys.readouterr().err
+
+
+def test_real_cli_reported_db_failure_leaves_owned_row_open(session_db, capsys):
+    session_id = "reported-db-failure"
+    session_db.create_session(session_id=session_id, source="cli")
+    agent = SimpleNamespace(
+        session_id=session_id,
+        platform="cli",
+        _session_messages=[{"role": "user", "content": "not durable"}],
+        _pending_cli_user_message=None,
+        _cached_system_prompt="system",
+        _session_persist_lock=None,
+        _ensure_db_session=lambda: None,
+        _persist_session=lambda _messages, _history: False,
+    )
+    real_cli = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    real_cli.agent = agent
+    real_cli.session_id = session_id
+    real_cli._session_db = session_db
+    real_cli.conversation_history = []
+
+    cli_mod._finalize_owned_cli_session_row(real_cli)
+
+    assert session_db.get_session(session_id)["ended_at"] is None
+    assert "session row was left open" in capsys.readouterr().err
+
+
+def test_agent_persistence_reports_sqlite_flush_failure():
+    fake_agent = AIAgent.__new__(AIAgent)
+    fake_agent._session_persist_lock = None
+    fake_agent._session_messages = None
+    fake_agent._session_db = None
+    fake_agent._drop_trailing_empty_response_scaffolding = lambda _messages: None
+    fake_agent._save_session_log = lambda _messages: None
+    fake_agent._flush_messages_to_session_db = lambda _messages, _history: False
+
+    assert fake_agent._persist_session(
+        [{"role": "user", "content": "not durable"}], []
+    ) is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="SIGKILL lifecycle probe is POSIX-only")
+def test_live_process_is_protected_then_killed_owner_is_recovered(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    db_path = hermes_home / "state.db"
+    ready_path = tmp_path / "ready"
+
+    db = SessionDB(db_path=db_path)
+    try:
+        epoch = db.get_or_create_lifecycle_recovery_epoch(now=time.time() - 1.0)
+    finally:
+        db.close()
+
+    child_code = """
+import os
+from pathlib import Path
+import time
+from hermes_cli.active_sessions import try_acquire_active_session
+from hermes_state import SessionDB
+
+db = SessionDB(db_path=Path(os.environ["HERMES_HOME"]) / "state.db")
+db.create_session(session_id="killed-owner", source="cli")
+db.append_message("killed-owner", role="user", content="preserve me")
+lease, error = try_acquire_active_session(
+    session_id="killed-owner", surface="cli", config={}
+)
+if error or lease is None:
+    raise RuntimeError(error or "lease missing")
+Path(os.environ["READY_PATH"]).write_text("ready", encoding="utf-8")
+while True:
+    time.sleep(1)
+"""
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["READY_PATH"] = str(ready_path)
+    repo_root = str(Path(__file__).resolve().parents[2])
+    env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+    child = subprocess.Popen(
+        [sys.executable, "-c", child_code],
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.time() + 10.0
+        while not ready_path.exists() and time.time() < deadline:
+            if child.poll() is not None:
+                stderr = child.stderr.read() if child.stderr else ""
+                raise AssertionError(f"probe exited before ready: {stderr}")
+            time.sleep(0.05)
+        assert ready_path.exists(), "probe did not become ready"
+
+        db = SessionDB(db_path=db_path)
+        try:
+            live = recover_abandoned_session_rows(
+                db,
+                apply=True,
+                older_than_seconds=0,
+                now=time.time() + 1.0,
+            )
+            assert live["excluded"] == {"killed-owner": ["active_lease"]}
+            live_row = db.get_session("killed-owner")
+            assert live_row is not None
+            assert live_row["ended_at"] is None
+        finally:
+            db.close()
+
+        os.kill(child.pid, 9)
+        child.wait(timeout=10)
+
+        db = SessionDB(db_path=db_path)
+        try:
+            recovered = recover_abandoned_session_rows(
+                db,
+                apply=True,
+                older_than_seconds=0,
+                now=time.time() + 2.0,
+            )
+            row = db.get_session("killed-owner")
+            assert row is not None
+            assert recovered["recovered_ids"] == ["killed-owner"]
+            assert row["ended_at"] is not None
+            assert row["end_reason"] == "orphan_recovered"
+            assert row["started_at"] >= epoch
+            assert [m["content"] for m in db.get_messages("killed-owner")] == [
+                "preserve me"
+            ]
+        finally:
+            db.close()
+    finally:
+        if child.poll() is None:
+            os.kill(child.pid, 9)
+            child.wait(timeout=10)

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -11,7 +11,10 @@ from types import SimpleNamespace
 
 import pytest
 
+import cli as cli_module
 import hermes_state
+from hermes_cli import active_sessions
+from hermes_cli import config as cli_config
 from hermes_state import FTS_STORAGE_VERSION, SCHEMA_VERSION, SessionDB
 from hermes_cli import session_recovery
 from hermes_cli.session_recovery import (
@@ -594,6 +597,53 @@ def test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf(
         min(_btree_leaf_pages(source, messages_root)[1]),
         max(_btree_leaf_pages(source, messages_root)[1]),
     }
+
+
+def test_startup_lifecycle_recovery_runs_before_native_prune(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    events = []
+
+    class FakeSessionDB:
+        def get_meta(self, key):
+            return "1"
+
+        def maybe_auto_prune_and_vacuum(self, **kwargs):
+            events.append(("prune", kwargs))
+
+    db = FakeSessionDB()
+    monkeypatch.setattr(
+        cli_config,
+        "load_config",
+        lambda: {
+            "sessions": {
+                "auto_archive": False,
+                "auto_prune": True,
+                "retention_days": 90,
+                "min_interval_hours": 2,
+                "vacuum_after_prune": False,
+            }
+        },
+    )
+
+    def fake_recover(session_db, **kwargs):
+        assert session_db is db
+        events.append(("recover", kwargs))
+        return {"candidate_ids": [], "recovered_ids": [], "excluded": {}}
+
+    monkeypatch.setattr(active_sessions, "recover_abandoned_session_rows", fake_recover)
+
+    cli_module._run_state_db_auto_maintenance(db)
+
+    assert events[0] == (
+        "recover",
+        {
+            "apply": True,
+            "older_than_seconds": 86400.0,
+            "limit": 100,
+            "respect_interval_seconds": 7200.0,
+        },
+    )
+    assert events[1][0] == "prune"
 
 
 

--- a/tests/hermes_cli/test_sessions_finalize_orphans.py
+++ b/tests/hermes_cli/test_sessions_finalize_orphans.py
@@ -1,0 +1,317 @@
+import json
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import sqlite3
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import active_sessions
+from hermes_cli.sessions_cmd import cmd_sessions
+import hermes_state
+
+
+class FakeDB:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _args(**overrides):
+    values = {
+        "sessions_action": "finalize-orphans",
+        "apply": False,
+        "yes": False,
+        "min_age_hours": 24.0,
+        "limit": 100,
+        "json": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_finalize_orphans_defaults_to_read_only_report(monkeypatch, capsys):
+    db = FakeDB()
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda **_kwargs: db)
+    calls = []
+
+    def fake_recover(session_db, **kwargs):
+        calls.append((session_db, kwargs))
+        return {
+            "candidate_ids": ["candidate"],
+            "recovered_ids": [],
+            "excluded": {"live": ["active_lease"]},
+        }
+
+    monkeypatch.setattr(active_sessions, "recover_abandoned_session_rows", fake_recover)
+
+    assert cmd_sessions(_args()) == 0
+
+    output = capsys.readouterr().out
+    assert "Dry run — no session rows were changed." in output
+    assert "proven candidates: 1" in output
+    assert calls == [
+        (
+            db,
+            {"apply": False, "older_than_seconds": 86400.0, "limit": 100},
+        )
+    ]
+
+
+def test_finalize_orphans_apply_reclassifies_after_explicit_approval(
+    monkeypatch, capsys
+):
+    db = FakeDB()
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda **_kwargs: db)
+    calls = []
+
+    def fake_recover(session_db, **kwargs):
+        calls.append((session_db, kwargs))
+        if kwargs["apply"]:
+            return {
+                "candidate_ids": ["candidate"],
+                "recovered_ids": ["candidate"],
+                "excluded": {},
+            }
+        return {
+            "candidate_ids": ["candidate"],
+            "recovered_ids": [],
+            "excluded": {},
+        }
+
+    monkeypatch.setattr(active_sessions, "recover_abandoned_session_rows", fake_recover)
+
+    assert cmd_sessions(_args(apply=True, yes=True)) == 0
+
+    output = capsys.readouterr().out
+    assert "Finalized 1 proven abandoned session row(s)" in output
+    assert [kwargs["apply"] for _, kwargs in calls] == [False, True]
+
+
+def test_finalize_orphans_apply_requires_yes_flag(monkeypatch, capsys):
+    db = FakeDB()
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda **_kwargs: db)
+    calls = []
+
+    def fake_recover(session_db, **kwargs):
+        calls.append(kwargs)
+        return {
+            "candidate_ids": ["candidate"],
+            "recovered_ids": [],
+            "excluded": {},
+        }
+
+    monkeypatch.setattr(active_sessions, "recover_abandoned_session_rows", fake_recover)
+    assert cmd_sessions(_args(apply=True, yes=False)) == 2
+
+    assert "requires --yes" in capsys.readouterr().out
+    assert [call["apply"] for call in calls] == [False]
+
+
+def test_finalize_orphans_reports_classifier_failure_without_traceback(
+    monkeypatch, capsys
+):
+    db = FakeDB()
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda **_kwargs: db)
+    monkeypatch.setattr(
+        active_sessions,
+        "recover_abandoned_session_rows",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("invalid active session registry")
+        ),
+    )
+
+    assert cmd_sessions(_args(json=True)) == 1
+    assert "invalid active session registry" in capsys.readouterr().out
+    assert db.closed
+
+
+def test_finalize_orphans_cli_is_dry_by_default_and_apply_requires_yes(tmp_path):
+    env = os.environ.copy()
+    hermes_home = tmp_path / ".hermes"
+    env["HERMES_HOME"] = str(hermes_home)
+    repo_root = Path(__file__).resolve().parents[2]
+
+    seed = hermes_state.SessionDB(db_path=hermes_home / "state.db")
+    seed.get_or_create_lifecycle_recovery_epoch(now=100.0)
+    seed.close()
+
+    def snapshot_lifecycle_state():
+        paths = [
+            hermes_home / "state.db",
+            hermes_home / "state.db-wal",
+            hermes_home / "state.db-shm",
+            hermes_home / "runtime" / "active_sessions.json",
+            hermes_home / "runtime" / "active_sessions.lock",
+        ]
+        return {
+            str(path.relative_to(hermes_home)): hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in paths
+            if path.is_file()
+        }
+
+    before = snapshot_lifecycle_state()
+
+    dry = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "sessions", "finalize-orphans", "--json"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert dry.returncode == 0, dry.stdout + dry.stderr
+    assert json.loads(dry.stdout)["mode"] == "dry_run"
+    assert snapshot_lifecycle_state() == before
+    db = hermes_state.SessionDB(db_path=hermes_home / "state.db")
+    try:
+        assert db.get_lifecycle_recovery_epoch() == 100.0
+    finally:
+        db.close()
+
+    rejected = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "sessions", "finalize-orphans", "--apply"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert rejected.returncode == 2
+    assert "requires --yes" in rejected.stdout
+
+
+def test_finalize_orphans_dry_refuses_active_wal_without_mutating(tmp_path):
+    env = os.environ.copy()
+    hermes_home = tmp_path / ".hermes"
+    env["HERMES_HOME"] = str(hermes_home)
+    repo_root = Path(__file__).resolve().parents[2]
+    live = hermes_state.SessionDB(db_path=hermes_home / "state.db")
+    live.get_or_create_lifecycle_recovery_epoch(now=100.0)
+    wal_path = hermes_home / "state.db-wal"
+    assert wal_path.stat().st_size > 0
+
+    paths = [
+        hermes_home / "state.db",
+        wal_path,
+        hermes_home / "state.db-shm",
+    ]
+    before = {
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in paths
+        if path.is_file()
+    }
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "hermes_cli.main",
+                "sessions",
+                "finalize-orphans",
+                "--json",
+            ],
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        after = {
+            path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in paths
+            if path.is_file()
+        }
+        assert result.returncode == 1
+        assert "active WAL" in result.stdout
+        assert after == before
+    finally:
+        live.close()
+
+
+def test_immutable_audit_refuses_nonempty_rollback_journal(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = hermes_state.SessionDB(db_path=db_path)
+    db.close()
+    journal_path = Path(f"{db_path}-journal")
+    journal_path.write_bytes(b"uncheckpointed")
+
+    with pytest.raises(RuntimeError, match="active rollback journal"):
+        hermes_state.SessionDB(db_path=db_path, read_only=True, immutable=True)
+
+
+def test_immutable_audit_refuses_wal_created_during_snapshot(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    db = hermes_state.SessionDB(db_path=db_path)
+    db.close()
+
+    def copy_then_create_wal(source, destination):
+        shutil.copyfile(source, destination)
+        Path(f"{source}-wal").write_bytes(b"concurrent writer")
+
+    monkeypatch.setattr(
+        hermes_state,
+        "_copy_file_for_immutable_audit",
+        copy_then_create_wal,
+        raising=False,
+    )
+
+    with pytest.raises(RuntimeError, match="changed during immutable audit snapshot"):
+        hermes_state.SessionDB(db_path=db_path, read_only=True, immutable=True)
+
+
+def test_immutable_audit_refuses_checkpoint_during_snapshot(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    db = hermes_state.SessionDB(db_path=db_path)
+    db.create_session("before-checkpoint", source="cli")
+    db.close()
+
+    def copy_then_checkpoint(source, destination):
+        shutil.copyfile(source, destination)
+        writer = sqlite3.connect(source, isolation_level=None)
+        try:
+            writer.execute(
+                "UPDATE sessions SET title = 'changed' WHERE id = 'before-checkpoint'"
+            )
+            writer.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        finally:
+            writer.close()
+
+    monkeypatch.setattr(
+        hermes_state,
+        "_copy_file_for_immutable_audit",
+        copy_then_checkpoint,
+    )
+
+    with pytest.raises(RuntimeError, match="changed during immutable audit snapshot"):
+        hermes_state.SessionDB(db_path=db_path, read_only=True, immutable=True)
+
+
+def test_immutable_audit_reads_stable_copy_and_removes_it_on_close(tmp_path):
+    db_path = tmp_path / "state.db"
+    live = hermes_state.SessionDB(db_path=db_path)
+    live.create_session("before", source="cli")
+    live.close()
+
+    audit = hermes_state.SessionDB(db_path=db_path, read_only=True, immutable=True)
+    snapshot_path = audit._immutable_snapshot_path
+    writer = hermes_state.SessionDB(db_path=db_path)
+    try:
+        writer.create_session("after", source="cli")
+        rows = audit._conn.execute("SELECT id FROM sessions ORDER BY id").fetchall()
+        assert [row[0] for row in rows] == ["before"]
+        assert snapshot_path is not None and snapshot_path.exists()
+    finally:
+        writer.close()
+        audit.close()
+
+    assert snapshot_path is not None and not snapshot_path.exists()

--- a/tests/hermes_state/test_abandoned_session_recovery.py
+++ b/tests/hermes_state/test_abandoned_session_recovery.py
@@ -1,0 +1,551 @@
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from hermes_cli.active_sessions import recover_abandoned_session_rows
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield session_db
+    finally:
+        session_db.close()
+
+
+def _old_cli_session(db, session_id="orphan", *, age_seconds=172800):
+    db.create_session(session_id=session_id, source="cli")
+    started_at = time.time() - age_seconds
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (started_at, session_id),
+    )
+    return started_at
+
+
+def test_recover_abandoned_session_is_metadata_only_and_idempotent(db):
+    started_at = _old_cli_session(db)
+    db.set_session_title("orphan", "Preserved session")
+    db.append_message("orphan", role="user", content="keep me", timestamp=started_at)
+
+    first = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=started_at - 1,
+        now=time.time(),
+    )
+    second = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=started_at - 1,
+        now=time.time(),
+    )
+
+    row = db.get_session("orphan")
+    assert first["recovered_ids"] == ["orphan"]
+    assert second["recovered_ids"] == []
+    assert row["ended_at"] is not None
+    assert row["end_reason"] == "orphan_recovered"
+    assert row["title"] == "Preserved session"
+    assert [m["content"] for m in db.get_messages("orphan")] == ["keep me"]
+
+
+def test_recovered_session_remains_discoverable_and_resumable(db):
+    started_at = _old_cli_session(db, session_id="resumable")
+    db.append_message(
+        "resumable", role="user", content="still searchable", timestamp=started_at
+    )
+
+    db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=started_at - 1,
+        now=time.time(),
+    )
+
+    assert "resumable" in {
+        row["id"] for row in db.search_sessions(source="cli", limit=100)
+    }
+    db.reopen_session("resumable")
+    reopened = db.get_session("resumable")
+    assert reopened is not None
+    assert reopened["ended_at"] is None
+    assert reopened["end_reason"] is None
+    assert [m["content"] for m in db.get_messages("resumable")] == [
+        "still searchable"
+    ]
+
+
+def test_live_lease_is_reported_and_never_recovered(db):
+    started_at = _old_cli_session(db, session_id="live")
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids={"live"},
+        eligible_started_after=started_at - 1,
+        now=time.time(),
+    )
+
+    assert result["recovered_ids"] == []
+    assert result["excluded"] == {"live": ["active_lease"]}
+    assert db.get_session("live")["ended_at"] is None
+
+
+def test_recent_activity_arriving_before_recovery_write_keeps_row_open(db):
+    started_at = _old_cli_session(db, session_id="recent-writer")
+    db.append_message(
+        "recent-writer", role="user", content="old", timestamp=started_at
+    )
+    # Simulate another writer committing activity immediately before recovery's
+    # BEGIN IMMEDIATE transaction. The locked classifier must see the new tip.
+    db.append_message(
+        "recent-writer", role="assistant", content="new", timestamp=time.time()
+    )
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=started_at - 1,
+        now=time.time(),
+    )
+
+    assert result["candidate_ids"] == []
+    row = db.get_session("recent-writer")
+    assert row is not None
+    assert row["ended_at"] is None
+
+
+def test_pre_lease_epoch_session_is_reported_as_unproven_legacy(db):
+    started_at = _old_cli_session(db, session_id="legacy")
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=started_at + 1,
+        now=time.time(),
+    )
+
+    assert result["recovered_ids"] == []
+    assert result["excluded"] == {"legacy": ["before_recovery_epoch"]}
+    assert db.get_session("legacy")["ended_at"] is None
+
+
+def test_direct_apply_requires_epoch_and_active_owner_snapshot(db):
+    started_at = _old_cli_session(db, session_id="direct-boundary")
+    now = time.time()
+
+    missing_snapshot = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        eligible_started_after=started_at - 1,
+        now=now,
+        apply=True,
+    )
+    missing_epoch = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        now=now,
+        apply=True,
+    )
+
+    assert missing_snapshot["skipped"] == "missing_active_session_snapshot"
+    assert missing_epoch["skipped"] == "missing_epoch"
+    assert db.get_session("direct-boundary")["ended_at"] is None
+
+
+def test_gateway_owned_row_is_never_recovered(db):
+    started_at = _old_cli_session(db, session_id="gateway-owned")
+    db._conn.execute(
+        "UPDATE sessions SET session_key = ?, chat_id = ?, thread_id = ? WHERE id = ?",
+        ("telegram:chat:thread", "chat", "thread", "gateway-owned"),
+    )
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=started_at - 1,
+        now=time.time(),
+    )
+
+    assert result["recovered_ids"] == []
+    assert result["excluded"] == {"gateway-owned": ["gateway_owned"]}
+    assert db.get_session("gateway-owned")["ended_at"] is None
+
+
+def test_ambiguous_or_protected_rows_are_never_recovered(db):
+    now = time.time()
+    started = {}
+    for session_id in (
+        "pinned",
+        "archived",
+        "handoff",
+        "handoff-completed",
+        "compression",
+        "lineage-parent",
+        "lineage-child",
+        "delegation",
+        "delegation-finalizing",
+        "delegation-undelivered",
+    ):
+        started[session_id] = _old_cli_session(db, session_id=session_id)
+
+    db._conn.execute("UPDATE sessions SET pinned = 1 WHERE id = 'pinned'")
+    db._conn.execute("UPDATE sessions SET archived = 1 WHERE id = 'archived'")
+    db._conn.execute(
+        "UPDATE sessions SET handoff_state = 'running' WHERE id = 'handoff'"
+    )
+    db._conn.execute(
+        "UPDATE sessions SET handoff_state = 'completed' "
+        "WHERE id = 'handoff-completed'"
+    )
+    db._conn.execute(
+        "INSERT INTO compression_locks(session_id, holder, acquired_at, expires_at) "
+        "VALUES ('compression', 'test', ?, ?)",
+        (now - 10, now + 3600),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET parent_session_id = 'lineage-parent' "
+        "WHERE id = 'lineage-child'"
+    )
+    db._conn.execute(
+        "INSERT INTO async_delegations("
+        "delegation_id, origin_session, parent_session_id, state, dispatched_at, updated_at"
+        ") VALUES ('deleg-1', 'delegation', 'delegation', 'running', ?, ?)",
+        (now - 10, now - 10),
+    )
+    db._conn.execute(
+        "INSERT INTO async_delegations("
+        "delegation_id, origin_session, parent_session_id, state, dispatched_at, updated_at"
+        ") VALUES ('deleg-2', 'delegation-finalizing', "
+        "'delegation-finalizing', 'finalizing', ?, ?)",
+        (now - 10, now - 10),
+    )
+    db._conn.execute(
+        "INSERT INTO async_delegations("
+        "delegation_id, origin_session, parent_session_id, state, dispatched_at, "
+        "updated_at, delivery_state, delivery_claim, delivery_claimed_at"
+        ") VALUES ('deleg-3', 'delegation-undelivered', 'delegation-undelivered', "
+        "'completed', ?, ?, 'pending', 'claim', ?)",
+        (now - 10, now - 10, now - 5),
+    )
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=min(started.values()) - 1,
+        now=now,
+    )
+
+    assert result["recovered_ids"] == []
+    assert result["excluded"] == {
+        "archived": ["archived"],
+        "compression": ["compression_active"],
+        "delegation": ["delegation_active"],
+        "delegation-finalizing": ["delegation_active"],
+        "delegation-undelivered": ["delegation_active"],
+        "handoff": ["handoff_active"],
+        "handoff-completed": ["handoff_related"],
+        "lineage-child": ["live_parent"],
+        "lineage-parent": ["live_child"],
+        "pinned": ["pinned"],
+    }
+    assert all(db.get_session(session_id)["ended_at"] is None for session_id in started)
+
+
+def test_origin_session_id_only_active_delegation_is_never_recovered(db):
+    now = time.time()
+    started_at = _old_cli_session(db, session_id="delegation-origin-id-only")
+    columns = {
+        row["name"] for row in db._conn.execute("PRAGMA table_info(async_delegations)")
+    }
+    if "origin_session_id" not in columns:
+        db._conn.execute(
+            "ALTER TABLE async_delegations "
+            "ADD COLUMN origin_session_id TEXT NOT NULL DEFAULT ''"
+        )
+    db._conn.execute(
+        "INSERT INTO async_delegations("
+        "delegation_id, origin_session, origin_session_id, state, "
+        "dispatched_at, updated_at"
+        ") VALUES ('deleg-origin-id', 'unrelated-session-key', "
+        "'delegation-origin-id-only', 'running', ?, ?)",
+        (now - 10, now - 10),
+    )
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=started_at - 1,
+        now=now,
+    )
+
+    assert result["recovered_ids"] == []
+    assert result["excluded"] == {
+        "delegation-origin-id-only": ["delegation_active"]
+    }
+    assert db.get_session("delegation-origin-id-only")["ended_at"] is None
+
+
+def test_external_routing_references_are_never_recovered(db):
+    now = time.time()
+    routing_started = _old_cli_session(db, session_id="routing-ref")
+    topic_started = _old_cli_session(db, session_id="topic-ref")
+    db._conn.execute(
+        "INSERT INTO gateway_routing(scope, session_key, entry_json, updated_at) "
+        "VALUES ('', 'route', ?, ?)",
+        ('{"session_id":"routing-ref"}', now),
+    )
+    db.apply_telegram_topic_migration()
+    db._conn.execute(
+        "INSERT INTO telegram_dm_topic_bindings("
+        "chat_id, thread_id, user_id, session_key, session_id, linked_at, updated_at"
+        ") VALUES ('chat', 'thread', 'user', 'topic-key', 'topic-ref', ?, ?)",
+        (now, now),
+    )
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=min(routing_started, topic_started) - 1,
+        now=now,
+    )
+
+    assert result["recovered_ids"] == []
+    assert result["excluded"] == {
+        "routing-ref": ["gateway_routing_reference"],
+        "topic-ref": ["telegram_topic_binding"],
+    }
+
+
+def test_dry_run_reports_candidate_without_mutating(db, monkeypatch):
+    started_at = _old_cli_session(db, session_id="dry-run")
+    writes_before = db._write_count
+
+    def reject_write(*_args, **_kwargs):
+        raise AssertionError("dry-run classification must not open a write transaction")
+
+    monkeypatch.setattr(db, "_execute_write", reject_write)
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=started_at - 1,
+        now=time.time(),
+        apply=False,
+    )
+
+    assert result["candidate_ids"] == ["dry-run"]
+    assert result["recovered_ids"] == []
+    assert db._write_count == writes_before
+    assert db.get_session("dry-run")["ended_at"] is None
+
+
+def test_lifecycle_recovery_epoch_is_created_once(db):
+    assert db.get_or_create_lifecycle_recovery_epoch(now=100.0) == 100.0
+    assert db.get_or_create_lifecycle_recovery_epoch(now=200.0) == 100.0
+
+
+@pytest.mark.parametrize(
+    "invalid_epoch",
+    ["not-a-number", "-inf", "nan", "0", "-1", "99999999999"],
+)
+def test_invalid_lifecycle_epoch_never_recovers_legacy_row(
+    db, tmp_path, monkeypatch, invalid_epoch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _old_cli_session(db, session_id="legacy-invalid-epoch", age_seconds=172800)
+    db._conn.execute(
+        "INSERT INTO state_meta(key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        ("session_lifecycle_owner_registry_epoch", invalid_epoch),
+    )
+
+    result = recover_abandoned_session_rows(
+        db,
+        apply=True,
+        older_than_seconds=86400,
+        now=time.time(),
+    )
+
+    assert result["recovered_ids"] == []
+    assert db.get_session("legacy-invalid-epoch")["ended_at"] is None
+    row = db._conn.execute(
+        "SELECT value FROM state_meta "
+        "WHERE key = 'session_lifecycle_owner_registry_epoch'"
+    ).fetchone()
+    assert row["value"] == invalid_epoch
+
+
+def test_lifecycle_recovery_attempt_interval_is_claimed_atomically(db):
+    assert db.claim_lifecycle_recovery_attempt(now=100.0, interval_seconds=10.0)
+    assert not db.claim_lifecycle_recovery_attempt(now=105.0, interval_seconds=10.0)
+    assert db.claim_lifecycle_recovery_attempt(now=111.0, interval_seconds=10.0)
+
+
+@pytest.mark.parametrize(
+    "invalid_attempt",
+    ["not-a-number", "-inf", "nan", "0", "-1", "99999999999"],
+)
+def test_invalid_recovery_attempt_marker_suppresses_unattended_work(db, invalid_attempt):
+    key = "session_lifecycle_recovery_last_attempt_at"
+    db._conn.execute(
+        "INSERT INTO state_meta(key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, invalid_attempt),
+    )
+
+    assert not db.claim_lifecycle_recovery_attempt(now=100.0, interval_seconds=10.0)
+    row = db._conn.execute("SELECT value FROM state_meta WHERE key = ?", (key,)).fetchone()
+    assert row["value"] == invalid_attempt
+
+
+def test_startup_scan_is_not_starved_by_legacy_rows(db):
+    now = time.time()
+    legacy_started = _old_cli_session(db, session_id="legacy-old", age_seconds=259200)
+    eligible_started = _old_cli_session(db, session_id="eligible", age_seconds=172800)
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=(legacy_started + eligible_started) / 2,
+        limit=1,
+        now=now,
+        report_legacy_exclusions=False,
+    )
+
+    assert result["recovered_ids"] == ["eligible"]
+    assert db.get_session("legacy-old")["ended_at"] is None
+
+
+def test_manual_audit_candidates_are_not_starved_by_legacy_exclusions(db):
+    now = time.time()
+    legacy_started = []
+    for index in range(3):
+        legacy_started.append(
+            _old_cli_session(
+                db, session_id=f"legacy-{index}", age_seconds=259200 + index
+            )
+        )
+    eligible_started = _old_cli_session(
+        db, session_id="manual-eligible", age_seconds=172800
+    )
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids=set(),
+        eligible_started_after=(max(legacy_started) + eligible_started) / 2,
+        limit=1,
+        now=now,
+        apply=False,
+        report_legacy_exclusions=True,
+    )
+
+    assert result["candidate_ids"] == ["manual-eligible"]
+    assert result["recovered_ids"] == []
+    assert len(result["excluded"]) == 1
+    assert next(iter(result["excluded"].values())) == ["before_recovery_epoch"]
+
+
+def test_protected_rows_do_not_consume_candidate_batch_limit(db):
+    now = time.time()
+    protected_ids = (
+        "pinned-old",
+        "handoff-old",
+        "compression-old",
+        "delegation-old",
+        "routing-old",
+        "topic-old",
+        "lineage-parent-old",
+        "lineage-child-old",
+        "live-lease-old",
+    )
+    for offset, session_id in enumerate(protected_ids):
+        _old_cli_session(db, session_id=session_id, age_seconds=250000 - offset * 1000)
+    _old_cli_session(db, session_id="recoverable-later", age_seconds=230000)
+    db._conn.execute("UPDATE sessions SET pinned = 1 WHERE id = 'pinned-old'")
+    db._conn.execute(
+        "UPDATE sessions SET handoff_state = 'completed' WHERE id = 'handoff-old'"
+    )
+    db._conn.execute(
+        "INSERT INTO compression_locks(session_id, holder, acquired_at, expires_at) "
+        "VALUES ('compression-old', 'test', ?, ?)",
+        (now - 10, now + 3600),
+    )
+    db._conn.execute(
+        "INSERT INTO async_delegations("
+        "delegation_id, origin_session, parent_session_id, state, dispatched_at, updated_at"
+        ") VALUES ('starvation-delegation', 'delegation-old', 'delegation-old', "
+        "'running', ?, ?)",
+        (now - 10, now - 10),
+    )
+    db._conn.execute(
+        "INSERT INTO gateway_routing(scope, session_key, entry_json, updated_at) "
+        "VALUES ('', 'starvation-route', ?, ?)",
+        ('{"session_id":"routing-old"}', now),
+    )
+    db.apply_telegram_topic_migration()
+    db._conn.execute(
+        "INSERT INTO telegram_dm_topic_bindings("
+        "chat_id, thread_id, user_id, session_key, session_id, linked_at, updated_at"
+        ") VALUES ('chat', 'thread', 'user', 'topic-key', 'topic-old', ?, ?)",
+        (now, now),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET parent_session_id = 'lineage-parent-old' "
+        "WHERE id = 'lineage-child-old'"
+    )
+
+    result = db.recover_abandoned_sessions(
+        older_than_seconds=86400,
+        active_session_ids={"live-lease-old"},
+        eligible_started_after=now - 300000,
+        limit=2,
+        now=now,
+        apply=True,
+    )
+
+    assert result["recovered_ids"] == ["recoverable-later"]
+    assert all(db.get_session(session_id)["ended_at"] is None for session_id in protected_ids)
+
+
+def test_recovery_rechecks_recent_activity_after_waiting_for_writer(db):
+    started_at = _old_cli_session(db, session_id="writer-race")
+    writer = sqlite3.connect(db.db_path, isolation_level=None, timeout=5.0)
+    writer.execute("BEGIN IMMEDIATE")
+    writer.execute(
+        "INSERT INTO messages(session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+        ("writer-race", "user", "recent", time.time()),
+    )
+    started = threading.Event()
+    finished = threading.Event()
+    outcome = {}
+
+    def recover():
+        started.set()
+        try:
+            outcome["result"] = db.recover_abandoned_sessions(
+                older_than_seconds=86400,
+                active_session_ids=set(),
+                eligible_started_after=started_at - 1,
+                now=time.time(),
+            )
+        except Exception as exc:
+            outcome["error"] = exc
+        finally:
+            finished.set()
+
+    worker = threading.Thread(target=recover)
+    worker.start()
+    assert started.wait(timeout=2)
+    assert not finished.wait(timeout=0.1)
+    writer.execute("COMMIT")
+    writer.close()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert "error" not in outcome
+    assert outcome["result"]["recovered_ids"] == []
+    assert db.get_session("writer-race")["ended_at"] is None

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17,6 +17,42 @@ from hermes_cli.browser_connect import ChromeDebugLaunch
 from tui_gateway import server
 
 
+def test_tui_owner_registration_exception_rejects_turn(monkeypatch):
+    from hermes_cli import active_sessions
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    def fail_registration(**_kwargs):
+        raise OSError("registry unavailable")
+
+    monkeypatch.setattr(active_sessions, "try_acquire_active_session", fail_registration)
+    session = {"session_key": "session", "source": "tui"}
+
+    message = server._ensure_active_session_slot("live", session)
+
+    assert message is not None
+    assert "ownership" in message.lower()
+    assert session.get("active_session_lease") is None
+
+
+def test_tui_missing_owner_lease_rejects_turn(monkeypatch):
+    from hermes_cli import active_sessions
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(
+        active_sessions,
+        "try_acquire_active_session",
+        lambda **_kwargs: (None, None),
+    )
+    session = {"session_key": "session", "source": "tui"}
+
+    message = server._ensure_active_session_slot("live", session)
+
+    assert message is not None
+    assert "ownership" in message.lower()
+    assert session.get("active_session_lease") is None
+
+
 @pytest.fixture(autouse=True)
 def _neuter_agent_prewarm_timer(request, monkeypatch):
     """Stub the deferred agent pre-warm timer for every test in this module.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -507,15 +507,25 @@ def _claim_active_session_slot(
     try:
         from hermes_cli.active_sessions import try_acquire_active_session
 
-        return try_acquire_active_session(
+        lease, message = try_acquire_active_session(
             session_id=session_key,
             surface=surface,
             config=_load_cfg(),
             metadata={"live_session_id": live_session_id},
         )
+        if lease is None and message is None:
+            message = (
+                "Hermes could not register process ownership; refusing this turn "
+                "without lifecycle safety evidence."
+            )
+        return lease, message
     except Exception as exc:
         logger.warning("Failed to claim active session slot: %s", exc)
-        return None, None
+        return (
+            None,
+            "Hermes could not register process ownership; refusing this turn "
+            "without lifecycle safety evidence.",
+        )
 
 
 def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
@@ -541,6 +551,11 @@ def _ensure_active_session_slot(sid: str, session: dict) -> str | None:
     )
     if limit_message is not None:
         return limit_message
+    if lease is None:
+        return (
+            "Hermes could not register process ownership; refusing this turn "
+            "without lifecycle safety evidence."
+        )
     session["active_session_lease"] = lease
     return None
 

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -435,6 +435,44 @@ hermes sessions rename 20250305_091523_a1b2c3d4 debugging auth flow
 
 If the title is already in use by another session, an error is shown.
 
+### Audit Crash-Abandoned CLI Sessions
+
+Hermes normally persists the transcript and ends each process-owned session row
+before releasing its process lease. After a hard kill or power loss, bounded
+startup maintenance can finalize only an old CLI row that has no live
+PID/start-time owner and no gateway route, topic binding, handoff, delegation,
+compression lock, pinned/archive state, or ambiguous parent/child relationship.
+This recovery only records `ended_at` and `end_reason=orphan_recovered`; it does
+not delete or rewrite messages, titles, usage, routing, or bindings.
+
+Audit the same classifier without writing anything:
+
+```bash
+hermes sessions finalize-orphans
+hermes sessions finalize-orphans --json
+hermes sessions finalize-orphans --min-age-hours 48 --limit 200
+```
+
+A dry run does not create the recovery epoch or registry lock, prune the owner
+registry, enter the SQLite write/checkpoint path, or change session rows. It
+copies a verified-stable main database to a temporary file and opens only that
+copy with immutable SQLite access, preserving the live database and WAL/SHM
+sidecars. A non-empty WAL or rollback journal, or any source change observed
+while taking the snapshot, makes the command refuse the audit rather than
+return a potentially incomplete report. The temporary snapshot is removed on
+close. Applying requires
+both flags and reclassifies under the cross-process owner-registry lock before
+writing:
+
+```bash
+hermes sessions finalize-orphans --apply --yes
+```
+
+Rows from before trustworthy always-on owner registration are reported as
+legacy/unproven and are never finalized automatically. Native retention only
+considers ended sessions, so `retention_days` begins to matter after a normal
+or recovered lifecycle boundary; recovery itself is not deletion.
+
 ### Prune Old Sessions
 
 ```bash


### PR DESCRIPTION
## Summary

- finalize normal CLI/TUI/gateway-owned session rows only after transcript persistence succeeds, while releasing leases on failure
- add fail-closed abandoned-session recovery guarded by owner registration, lifecycle epochs, live leases, gateway/topic routes, handoffs, delegations, compression, lineage, and immutable dry-run evidence
- add `hermes sessions finalize-orphans` audit/apply workflow with explicit confirmation and bounded metadata-only recovery
- document lifecycle ownership, retention, dry-run/apply behavior, and recovery safety boundaries

## Safety properties

- recovery never deletes messages, sessions, FTS rows, transcripts, or gateway/topic bindings
- apply requires the lock-owning wrapper and rejects stale, malformed, non-finite, non-positive, or future lifecycle evidence
- active delegation parent/child/origin references, uncertain process probes, and ambiguous ownership fail closed
- transcript persistence failure leaves the session row open instead of falsely finalizing it

## Test plan

- `scripts/run_tests.sh tests/gateway/test_owner_registration_fail_closed.py tests/hermes_cli/test_active_sessions.py tests/hermes_cli/test_cli_active_session_limit.py tests/hermes_cli/test_session_lifecycle_finalization.py tests/hermes_cli/test_session_recovery.py tests/hermes_cli/test_sessions_finalize_orphans.py tests/hermes_state/test_abandoned_session_recovery.py tests/test_tui_gateway_server.py -v --tb=short` — 579 passed after rebasing onto current `origin/main`
- `uvx ruff check <changed Python files and tests>` — passed
- `python -m py_compile <changed production Python files>` — passed
- `git diff origin/main...HEAD --check` — passed
- pre-rebase frozen-tree review passed with no security, logic, or test findings; broad local matrix passed (988 tests), with one unrelated TUI concurrency flake passing on rerun

## Live-state proof

- SQLite `PRAGMA quick_check`: `ok`
- the existing external zero-message hygiene job atomically removed one eligible ended empty row; it removed zero transcript/message rows and touched zero filesystem artifacts; repeat dry-run reports zero candidates
- after a successful WAL checkpoint, `hermes sessions finalize-orphans --json` completed against live state with zero recovery candidates; the bounded 100 legacy rows were all excluded as `before_recovery_epoch`
- no orphan recovery apply was necessary or performed
- both default and Tracker gateways remained healthy under launchd
