### PR TITLE
fix(config): preserve scalar model id when setting model sub-keys

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4855,6 +4855,16 @@ def set_config_value(key: str, value: str, force: bool = False):
             coerced_value = float(value)
 
     value = coerced_value
+    # Normalize a scalar ``model`` key before writing sub-keys so that
+    # ``hermes config set model.provider openai`` doesn't silently
+    # destroy the model id when ``model`` is a bare string shorthand
+    # (e.g. ``model: gpt-4o``).  Without this _set_nested replaces the
+    # scalar with an empty dict, dropping the model id permanently.
+    _model_key = key.strip().lower()
+    if _model_key.startswith("model."):
+        _model_val = user_config.get("model")
+        if isinstance(_model_val, str) and _model_val:
+            user_config["model"] = {"default": _model_val}
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -564,3 +564,33 @@ class TestDisplaySkinTouch:
 
         set_config_value("display.skin", "neon")
         assert (skins / "neon.yaml").read_text() == body
+
+
+class TestScalarModelSubKeyPreservation:
+    """#75426: setting model.provider when model is a scalar must not lose the model id."""
+
+    def test_scalar_model_id_preserved_after_provider_write(self, _isolated_hermes_home):
+        """Seed model: gpt-4o, then set model.provider → model.default must survive."""
+        import yaml
+
+        set_config_value("model", "gpt-4o")
+        set_config_value("model.provider", "openai")
+
+        raw = _read_config(_isolated_hermes_home)
+        parsed = yaml.safe_load(raw)
+        model = parsed["model"]
+        assert model["default"] == "gpt-4o", f"model.default lost: {model}"
+        assert model["provider"] == "openai"
+
+    def test_scalar_model_id_preserved_after_api_key_write(self, _isolated_hermes_home):
+        """model.api_key must also preserve the existing scalar model id."""
+        import yaml
+
+        set_config_value("model", "claude-sonnet")
+        # model.api_key is a sub-key (has a dot), so it stays in config.yaml
+        set_config_value("model.api_key", "sk-test")
+
+        raw = _read_config(_isolated_hermes_home)
+        parsed = yaml.safe_load(raw)
+        assert parsed["model"]["default"] == "claude-sonnet"
+        assert parsed["model"]["api_key"] == "sk-test"


### PR DESCRIPTION
## Summary

When `model` is a bare scalar shorthand (e.g. `model: gpt-4o`), running:

    hermes config set model.provider openai

silently destroyed the model id because `_set_nested` replaces scalar intermediate values with empty dicts. Result:

```yaml
# Before:
model: gpt-4o

# After (BUG):
model:
  provider: openai
```

The original model id `gpt-4o` is permanently lost.

## Fix

Normalize a scalar `model` to `{default: <id>}` before writing any sub-key. This mirrors what `_normalize_root_model_keys` does at load time, but applied at write time so the data survives the intermediate `_set_nested` transformation.

```yaml
# After (fixed):
model:
  default: gpt-4o
  provider: openai
```

## Reproduction

```bash
echo 'model: gpt-4o' > ~/.hermes/config.yaml
hermes config set model.provider openai
hermes config get model.default  # should still be gpt-4o
```