### PR TITLE
fix(agent): add Claude Opus 5 to BEDROCK_CONTEXT_LENGTHS (#74263)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1402,16 +1402,21 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock.
     # Context windows per Anthropic's official models comparison
     # (https://platform.claude.com/docs/en/about-claude/models/overview).
-    # Fable / Sonnet 5 / Opus 4.8 / 4.7 / 4.6 / Sonnet 4.6 have 1M generally
-    # available (no beta header required as of April 2026). Sonnet 4.5 and
-    # Sonnet 4 had their `context-1m-2025-08-07` beta retired on
+    # Fable / Opus 5 / Sonnet 5 / Opus 4.8 / 4.7 / 4.6 / Sonnet 4.6 have 1M
+    # generally available (no beta header required as of April 2026). Sonnet
+    # 4.5 and Sonnet 4 had their `context-1m-2025-08-07` beta retired on
     # April 30, 2026, so they are standard 200K; Haiku 4.5 is 200K.
     # These 1M entries must match agent/model_metadata.py
     # DEFAULT_CONTEXT_LENGTHS or the agent compresses context prematurely.
+    # tests/agent/test_bedrock_adapter.py::test_million_token_entries_match_model_metadata
+    # enforces that pairing — a new 1M Claude generation added to
+    # DEFAULT_CONTEXT_LENGTHS but not here fails the suite instead of
+    # silently inheriting BEDROCK_DEFAULT_CONTEXT_LENGTH (#74263).
     # Keys are matched by longest-substring, so the versioned 4-6/4-7/4-8
     # entries win over the generic "anthropic.claude-opus-4" fallback.
     "anthropic.claude-fable-5":      1_000_000,
     "anthropic.claude-fable":        1_000_000,
+    "anthropic.claude-opus-5":       1_000_000,
     "anthropic.claude-sonnet-5":     1_000_000,
     "anthropic.claude-opus-4-8":     1_000_000,
     "anthropic.claude-opus-4-7":     1_000_000,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -695,6 +695,53 @@ class TestBedrockContextLength:
         from agent.bedrock_adapter import get_bedrock_context_length, BEDROCK_DEFAULT_CONTEXT_LENGTH
         assert get_bedrock_context_length("unknown.model-v1:0") == BEDROCK_DEFAULT_CONTEXT_LENGTH
 
+    @pytest.mark.parametrize("model_id", [
+        "anthropic.claude-opus-5",
+        "eu.anthropic.claude-opus-5",
+        "us.anthropic.claude-opus-5",
+        "global.anthropic.claude-opus-5",
+        "eu.anthropic.claude-opus-5-v1:0",
+    ])
+    def test_opus_5_inference_profiles_get_1m(self, model_id):
+        """Opus 5 is 1M, including the regional/global inference profiles.
+
+        Regression for #74263: with no `-5` opus entry the lookup fell
+        through to BEDROCK_DEFAULT_CONTEXT_LENGTH (128K), under-reporting
+        the window ~8x and making the compressor compact far too early.
+        """
+        from agent.bedrock_adapter import get_bedrock_context_length
+        with patch("agent.bedrock_adapter.probe_bedrock_context_length") as mock_probe:
+            assert get_bedrock_context_length(model_id) == 1_000_000
+            mock_probe.assert_not_called()
+
+    def test_million_token_entries_match_model_metadata(self):
+        """BEDROCK_CONTEXT_LENGTHS must not drift from DEFAULT_CONTEXT_LENGTHS.
+
+        The Bedrock table's own comment requires the 1M Claude entries to
+        match ``agent.model_metadata.DEFAULT_CONTEXT_LENGTHS``; nothing
+        enforced it, so ``claude-opus-5`` was added to one table and not the
+        other (#74263).  Bedrock model IDs use hyphens, so the dotted
+        aliases in DEFAULT_CONTEXT_LENGTHS have no Bedrock counterpart and
+        are skipped.
+        """
+        from agent.bedrock_adapter import get_bedrock_context_length
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+
+        missing = []
+        with patch("agent.bedrock_adapter.probe_bedrock_context_length"):
+            for name, ctx in DEFAULT_CONTEXT_LENGTHS.items():
+                if ctx != 1_000_000 or not name.startswith("claude") or "." in name:
+                    continue
+                resolved = get_bedrock_context_length(f"anthropic.{name}")
+                if resolved != 1_000_000:
+                    missing.append(f"anthropic.{name} -> {resolved:,}")
+
+        assert not missing, (
+            "BEDROCK_CONTEXT_LENGTHS is missing 1M entries present in "
+            "DEFAULT_CONTEXT_LENGTHS; these models silently fall back to "
+            f"BEDROCK_DEFAULT_CONTEXT_LENGTH: {missing}"
+        )
+
 
 
     def test_no_region_skips_probe_uses_table(self):


### PR DESCRIPTION
Fixes the remaining half of #74263.

## What

`anthropic.claude-opus-5` is missing from `BEDROCK_CONTEXT_LENGTHS`, so every Opus 5 inference profile falls through to `BEDROCK_DEFAULT_CONTEXT_LENGTH = 128_000`.

On `main` (`1789e06ed`):

```python
>>> from agent.bedrock_adapter import get_bedrock_context_length as g
>>> g("eu.anthropic.claude-opus-5")        # 128,000  ← catch-all
>>> g("global.anthropic.claude-opus-5")    # 128,000  ← catch-all
>>> g("eu.anthropic.claude-sonnet-5")      # 1,000,000
```

## Why

Hermes under-reports the window by ~8x, and the value feeds compression — so the compressor compacts far earlier than necessary, and the auxiliary summariser auto-lowers the session threshold to 128000. A Bedrock user on Opus 5 has to discover and set **two** config keys by hand (`model.context_length` and `auxiliary.compression.context_length`) just to get the window the model actually has.

The number is not a guess: `claude-opus-5` is already `1000000` in `agent/model_metadata.py` `DEFAULT_CONTEXT_LENGTHS`. The Bedrock table's own comment says these entries *must* match —

> These 1M entries must match agent/model_metadata.py DEFAULT_CONTEXT_LENGTHS or the agent compresses context prematurely.

— but nothing enforced it, so the two drifted when Opus 5 was added to one and not the other.

## Changes

- `agent/bedrock_adapter.py` — add `"anthropic.claude-opus-5": 1_000_000`, and note in the comment where the pairing is now enforced.
- `tests/agent/test_bedrock_adapter.py` — two regression tests:
  - `test_opus_5_inference_profiles_get_1m` — parametrized over `anthropic.`, `eu.`, `us.`, `global.` and a `-v1:0` suffixed ID.
  - `test_million_token_entries_match_model_metadata` — the drift guard the issue asked for. Any 1M Claude entry in `DEFAULT_CONTEXT_LENGTHS` that does not resolve to 1M through the Bedrock lookup now fails the suite, so the next generation cannot silently inherit the catch-all. (Dotted aliases like `claude-opus-4.8` are skipped — Bedrock model IDs use hyphens.)

No behavior change for any other model: this is one added key in a longest-substring lookup table.

## How to test

```
pytest tests/agent/test_bedrock_adapter.py -v
```

Both new tests fail on `main` (`anthropic.claude-opus-5 -> 128,000`) and pass with the fix.

- `pytest tests/agent/test_bedrock_adapter.py` → 68 passed
- `pytest tests -k "bedrock or context_length or model_metadata"` → 259 passed, 2 skipped
- `ruff check` clean

Platform tested: Linux. No platform-specific code touched (a dict literal and its tests).

## Not covered

The issue also flagged the same gap in `DEFAULT_CONTEXT_LENGTHS` and the missing `anthropic.claude-sonnet-5` Bedrock entry — both have since landed on `main`. Only the Opus 5 Bedrock entry was still missing.