### PR TITLE
fix(dashboard): show cron job assignments

### DIFF
--- a/web/src/lib/cron-job.test.ts
+++ b/web/src/lib/cron-job.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildCronJobPayload,
+  cronJobBaseUrlDisplay,
   cronJobHasExecutionContent,
   cronJobFormFromJob,
+  cronJobModelDisplay,
   splitCronList,
   type CronJobFormState,
 } from "./cron-job";
@@ -85,6 +87,21 @@ describe("cronJobHasExecutionContent", () => {
     const payload = buildCronJobPayload(form({ prompt: "", skills: [], script: "" }));
 
     expect(cronJobHasExecutionContent(payload)).toBe(false);
+  });
+});
+
+describe("cron job assignment displays", () => {
+  it("distinguishes inherited assignments from pinned provider/model pairs", () => {
+    expect(cronJobModelDisplay({})).toBe("default");
+    expect(
+      cronJobModelDisplay({ provider: "openai-codex", model: "gpt-5.4-mini" }),
+    ).toBe("openai-codex/gpt-5.4-mini");
+  });
+
+  it("keeps endpoint overrides visible without surrounding whitespace", () => {
+    expect(
+      cronJobBaseUrlDisplay({ base_url: " https://example.invalid/v1 " }),
+    ).toBe("https://example.invalid/v1");
   });
 });
 

--- a/web/src/lib/cron-job.ts
+++ b/web/src/lib/cron-job.ts
@@ -44,6 +44,23 @@ function asString(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
+/** Describe the model assignment shown on a cron card. */
+export function cronJobModelDisplay(
+  job: Pick<CronJob, "provider" | "model">,
+): string {
+  const provider = asString(job.provider).trim();
+  const model = asString(job.model).trim();
+  if (provider && model) return `${provider}/${model}`;
+  return model || provider || "default";
+}
+
+/** Return a normalized endpoint override when the job has one. */
+export function cronJobBaseUrlDisplay(
+  job: Pick<CronJob, "base_url">,
+): string {
+  return asString(job.base_url).trim();
+}
+
 /** Build the create/update payload. Optional fields collapse to null so an
  * update explicitly clears them rather than leaving stale values. */
 export function buildCronJobPayload(form: CronJobFormState): CronJobMutation {

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -16,8 +16,10 @@ import type {
 } from "@/lib/api";
 import {
   buildCronJobPayload,
+  cronJobBaseUrlDisplay,
   cronJobHasExecutionContent,
   cronJobFormFromJob,
+  cronJobModelDisplay,
   type CronJobFormState,
 } from "@/lib/cron-job";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
@@ -473,13 +475,6 @@ function getJobMode(job: CronJob): string {
   if (job.no_agent) return "no_agent";
   if (job.script) return "script+agent";
   return "agent";
-}
-
-function getModelDisplay(job: CronJob): string {
-  const provider = asText(job.provider);
-  const model = asText(job.model);
-  if (provider && model) return `${provider}/${model}`;
-  return model || provider;
 }
 
 function getJobProfile(job: CronJob): string {
@@ -1005,7 +1000,8 @@ export default function CronPage() {
           const profile = getJobProfile(job);
           const jobKey = getJobKey(job);
           const mode = getJobMode(job);
-          const modelDisplay = getModelDisplay(job);
+          const modelDisplay = cronJobModelDisplay(job);
+          const baseUrlDisplay = cronJobBaseUrlDisplay(job);
           const toolsets = Array.isArray(job.enabled_toolsets)
             ? job.enabled_toolsets.filter(Boolean)
             : [];
@@ -1014,7 +1010,7 @@ export default function CronPage() {
             <Card key={jobKey}>
               <CardContent className="flex items-start gap-4 py-4">
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
+                  <div className="flex flex-wrap items-center gap-2 mb-1">
                     <span className="font-medium text-sm truncate">
                       {title}
                     </span>
@@ -1035,9 +1031,16 @@ export default function CronPage() {
                     {mode !== "agent" && (
                       <Badge tone="outline">{mode}</Badge>
                     )}
-                    {modelDisplay && (
-                      <Badge tone="outline" title={modelDisplay}>
-                        model
+                    <Badge tone="outline" title={`Model: ${modelDisplay}`}>
+                      model: {modelDisplay}
+                    </Badge>
+                    {baseUrlDisplay && (
+                      <Badge
+                        tone="outline"
+                        className="max-w-80 truncate"
+                        title={`Base URL: ${baseUrlDisplay}`}
+                      >
+                        endpoint: {baseUrlDisplay}
                       </Badge>
                     )}
                     {toolsets.length > 0 && (


### PR DESCRIPTION
## What changed and why

Per the follow-up on 2026-07-30, cron cards now show whether they use the inherited default assignment or a pinned `provider/model` pair, rather than a generic tooltip-only badge. Cards also show a per-job `base_url` endpoint override when one is configured.

The existing create and edit forms already persist these overrides; this change completes their on-card visibility without changing scheduler behavior or override precedence.

Fixes #24258

## How to test

1. Open Dashboard > Cron and create or edit one job with no model/provider override and another with a provider, model, and base URL override.
2. Confirm the first card shows `model: default`; confirm the pinned card visibly shows its `provider/model` and endpoint, with the complete endpoint available in the hover title when truncated.
3. Clear the overrides in Edit, save, and confirm the card returns to `model: default` and no endpoint badge.

Automated: `pytest tests/hermes_cli/test_cron.py -q -x --timeout=60` (8 passed). The required full Python command could not collect because this sandbox lacks FastAPI and its system Python is externally managed; the focused frontend Vitest command could not start because `web/node_modules` is absent.

## What platforms tested on

macOS sandbox (Python cron regression subset). Browser rendering was not exercised because frontend dependencies are not installed in this checkout.

<!-- autocontrib:worker-id=issue-followup-f168591c kind=pr-open -->