### PR TITLE
fix(gateway): block destructive start --all in gateway sessions

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -1,7 +1,8 @@
 """Gateway lifecycle guard for cron job creation (#30719).
 
 An agent running inside a gateway can schedule a cron job that calls
-``hermes gateway restart`` (or ``launchctl kickstart ai.hermes.gateway``
+``hermes gateway restart`` (or ``hermes gateway start --all``,
+``launchctl kickstart ai.hermes.gateway``
 or ``systemctl restart hermes-gateway``).  When the cron fires, the
 gateway dies, the supervisor (launchd KeepAlive / systemd Restart=)
 revives it, auto-resume picks up the offending session, and the resumed
@@ -25,7 +26,8 @@ command shape.
 
 This is a defence-in-depth layer.  ``tools/terminal_tool.py`` already
 blocks these commands at *execution* time when ``_HERMES_GATEWAY=1``, and
-``hermes gateway stop|restart`` refuse to self-target from inside the
+``hermes gateway stop|restart`` and ``gateway start --all`` refuse to
+self-target from inside the
 gateway.  Blocking at *creation* time as well means the agent gets an
 immediate, informative rejection instead of scheduling a job that will
 only fail (silently) when it fires.
@@ -42,16 +44,32 @@ class GatewayLifecycleBlocked(ValueError):
     """Raised when a cron job spec contains a gateway-lifecycle command."""
 
 
+# The CLI intentionally accepts -p/--profile anywhere before ``--`` and strips
+# it before argparse sees the remaining command (hermes_cli.main:556-596).
+# Normalize the same valid profile selectors before lifecycle matching so
+# equivalent spellings such as ``hermes gateway -p alex restart`` cannot bypass
+# the cron/terminal defense-in-depth layer.
+_PROFILE_SELECTOR_PATTERN = re.compile(
+    r"(?i)(?<!\S)(?:(?:-p|--profile)\s+[a-z0-9][a-z0-9_-]{0,63}"
+    r"|--profile=[a-z0-9][a-z0-9_-]{0,63})(?!\S)"
+)
+
+
 # Shell-level command shapes that target the gateway lifecycle. Each branch
 # is anchored on a concrete command identifier so a match can only fire on
 # actual shell-command-shaped strings, not on prose.
 _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"(?i)"
-    # Branch A: `hermes gateway restart|stop` — the canonical foot-gun.
-    # `start` is intentionally excluded: starting a gateway from inside a
-    # gateway is benign (a no-op or "already running" error), and a
-    # legitimate cron job might start a sibling profile's gateway.
-    r"(?:hermes\s+gateway\s+(?:restart|stop))"
+    # Branch A: `hermes gateway restart|stop` — the canonical foot-gun —
+    # Profile selectors are normalized out before this pattern runs. Plain
+    # `start` stays allowed because a legitimate job may start a stopped
+    # sibling profile.
+    # `start --all` is different: it kills gateway processes across every
+    # profile before starting the selected profile's service, so it belongs in
+    # the lifecycle block. Accept options before/after --all and common shell
+    # delimiters after it without broadening the match to plain start.
+    r"(?:hermes\s+gateway\s+"
+    r"(?:(?:restart|stop)\b|start\b[^\n;&|]*\s--a(?:l(?:l)?)?(?:\s|[;&|)]|$)))"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.
@@ -70,7 +88,8 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
-    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(text))
+    normalized = _PROFILE_SELECTOR_PATTERN.sub(" ", text)
+    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
 
 
 def _resolve_script_path(script_path: str) -> Path:
@@ -134,8 +153,8 @@ def check_gateway_lifecycle(
     if contains_gateway_lifecycle_command(combined):
         raise GatewayLifecycleBlocked(
             "Blocked: cron job contains a gateway lifecycle command "
-            "(restart/stop/kill). This is blocked to prevent agent-driven "
+            "(restart/stop/start --all/kill). This is blocked to prevent agent-driven "
             "SIGTERM-respawn loops under launchd/systemd supervision "
-            "(#30719). Run `hermes gateway restart` from a shell outside "
-            "the running gateway instead."
+            "(#30719). Run destructive gateway lifecycle commands from a "
+            "shell outside the running gateway instead."
         )

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6935,6 +6935,22 @@ def _gateway_command_inner(args):
         system = getattr(args, "system", False)
         start_all = getattr(args, "all", False)
 
+        # Plain start is intentionally allowed from a gateway session: it is
+        # profile-scoped, so an operator/cron job may start a stopped sibling
+        # profile. `start --all` is not profile-scoped — it calls
+        # kill_gateway_processes(all_profiles=True) below and can terminate the
+        # gateway running this command plus every sibling. Refuse only that
+        # destructive variant, preserving the legitimate sibling-start path.
+        if start_all and os.getenv("_HERMES_GATEWAY") == "1":
+            print_error(
+                "Refusing to start all gateways from inside a gateway process.\n"
+                "`gateway start --all` stops gateway processes across every profile "
+                "before starting one service.\n"
+                "Use plain `hermes -p <profile> gateway start` for a stopped sibling, "
+                "or run `hermes gateway start --all` from an external shell."
+            )
+            sys.exit(1)
+
         # Phase 4: inside a container with s6, dispatch via the service
         # manager instead of falling through to systemd/launchd/windows.
         # `--all` isn't meaningful here (each profile has its own service

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -28,6 +28,18 @@ class TestGatewayLifecyclePattern:
     @pytest.mark.parametrize("text", [
         "hermes gateway restart",
         "hermes gateway stop",
+        "hermes -p alex gateway restart",
+        "hermes --profile alex gateway stop",
+        "hermes --profile=alex gateway restart",
+        "hermes gateway -p alex restart",
+        "hermes gateway --profile=alex stop",
+        "hermes gateway start --all",
+        "hermes gateway start --system --all",
+        "hermes -p alex gateway start --all",
+        "hermes gateway start -p alex --all",
+        "hermes gateway start --all --profile alex",
+        "hermes gateway start --a",          # argparse abbreviation for --all
+        "hermes gateway start --al",         # argparse abbreviation for --all
         "hermes  gateway  restart",         # double spaces
         "Hermez Gateway Restart".lower().replace("z", "s"),  # case handled
         "HERMES GATEWAY RESTART",           # uppercase
@@ -44,12 +56,15 @@ class TestGatewayLifecyclePattern:
         "echo 'just a normal cron job'",
         "run the backup script",
         "gateway is running fine",
-        # `hermes gateway start` is benign — starting a gateway from inside a
-        # gateway is a no-op / "already running", and a legit cron job may
-        # start a sibling profile's gateway. Only restart/stop/kill are the
-        # foot-gun (#30719 lists only those).
+        # Plain `hermes gateway start` is benign — starting the current
+        # profile is a no-op / "already running", and a legit cron job may
+        # start a sibling profile's gateway. `start --all` is different: it
+        # kills processes across every profile before starting one service.
         "hermes gateway start",
-        "hermes gateway start --all",
+        "hermes -p alex gateway start",
+        "hermes --profile alex gateway start",
+        "hermes --profile=alex gateway start",
+        "hermes gateway start && echo --all",  # --all belongs to another command
         # Tightened launchctl/systemctl branches: ops on NON-gateway hermes
         # services must not be falsely blocked (the old `.*hermes` matched any
         # hermes token).
@@ -161,7 +176,33 @@ class TestCronCreateLifecycleBlock:
 # ---------------------------------------------------------------------------
 
 class TestGatewaySelfTargetingGuard:
-    """Verify hermes gateway stop/restart refuse when _HERMES_GATEWAY=1."""
+    """Verify destructive gateway lifecycle commands refuse in a gateway."""
+
+    def test_start_all_refuses_inside_gateway(self, monkeypatch):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        from hermes_cli.gateway import gateway_command
+        args = Namespace(gateway_command="start", all=True, system=False)
+        with pytest.raises(SystemExit) as exc_info:
+            gateway_command(args)
+        assert exc_info.value.code == 1
+
+    def test_plain_start_allows_inside_gateway(self, monkeypatch):
+        # Plain start is intentionally allowed: it is profile-scoped, so a
+        # gateway may start a stopped sibling profile. Stop before any real
+        # service-manager call by sentineling the first downstream dispatch.
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        import hermes_cli.gateway as gw
+
+        class _Reached(Exception):
+            pass
+
+        def _sentinel(*a, **k):
+            raise _Reached()
+
+        monkeypatch.setattr(gw, "_dispatch_via_service_manager_if_s6", _sentinel)
+        args = Namespace(gateway_command="start", all=False, system=False)
+        with pytest.raises(_Reached):
+            gw.gateway_command(args)
 
     def test_stop_refuses_inside_gateway(self, monkeypatch):
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
@@ -233,6 +274,15 @@ class TestTerminalToolGatewayLifecycleGuard:
         "systemctl --user restart hermes-gateway",
         "systemctl stop hermes-gateway.service",
         "hermes gateway restart",
+        "hermes -p alex gateway restart",
+        "hermes --profile alex gateway stop",
+        "hermes gateway -p alex restart",
+        "hermes gateway --profile=alex stop",
+        "hermes gateway start --all",
+        "hermes -p alex gateway start --all",
+        "hermes gateway start --all --profile alex",
+        "hermes gateway start --a",
+        "hermes gateway start --al",
         "launchctl kickstart gui/501/ai.hermes.gateway",
         "pkill -f hermes.*gateway",
     ])
@@ -276,6 +326,48 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 0
         assert calls == ["systemctl status nginx"]
 
+    def test_plain_sibling_start_passes_through_inside_gateway(self, monkeypatch):
+        """Profile-scoped start without --all is intentionally allowed."""
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "starting...", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True})
+
+        command = "hermes -p alex gateway start"
+        result = json.loads(tt.terminal_tool(command=command))
+
+        assert result["exit_code"] == 0
+        assert calls == [command]
+
+    def test_guard_inactive_outside_gateway(self, monkeypatch):
+        """Without _HERMES_GATEWAY=1 the lifecycle guard must not fire."""
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "restarting...", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=False)
+        monkeypatch.setattr(tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True})
+
+        result = json.loads(tt.terminal_tool(command="systemctl restart hermes-gateway"))
+
+        # Outside the gateway the lifecycle guard doesn't block — the normal
+        # approval flow handles it (here mocked as approved).
+        assert result["exit_code"] == 0
+        assert calls == ["systemctl restart hermes-gateway"]
 
 # ---------------------------------------------------------------------------
 # cron.lifecycle_guard module — the shared checker create_job/CLI/terminal use
@@ -290,6 +382,47 @@ class TestLifecycleGuardModule:
             check_gateway_lifecycle("please run hermes gateway restart", None)
         assert "#30719" in str(exc.value)
 
+    def test_clean_prompt_does_not_raise(self):
+        from cron.lifecycle_guard import check_gateway_lifecycle
+        check_gateway_lifecycle("research the gateway architecture", None)
+        check_gateway_lifecycle("check server health and restart watchers", None)
+
+    @pytest.mark.parametrize("command", [
+        "hermes -p alex gateway start --all",
+        "hermes gateway -p alex start --all",
+        "hermes gateway start --all --profile alex",
+        "hermes gateway start --a",
+        "hermes gateway start --al",
+    ])
+    def test_profile_scoped_start_all_raises(self, command):
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle(command, None)
+
+    @pytest.mark.parametrize("command", [
+        "hermes -p alex gateway start",
+        "hermes gateway -p alex start",
+        "hermes gateway start --profile=alex",
+    ])
+    def test_plain_sibling_start_does_not_raise(self, command):
+        from cron.lifecycle_guard import check_gateway_lifecycle
+        check_gateway_lifecycle(command, None)
+
+    def test_script_with_command_raises(self, tmp_path, monkeypatch):
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/bash\nhermes gateway restart\n")
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("clean prompt", str(script))
+
+    def test_split_across_prompt_and_script_still_blocks(self, tmp_path):
+        """Concatenated scan prevents splitting the command between prompt and
+        script to slip through."""
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+        script = tmp_path / "ops.sh"
+        script.write_text("hermes gateway stop\n")
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops job", str(script))
 
     def test_binary_script_does_not_silently_bypass(self, tmp_path):
         """Non-UTF-8 bytes used to be swallowed by UnicodeDecodeError; now we

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2432,7 +2432,7 @@ def terminal_tool(
             }, ensure_ascii=False)
 
         # Hard-block: gateway lifecycle commands (systemctl/launchctl/hermes
-        # restart|stop targeting hermes-gateway) must never run inside the
+        # restart|stop or start --all targeting hermes-gateway) must never run inside the
         # gateway process itself. The restart would SIGTERM the gateway, which
         # kills this very subprocess before it can complete — the service may
         # never restart. This mirrors the `hermes gateway restart` guard in
@@ -2445,11 +2445,11 @@ def terminal_tool(
                     "output": "",
                     "exit_code": 1,
                     "error": (
-                        "Blocked: cannot restart or stop the gateway from inside the "
+                        "Blocked: cannot restart, stop, or start all gateways from inside the "
                         "gateway process. The gateway would kill this command before "
                         "it could complete (SIGTERM propagates to child processes). "
-                        "Run `hermes gateway restart` from a separate shell outside "
-                        "the running gateway."
+                        "Plain profile-scoped `gateway start` remains allowed; run destructive "
+                        "gateway lifecycle commands from a separate shell outside the gateway."
                     ),
                     "status": "error",
                 }, ensure_ascii=False)


### PR DESCRIPTION
## Summary

- block only destructive `hermes gateway start --all` from inside a running gateway
- preserve intentionally allowed plain and sibling-profile `gateway start`
- normalize valid profile selectors in every CLI-supported position
- block argparse abbreviations `--a` and `--al` for `--all`
- cover direct CLI, terminal, and cron lifecycle paths

## Consolidation

This supersedes #70639 and consolidates the narrower current-main solution developed in #54157. The implementation commit was cherry-picked so the original author, `vexclawx31`, remains credited in Git history.

The earlier broad approach was incorrect because it blocked legitimate sibling-profile starts. This version targets only `start --all`, which calls `kill_gateway_processes(all_profiles=True)` and can terminate the invoking gateway plus sibling profiles.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py -q` — 83 passed
- Ruff passed for all changed Python files
- `py_compile` passed for all changed Python files
- Windows-footgun scan passed across 893 files
- `git diff origin/main...HEAD --check` passed
- public-diff sensitive scan found 0 hits

No live gateway or service-manager operation was executed.
