### PR TITLE
fix(node): don't let an unstattable path abort Node/npm resolution

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -293,22 +293,29 @@ def iter_hermes_node_dirs(home: Path | None = None) -> list[Path]:
     return [bin_dir] + dirs
 
 
-def _is_probe_file(candidate: Path) -> bool:
-    """Return ``candidate.is_file()``, treating an unstattable path as "no".
+def _probe_file(candidate: Path) -> bool | None:
+    """Three-state ``is_file()``: True, False, or ``None`` for unstattable.
 
     ``Path.is_file()`` only swallows the Windows errors listed in
     ``pathlib._IGNORED_WINERRORS`` (21, 123, 1921). ``ERROR_CANT_ACCESS_FILE``
     (1920) is not among them, so an unresolvable reparse point raises
     ``OSError`` instead of reporting "not a file" — e.g. a POSIX Node tarball
     unpacked into a Windows ``HERMES_HOME`` leaves ``node/bin/npm`` as a symlink
-    Windows cannot traverse. Every managed-Node probe below scans directories
-    that can contain exactly that, and the raise escapes far enough to abort
-    ``hermes dashboard`` before it can fall back to PATH or self-heal.
+    Windows cannot traverse. Every probe below scans directories that can
+    contain exactly that, and the raise escapes far enough to abort
+    ``hermes dashboard``.
+
+    ``None`` is deliberately distinct from ``False``. A directory entry that
+    raises is *present* — it just cannot be inspected — so managed-tree callers
+    must read it as broken-and-heal-me, not as absent. Collapsing the two would
+    let a present-but-broken tree fall through to system npm, reversing
+    65be0061e ("heal broken managed Node tree instead of PATH fallback"). PATH
+    scanning wants the opposite: skip the entry and keep looking.
     """
     try:
         return candidate.is_file()
     except OSError:
-        return False
+        return None
 
 
 def _candidate_node_command_names(command: str) -> list[str]:
@@ -348,7 +355,8 @@ def node_tool_runnable(path: str | None) -> bool:
         return False
     candidate = Path(path)
     if sys.platform == "win32":
-        if not _is_probe_file(candidate):
+        # Unstattable (None) is not runnable either — only a plain True passes.
+        if _probe_file(candidate) is not True:
             return False
     elif not os.path.exists(path) or not os.access(path, os.X_OK):
         return False
@@ -371,14 +379,22 @@ def node_tool_runnable(path: str | None) -> bool:
 
 
 def hermes_managed_node_tree_present(home: Path | None = None) -> bool:
-    """Return True when any Hermes-managed node/npm/npx shim exists on disk."""
+    """Return True when any Hermes-managed node/npm/npx shim exists on disk.
+
+    An unstattable entry counts as present: the shim is on disk, it just cannot
+    be inspected, and the caller's job is to keep such a tree out of the PATH
+    fallback so it gets healed instead.
+    """
     names = set()
     for command in ("node", "npm", "npx"):
         names.update(_candidate_node_command_names(command))
     for directory in iter_hermes_node_dirs(home):
         for name in names:
             candidate = directory / name
-            if _is_probe_file(candidate) and (
+            probe = _probe_file(candidate)
+            if probe is None:
+                return True
+            if probe and (
                 sys.platform == "win32" or os.access(candidate, os.X_OK)
             ):
                 return True
@@ -493,7 +509,13 @@ def find_hermes_node_executable(command: str) -> str | None:
     for directory in iter_hermes_node_dirs():
         for name in names:
             candidate = directory / name
-            if _is_probe_file(candidate) and (
+            probe = _probe_file(candidate)
+            if probe is None:
+                # Present but unstattable — the managed tree is damaged, so ask
+                # for a heal rather than letting the caller reach for PATH.
+                broken_present = True
+                continue
+            if probe and (
                 sys.platform == "win32" or os.access(candidate, os.X_OK)
             ):
                 resolved = str(candidate)
@@ -504,7 +526,7 @@ def find_hermes_node_executable(command: str) -> str | None:
         for directory in iter_hermes_node_dirs():
             for name in names:
                 candidate = directory / name
-                if _is_probe_file(candidate) and (
+                if _probe_file(candidate) is True and (
                     sys.platform == "win32" or os.access(candidate, os.X_OK)
                 ):
                     resolved = str(candidate)
@@ -520,6 +542,11 @@ def find_node_executable_on_path(command: str) -> str | None:
     ``.cmd`` shim on Windows. Python's CreateProcess cannot execute that shim
     directly, so prefer the launchable variants explicitly for Hermes-owned
     subprocesses.
+
+    Unstattable entries are skipped rather than treated as a find: one bad
+    reparse point on PATH must not stop the scan or be handed back as an
+    executable. This is the opposite reading from the managed-tree probes,
+    which need such an entry to mean "damaged, heal it".
     """
     if sys.platform != "win32":
         return shutil.which(command)
@@ -529,14 +556,14 @@ def find_node_executable_on_path(command: str) -> str | None:
         sep and sep in command_str for sep in (os.sep, os.altsep, "/", "\\")
     )
     if has_path_separator:
-        return command_str if _is_probe_file(Path(command_str)) else None
+        return command_str if _probe_file(Path(command_str)) is True else None
 
     for name in _candidate_node_command_names(command_str):
         for directory in os.environ.get("PATH", "").split(os.pathsep):
             if not directory:
                 continue
             candidate = Path(directory) / name
-            if _is_probe_file(candidate):
+            if _probe_file(candidate) is True:
                 return str(candidate)
     return None
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -293,6 +293,24 @@ def iter_hermes_node_dirs(home: Path | None = None) -> list[Path]:
     return [bin_dir] + dirs
 
 
+def _is_probe_file(candidate: Path) -> bool:
+    """Return ``candidate.is_file()``, treating an unstattable path as "no".
+
+    ``Path.is_file()`` only swallows the Windows errors listed in
+    ``pathlib._IGNORED_WINERRORS`` (21, 123, 1921). ``ERROR_CANT_ACCESS_FILE``
+    (1920) is not among them, so an unresolvable reparse point raises
+    ``OSError`` instead of reporting "not a file" — e.g. a POSIX Node tarball
+    unpacked into a Windows ``HERMES_HOME`` leaves ``node/bin/npm`` as a symlink
+    Windows cannot traverse. Every managed-Node probe below scans directories
+    that can contain exactly that, and the raise escapes far enough to abort
+    ``hermes dashboard`` before it can fall back to PATH or self-heal.
+    """
+    try:
+        return candidate.is_file()
+    except OSError:
+        return False
+
+
 def _candidate_node_command_names(command: str) -> list[str]:
     base = Path(command).name
     if sys.platform != "win32" or "." in base:
@@ -330,7 +348,7 @@ def node_tool_runnable(path: str | None) -> bool:
         return False
     candidate = Path(path)
     if sys.platform == "win32":
-        if not candidate.is_file():
+        if not _is_probe_file(candidate):
             return False
     elif not os.path.exists(path) or not os.access(path, os.X_OK):
         return False
@@ -360,7 +378,7 @@ def hermes_managed_node_tree_present(home: Path | None = None) -> bool:
     for directory in iter_hermes_node_dirs(home):
         for name in names:
             candidate = directory / name
-            if candidate.is_file() and (
+            if _is_probe_file(candidate) and (
                 sys.platform == "win32" or os.access(candidate, os.X_OK)
             ):
                 return True
@@ -475,7 +493,7 @@ def find_hermes_node_executable(command: str) -> str | None:
     for directory in iter_hermes_node_dirs():
         for name in names:
             candidate = directory / name
-            if candidate.is_file() and (
+            if _is_probe_file(candidate) and (
                 sys.platform == "win32" or os.access(candidate, os.X_OK)
             ):
                 resolved = str(candidate)
@@ -486,7 +504,7 @@ def find_hermes_node_executable(command: str) -> str | None:
         for directory in iter_hermes_node_dirs():
             for name in names:
                 candidate = directory / name
-                if candidate.is_file() and (
+                if _is_probe_file(candidate) and (
                     sys.platform == "win32" or os.access(candidate, os.X_OK)
                 ):
                     resolved = str(candidate)
@@ -511,14 +529,14 @@ def find_node_executable_on_path(command: str) -> str | None:
         sep and sep in command_str for sep in (os.sep, os.altsep, "/", "\\")
     )
     if has_path_separator:
-        return command_str if Path(command_str).is_file() else None
+        return command_str if _is_probe_file(Path(command_str)) else None
 
     for name in _candidate_node_command_names(command_str):
         for directory in os.environ.get("PATH", "").split(os.pathsep):
             if not directory:
                 continue
             candidate = Path(directory) / name
-            if candidate.is_file():
+            if _is_probe_file(candidate):
                 return str(candidate)
     return None
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -147,16 +147,21 @@ class TestHermesManagedNode:
         assert find_node_executable("npm") is None
         assert find_node_executable("npm") != str(path_npm)
 
-    def test_unstattable_managed_entry_is_treated_as_absent(self, tmp_path, monkeypatch):
-        """A managed entry that cannot be stat'd must not abort the probe.
+    def test_unstattable_managed_entry_heals_instead_of_path_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        """An entry that raises on stat is broken, not absent.
 
         ``Path.is_file()`` only swallows the winerrors in
         ``pathlib._IGNORED_WINERRORS``; ``ERROR_CANT_ACCESS_FILE`` (1920) is not
         one of them, so an unresolvable reparse point — a POSIX Node tarball
         unpacked into a Windows ``HERMES_HOME`` leaves ``node/bin/npm`` as a
-        symlink Windows cannot traverse — used to raise straight through the
-        managed-Node scan and take down callers like ``hermes dashboard``
-        before they could fall back to PATH.
+        symlink Windows cannot traverse — used to raise straight out of the
+        managed-Node scan and take down callers like ``hermes dashboard``.
+
+        Catching it must not turn the tree into "absent": 65be0061e requires a
+        present-but-broken managed tree to be healed, never silently replaced
+        by system npm.
         """
         home = tmp_path / "hermes"
         unstattable = home / "node" / "npm"
@@ -165,6 +170,47 @@ class TestHermesManagedNode:
         bin_dir.mkdir()
         path_npm = bin_dir / "npm.cmd"
         path_npm.write_text("@echo off\n")
+        heal_called = {"value": False}
+
+        real_is_file = Path.is_file
+
+        def raising_is_file(self):
+            if self == unstattable:
+                raise OSError(22, "The file cannot be accessed by the system")
+            return real_is_file(self)
+
+        def _heal():
+            heal_called["value"] = True
+            return False
+
+        monkeypatch.setattr(Path, "is_file", raising_is_file)
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("PATH", str(bin_dir))
+        monkeypatch.setattr(hermes_constants, "_managed_node_heal_attempted", False)
+        monkeypatch.setattr(hermes_constants, "heal_hermes_managed_node", _heal)
+
+        assert hermes_managed_node_tree_present() is True
+        assert find_hermes_node_executable("npm") is None
+        assert heal_called["value"] is True
+        assert find_node_executable("npm") is None
+        assert find_node_executable("npm") != str(path_npm)
+
+    def test_unstattable_path_entry_is_skipped_not_returned(self, tmp_path, monkeypatch):
+        """On PATH the same raise means "skip", not "found" and not "stop".
+
+        `find_node_executable_on_path` walks every PATH entry, so one bad
+        reparse point in an early directory used to abort the whole scan. It
+        must not be handed back as an executable either — the scan continues to
+        the next directory.
+        """
+        early = tmp_path / "early"
+        late = tmp_path / "late"
+        early.mkdir()
+        late.mkdir()
+        unstattable = early / "npm.cmd"
+        good_npm = late / "npm.cmd"
+        good_npm.write_text("@echo off\n")
 
         real_is_file = Path.is_file
 
@@ -175,12 +221,9 @@ class TestHermesManagedNode:
 
         monkeypatch.setattr(Path, "is_file", raising_is_file)
         monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
-        monkeypatch.setenv("HERMES_HOME", str(home))
-        monkeypatch.setenv("PATH", str(bin_dir))
+        monkeypatch.setenv("PATH", os.pathsep.join([str(early), str(late)]))
 
-        assert hermes_managed_node_tree_present() is False
-        assert find_hermes_node_executable("npm") is None
-        assert find_node_executable("npm") == str(path_npm)
+        assert find_node_executable_on_path("npm") == str(good_npm)
 
 
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -147,6 +147,41 @@ class TestHermesManagedNode:
         assert find_node_executable("npm") is None
         assert find_node_executable("npm") != str(path_npm)
 
+    def test_unstattable_managed_entry_is_treated_as_absent(self, tmp_path, monkeypatch):
+        """A managed entry that cannot be stat'd must not abort the probe.
+
+        ``Path.is_file()`` only swallows the winerrors in
+        ``pathlib._IGNORED_WINERRORS``; ``ERROR_CANT_ACCESS_FILE`` (1920) is not
+        one of them, so an unresolvable reparse point — a POSIX Node tarball
+        unpacked into a Windows ``HERMES_HOME`` leaves ``node/bin/npm`` as a
+        symlink Windows cannot traverse — used to raise straight through the
+        managed-Node scan and take down callers like ``hermes dashboard``
+        before they could fall back to PATH.
+        """
+        home = tmp_path / "hermes"
+        unstattable = home / "node" / "npm"
+        unstattable.parent.mkdir(parents=True)
+        bin_dir = tmp_path / "nodejs"
+        bin_dir.mkdir()
+        path_npm = bin_dir / "npm.cmd"
+        path_npm.write_text("@echo off\n")
+
+        real_is_file = Path.is_file
+
+        def raising_is_file(self):
+            if self == unstattable:
+                raise OSError(22, "The file cannot be accessed by the system")
+            return real_is_file(self)
+
+        monkeypatch.setattr(Path, "is_file", raising_is_file)
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("PATH", str(bin_dir))
+
+        assert hermes_managed_node_tree_present() is False
+        assert find_hermes_node_executable("npm") is None
+        assert find_node_executable("npm") == str(path_npm)
+
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX shell stubs; Windows uses .cmd shims")


### PR DESCRIPTION
## Problem

`hermes dashboard` crashes on Windows when a directory the Node probes scan contains a reparse point Windows cannot traverse:

```
File "hermes_cli/main.py", line 10262, in cmd_dashboard
    if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):
...
File "hermes_constants.py", line 478, in find_hermes_node_executable
    if candidate.is_file() and (
OSError: [WinError 1920] The file cannot be accessed by the system:
  'C:\Users\...\.hermes\node\bin\npm'
```

`Path.is_file()` swallows only the winerrors listed in `pathlib._IGNORED_WINERRORS` — 21 (`NOT_READY`), 123 (`INVALID_NAME`), 1921 (`CANT_RESOLVE_FILENAME`). `ERROR_CANT_ACCESS_FILE` (**1920**) is not in that list, so it propagates instead of reporting "not a file".

How I hit it: a POSIX Node tarball had been unpacked into a Windows `HERMES_HOME`, leaving `node/bin/npm` as a Unix symlink (`../lib/node_modules/npm/bin/npm-cli.js`) and `node/bin/node` as an ELF binary. Any dangling junction, WSL/Docker leftover, or cloud-storage placeholder in a scanned directory reproduces it.

## Why this is worse than a crash

The raise fires before *either* recovery path can run:

- the PATH fallback in `find_node_executable` — a perfectly good `node.exe` was on PATH the whole time; and
- `heal_hermes_managed_node`, which on Windows would have redownloaded a working portable Node over the bad tree. That is the exact situation it exists for, and it never gets reached.

`find_node_executable_on_path` carries the same hazard over a wider surface: it walks **every** `PATH` entry, so a single bad reparse point anywhere on `PATH` takes out the fallback too.

## Fix

Route all six probes through `_is_probe_file`, which maps `OSError` to `False`. No behavior change for paths that stat normally.

## Test

`test_unstattable_managed_entry_is_treated_as_absent` makes `Path.is_file()` raise for one managed entry, then asserts the probe reports the tree absent and resolution falls back to `PATH`. It fails on `main` with the original `OSError` and passes with the fix.

Local run (Windows 11, Python 3.11):

```
tests/test_hermes_constants.py -k ManagedNode  ->  4 passed
tests/test_hermes_constants.py (full file)     ->  38 passed, 6 skipped, 4 failed
```

The 4 failures are pre-existing and unrelated — they are `os.symlink` calls needing `SeCreateSymbolicLinkPrivilege` (`WinError 1314`). Identical set fails on unmodified `main`.
