### PR TITLE
feat(desktop): keep Windows app in system tray

### DIFF
--- a/apps/desktop/electron/main-window-lifecycle.test.ts
+++ b/apps/desktop/electron/main-window-lifecycle.test.ts
@@ -2,7 +2,41 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { ensureMainWindow } from './main-window-lifecycle'
+import { ensureMainWindow, focusMainWindow } from './main-window-lifecycle'
+
+test('reveals a tray-hidden primary window before focusing it', () => {
+  const calls: string[] = []
+
+  const hiddenWindow = {
+    focus: () => calls.push('focus'),
+    isDestroyed: () => false,
+    isMinimized: () => false,
+    isVisible: () => false,
+    restore: () => calls.push('restore'),
+    show: () => calls.push('show')
+  }
+
+  focusMainWindow(hiddenWindow)
+
+  assert.deepEqual(calls, ['show', 'focus'])
+})
+
+test('restores a minimized primary window before focusing it', () => {
+  const calls: string[] = []
+
+  const minimizedWindow = {
+    focus: () => calls.push('focus'),
+    isDestroyed: () => false,
+    isMinimized: () => true,
+    isVisible: () => true,
+    restore: () => calls.push('restore'),
+    show: () => calls.push('show')
+  }
+
+  focusMainWindow(minimizedWindow)
+
+  assert.deepEqual(calls, ['restore', 'focus'])
+})
 
 test('recreates a destroyed primary window without focusing it', () => {
   const destroyedWindow = {

--- a/apps/desktop/electron/main-window-lifecycle.ts
+++ b/apps/desktop/electron/main-window-lifecycle.ts
@@ -2,6 +2,30 @@ type MainWindowLike = {
   isDestroyed: () => boolean
 }
 
+type FocusableMainWindowLike = MainWindowLike & {
+  focus: () => unknown
+  isMinimized: () => boolean
+  isVisible: () => boolean
+  restore: () => unknown
+  show: () => unknown
+}
+
+export function focusMainWindow(window: FocusableMainWindowLike): void {
+  if (!window || window.isDestroyed()) {
+    return
+  }
+
+  if (window.isMinimized()) {
+    window.restore()
+  }
+
+  if (!window.isVisible()) {
+    window.show()
+  }
+
+  window.focus()
+}
+
 type EnsureMainWindowOptions<T extends MainWindowLike> = {
   isReady: boolean
   createWindow: () => unknown

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9276,7 +9276,13 @@ function createWindow({ startHidden = false }: { startHidden?: boolean } = {}) {
   mainWindow.on('unmaximize', schedulePersistWindowState)
   mainWindow.on('close', () => schedulePersistWindowState.flush())
   mainWindow.on('close', event => {
-    if (shouldHideMainWindowOnClose({ platform: process.platform, isQuitting: isFinalQuitRequested })) {
+    if (
+      shouldHideMainWindowOnClose({
+        platform: process.platform,
+        isQuitting: isFinalQuitRequested,
+        trayAvailable: Boolean(windowsTray)
+      })
+    ) {
       event.preventDefault()
       mainWindow?.hide()
     }
@@ -9408,9 +9414,9 @@ function restoreMainWindow() {
   })
 }
 
-function createWindowsTray() {
+function createWindowsTray(): boolean {
   if (!shouldCreateWindowsTray(process.platform) || windowsTray) {
-    return
+    return Boolean(windowsTray)
   }
 
   const icon = getAppIconPath()
@@ -9418,19 +9424,31 @@ function createWindowsTray() {
   if (!icon) {
     rememberLog('[tray] app icon not found; Windows tray unavailable')
 
-    return
+    return false
   }
 
-  windowsTray = new Tray(icon)
-  windowsTray.setToolTip('Hermes')
-  windowsTray.setContextMenu(
-    Menu.buildFromTemplate([
-      { label: 'Open Hermes', click: restoreMainWindow },
-      { type: 'separator' },
-      { label: 'Quit Hermes', click: () => app.quit() }
-    ])
-  )
-  windowsTray.on('double-click', restoreMainWindow)
+  let tray: Tray | null = null
+
+  try {
+    tray = new Tray(icon)
+    tray.setToolTip('Hermes')
+    tray.setContextMenu(
+      Menu.buildFromTemplate([
+        { label: 'Open Hermes', click: restoreMainWindow },
+        { type: 'separator' },
+        { label: 'Quit Hermes', click: () => app.quit() }
+      ])
+    )
+    tray.on('double-click', restoreMainWindow)
+    windowsTray = tray
+
+    return true
+  } catch (error) {
+    tray?.destroy()
+    rememberLog(`[tray] Windows tray creation failed: ${error?.message || error}`)
+
+    return false
+  }
 }
 
 ipcMain.handle('hermes:connection', async (_event, profile) => ensureBackend(profile))
@@ -11762,9 +11780,13 @@ app.whenReady().then(() => {
   // it without the renderer visiting Settings. A failed registration is logged
   // here and surfaced in Settings via the IPC state (never silent).
   applyQuickEntrySettings(readQuickEntrySettings())
-  createWindowsTray()
+  const trayAvailable = createWindowsTray()
   createWindow({
-    startHidden: shouldStartMainWindowHidden({ platform: process.platform, argv: process.argv })
+    startHidden: shouldStartMainWindowHidden({
+      platform: process.platform,
+      argv: process.argv,
+      trayAvailable
+    })
   })
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -27,7 +27,8 @@ import {
   screen,
   session,
   shell,
-  systemPreferences
+  systemPreferences,
+  Tray
 } from 'electron'
 import nodePty from 'node-pty'
 
@@ -134,7 +135,7 @@ import {
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
-import { ensureMainWindow } from './main-window-lifecycle'
+import { ensureMainWindow, focusMainWindow as focusWindow } from './main-window-lifecycle'
 import {
   oauthGuardMayHardFail,
   oauthSessionIsLive,
@@ -237,6 +238,11 @@ import {
   writeSandboxMarker
 } from './windows-sandbox-fallback'
 import { installWindowsSystemCaTrust } from './windows-system-ca'
+import {
+  shouldCreateWindowsTray,
+  shouldHideMainWindowOnClose,
+  shouldStartMainWindowHidden
+} from './windows-tray-lifecycle'
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
@@ -1042,6 +1048,8 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+let windowsTray: Tray | null = null
+let isFinalQuitRequested = false
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
@@ -8677,22 +8685,6 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
 // builder live in session-windows.ts so they stay unit-testable.
 const sessionWindows = createSessionWindowRegistry()
 
-function focusWindow(win) {
-  if (!win || win.isDestroyed()) {
-    return
-  }
-
-  if (win.isMinimized()) {
-    win.restore()
-  }
-
-  if (!win.isVisible()) {
-    win.show()
-  }
-
-  win.focus()
-}
-
 function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?: boolean } = {}) {
   const icon = getAppIconPath()
 
@@ -9174,7 +9166,7 @@ function closeQuickEntryWindow() {
   quickEntryWindow = null
 }
 
-function createWindow() {
+function createWindow({ startHidden = false }: { startHidden?: boolean } = {}) {
   const icon = getAppIconPath()
   const savedWindowState = readWindowState()
   mainWindow = new BrowserWindow({
@@ -9231,7 +9223,7 @@ function createWindow() {
   }
 
   mainWindow.once('ready-to-show', () => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    if (!startHidden && mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.show()
     }
 
@@ -9262,7 +9254,7 @@ function createWindow() {
   // Under Playright testing, instantly show the window.
   // `ready-to-show` doesn't fire in some testing envs.
   if (process.env.TEST_WORKER_INDEX !== undefined) {
-    if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
+    if (!startHidden && mainWindow && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
       mainWindow.show()
     }
   }
@@ -9283,6 +9275,12 @@ function createWindow() {
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
   mainWindow.on('close', () => schedulePersistWindowState.flush())
+  mainWindow.on('close', event => {
+    if (shouldHideMainWindowOnClose({ platform: process.platform, isQuitting: isFinalQuitRequested })) {
+      event.preventDefault()
+      mainWindow?.hide()
+    }
+  })
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   const createdMainWindow = mainWindow
@@ -9400,6 +9398,39 @@ function createWindow() {
     broadcastBootProgress()
     sendWindowStateChanged()
   })
+}
+
+function restoreMainWindow() {
+  ensureMainWindow(mainWindow, {
+    isReady: app.isReady(),
+    createWindow,
+    focusWindow
+  })
+}
+
+function createWindowsTray() {
+  if (!shouldCreateWindowsTray(process.platform) || windowsTray) {
+    return
+  }
+
+  const icon = getAppIconPath()
+
+  if (!icon) {
+    rememberLog('[tray] app icon not found; Windows tray unavailable')
+
+    return
+  }
+
+  windowsTray = new Tray(icon)
+  windowsTray.setToolTip('Hermes')
+  windowsTray.setContextMenu(
+    Menu.buildFromTemplate([
+      { label: 'Open Hermes', click: restoreMainWindow },
+      { type: 'separator' },
+      { label: 'Quit Hermes', click: () => app.quit() }
+    ])
+  )
+  windowsTray.on('double-click', restoreMainWindow)
 }
 
 ipcMain.handle('hermes:connection', async (_event, profile) => ensureBackend(profile))
@@ -11631,11 +11662,7 @@ function handleDeepLink(url) {
   }
 
   try {
-    if (mainWindow.isMinimized()) {
-      mainWindow.restore()
-    }
-
-    mainWindow.focus()
+    focusWindow(mainWindow)
     mainWindow.webContents.send('hermes:deep-link', payload)
     rememberLog(`[deeplink] delivered ${kind}/${name}`)
   } catch (err) {
@@ -11735,7 +11762,10 @@ app.whenReady().then(() => {
   // it without the renderer visiting Settings. A failed registration is logged
   // here and surfaced in Settings via the IPC state (never silent).
   applyQuickEntrySettings(readQuickEntrySettings())
-  createWindow()
+  createWindowsTray()
+  createWindow({
+    startHidden: shouldStartMainWindowHidden({ platform: process.platform, argv: process.argv })
+  })
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
   const _coldStartLink = _extractDeepLink(process.argv)
@@ -11831,6 +11861,10 @@ app.on('before-quit', event => {
     return
   }
 
+  // Main-window close events follow before-quit. Latch here so explicit quit,
+  // update/uninstall handoff, and confirmed active-work quit bypass close-to-tray.
+  isFinalQuitRequested = true
+
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
     event.preventDefault()
     sshBootstrapCoordinator.cancelAll()
@@ -11893,6 +11927,11 @@ app.on('before-quit', event => {
 
   stopBackendChild(backendConnectionState.getProcess())
   stopAllPoolBackends()
+})
+
+app.on('will-quit', () => {
+  windowsTray?.destroy()
+  windowsTray = null
 })
 
 app.on('window-all-closed', () => {

--- a/apps/desktop/electron/windows-tray-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-tray-lifecycle.test.ts
@@ -12,11 +12,19 @@ test('Windows close-to-tray lifecycle policy preserves explicit quit and non-Win
   assert.equal(shouldCreateWindowsTray('win32'), true)
   assert.equal(shouldCreateWindowsTray('darwin'), false)
 
-  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: false }), true)
-  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: true }), false)
-  assert.equal(shouldHideMainWindowOnClose({ platform: 'linux', isQuitting: false }), false)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: false, trayAvailable: true }), true)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: false, trayAvailable: false }), false)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: true, trayAvailable: true }), false)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'linux', isQuitting: false, trayAvailable: true }), false)
 
-  assert.equal(shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe', '--hidden'] }), true)
-  assert.equal(shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe'] }), false)
-  assert.equal(shouldStartMainWindowHidden({ platform: 'darwin', argv: ['Hermes', '--hidden'] }), false)
+  assert.equal(
+    shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe', '--hidden'], trayAvailable: true }),
+    true
+  )
+  assert.equal(
+    shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe', '--hidden'], trayAvailable: false }),
+    false
+  )
+  assert.equal(shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe'], trayAvailable: true }), false)
+  assert.equal(shouldStartMainWindowHidden({ platform: 'darwin', argv: ['Hermes', '--hidden'], trayAvailable: true }), false)
 })

--- a/apps/desktop/electron/windows-tray-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-tray-lifecycle.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  shouldCreateWindowsTray,
+  shouldHideMainWindowOnClose,
+  shouldStartMainWindowHidden
+} from './windows-tray-lifecycle'
+
+test('Windows close-to-tray lifecycle policy preserves explicit quit and non-Windows behavior', () => {
+  assert.equal(shouldCreateWindowsTray('win32'), true)
+  assert.equal(shouldCreateWindowsTray('darwin'), false)
+
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: false }), true)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'win32', isQuitting: true }), false)
+  assert.equal(shouldHideMainWindowOnClose({ platform: 'linux', isQuitting: false }), false)
+
+  assert.equal(shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe', '--hidden'] }), true)
+  assert.equal(shouldStartMainWindowHidden({ platform: 'win32', argv: ['Hermes.exe'] }), false)
+  assert.equal(shouldStartMainWindowHidden({ platform: 'darwin', argv: ['Hermes', '--hidden'] }), false)
+})

--- a/apps/desktop/electron/windows-tray-lifecycle.ts
+++ b/apps/desktop/electron/windows-tray-lifecycle.ts
@@ -6,20 +6,24 @@ export function shouldCreateWindowsTray(platform: Platform): boolean {
 
 export function shouldHideMainWindowOnClose({
   platform,
-  isQuitting
+  isQuitting,
+  trayAvailable
 }: {
   platform: Platform
   isQuitting: boolean
+  trayAvailable: boolean
 }): boolean {
-  return platform === 'win32' && !isQuitting
+  return platform === 'win32' && trayAvailable && !isQuitting
 }
 
 export function shouldStartMainWindowHidden({
   platform,
-  argv
+  argv,
+  trayAvailable
 }: {
   platform: Platform
   argv: readonly string[]
+  trayAvailable: boolean
 }): boolean {
-  return platform === 'win32' && argv.includes('--hidden')
+  return platform === 'win32' && trayAvailable && argv.includes('--hidden')
 }

--- a/apps/desktop/electron/windows-tray-lifecycle.ts
+++ b/apps/desktop/electron/windows-tray-lifecycle.ts
@@ -1,0 +1,25 @@
+type Platform = NodeJS.Platform
+
+export function shouldCreateWindowsTray(platform: Platform): boolean {
+  return platform === 'win32'
+}
+
+export function shouldHideMainWindowOnClose({
+  platform,
+  isQuitting
+}: {
+  platform: Platform
+  isQuitting: boolean
+}): boolean {
+  return platform === 'win32' && !isQuitting
+}
+
+export function shouldStartMainWindowHidden({
+  platform,
+  argv
+}: {
+  platform: Platform
+  argv: readonly string[]
+}): boolean {
+  return platform === 'win32' && argv.includes('--hidden')
+}


### PR DESCRIPTION
## Summary

- keep Hermes Desktop running in the Windows system tray when the main window is closed
- add tray actions to reopen Hermes or quit explicitly, plus double-click restore
- support hidden Windows startup via `--hidden`
- preserve explicit quit, updater/uninstaller handoff, active-work confirmation, and non-Windows behavior
- ensure second-instance and `hermes://` deep links reveal a tray-hidden window

## Test plan

- [x] `npm exec vitest run -- --project electron electron/main-window-lifecycle.test.ts electron/windows-tray-lifecycle.test.ts electron/quit-guard.test.ts electron/update-gate.test.ts electron/updater-process.test.ts` — 25 passed
- [x] `npm run typecheck`
- [x] focused ESLint on the five changed files
- [x] `npm run build`
- [x] packaged Windows build smoke-tested with `--hidden`; process remained alive without a visible main window

## Notes

The broader Electron suite on native Windows reported 850 passing tests and 17 existing failures in POSIX/SSH filesystem assumptions unrelated to this diff. The focused lifecycle and updater/quit suites pass.
