### PR TITLE
[verified] fix(kanban): make manual promotion atomic

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5700,47 +5700,61 @@ def promote_task(
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
     promotion would succeed without mutating state.
     """
-    row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (task_id,)
-    ).fetchone()
-    if row is None:
-        return False, f"task {task_id} not found"
+    with write_txn(conn):
+        # Read and validate under the same write transaction as the update.
+        # Otherwise a dispatcher/worker can change todo -> blocked between the
+        # read and update, causing manual promotion to miss the sticky-block
+        # release event.
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            return False, f"task {task_id} not found"
 
-    cur_status = row["status"]
-    if cur_status not in ("todo", "blocked"):
-        return False, (
-            f"task {task_id} is {cur_status!r}; promote only applies to "
-            f"'todo' or 'blocked'"
-        )
-
-    if not force:
-        parents = conn.execute(
-            "SELECT t.id, t.status FROM tasks t "
-            "JOIN task_links l ON l.parent_id = t.id "
-            "WHERE l.child_id = ?",
-            (task_id,),
-        ).fetchall()
-        unsatisfied = [
-            p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
-        ]
-        if unsatisfied:
+        cur_status = row["status"]
+        if cur_status not in ("todo", "blocked"):
             return False, (
-                f"unsatisfied parent dependencies: "
-                f"{', '.join(unsatisfied)} (use --force to override)"
+                f"task {task_id} is {cur_status!r}; promote only applies to "
+                f"'todo' or 'blocked'"
             )
 
-    if dry_run:
-        return True, None
+        if not force:
+            parents = conn.execute(
+                "SELECT t.id, t.status FROM tasks t "
+                "JOIN task_links l ON l.parent_id = t.id "
+                "WHERE l.child_id = ?",
+                (task_id,),
+            ).fetchall()
+            unsatisfied = [
+                p["id"] for p in parents
+                if p["status"] not in ("done", "archived")
+            ]
+            if unsatisfied:
+                return False, (
+                    f"unsatisfied parent dependencies: "
+                    f"{', '.join(unsatisfied)} (use --force to override)"
+                )
 
-    with write_txn(conn):
+        if dry_run:
+            return True, None
+
         upd = conn.execute(
             "UPDATE tasks SET status = 'ready' "
-            "WHERE id = ? AND status IN ('todo', 'blocked')",
-            (task_id,),
+            "WHERE id = ? AND status = ?",
+            (task_id, cur_status),
         )
         if upd.rowcount != 1:
             return False, f"task {task_id} status changed during promotion"
+        if cur_status == "blocked":
+            # Manual promotion is an explicit operator release, just like
+            # ``unblock_task``. Clear the sticky event so a later transient
+            # circuit-breaker block can auto-recover normally.
+            _append_event(
+                conn,
+                task_id,
+                "unblocked",
+                {"actor": actor, "reason": reason, "via": "promote_task"},
+            )
         _append_event(
             conn,
             task_id,

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -9,8 +9,10 @@ Direct-SQL setup is used to construct that state deterministically.
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 import json
 from pathlib import Path
+import time
 
 import pytest
 
@@ -61,6 +63,105 @@ def test_promote_stuck_todo_succeeds(conn):
     ok, err = kb.promote_task(conn, child, actor="tester")
     assert ok and err is None
     assert kb.get_task(conn, child).status == "ready"
+    kinds = [event.kind for event in kb.list_events(conn, child)]
+    assert kinds[-1] == "promoted_manual"
+    assert "unblocked" not in kinds
+
+
+def test_promote_dry_run_does_not_mutate_status_or_events(conn):
+    child, _ = _stuck_todo(conn, parents_done=True)
+    before = [event.kind for event in kb.list_events(conn, child)]
+
+    ok, err = kb.promote_task(conn, child, actor="tester", dry_run=True)
+
+    assert ok and err is None
+    assert kb.get_task(conn, child).status == "todo"
+    assert [event.kind for event in kb.list_events(conn, child)] == before
+
+
+def test_promote_refuses_open_parent_unless_forced(conn):
+    child, _ = _stuck_todo(conn, parents_done=False)
+    before = [event.kind for event in kb.list_events(conn, child)]
+
+    ok, err = kb.promote_task(conn, child, actor="tester")
+
+    assert ok is False
+    assert "unsatisfied parent dependencies" in (err or "")
+    assert kb.get_task(conn, child).status == "todo"
+    assert [event.kind for event in kb.list_events(conn, child)] == before
+
+    ok, err = kb.promote_task(conn, child, actor="tester", force=True)
+    assert ok and err is None
+    assert kb.get_task(conn, child).status == "ready"
+
+
+def test_promote_blocked_task_explicitly_releases_sticky_block(conn):
+    tid = kb.create_task(conn, title="blocked then promoted", assignee="worker")
+    assert kb.claim_task(conn, tid)
+    run_id = kb.get_task(conn, tid).current_run_id
+    assert kb.block_task(
+        conn,
+        tid,
+        reason="review-required: operator release needed",
+        expected_run_id=run_id,
+    )
+
+    ok, err = kb.promote_task(conn, tid, actor="operator")
+
+    assert ok and err is None
+    assert kb.get_task(conn, tid).status == "ready"
+    kinds = [event.kind for event in kb.list_events(conn, tid)]
+    assert kinds[-3:] == ["blocked", "unblocked", "promoted_manual"]
+
+    # A later recoverable circuit-breaker block must not inherit the earlier
+    # operator block after manual promotion explicitly released it.
+    conn.execute(
+        "UPDATE tasks SET status='blocked', consecutive_failures=1 "
+        "WHERE id=?",
+        (tid,),
+    )
+    conn.execute(
+        "INSERT INTO task_events (task_id, kind, payload, created_at) "
+        "VALUES (?, 'gave_up', NULL, ?)",
+        (tid, int(time.time())),
+    )
+    conn.commit()
+    assert kb.recompute_ready(conn) == 1
+    assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_promote_reads_status_inside_write_transaction(conn, monkeypatch):
+    tid = kb.create_task(conn, title="racing promotion", assignee="worker")
+    conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (tid,))
+    conn.commit()
+
+    real_write_txn = kb.write_txn
+    injected = False
+
+    @contextmanager
+    def racing_write_txn(connection):
+        nonlocal injected
+        if not injected:
+            injected = True
+            connection.execute(
+                "UPDATE tasks SET status='blocked' WHERE id=?", (tid,),
+            )
+            connection.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                "VALUES (?, 'blocked', NULL, ?)",
+                (tid, int(time.time())),
+            )
+            connection.commit()
+        with real_write_txn(connection):
+            yield
+
+    monkeypatch.setattr(kb, "write_txn", racing_write_txn)
+
+    ok, err = kb.promote_task(conn, tid, actor="operator")
+
+    assert ok and err is None
+    kinds = [event.kind for event in kb.list_events(conn, tid)]
+    assert kinds[-3:] == ["blocked", "unblocked", "promoted_manual"]
 
 
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

