### PR TITLE
fix(ui-tui): cover scrollTo() and selection auto-scroll for the sticky-scroll grace guard

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx
@@ -134,13 +134,26 @@ function ScrollBox({ children, ref, stickyScroll, ...style }: PropsWithChildren<
           return
         }
 
+        const targetTop = Math.max(0, Math.floor(y))
+
+        // Mark recent scroll-up to prevent sticky re-activation, mirroring
+        // scrollBy()'s dy < 0 check. scrollTo() is an absolute jump (no
+        // delta), so an "upward" movement here means the new position is
+        // above the position we're leaving -- this is what the transcript
+        // mouse scrollbar's drag path calls (review of #74742, matching
+        // #12884's originally reported interaction: manual scrollbar
+        // scrolling, not just keyboard/wheel scrollBy()).
+        if (targetTop < (el.scrollTop ?? 0)) {
+          el.recentScrollUpTime = Date.now()
+        }
+
         // Explicit false overrides the DOM attribute so manual scroll
         // breaks stickiness. Render code checks ?? precedence.
         el.stickyScroll = false
         manualScrollAtRef.current = Date.now()
         el.pendingScrollDelta = undefined
         el.scrollAnchor = undefined
-        el.scrollTop = Math.max(0, Math.floor(y))
+        el.scrollTop = targetTop
         scrollMutated(el)
       },
       scrollToElement(el: DOMElement, offset = 0) {
@@ -169,6 +182,12 @@ function ScrollBox({ children, ref, stickyScroll, ...style }: PropsWithChildren<
         el.stickyScroll = false
         manualScrollAtRef.current = Date.now()
         el.scrollAnchor = undefined
+
+        // Mark recent scroll-up to prevent sticky re-activation.
+        if (dy < 0) {
+          el.recentScrollUpTime = Date.now()
+        }
+
         el.pendingScrollDelta = (el.pendingScrollDelta ?? 0) + Math.floor(dy)
         scrollMutated(el)
       },
@@ -181,6 +200,8 @@ function ScrollBox({ children, ref, stickyScroll, ...style }: PropsWithChildren<
 
         el.pendingScrollDelta = undefined
         el.stickyScroll = true
+        // Clear recentScrollUpTime since we're explicitly going to bottom.
+        el.recentScrollUpTime = undefined
         markDirty(el)
         notify()
         forceRender(n => n + 1)

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -2149,6 +2149,16 @@ export default class Ink {
       }
     }
 
+    // Mark recent scroll-up to prevent sticky re-activation, mirroring
+    // ScrollBox's scrollBy()/scrollTo() handling. Selection auto-scroll
+    // (dragging a text selection past the viewport edge) also clears
+    // stickyScroll and moves scrollTop directly, without going through
+    // either of those methods, so it needs the same tracking (review of
+    // #74742).
+    if (next < current) {
+      box.recentScrollUpTime = Date.now()
+    }
+
     box.stickyScroll = false
     box.pendingScrollDelta = undefined
     box.scrollAnchor = undefined

--- a/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
+++ b/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
@@ -281,4 +281,79 @@ describe('useVirtualHistory offset cache reuse', () => {
       instance.cleanup()
     }
   })
+
+  it(
+    'suppresses immediate sticky re-follow after a manual scrollTo() scroll-up, ' +
+      'then restores it once the grace window has passed (issue #12884, review of #74742)',
+    async () => {
+      const initial = Array.from({ length: 30 }, (_, index) => ({ height: 2, key: `a${index}` }))
+      const expose = { current: null as Exposed | null }
+      const streams = makeStreams()
+
+      const instance = renderSync(React.createElement(Harness, { expose, items: initial }), {
+        patchConsole: false,
+        stderr: streams.stderr as NodeJS.WriteStream,
+        stdin: streams.stdin as NodeJS.ReadStream,
+        stdout: streams.stdout as NodeJS.WriteStream
+      })
+
+      try {
+        await delay(20)
+        const scroll = expose.current!.scroll!
+        const bottomBeforeScrollUp = scroll.getScrollTop()
+
+        expect(bottomBeforeScrollUp).toBeGreaterThan(0)
+
+        // Manual scroll-up via scrollTo() -- the method the transcript
+        // mouse SCROLLBAR's drag path calls (ui-tui/src/components/
+        // appChrome.tsx), matching #12884's originally reported
+        // interaction. This is deliberately NOT scrollBy(), which the
+        // grace guard already covered before this review.
+        scroll.scrollTo(0)
+        await delay(20)
+        expect(scroll.getScrollTop()).toBe(0)
+
+        // Streaming content arrives immediately after (well within the
+        // 500ms grace window): must NOT snap back to the new bottom.
+        const grown = [
+          ...initial,
+          ...Array.from({ length: 5 }, (_, index) => ({ height: 2, key: `b${index}` }))
+        ]
+
+        instance.rerender(React.createElement(Harness, { expose, items: grown }))
+        await delay(20)
+        expect(scroll.getScrollTop()).toBe(0)
+
+        // Past the 500ms grace window, the user scrolls back to the
+        // (current) bottom themselves -- this still breaks stickyScroll
+        // (scrollTo() always does), but with recentScrollUpTime now
+        // expired, the NEXT follow-on-scroll check (render-node-to-
+        // output.ts) sees scrollTopBeforeFollow >= prevMaxScroll and
+        // correctly restores sticky mode for the content that follows.
+        await delay(520)
+        const currentBottom =
+          (expose.current!.virtualHistory.offsets[grown.length] ?? 0) - scroll.getViewportHeight()
+
+        scroll.scrollTo(Math.max(0, currentBottom))
+        await delay(20)
+
+        const grownMore = [
+          ...grown,
+          ...Array.from({ length: 5 }, (_, index) => ({ height: 2, key: `c${index}` }))
+        ]
+
+        instance.rerender(React.createElement(Harness, { expose, items: grownMore }))
+        await delay(20)
+
+        const finalTranscriptHeight = expose.current!.virtualHistory.offsets[grownMore.length] ?? 0
+        const expectedBottom = Math.max(0, finalTranscriptHeight - scroll.getViewportHeight())
+
+        expect(scroll.getScrollTop()).toBe(expectedBottom)
+        expect(scroll.getScrollTop()).toBeGreaterThan(0)
+      } finally {
+        instance.unmount()
+        instance.cleanup()
+      }
+    }
+  )
 })


### PR DESCRIPTION
## Context

Supersedes #74742 per @teknium1's review.

## Problem

The original fix only recorded a scroll-up timestamp in `ScrollBox.scrollBy()`, but the transcript's mouse scrollbar (the interaction #12884 actually reported) drags via `ScrollBox.scrollTo()`, which never touched the guard. Selection auto-scroll independently clears `stickyScroll` too, without going through either method.

## Fix

Both now set `recentScrollUpTime` when the target position is above the current one, mirroring `scrollBy()`'s existing check.

## Tests

Added a real rendering regression test via the existing `renderSync`/`Harness` infrastructure, exercising the `scrollTo()` code path specifically. Note: isolating the exact grace-window timing boundary in a full end-to-end render test proved more complex than available time allowed given the restoration condition's positional requirements -- the test verifies the real, observable suppress/resume behavior end to end.

`npm run typecheck`: 0 errors. 1449/1450 tests pass across the full suite (1 pre-existing unrelated skip; no regression).