### PR TITLE
fix(search): keep native Windows paths for rg/grep on Windows

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -294,6 +294,44 @@ class TestShellFileOpsHelpers:
             "C:/Users/alice/notes.txt"
         ) == "'/c/Users/alice/notes.txt'"
 
+    def test_escape_shell_arg_native_keeps_windows_drive_path(self, monkeypatch, file_ops):
+        # Native Windows binaries (rg via WinGet/MSVC) cannot resolve the
+        # /c/... form when MSYS2_ARG_CONV_EXCL=* disables MSYS conversion.
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert file_ops._escape_shell_arg_native(
+            r"C:\Users\alice\notes.txt"
+        ) == r"'C:\Users\alice\notes.txt'"
+
+    def test_escape_shell_arg_native_converts_msys_back_to_native(self, monkeypatch, file_ops):
+        # MSYS-form input (e.g. from ~ expansion) is converted back to the
+        # native form before quoting.
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert file_ops._escape_shell_arg_native(
+            "/c/Users/alice/notes.txt"
+        ) == r"'C:\Users\alice\notes.txt'"
+
+    def test_escape_shell_arg_native_relative_path_unchanged(self, monkeypatch, file_ops):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert file_ops._escape_shell_arg_native("notes.txt") == "'notes.txt'"
+
+    def test_escape_shell_arg_native_noop_off_windows(self, monkeypatch, file_ops):
+        # Non-Windows hosts keep POSIX paths untouched (CI runs Linux).
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        assert file_ops._escape_shell_arg_native(
+            "/c/Users/alice/notes.txt"
+        ) == "'/c/Users/alice/notes.txt'"
+        assert file_ops._escape_shell_arg_native(
+            "/home/alice/notes.txt"
+        ) == "'/home/alice/notes.txt'"
+
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
         import tools.environments.local as local_mod
 

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -2,6 +2,8 @@
 
 import os
 import re
+import shutil
+import sys
 import pytest
 import subprocess
 from pathlib import Path
@@ -255,9 +257,11 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
     env.cwd = cwd
 
     def execute(command, **kwargs):
+        # Explicit bash -c: on Windows, subprocess.run(shell=True) invokes
+        # cmd.exe (or mangles args as "<exe> /c ..."), which cannot run the
+        # POSIX find/sort/tail pipelines these tests drive.
         completed = subprocess.run(
-            command,
-            shell=True,
+            [shutil.which("bash") or "/bin/bash", "-c", command],
             text=True,
             capture_output=True,
             input=kwargs.get("stdin_data"),
@@ -666,6 +670,10 @@ class _DeletedTestGitBaselineCheck:
 class TestAtomicWriteNewFilePermissions:
     """_atomic_write should apply umask-default perms to new files (not 0600)."""
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX umask permission semantics don't apply on Windows",
+    )
     @pytest.mark.parametrize("test_umask", [0o022, 0o002, 0o077])
     def test_new_file_gets_umask_default_permissions(self, tmp_path, test_umask):
         """Newly created file should get umask-computed perms, not mktemp's 0600.
@@ -691,6 +699,10 @@ class TestAtomicWriteNewFilePermissions:
             f"got {actual_mode:04o}"
         )
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX chmod mode bits don't apply on Windows",
+    )
     def test_overwrite_still_preserves_existing_mode(self, tmp_path):
         """The new-file branch must not disturb the overwrite path's
         mode preservation (e.g. an executable script stays 0755)."""

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -332,6 +332,57 @@ class TestShellFileOpsHelpers:
             "/home/alice/notes.txt"
         ) == "'/home/alice/notes.txt'"
 
+    def test_search_files_rg_emits_native_windows_path(self, mock_env, monkeypatch):
+        # The sorted rg --files command AND its unsorted fallback must both
+        # carry the native drive path, not the /c/... rewrite (which native
+        # rg cannot resolve when MSYS2_ARG_CONV_EXCL=* disables conversion).
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._search_files_rg("notes.txt", r"C:\Users\alice", 10, 0)
+
+        commands = [c.args[0] for c in mock_env.execute.call_args_list]
+        assert len(commands) >= 2  # sorted attempt + fallback (empty output)
+        assert commands[0] == (
+            "rg --files --sortr=modified -g '*notes.txt' "
+            r"'C:\Users\alice' 2>/dev/null | head -n 10"
+        )
+        assert commands[1] == (
+            "rg --files -g '*notes.txt' "
+            r"'C:\Users\alice' 2>/dev/null | head -n 10"
+        )
+        assert "/c/Users" not in commands[0]
+        assert "/c/Users" not in commands[1]
+
+    def test_search_with_rg_emits_native_windows_path(self, mock_env, monkeypatch):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._search_with_rg("pattern", r"C:\Users\alice", None, 10, 0, "content", 0)
+
+        cmd = mock_env.execute.call_args.args[0]
+        assert cmd == (
+            "set -o pipefail; rg --line-number --no-heading --with-filename "
+            r"'pattern' 'C:\Users\alice' | head -n 10"
+        )
+        assert "/c/Users" not in cmd
+
+    def test_search_with_grep_emits_native_windows_path(self, mock_env, monkeypatch):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        ops._search_with_grep("pattern", r"C:\Users\alice", None, 10, 0, "content", 0)
+
+        cmd = mock_env.execute.call_args.args[0]
+        assert cmd == (
+            "set -o pipefail; grep -rnH --exclude-dir='.*' "
+            r"'pattern' 'C:\Users\alice' | head -n 10"
+        )
+        assert "/c/Users" not in cmd
+
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
         import tools.environments.local as local_mod
 

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -304,6 +304,9 @@ class TestShellFileOpsHelpers:
         import tools.environments.local as local_mod
 
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(
+            file_ops, "_uses_native_windows_search_paths", lambda: True
+        )
         assert file_ops._escape_shell_arg_native(
             r"C:\Users\alice\notes.txt"
         ) == r"'C:\Users\alice\notes.txt'"
@@ -314,6 +317,9 @@ class TestShellFileOpsHelpers:
         import tools.environments.local as local_mod
 
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(
+            file_ops, "_uses_native_windows_search_paths", lambda: True
+        )
         assert file_ops._escape_shell_arg_native(
             "/c/Users/alice/notes.txt"
         ) == r"'C:\Users\alice\notes.txt'"
@@ -322,6 +328,9 @@ class TestShellFileOpsHelpers:
         import tools.environments.local as local_mod
 
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(
+            file_ops, "_uses_native_windows_search_paths", lambda: True
+        )
         assert file_ops._escape_shell_arg_native("notes.txt") == "'notes.txt'"
 
     def test_escape_shell_arg_native_noop_off_windows(self, monkeypatch, file_ops):
@@ -344,6 +353,7 @@ class TestShellFileOpsHelpers:
 
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(ops, "_uses_native_windows_search_paths", lambda: True)
         ops._search_files_rg("notes.txt", r"C:\Users\alice", 10, 0)
 
         commands = [c.args[0] for c in mock_env.execute.call_args_list]
@@ -364,6 +374,7 @@ class TestShellFileOpsHelpers:
 
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(ops, "_uses_native_windows_search_paths", lambda: True)
         ops._search_with_rg("pattern", r"C:\Users\alice", None, 10, 0, "content", 0)
 
         cmd = mock_env.execute.call_args.args[0]
@@ -378,6 +389,7 @@ class TestShellFileOpsHelpers:
 
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(ops, "_uses_native_windows_search_paths", lambda: True)
         ops._search_with_grep("pattern", r"C:\Users\alice", None, 10, 0, "content", 0)
 
         cmd = mock_env.execute.call_args.args[0]
@@ -385,6 +397,27 @@ class TestShellFileOpsHelpers:
             "set -o pipefail; grep -rnH --exclude-dir='.*' "
             r"'pattern' 'C:\Users\alice' | head -n 10"
         )
+        assert "/c/Users" not in cmd
+
+    def test_lint_uses_native_windows_path(self, mock_env, monkeypatch):
+        # Linters (node/go/rustfmt) are native Windows binaries too; the
+        # {file} placeholder must carry the drive-qualified path.
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(ops, "_uses_native_windows_search_paths", lambda: True)
+
+        def side_effect(command, **kwargs):
+            if "command -v" in command:
+                return {"output": "yes", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops._check_lint(r"C:\Users\alice\file.js")
+
+        cmd = mock_env.execute.call_args_list[-1].args[0]
+        assert "node --check 'C:\\Users\\alice\\file.js'" in cmd
         assert "/c/Users" not in cmd
 
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2182,7 +2182,11 @@ class ShellFileOperations(FileOperations):
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
 
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+        # LC_ALL=C forces a locale-independent '%T@' mtime format: on
+        # non-C locales (e.g. hu_HU) Cygwin find emits NBSP thousands
+        # separators (byte 0xa0) and a comma decimal separator, which both
+        # break UTF-8 decoding and the 'mtime path' parse below.
+        cmd = f"LC_ALL=C find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
 
         result = self._exec(cmd, timeout=60)
@@ -2190,7 +2194,7 @@ class ShellFileOperations(FileOperations):
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+            cmd_simple = f"LC_ALL=C find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
                         f"2>/dev/null | sort -rn{pagination_expr}"
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
@@ -2204,6 +2208,12 @@ class ShellFileOperations(FileOperations):
                 files.append(parts[1])
             else:
                 files.append(line)
+
+        # find emits MSYS-form paths (/c/Users/x) on Windows; normalize to
+        # the native drive form so results match the rg path and resolve
+        # correctly in the hidden-root filtering below.
+        from tools.environments.local import _msys_to_windows_path
+        files = [_msys_to_windows_path(f) for f in files]
 
         # For explicit hidden roots, find's path-based filtering excludes every
         # file under the hidden path. Apply descendant filtering after command

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -975,8 +975,25 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _escape_shell_arg_native(self, arg: str) -> str:
+        """Quote *arg* for shell use WITHOUT the Git Bash ``/c/`` rewrite.
+
+        ``_escape_shell_arg`` rewrites ``C:\\...`` to ``/c/...`` for bash
+        builtins and MSYS/Cygwin binaries. Native Windows executables (e.g.
+        rg installed via WinGet/MSVC builds) cannot resolve ``/c/...`` when
+        ``MSYS2_ARG_CONV_EXCL=*`` disables MSYS argument auto-conversion:
+        they treat it as a root-relative path (``C:\\c\\...``) and fail with
+        "os error 3: The system cannot find the path specified". Single
+        quotes preserve backslashes verbatim, so the native ``C:\\...``
+        form survives bash untouched and works with both native and
+        MSYS binaries.
+        """
+        from tools.environments.local import _msys_to_windows_path
+        arg = _msys_to_windows_path(arg)  # /c/Users/x -> C:\Users\x; no-op otherwise
+        return "'" + arg.replace("'", "'\"'\"'") + "'"
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
-        """Write ``content`` to ``path`` atomically via temp-file + rename.
+        """Write ``content`` to ``path`` atomically via tempfile + rename.
 
         Streams ``content`` over stdin into a temp file in the SAME
         directory as ``path`` (so the final ``mv`` is a real rename on the
@@ -2231,7 +2248,7 @@ class ShellFileOperations(FileOperations):
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._escape_shell_arg_native(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2242,7 +2259,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._escape_shell_arg_native(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2298,7 +2315,10 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        # Path must stay in native Windows form (no /c/ rewrite): native
+        # rg.exe cannot resolve /c/... when MSYS2_ARG_CONV_EXCL=* disables
+        # MSYS argument auto-conversion.
+        cmd_parts.append(self._escape_shell_arg_native(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,
@@ -2428,7 +2448,9 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        # Same native-path treatment as the rg variant: keep the Windows
+        # form so the path resolves regardless of which grep is on PATH.
+        cmd_parts.append(self._escape_shell_arg_native(path))
         
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -975,6 +975,22 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _uses_native_windows_search_paths(self) -> bool:
+        """True when search/lint commands run against the LOCAL Git Bash
+        backend on Windows.
+
+        Native Windows binaries (rg, node, go, rustfmt) need drive-qualified
+        paths because ``MSYS2_ARG_CONV_EXCL=*`` disables MSYS argument
+        conversion in this environment. Remote/container backends must keep
+        their own POSIX path semantics even when the Hermes host itself is
+        Windows — ``/c/Users/x`` may be a real path there.
+        """
+        try:
+            from tools.environments.local import LocalEnvironment, _IS_WINDOWS
+            return _IS_WINDOWS and isinstance(self.env, LocalEnvironment)
+        except Exception:
+            return False
+
     def _escape_shell_arg_native(self, arg: str) -> str:
         """Quote *arg* for shell use WITHOUT the Git Bash ``/c/`` rewrite.
 
@@ -986,10 +1002,12 @@ class ShellFileOperations(FileOperations):
         "os error 3: The system cannot find the path specified". Single
         quotes preserve backslashes verbatim, so the native ``C:\\...``
         form survives bash untouched and works with both native and
-        MSYS binaries.
+        MSYS binaries. Only applies on the local Windows backend; remote
+        backends keep POSIX path semantics.
         """
-        from tools.environments.local import _msys_to_windows_path
-        arg = _msys_to_windows_path(arg)  # /c/Users/x -> C:\Users\x; no-op otherwise
+        if self._uses_native_windows_search_paths():
+            from tools.environments.local import _msys_to_windows_path
+            arg = _msys_to_windows_path(arg)  # /c/Users/x -> C:\Users\x; no-op otherwise
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
@@ -1797,8 +1815,11 @@ class ShellFileOperations(FileOperations):
         if not self._has_command(base_cmd):
             return LintResult(skipped=True, message=f"{base_cmd} not available")
 
-        # Run linter
-        cmd = linter_cmd.replace("{file}", self._escape_shell_arg(path))
+        # Run linter. Use the native-Windows path form (C:/...) for the
+        # file argument: linters like node/go/rustfmt are NATIVE Windows
+        # binaries that reject the MSYS /c/... spelling (_bash_safe_path
+        # would produce), while python/npx (MSYS) also accept C:/...
+        cmd = linter_cmd.replace("{file}", self._escape_shell_arg_native(path))
         result = self._exec(cmd, timeout=30)
 
         if result.exit_code != 0 and _looks_like_linter_unusable(base_cmd, result.stdout):


### PR DESCRIPTION
_escape_shell_arg rewrites C:\... to /c/... for bash builtins, but native Windows rg (WinGet/MSVC build) cannot resolve /c/... when MSYS2_ARG_CONV_EXCL=* disables MSYS argument conversion - it treats the path as root-relative and fails with os error 3. _search_files_rg swallowed the error via 2>/dev/null, silently returning 0 results.

Add _escape_shell_arg_native() which quotes without the /c/ rewrite and converts MSYS paths back to native form; use it for the path argument in _search_files_rg, _search_with_rg and _search_with_grep.

