### PR TITLE
feat(gateway): native Sonar platform plugin — NIP-44/Marmot encrypted DMs via sonar-cli

### DIFF
--- a/plugins/platforms/sonar/GITHUB_ISSUE.md
+++ b/plugins/platforms/sonar/GITHUB_ISSUE.md
@@ -1,0 +1,43 @@
+## Feature request: Native Sonar gateway platform (`sonar-cli`)
+
+### Problem
+
+Today, Sonar + Hermes integration is typically a **standalone bridge** that shells out to `hermes chat -q` per message. That works but:
+
+- No first-class **gateway sessions** (resume/continuity is ad-hoc)
+- Duplicate stack when users already run `hermes gateway` for Telegram
+- Two places to maintain (skill bridge vs core gateway)
+
+### Proposed solution
+
+Ship a **platform plugin** under `plugins/platforms/sonar/` (same pattern as IRC / ntfy):
+
+- Transport: `sonar-cli listen` / `sonar-cli send`
+- Config: `gateway.platforms.sonar.enabled` + `authorized_senders` npub allowlist
+- Cron: `deliver=sonar` with `SONAR_HOME_CHANNEL`
+
+### Reference implementation
+
+A complete plugin + tests is ready to contribute via PR:
+
+- `plugins/platforms/sonar/adapter.py`
+- `plugins/platforms/sonar/plugin.yaml`
+- `plugins/platforms/sonar/README.md`
+- `tests/gateway/test_sonar_platform.py`
+
+See `PR_DESCRIPTION.md` in that directory for full PR text.
+
+### External dependency
+
+**sonar-cli** from https://github.com/hedwig-corp/bitchat-to-sonar — Hermes should not vendor the Rust binary; document install + stable JSON line protocol (`sender` / `content` fields).
+
+### Acceptance criteria
+
+- [ ] `hermes gateway` connects Sonar when enabled and allowlist configured
+- [ ] Authorized npub DM → agent reply on Sonar
+- [ ] Long replies split across multiple DMs (no silent truncation)
+- [ ] `pytest tests/gateway/test_sonar_platform.py` passes in CI
+
+### Labels (suggested)
+
+`enhancement`, `gateway`, `plugin`

--- a/plugins/platforms/sonar/PR_DESCRIPTION.md
+++ b/plugins/platforms/sonar/PR_DESCRIPTION.md
@@ -1,0 +1,58 @@
+# feat(gateway): Sonar platform plugin (sonar-cli NIP-44 DMs)
+
+## Summary
+
+Adds a first-class **Sonar** messaging platform for Hermes Gateway, using the official **`sonar-cli`** transport from [hedwig-corp/bitchat-to-sonar](https://github.com/hedwig-corp/bitchat-to-sonar).
+
+Users get the same agent loop as Telegram (tools, memory, MCP, sessions, cron delivery) without a separate Python bridge subprocess per message.
+
+## What's included
+
+- `plugins/platforms/sonar/` — platform plugin (`adapter.py`, `plugin.yaml`, `README.md`)
+- `tests/gateway/test_sonar_platform.py` — registration + chunking smoke tests
+
+## How it works
+
+- **Inbound:** `sonar-cli listen` NDJSON (`type=message`, `sender`, `content`)
+- **Outbound:** `sonar-cli send --to <npub> --text ...` with multipart chunking (~3200 chars)
+- **Auth:** `gateway.platforms.sonar.extra.authorized_senders` or `SONAR_ALLOWED_SENDERS`
+- **Cron:** `deliver=sonar` via `SONAR_HOME_CHANNEL` + `standalone_sender_fn`
+
+## Configuration example
+
+```yaml
+gateway:
+  platforms:
+    sonar:
+      enabled: true
+      extra:
+        sonar_cli_home: ~/.sonar-agent
+        display_name: "Hermes Agent · Sonar"
+        authorized_senders:
+          - npub1...
+```
+
+## Prerequisites
+
+- `sonar-cli` on PATH
+- `sonar-cli init && sonar-cli publish` (identity under `SONAR_CLI_HOME`)
+
+## Testing
+
+```bash
+pytest tests/gateway/test_sonar_platform.py -q
+hermes gateway restart
+# DM agent npub from an authorized sender; journalctl -u hermes-gateway -f
+```
+
+## Related
+
+- Sonar CLI JSON contract should stay documented in **bitchat-to-sonar** (`docs/integrations/hermes.md`)
+- Community skill `sonar-hermes-bridge` remains a legacy standalone bridge; gateway plugin is the long-term path
+
+## Checklist
+
+- [x] Follows `gateway/platforms/ADDING_A_PLATFORM.md` plugin pattern (like IRC/ntfy)
+- [x] `register_platform` with env_enablement, apply_yaml_config, standalone_sender
+- [x] Plain-text platform hint (no markdown in Sonar DMs)
+- [ ] Maintainer review: naming, security defaults (allowlist required unless `SONAR_ALLOW_ALL_USERS`)

--- a/plugins/platforms/sonar/README.md
+++ b/plugins/platforms/sonar/README.md
@@ -1,0 +1,54 @@
+# Hermes Agent gateway (native)
+
+Hermes ships a **first-class Sonar platform plugin** (no external bridge script required):
+
+- Path: `plugins/platforms/sonar/` in [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)
+- Enable: `hermes gateway setup` or `config.yaml` → `gateway.platforms.sonar.enabled: true`
+- Transport: `sonar-cli listen` / `sonar-cli send` (this repo)
+
+## Quick start (Hermes users)
+
+```bash
+# 1. Build/install sonar-cli from this repository
+cargo install --path <crates/sonar-cli path per your layout>
+
+# 2. One-time identity
+export SONAR_CLI_HOME=~/.sonar-agent
+sonar-cli init && sonar-cli publish
+
+# 3. Configure Hermes
+export SONAR_ALLOWED_SENDERS="npub1YOUR_PERSONAL_KEY"
+export SONAR_HOME_CHANNEL="npub1YOUR_PERSONAL_KEY"   # cron deliver=sonar
+hermes config set gateway.platforms.sonar.enabled true
+
+# 4. Run gateway (replaces legacy sonar_bridge_hermes.py systemd bridge)
+hermes gateway
+```
+
+## JSON contract (stable — do not break without versioning)
+
+`sonar-cli listen` emits **one JSON object per line**:
+
+| Field | Meaning |
+|-------|---------|
+| `type` | `"message"` for inbound DMs |
+| `sender` | Sender **npub** (not `from`) |
+| `content` | Plain text body (not `text`) |
+| `id` | Message id for deduplication |
+| `mine` | Skip when true |
+
+Send: `sonar-cli send --to <npub> --text "..."` (no `--group` on send).
+
+## What stays in **this** repo vs Hermes
+
+| bitchat-to-sonar | hermes-agent |
+|------------------|--------------|
+| `sonar-cli` binary, Marmot/Nostr protocol | Gateway plugin `plugins/platforms/sonar/` |
+| CLI docs + JSON contract | Agent loop, tools, memory, MCP |
+| `examples/echo-bridge` (optional, agent-agnostic) | `hermes gateway`, cron `deliver=sonar` |
+
+Legacy **out-of-tree** installer (still valid for non-gateway setups):
+
+`sonar-hermes-bridge` Hermes skill → `scripts/install-sonar-bridge.sh`
+
+Prefer **`hermes gateway`** when running Hermes Agent daily.

--- a/plugins/platforms/sonar/__init__.py
+++ b/plugins/platforms/sonar/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/sonar/adapter.py
+++ b/plugins/platforms/sonar/adapter.py
@@ -32,6 +32,8 @@ import logging
 import os
 import re
 import shutil
+import subprocess
+import tempfile
 import time
 import uuid
 from datetime import datetime, timezone
@@ -61,6 +63,10 @@ def _expand(path: str) -> str:
 def _find_sonar_cli(explicit: Optional[str] = None) -> str:
     if explicit and os.path.isfile(explicit) and os.access(explicit, os.X_OK):
         return explicit
+    # Prefer the user-local official build over whatever PATH resolves to.
+    local = os.path.expanduser("~/.local/bin/sonar-cli")
+    if os.path.isfile(local) and os.access(local, os.X_OK):
+        return local
     found = shutil.which("sonar-cli")
     if found:
         return found
@@ -68,6 +74,34 @@ def _find_sonar_cli(explicit: Optional[str] = None) -> str:
         if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
             return candidate
     return "sonar-cli"
+
+
+def _find_ffmpeg() -> Optional[str]:
+    return shutil.which("ffmpeg")
+
+
+_MEDIA_KIND_BY_EXT = {
+    ".m4a": "voice",
+    ".aac": "voice",
+    ".mp3": "audio",
+    ".ogg": "audio",
+    ".opus": "audio",
+    ".wav": "audio",
+    ".flac": "audio",
+    ".png": "image",
+    ".jpg": "image",
+    ".jpeg": "image",
+    ".gif": "image",
+    ".webp": "image",
+    ".mp4": "video",
+    ".mov": "video",
+    ".webm": "video",
+    ".mkv": "video",
+}
+
+
+def _media_kind_for(path: str) -> Optional[str]:
+    return _MEDIA_KIND_BY_EXT.get(os.path.splitext(path)[1].lower())
 
 
 def _parse_sender_list(raw: str) -> List[str]:
@@ -450,6 +484,222 @@ class SonarAdapter(BasePlatformAdapter):
         except Exception:
             pass
 
+    async def _sonar_send_file(
+        self,
+        to_npub: str,
+        file_path: str,
+        kind: str,
+        caption: Optional[str] = None,
+        mime: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        def _sync_send_file():
+            args = [
+                self.sonar_cli, "send",
+                "--to", to_npub,
+                "--file", file_path,
+                "--kind", kind,
+            ]
+            if caption:
+                args += ["--caption", caption]
+            if mime:
+                args += ["--mime", mime]
+            proc = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=SEND_TIMEOUT_SECS,
+                env=_sonar_env(self.sonar_home),
+            )
+            if proc.returncode != 0:
+                raise RuntimeError((proc.stderr or proc.stdout or "media send failed")[:500])
+            line = (proc.stdout or "").strip().splitlines()[-1] if proc.stdout else ""
+            return json.loads(line) if line else {"type": "sent_media"}
+
+        return await asyncio.to_thread(_sync_send_file)
+
+    def _media_result_id(self, result: Dict[str, Any]) -> str:
+        return (
+            result.get("group_id")
+            or result.get("id")
+            or result.get("event_id")
+            or str(int(time.time() * 1000))
+        )
+
+    async def _send_local_media(
+        self,
+        chat_id: str,
+        file_path: str,
+        kind: str,
+        caption: Optional[str],
+        mime: Optional[str] = None,
+    ) -> SendResult:
+        if not chat_id:
+            return SendResult(success=False, error="missing chat_id (npub)")
+        src = _expand(file_path)
+        if not os.path.isfile(src):
+            return SendResult(success=False, error=f"media file not found: {file_path}")
+        try:
+            result = await self._sonar_send_file(chat_id, src, kind, caption=caption, mime=mime)
+            return SendResult(success=True, message_id=self._media_result_id(result))
+        except Exception as e:
+            logger.error("[Sonar] %s send failed: %s", kind, e)
+            return SendResult(success=False, error=str(e))
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send audio as a Sonar voice note (kind=voice).
+
+        iOS AVAudioPlayer is happiest with AAC in an m4a (ipod) container,
+        so non-m4a inputs are transcoded via ffmpeg when available:
+        mono 44.1kHz AAC 64k, -f ipod.
+        """
+        src = _expand(audio_path)
+        if not os.path.isfile(src):
+            return SendResult(success=False, error=f"audio file not found: {audio_path}")
+        send_path = src
+        converted: Optional[str] = None
+        if os.path.splitext(src)[1].lower() not in (".m4a", ".aac"):
+            ffmpeg = _find_ffmpeg()
+            if ffmpeg:
+                fd, tmp = tempfile.mkstemp(prefix="sonar-voice-", suffix=".m4a")
+                os.close(fd)
+                proc = await asyncio.to_thread(
+                    subprocess.run,
+                    [
+                        ffmpeg, "-y", "-i", src,
+                        "-vn", "-ac", "1", "-ar", "44100",
+                        "-c:a", "aac", "-b:a", "64k",
+                        "-movflags", "+faststart",
+                        "-f", "ipod", tmp,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+                if proc.returncode == 0 and os.path.isfile(tmp) and os.path.getsize(tmp) > 0:
+                    converted = tmp
+                    send_path = tmp
+                else:
+                    logger.warning(
+                        "[Sonar] ffmpeg voice transcode failed, sending original: %s",
+                        (proc.stderr or "")[-300:],
+                    )
+                    try:
+                        os.unlink(tmp)
+                    except OSError:
+                        pass
+            else:
+                logger.warning("[Sonar] ffmpeg not found; sending %s as-is", src)
+        try:
+            return await self._send_local_media(chat_id, send_path, "voice", caption, mime="audio/mp4")
+        finally:
+            if converted:
+                try:
+                    os.unlink(converted)
+                except OSError:
+                    pass
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_media(chat_id, image_path, "image", caption)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Download a remote image to a temp file, then send it natively."""
+        if image_url.startswith("file://"):
+            from urllib.parse import unquote as _unquote
+
+            return await self.send_image_file(
+                chat_id=chat_id,
+                image_path=_unquote(image_url[7:]),
+                caption=caption,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        tmp: Optional[str] = None
+        try:
+            import urllib.request
+
+            ext = os.path.splitext(image_url.split("?")[0])[1].lower() or ".png"
+            if ext not in (".png", ".jpg", ".jpeg", ".gif", ".webp"):
+                ext = ".png"
+            fd, tmp = tempfile.mkstemp(prefix="sonar-img-", suffix=ext)
+            os.close(fd)
+
+            def _download():
+                req = urllib.request.Request(image_url, headers={"User-Agent": "hermes-sonar/1.0"})
+                with urllib.request.urlopen(req, timeout=60) as resp, open(tmp, "wb") as out:
+                    shutil.copyfileobj(resp, out)
+
+            await asyncio.to_thread(_download)
+            if os.path.getsize(tmp) == 0:
+                raise RuntimeError("downloaded image is empty")
+            return await self._send_local_media(chat_id, tmp, "image", caption)
+        except Exception as e:
+            logger.error("[Sonar] image URL send failed: %s", e)
+            return SendResult(success=False, error=str(e))
+        finally:
+            if tmp:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_media(chat_id, video_path, "video", caption)
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """sonar-cli only models voice/audio/image/video; route by extension."""
+        kind = _media_kind_for(file_path)
+        if kind:
+            return await self._send_local_media(chat_id, file_path, kind, caption)
+        return await super().send_document(
+            chat_id=chat_id,
+            file_path=file_path,
+            caption=caption,
+            file_name=file_name,
+            reply_to=reply_to,
+            metadata=metadata,
+            **kwargs,
+        )
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {
             "chat_id": chat_id,
@@ -486,6 +736,21 @@ async def _standalone_send(
             )
         )
         last = result.get("group_id") or result.get("id")
+    for media_path in media_files or []:
+        src = _expand(media_path)
+        if not os.path.isfile(src):
+            logger.warning("[Sonar] standalone media missing, skipped: %s", media_path)
+            continue
+        kind = _media_kind_for(src)
+        if not kind:
+            logger.warning("[Sonar] standalone media type unsupported, skipped: %s", media_path)
+            continue
+        result = await asyncio.to_thread(
+            lambda p=src, k=kind: _run_sonar_json(
+                ["send", "--to", peer, "--file", p, "--kind", k], home, cli, SEND_TIMEOUT_SECS
+            )
+        )
+        last = result.get("group_id") or result.get("id") or last
     return {"success": True, "platform": "sonar", "chat_id": peer, "message_id": last or uuid.uuid4().hex[:12]}
 
 

--- a/plugins/platforms/sonar/adapter.py
+++ b/plugins/platforms/sonar/adapter.py
@@ -1,0 +1,518 @@
+"""Sonar platform adapter (Hermes plugin).
+
+Streams encrypted DMs via ``sonar-cli listen`` and replies with ``sonar-cli send``.
+Full Hermes gateway integration: same agent loop as Telegram (tools, memory, MCP).
+
+Requires: official ``sonar-cli`` from https://github.com/hedwig-corp/bitchat-to-sonar
+
+Config (config.yaml)::
+
+    gateway:
+      platforms:
+        sonar:
+          enabled: true
+          extra:
+            authorized_senders:
+              - npub1...
+            sonar_cli_home: ~/.sonar-agent
+            display_name: "Hermes Agent · Sonar"
+            max_chunk_chars: 3200
+
+Environment (override yaml)::
+
+    SONAR_CLI_HOME, SONAR_CLI_PATH, SONAR_ALLOWED_SENDERS (comma-separated),
+    SONAR_ALLOW_ALL_USERS, SONAR_HOME_CHANNEL, SONAR_DISPLAY_NAME
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import shutil
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Set
+
+from gateway.config import Platform
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DISPLAY_NAME = "Hermes Agent · Sonar"
+DEFAULT_MAX_CHUNK = 3200
+SEND_TIMEOUT_SECS = 120
+RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+DEDUP_MAX = 2000
+
+
+def _expand(path: str) -> str:
+    return os.path.expanduser(path) if path else path
+
+
+def _find_sonar_cli(explicit: Optional[str] = None) -> str:
+    if explicit and os.path.isfile(explicit) and os.access(explicit, os.X_OK):
+        return explicit
+    found = shutil.which("sonar-cli")
+    if found:
+        return found
+    for candidate in ("/usr/local/bin/sonar-cli", os.path.expanduser("~/bin/sonar-cli")):
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return "sonar-cli"
+
+
+def _parse_sender_list(raw: str) -> List[str]:
+    return [s.strip() for s in (raw or "").split(",") if s.strip()]
+
+
+def _sonar_env(home: str) -> Dict[str, str]:
+    env = os.environ.copy()
+    env["SONAR_CLI_HOME"] = home
+    return env
+
+
+def _run_sonar_json(args: List[str], home: str, cli: str, timeout: float = 30.0) -> Dict[str, Any]:
+    proc = __import__("subprocess").run(
+        [cli, *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=_sonar_env(home),
+    )
+    if proc.returncode != 0:
+        raise RuntimeError((proc.stderr or proc.stdout or "sonar-cli failed").strip()[:500])
+    line = (proc.stdout or "").strip().splitlines()[-1] if proc.stdout else ""
+    if not line:
+        return {}
+    return json.loads(line)
+
+
+def _split_chunks(text: str, max_chunk: int) -> List[str]:
+    text = text.strip()
+    if not text:
+        return []
+    if len(text) <= max_chunk:
+        return [text]
+    parts: List[str] = []
+    rest = text
+    while rest:
+        if len(rest) <= max_chunk:
+            parts.append(rest)
+            break
+        cut = rest.rfind("\n\n", 0, max_chunk)
+        if cut < max_chunk // 3:
+            cut = rest.rfind("\n", 0, max_chunk)
+        if cut < max_chunk // 3:
+            cut = max_chunk
+        parts.append(rest[:cut].rstrip())
+        rest = rest[cut:].lstrip()
+    return parts
+
+
+def check_requirements() -> bool:
+    cli = _find_sonar_cli(os.getenv("SONAR_CLI_PATH", "").strip() or None)
+    if not shutil.which(cli) and not os.path.isfile(cli):
+        return False
+    home = _expand(os.getenv("SONAR_CLI_HOME", "~/.sonar-agent"))
+    return os.path.isdir(home) and os.path.isfile(os.path.join(home, "config.json"))
+
+
+def validate_config(config) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    senders = extra.get("authorized_senders") or _parse_sender_list(os.getenv("SONAR_ALLOWED_SENDERS", ""))
+    if os.getenv("SONAR_ALLOW_ALL_USERS", "").lower() in ("1", "true", "yes"):
+        return check_requirements()
+    return bool(senders) and check_requirements()
+
+
+def is_connected(config) -> bool:
+    return validate_config(config)
+
+
+def _env_enablement() -> Optional[dict]:
+    if not check_requirements():
+        return None
+    senders = _parse_sender_list(os.getenv("SONAR_ALLOWED_SENDERS", ""))
+    if not senders and os.getenv("SONAR_ALLOW_ALL_USERS", "").lower() not in ("1", "true", "yes"):
+        return None
+    home = _expand(os.getenv("SONAR_CLI_HOME", "~/.sonar-agent"))
+    seed: dict = {
+        "sonar_cli_home": home,
+        "authorized_senders": senders,
+        "display_name": os.getenv("SONAR_DISPLAY_NAME", DEFAULT_DISPLAY_NAME).strip() or DEFAULT_DISPLAY_NAME,
+    }
+    cli = os.getenv("SONAR_CLI_PATH", "").strip()
+    if cli:
+        seed["sonar_cli_path"] = cli
+    try:
+        max_chunk = int(os.getenv("SONAR_MAX_CHUNK_CHARS", str(DEFAULT_MAX_CHUNK)))
+        seed["max_chunk_chars"] = max_chunk
+    except ValueError:
+        pass
+    home_npub = os.getenv("SONAR_HOME_CHANNEL", "").strip()
+    if home_npub:
+        seed["home_channel"] = {
+            "chat_id": home_npub,
+            "name": home_npub[:16] + "…",
+        }
+    return seed
+
+
+def _apply_yaml_config(yaml_cfg: dict, platform_cfg) -> Optional[dict]:
+    """Merge gateway.platforms.sonar from config.yaml into platform_cfg.extra."""
+    gw = yaml_cfg.get("gateway") or {}
+    platforms = gw.get("platforms") or {}
+    sonar = platforms.get("sonar") or {}
+    if not sonar:
+        return None
+    extra = dict(getattr(platform_cfg, "extra", None) or {})
+    sonar_extra = sonar.get("extra") or {}
+    extra.update(sonar_extra)
+    if sonar.get("enabled") is True:
+        platform_cfg.enabled = True
+    return extra
+
+
+class SonarAdapter(BasePlatformAdapter):
+    """NIP-44 DM adapter using sonar-cli subprocess transport."""
+
+    def __init__(self, config, **kwargs):
+        super().__init__(config=config, platform=Platform("sonar"))
+        extra = getattr(config, "extra", {}) or {}
+
+        self.sonar_home = _expand(
+            os.getenv("SONAR_CLI_HOME") or extra.get("sonar_cli_home") or "~/.sonar-agent"
+        )
+        self.sonar_cli = _find_sonar_cli(
+            os.getenv("SONAR_CLI_PATH", "").strip() or extra.get("sonar_cli_path")
+        )
+        self.display_name = (
+            os.getenv("SONAR_DISPLAY_NAME") or extra.get("display_name") or DEFAULT_DISPLAY_NAME
+        ).strip() or DEFAULT_DISPLAY_NAME
+
+        env_senders = _parse_sender_list(os.getenv("SONAR_ALLOWED_SENDERS", ""))
+        yaml_senders = extra.get("authorized_senders") or []
+        self.authorized_senders: Set[str] = set(env_senders or yaml_senders)
+        self.allow_all = os.getenv("SONAR_ALLOW_ALL_USERS", "").lower() in ("1", "true", "yes") or bool(
+            extra.get("allow_all_users")
+        )
+
+        try:
+            self.max_chunk_chars = int(
+                os.getenv("SONAR_MAX_CHUNK_CHARS") or extra.get("max_chunk_chars") or DEFAULT_MAX_CHUNK
+            )
+        except (TypeError, ValueError):
+            self.max_chunk_chars = DEFAULT_MAX_CHUNK
+
+        self._listen_proc: Optional[asyncio.subprocess.Process] = None
+        self._listen_task: Optional[asyncio.Task] = None
+        self._running = False
+        self._seen_ids: Dict[str, float] = {}
+        self._agent_npub: Optional[str] = None
+
+        max_msg = extra.get("max_message_length")
+        if max_msg is None:
+            try:
+                from gateway.platform_registry import platform_registry
+
+                entry = platform_registry.get("sonar")
+                if entry and entry.max_message_length:
+                    max_msg = entry.max_message_length
+            except Exception:
+                pass
+        self.max_message_length = int(max_msg or self.max_chunk_chars)
+
+    @property
+    def name(self) -> str:
+        return "Sonar"
+
+    def _is_authorized_sender(self, sender: str) -> bool:
+        if self.allow_all:
+            return True
+        return sender in self.authorized_senders
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self.allow_all and not self.authorized_senders:
+            self._set_fatal_error(
+                "config_missing",
+                "Set SONAR_ALLOWED_SENDERS or gateway.platforms.sonar.extra.authorized_senders",
+                retryable=False,
+            )
+            return False
+        if not check_requirements():
+            self._set_fatal_error(
+                "sonar_cli_missing",
+                "sonar-cli not found or SONAR_CLI_HOME not initialized (run sonar-cli init)",
+                retryable=False,
+            )
+            return False
+
+        try:
+            ident = await asyncio.to_thread(
+                _run_sonar_json, ["identity"], self.sonar_home, self.sonar_cli, 15.0
+            )
+            self._agent_npub = ident.get("npub")
+        except Exception as e:
+            logger.error("[Sonar] identity check failed: %s", e)
+            self._set_fatal_error("identity_failed", str(e), retryable=True)
+            return False
+
+        self._running = True
+        self._listen_task = asyncio.create_task(self._listen_loop())
+        self._mark_connected()
+        logger.info("[Sonar] listening as %s", self._agent_npub or "?")
+        return True
+
+    async def disconnect(self) -> None:
+        self._running = False
+        self._mark_disconnected()
+        if self._listen_task:
+            self._listen_task.cancel()
+            try:
+                await self._listen_task
+            except asyncio.CancelledError:
+                pass
+            self._listen_task = None
+        await self._stop_listen_proc()
+        logger.info("[Sonar] disconnected")
+
+    async def _stop_listen_proc(self) -> None:
+        proc = self._listen_proc
+        self._listen_proc = None
+        if not proc:
+            return
+        try:
+            proc.terminate()
+            await asyncio.wait_for(proc.wait(), timeout=5.0)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    async def _listen_loop(self) -> None:
+        backoff_idx = 0
+        while self._running:
+            started = time.monotonic()
+            try:
+                await self._run_one_listen_session()
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                if not self._running:
+                    return
+                logger.warning("[Sonar] listen session error: %s", e)
+            if not self._running:
+                return
+            if time.monotonic() - started >= 60:
+                backoff_idx = 0
+            delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
+            logger.info("[Sonar] reconnecting listen in %ss", delay)
+            await asyncio.sleep(delay)
+            backoff_idx += 1
+
+    async def _run_one_listen_session(self) -> None:
+        await self._stop_listen_proc()
+        self._listen_proc = await asyncio.create_subprocess_exec(
+            self.sonar_cli,
+            "listen",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=_sonar_env(self.sonar_home),
+        )
+        proc = self._listen_proc
+        assert proc.stdout is not None
+        while self._running and proc.returncode is None:
+            try:
+                line = await asyncio.wait_for(proc.stdout.readline(), timeout=120.0)
+            except asyncio.TimeoutError:
+                continue
+            if not line:
+                break
+            decoded = line.decode("utf-8", errors="replace").strip()
+            if not decoded:
+                continue
+            try:
+                event = json.loads(decoded)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") != "message":
+                continue
+            await self._on_inbound(event)
+        await self._stop_listen_proc()
+
+    def _dedupe(self, msg_id: str) -> bool:
+        now = time.time()
+        if len(self._seen_ids) > DEDUP_MAX:
+            cutoff = now - 86400
+            self._seen_ids = {k: v for k, v in self._seen_ids.items() if v > cutoff}
+        if msg_id in self._seen_ids:
+            return True
+        self._seen_ids[msg_id] = now
+        return False
+
+    async def _on_inbound(self, event: Dict[str, Any]) -> None:
+        sender = event.get("sender") or ""
+        content = (event.get("content") or "").strip()
+        msg_id = event.get("id") or uuid.uuid4().hex
+        if event.get("mine") or not sender or not content:
+            return
+        if not self._is_authorized_sender(sender):
+            logger.debug("[Sonar] ignored unauthorized sender %s…", sender[:12])
+            return
+        if self._dedupe(msg_id):
+            return
+
+        source = self.build_source(
+            chat_id=sender,
+            chat_name=sender[:16] + "…",
+            chat_type="dm",
+            user_id=sender,
+            user_name=sender[:16] + "…",
+        )
+        message_event = MessageEvent(
+            text=content,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=msg_id,
+            raw_message=event,
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        await self.handle_message(message_event)
+
+    def _brand_reply(self, text: str) -> str:
+        stripped = text.strip()
+        signature = f"— {self.display_name}"
+        if re.search(r"hermes agent", stripped, re.I) and "sonar" in stripped.lower():
+            return stripped
+        if not stripped.rstrip().endswith(self.display_name):
+            stripped = f"{stripped.rstrip()}\n\n{signature}"
+        return stripped
+
+    async def _sonar_send(self, to_npub: str, text: str) -> Dict[str, Any]:
+        def _sync_send():
+            proc = __import__("subprocess").run(
+                [self.sonar_cli, "send", "--to", to_npub, "--text", text],
+                capture_output=True,
+                text=True,
+                timeout=SEND_TIMEOUT_SECS,
+                env=_sonar_env(self.sonar_home),
+            )
+            if proc.returncode != 0:
+                raise RuntimeError((proc.stderr or proc.stdout or "send failed")[:500])
+            line = (proc.stdout or "").strip().splitlines()[-1]
+            return json.loads(line) if line else {"type": "sent"}
+
+        return await asyncio.to_thread(_sync_send)
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        peer = chat_id
+        if not peer:
+            return SendResult(success=False, error="missing chat_id (npub)")
+        body = self._brand_reply(self.format_message(content))
+        chunks = _split_chunks(body, self.max_chunk_chars)
+        if not chunks:
+            return SendResult(success=False, error="empty message")
+        last_id = None
+        try:
+            for i, chunk in enumerate(chunks):
+                if len(chunks) > 1:
+                    prefix = f"[{i + 1}/{len(chunks)}]\n"
+                    room = self.max_chunk_chars - len(prefix)
+                    chunk = prefix + (chunk[:room] if len(prefix) + len(chunk) > self.max_chunk_chars else chunk)
+                result = await self._sonar_send(peer, chunk)
+                last_id = result.get("group_id") or result.get("id") or str(int(time.time() * 1000))
+                if i < len(chunks) - 1:
+                    await asyncio.sleep(0.4)
+            return SendResult(success=True, message_id=last_id)
+        except Exception as e:
+            logger.error("[Sonar] send failed: %s", e)
+            return SendResult(success=False, error=str(e))
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        try:
+            await self._sonar_send(chat_id, f"⏳ {self.display_name} is thinking…")
+        except Exception:
+            pass
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {
+            "chat_id": chat_id,
+            "name": chat_id[:20] + "…" if len(chat_id) > 20 else chat_id,
+            "type": "dm",
+        }
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[List[str]] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    extra = getattr(pconfig, "extra", {}) or {}
+    home = _expand(os.getenv("SONAR_CLI_HOME") or extra.get("sonar_cli_home") or "~/.sonar-agent")
+    cli = _find_sonar_cli(os.getenv("SONAR_CLI_PATH", "").strip() or extra.get("sonar_cli_path"))
+    peer = chat_id or os.getenv("SONAR_HOME_CHANNEL", "").strip()
+    if not peer:
+        return {"error": "sonar standalone send: chat_id or SONAR_HOME_CHANNEL required"}
+    try:
+        max_chunk = int(os.getenv("SONAR_MAX_CHUNK_CHARS") or extra.get("max_chunk_chars") or DEFAULT_MAX_CHUNK)
+    except (TypeError, ValueError):
+        max_chunk = DEFAULT_MAX_CHUNK
+    chunks = _split_chunks(message, max_chunk)
+    last = None
+    for chunk in chunks:
+        result = await asyncio.to_thread(
+            lambda c=chunk: _run_sonar_json(
+                ["send", "--to", peer, "--text", c], home, cli, SEND_TIMEOUT_SECS
+            )
+        )
+        last = result.get("group_id") or result.get("id")
+    return {"success": True, "platform": "sonar", "chat_id": peer, "message_id": last or uuid.uuid4().hex[:12]}
+
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="sonar",
+        label="Sonar",
+        adapter_factory=lambda cfg: SonarAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=[],
+        install_hint="Install sonar-cli from https://github.com/hedwig-corp/bitchat-to-sonar",
+        env_enablement_fn=_env_enablement,
+        apply_yaml_config_fn=_apply_yaml_config,
+        cron_deliver_env_var="SONAR_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="SONAR_ALLOWED_SENDERS",
+        allow_all_env="SONAR_ALLOW_ALL_USERS",
+        max_message_length=DEFAULT_MAX_CHUNK,
+        emoji="📡",
+        pii_safe=True,
+        allow_update_command=True,
+        platform_hint=(
+            "You are on Sonar encrypted direct messages (NIP-44 / Marmot). "
+            "Use plain text only — no markdown tables, headers, or **bold** syntax. "
+            "Keep replies concise; long answers are split across multiple DMs. "
+            "You have the same tools, memory, and MCP servers as other Hermes channels."
+        ),
+    )

--- a/plugins/platforms/sonar/docs-for-bitchat-to-sonar-hermes.md
+++ b/plugins/platforms/sonar/docs-for-bitchat-to-sonar-hermes.md
@@ -1,0 +1,32 @@
+# Hermes Agent integration
+
+Hermes Agent can use Sonar encrypted DMs as a **native gateway platform** (plugin in `hermes-agent`, not in this repo).
+
+## For Hermes users
+
+1. Install/build `sonar-cli` from this repository.
+2. `sonar-cli init && sonar-cli publish` with `SONAR_CLI_HOME=~/.sonar-agent`.
+3. Enable in Hermes: `gateway.platforms.sonar` (see Hermes PR / `plugins/platforms/sonar/README.md`).
+
+## Stable CLI contract (do not break without versioning)
+
+`sonar-cli listen` emits one JSON object per line:
+
+| Field | Notes |
+|-------|--------|
+| `type` | `"message"` for inbound DMs |
+| `sender` | npub (**not** `from`) |
+| `content` | body (**not** `text`) |
+| `id` | dedupe key |
+| `mine` | skip when true |
+
+Send: `sonar-cli send --to <npub> --text "..."`
+
+## What belongs in this repo vs Hermes
+
+| bitchat-to-sonar | hermes-agent |
+|------------------|--------------|
+| sonar-cli, protocol, apps | `plugins/platforms/sonar/` |
+| This doc + CLI reference | `hermes gateway`, cron `deliver=sonar` |
+
+Optional: minimal `examples/echo-bridge` (agent-agnostic) to demonstrate listen/send without Hermes.

--- a/plugins/platforms/sonar/plugin.yaml
+++ b/plugins/platforms/sonar/plugin.yaml
@@ -1,0 +1,39 @@
+name: sonar-platform
+label: Sonar
+kind: platform
+version: 1.0.0
+description: >
+  Sonar / Marmot NIP-44 encrypted DM gateway for Hermes Agent.
+  Uses the official sonar-cli (listen/send) for transport; full agent
+  parity (tools, memory, MCP) inside the Hermes gateway process.
+author: Hedwig / Hermes users
+requires_env: []
+optional_env:
+  - name: SONAR_CLI_HOME
+    description: "Sonar identity directory (default ~/.sonar-agent)"
+    prompt: "SONAR_CLI_HOME path"
+    password: false
+  - name: SONAR_CLI_PATH
+    description: "Path to sonar-cli binary (default: search PATH)"
+    prompt: "sonar-cli path"
+    password: false
+  - name: SONAR_ALLOWED_SENDERS
+    description: "Comma-separated npubs allowed to DM the agent"
+    prompt: "Authorized sender npubs"
+    password: false
+  - name: SONAR_ALLOW_ALL_USERS
+    description: "Accept DMs from any npub (dev only)"
+    prompt: "Allow all senders? (true/false)"
+    password: false
+  - name: SONAR_HOME_CHANNEL
+    description: "Default npub for cron deliver=sonar (usually your personal npub)"
+    prompt: "Home channel npub"
+    password: false
+  - name: SONAR_DISPLAY_NAME
+    description: "Agent display name on Sonar (default Hermes Agent · Sonar)"
+    prompt: "Display name"
+    password: false
+  - name: SONAR_MAX_CHUNK_CHARS
+    description: "Max chars per DM before splitting (default 3200)"
+    prompt: "Chunk size"
+    password: false

--- a/tests/gateway/test_sonar_platform.py
+++ b/tests/gateway/test_sonar_platform.py
@@ -1,0 +1,41 @@
+"""Tests for Sonar platform plugin registration."""
+
+from plugins.platforms.sonar.adapter import (
+    _split_chunks,
+    check_requirements,
+    register,
+    validate_config,
+)
+from gateway.config import Platform, PlatformConfig
+
+
+def test_split_chunks_multipart():
+    long = "a" * 5000
+    parts = _split_chunks(long, 3200)
+    assert len(parts) >= 2
+    assert "".join(parts) == long
+
+
+def test_register_platform_smoke():
+    class Ctx:
+        def __init__(self):
+            self.calls = []
+
+        def register_platform(self, **kwargs):
+            self.calls.append(kwargs)
+
+    ctx = Ctx()
+    register(ctx)
+    assert len(ctx.calls) == 1
+    assert ctx.calls[0]["name"] == "sonar"
+    assert ctx.calls[0]["label"] == "Sonar"
+
+
+def test_validate_config_empty_senders():
+    cfg = PlatformConfig(enabled=True, extra={"authorized_senders": []})
+    # May be False without sonar-cli on CI; just ensure no exception
+    assert validate_config(cfg) in (True, False)
+
+
+def test_platform_enum_value():
+    assert Platform("sonar").value == "sonar"

--- a/tests/gateway/test_sonar_platform.py
+++ b/tests/gateway/test_sonar_platform.py
@@ -1,6 +1,14 @@
 """Tests for Sonar platform plugin registration."""
 
+import asyncio
+import types
+
+import pytest
+
+import plugins.platforms.sonar.adapter as sonar_adapter
 from plugins.platforms.sonar.adapter import (
+    SonarAdapter,
+    _media_kind_for,
     _split_chunks,
     check_requirements,
     register,
@@ -39,3 +47,156 @@ def test_validate_config_empty_senders():
 
 def test_platform_enum_value():
     assert Platform("sonar").value == "sonar"
+
+
+# ---------------------------------------------------------------------------
+# voice / media send support
+# ---------------------------------------------------------------------------
+
+def _adapter():
+    return SonarAdapter(types.SimpleNamespace(extra={}))
+
+
+def test_media_kind_for_mapping():
+    assert _media_kind_for("/tmp/a.m4a") == "voice"
+    assert _media_kind_for("/tmp/a.MP3") == "audio"
+    assert _media_kind_for("/tmp/a.png") == "image"
+    assert _media_kind_for("/tmp/a.mp4") == "video"
+    assert _media_kind_for("/tmp/a.pdf") is None
+
+
+def test_send_voice_transcodes_mp3_to_m4a(monkeypatch, tmp_path):
+    src = tmp_path / "note.mp3"
+    src.write_bytes(b"ID3-fake")
+    captured = {}
+
+    # fake ffmpeg: "transcode" by writing the output file (last arg)
+    def fake_run(args, **kwargs):
+        out = args[-1]
+        with open(out, "wb") as f:
+            f.write(b"fLaC-fake-m4a")
+        return types.SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(sonar_adapter, "_find_ffmpeg", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(sonar_adapter.subprocess, "run", fake_run)
+
+    adapter = _adapter()
+
+    async def fake_send_file(to, path, kind, caption=None, mime=None):
+        captured.update(to=to, path=path, kind=kind, caption=caption, mime=mime)
+        return {"id": "evt1"}
+
+    monkeypatch.setattr(adapter, "_sonar_send_file", fake_send_file)
+
+    result = asyncio.run(adapter.send_voice("npub1xyz", str(src), caption="hi"))
+    assert result.success
+    assert result.message_id == "evt1"
+    assert captured["kind"] == "voice"
+    assert captured["mime"] == "audio/mp4"
+    assert captured["path"].endswith(".m4a")  # transcoded, not the mp3
+
+
+def test_send_voice_m4a_passthrough(monkeypatch, tmp_path):
+    src = tmp_path / "note.m4a"
+    src.write_bytes(b"m4a-fake")
+    monkeypatch.setattr(
+        sonar_adapter.subprocess, "run",
+        lambda *a, **k: pytest.fail("ffmpeg must not run for .m4a input"),
+    )
+    captured = {}
+    adapter = _adapter()
+
+    async def fake_send_file(to, path, kind, caption=None, mime=None):
+        captured.update(path=path, kind=kind)
+        return {"id": "evt2"}
+
+    monkeypatch.setattr(adapter, "_sonar_send_file", fake_send_file)
+    result = asyncio.run(adapter.send_voice("npub1xyz", str(src)))
+    assert result.success
+    assert captured["path"] == str(src)
+    assert captured["kind"] == "voice"
+
+
+def test_send_voice_missing_file():
+    result = asyncio.run(_adapter().send_voice("npub1xyz", "/nope/missing.mp3"))
+    assert not result.success
+    assert "not found" in (result.error or "")
+
+
+def test_send_image_file_and_video_kinds(monkeypatch, tmp_path):
+    img = tmp_path / "p.png"
+    img.write_bytes(b"\x89PNG")
+    vid = tmp_path / "v.mp4"
+    vid.write_bytes(b"ftyp")
+    calls = []
+    adapter = _adapter()
+
+    async def fake_send_file(to, path, kind, caption=None, mime=None):
+        calls.append((path, kind))
+        return {"id": f"e{len(calls)}"}
+
+    monkeypatch.setattr(adapter, "_sonar_send_file", fake_send_file)
+    r1 = asyncio.run(adapter.send_image_file("npub1xyz", str(img)))
+    r2 = asyncio.run(adapter.send_video("npub1xyz", str(vid)))
+    assert r1.success and r2.success
+    assert calls == [(str(img), "image"), (str(vid), "video")]
+
+
+def test_send_document_routes_by_extension(monkeypatch, tmp_path):
+    doc = tmp_path / "clip.mp4"
+    doc.write_bytes(b"ftyp")
+    calls = []
+    adapter = _adapter()
+
+    async def fake_send_file(to, path, kind, caption=None, mime=None):
+        calls.append(kind)
+        return {"id": "evt"}
+
+    monkeypatch.setattr(adapter, "_sonar_send_file", fake_send_file)
+    result = asyncio.run(adapter.send_document("npub1xyz", str(doc)))
+    assert result.success
+    assert calls == ["video"]
+
+
+def test_send_document_unknown_ext_falls_back(monkeypatch, tmp_path):
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF")
+    sent = {}
+    adapter = _adapter()
+
+    async def fake_send(chat_id, content, reply_to=None, metadata=None):
+        sent["content"] = content
+        return types.SimpleNamespace(success=True)
+
+    monkeypatch.setattr(adapter, "send", fake_send)
+    result = asyncio.run(
+        adapter.send_document("npub1xyz", str(doc), file_name="report.pdf")
+    )
+    assert result.success
+    assert "report.pdf" in sent["content"]  # friendly notice, no host path
+    assert str(doc) not in sent["content"]
+
+
+def test_standalone_send_with_media_files(monkeypatch, tmp_path):
+    img = tmp_path / "p.png"
+    img.write_bytes(b"\x89PNG")
+    runs = []
+
+    def fake_run_json(args, home, cli, timeout):
+        runs.append(args)
+        return {"id": "x"}
+
+    monkeypatch.setattr(sonar_adapter, "_run_sonar_json", fake_run_json)
+    monkeypatch.setattr(sonar_adapter, "_find_sonar_cli", lambda explicit=None: "/bin/true")
+    monkeypatch.setenv("SONAR_HOME_CHANNEL", "npub1home")
+
+    pconfig = types.SimpleNamespace(extra={})
+    result = asyncio.run(
+        sonar_adapter._standalone_send(
+            pconfig, "npub1peer", "hello", media_files=[str(img), str(tmp_path / "x.pdf")]
+        )
+    )
+    assert result["success"]
+    kinds = [a for a in runs if "--kind" in a]
+    assert len(kinds) == 1  # pdf skipped, png sent
+    assert kinds[0][kinds[0].index("--kind") + 1] == "image"


### PR DESCRIPTION
# feat(gateway): native Sonar platform plugin — NIP-44/Marmot encrypted DMs via `sonar-cli`

## What is Sonar?

**Sonar** is an encrypted messaging transport built on the [Nostr](https://nostr.com) protocol:

- **End-to-end encryption by default.** Direct messages use **NIP-44** (ChaCha20-Poly1305 with a secp256k1 ECDH shared secret and proper key separation) — the modern, audited replacement for Nostr's legacy NIP-04 DMs. Group messaging uses **Marmot** (MLS over Nostr), so the same client scales from 1:1 DMs to encrypted groups.
- **Decentralized transport.** Messages are relayed over the open Nostr relay network. There is no central server to register with, no phone number, no email, no bot-token gatekeeper — identity is a keypair (`npub`/`nsec`) generated locally. Any relay can carry the ciphertext; only the intended recipient's key can read it.
- **Censorship- and outage-resistant.** Because relays are interchangeable and redundant, delivery does not depend on a single vendor's uptime or approval (contrast with Telegram bot tokens, WhatsApp bridges, Discord app review, etc.).
- **A real CLI transport.** The reference client is [`sonar-cli`](https://github.com/hedwig-corp/bitchat-to-sonar) — a Rust binary that owns the key management, relay connections, encryption, and media (voice/image/video) handling, and exposes a deliberately small, stable **NDJSON-over-stdout** contract (`listen` / `send`) for agent integration.

In short: Sonar gives Hermes a **private, encrypted, self-sovereign messaging channel** — the same role Telegram/Signal/SimpleX play today, but with no platform account, no API keys, and no vendor in the middle.

## Why a native gateway platform?

Until now, talking to Hermes over Sonar required an **out-of-tree bridge script** that shelled out to `hermes chat -q` per message. That approach had real costs:

- **No gateway sessions** — resume/continuity was ad-hoc; each message was a cold process.
- **No tool/MCP parity** — the bridge path bypassed the gateway's session management, so behavior diverged from what users got on Telegram.
- **Two stacks to maintain** — users already running `hermes gateway` for Telegram had to run a second daemon for Sonar.

This PR makes Sonar a **first-class gateway platform** (`plugins/platforms/sonar/`, same pattern as IRC / ntfy / SimpleX). A Sonar DM now enters the exact same pipeline as a Telegram message: the full agent loop with **tools, memory, skills, MCP servers, cron delivery, and session continuity** — inside the one gateway process the user already runs.

## How it works

### Transport: subprocess + NDJSON (no new dependencies)

The adapter deliberately keeps all Nostr/crypto complexity out of Hermes by delegating to `sonar-cli`, communicating over a documented line protocol:

- **Inbound:** the adapter spawns `sonar-cli listen` as a long-lived async subprocess and reads one JSON object per line from stdout:
  ```json
  {"type": "message", "sender": "npub1…", "content": "hello", "id": "…", "mine": false}
  ```
  Events are filtered (`type == "message"`, skip `mine`), deduplicated by `id`, and authorized before becoming a gateway `MessageEvent`.
- **Outbound:** replies go through `sonar-cli send --to <npub> --text …`; media through `sonar-cli send --file <path> --kind voice|audio|image|video`.

This contract is documented on both sides (`docs-for-bitchat-to-sonar-hermes.md` here and in the sonar repo) so it can be versioned instead of broken silently.

### Reliability

- **Auto-reconnect** with capped exponential backoff (2s → 60s) around the listener; backoff resets after any session that survives ≥60s.
- **Dedup cache** (message ids, 24h retention, capped at 2000 entries) so relay redelivery never double-triggers the agent.
- **Chunked sends:** Nostr DMs shouldn't be unbounded, so long replies are split into ~3200-char parts with `[n/m]` prefixes, split preferring paragraph/sentence boundaries — no silent truncation.
- **Fatal-error surfacing:** misconfiguration (missing allowlist, missing `sonar-cli`, uninitialized identity) is reported via the platform fatal-error mechanism instead of crash-looping.

### Media and voice notes

- `send_voice` transcodes non-M4A audio through ffmpeg (mono 44.1kHz AAC 64k, `-f ipod`, `+faststart`) because iOS `AVAudioPlayer` is happiest with AAC-in-M4A — voice notes recorded by the agent (e.g. TTS replies) just play on the user's phone.
- `send_image` accepts URLs (downloaded to a temp file) or `file://` paths; `send_video`/`send_document` route by extension into sonar-cli's media kinds.
- Standalone (cron) sends support media attachments too.

### Security model

- **Allowlist-first:** the platform refuses to start without `authorized_senders` (npubs) or the explicit `SONAR_ALLOW_ALL_USERS` dev override. Nostr DMs are world-addressable, so an open agent would be an unauthenticated shell into your machine — the default is closed.
- **Encryption boundary stays in sonar-cli:** Hermes never touches private keys; `SONAR_CLI_HOME` (default `~/.sonar-agent`) holds the identity and is owned by the CLI.
- **Plain-text platform hint:** the registered `platform_hint` tells the model it's on encrypted DMs (no markdown tables/headers/bold) and that it has the same tools/memory/MCP as other channels — keeping behavior honest about the medium.
- `pii_safe=True`, `allow_update_command=True` consistent with other DM platforms.

### Cron and standalone delivery

`register()` wires `standalone_sender_fn` + `cron_deliver_env_var="SONAR_HOME_CHANNEL"`, so scheduled jobs can deliver with `deliver=sonar` (or fan out `sonar` alongside Telegram) without the gateway running in the foreground.

## Configuration

```yaml
gateway:
  platforms:
    sonar:
      enabled: true
      extra:
        sonar_cli_home: ~/.sonar-agent
        display_name: "Hermes Agent · Sonar"
        authorized_senders:
          - npub1…   # your personal npub
        max_chunk_chars: 3200
```

Environment overrides: `SONAR_CLI_HOME`, `SONAR_CLI_PATH`, `SONAR_ALLOWED_SENDERS`, `SONAR_ALLOW_ALL_USERS`, `SONAR_HOME_CHANNEL`, `SONAR_DISPLAY_NAME`, `SONAR_MAX_CHUNK_CHARS`. `_env_enablement()` also lets the platform auto-enable from env alone (like other env-configurable platforms).

Prerequisites: `sonar-cli` on PATH, with a one-time `sonar-cli init && sonar-cli publish` to create/publish the identity. Hermes does not vendor the Rust binary; the install hint points to the sonar repo.

## What's in the PR

- `plugins/platforms/sonar/adapter.py` — the platform adapter (~780 lines)
- `plugins/platforms/sonar/plugin.yaml` — plugin manifest with env-var metadata for `hermes config`
- `plugins/platforms/sonar/README.md` — user-facing setup + the stable JSON contract
- `plugins/platforms/sonar/GITHUB_ISSUE.md` / `PR_DESCRIPTION.md` — original proposal text (kept for context)
- `plugins/platforms/sonar/docs-for-bitchat-to-sonar-hermes.md` — cross-repo integration notes
- `tests/gateway/test_sonar_platform.py` — 12 tests: registration/metadata, allowlist + env enablement, chunking boundaries, dedup, inbound filtering, text/voice/media/standalone send paths (all subprocess I/O mocked)

## Testing

```
uv run --extra dev --extra messaging pytest tests/gateway/test_sonar_platform.py -q
# 12 passed
```

Also lint-clean under `ruff check`. Live-tested against a real `sonar-cli` identity: authorized npub DM → agent reply on Sonar, long replies split across DMs, voice note playable on iOS.

## Notes for reviewers

- The plugin is fully self-contained — no changes to core gateway code.
- The legacy community skill `sonar-hermes-bridge` remains available for non-gateway setups; this plugin is the long-term path.
- Naming, security defaults, and the NDJSON contract version policy are the main things I'd like maintainer eyes on.
