### PR TITLE
feat(gateway): support channel workspace routing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -543,7 +543,7 @@ class SessionResetPolicy:
 @dataclass
 class ChannelOverride:
     """
-    Per-channel override for model, provider, and system prompt.
+    Per-channel override for model, provider, system prompt, and working directory.
 
     Used in config under platforms.<name>.channel_overrides[channel_id].
     Enables different channels (e.g. Discord #daily vs #dev) to use different
@@ -552,6 +552,7 @@ class ChannelOverride:
     model: Optional[str] = None
     provider: Optional[str] = None
     system_prompt: Optional[str] = None
+    workdir: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {}
@@ -561,6 +562,8 @@ class ChannelOverride:
             out["provider"] = self.provider
         if self.system_prompt is not None:
             out["system_prompt"] = self.system_prompt
+        if self.workdir is not None:
+            out["workdir"] = self.workdir
         return out
 
     @classmethod
@@ -571,6 +574,7 @@ class ChannelOverride:
             model=data.get("model"),
             provider=data.get("provider"),
             system_prompt=data.get("system_prompt"),
+            workdir=data.get("workdir"),
         )
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -541,7 +541,7 @@ import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
+from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union, Sequence
 from enum import Enum
 
 from pathlib import Path as _Path
@@ -6567,6 +6567,7 @@ class BasePlatformAdapter(ABC):
         scope_id: Optional[str] = None,
         guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
+        ancestor_chat_ids: Optional[Sequence[str]] = None,
         message_id: Optional[str] = None,
         role_authorized: bool = False,
         auto_thread_created: bool = False,
@@ -6605,6 +6606,7 @@ class BasePlatformAdapter(ABC):
                         scope_id=str(scope_id) if scope_id else None,
                         guild_id=str(guild_id) if guild_id else None,
                         parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
+                        ancestor_chat_ids=tuple(str(value) for value in (ancestor_chat_ids or ())),
                         message_id=str(message_id) if message_id else None,
                     )
                 )
@@ -6629,6 +6631,7 @@ class BasePlatformAdapter(ABC):
             scope_id=str(scope_id) if scope_id else None,
             guild_id=str(guild_id) if guild_id else None,
             parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
+            ancestor_chat_ids=tuple(str(value) for value in (ancestor_chat_ids or ())),
             message_id=str(message_id) if message_id else None,
             profile=profile,
             role_authorized=role_authorized,

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -203,6 +203,10 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         chat_id_alt=src.get("chat_id_alt"),
         scope_id=src.get("scope_id"),
         parent_chat_id=src.get("parent_chat_id"),
+        ancestor_chat_ids=tuple(
+            str(value) for value in (src.get("ancestor_chat_ids") or ())
+            if value is not None
+        ),
         message_id=src.get("message_id"),
         # The HERMES profile this event is routed to (multiplex mode). The
         # connector stamps it on the wire source when NAS resolves the target

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -44,7 +44,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
+from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, Sequence, cast
 
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
@@ -2954,15 +2954,16 @@ def _channel_override_lookup_keys(
     *,
     thread_id: Optional[str] = None,
     parent_id: Optional[str] = None,
+    ancestor_ids: Optional[Sequence[str]] = None,
 ) -> list[str]:
     """Ordered, de-duplicated keys for ``channel_overrides`` lookup.
 
-    Matches ``resolve_channel_prompt`` semantics: exact thread/channel id first,
-    then parent channel/forum id (Discord threads inherit parent overrides).
+    Exact thread/channel ID wins, followed by the immediate parent and then
+    platform-supplied ancestors from nearest to farthest.
     """
     keys: list[str] = []
     seen: set[str] = set()
-    for key in (chat_id, thread_id, parent_id):
+    for key in (chat_id, thread_id, parent_id, *(ancestor_ids or ())):
         if not key:
             continue
         sk = str(key)
@@ -2980,11 +2981,12 @@ def _get_channel_override(
     *,
     thread_id: Optional[str] = None,
     parent_id: Optional[str] = None,
+    ancestor_ids: Optional[Sequence[str]] = None,
 ) -> Optional[ChannelOverride]:
     """Return per-channel override for this platform/chat_id, or None.
 
-    Looks up ``channel_overrides`` by ``chat_id``, then ``thread_id``, then
-    ``parent_id`` (forum threads / child channels inherit the parent entry).
+    Looks up ``channel_overrides`` by exact ID, immediate parent, then ordered
+    platform-supplied ancestors (for example a Discord category).
     """
     platforms = getattr(config, "platforms", None)
     if not platforms:
@@ -2994,7 +2996,8 @@ def _get_channel_override(
         return None
     overrides = platform_config.channel_overrides
     for key in _channel_override_lookup_keys(
-        chat_id, thread_id=thread_id, parent_id=parent_id
+        chat_id, thread_id=thread_id, parent_id=parent_id,
+        ancestor_ids=ancestor_ids,
     ):
         ov = overrides.get(key)
         if ov is not None:
@@ -4106,6 +4109,7 @@ class TurnRunner:
             ctx.source.chat_id or "",
             thread_id=getattr(ctx.source, "thread_id", None),
             parent_id=getattr(ctx.source, "parent_chat_id", None),
+            ancestor_ids=getattr(ctx.source, "ancestor_chat_ids", ()),
         )
         if cfg_channel_prompt:
             combined_ephemeral = (combined_ephemeral + "\n\n" + cfg_channel_prompt).strip()
@@ -6658,6 +6662,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_id,
                 thread_id=thread_id,
                 parent_id=parent_id,
+                ancestor_ids=getattr(source, "ancestor_chat_ids", ()),
             )
             if ch:
                 if ch.model:
@@ -7685,6 +7690,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config: Optional[dict] = None,
         thread_id: Optional[str] = None,
         parent_id: Optional[str] = None,
+        ancestor_ids: Optional[Sequence[str]] = None,
     ) -> str:
         """Resolve model for this channel: channel_overrides else global default.
 
@@ -7707,6 +7713,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_id,
                 thread_id=thread_id,
                 parent_id=parent_id,
+                ancestor_ids=ancestor_ids,
             )
         return resolve_effective_model(
             None,  # session tier applied downstream (_apply_session_model_override)
@@ -7721,6 +7728,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         *,
         thread_id: Optional[str] = None,
         parent_id: Optional[str] = None,
+        ancestor_ids: Optional[Sequence[str]] = None,
     ) -> str:
         """Ephemeral system prompt for this channel/thread.
 
@@ -7737,10 +7745,66 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_id,
                 thread_id=thread_id,
                 parent_id=parent_id,
+                ancestor_ids=ancestor_ids,
             )
             if override and override.system_prompt:
                 return (override.system_prompt or "").strip()
         return getattr(self, "_ephemeral_system_prompt", None) or ""
+
+    def _resolve_workdir_for_session(
+        self,
+        source: SessionSource,
+        session_key: str,
+    ) -> str:
+        """Return the validated, conversation-pinned channel workdir.
+
+        A missing override is represented by ``""``. Config changes take
+        effect only after a conversation boundary clears the pin.
+        """
+        conversation = self._session_state(session_key).conversation
+        if conversation.workdir is not None:
+            return conversation.workdir
+
+        override_config = self.config
+        if getattr(override_config, "multiplex_profiles", False):
+            # Channel overrides are profile-owned behavioral config. Resolve
+            # them from the routed profile rather than the multiplexer's
+            # default config, matching the profile scope used later for agent
+            # and context construction.
+            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+                override_config = load_gateway_config()
+
+        override = _get_channel_override(
+            override_config,
+            source.platform,
+            str(source.chat_id or ""),
+            thread_id=getattr(source, "thread_id", None),
+            parent_id=getattr(source, "parent_chat_id", None),
+            ancestor_ids=getattr(source, "ancestor_chat_ids", ()),
+        )
+        configured = (override.workdir or "").strip() if override else ""
+        if not configured:
+            conversation.workdir = ""
+            return ""
+
+        path = Path(configured)
+        if not path.is_absolute():
+            raise ValueError(
+                f"channel override workdir must be an absolute path: {configured!r}"
+            )
+        try:
+            resolved = path.resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise ValueError(
+                f"channel override workdir does not exist: {configured!r}"
+            ) from exc
+        if not resolved.is_dir():
+            raise ValueError(
+                f"channel override workdir is not a directory: {configured!r}"
+            )
+        value = str(resolved)
+        conversation.workdir = value
+        return value
 
     @staticmethod
     def _load_reasoning_config(model: str = "") -> dict | None:
@@ -15637,9 +15701,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # Build session context
         context = build_session_context(source, self.config, session_entry)
+
+        # Resolve once per conversation before binding any tool context. An
+        # invalid override must stop the turn rather than fall through to the
+        # gateway process cwd.
+        try:
+            session_workdir = self._resolve_workdir_for_session(source, session_key)
+        except ValueError as exc:
+            logger.error(
+                "Refusing gateway turn with invalid channel workdir for %s: %s",
+                session_key,
+                exc,
+            )
+            adapter = self._adapter_for_source(source)
+            if adapter:
+                await adapter.send(
+                    source.chat_id,
+                    f"⚠️ Invalid channel workspace configuration: {exc}",
+                    metadata=self._thread_metadata_for_source(source),
+                )
+            return None
+        if session_workdir:
+            # Tool calls use the conversation's session_id as task_id. Seed
+            # the existing per-task terminal/file cwd registry; no process
+            # cwd or global TERMINAL_CWD mutation is involved.
+            from tools.terminal_tool import update_task_env_overrides
+
+            update_task_env_overrides(
+                session_entry.session_id,
+                {"cwd": session_workdir},
+            )
+            self._session_state(
+                session_key
+            ).conversation.workdir_task_overrides[session_entry.session_id] = (
+                session_workdir
+            )
         
         # Set session context variables for tools (task-local, concurrency-safe)
-        _session_env_tokens = self._set_session_env(context)
+        _session_env_tokens = self._set_session_env(context, cwd=session_workdir)
         
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
@@ -20233,7 +20332,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return delivered
 
-    def _set_session_env(self, context: SessionContext) -> list:
+    def _set_session_env(self, context: SessionContext, *, cwd: str = "") -> list:
         """Set session context variables for the current async task.
 
         Uses ``contextvars`` instead of ``os.environ`` so that concurrent
@@ -20267,6 +20366,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,
+            cwd=cwd,
         )
 
     def _clear_session_env(self, tokens: list) -> None:
@@ -21849,6 +21949,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # call — no per-attribute pop-list to drift.
         state = self._peek_session_state(session_key)
         if state is not None:
+            from tools.terminal_tool import clear_task_env_override_cwd
+
+            for task_id, expected_cwd in tuple(
+                state.conversation.workdir_task_overrides.items()
+            ):
+                clear_task_env_override_cwd(
+                    task_id,
+                    expected_cwd=expected_cwd,
+                )
             state.conversation.clear()
         # Legacy plain-dict stores still registered in
         # _CONVERSATION_SCOPED_STATE (not yet folded into SessionState),

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -175,6 +175,10 @@ class SessionSource:
     scope_id: Optional[str] = None
     guild_id: Optional[str] = None  # @deprecated legacy alias for scope_id (D-Q2.5)
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
+    # Ordered nearest-to-farthest stable ancestor IDs. Platform adapters fill
+    # this when their hierarchy is deeper than parent_chat_id (Discord
+    # category ancestry, for example).
+    ancestor_chat_ids: tuple[str, ...] = ()
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
     role_authorized: bool = False  # True when adapter granted access via role (not user ID)
     # Profile this inbound message is routed to in a multiplexing gateway
@@ -260,6 +264,8 @@ class SessionSource:
             d["guild_id"] = scope
         if self.parent_chat_id:
             d["parent_chat_id"] = self.parent_chat_id
+        if self.ancestor_chat_ids:
+            d["ancestor_chat_ids"] = list(self.ancestor_chat_ids)
         if self.message_id:
             d["message_id"] = self.message_id
         if self.profile:
@@ -287,6 +293,10 @@ class SessionSource:
             # deprecated `guild_id` alias (a peer not yet migrated still sends it).
             scope_id=data.get("scope_id", data.get("guild_id")),
             parent_chat_id=data.get("parent_chat_id"),
+            ancestor_chat_ids=tuple(
+                str(value) for value in (data.get("ancestor_chat_ids") or ())
+                if value is not None
+            ),
             message_id=data.get("message_id"),
             profile=data.get("profile"),
             auto_thread_created=bool(data.get("auto_thread_created", False)),

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -109,6 +109,11 @@ class ConversationState:
     ephemeral_pin: Optional[Tuple[Any, ...]] = None
     # Last voice-channel context delivered (None = never delivered).
     vc_last: Optional[str] = None
+    # Channel-override workspace pin. None = unresolved; "" = resolved with
+    # no workspace; any other value is a validated absolute directory.
+    workdir: Optional[str] = None
+    # task/session id -> gateway-owned cwd value, for expected-value cleanup.
+    workdir_task_overrides: Dict[str, str] = field(default_factory=dict)
 
     def clear(self) -> None:
         """Reset every conversation-scoped field to its default.
@@ -126,6 +131,8 @@ class ConversationState:
         self.sidecar_notes = []
         self.ephemeral_pin = None
         self.vc_last = None
+        self.workdir = None
+        self.workdir_task_overrides = {}
 
 
 @dataclass

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5835,6 +5835,8 @@ class DiscordAdapter(BasePlatformAdapter):
         # For forum threads, inherit the parent forum's topic.
         chat_topic = self._get_effective_topic(interaction.channel, is_thread=is_thread)
 
+        interaction_channel = getattr(interaction, "channel", None)
+        parent_id = self._get_parent_channel_id(interaction_channel) if is_thread else None
         source = self.build_source(
             chat_id=str(interaction.channel_id),
             chat_name=chat_name,
@@ -5843,11 +5845,13 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            parent_chat_id=parent_id,
+            ancestor_chat_ids=self._channel_ancestor_ids(interaction_channel),
         )
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
         channel_id = str(interaction.channel_id)
-        parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
+        parent_id = parent_id or ""
         return MessageEvent(
             text=text,
             message_type=msg_type,
@@ -5928,6 +5932,12 @@ class DiscordAdapter(BasePlatformAdapter):
         # Inherit forum topic when the thread was created inside a forum channel.
         _chan = getattr(interaction, "channel", None)
         chat_topic = self._get_effective_topic(_chan, is_thread=True) if _chan else None
+        _parent_channel = (
+            self._thread_parent_channel(_chan)
+            if isinstance(_chan, discord.Thread)
+            else _chan
+        )
+        _parent_id = str(getattr(_parent_channel, "id", "") or "")
 
         source = self.build_source(
             chat_id=thread_id,
@@ -5937,10 +5947,10 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            parent_chat_id=_parent_id or None,
+            ancestor_chat_ids=self._channel_ancestor_ids(_parent_channel),
         )
 
-        _parent_channel = self._thread_parent_channel(getattr(interaction, "channel", None))
-        _parent_id = str(getattr(_parent_channel, "id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
         event = MessageEvent(
@@ -7221,6 +7231,33 @@ class DiscordAdapter(BasePlatformAdapter):
             return str(parent_id)
         return None
 
+    def _channel_ancestor_ids(self, channel: Any) -> tuple[str, ...]:
+        """Return stable Discord ancestor IDs, nearest first.
+
+        ``parent_chat_id`` carries a thread's immediate parent separately.
+        This list includes every more-distant Discord parent (notably the
+        category) and is deterministically de-duplicated by the gateway.
+        """
+        ids: list[str] = []
+        seen: set[str] = set()
+        current = channel
+        while current is not None:
+            parent = (
+                getattr(current, "parent", None)
+                or getattr(current, "category", None)
+            )
+            if parent is None:
+                category_id = str(getattr(current, "category_id", "") or "")
+                if category_id and category_id not in seen:
+                    ids.append(category_id)
+                break
+            parent_id = str(getattr(parent, "id", "") or "")
+            if parent_id and parent_id not in seen:
+                seen.add(parent_id)
+                ids.append(parent_id)
+            current = parent
+        return tuple(ids)
+
     def _is_forum_parent(self, channel: Any) -> bool:
         """Best-effort check for whether a Discord channel is a forum channel."""
         if channel is None:
@@ -7614,6 +7651,7 @@ class DiscordAdapter(BasePlatformAdapter):
             is_bot=getattr(message.author, "bot", False),
             guild_id=str(guild.id) if guild else None,
             parent_chat_id=parent_channel_id,
+            ancestor_chat_ids=self._channel_ancestor_ids(effective_channel),
             message_id=str(message.id),
             role_authorized=role_authorized,
             auto_thread_created=auto_threaded_channel is not None,

--- a/tests/gateway/test_channel_override_workdir.py
+++ b/tests/gateway/test_channel_override_workdir.py
@@ -1,0 +1,546 @@
+"""Channel-override workspace routing and isolation contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import nullcontext
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+from agent.prompt_builder import build_context_files_prompt
+from agent.runtime_cwd import resolve_context_cwd
+from gateway.config import (
+    ChannelOverride,
+    GatewayConfig,
+    Platform,
+    PlatformConfig,
+    load_gateway_config,
+)
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner, TurnRunner, _get_channel_override
+from gateway.session import SessionContext, SessionEntry, SessionSource, build_session_key
+from gateway.turn_context import TurnContext
+from tools.file_tools import read_file_tool
+from tools.terminal_tool import terminal_tool
+
+
+def _config(overrides: dict[str, ChannelOverride]) -> GatewayConfig:
+    return GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                channel_overrides=overrides,
+            ),
+            Platform.SLACK: PlatformConfig(
+                enabled=True,
+                channel_overrides=overrides,
+            ),
+        }
+    )
+
+
+def _runner(config: GatewayConfig) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.adapters = {}
+    return runner
+
+
+def _source(
+    platform: Platform = Platform.DISCORD,
+    *,
+    chat_id: str = "333",
+    parent_id: str | None = "222",
+    ancestors: tuple[str, ...] = ("222", "111"),
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        chat_type="thread",
+        thread_id=chat_id,
+        parent_chat_id=parent_id,
+        ancestor_chat_ids=ancestors,
+        user_id="user-1",
+    )
+
+
+def test_generic_direct_channel_workdir_resolution(tmp_path):
+    config = _config({"222": ChannelOverride(workdir=str(tmp_path))})
+    source = SessionSource(platform=Platform.SLACK, chat_id="222")
+
+    assert _runner(config)._resolve_workdir_for_session(source, "session-1") == str(
+        tmp_path.resolve()
+    )
+
+
+def test_multiplexed_workdir_uses_routed_profile_config(tmp_path, monkeypatch):
+    default_workspace = tmp_path / "default"
+    profile_workspace = tmp_path / "profile"
+    default_workspace.mkdir()
+    profile_workspace.mkdir()
+    default_config = _config(
+        {"222": ChannelOverride(workdir=str(default_workspace))}
+    )
+    default_config.multiplex_profiles = True
+    profile_config = _config(
+        {"222": ChannelOverride(workdir=str(profile_workspace))}
+    )
+    runner = _runner(default_config)
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="222",
+        profile="work",
+    )
+
+    monkeypatch.setattr(
+        runner,
+        "_resolve_profile_home_for_source",
+        lambda resolved_source: tmp_path / resolved_source.profile,
+    )
+    monkeypatch.setattr(
+        "gateway.run._profile_runtime_scope",
+        lambda profile_home: nullcontext(),
+    )
+    monkeypatch.setattr("gateway.run.load_gateway_config", lambda: profile_config)
+
+    assert runner._resolve_workdir_for_session(source, "profile-session") == str(
+        profile_workspace
+    )
+
+
+def test_discord_category_channel_thread_precedence(tmp_path):
+    category = tmp_path / "category"
+    channel = tmp_path / "channel"
+    thread = tmp_path / "thread"
+    for path in (category, channel, thread):
+        path.mkdir()
+    source = _source()
+
+    category_only = _config({"111": ChannelOverride(workdir=str(category))})
+    assert _runner(category_only)._resolve_workdir_for_session(source, "s1") == str(category)
+
+    channel_override = _config(
+        {
+            "111": ChannelOverride(workdir=str(category)),
+            "222": ChannelOverride(workdir=str(channel)),
+        }
+    )
+    assert _runner(channel_override)._resolve_workdir_for_session(source, "s2") == str(channel)
+
+    thread_override = _config(
+        {
+            "111": ChannelOverride(workdir=str(category)),
+            "222": ChannelOverride(workdir=str(channel)),
+            "333": ChannelOverride(workdir=str(thread)),
+        }
+    )
+    assert _runner(thread_override)._resolve_workdir_for_session(source, "s3") == str(thread)
+
+    # Override selection is whole-entry precedence: an exact child entry with
+    # no workdir intentionally stops category workspace inheritance.
+    stop_inheritance = _config(
+        {
+            "111": ChannelOverride(workdir=str(category)),
+            "333": ChannelOverride(model="thread-only-model"),
+        }
+    )
+    assert _runner(stop_inheritance)._resolve_workdir_for_session(source, "s4") == ""
+
+
+def test_override_lookup_is_deterministic_deduplicated_and_preserves_other_fields():
+    category = ChannelOverride(
+        model="model-category",
+        provider="provider-category",
+        system_prompt="category prompt",
+    )
+    channel = ChannelOverride(
+        model="model-channel",
+        provider="provider-channel",
+        system_prompt="channel prompt",
+    )
+    config = _config({"111": category, "222": channel})
+
+    selected = _get_channel_override(
+        config,
+        Platform.DISCORD,
+        "333",
+        thread_id="333",
+        parent_id="222",
+        ancestor_ids=("222", "111", "111"),
+    )
+
+    assert selected is channel
+    assert selected.model == "model-channel"
+    assert selected.provider == "provider-channel"
+    assert selected.system_prompt == "channel prompt"
+
+
+def test_turn_runner_live_prompt_lookup_receives_ancestor_ids():
+    class _LookupReached(Exception):
+        pass
+
+    class _StubRunner:
+        def _get_system_prompt_for_channel(self, *_args, **kwargs):
+            assert kwargs["ancestor_ids"] == ("222", "111")
+            raise _LookupReached
+
+    ctx = TurnContext(
+        source=_source(),
+        context_prompt="",
+        channel_prompt="",
+    )
+
+    with pytest.raises(_LookupReached):
+        TurnRunner(_StubRunner(), ctx).run_sync()
+
+
+def test_category_ancestor_routes_runtime_model_provider_and_prompt(monkeypatch):
+    override = ChannelOverride(
+        model="category/model",
+        provider="category-provider",
+        system_prompt="category system prompt",
+    )
+    runner = _runner(_config({"111": override}))
+    runner._session_model_overrides = {}
+    runner._ephemeral_system_prompt = "global prompt"
+    source = _source()
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda _cfg=None: "global/model")
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {"provider": "global-provider", "api_key": "test"},
+    )
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        lambda provider: {"provider": provider, "api_key": "test-provider"},
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source,
+        user_config={"model": {"default": "global/model"}},
+    )
+    prompt = runner._get_system_prompt_for_channel(
+        source.platform,
+        source.chat_id,
+        thread_id=source.thread_id,
+        parent_id=source.parent_chat_id,
+        ancestor_ids=source.ancestor_chat_ids,
+    )
+
+    assert model == "category/model"
+    assert runtime["provider"] == "category-provider"
+    assert prompt == "category system prompt"
+
+
+@pytest.mark.parametrize("configured", ["relative/project", "/missing/hermes-workdir"])
+def test_invalid_workdir_fails_clearly(configured):
+    runner = _runner(_config({"222": ChannelOverride(workdir=configured)}))
+    source = SessionSource(platform=Platform.SLACK, chat_id="222")
+
+    with pytest.raises(ValueError, match="absolute path|does not exist"):
+        runner._resolve_workdir_for_session(source, "session-invalid")
+
+
+def test_existing_file_is_not_accepted_as_workdir(tmp_path):
+    configured = tmp_path / "not-a-directory"
+    configured.write_text("content", encoding="utf-8")
+    runner = _runner(_config({"222": ChannelOverride(workdir=str(configured))}))
+    source = SessionSource(platform=Platform.SLACK, chat_id="222")
+
+    with pytest.raises(ValueError, match="not a directory"):
+        runner._resolve_workdir_for_session(source, "session-file")
+
+
+def test_workdir_mapping_is_pinned_until_conversation_scope_clears(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    override = ChannelOverride(workdir=str(first))
+    runner = _runner(_config({"222": override}))
+    source = SessionSource(platform=Platform.SLACK, chat_id="222")
+
+    assert runner._resolve_workdir_for_session(source, "session-1") == str(first)
+    override.workdir = str(second)
+    assert runner._resolve_workdir_for_session(source, "session-1") == str(first)
+
+    runner._clear_session_boundary_security_state = lambda _key: None
+    runner._clear_conversation_scope("session-1", reason="test reset")
+    assert runner._resolve_workdir_for_session(source, "session-1") == str(second)
+
+
+def test_conversation_boundary_clears_owned_workspace_after_terminal_cd(
+    tmp_path, monkeypatch
+):
+    import tools.terminal_tool as terminal_module
+
+    workspace = str(tmp_path.resolve())
+    monkeypatch.setattr(
+        terminal_module,
+        "_task_env_overrides",
+        {"task-1": {"docker_image": "neutral:latest", "cwd": workspace}},
+    )
+    monkeypatch.setattr(
+        terminal_module,
+        "_session_cwd",
+        {"task-1": f"{workspace}/subdir"},
+    )
+    runner = _runner(_config({}))
+    conversation = runner._session_state("session-1").conversation
+    conversation.workdir = workspace
+    conversation.workdir_task_overrides = {"task-1": workspace}
+    runner._clear_session_boundary_security_state = lambda _key: None
+
+    runner._clear_conversation_scope("session-1", reason="test boundary")
+
+    assert terminal_module._task_env_overrides == {
+        "task-1": {"docker_image": "neutral:latest"}
+    }
+    assert terminal_module.get_session_cwd("task-1") is None
+    assert conversation.workdir is None
+    assert conversation.workdir_task_overrides == {}
+    assert not hasattr(runner, "_session_workdirs")
+    assert not hasattr(runner, "_session_workdir_task_overrides")
+
+
+def test_session_source_ancestor_ids_roundtrip():
+    restored = SessionSource.from_dict(_source().to_dict())
+    assert restored.ancestor_chat_ids == ("222", "111")
+
+
+def test_relay_wire_preserves_ancestor_ids():
+    from gateway.relay.ws_transport import _event_from_wire
+
+    event = _event_from_wire(
+        {
+            "text": "hello",
+            "source": _source().to_dict(),
+        }
+    )
+
+    assert event.source.ancestor_chat_ids == ("222", "111")
+
+
+@pytest.mark.asyncio
+async def test_gateway_handler_routes_configured_workdir_to_real_tool_context(
+    tmp_path, monkeypatch
+):
+    """Drive config -> handler -> session context -> tool cwd as production does."""
+    workspace = tmp_path / "category-project"
+    workspace.mkdir()
+    (workspace / "AGENTS.md").write_text(
+        "gateway-e2e-workspace", encoding="utf-8"
+    )
+    (workspace / "marker.txt").write_text(
+        "gateway-e2e-file", encoding="utf-8"
+    )
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "discord:\n"
+        "  channel_overrides:\n"
+        '    "111":\n'
+        f"      workdir: {workspace}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    config = load_gateway_config()
+    runner = GatewayRunner(config)
+    source = _source()
+    session_key = build_session_key(source)
+    session_id = "workspace-e2e-session"
+    entry = SessionEntry(
+        session_key=session_key,
+        session_id=session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.DISCORD,
+        chat_type="thread",
+    )
+
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = MagicMock()
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _generation: True
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_platform_message_id.return_value = False
+    runner.session_store.update_session = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+
+    observed = {}
+
+    async def observe_agent_context(*_args, **_kwargs):
+        observed["context_cwd"] = resolve_context_cwd()
+        observed["prompt"] = build_context_files_prompt(cwd=resolve_context_cwd())
+        observed["file"] = read_file_tool("marker.txt", task_id=session_id)
+        from tools.code_execution_tool import _resolve_child_cwd
+
+        observed["code_cwd"] = _resolve_child_cwd(
+            "project", str(tmp_path), task_id=session_id
+        )
+        terminal_data = json.loads(terminal_tool("pwd", task_id=session_id))
+        observed["terminal_cwd"] = terminal_data["output"].strip()
+        return {
+            "final_response": "done",
+            "messages": [
+                {"role": "user", "content": "inspect workspace"},
+                {"role": "assistant", "content": "done"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+
+    runner._run_agent = AsyncMock(side_effect=observe_agent_context)
+    event = MessageEvent(text="inspect workspace", source=source, message_id="m1")
+
+    await runner._handle_message_with_agent(event, source, session_key, 1)
+
+    expected = str(workspace.resolve())
+    assert str(observed["context_cwd"]) == expected
+    assert "gateway-e2e-workspace" in observed["prompt"]
+    assert "gateway-e2e-file" in observed["file"]
+    assert observed["code_cwd"] == expected
+    assert observed["terminal_cwd"] == expected
+
+    # Invalid-workdir errors must retain Slack's workspace discriminator, not
+    # silently fall back to the adapter's primary workspace client.
+    slack_source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="slack-channel",
+        chat_type="thread",
+        user_id="slack-user",
+        thread_id="slack-thread",
+        scope_id="workspace-two",
+        message_id="slack-message",
+    )
+    slack_key = build_session_key(slack_source)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.SLACK: PlatformConfig(
+                enabled=True,
+                channel_overrides={
+                    "slack-channel": ChannelOverride(workdir="relative/project")
+                },
+            )
+        }
+    )
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key=slack_key,
+        session_id="slack-invalid-workdir-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="thread",
+    )
+    slack_adapter = MagicMock()
+    slack_adapter.send = AsyncMock()
+    runner.adapters[Platform.SLACK] = slack_adapter
+    runner._run_agent.reset_mock()
+
+    await runner._handle_message_with_agent(
+        MessageEvent(
+            text="inspect workspace",
+            source=slack_source,
+            message_id="slack-message",
+        ),
+        slack_source,
+        slack_key,
+        2,
+    )
+
+    runner._run_agent.assert_not_awaited()
+    assert slack_adapter.send.await_args.kwargs["metadata"] == {
+        "thread_id": "slack-thread",
+        "message_id": "slack-message",
+        "slack_team_id": "workspace-two",
+    }
+
+
+def test_concurrent_workdirs_isolate_context_file_terminal_and_file_tools(tmp_path):
+    workspaces = []
+    for name in ("alpha", "docs"):
+        workspace = tmp_path / name
+        workspace.mkdir()
+        (workspace / "AGENTS.md").write_text(f"workspace-context:{name}", encoding="utf-8")
+        (workspace / "marker.txt").write_text(f"workspace-file:{name}", encoding="utf-8")
+        workspaces.append((name, workspace))
+
+    async def observe(name: str, workspace) -> tuple[str, str, str]:
+        runner = _runner(_config({}))
+        source = SessionSource(platform=Platform.SLACK, chat_id=name)
+        context = SessionContext(
+            source=source,
+            connected_platforms=[Platform.SLACK],
+            home_channels={},
+            session_key=f"session-{name}",
+            session_id=f"id-{name}",
+        )
+        tokens = runner._set_session_env(context, cwd=str(workspace))
+        task_id = f"id-{name}"
+        try:
+            await asyncio.sleep(0)
+            prompt = build_context_files_prompt(cwd=resolve_context_cwd())
+            from tools.terminal_tool import register_task_env_overrides
+
+            register_task_env_overrides(task_id, {"cwd": str(workspace)})
+            file_result = read_file_tool("marker.txt", task_id=task_id)
+            from tools.code_execution_tool import _resolve_child_cwd
+
+            code_cwd = _resolve_child_cwd(
+                "project",
+                str(tmp_path),
+                task_id=task_id,
+            )
+            terminal_result = await asyncio.to_thread(
+                terminal_tool,
+                "pwd",
+                task_id=task_id,
+            )
+            terminal_data = json.loads(terminal_result)
+            assert code_cwd == str(workspace)
+            return prompt, file_result, terminal_data["output"].strip()
+        finally:
+            from tools.terminal_tool import clear_task_env_overrides
+
+            clear_task_env_overrides(task_id)
+            runner._clear_session_env(tokens)
+
+    async def run_both():
+        return await asyncio.gather(
+            *(observe(name, workspace) for name, workspace in workspaces)
+        )
+
+    alpha, docs = asyncio.run(run_both())
+
+    assert "workspace-context:alpha" in alpha[0]
+    assert "workspace-context:docs" not in alpha[0]
+    assert "workspace-file:alpha" in alpha[1]
+    assert alpha[2] == str(workspaces[0][1])
+    assert "workspace-context:docs" in docs[0]
+    assert "workspace-context:alpha" not in docs[0]
+    assert "workspace-file:docs" in docs[1]
+    assert docs[2] == str(workspaces[1][1])

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -101,6 +101,7 @@ class TestPlatformConfigRoundtrip:
                     model="openrouter/healer-alpha",
                     provider="openrouter",
                     system_prompt="You are a daily news summarizer.",
+                    workdir="/srv/projects/alpha",
                 ),
                 "9876543210": ChannelOverride(
                     model="anthropic/claude-opus-4.6",
@@ -113,9 +114,11 @@ class TestPlatformConfigRoundtrip:
         assert "channel_overrides" in d
         assert d["channel_overrides"]["1234567890"]["model"] == "openrouter/healer-alpha"
         assert d["channel_overrides"]["9876543210"]["system_prompt"] == "You are a coding assistant."
+        assert d["channel_overrides"]["1234567890"]["workdir"] == "/srv/projects/alpha"
         restored = PlatformConfig.from_dict(d)
         assert restored.channel_overrides["1234567890"].model == "openrouter/healer-alpha"
         assert restored.channel_overrides["9876543210"].provider == "anthropic"
+        assert restored.channel_overrides["1234567890"].workdir == "/srv/projects/alpha"
 
 
 class TestChannelOverride:
@@ -786,6 +789,27 @@ class TestLoadGatewayConfig:
         assert telegram.extra.get("require_mention") is True, (
             "require_mention configured under platforms.telegram must be "
             "bridged into PlatformConfig.extra by the shared-key loop"
+        )
+
+    def test_bridges_discord_channel_workdir_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "discord:\n"
+            "  channel_overrides:\n"
+            '    "1234567890":\n'
+            "      workdir: /srv/projects/alpha\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.DISCORD]
+            .channel_overrides["1234567890"]
+            .workdir
+            == "/srv/projects/alpha"
         )
 
 

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -102,6 +102,15 @@ def _make_source() -> SessionSource:
 
 
 class TestResolveChannelPrompts:
+    def test_channel_ancestor_ids_include_category_for_channel_and_thread(self):
+        adapter = _make_adapter()
+        category = SimpleNamespace(id=111, parent=None, category=None)
+        channel = SimpleNamespace(id=222, parent=None, category=category)
+        thread = SimpleNamespace(id=333, parent=channel, category=None)
+
+        assert adapter._channel_ancestor_ids(channel) == ("111",)
+        assert adapter._channel_ancestor_ids(thread) == ("222", "111")
+
     def test_no_prompt_returns_none(self):
         adapter = _make_adapter()
         assert adapter._resolve_channel_prompt("123") is None
@@ -123,6 +132,74 @@ class TestResolveChannelPrompts:
         assert adapter._resolve_channel_prompt("100") == "Research mode"
         # Pre-bridging numeric key would not match (bridging is responsible)
         adapter.config.extra = {"channel_prompts": {100: "Research mode"}}
+        assert adapter._resolve_channel_prompt("100") is None
+
+    def test_match_by_parent_id(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"200": "Forum prompt"}}
+        assert adapter._resolve_channel_prompt("999", parent_id="200") == "Forum prompt"
+
+    def test_exact_channel_overrides_parent(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_prompts": {
+                "999": "Thread override",
+                "200": "Forum prompt",
+            }
+        }
+        assert adapter._resolve_channel_prompt("999", parent_id="200") == "Thread override"
+
+    def test_build_message_event_sets_channel_prompt(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"321": "Command prompt"}}
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+
+        category = SimpleNamespace(id=111, parent=None)
+        interaction = SimpleNamespace(
+            channel_id=321,
+            channel=SimpleNamespace(
+                id=321,
+                name="general",
+                guild=None,
+                parent_id=111,
+                parent=category,
+            ),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+        adapter._get_effective_topic = MagicMock(return_value=None)
+
+        event = adapter._build_slash_event(interaction, "/retry")
+
+        assert event.channel_prompt == "Command prompt"
+        assert adapter.build_source.call_args.kwargs["ancestor_chat_ids"] == ("111",)
+
+    @pytest.mark.asyncio
+    async def test_dispatch_thread_session_inherits_parent_channel_prompt(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"200": "Parent prompt"}}
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+        adapter._get_effective_topic = MagicMock(return_value=None)
+        adapter.handle_message = AsyncMock()
+
+        category = SimpleNamespace(id=111, parent=None)
+        parent = SimpleNamespace(id=200, parent=category)
+        interaction = SimpleNamespace(
+            guild=SimpleNamespace(name="Wetlands"),
+            channel=parent,
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+
+        await adapter._dispatch_thread_session(interaction, "999", "new-thread", "hello")
+
+        dispatched_event = adapter.handle_message.await_args.args[0]
+        source_kwargs = adapter.build_source.call_args.kwargs
+        assert source_kwargs["parent_chat_id"] == "200"
+        assert source_kwargs["ancestor_chat_ids"] == ("111",)
+        assert dispatched_event.channel_prompt == "Parent prompt"
+
+    def test_blank_prompts_are_ignored(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"100": "   "}}
         assert adapter._resolve_channel_prompt("100") is None
 
 
@@ -152,5 +229,4 @@ async def test_retry_preserves_channel_prompt(monkeypatch):
     assert result == "ok"
     retried_event = runner._handle_message.await_args.args[0]
     assert retried_event.channel_prompt == "Channel prompt"
-
 

--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -43,6 +43,49 @@ class TestDualWriteSites:
         assert tt.get_session_cwd("desktop-sess") == "/wt/desktop"
 
 
+    def test_update_task_env_overrides_merges_without_changing_register_contract(self):
+        tt.register_task_env_overrides("session", {"docker_image": "neutral:latest"})
+        tt.update_task_env_overrides("session", {"cwd": "/work/neutral"})
+        assert tt._task_env_overrides["session"] == {
+            "docker_image": "neutral:latest",
+            "cwd": "/work/neutral",
+        }
+
+        tt.register_task_env_overrides("session", {"modal_image": "neutral:v2"})
+        assert tt._task_env_overrides["session"] == {"modal_image": "neutral:v2"}
+
+    def test_clear_task_env_override_cwd_preserves_other_keys_and_newer_cwd(self):
+        tt.register_task_env_overrides(
+            "session",
+            {"docker_image": "neutral:latest", "cwd": "/work/first"},
+        )
+        assert not tt.clear_task_env_override_cwd(
+            "session",
+            expected_cwd="/work/stale",
+        )
+        assert tt._task_env_overrides["session"]["cwd"] == "/work/first"
+
+        assert tt.clear_task_env_override_cwd(
+            "session",
+            expected_cwd="/work/first",
+        )
+        assert tt._task_env_overrides["session"] == {
+            "docker_image": "neutral:latest"
+        }
+
+    def test_clear_owned_override_drops_terminal_mutated_session_cwd(self):
+        tt.register_task_env_overrides("session", {"cwd": "/work/project"})
+        # A terminal `cd subdir` updates the session record but deliberately
+        # leaves the gateway-owned registry value as its ownership guard.
+        tt.record_session_cwd("session", "/work/project/subdir")
+
+        assert tt.clear_task_env_override_cwd(
+            "session",
+            expected_cwd="/work/project",
+        )
+        assert tt.get_session_cwd("session") is None
+        assert "session" not in tt._task_env_overrides
+
     def test_reregistration_updates_the_record(self):
         """ACP session/load switching project roots mid-session."""
         tt.register_task_env_overrides("acp-sess", {"cwd": "/proj/one"})

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1228,6 +1228,41 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
             env.cwd = new_cwd
 
 
+def update_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
+    """Merge *overrides* into a task's existing environment overrides.
+
+    Unlike :func:`register_task_env_overrides`, this helper preserves keys
+    already registered by another caller.  The registration API intentionally
+    retains its replacement semantics for rollout callers that depend on it.
+    """
+    merged = dict(_task_env_overrides.get(task_id, {}))
+    merged.update(overrides)
+    register_task_env_overrides(task_id, merged)
+
+
+def clear_task_env_override_cwd(task_id: str, *, expected_cwd: str) -> bool:
+    """Remove a caller-owned cwd override without disturbing sibling keys.
+
+    The expected-value guard prevents a stale conversation-boundary cleanup
+    from deleting a cwd installed later by another owner. Once ownership is
+    confirmed by the registry value, the session cwd record is cleared even if
+    a terminal ``cd`` moved it below the original workspace. Live environment
+    objects are deliberately left untouched so an already-running turn keeps
+    its cwd; subsequent resolution no longer sees stale conversation state.
+    """
+    current = _task_env_overrides.get(task_id)
+    if not isinstance(current, dict) or current.get("cwd") != expected_cwd:
+        return False
+    remaining = dict(current)
+    remaining.pop("cwd", None)
+    if remaining:
+        _task_env_overrides[task_id] = remaining
+    else:
+        _task_env_overrides.pop(task_id, None)
+    clear_session_cwd(task_id)
+    return True
+
+
 def clear_task_env_overrides(task_id: str):
     """
     Clear environment overrides for a task after rollout completes.

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -477,6 +477,35 @@ Behavior:
 - If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
 - Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
 
+#### Channel workspace overrides
+
+The existing `channel_overrides` mapping supports an optional `workdir` on
+every messaging platform. The value must be an existing absolute directory.
+Hermes uses it for project context discovery and as the base directory for
+terminal, file, and code-execution tools.
+
+```yaml
+discord:
+  channel_overrides:
+    "111":
+      workdir: /srv/projects/alpha
+    "222":
+      workdir: /home/user/projects/docs
+      model: example/model
+```
+
+Keys are stable platform IDs, not names. On Discord, an override on category
+ID `111` applies to its child channels and threads. A child channel override
+such as `222` wins over its category, and a thread override such as `333` wins
+over both. Lookup always proceeds from the exact thread/channel to its parent,
+then through more distant ancestors.
+
+The selected workspace is pinned for the lifetime of a conversation to keep
+the system prompt cache stable. After changing a mapping, start a new/reset
+session (or restart the gateway) before expecting the new workspace to apply.
+Invalid, relative, missing, or non-directory paths reject the turn with a
+configuration error instead of falling back to another working directory.
+
 #### `discord.history_backfill`
 
 **Type:** boolean — **Default:** `true`
@@ -921,5 +950,3 @@ Leave `everyone` and `roles` at `false` unless you know exactly why you need the
 :::
 
 For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
-
-


### PR DESCRIPTION
## Summary

- add optional `workdir` routing to existing platform `channel_overrides`
- resolve Discord overrides from thread to parent channel to category ancestry
- propagate ancestor IDs through session persistence and relay transport
- route context discovery, terminal, file, and code-execution tools through the isolated conversation workspace
- pin the selected workspace in current `ConversationState` and clear only gateway-owned CWD state at boundaries
- fail visibly on relative, missing, or non-directory workspace paths

## Current-main remediation

This supersedes #70654 and ports the feature through current `GatewayRunner`, `TurnRunner`, and consolidated session-state seams:

- `_set_session_env` forwards the resolved CWD to the existing session-context layer;
- live `TurnRunner.run_sync` prompt lookup receives ancestor IDs;
- runtime model/provider lookup and workspace lookup use the same ancestor-aware precedence;
- workspace pins and cleanup ownership live in `ConversationState`, not legacy runner dictionaries;
- an exact child override with no `workdir` intentionally stops inherited category workspace routing;
- a real-config gateway-handler regression drives `config.yaml` → channel override → handler → session context → context files, file tools, code execution, and terminal CWD;
- conversation-boundary cleanup removes terminal-mutated subdirectory state only after confirming gateway ownership;
- invalid-workdir replies preserve full source metadata, including Slack workspace routing.

## Validation

- 116 focused tests passed across workspace routing, channel overrides, config loading, Discord ancestry, TurnRunner wiring, consolidated session-state cleanup, post-`cd` session CWD cleanup, Slack source metadata, and terminal task CWD
- Ruff passed for all changed Python files
- `py_compile` passed for all changed Python files
- Windows-footgun scan passed across 893 files
- `git diff origin/main...HEAD --check` passed
- public-diff sensitive scan found 0 hits

The implementation remains process-CWD safe: it does not call global `chdir()` and does not share mutable working-directory state across conversations.
