### PR TITLE
fix(agent): reasoning_effort cannot disable Nemotron reasoning via OpenRouter — nvidia/ missing from allowlist (#75386)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6480,6 +6480,10 @@ class AIAgent:
             "qwen/qwen3",
             "tencent/hy3",
             "xiaomi/",
+            # Nemotron models default reasoning ON and accept OpenRouter's
+            # reasoning {"enabled": false} toggle — without this prefix,
+            # `reasoning_effort: none` could not disable it (#75386).
+            "nvidia/",
         )
         return any(model.startswith(prefix) for prefix in reasoning_model_prefixes)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -6480,10 +6480,15 @@ class AIAgent:
             "qwen/qwen3",
             "tencent/hy3",
             "xiaomi/",
-            # Nemotron models default reasoning ON and accept OpenRouter's
-            # reasoning {"enabled": false} toggle — without this prefix,
-            # `reasoning_effort: none` could not disable it (#75386).
-            "nvidia/",
+            # NVIDIA is allowlisted per-model, not as a family: this gate was
+            # introduced (3f0f4a04a) precisely because NVIDIA-via-OpenRouter
+            # 400'd on reasoning extra_body. Nemotron reasoning models default
+            # thinking ON and were verified to accept the OpenRouter
+            # reasoning toggle ({"enabled": false} → 0 reasoning tokens,
+            # reporter-tested in #75386); other nvidia/ slugs stay gated
+            # until individually verified. Prefix form covers the ":free"
+            # routing suffix.
+            "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         )
         return any(model.startswith(prefix) for prefix in reasoning_model_prefixes)
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5688,19 +5688,58 @@ class TestSupportsReasoningExtraBody:
             agent.model = model
             assert agent._supports_reasoning_extra_body() is True, model
 
-    def test_nvidia_models_are_treated_as_reasoning_capable(self):
-        """#75386: Nemotron models default reasoning ON; without nvidia/ in the
-        allowlist, `agent.reasoning_effort: none` never reached OpenRouter's
-        reasoning extra_body and reasoning could not be disabled (reporter
-        verified OpenRouter accepts reasoning {"enabled": false} for these)."""
+    def test_verified_nemotron_reasoning_model_is_allowlisted(self):
+        """#75386: this Nemotron model defaults reasoning ON; without an
+        allowlist entry, `agent.reasoning_effort: none` never reached
+        OpenRouter's reasoning extra_body and reasoning could not be
+        disabled. Reporter verified OpenRouter accepts
+        reasoning {"enabled": false} for exactly this model (0 reasoning
+        tokens)."""
         agent = self._make_agent()
         for model in (
             "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
             "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
-            "nvidia/llama-3.3-nemotron-super-49b-v1.5",
         ):
             agent.model = model
             assert agent._supports_reasoning_extra_body() is True, model
+
+    def test_unverified_nvidia_models_stay_gated(self):
+        """The gate exists because NVIDIA-via-OpenRouter 400'd on reasoning
+        extra_body (3f0f4a04a). Only individually verified NVIDIA models may
+        pass; the rest of the nvidia/ namespace stays excluded."""
+        agent = self._make_agent()
+        for model in (
+            "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+            "nvidia/nemotron-nano-9b-v2",
+        ):
+            agent.model = model
+            assert agent._supports_reasoning_extra_body() is False, model
+
+    def test_verified_nemotron_emits_disabled_reasoning_payload(self):
+        """Transport-level assertion (#75386): with the gate open for the
+        verified model, reasoning_effort: none ({"enabled": False} via
+        parse_reasoning_effort) must reach OpenRouter as
+        extra_body.reasoning == {"enabled": false} — the exact payload the
+        reporter verified yields 0 reasoning tokens."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("openrouter")
+        extra_body, _top_level = profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            supports_reasoning=True,
+            model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+        )
+        assert extra_body.get("reasoning") == {"enabled": False}
+
+        # Negative: an unverified NVIDIA model (gate closed →
+        # supports_reasoning=False) must emit no reasoning field at all,
+        # preserving the 3f0f4a04a 400-avoidance behavior.
+        extra_body, _top_level = profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            supports_reasoning=False,
+            model="nvidia/llama-3.3-nemotron-super-49b-v1.5",
+        )
+        assert "reasoning" not in extra_body
 
 
 class TestMemoryContextSanitization:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5688,6 +5688,20 @@ class TestSupportsReasoningExtraBody:
             agent.model = model
             assert agent._supports_reasoning_extra_body() is True, model
 
+    def test_nvidia_models_are_treated_as_reasoning_capable(self):
+        """#75386: Nemotron models default reasoning ON; without nvidia/ in the
+        allowlist, `agent.reasoning_effort: none` never reached OpenRouter's
+        reasoning extra_body and reasoning could not be disabled (reporter
+        verified OpenRouter accepts reasoning {"enabled": false} for these)."""
+        agent = self._make_agent()
+        for model in (
+            "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+            "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+            "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+        ):
+            agent.model = model
+            assert agent._supports_reasoning_extra_body() is True, model
+
 
 class TestMemoryContextSanitization:
     """sanitize_context() helper correctness — used at provider boundaries."""


### PR DESCRIPTION
## Summary

`agent.reasoning_effort: none` cannot disable reasoning for `nvidia/nemotron-*` models routed through OpenRouter — Nemotron defaults reasoning ON and burns 247-263 reasoning tokens even for "just say 1" (#75386). One-line allowlist fix plus regression test.

## Root cause

`_supports_reasoning_extra_body()` (`run_agent.py:6473-6484`) gates OpenRouter's `extra_body.reasoning` on a model-family prefix allowlist that lacks `nvidia/`. With `supports_reasoning=False`, `OpenRouterProfile.build_api_kwargs_extras()` (`plugins/model-providers/openrouter/__init__.py:141`) never emits the `reasoning` field, so the user's setting silently does nothing.

The full flow, verified end-to-end:

`agent.reasoning_effort: none` → `parse_reasoning_effort()` → `{"enabled": false}` (`hermes_constants.py`) → `agent.reasoning_config` → *(blocked here before this fix)* → `extra_body["reasoning"] = {"enabled": false}` — which is exactly the form the reporter proved OpenRouter accepts for this model (0 reasoning tokens vs Hermes' 247-263; comparison table in the issue).

## Changes

- `run_agent.py`: add `"nvidia/"` to `reasoning_model_prefixes` — the same whole-family treatment the merged `xiaomi/` addition used.
- `tests/run_agent/test_run_agent.py`: `test_nvidia_models_are_treated_as_reasoning_capable` in the existing `TestSupportsReasoningExtraBody` class, covering the reporter's exact model id (with and without `:free`) — fails on unfixed main.

## Validation

| | before | after |
|---|---|---|
| `_supports_reasoning_extra_body()` for `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | `False` — reasoning field never sent | `True` |
| `reasoning_effort: none` payload | *(nothing)* | `extra_body.reasoning = {"enabled": false}` (reporter-verified: 0 reasoning tokens) |
| `scripts/run_tests.sh tests/run_agent/test_run_agent.py` | new test fails | 221 passed, 0 failed |

## Scope notes

- The documented 400 hazard that motivates this allowlist (upstreams rejecting `reasoning`) has its known dangerous case — Anthropic mandatory-reasoning models — handled separately inside `build_api_kwargs_extras()` (#42991) and is unaffected. For nvidia models with reasoning left enabled, the enabled-form payload carries the same whole-family risk profile already accepted for `xiaomi/` and `x-ai/`.
- Direct NVIDIA NIM reasoning routing (#19883, #19888, #62140) is a different transport path (`is_nvidia_nim` in `build_kwargs`) — per the triage on the issue, deliberately not touched here.

Fixes #75386.
