### PR TITLE
fix(dashboard): resume loading notice + hydration gate on sanitized PTY payload

### DIFF
--- a/web/src/lib/pty-resume-loading.test.ts
+++ b/web/src/lib/pty-resume-loading.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PTY_RESUME_LOADING_MAX_MS,
+  shouldFinishResumeHydrationOnChunk,
+  shouldShowResumeLoadingOverlay,
+} from "./pty-resume-loading";
+
+describe("shouldFinishResumeHydrationOnChunk", () => {
+  it("finishes on the first non-empty chunk", () => {
+    expect(shouldFinishResumeHydrationOnChunk("")).toBe(false);
+    expect(shouldFinishResumeHydrationOnChunk("hello")).toBe(true);
+  });
+
+  it("keeps a positive hard-cap timeout for wedged resumes", () => {
+    expect(PTY_RESUME_LOADING_MAX_MS).toBeGreaterThan(0);
+  });
+});
+
+describe("shouldShowResumeLoadingOverlay", () => {
+  it("shows while a resume target is connecting or open and still hydrating", () => {
+    expect(
+      shouldShowResumeLoadingOverlay({
+        hasResumeTarget: true,
+        ptyState: "connecting",
+        hydrating: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowResumeLoadingOverlay({
+        hasResumeTarget: true,
+        ptyState: "open",
+        hydrating: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides when there is no resume target", () => {
+    expect(
+      shouldShowResumeLoadingOverlay({
+        hasResumeTarget: false,
+        ptyState: "connecting",
+        hydrating: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides once hydration finishes", () => {
+    expect(
+      shouldShowResumeLoadingOverlay({
+        hasResumeTarget: true,
+        ptyState: "open",
+        hydrating: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("defers to reconnect / closed / ended overlays", () => {
+    for (const ptyState of ["reconnecting", "closed", "ended"] as const) {
+      expect(
+        shouldShowResumeLoadingOverlay({
+          hasResumeTarget: true,
+          ptyState,
+          hydrating: true,
+        }),
+      ).toBe(false);
+    }
+  });
+});

--- a/web/src/lib/pty-resume-loading.test.ts
+++ b/web/src/lib/pty-resume-loading.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { PtyResumeSanitizer } from "./pty-resume-sanitizer";
 import {
   PTY_RESUME_LOADING_MAX_MS,
   shouldFinishResumeHydrationOnChunk,
@@ -15,6 +16,40 @@ describe("shouldFinishResumeHydrationOnChunk", () => {
   it("keeps a positive hard-cap timeout for wedged resumes", () => {
     expect(PTY_RESUME_LOADING_MAX_MS).toBeGreaterThan(0);
   });
+});
+
+describe("resume hydration gate over the real sanitizer", () => {
+  // Regression: the gate must key off the payload actually written to xterm,
+  // not the raw frame. The sanitizer collapses an erase-only / all-newline /
+  // partial-CSI resume frame to "", so a nonempty raw first frame would
+  // otherwise clear the wait notice while the terminal is still blank.
+  const ESC = String.fromCharCode(27);
+  const CRLF = String.fromCharCode(13, 10);
+  const VISIBLE = `Hello world${CRLF}`;
+
+  const controlOnlyFirstFrames: Array<[string, string]> = [
+    ["erase-only", `${ESC}[2K`],
+    ["all-newline", `${CRLF}${CRLF}`],
+    ["partial-CSI", `${ESC}[`],
+  ];
+
+  it.each(controlOnlyFirstFrames)(
+    "keeps hydrating on a %s first frame, then finishes on visible replay",
+    (_label, firstFrame) => {
+      const sanitizer = new PtyResumeSanitizer();
+
+      // Raw first frame is nonempty, but nothing is written to xterm...
+      expect(firstFrame.length).toBeGreaterThan(0);
+      const firstRendered = sanitizer.next(firstFrame);
+      expect(firstRendered).toBe("");
+      expect(shouldFinishResumeHydrationOnChunk(firstRendered)).toBe(false);
+
+      // ...so the notice only clears once real replay output arrives.
+      const secondRendered = sanitizer.next(VISIBLE);
+      expect(secondRendered.length).toBeGreaterThan(0);
+      expect(shouldFinishResumeHydrationOnChunk(secondRendered)).toBe(true);
+    },
+  );
 });
 
 describe("shouldShowResumeLoadingOverlay", () => {

--- a/web/src/lib/pty-resume-loading.ts
+++ b/web/src/lib/pty-resume-loading.ts
@@ -1,0 +1,47 @@
+import type { PtyConnectionState } from "@/lib/pty-reconnect";
+
+/**
+ * Hard cap so a wedged resume (never gets PTY payload) cannot leave the
+ * wait notice up forever.
+ */
+export const PTY_RESUME_LOADING_MAX_MS = 30000;
+
+export const PTY_RESUME_LOADING_MESSAGE =
+  "Please wait while the conversation loads…";
+
+export interface ResumeLoadingOverlayInput {
+  hasResumeTarget: boolean;
+  ptyState: PtyConnectionState;
+  hydrating: boolean;
+}
+
+/**
+ * Show a wait notice only while a resumed chat is still blank. Once the
+ * first real PTY payload arrives the terminal has something to show, so
+ * the notice hides and history can stream in underneath.
+ *
+ * Reconnect / ended / closed states keep their own overlays and must not
+ * stack this one on top.
+ */
+export function shouldShowResumeLoadingOverlay({
+  hasResumeTarget,
+  ptyState,
+  hydrating,
+}: ResumeLoadingOverlayInput): boolean {
+  if (!hasResumeTarget || !hydrating) {
+    return false;
+  }
+  if (
+    ptyState === "reconnecting" ||
+    ptyState === "closed" ||
+    ptyState === "ended"
+  ) {
+    return false;
+  }
+  return ptyState === "connecting" || ptyState === "open";
+}
+
+/** First non-empty PTY chunk means the blank window is over. */
+export function shouldFinishResumeHydrationOnChunk(chunkText: string): boolean {
+  return chunkText.length > 0;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1058,8 +1058,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           : decoder.decode(new Uint8Array(ev.data as ArrayBuffer), {
               stream: true,
             });
-      term.write(resumeParam ? sanitizer.next(text) : text);
-      noteResumePtyChunk(text);
+      // Gate hydration on the payload actually written to xterm. The
+      // sanitizer can turn a nonempty erase-only / all-newline / partial-CSI
+      // resume frame into "" (pty-resume-sanitizer.ts); keying off raw `text`
+      // would hide the wait notice while the terminal is still blank.
+      const rendered = resumeParam ? sanitizer.next(text) : text;
+      term.write(rendered);
+      noteResumePtyChunk(rendered);
     };
 
     ws.onclose = (ev) => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -48,6 +48,12 @@ import {
   shouldReconnectPtyOnPageResume,
 } from "@/lib/pty-reconnect";
 import {
+  PTY_RESUME_LOADING_MAX_MS,
+  PTY_RESUME_LOADING_MESSAGE,
+  shouldFinishResumeHydrationOnChunk,
+  shouldShowResumeLoadingOverlay,
+} from "@/lib/pty-resume-loading";
+import {
   MOBILE_REPLACEMENT_WINDOW_MS,
   normalizePtyMobileInput,
   shouldTreatInputAsMobileReplacement,
@@ -204,6 +210,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const [ptyState, setPtyState] =
     useState<PtyConnectionState>("connecting");
   const ptyStateRef = useRef<PtyConnectionState>("connecting");
+  // True until the first real PTY payload arrives for a resumed session.
+  // Covers the blank terminal + blinking-cursor window so users don't think
+  // chat is broken; clears as soon as there is something to show.
+  const [resumeHydrating, setResumeHydrating] = useState(false);
   const [lastCloseCode, setLastCloseCode] = useState<number | null>(null);
   // NS-504: when the agent process exits cleanly (the user typed `/exit`, or
   // started a new session that ended the current PTY child), the PTY socket
@@ -892,12 +902,42 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     let onDataDisposable: { dispose(): void } | null = null;
     let onResizeDisposable: { dispose(): void } | null = null;
     let eraseSuppressionTimer: ReturnType<typeof setTimeout> | null = null;
+    let resumeMaxTimer: ReturnType<typeof setTimeout> | null = null;
     const clearEraseSuppressionTimer = () => {
       if (eraseSuppressionTimer) {
         clearTimeout(eraseSuppressionTimer);
         eraseSuppressionTimer = null;
       }
     };
+    const clearResumeLoadingTimers = () => {
+      if (resumeMaxTimer) {
+        clearTimeout(resumeMaxTimer);
+        resumeMaxTimer = null;
+      }
+    };
+    const finishResumeHydration = () => {
+      clearResumeLoadingTimers();
+      if (!unmounting) {
+        setResumeHydrating(false);
+      }
+    };
+    const noteResumePtyChunk = (chunkText: string) => {
+      if (!resumeParam || unmounting) {
+        return;
+      }
+      if (shouldFinishResumeHydrationOnChunk(chunkText)) {
+        finishResumeHydration();
+      }
+    };
+    if (resumeParam) {
+      setResumeHydrating(true);
+      resumeMaxTimer = setTimeout(
+        finishResumeHydration,
+        PTY_RESUME_LOADING_MAX_MS,
+      );
+    } else {
+      setResumeHydrating(false);
+    }
     const forceFresh = forceFreshPtyRef.current;
     forceFreshPtyRef.current = false;
     // A connect attempt is now in flight — set synchronously (before the async
@@ -1019,6 +1059,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               stream: true,
             });
       term.write(resumeParam ? sanitizer.next(text) : text);
+      noteResumePtyChunk(text);
     };
 
     ws.onclose = (ev) => {
@@ -1180,6 +1221,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       imageUploadDisposed = true;
       syncMetricsRef.current = null;
       clearEraseSuppressionTimer();
+      clearResumeLoadingTimers();
+      setResumeHydrating(false);
       onDataDisposable?.dispose();
       onResizeDisposable?.dispose();
       mobileInputCleanup?.();
@@ -1354,6 +1397,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const visibleBanner = banner ?? reconnectBanner;
   const showReconnectOverlay =
     ptyState === "reconnecting" || (ptyState === "closed" && !banner);
+  const showResumeLoadingOverlay = shouldShowResumeLoadingOverlay({
+    hasResumeTarget: Boolean(resumeParam),
+    ptyState,
+    hydrating: resumeHydrating,
+  });
   const mobileModelToolsPortal =
     isActive &&
     narrow &&
@@ -1484,6 +1532,19 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
                 >
                   Reconnect now
                 </Button>
+              </div>
+            </div>
+          )}
+
+          {showResumeLoadingOverlay && (
+            <div
+              className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center"
+              role="status"
+              aria-live="polite"
+              aria-label={PTY_RESUME_LOADING_MESSAGE}
+            >
+              <div className="max-w-[min(28rem,calc(100vw-3rem))] border border-current/30 bg-black/80 px-4 py-3 text-center text-xs tracking-wide text-white/85 shadow-lg">
+                {PTY_RESUME_LOADING_MESSAGE}
               </div>
             </div>
           )}


### PR DESCRIPTION
## What this does

Adds the resume wait notice from #74757 and fixes the hydration gate that
cleared it too early.

When resuming a long chat in the web dashboard, the embedded TUI stays blank
with a blinking cursor for a few seconds before history replays. This shows a
"Please wait while the conversation loads…" notice over that blank window and
clears it once real output arrives. A hard-cap timeout still clears a wedged
resume; reconnect / ended / closed overlays keep owning their states.

## The fix on top of the original

The original ended hydration from the raw PTY frame (`text`), while xterm is
written `sanitizer.next(text)`. The resume sanitizer collapses an erase-only,
all-newline, or partial-CSI frame to `""`, so a nonempty raw control frame
hid the notice while the terminal was still blank.

This gates hydration on the payload actually written to xterm (`rendered`),
and adds a regression test over the real `PtyResumeSanitizer` covering a
control-only first frame followed by visible replay output — the case
teknium1 flagged in review.

## Testing

- `cd web && npx vitest run src/lib/pty-resume-loading.test.ts` — 9/9
- Full web suite — 144/144 across 21 files
- `npx tsc -p web --noEmit` — clean

## Credit

Supersedes #74757. Original feature by @xxxigm; hydration-gate fix from
@teknium1's review.

Co-authored-by: xxxigm <tuancanhnguyen706@gmail.com>
