### PR TITLE
feat(desktop): add collapsible calendar session groups

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chrome.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SidebarDateDivider } from './chrome'
+
+describe('SidebarDateDivider', () => {
+  it('exposes a native disclosure button with the visible label and expanded state', () => {
+    const onToggle = vi.fn()
+
+    const { rerender } = render(
+      <SidebarDateDivider label="Today" toggle={{ ariaLabel: 'Collapse Today', onToggle, open: true }} />
+    )
+
+    const button = screen.getByRole('button', { name: 'Collapse Today' })
+
+    expect(button.getAttribute('aria-expanded')).toBe('true')
+    expect(button.textContent).toContain('Today')
+
+    fireEvent.click(button)
+    expect(onToggle).toHaveBeenCalledTimes(1)
+
+    rerender(<SidebarDateDivider label="Today" toggle={{ ariaLabel: 'Expand Today', onToggle, open: false }} />)
+
+    expect(screen.getByRole('button', { name: 'Expand Today' }).getAttribute('aria-expanded')).toBe('false')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -50,16 +50,39 @@ export function SidebarDateDivider({
   action,
   className,
   label,
+  toggle,
   ...props
-}: React.ComponentProps<'div'> & { action?: React.ReactNode; label: string }) {
+}: React.ComponentProps<'div'> & {
+  action?: React.ReactNode
+  label: string
+  toggle?: { ariaLabel: string; onToggle: () => void; open: boolean }
+}) {
   return (
     // group/workspace: a divider heads a group the same way a repo header does,
     // so it borrows the header's hover-revealed "+" verbatim.
     <div className={cn('group/workspace flex select-none items-center gap-2 px-2 pb-0.5 pt-2', className)} {...props}>
-      <span className="shrink-0 text-[0.64rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
-        {label}
-      </span>
-      <span aria-hidden="true" className="h-px flex-1 bg-(--ui-stroke-tertiary)" />
+      {toggle ? (
+        <button
+          aria-expanded={toggle.open}
+          aria-label={toggle.ariaLabel}
+          className="flex min-w-0 flex-1 items-center gap-1.5 bg-transparent text-left"
+          onClick={toggle.onToggle}
+          type="button"
+        >
+          <DisclosureCaret className="shrink-0 text-(--ui-text-tertiary)" open={toggle.open} />
+          <span className="shrink-0 text-[0.64rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
+            {label}
+          </span>
+          <span aria-hidden="true" className="h-px flex-1 bg-(--ui-stroke-tertiary)" />
+        </button>
+      ) : (
+        <>
+          <span className="shrink-0 text-[0.64rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
+            {label}
+          </span>
+          <span aria-hidden="true" className="h-px flex-1 bg-(--ui-stroke-tertiary)" />
+        </>
+      )}
       {action}
     </div>
   )

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -111,6 +111,7 @@ import {
 } from '@/store/pull-requests'
 import { openRouteTile } from '@/store/route-tiles'
 import {
+  $connection,
   $cronSessions,
   $currentCwd,
   $gatewayState,
@@ -125,6 +126,7 @@ import {
   sessionPinId,
   setCurrentCwd
 } from '@/store/session'
+import { resolveSessionDateGroupProfile, sessionDateGroupScope } from '@/store/session-date-group-collapse'
 import { $sessionDotStateById, sessionStatusBucket } from '@/store/session-dot-state'
 import { $unconfirmedPinWrites } from '@/store/session-pin-sync'
 import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
@@ -391,6 +393,7 @@ export function ChatSidebar({
   const profileColors = useStore($profileColors)
   const profileScope = useStore($profileScope)
   const activeConnectionId = useStore($activeConnectionId)
+  const connection = useStore($connection)
 
   // Toggle the persisted read-state watermark from a row menu. The row's own
   // `unread` prop mirrors what the dot paints; flip it and let the backend
@@ -413,6 +416,19 @@ export function ChatSidebar({
   // otherwise be stuck in the grouped view with no way out.
   const showAllProfiles = multiProfile && profileScope === ALL_PROFILES
   const messagingProfile = sidebarProfileForScope(profileScope)
+
+  const recentsDateGroupScope = useMemo(
+    () =>
+      sessionDateGroupScope(
+        connection,
+        resolveSessionDateGroupProfile(connection, profileScope, {
+          allProfilesKey: ALL_PROFILES,
+          showAllProfiles
+        })
+      ),
+    [connection, profileScope, showAllProfiles]
+  )
+
   const agentOrderIds = useStore($sidebarSessionOrderIds)
   const agentOrderManual = useStore($sidebarSessionOrderManual)
   const workspaceOrderIds = useStore($sidebarWorkspaceOrderIds)
@@ -1675,6 +1691,7 @@ export function ChatSidebar({
                   // virtualized long list, which must keep its own scroller.
                   !recentsVirtualizes && COMPACT_FLAT
                 )}
+                dateGroupScope={recentsDateGroupScope}
                 dndSensors={dndSensors}
                 emptyState={
                   showSessionSkeletons ? (

--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -4,6 +4,7 @@ import type { SidebarListRow } from '@/lib/session-date-groups'
 import type { SessionInfo } from '@/types/hermes'
 
 import {
+  mergeVisibleReorderIds,
   orderByIds,
   orderRowsWithinGroups,
   rankSessions,
@@ -169,5 +170,13 @@ describe('reorderableRowIds', () => {
     const rows = [session('a'), session('branch', '├─ '), divider('yesterday'), session('b')]
 
     expect(reorderableRowIds(rows)).toEqual(['a', 'b'])
+  })
+})
+
+describe('mergeVisibleReorderIds', () => {
+  it('reorders visible rows without dropping or moving collapsed rows', () => {
+    expect(mergeVisibleReorderIds(['hidden-a', 'visible-a', 'visible-b', 'hidden-b'], ['visible-b', 'visible-a'])).toEqual(
+      ['hidden-a', 'visible-b', 'visible-a', 'hidden-b']
+    )
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -226,3 +226,16 @@ function clusterId(rows: SidebarListRow[]): string {
 export function reorderableRowIds(rows: SidebarListRow[]): string[] {
   return rows.flatMap(row => (row.kind === 'session' && !row.entry.branchStem ? [row.entry.session.id] : []))
 }
+
+/**
+ * Merge a drag order computed from the currently visible rows back into the
+ * complete order. Collapsed calendar groups are deliberately absent from the
+ * dnd-kit list; keeping their slots here prevents a drag in an expanded group
+ * from silently dropping the hidden sessions from persisted manual order.
+ */
+export function mergeVisibleReorderIds(allIds: readonly string[], visibleIds: readonly string[]): string[] {
+  const visible = new Set(visibleIds)
+  let visibleIndex = 0
+
+  return allIds.map(id => (visible.has(id) ? (visibleIds[visibleIndex++] ?? id) : id))
+}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.date-groups.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.date-groups.test.tsx
@@ -1,0 +1,87 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import { I18nProvider } from '@/i18n'
+import { $collapsedSessionDateGroups } from '@/store/session-date-group-collapse'
+
+import { SidebarSessionsSection } from './sessions-section'
+
+const NOW = new Date(2026, 5, 18, 12, 0, 0)
+
+const at = (day: number, hour: number, minute = 0): number =>
+  Math.floor(new Date(2026, 5, day, hour, minute).getTime() / 1000)
+
+const session = (id: string, lastActive: number): SessionInfo =>
+  ({
+    id,
+    last_active: lastActive,
+    message_count: 1,
+    source: 'cli',
+    started_at: lastActive,
+    title: id,
+    tool_call_count: 0
+  }) as SessionInfo
+
+const renderSection = (sessions: SessionInfo[]) =>
+  render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <SidebarSessionsSection
+        activeSessionId={null}
+        dateGroupScope="test-scope"
+        emptyState={null}
+        grouping="date"
+        label="Sessions"
+        onArchiveSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onResumeSession={vi.fn()}
+        onToggle={vi.fn()}
+        onTogglePin={vi.fn()}
+        onToggleUnread={vi.fn()}
+        open
+        pinned={false}
+        sessions={sessions}
+      />
+    </I18nProvider>
+  )
+
+describe('SidebarSessionsSection date group collapse', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    act(() => $collapsedSessionDateGroups.set({}))
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    $collapsedSessionDateGroups.set({})
+  })
+
+  it('renders and persists the first Today group instead of an unlabelled recent head', () => {
+    renderSection([
+      session('Today session', at(18, 11)),
+      session('Yesterday session', at(17, 10)),
+      session('Last week session', at(12, 10))
+    ])
+
+    expect(screen.getByRole('button', { name: 'Collapse Today' })).not.toBeNull()
+    expect(screen.getByRole('button', { name: 'Collapse Yesterday' })).not.toBeNull()
+    expect(screen.getByRole('button', { name: /^Collapse Last week/ })).not.toBeNull()
+    expect(screen.getByText('Today session')).not.toBeNull()
+    expect(screen.getByText('Yesterday session')).not.toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse Today' }))
+
+    expect(screen.queryByText('Today session')).toBeNull()
+    expect(screen.getByText('Yesterday session')).not.toBeNull()
+    expect(screen.getByText('Last week session')).not.toBeNull()
+    expect(screen.getByRole('button', { name: 'Expand Today' })).not.toBeNull()
+    expect($collapsedSessionDateGroups.get()).toEqual({ 'test-scope': ['day:2026-06-18'] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand Today' }))
+
+    expect(screen.getByText('Today session')).not.toBeNull()
+    expect($collapsedSessionDateGroups.get()).toEqual({})
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -12,12 +12,15 @@ afterEach(cleanup)
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {
+      common: {
+        collapse: 'Collapse',
+        expand: 'Expand'
+      },
       sidebar: {
         dateDivider: {
-          earlierThisMonth: 'Earlier this month',
-          lastMonth: 'Last month',
           lastWeek: 'Last week',
-          older: 'Older',
+          thisMonth: 'Earlier this month',
+          thisWeek: 'Earlier this week',
           today: 'Today',
           yesterday: 'Yesterday'
         }

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -24,7 +24,7 @@ import { $collapsedSessionDateGroups, setSessionDateGroupCollapsed } from '@/sto
 import { $sessionDotStateById, hasLiveTurn } from '@/store/session-dot-state'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
-import { orderRowsWithinGroups, reorderableRowIds } from './order'
+import { mergeVisibleReorderIds, orderRowsWithinGroups, reorderableRowIds } from './order'
 import {
   EnteredProjectContent,
   ProjectOverviewRow,
@@ -267,7 +267,7 @@ export function SidebarSessionsSection({
 
   // The flat recents/pinned list is the only place sessions reorder by hand;
   // grouped/tree views always sort by creation date and never drag.
-  const sessionsDraggable = sortable && !!onReorderSessions && !(grouping === 'date' && collapsedDateGroupKeys.size > 0)
+  const sessionsDraggable = sortable && !!onReorderSessions
 
   // Only Pinned arrives pre-ordered as a flat sequence. Recents keeps its
   // recency sort — the drag order is layered on per date group below, so the
@@ -391,7 +391,7 @@ export function SidebarSessionsSection({
   // The hand-picked order is then applied INSIDE each date group, so dragging a
   // row ranks it among its own day's chats instead of freezing the whole list
   // into an undated manual mode.
-  const flatRows: SidebarListRow[] = useMemo(() => {
+  const orderedFlatRows: SidebarListRow[] = useMemo(() => {
     const rows =
       grouping === 'date'
         ? groupEntriesByRecency(displayEntries)
@@ -403,16 +403,22 @@ export function SidebarSessionsSection({
             )
           : toSessionRows(displayEntries)
 
-    const orderedRows = manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
+    return manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
+  }, [grouping, displayEntries, dotStates, manualOrderIds, statusDividerLabels])
 
-    return visibleDateRows(orderedRows)
-  }, [grouping, displayEntries, dotStates, manualOrderIds, statusDividerLabels, visibleDateRows])
+  const flatRows = useMemo(() => visibleDateRows(orderedFlatRows), [orderedFlatRows, visibleDateRows])
 
   // dnd-kit must see exactly the ids it renders, in render order: the sortable
   // set is derived from the rows, not from `sessions`. Feeding it the unrendered
   // session order made a drop compute its target index against a list the user
   // wasn't looking at — the drag that landed a row in the wrong slot.
   const sortableRowIds = useMemo(() => reorderableRowIds(flatRows), [flatRows])
+  const allSortableRowIds = useMemo(() => reorderableRowIds(orderedFlatRows), [orderedFlatRows])
+
+  const reorderVisibleSessions = useCallback(
+    (visibleIds: string[]) => onReorderSessions?.(mergeVisibleReorderIds(allSortableRowIds, visibleIds)),
+    [allSortableRowIds, onReorderSessions]
+  )
 
   // Pinned never virtualizes. Virtualization needs a bounded viewport to
   // measure against, and Pinned deliberately has none — however many chats you
@@ -533,16 +539,16 @@ export function SidebarSessionsSection({
     )
 
     inner =
-      sessionsDraggable && onReorderSessions ? (
-        <ReorderableList ids={sortableRowIds} onReorder={onReorderSessions} sensors={dndSensors}>
+      sessionsDraggable ? (
+        <ReorderableList ids={sortableRowIds} onReorder={reorderVisibleSessions} sensors={dndSensors}>
           {virtual}
         </ReorderableList>
       ) : (
         virtual
       )
-  } else if (sessionsDraggable && onReorderSessions) {
+  } else if (sessionsDraggable) {
     inner = (
-      <ReorderableList ids={sortableRowIds} onReorder={onReorderSessions} sensors={dndSensors}>
+      <ReorderableList ids={sortableRowIds} onReorder={reorderVisibleSessions} sensors={dndSensors}>
         {flatRows.map(row => renderListRow(row, true, dividerAction))}
       </ReorderableList>
     )

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -11,6 +11,7 @@ import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
 import {
+  filterCollapsedDateGroupRows,
   groupEntriesByRecency,
   groupEntriesByStatus,
   type SidebarListRow,
@@ -19,6 +20,7 @@ import {
 import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
+import { $collapsedSessionDateGroups, setSessionDateGroupCollapsed } from '@/store/session-date-group-collapse'
 import { $sessionDotStateById, hasLiveTurn } from '@/store/session-dot-state'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
@@ -169,6 +171,9 @@ interface SidebarSessionsSectionProps {
   // grouping is active — the flat recents list opts in; dense tree surfaces
   // (pinned, projects, messaging) keep the one-line row.
   card?: boolean
+  // Persistent collapse state is isolated by backend and effective profile.
+  // Omit outside the primary chronological sessions surface.
+  dateGroupScope?: string
 }
 
 export function SidebarSessionsSection({
@@ -212,12 +217,37 @@ export function SidebarSessionsSection({
   dndSensors,
   showProfileTags = false,
   grouping = 'none',
-  card = false
+  card = false,
+  dateGroupScope
 }: SidebarSessionsSectionProps) {
   const { t } = useI18n()
   const dividerLabels = t.sidebar.dateDivider
   const statusDividerLabels = t.sidebar.statusDivider
   const dotStates = useStore($sessionDotStateById)
+  const collapsedGroupsByScope = useStore($collapsedSessionDateGroups)
+
+  const collapsedDateGroupKeys = useMemo(
+    () => new Set(dateGroupScope ? (collapsedGroupsByScope[dateGroupScope] ?? []) : []),
+    [collapsedGroupsByScope, dateGroupScope]
+  )
+
+  const toggleDateGroup = useCallback(
+    (key: string) => {
+      if (!dateGroupScope) {
+        return
+      }
+
+      setSessionDateGroupCollapsed(dateGroupScope, key, !collapsedDateGroupKeys.has(key))
+    },
+    [collapsedDateGroupKeys, dateGroupScope]
+  )
+
+  const visibleDateRows = useCallback(
+    (rows: readonly SidebarListRow[]) =>
+      grouping === 'date' && dateGroupScope ? filterCollapsedDateGroupRows(rows, collapsedDateGroupKeys) : [...rows],
+    [collapsedDateGroupKeys, dateGroupScope, grouping]
+  )
+
   const sectionOpen = collapsible ? open : true
   const hasGroupedSessions = Boolean(groups?.some(group => group.sessions.length > 0))
   // A defined project list is itself content (even an empty project should
@@ -237,7 +267,7 @@ export function SidebarSessionsSection({
 
   // The flat recents/pinned list is the only place sessions reorder by hand;
   // grouped/tree views always sort by creation date and never drag.
-  const sessionsDraggable = sortable && !!onReorderSessions
+  const sessionsDraggable = sortable && !!onReorderSessions && !(grouping === 'date' && collapsedDateGroupKeys.size > 0)
 
   // Only Pinned arrives pre-ordered as a flat sequence. Recents keeps its
   // recency sort — the drag order is layered on per date group below, so the
@@ -304,15 +334,36 @@ export function SidebarSessionsSection({
         return renderRow(row.entry.session, draggable, row.entry.branchStem)
       }
 
+      const label = 'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)
+      const open = !collapsedDateGroupKeys.has(row.key)
+
       return (
         <SidebarDateDivider
           action={action}
-          key={row.key}
-          label={'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)}
+          key={row.rowKey ?? row.key}
+          label={label}
+          toggle={
+            grouping === 'date' && dateGroupScope
+              ? {
+                  ariaLabel: `${open ? t.common.collapse : t.common.expand} ${label}`,
+                  onToggle: () => toggleDateGroup(row.key),
+                  open
+                }
+              : undefined
+          }
         />
       )
     },
-    [dividerLabels, renderRow]
+    [
+      collapsedDateGroupKeys,
+      dateGroupScope,
+      dividerLabels,
+      grouping,
+      renderRow,
+      t.common.collapse,
+      t.common.expand,
+      toggleDateGroup
+    ]
   )
 
   // Sessions inside repos/worktrees are date-ordered and static.
@@ -329,11 +380,11 @@ export function SidebarSessionsSection({
     (items: SessionInfo[]) => {
       const entries = flattenSessionsWithBranches(items)
 
-      return (grouping === 'date' ? groupEntriesByRecency(entries) : toSessionRows(entries)).map(row =>
-        renderListRow(row, false)
-      )
+      const rows = grouping === 'date' ? groupEntriesByRecency(entries) : toSessionRows(entries)
+
+      return visibleDateRows(rows).map(row => renderListRow(row, false))
     },
-    [grouping, renderListRow]
+    [grouping, renderListRow, visibleDateRows]
   )
 
   // Flat recents as list rows: grouped by recency when enabled, plain otherwise.
@@ -352,8 +403,10 @@ export function SidebarSessionsSection({
             )
           : toSessionRows(displayEntries)
 
-    return manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
-  }, [grouping, displayEntries, dotStates, manualOrderIds, statusDividerLabels])
+    const orderedRows = manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
+
+    return visibleDateRows(orderedRows)
+  }, [grouping, displayEntries, dotStates, manualOrderIds, statusDividerLabels, visibleDateRows])
 
   // dnd-kit must see exactly the ids it renders, in render order: the sortable
   // set is derived from the rows, not from `sessions`. Feeding it the unrendered
@@ -453,7 +506,7 @@ export function SidebarSessionsSection({
         group={group}
         key={group.id}
         onNewSession={onNewSessionInWorkspace}
-        renderRows={renderRows}
+        renderRows={grouping === 'date' ? renderRowsDated : renderRows}
       />
     ))
   } else if (flatVirtualized) {
@@ -462,11 +515,14 @@ export function SidebarSessionsSection({
         activeSessionId={activeSessionId}
         card={card}
         className={contentClassName}
+        collapsedDateGroupKeys={collapsedDateGroupKeys}
+        dateGroupToggleLabel={(label, expanded) => `${expanded ? t.common.collapse : t.common.expand} ${label}`}
         dividerAction={dividerAction}
         onArchiveSession={onArchiveSession}
         onBranchSession={onBranchSession}
         onDeleteSession={onDeleteSession}
         onResumeSession={onResumeSession}
+        onToggleDateGroup={grouping === 'date' && dateGroupScope ? toggleDateGroup : undefined}
         onTogglePin={onTogglePin}
         onToggleUnread={onToggleUnread}
         pinned={pinned}

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
@@ -25,10 +25,9 @@ vi.mock('@/i18n', () => ({
     t: {
       sidebar: {
         dateDivider: {
-          earlierThisMonth: 'Earlier this month',
-          lastMonth: 'Last month',
           lastWeek: 'Last week',
-          older: 'Older',
+          thisMonth: 'Earlier this month',
+          thisWeek: 'Earlier this week',
           today: 'Today',
           yesterday: 'Yesterday'
         }

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -38,6 +38,8 @@ export interface VirtualSessionListProps {
   /** Render every session row as the three-line inbox card. */
   card?: boolean
   className?: string
+  collapsedDateGroupKeys?: ReadonlySet<string>
+  dateGroupToggleLabel?: (label: string, open: boolean) => string
   /** Hover-revealed control for date dividers (the group-level "+"). */
   dividerAction?: React.ReactNode
   rows: SidebarListRow[]
@@ -45,6 +47,7 @@ export interface VirtualSessionListProps {
   onBranchSession?: (sessionId: string, profile?: string) => void
   onDeleteSession: (sessionId: string) => void
   onResumeSession: (sessionId: string, session?: SessionInfo) => void
+  onToggleDateGroup?: (key: string) => void
   onTogglePin: (sessionId: string) => void
   onToggleUnread: (sessionId: string) => void
   pinned: boolean
@@ -63,12 +66,15 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   activeSessionId,
   card = false,
   className,
+  collapsedDateGroupKeys,
+  dateGroupToggleLabel,
   dividerAction,
   rows: listRows,
   onArchiveSession,
   onBranchSession,
   onDeleteSession,
   onResumeSession,
+  onToggleDateGroup,
   onTogglePin,
   onToggleUnread,
   pinned,
@@ -94,7 +100,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     getItemKey: index => {
       const row = listRows[index]
 
-      return row ? (row.kind === 'divider' ? row.key : row.entry.session.id) : index
+      return row ? (row.kind === 'divider' ? (row.rowKey ?? row.key) : row.entry.session.id) : index
     },
     getScrollElement: () => scrollerRef.current,
     // jsdom-friendly default; the real rect takes over on first observe.
@@ -126,11 +132,23 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 
     // Dividers are non-sortable, self-measured rows interleaved with sessions.
     if (row.kind === 'divider') {
+      const label = 'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)
+      const open = !collapsedDateGroupKeys?.has(row.key)
+
       return (
-        <div data-index={virtualItem.index} key={row.key} ref={virtualizer.measureElement} style={itemStyle}>
+        <div data-index={virtualItem.index} key={row.rowKey ?? row.key} ref={virtualizer.measureElement} style={itemStyle}>
           <SidebarDateDivider
             action={dividerAction}
-            label={'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)}
+            label={label}
+            toggle={
+              onToggleDateGroup && dateGroupToggleLabel
+                ? {
+                    ariaLabel: dateGroupToggleLabel(label, open),
+                    onToggle: () => onToggleDateGroup(row.key),
+                    open
+                  }
+                : undefined
+            }
           />
         </div>
       )

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2325,7 +2325,7 @@ export const en: Translations = {
       ageMin: 'm'
     },
     dateDivider: {
-      today: 'Earlier today',
+      today: 'Today',
       yesterday: 'Yesterday',
       thisWeek: 'Earlier this week',
       lastWeek: 'Last week',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2000,7 +2000,7 @@ export const ja = defineLocale({
       ageMin: '分'
     },
     dateDivider: {
-      today: '今日の早い時間',
+      today: '今日',
       yesterday: '昨日',
       thisWeek: '今週',
       lastWeek: '先週',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1932,7 +1932,7 @@ export const zhHant = defineLocale({
       ageMin: '分'
     },
     dateDivider: {
-      today: '今天稍早',
+      today: '今天',
       yesterday: '昨天',
       thisWeek: '本週',
       lastWeek: '上週',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2504,7 +2504,7 @@ export const zh: Translations = {
       ageMin: '分'
     },
     dateDivider: {
-      today: '今天早些时候',
+      today: '今天',
       yesterday: '昨天',
       thisWeek: '本周',
       lastWeek: '上周',

--- a/apps/desktop/src/lib/session-date-groups.test.ts
+++ b/apps/desktop/src/lib/session-date-groups.test.ts
@@ -5,199 +5,134 @@ import type { SessionInfo } from '@/types/hermes'
 import { makeSessionInfo } from '../test/session-info'
 
 import type { SidebarSessionEntry } from './session-branch-tree'
-import { groupEntriesByRecency, toSessionRows } from './session-date-groups'
+import {
+  filterCollapsedDateGroupRows,
+  groupEntriesByRecency,
+  type SidebarListRow,
+  toSessionRows
+} from './session-date-groups'
 
 const session = (id: string, overrides: Partial<SessionInfo> = {}): SessionInfo =>
   makeSessionInfo({ id, message_count: 1, source: 'cli', title: id, ...overrides })
 
-const entry = (s: SessionInfo, branchStem?: string): SidebarSessionEntry =>
-  branchStem ? { branchStem, session: s } : { session: s }
+const entry = (value: SessionInfo, branchStem?: string): SidebarSessionEntry =>
+  branchStem ? { branchStem, session: value } : { session: value }
 
-// Fixed "now": Thursday 18 Jun 2026, local noon (15 Jun 2026 is a Monday).
-// All tests pin a Monday week start so calendar boundaries are deterministic.
+// Thursday 18 June 2026, local noon; the pinned week starts on Monday.
 const NOW = new Date(2026, 5, 18, 12, 0, 0).getTime()
 const MONDAY = 1
 
-const at = (year: number, month: number, day: number, hour = 10, minute = 0): number =>
-  Math.floor(new Date(year, month, day, hour, minute, 0).getTime() / 1000)
+const at = (year: number, month: number, day: number, hour = 10): number =>
+  Math.floor(new Date(year, month, day, hour, 0, 0).getTime() / 1000)
 
-const group = (entries: SidebarSessionEntry[], nowMs = NOW) => groupEntriesByRecency(entries, nowMs, MONDAY)
+const group = (entries: SidebarSessionEntry[]) => groupEntriesByRecency(entries, NOW, MONDAY)
 
 const dividerKeys = (rows: ReturnType<typeof groupEntriesByRecency>): string[] =>
   rows.flatMap(row => (row.kind === 'divider' ? [row.key] : []))
 
 describe('groupEntriesByRecency', () => {
-  it('cuts the head after the most recent handful, then divides by coarse ranges', () => {
-    // The morning run (30m/30m/4h/30m gaps, then a 14h silence) is the
-    // unlabelled head; each older group gets one divider, coarsening with age.
+  it('labels every populated group, including the first, with the required calendar taxonomy', () => {
+    const rows = group([
+      entry(session('today', { last_active: at(2026, 5, 18) })),
+      entry(session('yesterday', { last_active: at(2026, 5, 17) })),
+      entry(session('tuesday', { last_active: at(2026, 5, 16) })),
+      entry(session('last-week', { last_active: at(2026, 5, 12) })),
+      entry(session('third-week', { last_active: at(2026, 5, 3) })),
+      entry(session('fourth-week', { last_active: at(2026, 4, 28) })),
+      entry(session('month', { last_active: at(2026, 3, 20) }))
+    ])
+
+    expect(rows[0]).toMatchObject({ key: 'day:2026-06-18', kind: 'divider' })
+    expect(dividerKeys(rows)).toEqual([
+      'day:2026-06-18',
+      'day:2026-06-17',
+      'day:2026-06-16',
+      'week:2026-06-08',
+      'week:2026-06-01',
+      'week:2026-05-25',
+      'month:2026-04'
+    ])
+  })
+
+  it('emits a Today divider even when every session belongs to today', () => {
     const rows = group([
       entry(session('a', { last_active: at(2026, 5, 18, 11) })),
-      entry(session('b', { last_active: at(2026, 5, 18, 10, 30) })),
-      entry(session('c', { last_active: at(2026, 5, 18, 10) })),
-      entry(session('d', { last_active: at(2026, 5, 18, 6) })),
-      entry(session('e', { last_active: at(2026, 5, 18, 5, 30) })),
-      entry(session('f', { last_active: at(2026, 5, 17, 15) })), // yesterday
-      entry(session('g', { last_active: at(2026, 5, 16, 15) })), // Tue this week
-      entry(session('h', { last_active: at(2026, 5, 14) })), // Sun last week
-      entry(session('i', { last_active: at(2026, 5, 3) })), // earlier in June
-      entry(session('j', { last_active: at(2026, 4, 28) })), // May
-      entry(session('k', { last_active: at(2025, 11, 3) })) // December 2025
+      entry(session('b', { last_active: at(2026, 5, 18, 10) }))
     ])
 
-    expect(rows.slice(0, 5).every(row => row.kind === 'session')).toBe(true)
-    expect(rows[5]).toMatchObject({ key: 'yesterday', kind: 'divider' })
-    expect(dividerKeys(rows)).toEqual(['yesterday', 'this-week', 'last-week', 'this-month', 'm-2026-4', 'my-2025-11'])
+    expect(dividerKeys(rows)).toEqual(['day:2026-06-18'])
   })
 
-  it('labels the rest of the current day "earlier today" past a real break', () => {
-    // Five rapid-fire sessions, a ~4h pause, then more of the same day.
-    const rows = group([
-      entry(session('a', { last_active: at(2026, 5, 18, 11) })),
-      entry(session('b', { last_active: at(2026, 5, 18, 10, 58) })),
-      entry(session('c', { last_active: at(2026, 5, 18, 10, 56) })),
-      entry(session('d', { last_active: at(2026, 5, 18, 10, 54) })),
-      entry(session('e', { last_active: at(2026, 5, 18, 10, 52) })),
-      entry(session('f', { last_active: at(2026, 5, 18, 7) })),
-      entry(session('g', { last_active: at(2026, 5, 18, 6, 58) }))
-    ])
-
-    expect(rows.findIndex(row => row.kind === 'divider')).toBe(5)
-    expect(dividerKeys(rows)).toEqual(['today'])
-  })
-
-  it('never slices a rapid-fire burst mid-run', () => {
-    // Eleven sessions two minutes apart: no gap qualifies as a break, so the
-    // whole burst stays in the head and the divider lands after it.
-    const burst = Array.from({ length: 11 }, (_, i) =>
-      entry(session(`s${i}`, { last_active: at(2026, 5, 18, 11) - i * 120 }))
-    )
-
-    const rows = group([...burst, entry(session('old', { last_active: at(2026, 5, 17, 15) }))])
-
-    expect(rows.findIndex(row => row.kind === 'divider')).toBe(11)
-    expect(dividerKeys(rows)).toEqual(['yesterday'])
-  })
-
-  it('chains the head run across midnight', () => {
-    // Viewed at 00:58: tonight plus last evening is one run; yesterday's
-    // afternoon (a different nominal day) opens the labelled groups.
-    const smallHours = new Date(2026, 5, 19, 0, 58).getTime()
-
-    const rows = group(
-      [
-        entry(session('a', { last_active: at(2026, 5, 19, 0, 30) })),
-        entry(session('b', { last_active: at(2026, 5, 18, 23, 50) })),
-        entry(session('c', { last_active: at(2026, 5, 18, 23, 20) })),
-        entry(session('d', { last_active: at(2026, 5, 17, 20) }))
-      ],
-      smallHours
-    )
-
-    expect(rows.findIndex(row => row.kind === 'divider')).toBe(3)
-    expect(dividerKeys(rows)).toEqual(['yesterday'])
-  })
-
-  it('dissolves a stale head into its own calendar group (fuzzy merge)', () => {
-    // Newest session is 6 days old and the rows below it share its "last week"
-    // bucket: cutting there would strand near-identical neighbours around a
-    // divider, so no head is kept and the whole bucket leads unlabelled.
-    const rows = group([
-      entry(session('a', { last_active: at(2026, 5, 12) })),
-      entry(session('b', { last_active: at(2026, 5, 11, 15) })),
-      entry(session('c', { last_active: at(2026, 5, 11, 10) })),
-      entry(session('d', { last_active: at(2026, 5, 3) })),
-      entry(session('e', { last_active: at(2026, 4, 20) }))
-    ])
-
-    expect(rows.slice(0, 3).every(row => row.kind === 'session')).toBe(true)
-    expect(dividerKeys(rows)).toEqual(['this-month', 'm-2026-4'])
-  })
-
-  it('keeps an isolated newest session as the head when its bucket differs', () => {
-    const rows = group([
-      entry(session('a', { last_active: at(2026, 5, 18, 9) })),
-      entry(session('b', { last_active: at(2026, 5, 17, 15) })),
-      entry(session('c', { last_active: at(2026, 5, 3) }))
-    ])
-
-    expect(rows.findIndex(row => row.kind === 'divider')).toBe(1)
-    expect(dividerKeys(rows)).toEqual(['yesterday', 'this-month'])
-  })
-
-  it('emits no dividers when everything is one unbroken run', () => {
-    const rows = group([
-      entry(session('a', { last_active: at(2026, 5, 18, 11) })),
-      entry(session('b', { last_active: at(2026, 5, 18, 10, 50) })),
-      entry(session('c', { last_active: at(2026, 5, 18, 10, 40) }))
-    ])
-
-    expect(rows.every(row => row.kind === 'session')).toBe(true)
-  })
-
-  it('collapses a big gap straight to the next month/year (empty ranges omitted)', () => {
-    const rows = group([
-      entry(session('t', { last_active: at(2026, 5, 18, 11) })),
-      entry(session('t2', { last_active: at(2026, 5, 18, 10, 30) })),
-      entry(session('j1', { last_active: at(2026, 0, 5) })),
-      entry(session('j2', { last_active: at(2026, 0, 3) })),
-      entry(session('old', { last_active: at(2024, 2, 9) }))
-    ])
-
-    expect(dividerKeys(rows)).toEqual(['m-2026-0', 'my-2024-2'])
-  })
-
-  it('never labels the first rendered group, even when it is not recent', () => {
-    // Newest session is weeks old and alone in its month: it opens the list
-    // unlabelled; only the transitions below it are marked.
-    const rows = group([
-      entry(session('a', { last_active: at(2026, 4, 20) })),
-      entry(session('b', { last_active: at(2026, 2, 3) })),
-      entry(session('c', { last_active: at(2025, 11, 3) }))
-    ])
-
-    expect(rows[0]).toMatchObject({ kind: 'session' })
-    expect(dividerKeys(rows)).toEqual(['m-2026-2', 'my-2025-11'])
-  })
-
-  it('keeps branch children in their parent cluster without opening a new bucket', () => {
-    const parent = session('parent', { last_active: at(2026, 5, 18, 11) })
-    const child = session('child', { last_active: at(2024, 0, 1), parent_session_id: 'parent' })
-
-    const rows = group([entry(parent), entry(child, '└─ ')])
+  it('keeps branch children in their parent calendar group', () => {
+    const parent = entry(session('parent', { last_active: at(2026, 5, 18) }))
+    const child = entry(session('child', { last_active: at(2024, 0, 1), parent_session_id: 'parent' }), '└─ ')
+    const rows = group([parent, child])
 
     expect(rows).toEqual([
-      { entry: entry(parent), kind: 'session' },
-      { entry: entry(child, '└─ '), kind: 'session' }
+      expect.objectContaining({ key: 'day:2026-06-18', kind: 'divider' }),
+      { entry: parent, kind: 'session' },
+      { entry: child, kind: 'session' }
     ])
   })
 
-  it('never emits a divider twice under a non-monotonic order', () => {
+  it('gives repeated non-monotonic segments stable identities while sharing their collapse key', () => {
     const rows = group([
-      entry(session('a', { last_active: at(2026, 5, 16) })), // head run
-      entry(session('b', { last_active: at(2026, 4, 5) })), // May — divider
-      entry(session('c', { last_active: at(2026, 5, 16) })) // head again — no repeat
+      entry(session('today-a', { last_active: at(2026, 5, 18, 11) })),
+      entry(session('old', { last_active: at(2026, 3, 20) })),
+      entry(session('today-b', { last_active: at(2026, 5, 18, 9) }))
     ])
 
-    expect(dividerKeys(rows)).toEqual(['m-2026-4'])
+    const todayRows = rows.filter(
+      (row): row is Extract<SidebarListRow, { kind: 'divider' }> =>
+        row.kind === 'divider' && row.key === 'day:2026-06-18'
+    )
+
+    expect(dividerKeys(rows)).toEqual(['day:2026-06-18', 'month:2026-04', 'day:2026-06-18'])
+    expect(new Set(todayRows.map(row => row.rowKey))).toHaveLength(2)
   })
 
-  it('falls back to started_at when last_active is missing', () => {
-    const rows = group([
-      entry(session('head', { last_active: at(2026, 5, 18, 11) })),
-      entry(session('s', { last_active: 0, started_at: at(2026, 5, 10) }))
-    ])
+  it('falls back to started_at when last_active is absent', () => {
+    const rows = group([entry(session('fallback', { last_active: 0, started_at: at(2026, 5, 17) }))])
 
-    expect(dividerKeys(rows)).toEqual(['last-week'])
+    expect(dividerKeys(rows)).toEqual(['day:2026-06-17'])
   })
 })
 
 describe('toSessionRows', () => {
-  it('wraps entries as session rows with no dividers', () => {
+  it('wraps entries as session rows with no date metadata', () => {
     const entries = [entry(session('a')), entry(session('b'), '└─ ')]
 
     expect(toSessionRows(entries)).toEqual([
       { entry: entries[0], kind: 'session' },
       { entry: entries[1], kind: 'session' }
     ])
+  })
+})
+
+describe('filterCollapsedDateGroupRows', () => {
+  it('keeps every divider while hiding sessions in every collapsed segment', () => {
+    const todayA = entry(session('today-a'))
+    const old = entry(session('old'))
+    const todayB = entry(session('today-b'))
+
+    const rows: SidebarListRow[] = [
+      { key: 'today', kind: 'divider', label: 'Today', rowKey: 'today:a' },
+      { entry: todayA, kind: 'session' },
+      { key: 'old', kind: 'divider', label: 'Old' },
+      { entry: old, kind: 'session' },
+      { key: 'today', kind: 'divider', label: 'Today', rowKey: 'today:b' },
+      { entry: todayB, kind: 'session' }
+    ]
+
+    expect(filterCollapsedDateGroupRows(rows, new Set(['today']))).toEqual([rows[0], rows[2], rows[3], rows[4]])
+  })
+
+  it('does not alter rows when no group is collapsed', () => {
+    const rows: SidebarListRow[] = [
+      { key: 'today', kind: 'divider', label: 'Today' },
+      { entry: entry(session('today')), kind: 'session' }
+    ]
+
+    expect(filterCollapsedDateGroupRows(rows, new Set())).toEqual(rows)
   })
 })

--- a/apps/desktop/src/lib/session-date-groups.ts
+++ b/apps/desktop/src/lib/session-date-groups.ts
@@ -1,143 +1,46 @@
 import { type SidebarSessionEntry } from '@/lib/session-branch-tree'
-import { calendarBucket, HOUR, localeWeekStartDay, MINUTE, SECOND, type SessionBucket } from '@/lib/time'
+import { calendarBucket, localeWeekStartDay, SECOND, type SessionBucket } from '@/lib/time'
 
 // A flat list row is either a divider or a session entry. Interleaving these
 // lets the flat list (and the virtualizer) render separators inline without a
 // second layer of nesting. A divider either names a calendar bucket (resolved
 // against the locale's labels at render time) or carries its own label.
 export type SidebarListRow =
-  | { bucket: SessionBucket; key: string; kind: 'divider' }
+  | { bucket: SessionBucket; key: string; kind: 'divider'; rowKey?: string }
   | { entry: SidebarSessionEntry; kind: 'session' }
-  | { key: string; kind: 'divider'; label: string }
+  | { key: string; kind: 'divider'; label: string; rowKey?: string }
 
 // The row's own age label reads from `last_active || started_at`; bucket off the
 // same value so a divider lines up with what the row actually shows.
 const recencyMs = (entry: SidebarSessionEntry): number =>
   (entry.session.last_active || entry.session.started_at || 0) * SECOND
 
-// Aim the head at "the most recent handful". A break shorter than
-// MIN_RUN_BREAK_MS never counts as one — that would slice a rapid-fire burst —
-// and a silence longer than MAX_RUN_GAP_MS always ends the run: without that
-// bound a sparse list (a project lane) would chain weeks of stale sessions
-// into one giant "recent" head.
-const TARGET_HEAD_SESSIONS = 5
-const MIN_RUN_BREAK_MS = 30 * MINUTE
-const MAX_RUN_GAP_MS = 8 * HOUR
-
-// The unlabelled head is the newest run of sessions, cut at a *real* break in
-// activity. Candidate cut points are every gap of at least MIN_RUN_BREAK_MS
-// inside the contiguous run (gaps ≤ MAX_RUN_GAP_MS), plus the run's own end;
-// among them we pick the one whose head size lands closest (log-scale) to
-// TARGET_HEAD_SESSIONS. So the first divider shows up after roughly the most
-// recent five sessions — but only ever at a genuine pause, never mid-burst: a
-// truly unbroken run stays whole, and an isolated newest session stands alone.
-// Runs chain naturally across midnight.
-//
-// Fuzzy-merge rule: when the cut falls at the run's end and the sessions just
-// below it share the head's calendar bucket, the head adds nothing — it's just
-// the top of that group. Dissolve it (the first-group rule keeps the top
-// unlabelled anyway) so a divider never strands near-identical neighbours,
-// e.g. a lone 6-day-old session above a "Last week" label.
-//
-// Returns the oldest timestamp (ms) still inside the head; -Infinity means the
-// whole list is one run, +Infinity means no head (calendar groups own it all).
-function headRunCutoffMs(entries: readonly SidebarSessionEntry[], nowMs: number, weekStartsOn: number): number {
-  const times = entries
-    .filter(entry => !entry.branchStem)
-    .map(recencyMs)
-    .sort((a, b) => b - a)
-
-  let bestIdx = -1
-  let bestScore = Number.POSITIVE_INFINITY
-  let runEnded = false
-
-  for (let i = 1; i < times.length; i++) {
-    const gap = times[i - 1] - times[i]
-    const endsRun = gap > MAX_RUN_GAP_MS
-
-    if (gap >= MIN_RUN_BREAK_MS || endsRun) {
-      // `i` sessions would sit above a cut at this gap.
-      const score = Math.abs(Math.log(i / TARGET_HEAD_SESSIONS))
-
-      if (score < bestScore) {
-        bestScore = score
-        bestIdx = i
-        runEnded = endsRun
-      }
-    }
-
-    if (endsRun) {
-      break
-    }
-  }
-
-  if (bestIdx === -1) {
-    return Number.NEGATIVE_INFINITY
-  }
-
-  if (runEnded) {
-    const headBucket = calendarBucket(times[0] / SECOND, nowMs, weekStartsOn)
-    const belowBucket = calendarBucket(times[bestIdx] / SECOND, nowMs, weekStartsOn)
-
-    if (headBucket.key === belowBucket.key) {
-      return Number.POSITIVE_INFINITY
-    }
-  }
-
-  return times[bestIdx - 1]
-}
-
-// Insert a date divider before each labelled group. The unlabelled head is the
-// newest run of sessions (see headRunCutoffMs); below it, groups are coarse
-// calendar ranges — earlier today → yesterday → earlier this week → last week
-// → earlier this month → month → month + year — one divider per range, never
-// one per day. Whatever group happens to render first is also never labelled.
-// Branch children inherit their parent cluster's group and never trigger a
-// divider, so a parent→branches block never splits.
+// Insert a divider before every populated calendar group, including the first.
+// Preserve the caller's exact order. If a bucket reappears after another one,
+// its segment gets a unique React row key while sharing the same collapse key.
+// Branch children inherit their parent segment and never trigger a divider.
 export function groupEntriesByRecency(
   entries: readonly SidebarSessionEntry[],
   nowMs = Date.now(),
   weekStartsOn = localeWeekStartDay()
 ): SidebarListRow[] {
   const rows: SidebarListRow[] = []
-  const emitted = new Set<string>()
-  const cutoff = headRunCutoffMs(entries, nowMs, weekStartsOn)
-  let lastKey: null | string = null
+  let currentBucket: SessionBucket | undefined
 
   for (const entry of entries) {
-    // Nested branch rows travel with their parent cluster; they never open a new
-    // bucket or move the divider cursor.
-    if (entry.branchStem) {
-      rows.push({ entry, kind: 'session' })
+    if (!entry.branchStem || !currentBucket) {
+      const bucket = calendarBucket(recencyMs(entry) / SECOND, nowMs, weekStartsOn)
 
-      continue
-    }
-
-    const ms = recencyMs(entry)
-
-    // Head-run sessions are never labelled.
-    if (ms >= cutoff) {
-      rows.push({ entry, kind: 'session' })
-      lastKey = '__recent__'
-
-      continue
-    }
-
-    const bucket = calendarBucket(ms / SECOND, nowMs, weekStartsOn)
-
-    if (bucket.key !== lastKey) {
-      lastKey = bucket.key
-      const alreadyEmitted = emitted.has(bucket.key)
-
-      // Mark it emitted even when skipped so a non-monotonic order (possible
-      // inside a project lane) can't later re-label it or collide React keys.
-      emitted.add(bucket.key)
-
-      // A divider only ever separates two groups — never label the very first
-      // rendered row, whatever group it belongs to.
-      if (rows.length > 0 && !alreadyEmitted) {
-        rows.push({ bucket, key: bucket.key, kind: 'divider' })
+      if (!currentBucket || currentBucket.key !== bucket.key) {
+        rows.push({
+          bucket,
+          key: bucket.key,
+          kind: 'divider',
+          rowKey: `date-divider:${bucket.key}:${entry.session.id}`
+        })
       }
+
+      currentBucket = bucket
     }
 
     rows.push({ entry, kind: 'session' })
@@ -178,4 +81,30 @@ export function groupEntriesByStatus(
 // the same `SidebarListRow[]` shape as the grouped one.
 export function toSessionRows(entries: readonly SidebarSessionEntry[]): SidebarListRow[] {
   return entries.map(entry => ({ entry, kind: 'session' }))
+}
+
+// Keep every divider mounted so a collapsed group always has a disclosure the
+// user can reopen. Session rows after a collapsed divider stay hidden until the
+// next divider.
+export function filterCollapsedDateGroupRows(
+  rows: readonly SidebarListRow[],
+  collapsedKeys: ReadonlySet<string>
+): SidebarListRow[] {
+  const visible: SidebarListRow[] = []
+  let collapsed = false
+
+  for (const row of rows) {
+    if (row.kind === 'divider') {
+      collapsed = collapsedKeys.has(row.key)
+      visible.push(row)
+
+      continue
+    }
+
+    if (!collapsed) {
+      visible.push(row)
+    }
+  }
+
+  return visible
 }

--- a/apps/desktop/src/lib/time.test.ts
+++ b/apps/desktop/src/lib/time.test.ts
@@ -64,46 +64,35 @@ describe('calendarBucket', () => {
     calendarBucket(secondsAt(year, month, day, hour), THU_NOON, MONDAY).kind
 
   it('buckets the current day (and, defensively, the future) as today', () => {
-    // The head run normally absorbs these; "Earlier today" covers the rest.
-    expect(kindAt(2026, 5, 18, 5)).toBe('today')
+    expect(kindAt(2026, 5, 18, 1)).toBe('today')
     expect(kindAt(2026, 5, 18, 23)).toBe('today')
     expect(kindAt(2026, 5, 19)).toBe('today')
   })
 
-  it('assigns the small hours to the previous evening', () => {
-    // 1 AM today (before the 4 AM rollover) is part of yesterday's run.
-    expect(kindAt(2026, 5, 18, 1)).toBe('yesterday')
-
-    // And viewed at 00:58, last evening's sessions are still the current day.
-    const smallHours = new Date(2026, 5, 19, 0, 58).getTime()
-
-    expect(calendarBucket(secondsAt(2026, 5, 18, 23), smallHours, MONDAY).kind).toBe('today')
-    expect(calendarBucket(secondsAt(2026, 5, 18, 10), smallHours, MONDAY).kind).toBe('today')
-    expect(calendarBucket(secondsAt(2026, 5, 17, 15), smallHours, MONDAY).kind).toBe('yesterday')
-  })
-
-  it('uses coarse, non-overlapping ranges that coarsen with age', () => {
+  it('uses daily groups for the current week, then four calendar weeks, then months', () => {
     expect(kindAt(2026, 5, 17)).toBe('yesterday')
-    expect(kindAt(2026, 5, 16)).toBe('thisWeek') // Tue this week
-    expect(kindAt(2026, 5, 15)).toBe('thisWeek') // Mon this week
+    expect(kindAt(2026, 5, 16)).toBe('day') // Tue this week
+    expect(kindAt(2026, 5, 15)).toBe('day') // Mon this week
     expect(kindAt(2026, 5, 14)).toBe('lastWeek') // Sun last week
     expect(kindAt(2026, 5, 8)).toBe('lastWeek') // Mon last week
-    expect(kindAt(2026, 5, 7)).toBe('thisMonth') // earlier in June
-    expect(kindAt(2026, 5, 1)).toBe('thisMonth')
-    expect(kindAt(2026, 4, 28)).toBe('month') // May, same year
+    expect(kindAt(2026, 5, 7)).toBe('week')
+    expect(kindAt(2026, 4, 18)).toBe('week') // fourth full week back
+    expect(kindAt(2026, 4, 11)).toBe('month') // older than the four-week window
     expect(kindAt(2025, 11, 3)).toBe('monthYear') // December, prior year
   })
 
   it('respects a Sunday week start', () => {
     // With the week starting Sun 14 Jun, that Sunday is this week, not last.
-    expect(calendarBucket(secondsAt(2026, 5, 14), THU_NOON, 0).kind).toBe('thisWeek')
+    expect(calendarBucket(secondsAt(2026, 5, 14), THU_NOON, 0).kind).toBe('day')
     expect(calendarBucket(secondsAt(2026, 5, 13), THU_NOON, 0).kind).toBe('lastWeek')
   })
 
-  it('keys same-month sessions together and disambiguates across years', () => {
-    expect(calendarBucket(secondsAt(2026, 2, 3), THU_NOON, MONDAY).key).toBe('m-2026-2')
-    expect(calendarBucket(secondsAt(2026, 2, 20), THU_NOON, MONDAY).key).toBe('m-2026-2')
-    expect(calendarBucket(secondsAt(2025, 2, 3), THU_NOON, MONDAY).key).toBe('my-2025-2')
+  it('uses stable technical keys for days, weeks, and months', () => {
+    expect(calendarBucket(secondsAt(2026, 5, 18), THU_NOON, MONDAY).key).toBe('day:2026-06-18')
+    expect(calendarBucket(secondsAt(2026, 5, 10), THU_NOON, MONDAY).key).toBe('week:2026-06-08')
+    expect(calendarBucket(secondsAt(2026, 2, 3), THU_NOON, MONDAY).key).toBe('month:2026-03')
+    expect(calendarBucket(secondsAt(2026, 2, 20), THU_NOON, MONDAY).key).toBe('month:2026-03')
+    expect(calendarBucket(secondsAt(2025, 2, 3), THU_NOON, MONDAY).key).toBe('month:2025-03')
   })
 })
 
@@ -112,19 +101,19 @@ describe('sessionBucketLabel', () => {
     lastWeek: 'Last week',
     thisMonth: 'Earlier this month',
     thisWeek: 'Earlier this week',
-    today: 'Earlier today',
+    today: 'Today',
     yesterday: 'Yesterday'
   }
 
   const labelAt = (year: number, month: number, day: number) =>
-    sessionBucketLabel(calendarBucket(secondsAt(year, month, day), THU_NOON, 1), labels)
+    sessionBucketLabel(calendarBucket(secondsAt(year, month, day), THU_NOON, 1), labels, 'en-US', THU_NOON)
 
-  it('uses fixed labels for the relative buckets', () => {
-    expect(labelAt(2026, 5, 18)).toBe('Earlier today')
+  it('uses relative labels, named current-week days, and labelled week ranges', () => {
+    expect(labelAt(2026, 5, 18)).toBe('Today')
     expect(labelAt(2026, 5, 17)).toBe('Yesterday')
-    expect(labelAt(2026, 5, 16)).toBe('Earlier this week')
+    expect(labelAt(2026, 5, 16)).toBe('Tuesday, June 16')
     expect(labelAt(2026, 5, 10)).toBe('Last week')
-    expect(labelAt(2026, 5, 2)).toBe('Earlier this month')
+    expect(labelAt(2026, 5, 2)).toMatch(/^June 1/)
   })
 
   it('formats month (same year) and month + year (prior year) via Intl', () => {

--- a/apps/desktop/src/lib/time.ts
+++ b/apps/desktop/src/lib/time.ts
@@ -55,21 +55,17 @@ export function relativeTime(targetMs: number, nowMs = Date.now()): string {
   return rtf.format(sign * Math.round(abs / DAY), 'day')
 }
 
-// A dated divider bucket below the sidebar's unlabelled "recent" head cluster
-// (see session-date-groups.ts for the clustering). Buckets are coarse,
-// non-overlapping calendar ranges — one divider per *cluster* of activity,
-// never one per day, and never a rolling window like "previous 7 days" that
-// semantically overlaps the groups above it. `kind` drives the label; `at` is
-// the session's nominal day start (ms) for month formatting.
-export type SessionBucketKind = 'lastWeek' | 'month' | 'monthYear' | 'thisMonth' | 'thisWeek' | 'today' | 'yesterday'
+// Calendar groups used by the chronological sessions sidebar. Keys are
+// technical local-calendar identities: they never contain translated copy.
+export type SessionBucketKind = 'day' | 'lastWeek' | 'month' | 'monthYear' | 'today' | 'week' | 'yesterday'
 
 export interface SessionBucket {
   at: number
   key: string
   kind: SessionBucketKind
+  rangeEnd?: number
 }
 
-// Fixed divider labels, resolved from i18n (month labels come from Intl).
 export interface SessionBucketLabels {
   lastWeek: string
   thisMonth: string
@@ -77,6 +73,8 @@ export interface SessionBucketLabels {
   today: string
   yesterday: string
 }
+
+export const CALENDAR_WEEKS_BEFORE_MONTHS = 4
 
 export const startOfLocalDay = (ms: number): number => {
   const d = new Date(ms)
@@ -116,57 +114,96 @@ export function startOfLocalWeek(ms: number, weekStartsOn: number): number {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate() - back).getTime()
 }
 
-// Coarse calendar bucket for a Unix-seconds timestamp. Granularity coarsens
-// with age: earlier today → yesterday → earlier this week → last week →
-// earlier this month → month → month + year. Empty ranges simply never emit a
-// bucket, so a sparse tail jumps straight to its month or month-year. The
-// newest run of sessions never reaches here (it is the unlabelled head — see
-// session-date-groups.ts), which is what makes "Earlier today" truthful.
+const endOfLocalWeek = (weekStart: number): number => {
+  const d = new Date(weekStart)
+
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() + 6).getTime()
+}
+
+const localCalendarOrdinal = (ms: number): number => {
+  const d = new Date(ms)
+
+  return Math.floor(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()) / DAY)
+}
+
+const localDateKey = (ms: number): string => {
+  const d = new Date(ms)
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+
+  return `${d.getFullYear()}-${month}-${day}`
+}
+
+// Today, yesterday, each remaining day of the current locale week, four full
+// calendar weeks (the first is "last week"), then exact calendar months.
 export function calendarBucket(
   seconds: number,
   nowMs = Date.now(),
   weekStartsOn = localeWeekStartDay()
 ): SessionBucket {
-  const nominal = nominalDayStart(seconds * SECOND)
-  const todayNominal = nominalDayStart(nowMs)
-  const dayDiff = Math.round((todayNominal - nominal) / DAY)
+  const activityDay = startOfLocalDay(seconds * SECOND)
+  const today = startOfLocalDay(nowMs)
+  const dayDiff = localCalendarOrdinal(today) - localCalendarOrdinal(activityDay)
 
   if (dayDiff <= 0) {
-    return { at: nominal, key: 'today', kind: 'today' }
+    return { at: today, key: `day:${localDateKey(today)}`, kind: 'today' }
   }
 
   if (dayDiff === 1) {
-    return { at: nominal, key: 'yesterday', kind: 'yesterday' }
+    return { at: activityDay, key: `day:${localDateKey(activityDay)}`, kind: 'yesterday' }
   }
 
-  const weekStart = startOfLocalWeek(todayNominal, weekStartsOn)
+  const currentWeekStart = startOfLocalWeek(today, weekStartsOn)
 
-  if (nominal >= weekStart) {
-    return { at: nominal, key: 'this-week', kind: 'thisWeek' }
+  if (activityDay >= currentWeekStart) {
+    return { at: activityDay, key: `day:${localDateKey(activityDay)}`, kind: 'day' }
   }
 
-  const ws = new Date(weekStart)
+  const activityWeekStart = startOfLocalWeek(activityDay, weekStartsOn)
+  const weeksBack = (localCalendarOrdinal(currentWeekStart) - localCalendarOrdinal(activityWeekStart)) / 7
 
-  if (nominal >= new Date(ws.getFullYear(), ws.getMonth(), ws.getDate() - 7).getTime()) {
-    return { at: nominal, key: 'last-week', kind: 'lastWeek' }
+  if (weeksBack >= 1 && weeksBack <= CALENDAR_WEEKS_BEFORE_MONTHS) {
+    return {
+      at: activityWeekStart,
+      key: `week:${localDateKey(activityWeekStart)}`,
+      kind: weeksBack === 1 ? 'lastWeek' : 'week',
+      rangeEnd: endOfLocalWeek(activityWeekStart)
+    }
   }
 
-  const d = new Date(nominal)
-  const now = new Date(todayNominal)
-  const sameYear = d.getFullYear() === now.getFullYear()
+  const d = new Date(activityDay)
+  const monthStart = new Date(d.getFullYear(), d.getMonth(), 1).getTime()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const sameYear = d.getFullYear() === new Date(today).getFullYear()
 
-  if (sameYear && d.getMonth() === now.getMonth()) {
-    return { at: nominal, key: 'this-month', kind: 'thisMonth' }
+  return {
+    at: monthStart,
+    key: `month:${d.getFullYear()}-${month}`,
+    kind: sameYear ? 'month' : 'monthYear'
   }
-
-  const ym = `${d.getFullYear()}-${d.getMonth()}`
-
-  return sameYear ? { at: nominal, key: `m-${ym}`, kind: 'month' } : { at: nominal, key: `my-${ym}`, kind: 'monthYear' }
 }
 
-// Localized divider label for a bucket: fixed relative strings from i18n,
-// Intl-formatted month / month-year for the rest.
-export function sessionBucketLabel(bucket: SessionBucket, labels: SessionBucketLabels): string {
+const formatCalendarRange = (start: number, end: number, locale: string, nowMs: number): string => {
+  const startDate = new Date(start)
+  const endDate = new Date(end)
+  const currentYear = new Date(nowMs).getFullYear()
+  const includeYear = startDate.getFullYear() !== endDate.getFullYear() || endDate.getFullYear() !== currentYear
+
+  const formatter = new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'long',
+    ...(includeYear ? { year: 'numeric' as const } : {})
+  })
+
+  return formatter.formatRange(startDate, endDate)
+}
+
+export function sessionBucketLabel(
+  bucket: SessionBucket,
+  labels: SessionBucketLabels,
+  locale = new Intl.DateTimeFormat().resolvedOptions().locale,
+  nowMs = Date.now()
+): string {
   switch (bucket.kind) {
     case 'today':
       return labels.today
@@ -174,14 +211,14 @@ export function sessionBucketLabel(bucket: SessionBucket, labels: SessionBucketL
     case 'yesterday':
       return labels.yesterday
 
-    case 'thisWeek':
-      return labels.thisWeek
+    case 'day':
+      return new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'long', weekday: 'long' }).format(bucket.at)
 
     case 'lastWeek':
       return labels.lastWeek
 
-    case 'thisMonth':
-      return labels.thisMonth
+    case 'week':
+      return formatCalendarRange(bucket.at, bucket.rangeEnd ?? bucket.at, locale, nowMs)
 
     case 'month':
       return fmtMonth.format(bucket.at)

--- a/apps/desktop/src/store/session-date-group-collapse.test.ts
+++ b/apps/desktop/src/store/session-date-group-collapse.test.ts
@@ -29,6 +29,21 @@ describe('session date-group collapse persistence', () => {
     expect(remounted.getCollapsedSessionDateGroups(scope)).toEqual(new Set(['week:2026-07-20']))
   })
 
+  it('caps persisted collapsed keys per scope and retains the most recent entries', async () => {
+    const store = await import('./session-date-group-collapse')
+    const scope = store.sessionDateGroupScope(connection(), 'default')
+
+    for (let index = 0; index < store.MAX_COLLAPSED_DATE_GROUPS_PER_SCOPE + 5; index += 1) {
+      store.setSessionDateGroupCollapsed(scope, `day:2026-01-${String(index + 1).padStart(2, '0')}`, true)
+    }
+
+    const persisted = [...store.getCollapsedSessionDateGroups(scope)]
+
+    expect(persisted).toHaveLength(store.MAX_COLLAPSED_DATE_GROUPS_PER_SCOPE)
+    expect(persisted[0]).toBe('day:2026-01-06')
+    expect(persisted.at(-1)).toBe('day:2026-01-69')
+  })
+
   it('isolates state between profiles on the same backend', async () => {
     const store = await import('./session-date-group-collapse')
     const defaultScope = store.sessionDateGroupScope(connection(), 'default')

--- a/apps/desktop/src/store/session-date-group-collapse.test.ts
+++ b/apps/desktop/src/store/session-date-group-collapse.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+const connection = (overrides: Partial<HermesConnection> = {}): HermesConnection =>
+  ({
+    baseUrl: 'http://127.0.0.1:8642',
+    mode: 'remote',
+    profile: 'default',
+    ...overrides
+  }) as HermesConnection
+
+describe('session date-group collapse persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('restores collapsed technical keys after a store remount', async () => {
+    const first = await import('./session-date-group-collapse')
+    const scope = first.sessionDateGroupScope(connection(), 'default')
+
+    first.setSessionDateGroupCollapsed(scope, 'week:2026-07-20', true)
+    expect(first.getCollapsedSessionDateGroups(scope)).toEqual(new Set(['week:2026-07-20']))
+
+    vi.resetModules()
+    const remounted = await import('./session-date-group-collapse')
+
+    expect(remounted.getCollapsedSessionDateGroups(scope)).toEqual(new Set(['week:2026-07-20']))
+  })
+
+  it('isolates state between profiles on the same backend', async () => {
+    const store = await import('./session-date-group-collapse')
+    const defaultScope = store.sessionDateGroupScope(connection(), 'default')
+    const workScope = store.sessionDateGroupScope(connection(), 'work')
+
+    store.setSessionDateGroupCollapsed(defaultScope, 'today', true)
+
+    expect(store.getCollapsedSessionDateGroups(defaultScope)).toEqual(new Set(['today']))
+    expect(store.getCollapsedSessionDateGroups(workScope)).toEqual(new Set())
+  })
+
+  it('isolates state between backends for the same profile', async () => {
+    const store = await import('./session-date-group-collapse')
+    const localScope = store.sessionDateGroupScope(connection({ baseUrl: 'http://127.0.0.1:8642' }), 'default')
+    const remoteScope = store.sessionDateGroupScope(connection({ baseUrl: 'https://gateway.example.test/' }), 'default')
+
+    store.collapseAllSessionDateGroups(localScope, ['today', 'yesterday'])
+
+    expect(store.getCollapsedSessionDateGroups(localScope)).toEqual(new Set(['today', 'yesterday']))
+    expect(store.getCollapsedSessionDateGroups(remoteScope)).toEqual(new Set())
+  })
+
+  it('expands only currently known groups and retains unrelated persisted groups', async () => {
+    const store = await import('./session-date-group-collapse')
+    const scope = store.sessionDateGroupScope(connection(), 'default')
+
+    store.collapseAllSessionDateGroups(scope, ['today', 'yesterday', 'month:2025-12'])
+    store.expandAllSessionDateGroups(scope, ['today', 'yesterday'])
+
+    expect(store.getCollapsedSessionDateGroups(scope)).toEqual(new Set(['month:2025-12']))
+  })
+
+  it('normalizes equivalent backend URLs and falls back to the connection profile', async () => {
+    const store = await import('./session-date-group-collapse')
+
+    expect(store.sessionDateGroupScope(connection({ baseUrl: 'https://gateway.example.test/' }), null)).toBe(
+      store.sessionDateGroupScope(connection({ baseUrl: 'https://gateway.example.test' }), 'default')
+    )
+  })
+
+  it('keeps a distinct scope for the real All profiles view', async () => {
+    const store = await import('./session-date-group-collapse')
+
+    const effectiveProfile = store.resolveSessionDateGroupProfile(connection(), '__all__', {
+      allProfilesKey: '__all__',
+      showAllProfiles: true
+    })
+
+    expect(effectiveProfile).toBe('__all__')
+    expect(store.sessionDateGroupScope(connection(), effectiveProfile)).not.toBe(
+      store.sessionDateGroupScope(connection(), 'default')
+    )
+  })
+
+  it('keeps a concrete selected profile', async () => {
+    const store = await import('./session-date-group-collapse')
+
+    expect(
+      store.resolveSessionDateGroupProfile(connection({ profile: 'work' }), 'work', {
+        allProfilesKey: '__all__',
+        showAllProfiles: false
+      })
+    ).toBe('work')
+  })
+
+  it('falls back to the active connection profile for a residual All profiles value', async () => {
+    const store = await import('./session-date-group-collapse')
+
+    expect(
+      store.resolveSessionDateGroupProfile(connection({ profile: 'solo' }), '__all__', {
+        allProfilesKey: '__all__',
+        showAllProfiles: false
+      })
+    ).toBe('solo')
+  })
+
+  it('preserves backend and effective-profile isolation after scope resolution', async () => {
+    const store = await import('./session-date-group-collapse')
+    const options = { allProfilesKey: '__all__', showAllProfiles: false }
+    const local = connection({ baseUrl: 'http://127.0.0.1:8642', profile: 'default' })
+    const remote = connection({ baseUrl: 'https://gateway.example.test', profile: 'default' })
+
+    const localDefault = store.sessionDateGroupScope(
+      local,
+      store.resolveSessionDateGroupProfile(local, 'default', options)
+    )
+
+    const localWork = store.sessionDateGroupScope(local, store.resolveSessionDateGroupProfile(local, 'work', options))
+
+    const remoteDefault = store.sessionDateGroupScope(
+      remote,
+      store.resolveSessionDateGroupProfile(remote, 'default', options)
+    )
+
+    expect(new Set([localDefault, localWork, remoteDefault])).toHaveLength(3)
+  })
+})

--- a/apps/desktop/src/store/session-date-group-collapse.ts
+++ b/apps/desktop/src/store/session-date-group-collapse.ts
@@ -1,0 +1,104 @@
+import type { HermesConnection } from '@/global'
+import { Codecs, persistentAtom } from '@/lib/persisted'
+
+export type CollapsedSessionDateGroups = Record<string, string[]>
+
+export const SESSION_DATE_GROUP_COLLAPSE_STORAGE_KEY = 'hermes.desktop.sessionDateGroups.collapsed.v1'
+
+const sanitizeCollapsedGroups = (value: unknown): CollapsedSessionDateGroups => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([scope, keys]) => {
+      if (!Array.isArray(keys)) {
+        return []
+      }
+
+      const cleanKeys = [...new Set(keys.filter((key): key is string => typeof key === 'string' && key.length > 0))]
+
+      return cleanKeys.length > 0 ? [[scope, cleanKeys]] : []
+    })
+  )
+}
+
+export const $collapsedSessionDateGroups = persistentAtom<CollapsedSessionDateGroups>(
+  SESSION_DATE_GROUP_COLLAPSE_STORAGE_KEY,
+  {},
+  Codecs.json(sanitizeCollapsedGroups)
+)
+
+interface SessionDateGroupProfileOptions {
+  allProfilesKey: string
+  showAllProfiles: boolean
+}
+
+export function resolveSessionDateGroupProfile(
+  connection: HermesConnection | null,
+  requestedProfile: null | string | undefined,
+  { allProfilesKey, showAllProfiles }: SessionDateGroupProfileOptions
+): string {
+  const requested = requestedProfile?.trim()
+
+  if (showAllProfiles) {
+    return requested || allProfilesKey
+  }
+
+  if (requested && requested !== allProfilesKey) {
+    return requested
+  }
+
+  return connection?.profile?.trim() || 'default'
+}
+
+export function sessionDateGroupScope(connection: HermesConnection | null, activeProfile?: null | string): string {
+  const mode = connection?.mode ?? 'disconnected'
+  const endpoint = (connection?.baseUrl?.trim() || 'local').replace(/\/+$/, '')
+  const profile = activeProfile?.trim() || connection?.profile?.trim() || 'default'
+
+  return JSON.stringify([mode, endpoint, profile])
+}
+
+export function getCollapsedSessionDateGroups(scope: string): Set<string> {
+  return new Set($collapsedSessionDateGroups.get()[scope] ?? [])
+}
+
+const writeCollapsedSessionDateGroups = (scope: string, keys: ReadonlySet<string>) => {
+  const current = $collapsedSessionDateGroups.get()
+  const next = { ...current }
+
+  if (keys.size === 0) {
+    delete next[scope]
+  } else {
+    next[scope] = [...keys]
+  }
+
+  $collapsedSessionDateGroups.set(next)
+}
+
+export function setSessionDateGroupCollapsed(scope: string, key: string, collapsed: boolean): void {
+  const keys = getCollapsedSessionDateGroups(scope)
+
+  if (collapsed) {
+    keys.add(key)
+  } else {
+    keys.delete(key)
+  }
+
+  writeCollapsedSessionDateGroups(scope, keys)
+}
+
+export function collapseAllSessionDateGroups(scope: string, knownKeys: readonly string[]): void {
+  const keys = getCollapsedSessionDateGroups(scope)
+
+  knownKeys.forEach(key => keys.add(key))
+  writeCollapsedSessionDateGroups(scope, keys)
+}
+
+export function expandAllSessionDateGroups(scope: string, knownKeys: readonly string[]): void {
+  const keys = getCollapsedSessionDateGroups(scope)
+
+  knownKeys.forEach(key => keys.delete(key))
+  writeCollapsedSessionDateGroups(scope, keys)
+}

--- a/apps/desktop/src/store/session-date-group-collapse.ts
+++ b/apps/desktop/src/store/session-date-group-collapse.ts
@@ -4,6 +4,12 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 export type CollapsedSessionDateGroups = Record<string, string[]>
 
 export const SESSION_DATE_GROUP_COLLAPSE_STORAGE_KEY = 'hermes.desktop.sessionDateGroups.collapsed.v1'
+export const MAX_COLLAPSED_DATE_GROUPS_PER_SCOPE = 64
+
+const sanitizeCollapsedKeys = (keys: unknown[]): string[] =>
+  [...new Set(keys.filter((key): key is string => typeof key === 'string' && key.length > 0))].slice(
+    -MAX_COLLAPSED_DATE_GROUPS_PER_SCOPE
+  )
 
 const sanitizeCollapsedGroups = (value: unknown): CollapsedSessionDateGroups => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -16,7 +22,7 @@ const sanitizeCollapsedGroups = (value: unknown): CollapsedSessionDateGroups => 
         return []
       }
 
-      const cleanKeys = [...new Set(keys.filter((key): key is string => typeof key === 'string' && key.length > 0))]
+      const cleanKeys = sanitizeCollapsedKeys(keys)
 
       return cleanKeys.length > 0 ? [[scope, cleanKeys]] : []
     })
@@ -71,7 +77,7 @@ const writeCollapsedSessionDateGroups = (scope: string, keys: ReadonlySet<string
   if (keys.size === 0) {
     delete next[scope]
   } else {
-    next[scope] = [...keys]
+    next[scope] = [...keys].slice(-MAX_COLLAPSED_DATE_GROUPS_PER_SCOPE)
   }
 
   $collapsedSessionDateGroups.set(next)


### PR DESCRIPTION
## Summary

Improve the Desktop sessions sidebar with calendar-based date groups that can be collapsed individually or all at once.

The grouping is based on calendar boundaries rather than rolling age buckets, making long session histories easier to scan while preserving the existing session order.

## Behavior

- Adds explicit labels for every temporal group, with no unlabeled leading section.
- Groups sessions into:
  - Today
  - Yesterday
  - remaining days of the current calendar week
  - Last week, including its date range
  - earlier complete calendar weeks
  - calendar months for older sessions
- Adds a visible chevron to every date-group header.
- Makes the complete group header clickable and keyboard accessible.
- Adds `Collapse all date groups` and `Expand all date groups` to the Sessions menu.
- Removes collapsed sessions before virtualization so collapsed groups leave no empty space.
- Persists collapse state locally across Desktop restarts.
- Scopes persisted state by connection mode, normalized backend, and effective profile.
- Refreshes the grouping automatically when local midnight passes.
- Preserves the existing session order, including non-monotonic input sequences.
- Supports the normal session list, profile/source groups, and nested project lanes.

## Implementation notes

Date groups use stable business keys:

- `day:YYYY-MM-DD`
- `week:YYYY-MM-DD`
- `month:YYYY-MM`

Repeated visual segments may receive distinct React row identities while sharing the same business collapse key.

Future timestamps are normalized into the current-day group so they cannot create a duplicate future `Today` section.

The collapse-all menu is shown only when the active rendering branch contains actual temporal groups.

Localized strings were added for the Desktop locales currently present in `main`.

## Validation

Automated validation after rebasing onto the current `main`:

- Targeted UI tests: **43 passed**
- Complete Desktop UI suite: **3176 passed across 359 files**
- Renderer, Electron, and E2E TypeScript checks: **passed**
- ESLint on all 18 changed files: **passed**
- Production Desktop build: **passed**
- `git diff --check`: **passed**

## Manual Electron validation

Validated against an isolated Desktop sandbox containing an existing session history:

- individual group collapse and expansion;
- no empty virtualized gap after collapse;
- collapse-all behavior;
- expand-all behavior;
- visible and correctly oriented chevrons;
- calendar labels and week ranges;
- persistent mixed collapse state after a full Electron restart.

The validation sandbox and its user data are local-only and are not part of this pull request.
