### PR TITLE
fix(qqbot): drain stderr pipe post-kill in ffmpeg timeout fallback (salvages #63004)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2159,18 +2159,34 @@ class QQAdapter(BasePlatformAdapter):
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
             )
-            await asyncio.wait_for(proc.wait(), timeout=30)
-            if proc.returncode != 0:
-                stderr = await proc.stderr.read() if proc.stderr else b""
-                logger.warning(
-                    "[%s] ffmpeg failed for %s: %s",
-                    self._log_tag,
-                    Path(src_path).name,
-                    stderr[:200].decode(errors="replace"),
-                )
-                return None
-        except (asyncio.TimeoutError, FileNotFoundError) as exc:
+        except FileNotFoundError as exc:
             logger.warning("[%s] ffmpeg conversion error: %s", self._log_tag, exc)
+            return None
+        try:
+            # communicate() drains the stderr pipe; proc.wait() alone would
+            # deadlock if ffmpeg writes more than the ~64KB pipe buffer.
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+        except asyncio.TimeoutError:
+            # wait_for only cancels the local await — kill and reap the child
+            # so we don't leak an orphaned ffmpeg process and its pipe fd.
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+            logger.warning(
+                "[%s] ffmpeg conversion timed out for %s",
+                self._log_tag,
+                Path(src_path).name,
+            )
+            return None
+        if proc.returncode != 0:
+            logger.warning(
+                "[%s] ffmpeg failed for %s: %s",
+                self._log_tag,
+                Path(src_path).name,
+                (stderr or b"")[:200].decode(errors="replace"),
+            )
             return None
 
         if not Path(wav_path).exists() or Path(wav_path).stat().st_size <= 44:

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2169,15 +2169,22 @@ class QQAdapter(BasePlatformAdapter):
         except asyncio.TimeoutError:
             # wait_for only cancels the local await — kill and reap the child
             # so we don't leak an orphaned ffmpeg process and its pipe fd.
+            # communicate() (not wait()) also drains the stderr pipe: a dead-
+            # locked ffmpeg that filled the ~64KB buffer would otherwise keep
+            # the fd pinned and block reaping the killed child.
             try:
                 proc.kill()
             except ProcessLookupError:
                 pass
-            await proc.wait()
+            try:
+                _, stderr_tail = await proc.communicate()
+            except Exception:  # pragma: no cover - defensive: child already reaped
+                stderr_tail = b""
             logger.warning(
-                "[%s] ffmpeg conversion timed out for %s",
+                "[%s] ffmpeg conversion timed out for %s: %s",
                 self._log_tag,
                 Path(src_path).name,
+                (stderr_tail or b"")[:200].decode(errors="replace"),
             )
             return None
         if proc.returncode != 0:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1222,13 +1222,6 @@ class TestReadEventsClosedWsGuard:
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
 
-    def test_read_events_raises_when_ws_none(self):
-        adapter = self._make_adapter()
-        adapter._running = True
-        adapter._ws = None
-        with pytest.raises(RuntimeError):
-            asyncio.run(adapter._read_events())
-
 
 class TestConvertFfmpegToWav:
     @staticmethod

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1222,3 +1222,62 @@ class TestReadEventsClosedWsGuard:
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
 
+    def test_read_events_raises_when_ws_none(self):
+        adapter = self._make_adapter()
+        adapter._running = True
+        adapter._ws = None
+        with pytest.raises(RuntimeError):
+            asyncio.run(adapter._read_events())
+
+
+class TestConvertFfmpegToWav:
+    @staticmethod
+    def _adapter():
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = object.__new__(QQAdapter)
+        adapter._app_id = "test"  # _log_tag is a read-only property over this
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_child_and_returns_none(self, monkeypatch):
+        # A hung/verbose ffmpeg must be killed on timeout, not left orphaned.
+        killed = {"v": False}
+
+        class _FakeProc:
+            returncode = None
+
+            async def communicate(self):
+                await asyncio.sleep(3600)  # never resolves within the timeout
+
+            def kill(self):
+                killed["v"] = True
+
+            async def wait(self):
+                return 0
+
+        async def _fake_exec(*args, **kwargs):
+            return _FakeProc()
+
+        real_wait_for = asyncio.wait_for
+
+        async def _fast_wait_for(coro, timeout):
+            return await real_wait_for(coro, timeout=0.05)
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        monkeypatch.setattr(asyncio, "wait_for", _fast_wait_for)
+
+        result = await self._adapter()._convert_ffmpeg_to_wav("in.amr", "out.wav")
+        assert result is None
+        assert killed["v"] is True
+
+    @pytest.mark.asyncio
+    async def test_missing_ffmpeg_binary_returns_none(self, monkeypatch):
+        # FileNotFoundError is raised before `proc` is bound — the handler must
+        # not try to kill a nonexistent process.
+        async def _raise(*args, **kwargs):
+            raise FileNotFoundError("ffmpeg")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _raise)
+        result = await self._adapter()._convert_ffmpeg_to_wav("in.amr", "out.wav")
+        assert result is None

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1242,16 +1242,23 @@ class TestConvertFfmpegToWav:
     @pytest.mark.asyncio
     async def test_timeout_kills_child_and_returns_none(self, monkeypatch):
         # A hung/verbose ffmpeg must be killed on timeout, not left orphaned.
-        killed = {"v": False}
+        # Post-kill the handler must drain the stderr pipe (communicate, not
+        # wait) so a buffer-full ffmpeg cannot pin the fd or block reaping.
+        state = {"killed": False, "communicated_after_kill": False}
 
         class _FakeProc:
             returncode = None
 
             async def communicate(self):
-                await asyncio.sleep(3600)  # never resolves within the timeout
+                if state["killed"]:
+                    # drain path: a killed child's remaining pipe output.
+                    state["communicated_after_kill"] = True
+                    return b"", b""
+                # main path: hang so wait_for raises TimeoutError.
+                await asyncio.sleep(3600)
 
             def kill(self):
-                killed["v"] = True
+                state["killed"] = True
 
             async def wait(self):
                 return 0
@@ -1269,7 +1276,8 @@ class TestConvertFfmpegToWav:
 
         result = await self._adapter()._convert_ffmpeg_to_wav("in.amr", "out.wav")
         assert result is None
-        assert killed["v"] is True
+        assert state["killed"] is True
+        assert state["communicated_after_kill"] is True
 
     @pytest.mark.asyncio
     async def test_missing_ffmpeg_binary_returns_none(self, monkeypatch):


### PR DESCRIPTION
Salvages #63004 (original by @chuenchen309 — credit for identifying the bug and the main-path `communicate()` fix).

## Problem
`QQAdapter._convert_ffmpeg_to_wav` (transcodes inbound QQ voice messages to WAV for STT) deadlocks and leaks the ffmpeg subprocess. The original `await asyncio.wait_for(proc.wait(), timeout=30)` never reads the stderr pipe, so once ffmpeg fills the ~64K pipe buffer it blocks on the write side — `proc.wait()` never returns (guaranteed timeout) and the child is orphaned.

## Fix
- **Main path** (from #63004): `await asyncio.wait_for(proc.communicate(), timeout=30)` drains stderr and reaps the child.
- **Timeout fallback** (this PR, addresses sweeper feedback on #63004): after `proc.kill()`, call `await proc.communicate()` instead of `await proc.wait()`. Per the Python docs, `Process.wait()` with piped stderr can still deadlock; `communicate()` drains the pipe and reaps the killed child. `stderr` is captured for the timeout log.
- **Test** (`test_timeout_kills_child_and_returns_none`): the fake proc now distinguishes the main-path hang from the post-kill drain, and asserts `communicate()` is invoked after `kill()` — the original fake returned immediately from `wait()` and couldn't cover the PIPE-draining cleanup.

## Why salvage
#63004 went stale (merge conflict, author inactive). I left a comment on the original PR offering to pick it up, rebased onto current main, applied the sweeper-suggested `communicate()` fix, and kept the original commit to preserve credit for @chuenchen309.

## Verification
- `ruff check gateway/platforms/qqbot/adapter.py tests/gateway/test_qqbot.py` — clean
- `pytest tests/gateway/test_qqbot.py` — 64 passed
