### PR TITLE
fix(tui): preserve named custom provider identity for native vision

### DIFF
--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -27,6 +27,7 @@ import json
 import types
 from unittest.mock import MagicMock, patch
 
+from agent.image_routing import decide_image_input_mode
 import hermes_cli.runtime_provider as rp
 
 MIMO_URL = "https://token-plan-cn.xiaomimimo.com/v1"
@@ -48,6 +49,16 @@ PROVIDERS_DICT_CONFIG = {
         "mimo-v2.5-pro": {
             "api": MIMO_URL,
             "api_key": MIMO_KEY,
+        }
+    }
+}
+
+VISION_CONFIG = {
+    "providers": {
+        "vision-provider": {
+            "api": "https://vision.example.test/v1",
+            "api_key": "test-key",
+            "models": {"vision-model": {"supports_vision": True}},
         }
     }
 }
@@ -152,8 +163,30 @@ class TestResumeRoundTrip:
         )
 
         assert kwargs["provider"] == "custom"
+        assert kwargs["requested_provider"] == "custom:mimo-v2.5-pro"
         assert kwargs["base_url"] == MIMO_URL
         assert kwargs["api_key"] == MIMO_KEY
+
+    def test_named_provider_identity_enables_native_vision(self, monkeypatch):
+        """The Desktop/TUI agent must retain a named provider identity after
+        runtime resolution changes its transport provider to ``custom``."""
+        kwargs = _make_agent_with_override(
+            {"model": "vision-model", "provider": "vision-provider"},
+            monkeypatch,
+            VISION_CONFIG,
+        )
+
+        assert kwargs["provider"] == "custom"
+        assert kwargs["requested_provider"] == "vision-provider"
+        assert (
+            decide_image_input_mode(
+                kwargs["provider"],
+                "vision-model",
+                VISION_CONFIG,
+                requested_provider=kwargs["requested_provider"],
+            )
+            == "native"
+        )
 
     def test_legacy_row_with_bare_custom_heals_via_base_url(self, monkeypatch):
         """Rows persisted BEFORE the fix stored provider="custom"; the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6138,6 +6138,7 @@ def _make_agent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
+        requested_provider=runtime.get("requested_provider"),
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),


### PR DESCRIPTION
## Summary
- forward `requested_provider` when the TUI/Desktop session factory constructs `AIAgent`
- preserve the named custom-provider identity after runtime canonicalization to `custom`
- add regression coverage that verifies a per-model `supports_vision` declaration still selects native image routing

## Why
`resolve_runtime_provider()` correctly retains both the transport provider (`custom`) and the named configuration identity. `tui_gateway._make_agent()` forwarded only the transport provider, so image routing could not resolve per-model capabilities from `providers.<name>.models.<model>`. Vision-capable named custom providers were therefore downgraded to auxiliary `vision_analyze` preprocessing.

This mirrors the same `requested_provider` handoff already used by CLI/oneshot paths and complements #70313, which fixes a separate CLI background-task construction path.

## Test plan
- [x] `pytest -q tests/tui_gateway/test_custom_provider_session_persistence.py::TestResumeRoundTrip::test_round_trip_restores_entry_credentials tests/tui_gateway/test_custom_provider_session_persistence.py::TestResumeRoundTrip::test_named_provider_identity_enables_native_vision`
- [x] Verified `git diff --check`

Related to #69894 and #70313.