### PR TITLE
fix(tts): retry transient Gemini failures

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1319,7 +1319,7 @@ platform_toolsets:
 #   gemini:
 #     model: "gemini-3.1-flash-tts-preview"
 #     voice: "Kore"
-#     max_attempts: 3          # transient request/read failures
+#     max_attempts: 4          # transient request/read/HTTP failures
 #     timeout: 60              # per-attempt seconds
 #     retry_delay_seconds: 1.0
 #     audio_tags: false

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1319,9 +1319,9 @@ platform_toolsets:
 #   gemini:
 #     model: "gemini-3.1-flash-tts-preview"
 #     voice: "Kore"
-#     max_attempts: 4          # transient request/read/HTTP failures
-#     timeout: 60              # per-attempt seconds
-#     retry_delay_seconds: 1.0
+#     max_attempts: 4          # transient failures; clamped to 1-10
+#     timeout: 60              # connect/read inactivity; clamped to 1-300s
+#     retry_delay_seconds: 1.0 # clamped to 0-60s
 #     audio_tags: false
 #     persona_prompt_file: ""  # e.g. ~/.hermes/tts/radio-host.md
 #   xai:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1319,6 +1319,9 @@ platform_toolsets:
 #   gemini:
 #     model: "gemini-3.1-flash-tts-preview"
 #     voice: "Kore"
+#     max_attempts: 3          # transient request/read failures
+#     timeout: 60              # per-attempt seconds
+#     retry_delay_seconds: 1.0
 #     audio_tags: false
 #     persona_prompt_file: ""  # e.g. ~/.hermes/tts/radio-host.md
 #   xai:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1130,6 +1130,9 @@ platform_toolsets:
 #   gemini:
 #     model: "gemini-3.1-flash-tts-preview"
 #     voice: "Kore"
+#     max_attempts: 3          # transient request/read failures
+#     timeout: 60              # per-attempt seconds
+#     retry_delay_seconds: 1.0
 #     audio_tags: false
 #     persona_prompt_file: ""  # e.g. ~/.hermes/tts/radio-host.md
 #   xai:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6466,6 +6466,7 @@ class BasePlatformAdapter(ABC):
                 _tts_paths: List[str] = []
                 _tts_requested_path = None
                 _tts_error_notice = None
+                _tts_cleanup_paths = set()
                 if (self._should_auto_tts_for_chat(event.source.chat_id)
                         and event.message_type == MessageType.VOICE
                         and text_content
@@ -6504,23 +6505,37 @@ class BasePlatformAdapter(ABC):
                             raw_tts_paths = tts_data.get("file_paths") or [
                                 tts_data.get("file_path")
                             ]
-                            _tts_paths = [
-                                str(path) for path in raw_tts_paths
-                                if path and Path(path).exists()
+                            declared_tts_paths = [
+                                str(path) for path in raw_tts_paths if path
                             ]
-                            _tts_path = _tts_paths[0] if _tts_paths else None
+                            _tts_cleanup_paths.update(declared_tts_paths)
+                            if (
+                                len(declared_tts_paths) != len(raw_tts_paths)
+                                or not declared_tts_paths
+                                or any(
+                                    not Path(path).exists()
+                                    for path in declared_tts_paths
+                                )
+                            ):
+                                raise RuntimeError(
+                                    "TTS generation reported success without a complete "
+                                    "set of usable audio output files"
+                                )
+                            _tts_paths = declared_tts_paths
                         else:
                             raise RuntimeError("TTS provider requirements are unavailable")
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
                         _tts_error_notice = (
-                            "Audio was not sent because TTS failed with the "
+                            "Audio could not be fully delivered because TTS failed with the "
                             "configured provider."
                         )
 
                 # Play TTS audio before text (voice-first experience)
                 _tts_caption_delivered = False
-                _tts_cleanup_paths = {_tts_requested_path, *_tts_paths} - {None}
+                _tts_cleanup_paths.update(
+                    {_tts_requested_path, *_tts_paths} - {None}
+                )
                 for _tts_index, _tts_path in enumerate(_tts_paths):
                     try:
                         # Caption eligibility and payload stay on the ORIGINAL
@@ -6551,7 +6566,7 @@ class BasePlatformAdapter(ABC):
                                 self.name,
                             )
                             _tts_error_notice = (
-                                "Audio was not sent because TTS failed with the "
+                                "Audio could not be fully delivered because TTS failed with the "
                                 "configured provider."
                             )
                             break
@@ -6568,7 +6583,7 @@ class BasePlatformAdapter(ABC):
                             type(tts_delivery_error).__name__,
                         )
                         _tts_error_notice = (
-                            "Audio was not sent because TTS failed with the "
+                            "Audio could not be fully delivered because TTS failed with the "
                             "configured provider."
                         )
                         break

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6509,6 +6509,8 @@ class BasePlatformAdapter(ABC):
                                 if path and Path(path).exists()
                             ]
                             _tts_path = _tts_paths[0] if _tts_paths else None
+                        else:
+                            raise RuntimeError("TTS provider requirements are unavailable")
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
                         _tts_error_notice = (

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6465,6 +6465,7 @@ class BasePlatformAdapter(ABC):
                 _tts_path = None
                 _tts_paths: List[str] = []
                 _tts_requested_path = None
+                _tts_error_notice = None
                 if (self._should_auto_tts_for_chat(event.source.chat_id)
                         and event.message_type == MessageType.VOICE
                         and text_content
@@ -6496,17 +6497,24 @@ class BasePlatformAdapter(ABC):
                                 output_path=_tts_requested_path,
                             )
                             tts_data = _json.loads(tts_result_str)
-                            if tts_data.get("success", True):
-                                raw_tts_paths = tts_data.get("file_paths") or [
-                                    tts_data.get("file_path")
-                                ]
-                                _tts_paths = [
-                                    str(path) for path in raw_tts_paths
-                                    if path and Path(path).exists()
-                                ]
-                                _tts_path = _tts_paths[0] if _tts_paths else None
+                            if not tts_data.get("success", False):
+                                raise RuntimeError(
+                                    tts_data.get("error") or "TTS tool returned success=false"
+                                )
+                            raw_tts_paths = tts_data.get("file_paths") or [
+                                tts_data.get("file_path")
+                            ]
+                            _tts_paths = [
+                                str(path) for path in raw_tts_paths
+                                if path and Path(path).exists()
+                            ]
+                            _tts_path = _tts_paths[0] if _tts_paths else None
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
+                        _tts_error_notice = (
+                            "Audio was not sent because TTS failed with the "
+                            "configured provider."
+                        )
 
                 # Play TTS audio before text (voice-first experience)
                 _tts_caption_delivered = False
@@ -6558,6 +6566,9 @@ class BasePlatformAdapter(ABC):
                 # adapter while its in-flight handler was still producing a
                 # final response; that response is a new message, so resolve
                 # the current transport before sending it.
+                if _tts_error_notice and text_content and not _tts_caption_delivered:
+                    text_content = f"{_tts_error_notice}\n\n{text_content}"
+
                 if text_content and not _tts_caption_delivered:
                     delivery_adapter = self._final_delivery_adapter(event.source)
                     logger.info(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6545,24 +6545,44 @@ class BasePlatformAdapter(ABC):
                             metadata=_final_thread_metadata,
                         )
                         _record_delivery(tts_result)
-                        _tts_caption_delivered = bool(
-                            _tts_caption_delivered
-                            or (
-                                telegram_tts_caption
-                                and getattr(tts_result, "success", False)
+                        if not getattr(tts_result, "success", False):
+                            logger.warning(
+                                "[%s] Auto-TTS delivery returned success=false",
+                                self.name,
                             )
+                            _tts_error_notice = (
+                                "Audio was not sent because TTS failed with the "
+                                "configured provider."
+                            )
+                            break
+                        _tts_caption_delivered = bool(
+                            _tts_caption_delivered or telegram_tts_caption
                         )
+                    except Exception as tts_delivery_error:
+                        # Platform exceptions can include sensitive backend
+                        # details. Keep the original text reply deliverable and
+                        # log only the failure class.
+                        logger.warning(
+                            "[%s] Auto-TTS delivery failed (%s)",
+                            self.name,
+                            type(tts_delivery_error).__name__,
+                        )
+                        _tts_error_notice = (
+                            "Audio was not sent because TTS failed with the "
+                            "configured provider."
+                        )
+                        break
                     finally:
                         try:
                             os.remove(_tts_path)
                         except OSError:
                             pass
-                if not _tts_paths and _tts_cleanup_paths:
-                    for _cleanup_path in _tts_cleanup_paths:
-                        try:
-                            os.remove(_cleanup_path)
-                        except OSError:
-                            pass
+                        _tts_cleanup_paths.discard(_tts_path)
+                for _cleanup_path in _tts_cleanup_paths:
+                    try:
+                        os.remove(_cleanup_path)
+                    except OSError:
+                        pass
 
                 # Send the text portion. A reconnect may have replaced this
                 # adapter while its in-flight handler was still producing a

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5970,6 +5970,8 @@ class BasePlatformAdapter(ABC):
                                     tts_data.get("error") or "TTS tool returned success=false"
                                 )
                             _tts_path = tts_data.get("file_path") or _tts_requested_path
+                        else:
+                            raise RuntimeError("TTS provider requirements are unavailable")
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
                         _tts_error_notice = (

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5933,6 +5933,7 @@ class BasePlatformAdapter(ABC):
                 # (#60671) — the gateway streaming-TTS consumer sets the flag.
                 _tts_path = None
                 _tts_requested_path = None
+                _tts_error_notice = None
                 if (self._should_auto_tts_for_chat(event.source.chat_id)
                         and event.message_type == MessageType.VOICE
                         and text_content
@@ -5964,10 +5965,17 @@ class BasePlatformAdapter(ABC):
                                 output_path=_tts_requested_path,
                             )
                             tts_data = _json.loads(tts_result_str)
-                            if tts_data.get("success", True):
-                                _tts_path = tts_data.get("file_path") or _tts_requested_path
+                            if not tts_data.get("success", False):
+                                raise RuntimeError(
+                                    tts_data.get("error") or "TTS tool returned success=false"
+                                )
+                            _tts_path = tts_data.get("file_path") or _tts_requested_path
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
+                        _tts_error_notice = (
+                            "Audio was not sent because TTS failed with the "
+                            "configured provider."
+                        )
 
                 # Play TTS audio before text (voice-first experience)
                 _tts_caption_delivered = False
@@ -6013,6 +6021,9 @@ class BasePlatformAdapter(ABC):
                 # adapter while its in-flight handler was still producing a
                 # final response; that response is a new message, so resolve
                 # the current transport before sending it.
+                if _tts_error_notice and text_content and not _tts_caption_delivered:
+                    text_content = f"{_tts_error_notice}\n\n{text_content}"
+
                 if text_content and not _tts_caption_delivered:
                     delivery_adapter = self._final_delivery_adapter(event.source)
                     logger.info(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1653,9 +1653,9 @@ DEFAULT_CONFIG = {
         "gemini": {
             "model": "gemini-2.5-flash-preview-tts",
             "voice": "Kore",
-            "max_attempts": 4,
-            "timeout": 60,
-            "retry_delay_seconds": 1.0,
+            "max_attempts": 4,  # Clamped to 1-10.
+            "timeout": 60,  # Connect/read-inactivity seconds; clamped to 1-300.
+            "retry_delay_seconds": 1.0,  # Clamped to 0-60 seconds.
             # When true, Gemini 3.1 TTS uses a hidden auxiliary-model rewrite
             # pass to insert freeform square-bracket audio tags into the TTS
             # script. Visible chat replies are unchanged.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1627,9 +1627,10 @@ DEFAULT_CONFIG = {
 
     # Text-to-speech configuration
     # Each provider supports an optional `max_text_length:` override for the
-    # per-request input-character cap. Omit it to use the provider's documented
-    # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
-    # Gemini 32000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
+    # per-request input-character cap. Omit it to use the provider's default
+    # limits: OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k
+    # model-aware, Gemini practical sync cap 2000, Edge 5000, Mistral 4000,
+    # and NeuTTS/KittenTTS 2000.
     "tts": {
         # Set explicitly to pin a backend:
         # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
@@ -1652,6 +1653,9 @@ DEFAULT_CONFIG = {
         "gemini": {
             "model": "gemini-2.5-flash-preview-tts",
             "voice": "Kore",
+            "max_attempts": 4,
+            "timeout": 60,
+            "retry_delay_seconds": 1.0,
             # When true, Gemini 3.1 TTS uses a hidden auxiliary-model rewrite
             # pass to insert freeform square-bracket audio tags into the TTS
             # script. Visible chat replies are unchanged.

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -147,3 +147,27 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
         "\n\nreply text"
     )
     assert "backend exploded" not in adapter.sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_base_auto_tts_reports_unavailable_requirements():
+    adapter = _DummyAdapter(Platform.DISCORD)
+    adapter._keep_typing = _hold_typing()
+    adapter._should_auto_tts_for_chat = lambda _chat_id: True
+    adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="tts-1"))
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="reply text"))
+    event = _make_voice_event(Platform.DISCORD)
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=False), patch(
+        "tools.tts_tool.text_to_speech_tool"
+    ) as mock_tts:
+        await adapter._process_message_background(
+            event, build_session_key(event.source)
+        )
+
+    mock_tts.assert_not_called()
+    adapter.play_tts.assert_not_awaited()
+    assert adapter.sent and adapter.sent[0]["content"] == (
+        "Audio was not sent because TTS failed with the configured provider."
+        "\n\nreply text"
+    )

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -92,7 +92,7 @@ def test_output_path_is_mp3_for_non_opus_platforms(platform):
 
 async def _run_auto_tts(adapter: _DummyAdapter, platform: Platform):
     adapter._keep_typing = _hold_typing()
-    adapter._should_auto_tts_for_chat = lambda _chat_id: True
+    adapter._should_auto_tts_for_chat = lambda chat_id: True
     adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="tts-1"))
     long_reply = "x" * 2000  # avoid the telegram caption-collapse path
     adapter.set_message_handler(lambda _event: asyncio.sleep(0, result=long_reply))
@@ -120,7 +120,7 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
     """A success=False tool result must not deliver a stale/partial file."""
     adapter = _DummyAdapter(Platform.TELEGRAM)
     adapter._keep_typing = _hold_typing()
-    adapter._should_auto_tts_for_chat = lambda _chat_id: True
+    adapter._should_auto_tts_for_chat = lambda chat_id: True
     adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="tts-1"))
     adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="reply text"))
     event = _make_voice_event(Platform.TELEGRAM)
@@ -153,7 +153,7 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
 async def test_base_auto_tts_reports_unavailable_requirements():
     adapter = _DummyAdapter(Platform.DISCORD)
     adapter._keep_typing = _hold_typing()
-    adapter._should_auto_tts_for_chat = lambda _chat_id: True
+    adapter._should_auto_tts_for_chat = lambda chat_id: True
     adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="tts-1"))
     adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="reply text"))
     event = _make_voice_event(Platform.DISCORD)
@@ -171,3 +171,75 @@ async def test_base_auto_tts_reports_unavailable_requirements():
         "Audio was not sent because TTS failed with the configured provider."
         "\n\nreply text"
     )
+
+
+@pytest.mark.asyncio
+async def test_base_auto_tts_recovers_from_playback_exception_and_cleans_all_files(
+    tmp_path,
+):
+    adapter = _DummyAdapter(Platform.DISCORD)
+    adapter._keep_typing = _hold_typing()
+    adapter._should_auto_tts_for_chat = lambda chat_id: True
+    adapter.play_tts = AsyncMock(
+        side_effect=RuntimeError("upload rejected: internal-platform-detail")
+    )
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="reply text"))
+    event = _make_voice_event(Platform.DISCORD)
+    audio_paths = [tmp_path / "part-1.mp3", tmp_path / "part-2.mp3"]
+
+    def fake_tts(*, text, output_path=None):
+        for path in audio_paths:
+            path.write_bytes(b"fake audio")
+        return json.dumps(
+            {"success": True, "file_paths": [str(path) for path in audio_paths]}
+        )
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+        "tools.tts_tool.text_to_speech_tool", side_effect=fake_tts
+    ):
+        await adapter._process_message_background(
+            event, build_session_key(event.source)
+        )
+
+    adapter.play_tts.assert_awaited_once()
+    assert adapter.sent and adapter.sent[0]["content"] == (
+        "Audio was not sent because TTS failed with the configured provider."
+        "\n\nreply text"
+    )
+    assert "internal-platform-detail" not in adapter.sent[0]["content"]
+    assert all(not path.exists() for path in audio_paths)
+
+
+@pytest.mark.asyncio
+async def test_base_auto_tts_reports_unsuccessful_playback(tmp_path):
+    adapter = _DummyAdapter(Platform.DISCORD)
+    adapter._keep_typing = _hold_typing()
+    adapter._should_auto_tts_for_chat = lambda chat_id: True
+    adapter.play_tts = AsyncMock(
+        return_value=SendResult(
+            success=False,
+            error="upload rejected: internal-platform-detail",
+        )
+    )
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="reply text"))
+    event = _make_voice_event(Platform.DISCORD)
+    audio_path = tmp_path / "part-1.mp3"
+
+    def fake_tts(*, text, output_path=None):
+        audio_path.write_bytes(b"fake audio")
+        return json.dumps({"success": True, "file_path": str(audio_path)})
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+        "tools.tts_tool.text_to_speech_tool", side_effect=fake_tts
+    ):
+        await adapter._process_message_background(
+            event, build_session_key(event.source)
+        )
+
+    adapter.play_tts.assert_awaited_once()
+    assert adapter.sent and adapter.sent[0]["content"] == (
+        "Audio was not sent because TTS failed with the configured provider."
+        "\n\nreply text"
+    )
+    assert "internal-platform-detail" not in adapter.sent[0]["content"]
+    assert not audio_path.exists()

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -143,7 +143,8 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
     # silently dropping the requested audio. Internal provider details stay in
     # logs instead of being exposed in the chat response.
     assert adapter.sent and adapter.sent[0]["content"] == (
-        "Audio was not sent because TTS failed with the configured provider."
+        "Audio could not be fully delivered because TTS failed with the "
+        "configured provider."
         "\n\nreply text"
     )
     assert "backend exploded" not in adapter.sent[0]["content"]
@@ -168,9 +169,77 @@ async def test_base_auto_tts_reports_unavailable_requirements():
     mock_tts.assert_not_called()
     adapter.play_tts.assert_not_awaited()
     assert adapter.sent and adapter.sent[0]["content"] == (
-        "Audio was not sent because TTS failed with the configured provider."
+        "Audio could not be fully delivered because TTS failed with the "
+        "configured provider."
         "\n\nreply text"
     )
+
+
+@pytest.mark.asyncio
+async def test_base_auto_tts_reports_missing_generated_audio_path(tmp_path):
+    adapter = _DummyAdapter(Platform.DISCORD)
+    adapter._keep_typing = _hold_typing()
+    adapter._should_auto_tts_for_chat = lambda chat_id: True
+    adapter.play_tts = AsyncMock(
+        return_value=SendResult(success=True, message_id="tts-1")
+    )
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="reply text"))
+    event = _make_voice_event(Platform.DISCORD)
+    missing_path = tmp_path / "missing.mp3"
+
+    def fake_tts(*, text, output_path=None):
+        return json.dumps({"success": True, "file_path": str(missing_path)})
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+        "tools.tts_tool.text_to_speech_tool", side_effect=fake_tts
+    ):
+        await adapter._process_message_background(
+            event, build_session_key(event.source)
+        )
+
+    adapter.play_tts.assert_not_awaited()
+    assert adapter.sent and adapter.sent[0]["content"] == (
+        "Audio could not be fully delivered because TTS failed with the "
+        "configured provider."
+        "\n\nreply text"
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_auto_tts_reports_partial_generated_audio_paths(tmp_path):
+    adapter = _DummyAdapter(Platform.DISCORD)
+    adapter._keep_typing = _hold_typing()
+    adapter._should_auto_tts_for_chat = lambda chat_id: True
+    adapter.play_tts = AsyncMock(
+        return_value=SendResult(success=True, message_id="tts-1")
+    )
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="reply text"))
+    event = _make_voice_event(Platform.DISCORD)
+    existing_path = tmp_path / "part-1.mp3"
+    missing_path = tmp_path / "part-2.mp3"
+
+    def fake_tts(*, text, output_path=None):
+        existing_path.write_bytes(b"fake audio")
+        return json.dumps({
+            "success": True,
+            "file_paths": [str(existing_path), str(missing_path)],
+        })
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+        "tools.tts_tool.text_to_speech_tool", side_effect=fake_tts
+    ):
+        await adapter._process_message_background(
+            event, build_session_key(event.source)
+        )
+
+    adapter.play_tts.assert_not_awaited()
+    assert adapter.sent and adapter.sent[0]["content"] == (
+        "Audio could not be fully delivered because TTS failed with the "
+        "configured provider."
+        "\n\nreply text"
+    )
+    assert not existing_path.exists()
+    assert not missing_path.exists()
 
 
 @pytest.mark.asyncio
@@ -203,7 +272,8 @@ async def test_base_auto_tts_recovers_from_playback_exception_and_cleans_all_fil
 
     adapter.play_tts.assert_awaited_once()
     assert adapter.sent and adapter.sent[0]["content"] == (
-        "Audio was not sent because TTS failed with the configured provider."
+        "Audio could not be fully delivered because TTS failed with the "
+        "configured provider."
         "\n\nreply text"
     )
     assert "internal-platform-detail" not in adapter.sent[0]["content"]
@@ -238,7 +308,8 @@ async def test_base_auto_tts_reports_unsuccessful_playback(tmp_path):
 
     adapter.play_tts.assert_awaited_once()
     assert adapter.sent and adapter.sent[0]["content"] == (
-        "Audio was not sent because TTS failed with the configured provider."
+        "Audio could not be fully delivered because TTS failed with the "
+        "configured provider."
         "\n\nreply text"
     )
     assert "internal-platform-detail" not in adapter.sent[0]["content"]

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -139,5 +139,11 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
         )
 
     adapter.play_tts.assert_not_awaited()
-    # Text reply still goes out.
-    assert adapter.sent and adapter.sent[0]["content"] == "reply text"
+    # Text reply still goes out, with a user-visible explanation rather than
+    # silently dropping the requested audio. Internal provider details stay in
+    # logs instead of being exposed in the chat response.
+    assert adapter.sent and adapter.sent[0]["content"] == (
+        "Audio was not sent because TTS failed with the configured provider."
+        "\n\nreply text"
+    )
+    assert "backend exploded" not in adapter.sent[0]["content"]

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -118,6 +118,22 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("tts.gemini.max_attempts", "4"),
+            ("tts.gemini.timeout", "60"),
+            ("tts.gemini.retry_delay_seconds", "1.0"),
+        ],
+    )
+    def test_gemini_retry_settings_are_recognized(
+        self, key, value, _isolated_hermes_home, capsys
+    ):
+        set_config_value(key, value)
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert key.rsplit(".", 1)[-1] in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -323,6 +323,39 @@ class TestGenerateGeminiTts:
         assert mock_post.call_count == 4
         assert (tmp_path / "test.wav").exists()
 
+    def test_nonfinite_retry_config_uses_safe_defaults(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        output = tmp_path / "test.wav"
+        unavailable = MagicMock()
+        unavailable.status_code = 503
+        unavailable.headers = {}
+        unavailable.json.return_value = {"error": {"message": "try later"}}
+
+        with patch(
+            "requests.post",
+            side_effect=[unavailable, mock_gemini_response],
+        ) as mock_post, patch("time.sleep") as mock_sleep:
+            _generate_gemini_tts(
+                "Hi",
+                str(output),
+                {
+                    "gemini": {
+                        "max_attempts": float("inf"),
+                        "timeout": float("nan"),
+                        "retry_delay_seconds": float("inf"),
+                    }
+                },
+            )
+
+        assert mock_post.call_count == 2
+        assert all(call.kwargs["timeout"] == 60.0 for call in mock_post.call_args_list)
+        mock_sleep.assert_called_once_with(1.0)
+        assert output.exists()
+
     def test_persona_prompt_does_not_consume_transcript_chunk_budget(
         self, tmp_path, monkeypatch, mock_gemini_response
     ):

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -220,6 +220,45 @@ class TestGenerateGeminiTts:
         mock_sleep.assert_not_called()
         assert (tmp_path / "test.wav").exists()
 
+    def test_retries_transient_http_status_then_succeeds(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        unavailable = MagicMock()
+        unavailable.status_code = 503
+        unavailable.headers = {"Retry-After": "0"}
+        unavailable.json.return_value = {"error": {"message": "try later"}}
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch(
+            "requests.post",
+            side_effect=[unavailable, mock_gemini_response],
+        ) as mock_post, patch("time.sleep") as mock_sleep:
+            _generate_gemini_tts(
+                "Hi",
+                str(tmp_path / "test.wav"),
+                {"gemini": {"max_attempts": 3}},
+            )
+
+        assert mock_post.call_count == 2
+        mock_sleep.assert_not_called()
+
+    def test_does_not_retry_deterministic_http_error(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_gemini_tts
+
+        bad_request = MagicMock()
+        bad_request.status_code = 400
+        bad_request.headers = {}
+        bad_request.json.return_value = {"error": {"message": "Invalid voice"}}
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch("requests.post", return_value=bad_request) as mock_post:
+            with pytest.raises(RuntimeError, match="HTTP 400.*Invalid voice"):
+                _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), {})
+
+        mock_post.assert_called_once()
+
     def test_raises_after_configured_attempts(
         self, tmp_path, monkeypatch, caplog
     ):

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -356,6 +356,89 @@ class TestGenerateGeminiTts:
         mock_sleep.assert_called_once_with(1.0)
         assert output.exists()
 
+    def test_enormous_integer_retry_config_uses_safe_defaults(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        unavailable = MagicMock()
+        unavailable.status_code = 503
+        unavailable.headers = {}
+        unavailable.json.return_value = {"error": {"message": "try later"}}
+
+        with patch(
+            "requests.post",
+            side_effect=[unavailable, mock_gemini_response],
+        ) as mock_post, patch("time.sleep") as mock_sleep:
+            _generate_gemini_tts(
+                "Hi",
+                str(tmp_path / "test.wav"),
+                {
+                    "gemini": {
+                        "timeout": 10**400,
+                        "retry_delay_seconds": 10**400,
+                    }
+                },
+            )
+
+        assert mock_post.call_count == 2
+        assert all(call.kwargs["timeout"] == 60.0 for call in mock_post.call_args_list)
+        mock_sleep.assert_called_once_with(1.0)
+
+    def test_oversized_retry_config_is_bounded(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        unavailable = MagicMock()
+        unavailable.status_code = 503
+        unavailable.headers = {}
+        unavailable.json.return_value = {"error": {"message": "try later"}}
+
+        with patch(
+            "requests.post",
+            side_effect=[unavailable, mock_gemini_response],
+        ) as mock_post, patch("time.sleep") as mock_sleep:
+            _generate_gemini_tts(
+                "Hi",
+                str(tmp_path / "test.wav"),
+                {
+                    "gemini": {
+                        "max_attempts": 1_000_000,
+                        "timeout": 1_000_000,
+                        "retry_delay_seconds": 1_000_000,
+                    }
+                },
+            )
+
+        assert mock_post.call_count == 2
+        assert all(call.kwargs["timeout"] == 300.0 for call in mock_post.call_args_list)
+        mock_sleep.assert_called_once_with(60.0)
+
+    def test_oversized_attempt_budget_is_capped(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        with patch(
+            "requests.post",
+            side_effect=requests.exceptions.ReadTimeout("slow"),
+        ) as mock_post, patch("time.sleep"):
+            with pytest.raises(RuntimeError, match="failed after 10 attempts"):
+                _generate_gemini_tts(
+                    "Hi",
+                    str(tmp_path / "test.wav"),
+                    {
+                        "gemini": {
+                            "max_attempts": 1_000_000,
+                            "retry_delay_seconds": 0,
+                        }
+                    },
+                )
+
+        assert mock_post.call_count == 10
+
     def test_persona_prompt_does_not_consume_transcript_chunk_budget(
         self, tmp_path, monkeypatch, mock_gemini_response
     ):

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 
 @pytest.fixture(autouse=True)
@@ -165,6 +166,81 @@ class TestGenerateGeminiTts:
         )
         assert voice == "Puck"
 
+    def test_retries_request_exceptions_then_succeeds(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        output_path = str(tmp_path / "test.wav")
+
+        with patch(
+            "requests.post",
+            side_effect=[requests.exceptions.ReadTimeout("slow"), mock_gemini_response],
+        ) as mock_post, patch("time.sleep") as mock_sleep:
+            _generate_gemini_tts(
+                "Hi",
+                output_path,
+                {"gemini": {"max_attempts": 3, "retry_delay_seconds": 0}},
+            )
+
+        assert mock_post.call_count == 2
+        mock_sleep.assert_not_called()
+        assert (tmp_path / "test.wav").exists()
+
+    def test_retries_stream_read_timeout_then_succeeds(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        class TimeoutResponse:
+            status_code = 200
+
+            def iter_content(self, chunk_size):
+                raise requests.exceptions.ReadTimeout("stream stalled")
+                yield  # pragma: no cover - makes this a generator
+
+            def close(self):
+                pass
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        output_path = str(tmp_path / "test.wav")
+
+        with patch(
+            "requests.post",
+            side_effect=[TimeoutResponse(), mock_gemini_response],
+        ) as mock_post, patch("time.sleep") as mock_sleep:
+            _generate_gemini_tts(
+                "Hi",
+                output_path,
+                {"gemini": {"max_attempts": 3, "retry_delay_seconds": 0}},
+            )
+
+        assert mock_post.call_count == 2
+        mock_sleep.assert_not_called()
+        assert (tmp_path / "test.wav").exists()
+
+    def test_raises_after_configured_attempts(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch(
+            "requests.post",
+            side_effect=requests.exceptions.ReadTimeout("slow"),
+        ) as mock_post, patch("time.sleep") as mock_sleep:
+            with pytest.raises(RuntimeError, match="Gemini TTS failed after 3 attempts"):
+                _generate_gemini_tts(
+                    "Hi",
+                    str(tmp_path / "test.wav"),
+                    {"gemini": {"max_attempts": 3, "retry_delay_seconds": 0}},
+                )
+
+        assert mock_post.call_count == 3
+        mock_sleep.assert_not_called()
+        assert "slow" not in caplog.text
 
     def test_audio_tag_rewrite_failure_falls_back_to_original_text(
         self, tmp_path, monkeypatch, mock_gemini_response, caplog

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -244,6 +244,55 @@ class TestGenerateGeminiTts:
         assert mock_post.call_count == 2
         mock_sleep.assert_not_called()
 
+    def test_honors_bounded_http_date_retry_after(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from datetime import datetime, timedelta, timezone
+        from email.utils import format_datetime
+        from tools.tts_tool import _generate_gemini_tts
+
+        unavailable = MagicMock()
+        unavailable.status_code = 503
+        unavailable.headers = {
+            "Retry-After": format_datetime(
+                datetime.now(timezone.utc) + timedelta(minutes=2),
+                usegmt=True,
+            )
+        }
+        unavailable.json.return_value = {"error": {"message": "try later"}}
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch(
+            "requests.post",
+            side_effect=[unavailable, mock_gemini_response],
+        ), patch("time.sleep") as mock_sleep:
+            _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), {})
+
+        mock_sleep.assert_called_once_with(60.0)
+
+    def test_malformed_retry_after_uses_configured_delay(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        unavailable = MagicMock()
+        unavailable.status_code = 503
+        unavailable.headers = {"Retry-After": "not-a-delay"}
+        unavailable.json.return_value = {"error": {"message": "try later"}}
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch(
+            "requests.post",
+            side_effect=[unavailable, mock_gemini_response],
+        ), patch("time.sleep") as mock_sleep:
+            _generate_gemini_tts(
+                "Hi",
+                str(tmp_path / "test.wav"),
+                {"gemini": {"retry_delay_seconds": 0.25}},
+            )
+
+        mock_sleep.assert_called_once_with(0.25)
+
     def test_default_budget_recovers_from_timeouts_then_transient_http(
         self, tmp_path, monkeypatch, mock_gemini_response
     ):

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -244,6 +244,55 @@ class TestGenerateGeminiTts:
         assert mock_post.call_count == 2
         mock_sleep.assert_not_called()
 
+    def test_default_budget_recovers_from_timeouts_then_transient_http(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        """Regression for the Aug 19 production sequence: timeout, timeout, 500."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        transient = MagicMock()
+        transient.status_code = 500
+        transient.headers = {}
+        transient.json.return_value = {"error": {"message": "internal error"}}
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+
+        with patch(
+            "requests.post",
+            side_effect=[
+                requests.exceptions.ReadTimeout("slow-1"),
+                requests.exceptions.ReadTimeout("slow-2"),
+                transient,
+                mock_gemini_response,
+            ],
+        ) as mock_post, patch("time.sleep"):
+            _generate_gemini_tts(
+                "Hi",
+                str(tmp_path / "test.wav"),
+                {"gemini": {"retry_delay_seconds": 0}},
+            )
+
+        assert mock_post.call_count == 4
+        assert (tmp_path / "test.wav").exists()
+
+    def test_persona_prompt_does_not_consume_transcript_chunk_budget(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        """The practical 2k cap limits spoken text, not non-spoken direction."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        with patch(
+            "tools.tts_tool._read_gemini_persona_prompt",
+            return_value="P" * 1000,
+        ), patch("requests.post", return_value=mock_gemini_response):
+            _generate_gemini_tts(
+                "T" * 2000,
+                str(tmp_path / "test.wav"),
+                {"gemini": {}},
+            )
+
+        assert (tmp_path / "test.wav").exists()
+
     def test_does_not_retry_deterministic_http_error(self, tmp_path, monkeypatch):
         from tools.tts_tool import _generate_gemini_tts
 

--- a/tests/tools/test_tts_max_text_length.py
+++ b/tests/tools/test_tts_max_text_length.py
@@ -32,7 +32,10 @@ class TestResolveMaxTextLength:
         assert _resolve_max_text_length("mistral", {}) == PROVIDER_MAX_TEXT_LENGTH["mistral"]
 
     def test_gemini_default(self):
-        assert _resolve_max_text_length("gemini", {}) == PROVIDER_MAX_TEXT_LENGTH["gemini"]
+        # Gemini's 32k-token context is not a practical one-shot audio limit:
+        # multi-thousand-character generations repeatedly exceeded the 60s
+        # response deadline in production. Keep each synthesis bounded.
+        assert _resolve_max_text_length("gemini", {}) == 2000
 
     def test_unknown_provider_falls_back(self):
         assert _resolve_max_text_length("does-not-exist", {}) == FALLBACK_MAX_TEXT_LENGTH
@@ -114,6 +117,40 @@ class TestTextToSpeechToolChunking:
         assert result["success"] is True
         # xAI should accept the full 12000 chars in a single chunk
         assert len(captured_text["text"]) == 12000
+
+    def test_gemini_splits_long_reply_without_dropping_text(self, tmp_path, monkeypatch):
+        # Mirrors the 2707-character Aug 19 auto-TTS failure.
+        text = "D" * 2707
+        captured_text = []
+
+        def fake_gemini(t, out, cfg):
+            captured_text.append(t)
+            with open(out, "wb") as f:
+                f.write(b"\x00")
+            return out
+
+        def fake_combine(paths, output_path, *, voice_compatible=False):
+            with open(output_path, "wb") as destination:
+                for path in paths:
+                    with open(path, "rb") as source:
+                        destination.write(source.read())
+            return output_path
+
+        monkeypatch.setattr("tools.tts_tool._generate_gemini_tts", fake_gemini)
+        monkeypatch.setattr("tools.tts_tool._concat_audio_files", fake_combine)
+        monkeypatch.setattr(
+            "tools.tts_tool._load_tts_config",
+            lambda: {"provider": "gemini"},
+        )
+
+        from tools.tts_tool import text_to_speech_tool
+        out = str(tmp_path / "out.mp3")
+        result = json.loads(text_to_speech_tool(text=text, output_path=out))
+
+        assert result["success"] is True
+        assert [len(chunk) for chunk in captured_text] == [2000, 707]
+        assert "".join(captured_text) == text
+        assert result["chunk_count"] == 2
 
     def test_user_override_is_respected(self, tmp_path, monkeypatch):
         # User says "cap openai at 100 chars" -- we must honor it

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -40,6 +40,7 @@ import datetime
 import importlib.util
 import json
 import logging
+import math
 import os
 import queue
 import platform
@@ -2694,17 +2695,21 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     endpoint = f"{base_url}/models/{model}:generateContent"
     try:
         max_attempts = int(gemini_config.get("max_attempts", 4))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         max_attempts = 4
     max_attempts = max(1, max_attempts)
     try:
         timeout_seconds = float(gemini_config.get("timeout", 60))
     except (TypeError, ValueError):
         timeout_seconds = 60.0
+    if not math.isfinite(timeout_seconds):
+        timeout_seconds = 60.0
     timeout_seconds = max(1.0, timeout_seconds)
     try:
         retry_delay = float(gemini_config.get("retry_delay_seconds", 1.0))
     except (TypeError, ValueError):
+        retry_delay = 1.0
+    if not math.isfinite(retry_delay):
         retry_delay = 1.0
     retry_delay = max(0.0, retry_delay)
     retryable_statuses = {408, 429, 500, 502, 503, 504}

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -258,6 +258,7 @@ DEFAULT_DEEPINFRA_TTS_VOICE = "default"
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
 GEMINI_TTS_SAMPLE_WIDTH = 2  # 16-bit PCM (L16)
+GEMINI_TTS_CONTEXT_MAX_CHARS = 32000  # conservative proxy for the 32k-token context
 TTS_RESPONSE_BODY_LIMIT_BYTES = 16 * 1024 * 1024
 TTS_RESPONSE_BODY_CHUNK_BYTES = 64 * 1024
 
@@ -270,8 +271,10 @@ DEFAULT_OUTPUT_DIR = _get_default_output_dir()
 # ---------------------------------------------------------------------------
 # Per-provider input-character limits (from official provider docs).
 # A single global cap was wrong: OpenAI is 4096, xAI is 15k, MiniMax is 10k,
-# ElevenLabs is model-dependent (5k / 10k / 30k / 40k), Gemini has a 32k-token
-# context window.  Users can override any of these via
+# ElevenLabs is model-dependent (5k / 10k / 30k / 40k). Gemini has a 32k-token
+# context window, but its one-shot audio generation becomes unreliable well
+# before that context limit, so its practical request cap is lower. Users can
+# override any of these via
 # ``tts.<provider>.max_text_length`` in config.yaml.
 # ---------------------------------------------------------------------------
 PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
@@ -280,7 +283,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "xai": 15000,         # https://docs.x.ai/developers/model-capabilities/audio/text-to-speech
     "minimax": 10000,     # https://platform.minimax.io/docs/api-reference/speech-t2a-http (sync)
     "mistral": 4000,      # conservative; no published per-request cap
-    "gemini": 32000,      # Gemini TTS has a 32k-token context window; char cap is conservative
+    "gemini": 2000,       # practical sync cap; longer replies are split losslessly
     "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
@@ -2651,13 +2654,15 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         gemini_config,
         persona_prompt=persona_prompt,
     )
-    max_len = _resolve_max_text_length("gemini", tts_config)
-    if len(prompt_text) > max_len:
+    # ``tts.gemini.max_text_length`` is the practical spoken-transcript chunk
+    # size used by the public wrapper. Persona/performance direction does not
+    # produce audio duration, so validate the composed request against the
+    # model context separately rather than consuming the transcript budget.
+    if len(prompt_text) > GEMINI_TTS_CONTEXT_MAX_CHARS:
         raise ValueError(
-            "Gemini TTS composed prompt exceeds the provider request limit "
-            f"({len(prompt_text)} > {max_len} chars). Reduce the persona/audio-tag "
-            "prompt or lower tts.gemini.max_text_length so long-form text is "
-            "split with enough prompt headroom."
+            "Gemini TTS composed prompt exceeds the conservative context limit "
+            f"({len(prompt_text)} > {GEMINI_TTS_CONTEXT_MAX_CHARS} chars). "
+            "Reduce the persona or audio-tag prompt."
         )
 
     payload: Dict[str, Any] = {
@@ -2687,9 +2692,9 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
 
     endpoint = f"{base_url}/models/{model}:generateContent"
     try:
-        max_attempts = int(gemini_config.get("max_attempts", 3))
+        max_attempts = int(gemini_config.get("max_attempts", 4))
     except (TypeError, ValueError):
-        max_attempts = 3
+        max_attempts = 4
     max_attempts = max(1, max_attempts)
     try:
         timeout_seconds = float(gemini_config.get("timeout", 60))

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -57,6 +57,7 @@ from pathlib import Path
 from typing import Callable, Dict, Any, Iterator, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
+from agent.retry_utils import parse_retry_after_seconds
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import display_hermes_home
 
@@ -2732,14 +2733,12 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
                     and attempt < max_attempts
                 ):
                     delay = retry_delay
-                    retry_after = getattr(response, "headers", {}).get("Retry-After")
+                    retry_after = parse_retry_after_seconds(
+                        getattr(response, "headers", {})
+                    )
                     if retry_after is not None:
-                        try:
-                            # Support the common delta-seconds form and bound
-                            # an upstream-controlled delay to one minute.
-                            delay = min(60.0, max(0.0, float(retry_after)))
-                        except (TypeError, ValueError):
-                            pass
+                        # Bound an upstream-controlled delay to one minute.
+                        delay = min(60.0, retry_after)
                     logger.warning(
                         "Gemini TTS request attempt %d/%d returned retryable HTTP %d",
                         attempt,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2701,6 +2701,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     except (TypeError, ValueError):
         retry_delay = 1.0
     retry_delay = max(0.0, retry_delay)
+    retryable_statuses = {408, 429, 500, 502, 503, 504}
 
     data: Optional[Dict[str, Any]] = None
     for attempt in range(1, max_attempts + 1):
@@ -2716,11 +2717,33 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             )
 
             if response.status_code != 200:
-                # Surface the API error message when present. HTTP responses
-                # are deterministic application failures, so they are not
-                # retried; transport failures while reading the streamed body
-                # are caught below and retried.
+                # Consume and close the bounded response before deciding
+                # whether the status is transient. Deterministic client errors
+                # fail fast; common timeout, throttling, and server statuses
+                # retry within the same attempt budget as transport errors.
                 raw_body = _read_tts_response_bytes(response, label="Gemini TTS")
+                if (
+                    response.status_code in retryable_statuses
+                    and attempt < max_attempts
+                ):
+                    delay = retry_delay
+                    retry_after = getattr(response, "headers", {}).get("Retry-After")
+                    if retry_after is not None:
+                        try:
+                            # Support the common delta-seconds form and bound
+                            # an upstream-controlled delay to one minute.
+                            delay = min(60.0, max(0.0, float(retry_after)))
+                        except (TypeError, ValueError):
+                            pass
+                    logger.warning(
+                        "Gemini TTS request attempt %d/%d returned retryable HTTP %d",
+                        attempt,
+                        max_attempts,
+                        response.status_code,
+                    )
+                    if delay:
+                        time.sleep(delay)
+                    continue
                 try:
                     if raw_body:
                         err = json.loads(raw_body.decode("utf-8")).get("error", {})

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2686,33 +2686,83 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         headers["X-Goog-Api-Client"] = f"hermes-agent/{_hermes_version}"
 
     endpoint = f"{base_url}/models/{model}:generateContent"
-    response = requests.post(
-        endpoint,
-        params={"key": api_key},
-        headers=headers,
-        json=payload,
-        timeout=60,
-        stream=True,
-    )
-    if response.status_code != 200:
-        # Surface the API error message when present
-        raw_body = _read_tts_response_bytes(response, label="Gemini TTS")
+    try:
+        max_attempts = int(gemini_config.get("max_attempts", 3))
+    except (TypeError, ValueError):
+        max_attempts = 3
+    max_attempts = max(1, max_attempts)
+    try:
+        timeout_seconds = float(gemini_config.get("timeout", 60))
+    except (TypeError, ValueError):
+        timeout_seconds = 60.0
+    timeout_seconds = max(1.0, timeout_seconds)
+    try:
+        retry_delay = float(gemini_config.get("retry_delay_seconds", 1.0))
+    except (TypeError, ValueError):
+        retry_delay = 1.0
+    retry_delay = max(0.0, retry_delay)
+
+    data: Optional[Dict[str, Any]] = None
+    for attempt in range(1, max_attempts + 1):
+        response = None
         try:
-            if raw_body:
-                err = json.loads(raw_body.decode("utf-8")).get("error", {})
-            elif not _response_has_explicit_stream(response) and callable(getattr(response, "json", None)):
-                err = response.json().get("error", {})
-            else:
-                err = {}
-            detail = err.get("message") or raw_body.decode("utf-8", errors="replace")[:300]
-        except Exception:
-            detail = raw_body.decode("utf-8", errors="replace")[:300]
+            response = requests.post(
+                endpoint,
+                params={"key": api_key},
+                headers=headers,
+                json=payload,
+                timeout=timeout_seconds,
+                stream=True,
+            )
+
+            if response.status_code != 200:
+                # Surface the API error message when present. HTTP responses
+                # are deterministic application failures, so they are not
+                # retried; transport failures while reading the streamed body
+                # are caught below and retried.
+                raw_body = _read_tts_response_bytes(response, label="Gemini TTS")
+                try:
+                    if raw_body:
+                        err = json.loads(raw_body.decode("utf-8")).get("error", {})
+                    elif (
+                        not _response_has_explicit_stream(response)
+                        and callable(getattr(response, "json", None))
+                    ):
+                        err = response.json().get("error", {})
+                    else:
+                        err = {}
+                    detail = (
+                        err.get("message")
+                        or raw_body.decode("utf-8", errors="replace")[:300]
+                    )
+                except Exception:
+                    detail = raw_body.decode("utf-8", errors="replace")[:300]
+                raise RuntimeError(
+                    f"Gemini TTS API error (HTTP {response.status_code}): {detail}"
+                )
+
+            # Consume the streamed response inside the retry boundary. With
+            # stream=True, read timeouts happen here rather than in post().
+            data = _read_tts_response_json(response, label="Gemini TTS")
+            break
+        except requests.RequestException as exc:
+            if response is not None:
+                _close_response(response)
+            logger.warning(
+                "Gemini TTS request attempt %d/%d failed (%s)",
+                attempt,
+                max_attempts,
+                type(exc).__name__,
+            )
+            if attempt < max_attempts and retry_delay:
+                time.sleep(retry_delay)
+
+    if data is None:
         raise RuntimeError(
-            f"Gemini TTS API error (HTTP {response.status_code}): {detail}"
+            f"Gemini TTS failed after {max_attempts} attempts due to transport errors"
         )
 
     try:
-        data = _read_tts_response_json(response, label="Gemini TTS")
         parts = data["candidates"][0]["content"]["parts"]
         audio_part = next((p for p in parts if "inlineData" in p or "inline_data" in p), None)
         if audio_part is None:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -261,6 +261,9 @@ GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
 GEMINI_TTS_SAMPLE_WIDTH = 2  # 16-bit PCM (L16)
 GEMINI_TTS_CONTEXT_MAX_CHARS = 32000  # conservative proxy for the 32k-token context
+GEMINI_TTS_MAX_ATTEMPTS = 10
+GEMINI_TTS_MAX_TIMEOUT_SECONDS = 300.0
+GEMINI_TTS_MAX_RETRY_DELAY_SECONDS = 60.0
 TTS_RESPONSE_BODY_LIMIT_BYTES = 16 * 1024 * 1024
 TTS_RESPONSE_BODY_CHUNK_BYTES = 64 * 1024
 
@@ -2697,21 +2700,27 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         max_attempts = int(gemini_config.get("max_attempts", 4))
     except (TypeError, ValueError, OverflowError):
         max_attempts = 4
-    max_attempts = max(1, max_attempts)
+    max_attempts = min(GEMINI_TTS_MAX_ATTEMPTS, max(1, max_attempts))
     try:
         timeout_seconds = float(gemini_config.get("timeout", 60))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         timeout_seconds = 60.0
     if not math.isfinite(timeout_seconds):
         timeout_seconds = 60.0
-    timeout_seconds = max(1.0, timeout_seconds)
+    timeout_seconds = min(
+        GEMINI_TTS_MAX_TIMEOUT_SECONDS,
+        max(1.0, timeout_seconds),
+    )
     try:
         retry_delay = float(gemini_config.get("retry_delay_seconds", 1.0))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         retry_delay = 1.0
     if not math.isfinite(retry_delay):
         retry_delay = 1.0
-    retry_delay = max(0.0, retry_delay)
+    retry_delay = min(
+        GEMINI_TTS_MAX_RETRY_DELAY_SECONDS,
+        max(0.0, retry_delay),
+    )
     retryable_statuses = {408, 429, 500, 502, 503, 504}
 
     data: Optional[Dict[str, Any]] = None

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2325,33 +2325,83 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         headers["X-Goog-Api-Client"] = f"hermes-agent/{_hermes_version}"
 
     endpoint = f"{base_url}/models/{model}:generateContent"
-    response = requests.post(
-        endpoint,
-        params={"key": api_key},
-        headers=headers,
-        json=payload,
-        timeout=60,
-        stream=True,
-    )
-    if response.status_code != 200:
-        # Surface the API error message when present
-        raw_body = _read_tts_response_bytes(response, label="Gemini TTS")
+    try:
+        max_attempts = int(gemini_config.get("max_attempts", 3))
+    except (TypeError, ValueError):
+        max_attempts = 3
+    max_attempts = max(1, max_attempts)
+    try:
+        timeout_seconds = float(gemini_config.get("timeout", 60))
+    except (TypeError, ValueError):
+        timeout_seconds = 60.0
+    timeout_seconds = max(1.0, timeout_seconds)
+    try:
+        retry_delay = float(gemini_config.get("retry_delay_seconds", 1.0))
+    except (TypeError, ValueError):
+        retry_delay = 1.0
+    retry_delay = max(0.0, retry_delay)
+
+    data: Optional[Dict[str, Any]] = None
+    for attempt in range(1, max_attempts + 1):
+        response = None
         try:
-            if raw_body:
-                err = json.loads(raw_body.decode("utf-8")).get("error", {})
-            elif not _response_has_explicit_stream(response) and callable(getattr(response, "json", None)):
-                err = response.json().get("error", {})
-            else:
-                err = {}
-            detail = err.get("message") or raw_body.decode("utf-8", errors="replace")[:300]
-        except Exception:
-            detail = raw_body.decode("utf-8", errors="replace")[:300]
+            response = requests.post(
+                endpoint,
+                params={"key": api_key},
+                headers=headers,
+                json=payload,
+                timeout=timeout_seconds,
+                stream=True,
+            )
+
+            if response.status_code != 200:
+                # Surface the API error message when present. HTTP responses
+                # are deterministic application failures, so they are not
+                # retried; transport failures while reading the streamed body
+                # are caught below and retried.
+                raw_body = _read_tts_response_bytes(response, label="Gemini TTS")
+                try:
+                    if raw_body:
+                        err = json.loads(raw_body.decode("utf-8")).get("error", {})
+                    elif (
+                        not _response_has_explicit_stream(response)
+                        and callable(getattr(response, "json", None))
+                    ):
+                        err = response.json().get("error", {})
+                    else:
+                        err = {}
+                    detail = (
+                        err.get("message")
+                        or raw_body.decode("utf-8", errors="replace")[:300]
+                    )
+                except Exception:
+                    detail = raw_body.decode("utf-8", errors="replace")[:300]
+                raise RuntimeError(
+                    f"Gemini TTS API error (HTTP {response.status_code}): {detail}"
+                )
+
+            # Consume the streamed response inside the retry boundary. With
+            # stream=True, read timeouts happen here rather than in post().
+            data = _read_tts_response_json(response, label="Gemini TTS")
+            break
+        except requests.RequestException as exc:
+            if response is not None:
+                _close_response(response)
+            logger.warning(
+                "Gemini TTS request attempt %d/%d failed (%s)",
+                attempt,
+                max_attempts,
+                type(exc).__name__,
+            )
+            if attempt < max_attempts and retry_delay:
+                time.sleep(retry_delay)
+
+    if data is None:
         raise RuntimeError(
-            f"Gemini TTS API error (HTTP {response.status_code}): {detail}"
+            f"Gemini TTS failed after {max_attempts} attempts due to transport errors"
         )
 
     try:
-        data = _read_tts_response_json(response, label="Gemini TTS")
         parts = data["candidates"][0]["content"]["parts"]
         audio_part = next((p for p in parts if "inlineData" in p or "inline_data" in p), None)
         if audio_part is None:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2340,6 +2340,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     except (TypeError, ValueError):
         retry_delay = 1.0
     retry_delay = max(0.0, retry_delay)
+    retryable_statuses = {408, 429, 500, 502, 503, 504}
 
     data: Optional[Dict[str, Any]] = None
     for attempt in range(1, max_attempts + 1):
@@ -2355,11 +2356,33 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             )
 
             if response.status_code != 200:
-                # Surface the API error message when present. HTTP responses
-                # are deterministic application failures, so they are not
-                # retried; transport failures while reading the streamed body
-                # are caught below and retried.
+                # Consume and close the bounded response before deciding
+                # whether the status is transient. Deterministic client errors
+                # fail fast; common timeout, throttling, and server statuses
+                # retry within the same attempt budget as transport errors.
                 raw_body = _read_tts_response_bytes(response, label="Gemini TTS")
+                if (
+                    response.status_code in retryable_statuses
+                    and attempt < max_attempts
+                ):
+                    delay = retry_delay
+                    retry_after = getattr(response, "headers", {}).get("Retry-After")
+                    if retry_after is not None:
+                        try:
+                            # Support the common delta-seconds form and bound
+                            # an upstream-controlled delay to one minute.
+                            delay = min(60.0, max(0.0, float(retry_after)))
+                        except (TypeError, ValueError):
+                            pass
+                    logger.warning(
+                        "Gemini TTS request attempt %d/%d returned retryable HTTP %d",
+                        attempt,
+                        max_attempts,
+                        response.status_code,
+                    )
+                    if delay:
+                        time.sleep(delay)
+                    continue
                 try:
                     if raw_body:
                         err = json.loads(raw_body.decode("utf-8")).get("error", {})

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1782,6 +1782,9 @@ tts:
   gemini:
     model: "gemini-2.5-flash-preview-tts"   # or gemini-3.1-flash-tts-preview
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, etc.
+    max_attempts: 4             # Retry transient request/read/HTTP failures
+    timeout: 60                 # Per-attempt timeout in seconds
+    retry_delay_seconds: 1.0    # Delay between attempts
     audio_tags: false           # Hidden Gemini 3.1 TTS audio-tag insertion
     persona_prompt_file: ""      # Optional Markdown/text file with Gemini voice direction
   xai:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1782,9 +1782,9 @@ tts:
   gemini:
     model: "gemini-2.5-flash-preview-tts"   # or gemini-3.1-flash-tts-preview
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, etc.
-    max_attempts: 4             # Retry transient request/read/HTTP failures
-    timeout: 60                 # Per-attempt timeout in seconds
-    retry_delay_seconds: 1.0    # Delay between attempts
+    max_attempts: 4             # Retry transient failures (range 1-10)
+    timeout: 60                 # Connect/read-inactivity timeout (range 1-300s)
+    retry_delay_seconds: 1.0    # Delay between attempts (range 0-60s)
     audio_tags: false           # Hidden Gemini 3.1 TTS audio-tag insertion
     persona_prompt_file: ""      # Optional Markdown/text file with Gemini voice direction
   xai:

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -72,6 +72,9 @@ tts:
   gemini:
     model: "gemini-2.5-flash-preview-tts"  # or gemini-3.1-flash-tts-preview
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
+    max_attempts: 3             # Retry transient request/read failures
+    timeout: 60                 # Per-attempt timeout in seconds
+    retry_delay_seconds: 1.0    # Delay between attempts
     audio_tags: false           # Enable hidden Gemini 3.1 TTS audio-tag insertion
     persona_prompt_file: ""      # Optional Markdown/text file with Gemini voice direction
   xai:

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -72,7 +72,7 @@ tts:
   gemini:
     model: "gemini-2.5-flash-preview-tts"  # or gemini-3.1-flash-tts-preview
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
-    max_attempts: 3             # Retry transient request/read failures
+    max_attempts: 4             # Retry transient request/read/HTTP failures
     timeout: 60                 # Per-attempt timeout in seconds
     retry_delay_seconds: 1.0    # Delay between attempts
     audio_tags: false           # Enable hidden Gemini 3.1 TTS audio-tag insertion
@@ -161,7 +161,7 @@ Each provider has a documented per-request input-character cap. Hermes splits lo
 | xAI | 15000 |
 | MiniMax | 10000 |
 | Mistral | 4000 |
-| Google Gemini | 32000 |
+| Google Gemini | 2000 (practical sync-generation cap; 32k-token context) |
 | ElevenLabs | Model-aware (see below) |
 | NeuTTS | 2000 |
 | KittenTTS | 2000 |

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -72,9 +72,9 @@ tts:
   gemini:
     model: "gemini-2.5-flash-preview-tts"  # or gemini-3.1-flash-tts-preview
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
-    max_attempts: 4             # Retry transient request/read/HTTP failures
-    timeout: 60                 # Per-attempt timeout in seconds
-    retry_delay_seconds: 1.0    # Delay between attempts
+    max_attempts: 4             # Retry transient failures (range 1-10)
+    timeout: 60                 # Connect/read-inactivity timeout (range 1-300s)
+    retry_delay_seconds: 1.0    # Delay between attempts (range 0-60s)
     audio_tags: false           # Enable hidden Gemini 3.1 TTS audio-tag insertion
     persona_prompt_file: ""      # Optional Markdown/text file with Gemini voice direction
   xai:
@@ -121,7 +121,7 @@ MiniMax TTS selects its region, endpoint, and credential together:
 
 Gemini TTS can follow natural-language performance direction. Set `tts.gemini.persona_prompt_file` to a local Markdown or text file that describes the voice persona. The file can include Gemini-style sections such as `AUDIO PROFILE`, `SCENE`, `DIRECTOR'S NOTES`, `SAMPLE CONTEXT`, and `TRANSCRIPT`.
 
-If the file contains `{transcript}` or `{{ transcript }}`, Hermes replaces that placeholder with the live TTS text. Otherwise, Hermes appends a labeled `TRANSCRIPT` section automatically. The persona prompt stays local and is not shown in the chat reply.
+If the file contains `{transcript}` or `{{ transcript }}`, Hermes replaces that placeholder with the live TTS text. Otherwise, Hermes appends a labeled `TRANSCRIPT` section automatically. The persona prompt is not shown in the chat reply, but its contents are sent to Gemini as synthesis direction. If `audio_tags` is enabled, the prompt can also be sent to the configured `auxiliary.tts_audio_tags` model during the hidden rewrite pass. Do not include secrets or context you would not send to those providers.
 
 ```yaml
 tts:


### PR DESCRIPTION
## What does this PR do?

Gemini TTS transport failures could make gateway voice replies silently degrade to text-only delivery. Recent production logs exposed two related reliability gaps:

- long, one-shot Gemini synthesis requests repeatedly hit the 60-second read-inactivity deadline;
- the latest 2,707-character failure exhausted the old three-attempt budget with two read timeouts followed by a retryable HTTP 500.

This PR rebases the original retry fix onto current `main`, retries transient Gemini failures, bounds one-shot spoken-text size so long replies use the existing lossless chunking path, and adds a safe user-visible notice when gateway auto-TTS generation or delivery still fails.

## Type of Change

- [x] Bug fix (non-breaking change)
- [x] Documentation update
- [x] Tests

## Changes Made

- Retry Gemini TTS `requests.RequestException` failures, including read timeouts raised while consuming `stream=True` responses.
- Retry transient HTTP 408/429/500/502/503/504 responses while failing fast on deterministic client errors.
- Honor both delta-seconds and HTTP-date `Retry-After` values, bounded to one minute; malformed values fall back to the configured retry delay.
- Raise the default Gemini retry budget from 3 to 4 attempts, covering the observed timeout → timeout → HTTP 500 sequence while remaining configurable.
- Bound configuration to 1–10 attempts, 1–300 seconds of connect/read inactivity, and 0–60 seconds of retry delay; malformed and non-finite values fall back safely.
- Use a practical 2,000-character Gemini spoken-text cap. Longer replies are split through Hermes' existing ordered, sentence-aware chunking path without dropping text.
- Keep persona/performance direction outside the spoken-transcript chunk budget while independently bounding the composed Gemini prompt.
- Preserve bounded streamed-response reads and response cleanup.
- Avoid logging or displaying raw transport exception text, which may contain sensitive request details.
- Treat `success: false`, missing output files, unavailable provider requirements, thrown delivery exceptions, and unsuccessful `SendResult` values as auto-TTS failures.
- Preserve the original text reply, prepend a generic failure notice, and clean all temporary files after generation or partial delivery failure.
- Preserve current-main multi-file TTS delivery so chunked replies are delivered in order.
- Register and document the Gemini retry settings, practical chunk cap, real timeout semantics, and persona-prompt provider transmission.

## How to Test

Canonical targeted regression, gateway, and config coverage:

```bash
HERMES_TEST_WORKERS=2 scripts/run_tests.sh \
  tests/tools/test_tts_gemini.py \
  tests/tools/test_tts_max_text_length.py \
  tests/tools/test_tts_response_body_cap.py \
  tests/gateway/test_base_auto_tts_output_format.py \
  tests/gateway/test_tts_media_routing.py \
  tests/hermes_cli/test_set_config_value.py \
  -q
```

Result: **145 passed**.

Broader non-streaming TTS suite: **286 passed, 1 skipped**. The separate real-provider streaming E2E test fails in this environment and reproduces unchanged on pristine `origin/main` (`resolve_streaming_provider` returns `None` for the available key), so it is not introduced by this PR.

Static checks:

```bash
python -m ruff check \
  tools/tts_tool.py \
  gateway/platforms/base.py \
  hermes_cli/config_defaults.py \
  tests/tools/test_tts_gemini.py \
  tests/tools/test_tts_max_text_length.py \
  tests/gateway/test_base_auto_tts_output_format.py \
  tests/hermes_cli/test_set_config_value.py

git diff --check origin/main...HEAD
```

Result: **All checks passed**.

Live Gemini verification with a 2,707-character natural-text input: **success**, split into **2 chunks**, combined into one output file (1,199,210 bytes) in **17.47 seconds**.

## Checklist

- [x] Reproduced the latest observed failure sequence with a regression test.
- [x] Preserved contributor authorship while rebasing the original commits onto current `main`.
- [x] Added request-time, streamed-read, transient HTTP, and retry-exhaustion coverage.
- [x] Added `Retry-After` coverage for numeric, HTTP-date, malformed, and bounded delays.
- [x] Added finite/range validation for all new retry settings.
- [x] Added long-reply chunking coverage proving the full normalized text is preserved.
- [x] Added persona-prompt coverage for separate transcript and context budgets.
- [x] Added gateway coverage for missing files, false results, thrown delivery exceptions, partial multi-file cleanup, and privacy-safe fallback text.
- [x] Registered the config keys and updated both configuration guides.
- [x] Ran canonical targeted tests, broader TTS tests, lint, whitespace checks, a real Gemini generation, and independent review/fix cycles.
