### PR TITLE
fix(tui): expand collapsed paste tokens before submission

### DIFF
--- a/ui-tui/src/__tests__/useSubmission.test.ts
+++ b/ui-tui/src/__tests__/useSubmission.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ComposerToken } from '../app/interfaces.js'
+import { prepareSubmission, shouldInterpolateSubmission } from '../app/useSubmission.js'
+
+describe('prepareSubmission', () => {
+  it('keeps the collapsed paste for display and expands the model payload', () => {
+    const label = '[[ first.. [3 lines] .. last ]]'
+    const tokens: ComposerToken[] = [{ kind: 'paste', label, text: 'first\nmiddle\nlast' }]
+
+    expect(prepareSubmission(`review this: ${label}`, tokens)).toEqual({
+      display: `review this: ${label}`,
+      text: 'review this: first\nmiddle\nlast'
+    })
+  })
+
+  it('does not execute interpolation syntax hidden inside pasted content', () => {
+    const label = '[[ copied log [1 lines] ]]'
+    const tokens: ComposerToken[] = [{ kind: 'paste', label, text: 'untrusted {!touch /tmp/pwned}' }]
+    const submission = prepareSubmission(label, tokens)
+
+    expect(shouldInterpolateSubmission(submission.display)).toBe(false)
+    expect(submission.text).toContain('{!touch /tmp/pwned}')
+  })
+})

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -9,7 +9,7 @@ import { asRpcResult } from '../lib/rpc.js'
 import { hasInterpolation, INTERPOLATION_RE } from '../protocol/interpolation.js'
 import type { Msg } from '../types.js'
 
-import type { ComposerActions, ComposerRefs, ComposerState } from './interfaces.js'
+import type { ComposerActions, ComposerRefs, ComposerState, ComposerToken } from './interfaces.js'
 import { submitPrompt } from './submissionCore.js'
 import { turnController } from './turnController.js'
 import { getUiState, patchUiState } from './uiStore.js'
@@ -18,6 +18,13 @@ const DOUBLE_ENTER_MS = 450
 
 const spliceMatches = (text: string, matches: RegExpMatchArray[], results: string[]) =>
   matches.reduceRight((acc, m, i) => acc.slice(0, m.index!) + results[i] + acc.slice(m.index! + m[0].length), text)
+
+export const prepareSubmission = (display: string, tokens: ComposerToken[]) => ({
+  display,
+  text: expandTokens(tokens)(display)
+})
+
+export const shouldInterpolateSubmission = (display: string) => hasInterpolation(display)
 
 export function useSubmission(opts: UseSubmissionOptions) {
   const { appendMessage, composerActions, composerRefs, composerState, gw, setLastUserMsg, slashRef, submitRef, sys } =
@@ -56,10 +63,15 @@ export function useSubmission(opts: UseSubmissionOptions) {
   }, [composerState.input, composerState.inputBuf])
 
   const send = useCallback(
-    (text: string, showUserMessage = true, displayText?: string) => {
+    (
+      text: string,
+      showUserMessage = true,
+      displayText?: string,
+      expandOverride?: (value: string) => string
+    ) => {
       // Read tokens off the ref, not render state: a paste immediately followed
       // by Enter submits before React has re-rendered with the new token.
-      const expand = expandTokens(composerRefs.tokensRef.current)
+      const expand = expandOverride ?? expandTokens(composerRefs.tokensRef.current)
 
       submitPrompt(
         text,
@@ -213,7 +225,9 @@ export function useSubmission(opts: UseSubmissionOptions) {
       // nothing — a detached image can't be re-attached by recalling the text.
       // Idempotent on token-free text, so re-submitting a recalled entry is
       // stable.
-      const toHistory = expandTokens(composerRefs.tokensRef.current)(full)
+      const submissionTokens = [...composerRefs.tokensRef.current]
+      const submission = prepareSubmission(full, submissionTokens)
+      const toHistory = submission.text
 
       if (looksLikeSlashCommand(full)) {
         appendMessage({ kind: 'slash', role: 'system', text: full })
@@ -275,13 +289,15 @@ export function useSubmission(opts: UseSubmissionOptions) {
         return handleBusyInput(full)
       }
 
-      if (hasInterpolation(full)) {
+      if (shouldInterpolateSubmission(full)) {
         patchUiState({ busy: true })
 
-        return interpolate(full, send)
+        return interpolate(full, text =>
+          send(prepareSubmission(text, submissionTokens).text, true, submission.display, value => value)
+        )
       }
 
-      send(full)
+      send(submission.text, true, submission.display, value => value)
     },
     [
       appendMessage,


### PR DESCRIPTION
## Bug Description

Multiline pastes collapse into a `[[ ... ]]` composer token as intended, but ordinary non-busy TUI submission sends that literal token to the agent instead of the original pasted content.

## Root Cause

`dispatchSubmission()` expands composer tokens for history, then calls `clearIn()`. Since `clearIn()` synchronously clears `tokensRef.current`, the later `send(full)` call rebuilds its expander from an empty token list. The collapsed display label therefore reaches `prompt.submit` unchanged.

This regression was introduced when paste state moved from React state to synchronously updated composer refs in #75210.

## Fix

- Snapshot and expand composer tokens before clearing composer state.
- Submit the expanded payload while preserving the collapsed token as transcript display text.
- Keep interpolation detection on visible composer text so `{!...}` copied inside pasted content remains inert.
- Prevent asynchronous interpolation from consuming tokens belonging to a newer draft.
- Add focused regressions for payload expansion and hidden interpolation syntax.

This intentionally complements #74797, which addresses queued paste payloads. Queue, pre-session, queue-edit, and busy paths remain outside this PR.

## How to Verify

1. Paste five or more lines into an idle TUI so the composer shows a collapsed `[[ ... ]]` token.
2. Submit it normally.
3. Confirm the user transcript keeps the compact token.
4. Confirm the agent receives and can quote the full multiline payload.
5. Paste text containing `{!command}` and confirm it is delivered literally rather than executed.

## Test Plan

- [x] `npm test -- --run src/__tests__/useSubmission.test.ts src/__tests__/attachments.test.ts src/__tests__/submissionCore.test.ts` (23 passed)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `git diff --check`
- [ ] Full TUI suite currently has unrelated failures already present on clean `main`: subscription overlay rendering and Ink backpressure timing

## Platforms Tested

- macOS 27.0
