### PR TITLE
fix(whatsapp): batch album media events into single agent turn

### DIFF
--- a/contributors/emails/mahdiwafy@users.noreply.github.com
+++ b/contributors/emails/mahdiwafy@users.noreply.github.com
@@ -1,0 +1,1 @@
+mahdiwafy

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1414,6 +1414,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             thread_sessions_per_user=self.config.extra.get(
                 "thread_sessions_per_user", False
             ),
+            profile=event.source.profile,
         )
         return f"{session_key}:media:{event.message_type.value}"
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -448,6 +448,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
 
+        # Media album batching (ports Feishu adapter pattern).
+        # WhatsApp delivers album images as separate messages — without
+        # batching, each photo triggers a separate agent turn. Buffer
+        # rapid-fire media events from the same session into one turn.
+        self._media_batch_delay_seconds = self._coerce_float_extra(
+            "media_batch_delay_seconds", 3.0,
+        )
+        self._pending_media_batches: Dict[str, MessageEvent] = {}
+        self._pending_media_batch_tasks: Dict[str, asyncio.Task] = {}
+
     def _coerce_float_extra(self, key: str, default: float) -> float:
         """Read a float from ``config.extra``, guarding against bad/non-finite values.
 
@@ -805,6 +815,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # path (which runs from other tasks like send() and the poll loop)
         # doesn't race us and report the intentional termination as fatal.
         self._shutting_down = True
+        # Cancel pending media batches
+        for task in self._pending_media_batch_tasks.values():
+            if not task.done():
+                task.cancel()
+        self._pending_media_batches.clear()
+        self._pending_media_batch_tasks.clear()
         if self._bridge_process:
             try:
                 try:
@@ -1277,6 +1293,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 asyncio.create_task(self._send_read_receipt(msg_data))
                                 if event.message_type == MessageType.TEXT:
                                     self._enqueue_text_event(event)
+                                elif event.message_type in (
+                                    MessageType.PHOTO,
+                                    MessageType.VIDEO,
+                                    MessageType.DOCUMENT,
+                                    MessageType.VOICE,
+                                    MessageType.AUDIO,
+                                    MessageType.STICKER,
+                                ):
+                                    await self._enqueue_media_event(event)
                                 else:
                                     await self.handle_message(event)
             except asyncio.CancelledError:
@@ -1375,6 +1400,80 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
+
+    # ── Media album batching (ports Feishu adapter pattern) ────────────────
+    def _media_batch_key(self, event: MessageEvent) -> str:
+        from gateway.session import build_session_key
+
+        session_key = build_session_key(
+            event.source,
+            group_sessions_per_user=self.config.extra.get(
+                "group_sessions_per_user", True
+            ),
+            thread_sessions_per_user=self.config.extra.get(
+                "thread_sessions_per_user", False
+            ),
+        )
+        return f"{session_key}:media:{event.message_type.value}"
+
+    @staticmethod
+    def _media_batch_is_compatible(existing: MessageEvent, incoming: MessageEvent) -> bool:
+        return (
+            existing.message_type == incoming.message_type
+            and existing.reply_to_message_id == incoming.reply_to_message_id
+            and existing.reply_to_text == incoming.reply_to_text
+            and existing.source.thread_id == incoming.source.thread_id
+        )
+
+    async def _enqueue_media_event(self, event: MessageEvent) -> None:
+        """Buffer a media event and reset the flush timer (album batching)."""
+        key = self._media_batch_key(event)
+        existing = self._pending_media_batches.get(key)
+        if existing is None:
+            self._pending_media_batches[key] = event
+            self._schedule_media_batch_flush(key)
+            return
+        if not self._media_batch_is_compatible(existing, event):
+            await self._flush_media_batch_now(key)
+            self._pending_media_batches[key] = event
+            self._schedule_media_batch_flush(key)
+            return
+        existing.media_urls.extend(event.media_urls)
+        existing.media_types.extend(event.media_types)
+        if event.text:
+            existing.text = self._merge_caption(existing.text, event.text)
+        existing.timestamp = event.timestamp
+        if event.message_id:
+            existing.message_id = event.message_id
+        self._schedule_media_batch_flush(key)
+
+    def _schedule_media_batch_flush(self, key: str) -> None:
+        prior_task = self._pending_media_batch_tasks.get(key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        self._pending_media_batch_tasks[key] = asyncio.create_task(
+            self._flush_media_batch(key)
+        )
+
+    async def _flush_media_batch(self, key: str) -> None:
+        """Wait for quiet period then dispatch aggregated media."""
+        current_task = asyncio.current_task()
+        try:
+            await asyncio.sleep(self._media_batch_delay_seconds)
+            await self._flush_media_batch_now(key)
+        finally:
+            if self._pending_media_batch_tasks.get(key) is current_task:
+                self._pending_media_batch_tasks.pop(key, None)
+
+    async def _flush_media_batch_now(self, key: str) -> None:
+        event = self._pending_media_batches.pop(key, None)
+        if not event:
+            return
+        logger.info(
+            "[%s] Flushing media batch %s with %d attachment(s)",
+            self.name, key, len(event.media_urls),
+        )
+        await self.handle_message(event)
 
     async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -815,12 +815,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # path (which runs from other tasks like send() and the poll loop)
         # doesn't race us and report the intentional termination as fatal.
         self._shutting_down = True
-        # Cancel pending media batches
-        for task in self._pending_media_batch_tasks.values():
+        # Cancel pending media batches (attribute may not exist in
+        # lightweight test harnesses that skip full __init__)
+        for task in getattr(self, "_pending_media_batch_tasks", {}).values():
             if not task.done():
                 task.cancel()
-        self._pending_media_batches.clear()
-        self._pending_media_batch_tasks.clear()
+        self._pending_media_batches = {}
+        self._pending_media_batch_tasks = {}
         if self._bridge_process:
             try:
                 try:

--- a/tests/gateway/test_whatsapp_media_batching.py
+++ b/tests/gateway/test_whatsapp_media_batching.py
@@ -1,0 +1,157 @@
+"""Media album batching for the WhatsApp adapter (PR #75414).
+
+WhatsApp delivers album images/videos as separate messages in rapid
+succession.  Without batching each photo triggers a separate agent turn,
+racing downloads and fragmenting replies.  This ports the Feishu
+adapter's _enqueue_media_event / _flush_media_batch pattern.
+
+Regression coverage:
+- media events from the same session aggregate into a single batch
+- media events from DIFFERENT profiles do not share a batch
+- pending batches are cancelled on disconnect
+"""
+
+import asyncio
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+
+def _make_adapter(**extra):
+    base = {"session_name": "test"}
+    base.update(extra)
+    return WhatsAppAdapter(PlatformConfig(enabled=True, extra=base))
+
+
+def _media_event(media_urls, profile=None, chat_type="dm", chat_id="chat123"):
+    src = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id="user1",
+        user_name="tester",
+        profile=profile,
+    )
+    return MessageEvent(
+        text="",
+        message_type=MessageType.PHOTO,
+        source=src,
+        media_urls=media_urls,
+        media_types=["image/jpeg"] * len(media_urls),
+    )
+
+
+def test_media_batch_delay_overridden_via_config_extra():
+    adapter = _make_adapter(media_batch_delay_seconds="1.5")
+    assert adapter._media_batch_delay_seconds == 1.5
+
+
+def test_media_batch_key_includes_profile():
+    """Two otherwise-identical events for separate profiles must NOT share a batch."""
+    adapter = _make_adapter()
+    e1 = _media_event(["/tmp/a.jpg"], profile="main")
+    e2 = _media_event(["/tmp/b.jpg"], profile="work")
+    assert adapter._media_batch_key(e1) != adapter._media_batch_key(e2)
+
+
+def test_media_batch_key_same_profile_same_chat_aggregates():
+    """Same profile + same chat => same batch key (album images merge)."""
+    adapter = _make_adapter()
+    e1 = _media_event(["/tmp/a.jpg"], profile="main")
+    e2 = _media_event(["/tmp/b.jpg"], profile="main")
+    assert adapter._media_batch_key(e1) == adapter._media_batch_key(e2)
+
+
+def test_enqueue_media_event_aggregates_attachments():
+    """Two rapid media events merge media_urls into the pending batch."""
+    adapter = _make_adapter()
+    e1 = _media_event(["/tmp/a.jpg"], profile="main")
+    e2 = _media_event(["/tmp/b.jpg"], profile="main")
+
+    async def run():
+        await adapter._enqueue_media_event(e1)
+        await adapter._enqueue_media_event(e2)
+        pending = adapter._pending_media_batches
+        # Both events should live under the same key with merged urls
+        key = adapter._media_batch_key(e1)
+        assert key in pending
+        assert pending[key].media_urls == ["/tmp/a.jpg", "/tmp/b.jpg"]
+
+    asyncio.run(run())
+
+
+def test_flush_media_batch_delivers_single_event():
+    """After the quiet period, the batch flushes as one event via handle_message."""
+    adapter = _make_adapter(media_batch_delay_seconds=0.05)
+    delivered = []
+
+    async def fake_handle(event):
+        delivered.append(event)
+
+    adapter.handle_message = fake_handle
+    e1 = _media_event(["/tmp/a.jpg"], profile="main")
+    e2 = _media_event(["/tmp/b.jpg"], profile="main")
+
+    async def run():
+        await adapter._enqueue_media_event(e1)
+        await adapter._enqueue_media_event(e2)
+        key = adapter._media_batch_key(e1)
+        await adapter._flush_media_batch(key)
+        # Give the flush task a beat to finish
+        await asyncio.sleep(0.1)
+
+    asyncio.run(run())
+    assert len(delivered) == 1
+    assert delivered[0].media_urls == ["/tmp/a.jpg", "/tmp/b.jpg"]
+
+
+def test_disconnect_cancels_pending_batches():
+    """disconnect() cancels pending media-batch tasks and clears state."""
+    adapter = _make_adapter()
+    e1 = _media_event(["/tmp/a.jpg"], profile="main")
+
+    async def run():
+        await adapter._enqueue_media_event(e1)
+        assert adapter._pending_media_batches
+        assert adapter._pending_media_batch_tasks
+        await adapter.disconnect()
+        assert not adapter._pending_media_batches
+        assert not adapter._pending_media_batch_tasks
+
+    asyncio.run(run())
+
+
+def test_disconnect_works_without_media_state(tmp_path):
+    """Lightweight harnesses (__new__ + manual attrs) must not crash on disconnect."""
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True, extra={"session_name": "test"})
+    adapter._bridge_process = None
+    adapter._http_session = None
+    adapter._poll_task = None
+    adapter._running = True
+    adapter._session_lock_identity = None
+    adapter._session_path = tmp_path
+    adapter._bridge_log_fh = None
+    adapter._bridge_log = None
+    adapter._reply_prefix = None
+    adapter._send_read_receipts = False
+    adapter._message_handler = None
+    adapter._fatal_error_code = None
+    adapter._fatal_error_message = None
+    adapter._fatal_error_retryable = True
+    adapter._fatal_error_handler = None
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._background_tasks = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._message_queue = asyncio.Queue()
+    adapter._message_queue_state = None
+    # Deliberately do NOT set _pending_media_batch_tasks / _pending_media_batches
+
+    async def run():
+        await adapter.disconnect()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Problem

WhatsApp delivers album images as **separate messages** in rapid succession (one `imageMessage` per photo in the album). The WhatsApp adapter dispatched each one directly via `handle_message()` — so a 7-image album triggered **7 parallel agent turns** that:

- raced each other on media downloads (some failed, `reuploadRequest` retry doesn't always recover)
- produced fragmented replies (agent counted "3 of 6" while the user had sent 7 images)
- flooded the user with near-duplicate reply fragments

## Fix

Port the **Feishu adapter's media-batch pattern** (`_enqueue_media_event` / `_flush_media_batch`) to the WhatsApp adapter:

- `PHOTO`/`VIDEO`/`DOCUMENT`/`VOICE`/`AUDIO`/`STICKER` events from the same session are buffered into one pending `MessageEvent` (media_urls + media_types merged, captions merged)
- Flushed as a **single agent turn** after a quiet period (default **3s**, tunable via `gateway.platforms.whatsapp.extra.media_batch_delay_seconds` — mirrors Feishu's `media_batch_delay_seconds`)
- Text events keep the existing text-debounce path
- Pending media batches are cancelled on `disconnect()`
- Reuses the existing `_coerce_float_extra`, `_merge_caption`, and `build_session_key` helpers — no new dependencies

## Why this approach

This is the same pattern the Feishu adapter already uses (`plugins/platforms/feishu/adapter.py`), and `base.py`'s `merge_pending_message_event()` documents the same intent ("Photo bursts/albums often arrive as multiple near-simultaneous PHOTO events"). WhatsApp was simply missing the wiring.

## Verification

Tested in production on a live WhatsApp group (Jul 31 2026):

```
[WhatsApp] Flushing media batch agent:main:whatsapp:group:...@g.us:media:photo with 6 attachment(s)
```

A 6-image album now flushes as **one** agent turn instead of 6 racing turns.