### PR TITLE
fix(tui_gateway): reconcile every build-relevant override with the deferred agent build

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15154,6 +15154,54 @@ def test_reasoning_pick_during_agent_build_reaches_installed_agent(monkeypatch):
         server._sessions.pop(sid, None)
 
 
+def test_global_reasoning_clear_during_agent_build_reaches_installed_agent(
+    tmp_path, monkeypatch
+):
+    """A *cleared* override is a reconciled transition too.
+
+    config.set reasoning with scope=global writes agent.reasoning_effort and
+    pops create_reasoning_override, applying it live only when an agent already
+    exists. During the build window neither happens, so the installed agent
+    would otherwise keep the effort the build snapshotted.
+    """
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: medium\n", encoding="utf-8"
+    )
+
+    sid, session, agent, release = _park_agent_build(
+        monkeypatch,
+        create_reasoning_override={"enabled": True, "effort": "low"},
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {
+                    "session_id": sid,
+                    "key": "reasoning",
+                    "value": "high",
+                    "scope": "global",
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        # The session pin is gone and the agent does not exist yet.
+        assert "create_reasoning_override" not in session
+        assert session.get("agent") is None, "build must still be in flight"
+
+        _finish_build(session, release)
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}, (
+            "a global reasoning change during the build window left the agent "
+            "on the stale snapshotted effort"
+        )
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)
+
+
 def test_explicit_provider_model_switch_during_agent_build_reaches_agent(monkeypatch):
     """config.set model with an explicit provider skips the initialization wait.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15022,6 +15022,301 @@ def test_start_agent_build_passes_session_model_override(
         server._sessions.clear()
 
 
+# ---------------------------------------------------------------------------
+# Deferred agent build <-> override race.
+#
+# _start_agent_build snapshots model_override / create_reasoning_override /
+# create_service_tier_override into the build kwargs and then blocks for
+# seconds inside _make_agent (MCP discovery, prompt/skill build).  Every writer
+# of those keys gates its live-apply on session["agent"] being set, so a pick
+# made inside that window reached neither the kwargs (already read) nor the
+# agent (not yet installed) and was silently lost for the life of the session.
+# ---------------------------------------------------------------------------
+
+
+class _BuildRaceAgent:
+    """Stand-in for the agent _make_agent returns, recording in-place switches."""
+
+    def __init__(self):
+        self.model = "old/model"
+        self.provider = "openrouter"
+        self.base_url = ""
+        self.api_key = "sk-or"
+        self.api_mode = "chat_completions"
+        self.reasoning_config = None
+        self.service_tier = None
+        self.request_overrides: dict = {}
+        self.tools: list = []
+        self.switch_calls: list = []
+
+    def switch_model(self, **kwargs):
+        self.switch_calls.append(kwargs)
+        self.model = kwargs.get("new_model", self.model)
+        self.provider = kwargs.get("new_provider", self.provider)
+
+
+def _park_agent_build(monkeypatch, **session_extra):
+    """Start a deferred agent build parked inside _make_agent.
+
+    Returns ``(sid, session, agent, release)``.  Until ``release`` is set the
+    build thread sits inside _make_agent with ``session["agent"]`` still None —
+    the exact window every override writer used to mishandle.
+    """
+    agent = _BuildRaceAgent()
+    entered = threading.Event()
+    release = threading.Event()
+
+    def _slow_make_agent(_sid, _key, **_kwargs):
+        entered.set()
+        release.wait(timeout=5.0)
+        return agent
+
+    monkeypatch.setattr(server, "_make_agent", _slow_make_agent)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_session_info", lambda _a, *a2: {"model": "x"})
+    monkeypatch.setattr(server, "_probe_config_health", lambda _cfg: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("old/model", ""))
+    monkeypatch.setattr(server, "_start_notification_poller", lambda _sid, _s: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_persist_live_session_runtime", lambda _s: None)
+    monkeypatch.setattr(server, "_persist_live_session_system_prompt", lambda _s: None)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda _sid, _s: None)
+    monkeypatch.setattr(server, "_append_model_switch_marker", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: types.SimpleNamespace(create_session=lambda *a, **kw: None),
+    )
+
+    import tools.approval as _approval
+
+    monkeypatch.setattr(_approval, "register_gateway_notify", lambda key, cb: None)
+    monkeypatch.setattr(_approval, "unregister_gateway_notify", lambda key: None)
+    monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
+
+    sid = "build-race-sid"
+    session = _session(agent_ready=threading.Event(), **session_extra)
+    session["agent"] = None
+    server._sessions[sid] = session
+    server._start_agent_build(sid, session)
+    assert entered.wait(timeout=2.0), "build thread never entered _make_agent"
+    assert session.get("agent") is None, "agent must not be installed yet"
+    return sid, session, agent, release
+
+
+def _finish_build(session, release):
+    release.set()
+    assert session["agent_ready"].wait(timeout=5.0), "build never completed"
+
+
+def _switch_result(model, provider, **extra):
+    return types.SimpleNamespace(
+        success=True,
+        new_model=model,
+        target_provider=provider,
+        api_key=extra.get("api_key", "sk-test"),
+        base_url=extra.get("base_url", "https://example.invalid"),
+        api_mode=extra.get("api_mode", "chat_completions"),
+        warning_message="",
+        model_info=None,
+    )
+
+
+def test_reasoning_pick_during_agent_build_reaches_installed_agent(monkeypatch):
+    """#63998's original shape: /reasoning during the build window was dropped.
+
+    config.set reasoning writes create_reasoning_override and then gates the
+    live apply on session["agent"] — None mid-build — so the effort never
+    reached the agent the build was about to install.
+    """
+    sid, session, agent, release = _park_agent_build(monkeypatch)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {"session_id": sid, "key": "reasoning", "value": "high"},
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert session.get("agent") is None, "build must still be in flight"
+
+        _finish_build(session, release)
+
+        assert session["create_reasoning_override"] is not None
+        assert agent.reasoning_config == session["create_reasoning_override"], (
+            "reasoning picked during the build window never reached the agent"
+        )
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)
+
+
+def test_explicit_provider_model_switch_during_agent_build_reaches_agent(monkeypatch):
+    """config.set model with an explicit provider skips the initialization wait.
+
+    That route calls _apply_model_switch with session["agent"] still None, so it
+    only records model_override; without reconciliation the built agent keeps
+    running the model the build snapshotted.
+    """
+    result = _switch_result("claude-sonnet-4.6", "anthropic")
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model", lambda **_kwargs: result
+    )
+
+    sid, session, agent, release = _park_agent_build(monkeypatch)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {
+                    "session_id": sid,
+                    "key": "model",
+                    "value": "claude-sonnet-4.6 --provider anthropic",
+                    "confirm_expensive_model": True,
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        # The explicit-provider path returned without ever waiting for a build.
+        assert session.get("agent") is None, "build must still be in flight"
+        assert session["model_override"]["model"] == "claude-sonnet-4.6"
+
+        _finish_build(session, release)
+
+        assert agent.switch_calls, (
+            "model picked during the build window never reached the agent"
+        )
+        assert agent.model == "claude-sonnet-4.6"
+        assert agent.provider == "anthropic"
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)
+
+
+def test_moa_one_shot_during_agent_build_reaches_agent(monkeypatch):
+    """The pre-agent /moa branch writes model_override and returns.
+
+    Its comment claimed "the override is consumed by the first build", which is
+    false once the build is already in flight — the MoA turn silently ran on the
+    old model.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.moa_config.normalize_moa_config",
+        lambda _cfg: {"default_preset": "balanced"},
+    )
+    result = _switch_result("balanced", "moa", base_url="moa://local")
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model", lambda **_kwargs: result
+    )
+
+    sid, session, agent, release = _park_agent_build(monkeypatch)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {"session_id": sid, "name": "moa", "arg": "summarize this"},
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert session["model_override"]["provider"] == "moa"
+
+        _finish_build(session, release)
+
+        assert agent.switch_calls, (
+            "/moa preset picked during the build window never reached the agent"
+        )
+        assert agent.provider == "moa"
+        assert agent.model == "balanced"
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)
+
+
+def test_failed_reconcile_does_not_leave_failed_model_override_pinned(monkeypatch):
+    """A failed reconcile must not persist the model it failed to switch to.
+
+    The live switch path raises *before* committing model_override (#50163).
+    The reconcile must match it: a retained failed target would be resurrected
+    by the next /new or resume and rebuild the session onto a broken model.
+    """
+    result = _switch_result("broken/model", "anthropic")
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model", lambda **_kwargs: result
+    )
+
+    sid, session, agent, release = _park_agent_build(monkeypatch)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {
+                    "session_id": sid,
+                    "key": "model",
+                    "value": "broken/model --provider anthropic",
+                    "confirm_expensive_model": True,
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert session["model_override"]["model"] == "broken/model"
+
+        # The in-place swap fails only once the build thread reconciles.
+        def _boom(**_kwargs):
+            raise RuntimeError("provider rejected the model")
+
+        agent.switch_model = _boom
+
+        _finish_build(session, release)
+
+        assert session.get("model_override") is None, (
+            "a failed reconcile left the failed model pinned on the session; "
+            "the next /new or resume would rebuild onto it"
+        )
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)
+
+
+def test_fast_mode_pick_during_agent_build_reaches_installed_agent(monkeypatch):
+    """create_service_tier_override is the third key the build snapshots.
+
+    config.set fast pins it, then gates the live apply on the agent existing —
+    the same race as reasoning.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.models.resolve_fast_mode_overrides",
+        lambda _model: {"service_tier": "priority"},
+    )
+
+    sid, session, agent, release = _park_agent_build(monkeypatch)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {"session_id": sid, "key": "fast", "value": "fast"},
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert session.get("agent") is None, "build must still be in flight"
+        assert session["create_service_tier_override"] == "priority"
+
+        _finish_build(session, release)
+
+        assert agent.service_tier == "priority", (
+            "fast mode picked during the build window never reached the agent"
+        )
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)
+
+
 # ── billing/subscription state + error serialization ─────────────────
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15365,6 +15365,137 @@ def test_fast_mode_pick_during_agent_build_reaches_installed_agent(monkeypatch):
         server._sessions.pop(sid, None)
 
 
+def test_reconcile_drops_the_fast_pin_when_the_switched_model_cannot_honor_it(
+    monkeypatch,
+):
+    """Reconciling both keys must not break the resolver's own invariant.
+
+    ``config.set fast`` returns 4002 ("fast mode is not available for this
+    model") *before* pinning anything, so ``create_service_tier_override ==
+    "priority"`` has always implied that ``resolve_fast_mode_overrides``
+    resolved for the session's model.  A model picked in the same build window
+    is reconciled first and can land on a model without fast support, at which
+    point setting the tier unconditionally leaves the session advertising
+    ``service_tier="priority"`` with no request overrides behind it — a state
+    the live path cannot produce.
+    """
+    monkeypatch.setattr(server, "_resolve_model", lambda: "old/model")
+    monkeypatch.setattr(
+        "hermes_cli.models.resolve_fast_mode_overrides",
+        lambda model: None if model == "no-fast/model" else {"service_tier": "priority"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **_kwargs: _switch_result("no-fast/model", "anthropic"),
+    )
+
+    sid, session, agent, release = _park_agent_build(monkeypatch)
+    try:
+        # Fast first: it validates against the model the session has *now*, so
+        # picking the unsupported model first would simply 4002 here.
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {"session_id": sid, "key": "fast", "value": "fast"},
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert session["create_service_tier_override"] == "priority"
+
+        resp = server.handle_request(
+            {
+                "id": "2",
+                "method": "config.set",
+                "params": {
+                    "session_id": sid,
+                    "key": "model",
+                    "value": "no-fast/model --provider anthropic",
+                    "confirm_expensive_model": True,
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert session.get("agent") is None, "build must still be in flight"
+
+        _finish_build(session, release)
+
+        assert agent.model == "no-fast/model", "the model reconcile must run first"
+        assert agent.service_tier is None, (
+            "the session advertises priority service tier on a model whose fast "
+            "overrides do not resolve; config.set fast refuses to create that state"
+        )
+        assert "service_tier" not in agent.request_overrides
+        assert "speed" not in agent.request_overrides
+        assert session.get("create_service_tier_override") is None, (
+            "an unhonorable fast pin must not survive to the next rebuild"
+        )
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)
+
+
+def test_reconcile_skips_a_model_switch_a_live_writer_already_applied(monkeypatch):
+    """``before`` is the pre-build snapshot, not the agent's live state.
+
+    A writer that takes its live branch after ``session["agent"]`` is set but
+    before reconciliation runs applies the switch itself and pins the same
+    ``model_override`` this function then reads, so the ``!= before`` guard
+    stays true and the switch runs a second time.  The duplicate is not
+    harmless: it restarts the slash worker, appends a second switch marker to
+    the transcript, and re-emits ``session.info``.
+    """
+    switch_calls: list = []
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kwargs: switch_calls.append(kwargs)
+        or _switch_result("new/model", "anthropic"),
+    )
+
+    side_effects: list[str] = []
+    monkeypatch.setattr(
+        server, "_restart_slash_worker", lambda *_a: side_effects.append("slash_worker")
+    )
+    monkeypatch.setattr(
+        server,
+        "_append_model_switch_marker",
+        lambda *_a, **_kw: side_effects.append("switch_marker"),
+    )
+    monkeypatch.setattr(
+        server, "_emit", lambda kind, *_a, **_kw: side_effects.append(f"emit:{kind}")
+    )
+    monkeypatch.setattr(server, "_session_info", lambda _a, *_a2: {"model": "x"})
+    monkeypatch.setattr(server, "_persist_live_session_runtime", lambda _s: None)
+    monkeypatch.setattr(server, "_persist_live_session_system_prompt", lambda _s: None)
+
+    agent = _BuildRaceAgent()
+    # The concurrent live-apply already landed: the agent runs the target model
+    # and the rich override it pinned is what the reconcile reads back.
+    agent.model = "new/model"
+    agent.provider = "anthropic"
+    session = _session(agent=agent)
+    session["model_override"] = {
+        "model": "new/model",
+        "provider": "anthropic",
+        "base_url": "https://example.invalid",
+        "api_key": "sk-test",
+        "api_mode": "chat_completions",
+    }
+
+    server._reconcile_deferred_build_overrides(
+        "sid", session, agent, {"model": None, "reasoning": None, "tier": None}
+    )
+
+    assert switch_calls == [], "resolved a switch for a model already installed"
+    assert agent.switch_calls == [], "swapped the client for a no-op switch"
+    assert side_effects == [], (
+        "duplicated the live writer's side effects: " f"{side_effects}"
+    )
+    assert session["model_override"]["model"] == "new/model", (
+        "the pin the live writer wrote must survive the skip"
+    )
+
+
 # ── billing/subscription state + error serialization ─────────────────
 
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -635,9 +635,12 @@ def _(rid, params: dict) -> dict:
                     session.pop("moa_one_shot_restore", None)
                     return _err(rid, 5030, f"moa unavailable: {exc}")
             else:
-                # No agent built yet (lazy/fresh session): the override is
-                # consumed by the first build, so the turn runs MoA without an
-                # in-place switch.
+                # No agent built yet (lazy/fresh session): the first build
+                # consumes the override, so the turn runs MoA without an
+                # in-place switch. If a build is already in flight it has
+                # already snapshotted the previous value, so
+                # _reconcile_deferred_build_overrides applies this one to the
+                # agent once it is installed.
                 session["model_override"] = {
                     "provider": "moa",
                     "model": preset,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2151,7 +2151,18 @@ def _reconcile_deferred_build_overrides(
     if isinstance(override, dict) and override != before.get("model"):
         model = str(override.get("model") or "").strip()
         provider = str(override.get("provider") or "").strip()
-        if model:
+        # Already running the requested model: a writer that took its LIVE
+        # branch between the agent's installation and this call has applied the
+        # switch itself and pinned the ``model_override`` we just read, but
+        # ``before`` is the pre-build snapshot, so the guard above cannot see
+        # that.  Re-running the switch would duplicate its side effects — a
+        # second slash-worker restart, a second switch marker in the
+        # transcript, a redundant ``session.info`` — for no change.  Same
+        # baseline-adoption check ``_sync_agent_model_with_config`` makes.
+        already_live = model == getattr(agent, "model", "") and (
+            not provider or provider == getattr(agent, "provider", "")
+        )
+        if model and not already_live:
             raw = f"{model} --provider {provider}" if provider else model
             try:
                 _apply_model_switch(
@@ -2187,16 +2198,31 @@ def _reconcile_deferred_build_overrides(
 
     tier = session.get("create_service_tier_override")
     if tier is not None and tier != before.get("tier"):
-        agent.service_tier = "priority" if tier == "priority" else None
-        request_overrides = dict(getattr(agent, "request_overrides", {}) or {})
-        request_overrides.pop("service_tier", None)
-        request_overrides.pop("speed", None)
+        fast_overrides = None
         if tier == "priority":
             from hermes_cli.models import resolve_fast_mode_overrides
 
             fast_overrides = resolve_fast_mode_overrides(getattr(agent, "model", None))
-            if fast_overrides:
-                request_overrides.update(fast_overrides)
+            if fast_overrides is None:
+                # ``config.set fast`` refuses the pin outright (4002, "fast mode
+                # is not available for this model") rather than recording a tier
+                # the model cannot honor, so ``create_service_tier_override ==
+                # "priority"`` has always implied resolvable overrides.  The
+                # model switch reconciled above can invalidate that after the
+                # fact.  Erroring is not available here — nothing is listening
+                # to a background build — so mirror the resolver precedence the
+                # live path enforces and drop the pin instead of advertising
+                # ``service_tier="priority"`` in ``session.info`` with no
+                # matching request overrides behind it.
+                session.pop("create_service_tier_override", None)
+        # Priority iff the overrides actually resolved: the same invariant the
+        # live path gets from its early return.
+        agent.service_tier = "priority" if fast_overrides else None
+        request_overrides = dict(getattr(agent, "request_overrides", {}) or {})
+        request_overrides.pop("service_tier", None)
+        request_overrides.pop("speed", None)
+        if fast_overrides:
+            request_overrides.update(fast_overrides)
         agent.request_overrides = request_overrides
         changed = True
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2126,6 +2126,89 @@ def _wait_agent_for_prompt(session: dict, rid: str, sid: str) -> dict | None:
     return _err(rid, 5032, err) if err else None
 
 
+def _reconcile_deferred_build_overrides(
+    sid: str, session: dict, agent, before: dict
+) -> None:
+    """Apply build-relevant overrides written while the agent was being built.
+
+    ``_start_agent_build`` reads ``model_override`` /
+    ``create_reasoning_override`` / ``create_service_tier_override`` into the
+    build kwargs and then spends seconds inside ``_make_agent`` (MCP discovery,
+    prompt/skill build).  Every writer of those keys gates its live-apply on
+    ``session["agent"]`` being set — ``config.set reasoning``,
+    ``config.set fast``, ``_apply_model_switch``, the pre-agent ``/moa`` branch,
+    and the explicit-provider ``config.set model`` path (which skips the
+    initialization wait entirely).  A pick made inside that window therefore
+    reaches neither the kwargs (already snapshotted) nor the agent (not yet
+    installed), so it is silently lost for the life of the session.
+
+    Re-read the three keys after installation and apply whatever changed
+    through the same helpers the live paths use.  Model goes first: the switch
+    rebuilds the agent's client, and fast-mode overrides must resolve against
+    the newly selected model.
+    """
+    override = session.get("model_override")
+    if isinstance(override, dict) and override != before.get("model"):
+        model = str(override.get("model") or "").strip()
+        provider = str(override.get("provider") or "").strip()
+        if model:
+            raw = f"{model} --provider {provider}" if provider else model
+            try:
+                _apply_model_switch(
+                    sid,
+                    session,
+                    raw,
+                    # The pick is already committed to the session, so its
+                    # cost confirmation (if any) was answered by whoever wrote
+                    # it. Re-prompting here would strand the switch: nothing is
+                    # listening to this background build, so a confirm_required
+                    # return would drop the user's model on the floor.
+                    confirm_expensive_model=True,
+                    pin_session_override=True,
+                    # Reconciling a session-scoped pick — never write config.yaml.
+                    persist_override=False,
+                )
+            except Exception as exc:
+                # The live path raises *before* committing the override
+                # (#50163), so a failed reconcile must not leave the failed
+                # target pinned: a later /new or resume rebuilds from
+                # model_override and would resurrect a model that does not
+                # work.  Put back exactly what the build baked in.
+                logger.warning(
+                    "Deferred-build model override reconcile failed: %s", exc
+                )
+                prior = before.get("model")
+                if prior is None:
+                    session.pop("model_override", None)
+                else:
+                    session["model_override"] = prior
+
+    changed = False
+
+    tier = session.get("create_service_tier_override")
+    if tier is not None and tier != before.get("tier"):
+        agent.service_tier = "priority" if tier == "priority" else None
+        request_overrides = dict(getattr(agent, "request_overrides", {}) or {})
+        request_overrides.pop("service_tier", None)
+        request_overrides.pop("speed", None)
+        if tier == "priority":
+            from hermes_cli.models import resolve_fast_mode_overrides
+
+            fast_overrides = resolve_fast_mode_overrides(getattr(agent, "model", None))
+            if fast_overrides:
+                request_overrides.update(fast_overrides)
+        agent.request_overrides = request_overrides
+        changed = True
+
+    reasoning = session.get("create_reasoning_override")
+    if reasoning is not None and reasoning != before.get("reasoning"):
+        agent.reasoning_config = reasoning
+        changed = True
+
+    if changed:
+        _persist_live_session_runtime(session)
+
+
 def _start_agent_build(sid: str, session: dict) -> None:
     """Start building the real AIAgent for a TUI session, once.
 
@@ -2229,6 +2312,17 @@ def _start_agent_build(sid: str, session: dict) -> None:
                         kw["reasoning_config_override"] = reasoning
                     if (tier := current.get("create_service_tier_override")) is not None:
                         kw["service_tier_override"] = tier
+                # Snapshot what the build is about to bake in. _make_agent
+                # blocks for seconds and every writer of these keys skips its
+                # live-apply while session["agent"] is None, so anything the
+                # user picks from here until installation must be reconciled
+                # afterwards or it is lost — see
+                # _reconcile_deferred_build_overrides.
+                pre_build_overrides = {
+                    "model": current.get("model_override"),
+                    "reasoning": current.get("create_reasoning_override"),
+                    "tier": current.get("create_service_tier_override"),
+                }
                 agent = _make_agent(sid, key, **kw)
             finally:
                 _clear_session_context(tokens)
@@ -2265,6 +2359,12 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 pass
 
             _wire_callbacks(sid)
+            # The agent is installed and wired, so writers now take their live
+            # branch. Adopt anything picked during the build window before the
+            # session.info below publishes the session's runtime identity.
+            _reconcile_deferred_build_overrides(
+                sid, current, agent, pre_build_overrides
+            )
             # Surface the self-improvement review's "💾 …" summary as an event
             # the TUI/desktop render in-transcript, honoring
             # display.memory_notifications. _init_session wires this for the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2201,9 +2201,26 @@ def _reconcile_deferred_build_overrides(
         changed = True
 
     reasoning = session.get("create_reasoning_override")
-    if reasoning is not None and reasoning != before.get("reasoning"):
-        agent.reasoning_config = reasoning
-        changed = True
+    before_reasoning = before.get("reasoning")
+    if reasoning is not None:
+        if reasoning != before_reasoning:
+            agent.reasoning_config = reasoning
+            changed = True
+    elif before_reasoning is not None:
+        # The session pin was *cleared* during the build: `config.set reasoning`
+        # with scope=global writes agent.reasoning_effort and pops the session
+        # key, then applies it live only when an agent already exists.  A
+        # removal is just as much a reconciled transition as a write — without
+        # this the freshly installed agent keeps the stale snapshotted effort
+        # even though the user moved the setting globally.
+        from hermes_constants import parse_reasoning_effort
+
+        cfg = _load_cfg()
+        agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+        global_reasoning = parse_reasoning_effort(agent_cfg.get("reasoning_effort"))
+        if global_reasoning is not None:
+            agent.reasoning_config = global_reasoning
+            changed = True
 
     if changed:
         _persist_live_session_runtime(session)


### PR DESCRIPTION
Supersedes #63998.

## What does this PR do?

`_start_agent_build` snapshots `model_override`, `create_reasoning_override` and
`create_service_tier_override` into the build kwargs (`tui_gateway/server.py`),
then calls `_make_agent`, which blocks for seconds (MCP discovery, prompt/skill
build), and finally installs the result with `current["agent"] = agent` — with
no re-read of those keys.

Every writer of those keys gates its live-apply on `session["agent"]` being set.
So a pick made during the build window reaches **neither** the kwargs (already
snapshotted) **nor** the agent (not yet installed), and is silently lost for the
life of the session. The user picks a model, sees no error, and the session runs
on the old one until they restart it.

#63998 identified this race but locks **`reasoning` only**. The maintainer review
on that PR asked for two things it does not do — this PR implements both:

1. *Synchronize all build-relevant override writers with installation, and
   restore/clear a failed reconciled model override.*
2. *Add barrier tests through the actual explicit-provider model and `/moa`
   routes, plus a failed-switch regression test.*

That PR also retains a failed `switch_model()` target in `model_override`; this
one restores it, matching the live path. (#63998 additionally predates
`f67ca220a refactor(tui): split @method handlers into methods_* modules`, so its
diff is written against the pre-refactor layout and it currently reads
`CONFLICTING`.)

## Related Issue

No filed issue — found via the deferred-build path in `tui_gateway/server.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py` — new `_reconcile_deferred_build_overrides()`; snapshot
  the three keys immediately before `_make_agent`; reconcile after
  `_wire_callbacks`, so the existing `session.info` emit publishes the reconciled
  identity. Model is reconciled first (the switch rebuilds the client, and
  fast-mode overrides resolve against the new model), then tier, then reasoning
  (a `switch_model` can reset `reasoning_config`).
- `tui_gateway/methods_tools.py` — correct the stale `/moa` comment.

### Writer coverage (the whole root cause, not one key)

| Writer | Key | Racy? | Covered |
|---|---|---|---|
| `config.set reasoning` (session scope) | `create_reasoning_override` | yes | ✅ (#63998's only case) |
| `config.set reasoning` (**global** scope) | clears `create_reasoning_override` | yes — the removal is a transition too | ✅ (added in ab86f7d1e) |
| `config.set model` w/ explicit provider | `model_override` | yes — this route skips the `_wait_agent` initialization wait entirely | ✅ |
| `_apply_model_switch` | `model_override` | yes | ✅ |
| pre-agent `/moa` | `model_override` | yes | ✅ |
| `config.set fast` | `create_service_tier_override` | yes — same agent-gated live-apply | ✅ |
| `methods_session.py` resume | `model_override` | **no** — eager resume path; the agent is built synchronously before it, so no deferred build is in flight | screened, excluded |

The `/moa` else-branch carried the comment *"the override is consumed by the
first build"* — false while a build is already in flight, and the site's own
neighbouring comment already records the sibling failure (`#53444: setting
session["model_override"] alone never switched the already-built agent`). The
comment is now accurate.

### Failed-switch handling

A failed reconcile restores the override the build baked in (or clears it)
instead of retaining the failed target. This matches the live path, which raises
*before* committing `model_override` (#50163). A retained failure would be
resurrected by the next `/new` or resume, rebuilding onto a model that does not
work.

The reconcile passes `confirm_expensive_model=True`: the pick is already
committed to the session, so its cost confirmation was answered by whoever wrote
it, and nothing is listening to this background build — a `confirm_required`
return would drop the user's model on the floor.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/test_tui_gateway_server.py -q` → 501 passed.
2. The five new tests park a real build inside `_make_agent` (mirroring the
   existing `_slow_make_agent` barrier idiom in this file), issue the override
   through its **real RPC route** while `session["agent"]` is still `None`,
   release the build, then assert the installed agent carries the pick.

### Red-before proof (two-way)

| New test | Full revert | Revert only the model/tier half (= #63998's reasoning-only shape) | With this PR |
|---|---|---|---|
| `test_reasoning_pick_during_agent_build_reaches_installed_agent` | ❌ fail | ✅ pass | ✅ pass |
| `test_global_reasoning_clear_during_agent_build_reaches_installed_agent` | ❌ fail | ❌ fail | ✅ pass |
| `test_explicit_provider_model_switch_during_agent_build_reaches_agent` | ❌ fail | ❌ fail | ✅ pass |
| `test_moa_one_shot_during_agent_build_reaches_agent` | ❌ fail | ❌ fail | ✅ pass |
| `test_failed_reconcile_does_not_leave_failed_model_override_pinned` | ❌ fail | ❌ fail | ✅ pass |
| `test_fast_mode_pick_during_agent_build_reaches_installed_agent` | ❌ fail | ❌ fail | ✅ pass |

The middle column is the point: reducing this PR to #63998's coverage leaves five
of the six failures live.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — pure Python, no platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

- #49756 (*close agents orphaned during session build*) edits the same install
  site but fixes a different defect — a session dying mid-build leaving an
  unclosed agent. No overlap with override staleness; both can land.
- #65567 (`run_after_agent_ready`) and #72857 (`switch_model` resetting reasoning
  at the agent layer) are disjoint.
- alt-glitch flagged #63998 as covering the same race. It does, for `reasoning`
  only, and it is `CONFLICTING` against current main after the `methods_*`
  refactor. This PR is the superset (see the writer-coverage and red-before
  tables above), so consolidating onto it loses nothing.
