### PR TITLE
fix(docker): resolve sibling bind sources on host

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from io import StringIO
@@ -600,12 +601,13 @@ def test_labels_attribute_populated_after_init(monkeypatch):
 
     env = _make_dummy_env(task_id="abc")
 
-    assert env._labels == {
+    assert {
         "hermes-agent": "1",
         "hermes-task-id": "abc",
         "hermes-profile": "default",
         "hermes-egress": "off",
-    }
+    }.items() <= env._labels.items()
+    assert len(env._labels["hermes-mounts"]) == 24
 
 
 # ── Cross-process container reuse (issue #20561) ──────────────────
@@ -625,6 +627,7 @@ def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
     Returns the captured call list so the test can verify which docker
     commands actually ran.
     """
+    docker_env._cgroup_limits_ok = True
     calls = []
 
     def _run(cmd, **kwargs):
@@ -712,6 +715,7 @@ def test_egress_enabled_does_not_reuse_pre_egress_container(monkeypatch):
                 # Simulate an old pre-egress container: without the egress label
                 # filter it would match; with the filter Docker returns no match.
                 assert any(str(part).startswith("label=hermes-egress=") for part in cmd)
+                assert any(str(part).startswith("label=hermes-mounts=") for part in cmd)
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
             if sub == "run":
                 return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")
@@ -1313,6 +1317,105 @@ def test_credential_mount_skipped_when_source_missing(monkeypatch, tmp_path, cap
         "source not found" in rec.getMessage()
         for rec in caplog.records
     )
+
+
+def test_auto_mounts_use_daemon_visible_source_from_outer_container(monkeypatch, tmp_path):
+    """Docker-socket sandboxes must bind the host path, not ``/opt/data``.
+
+    The files exist at the paths Hermes sees inside its outer container, while
+    the inner sandbox is created by the host daemon. Its ``-v`` sources must
+    therefore use the source from the outer container's own bind mount.
+    """
+    container_data = tmp_path / "container-data"
+    safe_skills_dir = tmp_path / "hermes-skills-safe-abc123"
+    cache_dir = container_data / "cache" / "documents"
+    credential = container_data / "google_token.json"
+    safe_skills_dir.mkdir()
+    cache_dir.mkdir(parents=True)
+    credential.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(
+        docker_env,
+        "_get_current_container_bind_mounts",
+        lambda _docker_exe: [(str(container_data), "/host/hermes-data")],
+    )
+    monkeypatch.setattr(
+        "tools.environments.base.get_sandbox_dir",
+        lambda: container_data / "sandboxes",
+    )
+    calls = _mock_subprocess_run(monkeypatch)
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts",
+        lambda: [{"host_path": str(credential), "container_path": "/root/.hermes/google_token.json"}],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_skills_directory_mount",
+        lambda: [{"host_path": str(safe_skills_dir), "container_path": "/root/.hermes/skills"}],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_cache_directory_mounts",
+        lambda: [{"host_path": str(cache_dir), "container_path": "/root/.hermes/cache/documents"}],
+    )
+
+    _make_dummy_env(persistent_filesystem=True)
+
+    run_args = _run_args_from_calls(calls)
+    assert "/host/hermes-data/google_token.json:/root/.hermes/google_token.json:ro" in run_args
+    assert next(arg for arg in run_args if arg.endswith(":/root/.hermes/skills:ro")).startswith(
+        "/host/hermes-data/sandboxes/docker/safe-skills-"
+    )
+    assert "/host/hermes-data/cache/documents:/root/.hermes/cache/documents:ro" in run_args
+    assert "/host/hermes-data/sandboxes/docker/test-task/home:/root" in run_args
+    assert "/host/hermes-data/sandboxes/docker/test-task/workspace:/workspace" in run_args
+    assert not any(str(container_data) in arg for arg in run_args)
+
+
+def test_daemon_visible_bind_source_uses_the_most_specific_matching_mount():
+    mounts = [
+        ("/opt/data", "/host/hermes-data"),
+        ("/opt/data/profiles/work", "/host/work-profile"),
+    ]
+
+    assert (
+        docker_env._daemon_visible_bind_source("/opt/data/profiles/work/cache/images/a.png", mounts)
+        == "/host/work-profile/cache/images/a.png"
+    )
+    assert (
+        docker_env._daemon_visible_bind_source("/opt/data-old/skills", mounts)
+        == "/opt/data-old/skills"
+    )
+    assert (
+        docker_env._daemon_visible_volume_spec(
+            "/opt/data/proxy/ca.crt:/etc/ssl/certs/hermes-ca.crt:ro", mounts,
+        )
+        == "/host/hermes-data/proxy/ca.crt:/etc/ssl/certs/hermes-ca.crt:ro"
+    )
+
+
+def test_current_container_bind_mounts_use_docker_inspection(monkeypatch):
+    container_id = "0123456789ab"
+    monkeypatch.setattr(docker_env, "_current_container_ids", lambda: [container_id])
+
+    def _run(cmd, **kwargs):
+        assert cmd == ["/usr/bin/docker", "container", "inspect", container_id]
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps([{
+                "Mounts": [
+                    {"Type": "volume", "Source": "ignored", "Destination": "/var/lib/data"},
+                    {"Type": "bind", "Source": "/home/user/.hermes", "Destination": "/opt/data"},
+                ],
+            }]),
+            stderr="",
+        )
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    assert docker_env._get_current_container_bind_mounts("/usr/bin/docker") == [
+        ("/opt/data", "/home/user/.hermes"),
+    ]
 
 
 # ── s6-overlay /init image handling (issue #34628) ────────────────

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from io import StringIO
@@ -750,12 +751,13 @@ def test_labels_attribute_populated_after_init(monkeypatch):
 
     env = _make_dummy_env(task_id="abc")
 
-    assert env._labels == {
+    assert {
         "hermes-agent": "1",
         "hermes-task-id": "abc",
         "hermes-profile": "default",
         "hermes-egress": "off",
-    }
+    }.items() <= env._labels.items()
+    assert len(env._labels["hermes-mounts"]) == 24
 
 
 def test_shared_container_key_replaces_profile_identity(monkeypatch):
@@ -825,6 +827,7 @@ def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
     Returns the captured call list so the test can verify which docker
     commands actually ran.
     """
+    docker_env._cgroup_limits_ok = True
     calls = []
 
     def _run(cmd, **kwargs):
@@ -911,6 +914,7 @@ def test_egress_enabled_does_not_reuse_pre_egress_container(monkeypatch):
                 # Simulate an old pre-egress container: without the egress label
                 # filter it would match; with the filter Docker returns no match.
                 assert any(str(part).startswith("label=hermes-egress=") for part in cmd)
+                assert any(str(part).startswith("label=hermes-mounts=") for part in cmd)
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
             if sub == "run":
                 return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")
@@ -1566,6 +1570,105 @@ def test_credential_mount_skipped_when_source_missing(monkeypatch, tmp_path, cap
         "source not found" in rec.getMessage()
         for rec in caplog.records
     )
+
+
+def test_auto_mounts_use_daemon_visible_source_from_outer_container(monkeypatch, tmp_path):
+    """Docker-socket sandboxes must bind the host path, not ``/opt/data``.
+
+    The files exist at the paths Hermes sees inside its outer container, while
+    the inner sandbox is created by the host daemon. Its ``-v`` sources must
+    therefore use the source from the outer container's own bind mount.
+    """
+    container_data = tmp_path / "container-data"
+    safe_skills_dir = tmp_path / "hermes-skills-safe-abc123"
+    cache_dir = container_data / "cache" / "documents"
+    credential = container_data / "google_token.json"
+    safe_skills_dir.mkdir()
+    cache_dir.mkdir(parents=True)
+    credential.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(
+        docker_env,
+        "_get_current_container_bind_mounts",
+        lambda _docker_exe: [(str(container_data), "/host/hermes-data")],
+    )
+    monkeypatch.setattr(
+        "tools.environments.base.get_sandbox_dir",
+        lambda: container_data / "sandboxes",
+    )
+    calls = _mock_subprocess_run(monkeypatch)
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts",
+        lambda: [{"host_path": str(credential), "container_path": "/root/.hermes/google_token.json"}],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_skills_directory_mount",
+        lambda: [{"host_path": str(safe_skills_dir), "container_path": "/root/.hermes/skills"}],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_cache_directory_mounts",
+        lambda: [{"host_path": str(cache_dir), "container_path": "/root/.hermes/cache/documents"}],
+    )
+
+    _make_dummy_env(persistent_filesystem=True)
+
+    run_args = _run_args_from_calls(calls)
+    assert "/host/hermes-data/google_token.json:/root/.hermes/google_token.json:ro" in run_args
+    assert next(arg for arg in run_args if arg.endswith(":/root/.hermes/skills:ro")).startswith(
+        "/host/hermes-data/sandboxes/docker/safe-skills-"
+    )
+    assert "/host/hermes-data/cache/documents:/root/.hermes/cache/documents:ro" in run_args
+    assert "/host/hermes-data/sandboxes/docker/test-task/home:/root" in run_args
+    assert "/host/hermes-data/sandboxes/docker/test-task/workspace:/workspace" in run_args
+    assert not any(str(container_data) in arg for arg in run_args)
+
+
+def test_daemon_visible_bind_source_uses_the_most_specific_matching_mount():
+    mounts = [
+        ("/opt/data", "/host/hermes-data"),
+        ("/opt/data/profiles/work", "/host/work-profile"),
+    ]
+
+    assert (
+        docker_env._daemon_visible_bind_source("/opt/data/profiles/work/cache/images/a.png", mounts)
+        == "/host/work-profile/cache/images/a.png"
+    )
+    assert (
+        docker_env._daemon_visible_bind_source("/opt/data-old/skills", mounts)
+        == "/opt/data-old/skills"
+    )
+    assert (
+        docker_env._daemon_visible_volume_spec(
+            "/opt/data/proxy/ca.crt:/etc/ssl/certs/hermes-ca.crt:ro", mounts,
+        )
+        == "/host/hermes-data/proxy/ca.crt:/etc/ssl/certs/hermes-ca.crt:ro"
+    )
+
+
+def test_current_container_bind_mounts_use_docker_inspection(monkeypatch):
+    container_id = "0123456789ab"
+    monkeypatch.setattr(docker_env, "_current_container_ids", lambda: [container_id])
+
+    def _run(cmd, **kwargs):
+        assert cmd == ["/usr/bin/docker", "container", "inspect", container_id]
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps([{
+                "Mounts": [
+                    {"Type": "volume", "Source": "ignored", "Destination": "/var/lib/data"},
+                    {"Type": "bind", "Source": "/home/user/.hermes", "Destination": "/opt/data"},
+                ],
+            }]),
+            stderr="",
+        )
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    assert docker_env._get_current_container_bind_mounts("/usr/bin/docker") == [
+        ("/opt/data", "/home/user/.hermes"),
+    ]
 
 
 # ── s6-overlay /init image handling (issue #34628) ────────────────

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -39,6 +39,7 @@ _DOCKER_SEARCH_PATHS = [
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EGRESS_LABEL_KEY = "hermes-egress"
+_MOUNT_LABEL_KEY = "hermes-mounts"
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -315,6 +316,118 @@ def find_docker() -> Optional[str]:
     return None
 
 
+_CONTAINER_ID_RE = re.compile(r"(?<![0-9a-f])[0-9a-f]{12,64}(?![0-9a-f])", re.IGNORECASE)
+
+
+def _current_container_ids() -> list[str]:
+    """Return Docker IDs that can identify this process's container.
+
+    Docker's default hostname is the short container ID. A cgroup path is a
+    useful fallback for runtimes that do not expose that default hostname.
+    Deliberately ignore arbitrary hostnames: inspecting a same-named but
+    unrelated container could turn its bind mounts into sandbox sources.
+    """
+    candidates: list[str] = []
+
+    hostname = os.environ.get("HOSTNAME", "").strip()
+    if _CONTAINER_ID_RE.fullmatch(hostname):
+        candidates.append(hostname)
+
+    for path in ("/proc/self/cgroup", "/proc/1/cpuset"):
+        try:
+            contents = Path(path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        candidates.extend(match.group(0) for match in _CONTAINER_ID_RE.finditer(contents))
+
+    return list(dict.fromkeys(candidates))
+
+
+def _get_current_container_bind_mounts(docker_exe: str) -> list[tuple[str, str]]:
+    """Return ``(container_destination, daemon_source)`` bind mounts for self.
+
+    When Hermes runs in a container but talks to the host Docker socket, the
+    daemon resolves ``-v`` sources on the host, not inside Hermes. Inspecting
+    the current container gives the one path translation the daemon already
+    knows to be correct. On a normal host install there is no container ID to
+    inspect, so this is a no-op and existing Docker behaviour is unchanged.
+    """
+    for container_id in _current_container_ids():
+        try:
+            result = subprocess.run(
+                [docker_exe, "container", "inspect", container_id],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+                stdin=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.debug("Docker: could not inspect current container mounts: %s", exc)
+            continue
+
+        if result.returncode != 0:
+            continue
+        try:
+            inspected = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError:
+            logger.debug("Docker: current container mount inspection returned invalid JSON")
+            continue
+
+        if not isinstance(inspected, list):
+            continue
+        for container in inspected:
+            if not isinstance(container, dict):
+                continue
+            mounts = container.get("Mounts")
+            if not isinstance(mounts, list):
+                continue
+            bind_mounts: list[tuple[str, str]] = []
+            for mount in mounts:
+                if not isinstance(mount, dict) or mount.get("Type") != "bind":
+                    continue
+                destination = mount.get("Destination")
+                source = mount.get("Source")
+                if not isinstance(destination, str) or not isinstance(source, str):
+                    continue
+                if not destination.startswith("/") or not source.startswith("/"):
+                    continue
+                bind_mounts.append((destination.rstrip("/") or "/", source.rstrip("/") or "/"))
+            if bind_mounts:
+                return sorted(bind_mounts, key=lambda mount: len(mount[0]), reverse=True)
+
+    return []
+
+
+def _daemon_visible_bind_source(
+    source_path: str,
+    current_bind_mounts: list[tuple[str, str]],
+) -> str:
+    """Map an in-container path to the Docker daemon's source path when known."""
+    source = os.path.normpath(source_path)
+    for container_destination, daemon_source in sorted(
+        current_bind_mounts, key=lambda mount: len(mount[0]), reverse=True,
+    ):
+        if source == container_destination:
+            return daemon_source
+        prefix = container_destination.rstrip("/") + "/"
+        if source.startswith(prefix):
+            return daemon_source.rstrip("/") + source[len(container_destination):]
+    return source_path
+
+
+def _daemon_visible_volume_spec(
+    volume_spec: str,
+    current_bind_mounts: list[tuple[str, str]],
+) -> str:
+    """Rewrite the source of a POSIX ``-v`` spec when Docker sees a host path."""
+    source, separator, remainder = volume_spec.partition(":")
+    if not separator or not source.startswith("/"):
+        return volume_spec
+    return f"{_daemon_visible_bind_source(source, current_bind_mounts)}:{remainder}"
+
+
 # Security flags applied to every container.
 # The container itself is the security boundary (isolated from host).
 # We drop all capabilities then add back the minimum needed:
@@ -565,6 +678,18 @@ def _egress_reuse_fingerprint(
             "env_overrides": env_overrides,
             "host_args": host_args,
         },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+
+def _mount_reuse_fingerprint(
+    writable_args: list[str], volume_args: list[str],
+) -> str:
+    """Fingerprint immutable mount arguments for safe cross-process reuse."""
+    payload = json.dumps(
+        {"writable_args": writable_args, "volume_args": volume_args},
         sort_keys=True,
         separators=(",", ":"),
     )
@@ -894,6 +1019,10 @@ class DockerEnvironment(BaseEnvironment):
 
         # Fail fast if Docker is not available.
         _ensure_docker_available()
+        # Resolve once before assembling automatic mounts as those mounts may
+        # need to inspect this outer container through the same Docker client.
+        self._docker_exe = find_docker() or "docker"
+        self._current_bind_mounts = _get_current_container_bind_mounts(self._docker_exe)
 
         # Build resource limit args (gated by cgroup availability probe so
         # they degrade gracefully on hosts without controller delegation,
@@ -928,6 +1057,8 @@ class DockerEnvironment(BaseEnvironment):
         # mode uses tmpfs (ephemeral, fast, gone on cleanup).
         from tools.environments.base import get_sandbox_dir
 
+        sandbox_root = get_sandbox_dir()
+
         # User-configured volume mounts (from config.yaml docker_volumes)
         volume_args = []
         workspace_explicitly_mounted = False
@@ -959,17 +1090,17 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            sandbox = sandbox_root / "docker" / task_id
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([
-                "-v", f"{self._home_dir}:/root",
+                "-v", f"{_daemon_visible_bind_source(self._home_dir, self._current_bind_mounts)}:/root",
             ])
             if not bind_host_cwd and not workspace_explicitly_mounted:
                 self._workspace_dir = str(sandbox / "workspace")
                 os.makedirs(self._workspace_dir, exist_ok=True)
                 writable_args.extend([
-                    "-v", f"{self._workspace_dir}:/workspace",
+                    "-v", f"{_daemon_visible_bind_source(self._workspace_dir, self._current_bind_mounts)}:/workspace",
                 ])
         else:
             if not bind_host_cwd and not workspace_explicitly_mounted:
@@ -982,8 +1113,11 @@ class DockerEnvironment(BaseEnvironment):
             ])
 
         if bind_host_cwd:
-            logger.info("Mounting configured host cwd to /workspace: %s", host_cwd_abs)
-            volume_args = ["-v", f"{host_cwd_abs}:/workspace", *volume_args]
+            daemon_source = _daemon_visible_bind_source(
+                host_cwd_abs, self._current_bind_mounts,
+            )
+            logger.info("Mounting configured host cwd to /workspace: %s", daemon_source)
+            volume_args = ["-v", f"{daemon_source}:/workspace", *volume_args]
         elif workspace_explicitly_mounted:
             logger.debug("Skipping docker cwd mount: /workspace already mounted by user config")
 
@@ -1013,13 +1147,16 @@ class DockerEnvironment(BaseEnvironment):
                         "Docker: skipping credential mount — source not found: %s", src,
                     )
                     continue
+                daemon_source = _daemon_visible_bind_source(
+                    mount_entry["host_path"], self._current_bind_mounts,
+                )
                 volume_args.extend([
                     "-v",
-                    f"{mount_entry['host_path']}:{mount_entry['container_path']}:ro",
+                    f"{daemon_source}:{mount_entry['container_path']}:ro",
                 ])
                 logger.info(
                     "Docker: mounting credential %s -> %s",
-                    mount_entry["host_path"],
+                    daemon_source,
                     mount_entry["container_path"],
                 )
 
@@ -1033,13 +1170,32 @@ class DockerEnvironment(BaseEnvironment):
                         src,
                     )
                     continue
+                daemon_source = _daemon_visible_bind_source(str(src), self._current_bind_mounts)
+                skills_fingerprint = "\0".join(
+                    f"{skill_path.relative_to(src)}:{skill_path.stat().st_mtime_ns}:{skill_path.stat().st_size}"
+                    for skill_path in sorted(src.rglob("*")) if skill_path.is_file()
+                )
+                staged_path = sandbox_root / "docker" / f"safe-skills-{hashlib.sha256(skills_fingerprint.encode()).hexdigest()}"
+                staged_daemon_source = _daemon_visible_bind_source(
+                    str(staged_path), self._current_bind_mounts,
+                )
+                if daemon_source == str(src) and staged_daemon_source != str(staged_path):
+                    # credential_files already returned a symlink-safe source.
+                    try:
+                        if not staged_path.is_dir():
+                            staged_path.parent.mkdir(parents=True, exist_ok=True)
+                            shutil.copytree(src, staged_path)
+                    except OSError as exc:
+                        logger.warning("Docker: could not stage skills for host Docker socket: %s", exc)
+                    else:
+                        daemon_source = staged_daemon_source
                 volume_args.extend([
                     "-v",
-                    f"{skills_mount['host_path']}:{skills_mount['container_path']}:ro",
+                    f"{daemon_source}:{skills_mount['container_path']}:ro",
                 ])
                 logger.info(
                     "Docker: mounting skills dir %s -> %s",
-                    skills_mount["host_path"],
+                    daemon_source,
                     skills_mount["container_path"],
                 )
 
@@ -1055,13 +1211,16 @@ class DockerEnvironment(BaseEnvironment):
                         src,
                     )
                     continue
+                daemon_source = _daemon_visible_bind_source(
+                    cache_mount["host_path"], self._current_bind_mounts,
+                )
                 volume_args.extend([
                     "-v",
-                    f"{cache_mount['host_path']}:{cache_mount['container_path']}:ro",
+                    f"{daemon_source}:{cache_mount['container_path']}:ro",
                 ])
                 logger.info(
                     "Docker: mounting cache dir %s -> %s",
-                    cache_mount["host_path"],
+                    daemon_source,
                     cache_mount["container_path"],
                 )
         except Exception as e:
@@ -1074,6 +1233,12 @@ class DockerEnvironment(BaseEnvironment):
         egress_volume_args, egress_env_overrides, egress_host_args = (
             _egress_proxy_args_for_docker()
         )
+        egress_volume_args = [
+            _daemon_visible_volume_spec(value, self._current_bind_mounts)
+            if index > 0 and egress_volume_args[index - 1] in {"-v", "--volume"}
+            else value
+            for index, value in enumerate(egress_volume_args)
+        ]
         egress_label = _egress_reuse_fingerprint(
             egress_volume_args, egress_env_overrides, egress_host_args,
         )
@@ -1276,10 +1441,6 @@ class DockerEnvironment(BaseEnvironment):
                 # Fall back to the full cap set — without --user, an image's
                 # init may still need s6-setuidgid/gosu/su to drop privileges.
 
-        # Resolve the docker executable once so it works even when
-        # /usr/local/bin is not in PATH (common on macOS gateway/service).
-        self._docker_exe = find_docker() or "docker"
-
         # s6-overlay images (e.g. hermes-agent:latest) already use /init as PID 1
         # and exec /run/s6/basedir/bin/init during startup. For those images we
         # must (a) skip Docker's --init (two competing PID-1 inits) and (b) mount
@@ -1343,17 +1504,20 @@ class DockerEnvironment(BaseEnvironment):
         # Labels make hermes-created containers identifiable to:
         #   * the orphan reaper (`hermes-agent=1` for the global sweep filter)
         #   * future cross-process reuse (`hermes-task-id`, `hermes-profile`)
+        #   * immutable mount configuration (`hermes-mounts`)
         #   * operators running `docker ps --filter label=hermes-agent=1`
         # Values are limited to the safe character set defined by
         # _sanitize_label_value(); the active Hermes profile is captured at
         # container-start time and never changes for the container's lifetime.
         profile_name = _sanitize_label_value(_get_active_profile_name())
         task_label = _sanitize_label_value(task_id)
+        mount_label = _mount_reuse_fingerprint(writable_args, volume_args)
         label_args = [
             "--label", "hermes-agent=1",
             "--label", f"hermes-task-id={task_label}",
             "--label", f"hermes-profile={profile_name}",
             "--label", f"{_EGRESS_LABEL_KEY}={egress_label}",
+            "--label", f"{_MOUNT_LABEL_KEY}={mount_label}",
         ]
         # Save args for container recreation on "No such container" recovery.
         self._image = image
@@ -1366,6 +1530,7 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label,
+            _MOUNT_LABEL_KEY: mount_label,
         }
 
         # Cross-process container reuse (issue #20561 — docs claim "ONE long-lived
@@ -1375,14 +1540,14 @@ class DockerEnvironment(BaseEnvironment):
         # restores the documented contract; opt out via
         # ``terminal.docker_persist_across_processes: false``.
         #
-        # Reuse matches on labels only.  The egress posture gets its own label
-        # because env vars, CA mounts, and host mappings are immutable after
-        # container creation — reusing a pre-egress or pre-rotation container
-        # would silently bypass the credential firewall.
+        # Reuse matches on labels only. Egress posture and mount sources get
+        # their own labels because env vars, CA mounts, and bind mounts are
+        # immutable after container creation. Reusing an old container could
+        # otherwise bypass the credential firewall or retain stale mount paths.
         reused = False
         if persist_across_processes:
             existing = self._find_reusable_container(
-                task_label, profile_name, egress_label,
+                task_label, profile_name, egress_label, mount_label,
             )
             if existing is not None:
                 container_id, state = existing
@@ -1642,7 +1807,10 @@ class DockerEnvironment(BaseEnvironment):
         task_label = self._labels.get("hermes-task-id", "")
         profile_label = self._labels.get("hermes-profile", "")
         existing = self._find_reusable_container(
-            task_label, profile_label, self._labels.get(_EGRESS_LABEL_KEY, "off"),
+            task_label,
+            profile_label,
+            self._labels.get(_EGRESS_LABEL_KEY, "off"),
+            self._labels.get(_MOUNT_LABEL_KEY, ""),
         )
         if existing is not None:
             cid, state = existing
@@ -1807,6 +1975,7 @@ class DockerEnvironment(BaseEnvironment):
         task_label: str,
         profile_label: str,
         egress_label: str,
+        mount_label: str,
     ) -> Optional[tuple[str, str]]:
         """Look for an existing container labeled for this (task, profile).
 
@@ -1825,6 +1994,7 @@ class DockerEnvironment(BaseEnvironment):
                 "--filter", "label=hermes-agent=1",
                 "--filter", f"label=hermes-task-id={task_label}",
                 "--filter", f"label=hermes-profile={profile_label}",
+                "--filter", f"label={_MOUNT_LABEL_KEY}={mount_label}",
             ]
             if egress_label != "off":
                 filters.extend(["--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}"])

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -42,6 +42,7 @@ _DOCKER_SEARCH_PATHS = [
 
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = _SHELL_ENV_NAME_RE
+_MOUNT_LABEL_KEY = "hermes-mounts"
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -226,6 +227,124 @@ def find_docker() -> Optional[str]:
     if found:
         _docker_executable = found
     return found
+
+
+_CONTAINER_ID_RE = re.compile(r"(?<![0-9a-f])[0-9a-f]{12,64}(?![0-9a-f])", re.IGNORECASE)
+
+
+def _current_container_ids() -> list[str]:
+    """Return Docker IDs that can identify this process's container.
+
+    Docker's default hostname is the short container ID. A cgroup path is a
+    useful fallback for runtimes that do not expose that default hostname.
+    Deliberately ignore arbitrary hostnames: inspecting a same-named but
+    unrelated container could turn its bind mounts into sandbox sources.
+    """
+    candidates: list[str] = []
+
+    hostname = os.environ.get("HOSTNAME", "").strip()
+    if _CONTAINER_ID_RE.fullmatch(hostname):
+        candidates.append(hostname)
+
+    for path in ("/proc/self/cgroup", "/proc/1/cpuset"):
+        try:
+            contents = Path(path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        candidates.extend(match.group(0) for match in _CONTAINER_ID_RE.finditer(contents))
+
+    return list(dict.fromkeys(candidates))
+
+
+def _get_current_container_bind_mounts(docker_exe: str) -> list[tuple[str, str]]:
+    """Return ``(container_destination, daemon_source)`` bind mounts for self.
+
+    When Hermes runs in a container but talks to the host Docker socket, the
+    daemon resolves ``-v`` sources on the host, not inside Hermes. Inspecting
+    the current container gives the one path translation the daemon already
+    knows to be correct. On a normal host install there is no container ID to
+    inspect, so this is a no-op and existing Docker behaviour is unchanged.
+    """
+    for container_id in _current_container_ids():
+        try:
+            result = run_capture(
+                [docker_exe, "container", "inspect", container_id], timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.debug("Docker: could not inspect current container mounts: %s", exc)
+            continue
+
+        if result.returncode != 0:
+            continue
+        try:
+            inspected = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError:
+            logger.debug("Docker: current container mount inspection returned invalid JSON")
+            continue
+
+        if not isinstance(inspected, list):
+            continue
+        for container in inspected:
+            if not isinstance(container, dict):
+                continue
+            mounts = container.get("Mounts")
+            if not isinstance(mounts, list):
+                continue
+            bind_mounts: list[tuple[str, str]] = []
+            for mount in mounts:
+                if not isinstance(mount, dict) or mount.get("Type") != "bind":
+                    continue
+                destination = mount.get("Destination")
+                source = mount.get("Source")
+                if not isinstance(destination, str) or not isinstance(source, str):
+                    continue
+                if not destination.startswith("/") or not source.startswith("/"):
+                    continue
+                bind_mounts.append((destination.rstrip("/") or "/", source.rstrip("/") or "/"))
+            if bind_mounts:
+                return sorted(bind_mounts, key=lambda mount: len(mount[0]), reverse=True)
+
+    return []
+
+
+def _daemon_visible_bind_source(
+    source_path: str,
+    current_bind_mounts: list[tuple[str, str]],
+) -> str:
+    """Map an in-container path to the Docker daemon's source path when known."""
+    source = os.path.normpath(source_path)
+    for container_destination, daemon_source in sorted(
+        current_bind_mounts, key=lambda mount: len(mount[0]), reverse=True,
+    ):
+        if source == container_destination:
+            return daemon_source
+        prefix = container_destination.rstrip("/") + "/"
+        if source.startswith(prefix):
+            return daemon_source.rstrip("/") + source[len(container_destination):]
+    return source_path
+
+
+def _daemon_visible_volume_spec(
+    volume_spec: str,
+    current_bind_mounts: list[tuple[str, str]],
+) -> str:
+    """Rewrite the source of a POSIX ``-v`` spec when Docker sees a host path."""
+    source, separator, remainder = volume_spec.partition(":")
+    if not separator or not source.startswith("/"):
+        return volume_spec
+    return f"{_daemon_visible_bind_source(source, current_bind_mounts)}:{remainder}"
+
+
+def _mount_reuse_fingerprint(
+    writable_args: list[str], volume_args: list[str],
+) -> str:
+    """Fingerprint immutable mount arguments for safe cross-process reuse."""
+    payload = json.dumps(
+        {"writable_args": writable_args, "volume_args": volume_args},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
 
 
 # Security flags applied to every container. The container is the security
@@ -440,7 +559,10 @@ _RO_MOUNT_SOURCES = (
     ("get_cache_directory_mounts", False, "cache dir"))
 
 
-def _readonly_skill_mount_args() -> list[str]:
+def _readonly_skill_mount_args(
+    current_bind_mounts: list[tuple[str, str]],
+    sandbox_root: Path,
+) -> list[str]:
     """``-v host:container:ro`` args for credential files, skill dirs and cache dirs. Read-only so the
     container can authenticate/read but never modify host state. Missing or wrong-kind sources are
     skipped with a warning (Docker-in-Docker auto-creates a missing file source as a directory,
@@ -459,8 +581,31 @@ def _readonly_skill_mount_args() -> list[str]:
                 if problem:
                     logger.warning("Docker: skipping %s mount — %s: %s", noun.split()[0], problem, src)
                     continue
-                args.extend(["-v", f"{entry['host_path']}:{entry['container_path']}:ro"])
-                logger.info("Docker: mounting %s %s -> %s", noun, entry["host_path"], entry["container_path"])
+                daemon_source = _daemon_visible_bind_source(str(src), current_bind_mounts)
+                if getter == "get_skills_directory_mount":
+                    skills_fingerprint = "\0".join(
+                        f"{skill_path.relative_to(src)}:{skill_path.stat().st_mtime_ns}:{skill_path.stat().st_size}"
+                        for skill_path in sorted(src.rglob("*")) if skill_path.is_file()
+                    )
+                    staged_path = sandbox_root / "docker" / (
+                        f"safe-skills-{hashlib.sha256(skills_fingerprint.encode()).hexdigest()}"
+                    )
+                    staged_daemon_source = _daemon_visible_bind_source(
+                        str(staged_path), current_bind_mounts,
+                    )
+                    if daemon_source == str(src) and staged_daemon_source != str(staged_path):
+                        # credential_files returned a symlink-safe copy outside the
+                        # outer bind, so stage it below the daemon-visible sandbox.
+                        try:
+                            if not staged_path.is_dir():
+                                staged_path.parent.mkdir(parents=True, exist_ok=True)
+                                shutil.copytree(src, staged_path)
+                        except OSError as exc:
+                            logger.warning("Docker: could not stage skills for host Docker socket: %s", exc)
+                        else:
+                            daemon_source = staged_daemon_source
+                args.extend(["-v", f"{daemon_source}:{entry['container_path']}:ro"])
+                logger.info("Docker: mounting %s %s -> %s", noun, daemon_source, entry["container_path"])
     except Exception as e:
         logger.debug("Docker: could not load credential file mounts: %s", e)
     return args
@@ -536,17 +681,29 @@ class DockerEnvironment(BaseEnvironment):
             volumes = []
 
         _ensure_docker_available()
+        # Resolve once before assembling automatic mounts as those mounts may
+        # need to inspect this outer container through the same Docker client.
+        self._docker_exe = find_docker() or "docker"
+        self._current_bind_mounts = _get_current_container_bind_mounts(self._docker_exe)
+
+        from tools.environments.base import get_sandbox_dir
+        sandbox_root = get_sandbox_dir()
 
         resource_args = self._resource_args(image, cpu, memory, disk, network, shm_size, extra_args)
-        volume_args, writable_args = self._mount_args(volumes, host_cwd, auto_mount_cwd, task_id)
-        volume_args.extend(_readonly_skill_mount_args())
+        volume_args, writable_args = self._mount_args(
+            volumes, host_cwd, auto_mount_cwd, task_id, sandbox_root,
+        )
+        volume_args.extend(_readonly_skill_mount_args(self._current_bind_mounts, sandbox_root))
         egress_label, egress_volume_args, egress_host_args, env_args, validated_extra = (
             self._egress_and_env_args(extra_args))
+        egress_volume_args = [
+            _daemon_visible_volume_spec(value, self._current_bind_mounts)
+            if index > 0 and egress_volume_args[index - 1] in {"-v", "--volume"}
+            else value
+            for index, value in enumerate(egress_volume_args)
+        ]
         volume_args.extend(egress_volume_args)
         user_args = _host_user_args(run_as_host_user)
-
-        # Resolved once so it works when /usr/local/bin is not in PATH (macOS services).
-        self._docker_exe = find_docker() or "docker"
 
         # s6-overlay images (e.g. hermes-agent:latest) already use /init as PID 1 and exec
         # /run/s6/basedir/bin/init during startup. For those images we must (a) skip Docker's --init (two
@@ -580,18 +737,20 @@ class DockerEnvironment(BaseEnvironment):
         # creation, so reusing a pre-egress container would bypass the firewall.
         profile_name = _container_identity(shared_container_key)
         task_label = _sanitize_label_value(task_id)
+        mount_label = _mount_reuse_fingerprint(writable_args, volume_args)
         self._labels = {
             "hermes-agent": "1",
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
-            _EGRESS_LABEL_KEY: egress_label}
+            _EGRESS_LABEL_KEY: egress_label,
+            _MOUNT_LABEL_KEY: mount_label}
         # Saved for container recreation on "No such container" recovery.
         self._image = image
         self._image_uses_s6_init = image_uses_s6_init
         self._all_run_args = all_run_args
 
         reused = persist_across_processes and self._attach_existing_container(
-            task_label, profile_name, egress_label, network)
+            task_label, profile_name, egress_label, mount_label, network)
         if not reused:
             self._container_id = self._docker_run(cwd)
 
@@ -664,7 +823,9 @@ class DockerEnvironment(BaseEnvironment):
             # extra_network == "none": same intent stated twice; the extra arg carries it once.
         return args
 
-    def _mount_args(self, volumes, host_cwd, auto_mount_cwd, task_id) -> tuple[list[str], list[str]]:
+    def _mount_args(
+        self, volumes, host_cwd, auto_mount_cwd, task_id, sandbox_root: Path,
+    ) -> tuple[list[str], list[str]]:
         """``(volume_args, writable_args)`` for user volumes, host cwd and /workspace,/root.
         Persistent mode bind-mounts from TERMINAL_SANDBOX_DIR (default ~/.hermes/sandboxes/)."""
         volume_args: list[str] = []
@@ -691,35 +852,43 @@ class DockerEnvironment(BaseEnvironment):
 
         writable_args: list[str] = []
         if self._persistent:
-            from tools.environments.base import get_sandbox_dir
             # _sandbox_dir_name(): a raw session-key task_id carries colons,
             # which `-v` reads as extra spec fields (exit 125).
-            sandbox = get_sandbox_dir() / "docker" / _sandbox_dir_name(task_id)
+            sandbox = sandbox_root / "docker" / _sandbox_dir_name(task_id)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
-            writable_args += ["-v", f"{self._home_dir}:/root"]
+            writable_args += [
+                "-v",
+                f"{_daemon_visible_bind_source(self._home_dir, self._current_bind_mounts)}:/root",
+            ]
             if mount_workspace:
                 self._workspace_dir = str(sandbox / "workspace")
                 os.makedirs(self._workspace_dir, exist_ok=True)
-                writable_args += ["-v", f"{self._workspace_dir}:/workspace"]
+                writable_args += [
+                    "-v",
+                    f"{_daemon_visible_bind_source(self._workspace_dir, self._current_bind_mounts)}:/workspace",
+                ]
         else:
             writable_args += ["--tmpfs", "/workspace:rw,exec,size=10g"] if mount_workspace else []
             writable_args += ["--tmpfs", "/home:rw,exec,size=1g", "--tmpfs", "/root:rw,exec,size=1g"]
 
         if bind_host_cwd:
-            logger.info("Mounting configured host cwd to /workspace: %s", host_cwd_abs)
-            volume_args = ["-v", f"{host_cwd_abs}:/workspace", *volume_args]
+            daemon_source = _daemon_visible_bind_source(host_cwd_abs, self._current_bind_mounts)
+            logger.info("Mounting configured host cwd to /workspace: %s", daemon_source)
+            volume_args = ["-v", f"{daemon_source}:/workspace", *volume_args]
         elif workspace_explicitly_mounted:
             logger.debug("Skipping docker cwd mount: /workspace already mounted by user config")
         return volume_args, writable_args
 
-    def _attach_existing_container(self, task_label, profile_name, egress_label, network: bool) -> bool:
+    def _attach_existing_container(
+        self, task_label, profile_name, egress_label, mount_label, network: bool,
+    ) -> bool:
         """Attach to a prior process's labeled container ("ONE long-lived container shared
         across sessions"; opt out via ``docker_persist_across_processes: false``).
         Network guard is lockdown-only: a bridge container under ``docker_network: false``
         is removed and recreated, but a ``none`` container under default config is kept so
         ``--network=none`` in extra args doesn't churn containers every startup."""
-        existing = self._find_reusable_container(task_label, profile_name, egress_label)
+        existing = self._find_reusable_container(task_label, profile_name, egress_label, mount_label)
         if existing is None:
             return False
         container_id, state = existing
@@ -882,7 +1051,8 @@ class DockerEnvironment(BaseEnvironment):
         existing = self._find_reusable_container(
             self._labels.get("hermes-task-id", ""),
             self._labels.get("hermes-profile", ""),
-            self._labels.get(_EGRESS_LABEL_KEY, "off"))
+            self._labels.get(_EGRESS_LABEL_KEY, "off"),
+            self._labels.get(_MOUNT_LABEL_KEY, ""))
         if existing is not None:
             cid, state = existing
             if state == "running":
@@ -963,7 +1133,8 @@ class DockerEnvironment(BaseEnvironment):
         return (result.stdout.strip() or None) if result is not None else None
 
     def _find_reusable_container(
-        self, task_label: str, profile_label: str, egress_label: str) -> Optional[tuple[str, str]]:
+        self, task_label: str, profile_label: str, egress_label: str, mount_label: str,
+    ) -> Optional[tuple[str, str]]:
         """``(container_id, state)`` of an existing container labeled for this task/profile/
         egress posture, or ``None`` on miss or any failure. The egress posture is a label
         FILTER for every posture, "off" included: a container built with egress on must not be
@@ -974,7 +1145,9 @@ class DockerEnvironment(BaseEnvironment):
             "--filter", "label=hermes-agent=1",
             "--filter", f"label=hermes-task-id={task_label}",
             "--filter", f"label=hermes-profile={profile_label}",
-            "--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}"]
+            "--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}",
+            "--filter", f"label={_MOUNT_LABEL_KEY}={mount_label}",
+        ]
         result = _docker_query(
             [self._docker_exe, "ps", "-a", *filters, "--format", "{{.ID}}\t{{.State}}"], timeout=10,
             fail="docker ps probe failed: %s — will start a fresh container",

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -555,9 +555,11 @@ docker compose up -d
 Set `HERMES_SKIP_CONFIG_MIGRATION=1` only if you need to inspect or migrate the
 persisted config manually before letting the new image rewrite it.
 
-## Skills and credential files
+## Skills, caches, and credential files
 
-When using Docker as the execution environment (not the methods above, but when the agent runs commands inside a Docker sandbox — see [Configuration → Docker Backend](./configuration.md#docker-backend)), Hermes reuses a single long-lived container for all tool calls and automatically bind-mounts the skills directory (`~/.hermes/skills/`) and any credential files declared by skills into that container as read-only volumes. Skill scripts, templates, and references are available inside the sandbox without manual configuration, and because the container persists for the life of the Hermes process, any dependencies you install or files you write stay around for the next tool call.
+When using Docker as the execution environment (not the methods above, but when the agent runs commands inside a Docker sandbox — see [Configuration → Docker Backend](./configuration.md#docker-backend)), Hermes reuses a single long-lived container for all tool calls and automatically bind-mounts the skills directory (`~/.hermes/skills/`), cache directories, and credential files declared by skills into that container as read-only volumes.
+
+This also works when Hermes itself runs in Docker with the host Docker socket mounted: Hermes inspects its own data-volume bind mount and gives the sandbox the daemon-visible host source. Skill scripts, templates, and references are available inside the sandbox without manual configuration, and because the container persists for the life of the Hermes process, any dependencies you install or files you write stay around for the next tool call.
 
 The same syncing happens for SSH and Modal backends — skills and credential files are uploaded via rsync or the Modal mount API before each command.
 

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -570,9 +570,11 @@ docker compose up -d
 Set `HERMES_SKIP_CONFIG_MIGRATION=1` only if you need to inspect or migrate the
 persisted config manually before letting the new image rewrite it.
 
-## Skills and credential files
+## Skills, caches, and credential files
 
-When using Docker as the execution environment (not the methods above, but when the agent runs commands inside a Docker sandbox — see [Configuration → Docker Backend](./configuration.md#docker-backend)), Hermes reuses a single long-lived container for all tool calls and automatically bind-mounts the skills directory (`~/.hermes/skills/`) and any credential files declared by skills into that container as read-only volumes. Skill scripts, templates, and references are available inside the sandbox without manual configuration, and because the container persists for the life of the Hermes process, any dependencies you install or files you write stay around for the next tool call.
+When using Docker as the execution environment (not the methods above, but when the agent runs commands inside a Docker sandbox — see [Configuration → Docker Backend](./configuration.md#docker-backend)), Hermes reuses a single long-lived container for all tool calls and automatically bind-mounts the skills directory (`~/.hermes/skills/`), cache directories, and credential files declared by skills into that container as read-only volumes.
+
+This also works when Hermes itself runs in Docker with the host Docker socket mounted: Hermes inspects its own data-volume bind mount and gives the sandbox the daemon-visible host source. Skill scripts, templates, and references are available inside the sandbox without manual configuration, and because the container persists for the life of the Hermes process, any dependencies you install or files you write stay around for the next tool call.
 
 The same syncing happens for SSH and Modal backends — skills and credential files are uploaded via rsync or the Modal mount API before each command.
 


### PR DESCRIPTION
## What changed and why

Fixes #50798.

When Hermes runs in Docker and creates a sandbox through the host Docker socket, the daemon resolves bind sources on the host rather than in the Hermes container. The Docker backend now inspects Hermes's own bind mounts, translates automatically managed sources to their daemon-visible paths, and leaves user-configured `terminal.docker_volumes` unchanged.

The translation covers credentials, skills, caches, persistent sandbox home/workspace directories, the automatic host-CWD mount, and the egress CA mount. A mount fingerprint is included in cross-process container reuse so a pre-fix container with immutable stale mounts is replaced instead of silently reused.

## Related discussion

- #50874 (closed) established the path-translation diagnosis; this replaces its user-facing environment-variable setting with automatic Docker mount inspection.
- #66086 was identified in the follow-up consolidation as related Docker behavior. This PR limits its claim to #50798 while sharing the corrected sibling-daemon source handling.

## How to test

```sh
pytest tests/tools/test_docker_environment.py tests/tools/test_credential_files.py -q --timeout=60
```

The regression test mocks an outer Hermes data bind and verifies that the generated `docker run` command uses the host source for credential, skill, cache, and persistent sandbox mounts.

## What platforms tested on

- macOS development host: focused pytest coverage with mocked Docker CLI and Docker inspect responses (39 selected tests passed).
- No live Docker daemon or Linux container integration test was available in this worker environment.

The prescribed full test-suite command was also started, but this sandbox did not return a terminal result; it is not reported as a pass.

<!-- autocontrib:worker-id=issue-followup-aa210ddb kind=pr-open -->