### PR TITLE
fix(slack): trust adapter routing after stripping self mention

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3936,11 +3936,16 @@ class SlackAdapter(BasePlatformAdapter):
             return ""
         return (
             f"You are connected to this Slack workspace as the bot "
-            f'"@{name}". In messages, each line is prefixed with the sender\'s '
-            f"name, and mentions are shown as @DisplayName. Only treat a "
-            f'message as directed at you when it mentions "@{name}" '
-            f"specifically; a mention of any other participant is not a "
-            f"mention of you, even if their name is similar."
+            f'"@{name}". The Slack adapter already applied authorization, mention, '
+            f"and channel-routing rules before delivering this message. Treat every "
+            f"delivered turn as intentionally routed to you, including a message "
+            f"accepted from a free-response channel or active thread. Your own routing "
+            f'mention "@{name}" may have been removed from the model-visible text. '
+            f"Do not ask for another mention, reject the message, or stay silent solely "
+            f'because "@{name}" is absent. In messages, each line is prefixed with the '
+            f"sender's name, and visible mentions are shown as @DisplayName; a mention "
+            f"of any other participant is not a mention of you, even if their name is "
+            f"similar."
         )
 
     async def _resolve_user_is_bot(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3936,16 +3936,14 @@ class SlackAdapter(BasePlatformAdapter):
             return ""
         return (
             f"You are connected to this Slack workspace as the bot "
-            f'"@{name}". The Slack adapter already applied authorization, mention, '
-            f"and channel-routing rules before delivering this message. Treat every "
-            f"delivered turn as intentionally routed to you, including a message "
-            f"accepted from a free-response channel or active thread. Your own routing "
-            f'mention "@{name}" may have been removed from the model-visible text. '
-            f"Do not ask for another mention, reject the message, or stay silent solely "
-            f'because "@{name}" is absent. In messages, each line is prefixed with the '
-            f"sender's name, and visible mentions are shown as @DisplayName; a mention "
-            f"of any other participant is not a mention of you, even if their name is "
-            f"similar."
+            f'"@{name}". The adapter already applied mention and channel '
+            f"routing; treat every delivered turn as intentionally routed to "
+            f'you. Your routing mention "@{name}" may have been stripped from '
+            f'the visible text — do not reject or ignore a message solely '
+            f'because "@{name}" is absent. In messages, each line is prefixed '
+            f"with the sender's name, and visible mentions are shown as "
+            f"@DisplayName; a mention of any other participant is not a "
+            f"mention of you, even if their name is similar."
         )
 
     async def _resolve_user_is_bot(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1864,6 +1864,38 @@ class TestMessageRouting:
         assert msg_event.text == "what's the weather?"
         assert "<@U_BOT>" not in msg_event.text
 
+    @pytest.mark.asyncio
+    async def test_accepted_mention_prompt_trusts_adapter_routing(self, adapter):
+        """Cleaned text must not make the model revalidate an accepted mention."""
+        adapter.config.extra.update({"require_mention": True, "strict_mention": True})
+        adapter._bot_display_name = "TestBot"
+        adapter._team_bot_names = {"T123": "WorkspaceBot"}
+        event = {
+            "text": "<@U_BOT> Hi",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T123",
+            "ts": "1234567890.000001",
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.await_args.args[0]
+        prompt = msg_event.channel_prompt
+        assert msg_event.text == "Hi"
+        assert "@WorkspaceBot" in prompt
+        assert "already applied" in prompt
+        assert "may have been removed" in prompt
+        assert "Do not ask for another mention" in prompt
+        assert "free-response channel or active thread" in prompt
+        assert "not a mention of you" in prompt
+        assert "Only treat a message as directed" not in prompt
+
+    @pytest.mark.asyncio
+
+
 
     @pytest.mark.asyncio
     async def test_allow_bots_mentions_ignores_bot_user_without_current_mention(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1887,9 +1887,9 @@ class TestMessageRouting:
         assert msg_event.text == "Hi"
         assert "@WorkspaceBot" in prompt
         assert "already applied" in prompt
-        assert "may have been removed" in prompt
-        assert "Do not ask for another mention" in prompt
-        assert "free-response channel or active thread" in prompt
+        assert "may have been stripped" in prompt
+        assert "do not reject or ignore" in prompt
+        assert "intentionally routed" in prompt
         assert "not a mention of you" in prompt
         assert "Only treat a message as directed" not in prompt
 


### PR DESCRIPTION
## Summary
The Slack identity prompt no longer contradicts the adapter's own mention stripping — the model trusts the adapter's routing decision instead of re-validating a mention that was already removed.

## Root cause
Commit `5d747a91` added `_build_identity_prompt()` which told the model: "Only treat a message as directed at you when it mentions @name specifically." But the adapter strips the bot's own `<@U_BOT>` mention from the text (line 5725) before the model sees it — so the prompt told the model to require a token that no longer existed. The model could refuse to respond, ask for a mention, or stay silent on validly-routed messages.

## Changes
- `plugins/platforms/slack/adapter.py`: Rewrote `_build_identity_prompt()` — replaces the old "require a mention" language with "the adapter already routed this to you, don't re-validate." Preserves the humanization guard ("a mention of any other participant is not a mention of you"). Trimmed of internal jargon ("free-response channel", "authorization") and the triple-negative directive collapsed to a single concise instruction.
- `tests/gateway/test_slack.py`: New test `test_accepted_mention_prompt_trusts_adapter_routing` — verifies stripped text, new prompt phrases present, old contradicting language absent.

## Validation
| | Before | After |
|---|---|---|
| Slack test suite | — | 310 passed |
| Targeted test | — | 3/3 passed |
| Ruff lint | — | clean |
| E2E smoke | — | 5/5 passed |

Salvaged from #70238 by @KCAYAAI. Prompt text trimmed (jargon removed, ~70 tokens vs ~175 in the original PR).

Closes #70238
