### PR TITLE
fix(desktop): re-sign app ad-hoc without hardenedRuntime after local rebuild (#75422)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3497,6 +3497,14 @@ if [ "$SRC" != "$DST" ]; then
   fi
 fi
 /usr/bin/xattr -dr com.apple.quarantine "$DST" 2>/dev/null || true
+# Ad-hoc + hardenedRuntime (from electron-builder config) is rejected by
+# Gatekeeper.  When APPLE notarization was not configured the build is
+# unsigned, so strip hardened runtime by re-signing ad-hoc without
+# --options runtime.  Already-notarized builds pass codesign --verify and
+# are left untouched.  (#75422)
+if ! /usr/bin/codesign --verify "$DST" 2>/dev/null; then
+  /usr/bin/codesign --force --sign - --deep "$DST" 2>/dev/null || true
+fi
 /usr/bin/open "$DST"
 `
 


### PR DESCRIPTION
## Summary

When APPLE notarization credentials are not configured, `hermes desktop --build-only` produces an ad-hoc + hardenedRuntime signed `.app` bundle. Gatekeeper **flatly rejects** this combination (not just warns), so the swap+relaunch completes but the rebuilt app silently fails to open.

Fixes #75422.

## Root cause

`apps/desktop/package.json` hardcodes `"hardenedRuntime": true` in the mac build config. This is correct for official notarized CI builds, but when running a local rebuild without `APPLE_API_KEY`/`APPLE_API_KEY_ID`/`APPLE_API_ISSUER`, the resulting app is ad-hoc signed with hardened runtime — a combination Gatekeeper rejects entirely.

## Fix

Add a `codesign --verify` check to the macOS swap script in `applyUpdatesPosixInApp()` (`electron/main.ts`). When verification fails (unsigned / ad-hoc signature), re-sign the app with a plain ad-hoc signature (`codesign --force --sign - --deep`), which strips hardened runtime. Already-notarized builds pass verification and are left untouched.

This mirrors the existing `repairMacUpdaterHelper()` pattern, which already handles the same class of problem for the updater helper binary.

## Changes

- `apps/desktop/electron/main.ts`: 8 lines added to the swap script template

## Test plan

- [ ] On macOS without notarization credentials: `hermes update` → app rebuilds, quits, and relaunches successfully
- [ ] On macOS with notarization credentials: `hermes update` → notarized app is not re-signed (codesign --verify passes)
- [ ] `spctl -a -vvv` on the rebuilt app shows "accepted" (not "rejected") for non-notarized builds