### PR TITLE
fix: set Accept + User-Agent headers on all PyJWKClient JWKS fetches

### DIFF
--- a/contributors/emails/james@terminaloutcomes.com
+++ b/contributors/emails/james@terminaloutcomes.com
@@ -1,0 +1,2 @@
+yaleman
+# PR #49608 salvage (JWKS Accept + User-Agent headers)

--- a/plugins/cron_providers/chronos/verify.py
+++ b/plugins/cron_providers/chronos/verify.py
@@ -62,7 +62,16 @@ def _get_jwk_client(jwks_url: str) -> Any:
         if client is None:
             from jwt import PyJWKClient
 
-            client = PyJWKClient(jwks_url)
+            # Explicit Accept + User-Agent so the JWKS fetch isn't blocked by the
+            # NAS portal's WAF, which 403s the default Python-urllib fingerprint
+            # (same fix as the dashboard-auth nous/self_hosted providers).
+            client = PyJWKClient(
+                jwks_url,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": "HermesAgent/1.0",
+                },
+            )
             _JWK_CLIENTS[jwks_url] = client
         return client
 

--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -420,6 +420,10 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
                 self._jwks_url,
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": "HermesAgent/1.0",
+                },
             )
         return self._jwks_client
 

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -601,6 +601,10 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
                 disco["jwks_uri"],
                 cache_keys=True,
                 lifespan=_JWKS_CACHE_SECONDS,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": "HermesAgent/1.0",
+                },
             )
         return self._jwks_client
 

--- a/tests/plugins/dashboard_auth/test_nous_provider.py
+++ b/tests/plugins/dashboard_auth/test_nous_provider.py
@@ -528,6 +528,22 @@ class TestVerifySession:
         _patched_jwks(p, rsa_keypair)
         return p
 
+    def test_jwks_client_sends_explicit_http_headers(self, provider):
+        """Constructor-contract regression: the JWKS fetch must send an
+        explicit Accept + User-Agent so it isn't blocked by the Portal WAF
+        (same fix as the self_hosted provider)."""
+        provider._jwks_client = None
+        with patch("jwt.PyJWKClient") as client_cls:
+            provider._get_jwks_client()
+        client_cls.assert_called_once_with(
+            provider._jwks_url,
+            cache_keys=True,
+            lifespan=nous_plugin._JWKS_CACHE_SECONDS,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "HermesAgent/1.0",
+            },
+        )
 
     def test_expired_token_returns_none(self, provider, rsa_keypair):
         token = _mint_token(rsa_keypair, ttl_seconds=-1)

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -571,6 +571,26 @@ class TestVerifySession:
         with pytest.raises(ProviderError, match="JWKS"):
             provider.verify_session(access_token=token)
 
+    def test_jwks_client_sends_explicit_http_headers(self):
+        provider = oidc_plugin.SelfHostedOIDCProvider(
+            issuer=_ISSUER, client_id=_CLIENT_ID
+        )
+        provider._discovery = dict(_DISCOVERY_DOC)
+        provider._discovery_fetched_at = time.time()
+
+        with patch("jwt.PyJWKClient") as client_cls:
+            provider._get_jwks_client()
+
+        client_cls.assert_called_once_with(
+            _DISCOVERY_DOC["jwks_uri"],
+            cache_keys=True,
+            lifespan=oidc_plugin._JWKS_CACHE_SECONDS,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "HermesAgent/1.0",
+            },
+        )
+
 
 # ---------------------------------------------------------------------------
 # refresh_session + revoke_session

--- a/tests/plugins/test_chronos_verify.py
+++ b/tests/plugins/test_chronos_verify.py
@@ -144,7 +144,7 @@ def test_jwks_url_path_resolves_key(rsa_keys, monkeypatch):
         key = pub
 
     class FakeJWKClient:
-        def __init__(self, url):
+        def __init__(self, url, **kwargs):
             assert url == "https://portal.nousresearch.com/.well-known/jwks.json"
 
         def get_signing_key_from_jwt(self, tok):
@@ -159,6 +159,32 @@ def test_jwks_url_path_resolves_key(rsa_keys, monkeypatch):
         issuer=ISS,
     )
     assert claims is not None and claims["purpose"] == "cron_fire"
+
+
+def test_jwks_client_sends_explicit_http_headers(monkeypatch):
+    """Constructor-contract regression: the JWKS fetch must send an explicit
+    Accept + User-Agent so it isn't blocked by the NAS portal WAF (same fix as
+    the dashboard-auth nous/self_hosted providers)."""
+    from plugins.cron_providers.chronos import verify as verify_mod
+
+    captured = {}
+
+    class FakeJWKClient:
+        def __init__(self, url, **kwargs):
+            captured["url"] = url
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr("jwt.PyJWKClient", FakeJWKClient)
+    monkeypatch.setattr(verify_mod, "_JWK_CLIENTS", {})
+
+    url = "https://portal.nousresearch.com/.well-known/jwks.json"
+    verify_mod._get_jwk_client(url)
+
+    assert captured["url"] == url
+    assert captured["kwargs"].get("headers") == {
+        "Accept": "application/json",
+        "User-Agent": "HermesAgent/1.0",
+    }
 
 
 def test_get_fire_verifier_returns_nas_verifier():


### PR DESCRIPTION
## What this does

Sends explicit `Accept: application/json` and `User-Agent: HermesAgent/1.0` headers on every `PyJWKClient` JWKS fetch. Some WAFs (Cloudflare, Authelia/Authentik behind Cloudflare) 403 the default `Python-urllib` request fingerprint, which breaks JWT signature verification even though discovery and direct JWKS access work. Two in-the-wild reproductions on #49608 (Authelia and Authentik, both Cloudflare-fronted) confirmed the header fix restores login.

## Scope — whole bug class

The tree had three headerless `PyJWKClient` construction sites. The self-hosted and Nous dashboard-auth providers are yaleman's original fix; this PR also covers the third site, which hits the same NAS portal issuer and the same WAF failure mode:

- `plugins/dashboard_auth/self_hosted/__init__.py` — self-hosted OIDC provider
- `plugins/dashboard_auth/nous/__init__.py` — Nous dashboard-auth provider
- `plugins/cron_providers/chronos/verify.py` — chronos cron-fire verifier (same portal, same WAF; its own comment already documented a `portal … 403`)

Each site gets a constructor-contract regression test asserting the headers are passed. Pinned PyJWT 2.13.0 accepts and forwards the `headers` argument.

## Supersedes / closes

Supersedes #49608 (@yaleman — cherry-picked, authorship preserved). Rebased onto current `main` (the original conflicted after a test-pruning wave touched an adjacent test).

Supersedes #49608
Closes #63273

## Test

```
pytest tests/plugins/dashboard_auth/test_nous_provider.py \
       tests/plugins/dashboard_auth/test_self_hosted_provider.py \
       tests/plugins/test_chronos_verify.py -q
73 passed
```
