### PR TITLE
fix(gateway): compare equivalent systemd paths

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2884,6 +2884,53 @@ def _normalize_service_definition(text: str) -> str:
     return "\n".join(line.rstrip() for line in text.strip().splitlines())
 
 
+def _resolve_existing_service_path(path: str) -> str:
+    """Resolve a plain absolute path for comparison, failing closed."""
+    if not path.startswith(os.sep):
+        return path
+    try:
+        return str(Path(path).resolve(strict=True))
+    except (OSError, RuntimeError, ValueError):
+        return path
+
+
+def _normalize_systemd_unit_paths(text: str) -> str:
+    """Canonicalize existing paths in Hermes-generated systemd fields.
+
+    A stable install symlink and its resolved release path are equivalent for
+    the current unit, but a literal text comparison reports them as stale.
+    Limit canonicalization to the path positions emitted by
+    :func:`generate_systemd_unit`; arguments and unrelated environment values
+    remain byte-significant. Missing and broken paths are left untouched.
+    """
+    normalized_lines: list[str] = []
+    for line in _normalize_service_definition(text).splitlines():
+        if line.startswith("WorkingDirectory="):
+            key, path = line.split("=", 1)
+            line = f"{key}={_resolve_existing_service_path(path)}"
+        elif line.startswith(("ExecStart=", "ExecStopPost=")):
+            key, command = line.split("=", 1)
+            prefix_length = len(command) - len(command.lstrip("-@:+!"))
+            prefix = command[:prefix_length]
+            executable, separator, arguments = command[prefix_length:].partition(" ")
+            executable = _resolve_existing_service_path(executable)
+            line = f"{key}={prefix}{executable}{separator}{arguments}"
+        elif line.startswith('Environment="') and line.endswith('"'):
+            body = line[len('Environment="') : -1]
+            name, separator, value = body.partition("=")
+            if separator and name in {"HERMES_HOME", "VIRTUAL_ENV"}:
+                value = _resolve_existing_service_path(value)
+                line = f'Environment="{name}={value}"'
+            elif separator and name == "PATH":
+                value = os.pathsep.join(
+                    _resolve_existing_service_path(path)
+                    for path in value.split(os.pathsep)
+                )
+                line = f'Environment="PATH={value}"'
+        normalized_lines.append(line)
+    return "\n".join(normalized_lines)
+
+
 # Directives that older systemd versions silently ignore/strip.  Normalize
 # them out of stale-check comparisons so a unit that differs only by these
 # directives is not perpetually flagged as outdated.
@@ -2953,12 +3000,13 @@ def systemd_unit_is_current(system: bool = False) -> bool:
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
     expected = generate_systemd_unit(system=system, run_as_user=expected_user)
     # Normalize out directives that older systemd versions silently drop
-    # (RestartMaxDelaySec, RestartSteps) so a unit that differs only by
-    # those directives is not perpetually flagged as outdated.
-    norm_installed = _normalize_service_definition(
+    # (RestartMaxDelaySec, RestartSteps), then canonicalize existing paths in
+    # Hermes-generated fields so stable install symlinks compare equal to
+    # their resolved release paths.
+    norm_installed = _normalize_systemd_unit_paths(
         _strip_optional_systemd_directives(installed)
     )
-    norm_expected = _normalize_service_definition(
+    norm_expected = _normalize_systemd_unit_paths(
         _strip_optional_systemd_directives(expected)
     )
     return norm_installed == norm_expected

--- a/tests/hermes_cli/test_systemd_service_path_normalization.py
+++ b/tests/hermes_cli/test_systemd_service_path_normalization.py
@@ -1,0 +1,109 @@
+"""Regression tests for path-aware systemd service staleness checks."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="systemd path comparison is POSIX-only"
+)
+
+
+def _unit(*lines: str) -> str:
+    return "[Service]\n" + "\n".join(lines) + "\n"
+
+
+def _is_current(monkeypatch, tmp_path, installed: str, expected: str) -> bool:
+    from hermes_cli import gateway as gw
+
+    unit_file = tmp_path / "hermes-gateway.service"
+    unit_file.write_text(installed)
+    monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+    monkeypatch.setattr(
+        gw,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: expected,
+    )
+    return gw.systemd_unit_is_current(system=False)
+
+
+def test_symlinked_and_resolved_generated_paths_are_current(tmp_path, monkeypatch):
+    release = tmp_path / "hermes-agent.release"
+    (release / "venv" / "bin").mkdir(parents=True)
+    (release / "node_modules" / ".bin").mkdir(parents=True)
+    (release / "venv" / "bin" / "python").write_text("")
+    stable = tmp_path / "hermes-agent"
+    stable.symlink_to(release, target_is_directory=True)
+
+    installed = _unit(
+        f"ExecStart={stable}/venv/bin/python -m hermes_cli.main gateway run",
+        f"WorkingDirectory={stable}",
+        f'Environment="PATH={stable}/venv/bin:{stable}/node_modules/.bin:/usr/bin"',
+        f'Environment="VIRTUAL_ENV={stable}/venv"',
+        f'Environment="HERMES_HOME={stable}"',
+        f"ExecStopPost=-{stable}/venv/bin/python -m gateway.cgroup_cleanup",
+    )
+    expected = installed.replace(str(stable), str(release))
+
+    assert _is_current(monkeypatch, tmp_path, installed, expected) is True
+    assert _is_current(monkeypatch, tmp_path, expected, installed) is True
+
+
+def test_different_existing_service_paths_are_stale(tmp_path, monkeypatch):
+    first = tmp_path / "first" / "bin"
+    second = tmp_path / "second" / "bin"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "python").write_text("")
+    (second / "python").write_text("")
+
+    installed = _unit(f"ExecStart={first}/python -m hermes_cli.main gateway run")
+    expected = _unit(f"ExecStart={second}/python -m hermes_cli.main gateway run")
+
+    assert _is_current(monkeypatch, tmp_path, installed, expected) is False
+
+
+def test_missing_or_broken_service_paths_are_stale(tmp_path, monkeypatch):
+    missing = tmp_path / "missing" / "python"
+    broken = tmp_path / "broken-python"
+    broken.symlink_to(missing)
+
+    installed = _unit(f"ExecStart={broken} -m hermes_cli.main gateway run")
+    expected = _unit(f"ExecStart={missing} -m hermes_cli.main gateway run")
+
+    assert _is_current(monkeypatch, tmp_path, installed, expected) is False
+
+
+def test_resolution_errors_leave_paths_unchanged(monkeypatch):
+    from hermes_cli import gateway as gw
+
+    def deny_resolution(self, strict=False):
+        raise PermissionError(self)
+
+    monkeypatch.setattr(gw.Path, "resolve", deny_resolution)
+
+    assert gw._resolve_existing_service_path("/restricted/python") == "/restricted/python"
+
+
+def test_non_path_exec_arguments_remain_significant(tmp_path, monkeypatch):
+    executable = tmp_path / "python"
+    executable.write_text("")
+    installed = _unit(f"ExecStart={executable} -m hermes_cli.main gateway run --profile one")
+    expected = _unit(f"ExecStart={executable} -m hermes_cli.main gateway run --profile two")
+
+    assert _is_current(monkeypatch, tmp_path, installed, expected) is False
+
+
+def test_unrecognized_environment_paths_are_not_normalized(tmp_path, monkeypatch):
+    release = tmp_path / "release"
+    release.mkdir()
+    stable = tmp_path / "stable"
+    stable.symlink_to(release, target_is_directory=True)
+
+    installed = _unit(f'Environment="CUSTOM_ROOT={stable}"')
+    expected = _unit(f'Environment="CUSTOM_ROOT={release}"')
+
+    assert _is_current(monkeypatch, tmp_path, installed, expected) is False


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes gateway status` from reporting a generated systemd unit as stale when the installed and generated definitions use a stable symlink and its resolved release path for the same existing Hermes runtime.

The comparison now canonicalizes only path positions emitted by `generate_systemd_unit`:

- `ExecStart` and `ExecStopPost` executable paths
- `WorkingDirectory`
- `PATH`, `VIRTUAL_ENV`, and `HERMES_HOME` environment values

Resolution is strict and fail-closed: relative, missing, broken, inaccessible, and otherwise unresolvable paths remain textually significant. Command arguments and unrecognized environment variables are not normalized.

This is comparison-only and does not change systemd unit generation. It is distinct from #71251, which stabilizes FNM's per-shell Node paths during generation.

## Related Issue

No existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add narrow, path-aware normalization to the systemd unit staleness comparison in `hermes_cli/gateway.py`.
- Add regression coverage for symlink/resolved symmetry, distinct existing targets, missing and broken paths, resolution errors, argument changes, and unrecognized environment values.

## How to Test

1. Run `pytest -q -o 'addopts=' tests/hermes_cli/test_systemd_service_path_normalization.py tests/hermes_cli/test_systemd_optional_directives.py tests/hermes_cli/test_gateway_service.py`.
2. Confirm a stable symlink and its current resolved target compare as current in both directions.
3. Confirm different, missing, broken, or unrecognized path changes still compare as stale.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal comparison fix with docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — systemd-only; regression module skips Windows symlink setup
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Verification

- Gateway/systemd regression suite: **171 passed**
- Focused service-generation and normalization suite: **81 passed**
- Ruff: **passed**
- Python compilation: **passed**
- `git diff --check`: **passed**

**AI Assistance:** The implementation, regression tests, and initial analysis were prepared with AI agents.
