### PR TITLE
fix(gateway): prefix all busy-ack messages with [System], including a second priority-path drain site and a slash-command site

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8375,9 +8375,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
             if self._queue_during_drain_enabled():
                 self._queue_or_replace_pending_event(session_key, event)
-                message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                message = f"[System] ⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
             else:
-                message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                message = f"[System] ⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
 
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
@@ -8769,6 +8769,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 mark_seen(_hermes_home / "config.yaml", BUSY_INPUT_FLAG)
         except Exception as _onb_err:
             logger.debug("Failed to apply busy-input onboarding hint: %s", _onb_err)
+
+        # Prefix all busy-ack messages with [System] so the user and the
+        # agent can distinguish automated gateway notices from agent replies.
+        message = "[System] " + message
 
         reply_anchor = self._reply_anchor_for_event(event)
         thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
@@ -14080,9 +14084,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if self._queue_during_drain_enabled():
                     self._queue_or_replace_pending_event(_quick_key, event)
                 return (
-                    f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                    f"[System] ⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
                     if self._queue_during_drain_enabled()
-                    else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                    else f"[System] ⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
             if self._busy_input_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
@@ -14623,7 +14627,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return await self._handle_voice_command(event)
 
         if self._draining:
-            return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
+            return f"[System] ⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
@@ -14880,7 +14884,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _quick_key,
             )
             return (
-                "⏳ This agent is draining for a maintenance action and isn't "
+                "[System] ⏳ This agent is draining for a maintenance action and isn't "
                 "accepting new turns right now. It'll be back in a moment — "
                 "please resend shortly."
             )

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -640,6 +640,8 @@ _SYSTEM_BYPASS_PREFIXES: Tuple[str, ...] = (
 def _is_system_bypass(content: str) -> bool:
     if not content:
         return False
+    if content.startswith("[System] "):
+        content = content[len("[System] "):]
     return any(content.startswith(p) for p in _SYSTEM_BYPASS_PREFIXES)
 
 

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -403,6 +403,144 @@ class TestBusySessionAck:
         assert "10 min" in content  # elapsed
 
 
+class TestBusyAckSystemPrefix:
+    """All busy-ack and drain-ack messages must carry a '[System] ' prefix
+    so users/the agent can distinguish automated gateway notices from agent
+    replies, and so LINE's postback-bypass detection (which strips this
+    prefix before matching) keeps working across every mode."""
+
+    def _content_of(self, adapter):
+        call_kwargs = adapter._send_with_retry.call_args
+        return call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+
+    @pytest.mark.asyncio
+    async def test_interrupt_mode_prefixed(self):
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {}
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Interrupting" in content
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_prefixed(self):
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Queued for the next turn" in content
+
+    @pytest.mark.asyncio
+    async def test_steer_mode_prefixed(self, monkeypatch):
+        import gateway.run as _gr
+
+        monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+        event = _make_event(text="steer this")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Steered" in content
+
+    @pytest.mark.asyncio
+    async def test_subagent_demotion_prefixed(self, monkeypatch):
+        """interrupt demoted to queue because the running agent has active
+        subagents (#30170) — a distinct message branch from plain queue."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[event.source.platform] = adapter
+        monkeypatch.setattr(
+            type(runner), "_agent_has_active_subagents", staticmethod(lambda _agent: True)
+        )
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Subagent working" in content
+
+    @pytest.mark.asyncio
+    async def test_compression_demotion_prefixed(self, monkeypatch):
+        """interrupt demoted to queue because compression is in flight (#56391)."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hi")
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()
+        runner.adapters[event.source.platform] = adapter
+        monkeypatch.setattr(
+            type(runner), "_agent_has_active_subagents", staticmethod(lambda _agent: False)
+        )
+
+        async def _compression_in_flight(_sk):
+            return True
+
+        runner._session_has_compression_in_flight = _compression_in_flight
+
+        with patch("gateway.run.merge_pending_message_event"):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "Compressing context" in content
+
+    @pytest.mark.asyncio
+    async def test_draining_case_prefixed(self):
+        """The draining-case ack is a separate early-return branch from the
+        busy-mode message selection above; it must also carry the prefix."""
+        runner, sentinel = _make_runner()
+        runner._draining = True
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="hello")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        runner._queue_during_drain_enabled = lambda: True
+        runner._status_action_gerund = lambda: "restarting"
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        content = self._content_of(adapter)
+        assert content.startswith("[System] "), content
+        assert "restarting" in content
+
+
 class TestBusySessionOnboardingHint:
     """First-touch hint appended to the busy-ack the first time it fires."""
 

--- a/tests/gateway/test_external_drain_control.py
+++ b/tests/gateway/test_external_drain_control.py
@@ -210,4 +210,43 @@ class TestNewTurnGate:
         result = await runner._handle_message(event)
         assert result is not None
         assert "draining" in result.lower()
+        assert result.startswith("[System] "), (
+            "The external-drain new-turn gate's acknowledgement must carry "
+            "the [System] prefix like every other busy-ack message "
+            f"(review of #68501/#74641): {result!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_priority_active_session_drain_ack_prefixed(self):
+        """Regression (review of #74641): a SEPARATE priority fast-path
+        inside _handle_message() -- reached when a message arrives for a
+        session that ALREADY has a running (non-pending) agent while the
+        gateway is draining -- returns its own bare drain acknowledgement,
+        distinct from both the external-drain gate tested above and
+        _handle_active_session_busy_message()'s prefix logic. Drives the
+        real handler end to end via the session-key routing this specific
+        branch depends on."""
+        from gateway.session import build_session_key
+
+        runner, _ = _drain_runner()
+        runner._draining = True
+        runner._queue_during_drain_enabled = lambda: False
+        runner._status_action_gerund = lambda: "restarting"
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=make_restart_source(),
+            message_id="m2",
+        )
+        sk = build_session_key(event.source)
+        runner._running_agents[sk] = MagicMock()  # active, non-pending agent
+
+        result = await runner._handle_message(event)
+
+        assert result is not None
+        assert "draining" in result.lower() or "restarting" in result.lower()
+        assert result.startswith("[System] "), (
+            "The priority active-session drain acknowledgement must also "
+            f"carry the [System] prefix: {result!r}"
+        )
 

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -243,6 +243,16 @@ class TestSendRouting:
         assert not _is_system_bypass("Hello world")
         assert not _is_system_bypass("")
 
+    def test_system_bypass_recognized_with_system_prefix(self):
+        """gateway/run.py wraps all busy-ack messages with a '[System] '
+        prefix; the bypass check must strip it before matching the known
+        emoji prefixes, or every busy-ack silently stops bypassing the
+        postback cache on LINE."""
+        assert _is_system_bypass("[System] ⚡ Interrupting current run")
+        assert _is_system_bypass("[System] ⏳ Queued — agent is busy")
+        assert _is_system_bypass("[System] ⏩ Steered toward new task")
+        assert not _is_system_bypass("[System] Hello world")
+
 
     def test_send_caps_messages_per_call_at_five(self, adapter):
         # Build a payload that would naturally split into more than 5 LINE


### PR DESCRIPTION
## Context

Supersedes #74641 per @teknium1's review.

## Problem

The prior fix covered the main busy-ack selection logic and one priority-path fast route (the external-drain new-turn gate). Review identified a SEPARATE priority-path branch inside `_handle_message()` -- the "active, non-pending running agent + draining" fast path -- that still returned a bare drain acknowledgement. A full re-sweep also caught a third, previously-unflagged site in the slash-command handler.

## Fix

Fixed all three sites.

## Tests

Replaced the banned `inspect.getsource()` test with two real behavioral tests via the existing `make_restart_runner`/`_drain_runner` infrastructure: extended the existing external-drain gate test with a `[System]`-prefix assertion, and added a new test driving the priority active-session branch end to end. Reverting only the fix reproduces the exact unprefixed bug in both cases.

59/60 pass (1 pre-existing skip, unrelated) across three test files (no regression).