### PR TITLE
fix(desktop): hide terminal overlay when its pane layer is hidden

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -244,6 +244,50 @@ describe('PersistentTerminal rect tracking', () => {
     expect(raf.pending()).toBe(0)
   })
 
+  it('hides the overlay while the slot sits inside a hidden pane layer (data-pane-hidden)', () => {
+    const raf = installRaf()
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect(10, 20, 200, 100))
+
+    render(
+      <div data-pane-hidden="">
+        <Harness />
+      </div>
+    )
+
+    // Initial measure: slot rect is non-zero, but the slot lives under a
+    // hidden pane layer — the overlay must stay collapsed (visibility:hidden,
+    // zero-sized) instead of painting over the active tab. No RAF is ever
+    // scheduled because the very first measure already reports invisible.
+    const wrapper = container!.firstElementChild as HTMLElement
+    const overlay = wrapper.lastElementChild as HTMLElement
+    expect(overlay.style.visibility).toBe('hidden')
+    expect(overlay.style.width).toBe('0px')
+    expect(raf.request).not.toHaveBeenCalled()
+
+    // Un-hide the pane layer: the overlay must come back with the slot rect.
+    wrapper.removeAttribute('data-pane-hidden')
+
+    act(() => {
+      mutationObserverCallback?.([], {} as MutationObserver)
+    })
+
+    expect(raf.pending()).toBe(1)
+
+    act(() => {
+      raf.runNext()
+    })
+
+    // First remeasure lands the rect; the settle frame then quiesces.
+    act(() => {
+      raf.runNext()
+    })
+
+    expect(overlay.style.visibility).toBe('visible')
+    expect(overlay.style.top).toBe('10px')
+    expect(overlay.style.left).toBe('20px')
+    expect(raf.pending()).toBe(0)
+  })
+
   it('does not schedule rect RAFs while the Electron window is paused, then resumes when visible', () => {
     const raf = installRaf()
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect(10, 20, 200, 100))

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -4,6 +4,8 @@ import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from
 
 import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 
+import { PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
+
 import { $terminalTakeover } from '../store'
 
 import { ensureTerminal } from './terminals'
@@ -102,6 +104,23 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
         return false
       }
 
+      // A kept-alive pane layer hides with `visibility: hidden` — its layout
+      // box (and therefore its rect) survives, so an inactive tab's slot still
+      // measures non-zero and the overlay would keep painting the terminal
+      // over whatever tab IS active (sessions ghosting the terminal). Treat a
+      // slot inside a hidden pane layer as zero-size — same policy as
+      // queryVisible in pane-visibility.ts.
+      if (slot.closest(`[${PANE_HIDDEN_ATTR}]`)) {
+        if (prev !== null) {
+          prev = null
+          setRect(null)
+
+          return true
+        }
+
+        return false
+      }
+
       const r = slot.getBoundingClientRect()
       // floor top/left + ceil right/bottom: overlay always covers the slot's
       // full pixel footprint, so half-pixel rects can't leak page bg through.
@@ -171,7 +190,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
 
     for (let node: HTMLElement | null = slot; node; node = node.parentElement) {
       positionObserver?.observe(node, {
-        attributeFilter: ['class', 'style', 'hidden', 'aria-hidden', 'data-state'],
+        attributeFilter: ['class', 'style', 'hidden', 'aria-hidden', 'data-state', PANE_HIDDEN_ATTR],
         attributes: true,
         childList: true,
         subtree: true


### PR DESCRIPTION
## What

`PersistentTerminal` renders as a `position:fixed` overlay whose visibility is decided only by the slot rect size. The pane shell keeps inactive tabs **mounted** with `visibility:hidden` (layout box preserved — see `pane-visibility.ts`), so a terminal stacked in a tab group with sessions keeps reporting a non-zero rect after the tab is closed. The overlay then keeps painting the terminal over the active tab: the sessions sidebar goes blank, or a second terminal layer ghosts on top of it.

## Fix

- `measure()` now treats a slot under `[data-pane-hidden]` as zero-size — the same policy `queryVisible` already applies to every document-wide lookup.
- The position `MutationObserver` watches the marker attribute, so the overlay collapses/restores the moment the tab visibility flips (no stale rect between observer rounds).

## Test

New `persistent.test.tsx` case: slot inside a `data-pane-hidden` layer → overlay hidden (0×0, no RAF scheduled); removing the marker → overlay restores with the slot rect. Full terminal + pane-shell suites pass (104 tests).