### PR TITLE
fix(config): refuse to write when config.yaml has YAML syntax errors

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4832,8 +4832,15 @@ def set_config_value(key: str, value: str, force: bool = False):
         try:
             with open(config_path, encoding="utf-8") as f:
                 user_config = fast_safe_load(f) or {}
-        except Exception:
-            user_config = {}
+        except Exception as exc:
+            print(
+                f"✗ Cannot parse {config_path}: {exc}\n"
+                f"  The file contains a YAML syntax error. Fix the error\n"
+                f"  in your config file first, then retry.\n"
+                f"  (hermes config edit will open it in your editor.)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
@@ -4973,8 +4980,15 @@ def unset_config_value(key: str):
         try:
             with open(config_path, encoding="utf-8") as f:
                 user_config = fast_safe_load(f) or {}
-        except Exception:
-            user_config = {}
+        except Exception as exc:
+            print(
+                f"✗ Cannot parse {config_path}: {exc}\n"
+                f"  The file contains a YAML syntax error. Fix the error\n"
+                f"  in your config file first, then retry.\n"
+                f"  (hermes config edit will open it in your editor.)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     removed = _unset_nested(user_config, key)
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -564,3 +564,39 @@ class TestDisplaySkinTouch:
 
         set_config_value("display.skin", "neon")
         assert (skins / "neon.yaml").read_text() == body
+
+
+class TestMalformedYAMLConfigPreservation:
+    """#75431: config.yaml with YAML syntax errors must not be overwritten."""
+
+    BROKEN_CONFIG = "model: gpt-4o\nterminal:\n  backend: docker\n  broken: [this is invalid YAML"
+
+    def _write_broken_config(self, home):
+        (home / "config.yaml").write_text(self.BROKEN_CONFIG)
+
+    def test_set_config_value_refuses_broken_yaml(self, _isolated_hermes_home, capsys):
+        """set_config_value must exit with error, not overwrite the broken config."""
+        self._write_broken_config(_isolated_hermes_home)
+
+        with pytest.raises(SystemExit):
+            set_config_value("agent.max_turns", "50")
+
+        captured = capsys.readouterr()
+        assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
+        # Original config must remain intact
+        raw = _read_config(_isolated_hermes_home)
+        assert raw == self.BROKEN_CONFIG, f"Config was overwritten:\n{raw}"
+
+    def test_unset_config_value_refuses_broken_yaml(self, _isolated_hermes_home, capsys):
+        """unset_config_value must exit with error, not overwrite the broken config."""
+        from hermes_cli.config import unset_config_value
+
+        self._write_broken_config(_isolated_hermes_home)
+
+        with pytest.raises(SystemExit):
+            unset_config_value("model")
+
+        captured = capsys.readouterr()
+        assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
+        raw = _read_config(_isolated_hermes_home)
+        assert raw == self.BROKEN_CONFIG


### PR DESCRIPTION
## Summary

`set_config_value()` and `unset_config_value()` silently replaced the entire config with an empty dict when `config.yaml` could not be parsed. A single YAML syntax error (e.g. unclosed bracket, missing quote) would cause `hermes config set` to **wipe all settings** and write only the new key.

## Reproduction

```bash
# config.yaml with a syntax error
cat > ~/.hermes/config.yaml << 'EOF'
model: gpt-4o
terminal:
  backend: docker
  shell: bash
gateway:
  platforms:
    telegram: true
broken: [unclosed
EOF

# This wipes EVERYTHING:
hermes config set model.default claude-opus
# Result: config.yaml contains ONLY model.default: claude-opus
```

## Fix

Instead of silently falling back to an empty dict, the command now exits with code 1 and a clear error message pointing the user to `hermes config edit`.

The fix applies to both `set_config_value` (set) and `unset_config_value` (unset).