### PR TITLE
fix(agent): add nvidia/ to OpenRouter reasoning model prefixes (#75386)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6477,6 +6477,7 @@ class AIAgent:
             "x-ai/",
             "google/gemini-2",
             "google/gemma-4",
+            "nvidia/",
             "qwen/qwen3",
             "tencent/hy3",
             "xiaomi/",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5688,6 +5688,19 @@ class TestSupportsReasoningExtraBody:
             agent.model = model
             assert agent._supports_reasoning_extra_body() is True, model
 
+    def test_nvidia_models_are_treated_as_reasoning_capable(self):
+        """NVIDIA Nemotron reasoning models on OpenRouter must support
+        reasoning extra_body so that ``reasoning_effort: none`` can disable
+        reasoning (GH #75386)."""
+        agent = self._make_agent()
+        for model in (
+            "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+            "nvidia/nemotron-ultra-253b",
+            "nvidia/llama-3.1-nemotron-70b-instruct:free",
+        ):
+            agent.model = model
+            assert agent._supports_reasoning_extra_body() is True, model
+
 
 class TestMemoryContextSanitization:
     """sanitize_context() helper correctness — used at provider boundaries."""


### PR DESCRIPTION
## Summary

`_supports_reasoning_extra_body()` uses a hardcoded allowlist of OpenRouter model-family prefixes to decide whether to send `reasoning.enabled: false` in the API extra_body. `nvidia/` was absent, so NVIDIA Nemotron reasoning models routed through OpenRouter never received the disable-reasoning signal — reasoning remained active (247-263 tokens/turn) even with explicit `reasoning_effort: none`.

## Changes

- Added `"nvidia/"` to `reasoning_model_prefixes` in `run_agent.py:6473`
- Added regression test `test_nvidia_models_are_treated_as_reasoning_capable` covering three NVIDIA model variants

## Test Plan

- [x] `pytest tests/run_agent/test_run_agent.py::TestSupportsReasoningExtraBody -xvs` — 2 passed

Fixes #75386