### PR TITLE
fix(tests): mock sys.platform in test_no_hermes_home_returns_native

### DIFF
--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -34,9 +34,10 @@ class TestGetDefaultHermesRoot:
     """Tests for get_default_hermes_root() — Docker/custom deployment awareness."""
 
     def test_no_hermes_home_returns_native(self, tmp_path, monkeypatch):
-        """When HERMES_HOME is not set, returns ~/.hermes."""
+        """When HERMES_HOME is not set, returns ~/.hermes on non-Windows."""
         monkeypatch.delenv("HERMES_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(hermes_constants.sys, "platform", "linux")
 
         assert get_default_hermes_root() == tmp_path / ".hermes"
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only false test failure in `tests/test_hermes_constants.py::TestGetDefaultHermesRoot::test_no_hermes_home_returns_native`.

The test asserts `get_default_hermes_root()` returns `~/.hermes` when `HERMES_HOME` is unset, but never mocks `sys.platform`. On real Windows (`sys.platform == "win32"`), `_get_platform_default_hermes_home()` correctly takes the Windows branch and returns `%LOCALAPPDATA%\hermes` instead — so the test fails unconditionally on Windows, even though the production code (`hermes_constants.py`) is behaving exactly as documented. It's a test bug, not a product bug.

The two sibling tests right next to it already establish the correct pattern for exercising a specific platform branch:
- `test_no_hermes_home_returns_localappdata_root_on_windows` (same class)
- `TestGetHermesHome::test_windows_fallback_uses_localappdata`

Both use `monkeypatch.setattr(hermes_constants.sys, "platform", "win32")`. `test_no_hermes_home_returns_native` is the POSIX counterpart and was just missing the equivalent mock (`"linux"`) to pin it to the branch it's actually meant to test.

## Related Issue

No existing issue or PR found for this (searched `gh search issues`/`gh search prs` for `test_no_hermes_home_returns_native`, `get_default_hermes_root`, and related terms before opening this). Happy to file one first if preferred — this seemed small and self-contained enough to go straight to a PR with reproduction steps included.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/test_hermes_constants.py`: added `monkeypatch.setattr(hermes_constants.sys, "platform", "linux")` to `test_no_hermes_home_returns_native`, matching the pattern already used by its Windows-specific sibling tests. Updated the docstring from "returns ~/.hermes" to "returns ~/.hermes on non-Windows" for clarity.

## How to Test

1. On a Windows machine (or CI runner with `sys.platform == "win32"`), checkout `main` before this change.
2. Run `pytest tests/test_hermes_constants.py::TestGetDefaultHermesRoot -v` — `test_no_hermes_home_returns_native` fails with `AssertionError: assert WindowsPath('C:/Users/<user>/AppData/Local/hermes') == ...`.
3. Apply this PR's diff and re-run the same command — all 3 tests in the class pass.
4. Ran the full `tests/test_hermes_constants.py` file before and after: same 3 pre-existing, unrelated failures both times (`TestSecureParentDir::test_symlink_resolved`, `TestGetHermesDir::test_dangling_legacy_symlink_returns_new`, `TestGetHermesDir::test_symlink_to_populated_dir_returns_legacy` — all fail locally because my Windows account doesn't have symlink privilege / Developer Mode enabled, unrelated to this change and not touched by this PR).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tests): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single file, 2 lines)
- [x] I've run `pytest tests/ -q` — pre-existing failures unrelated to this change confirmed on a clean checkout of `main` before touching anything (see "How to Test")
- [x] I've added tests for my changes — N/A, this *is* a test fix; no new test needed since the existing test now correctly covers the POSIX branch
- [x] I've tested on my platform: Windows 11 (win32), Python 3.13.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — this fix exists *because of* a cross-platform (Windows) gap; macOS/Linux behavior is unaffected since `sys.platform` there was already non-`"win32"`
- [x] I've updated tool descriptions/schemas — N/A
