### PR TITLE
fix(desktop): open safe local and Obsidian response links

### DIFF
--- a/apps/desktop/electron/external-url-policy.test.ts
+++ b/apps/desktop/electron/external-url-policy.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { classifyExternalUrl } from './external-url-policy'
+
+test('classifyExternalUrl accepts validated local file URLs', () => {
+  const result = classifyExternalUrl('file:///C:/Users/example/My%20Note.md')
+
+  assert.equal(result?.kind, 'file')
+  assert.equal(result?.url.protocol, 'file:')
+})
+
+test('classifyExternalUrl accepts Obsidian open-note URLs', () => {
+  const result = classifyExternalUrl('obsidian://open?vault=Personal&file=00%20Inbox%2FMy%20Note.md')
+
+  assert.equal(result?.kind, 'external')
+  assert.equal(result?.url.protocol, 'obsidian:')
+  assert.equal(result?.url.hostname, 'open')
+})
+
+test('classifyExternalUrl rejects other application protocols and Obsidian actions', () => {
+  assert.equal(classifyExternalUrl('file://attacker/share/note.md'), null)
+  assert.equal(classifyExternalUrl('file:////attacker/share/note.md'), null)
+  assert.equal(classifyExternalUrl('file://///attacker/share/note.md'), null)
+  assert.equal(classifyExternalUrl('file://localhost//attacker/share/note.md'), null)
+  assert.equal(classifyExternalUrl('vscode://file/C:/Users/example/note.md'), null)
+  assert.equal(classifyExternalUrl('javascript:alert(1)'), null)
+  assert.equal(classifyExternalUrl('obsidian://new?vault=Personal&name=Injected'), null)
+  assert.equal(classifyExternalUrl('obsidian://open@attacker?vault=Personal'), null)
+  assert.equal(classifyExternalUrl('obsidian://open/other-action?vault=Personal'), null)
+})

--- a/apps/desktop/electron/external-url-policy.test.ts
+++ b/apps/desktop/electron/external-url-policy.test.ts
@@ -2,21 +2,25 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { classifyExternalUrl } from './external-url-policy'
+import { classifyExternalUrl, classifyResponseLinkUrl, wslExternalOpenCommand } from './external-url-policy'
 
-test('classifyExternalUrl accepts validated local file URLs', () => {
-  const result = classifyExternalUrl('file:///C:/Users/example/My%20Note.md')
+test('classifyExternalUrl preserves trusted arbitrary local artifact URLs', () => {
+  const result = classifyExternalUrl('file:///C:/Users/example/script.py')
 
   assert.equal(result?.kind, 'file')
   assert.equal(result?.url.protocol, 'file:')
 })
 
-test('classifyExternalUrl accepts Obsidian open-note URLs', () => {
-  const result = classifyExternalUrl('obsidian://open?vault=Personal&file=00%20Inbox%2FMy%20Note.md')
+test('classifyResponseLinkUrl accepts passive local files and Obsidian open-note URLs', () => {
+  const fileResult = classifyResponseLinkUrl('file:///C:/Users/example/My%20Note.md')
+  const obsidianResult = classifyResponseLinkUrl('obsidian://open?vault=Personal&file=00%20Inbox%2FMy%20Note.md')
 
-  assert.equal(result?.kind, 'external')
-  assert.equal(result?.url.protocol, 'obsidian:')
-  assert.equal(result?.url.hostname, 'open')
+  assert.equal(fileResult?.kind, 'file')
+  assert.equal(fileResult?.url.protocol, 'file:')
+  assert.equal(obsidianResult?.kind, 'external')
+  assert.equal(obsidianResult?.url.protocol, 'obsidian:')
+  assert.equal(obsidianResult?.url.hostname, 'open')
+  assert.equal(classifyExternalUrl('obsidian://open?vault=Personal&file=Note.md'), null)
 })
 
 test('classifyExternalUrl rejects other application protocols and Obsidian actions', () => {
@@ -24,9 +28,37 @@ test('classifyExternalUrl rejects other application protocols and Obsidian actio
   assert.equal(classifyExternalUrl('file:////attacker/share/note.md'), null)
   assert.equal(classifyExternalUrl('file://///attacker/share/note.md'), null)
   assert.equal(classifyExternalUrl('file://localhost//attacker/share/note.md'), null)
+  assert.equal(classifyExternalUrl('file:///C:/Users/example/note%2Fescape.md'), null)
+  assert.equal(classifyExternalUrl('file:///C:/Users/example/note%5Cescape.md'), null)
+  assert.equal(classifyResponseLinkUrl('file:///C:/Users/example/note%2Fescape.md'), null)
+  assert.equal(classifyResponseLinkUrl('file:///C:/Users/example/note%5Cescape.md'), null)
   assert.equal(classifyExternalUrl('vscode://file/C:/Users/example/note.md'), null)
   assert.equal(classifyExternalUrl('javascript:alert(1)'), null)
   assert.equal(classifyExternalUrl('obsidian://new?vault=Personal&name=Injected'), null)
   assert.equal(classifyExternalUrl('obsidian://open@attacker?vault=Personal'), null)
   assert.equal(classifyExternalUrl('obsidian://open/other-action?vault=Personal'), null)
+})
+
+test.each([
+  'file:///C:/Users/example/payload.exe',
+  'file:///C:/Users/example/payload.cmd',
+  'file:///C:/Users/example/payload.bat',
+  'file:///C:/Users/example/installer.msi',
+  'file:///C:/Users/example/shortcut.lnk',
+  'file:///C:/Users/example/website.url',
+  'file:///C:/Users/example/script.ps1',
+  'file:///C:/Users/example/document.pdf.exe',
+  'file:///C:/Users/example/encoded%2Eexe'
+])('classifyResponseLinkUrl rejects active response file targets: %s', target => {
+  assert.equal(classifyResponseLinkUrl(target), null)
+})
+
+test('wslExternalOpenCommand bypasses cmd parsing and preserves URL metacharacters', () => {
+  const url = 'obsidian://open?vault=Personal&file=00%20Inbox%2FNote%20(1)%5E%7C%3C%3E.md'
+  const command = wslExternalOpenCommand(url)
+
+  assert.equal(command.executable, 'rundll32.exe')
+  assert.deepEqual(command.args, ['url.dll,FileProtocolHandler', url])
+  assert.equal(command.args.length, 2)
+  assert.ok(!command.args.some(argument => /cmd\.exe|\/c|start/i.test(argument)))
 })

--- a/apps/desktop/electron/external-url-policy.ts
+++ b/apps/desktop/electron/external-url-policy.ts
@@ -1,0 +1,49 @@
+export type ExternalUrlClassification = {
+  kind: 'external' | 'file'
+  url: URL
+}
+
+export function classifyExternalUrl(rawUrl: unknown): ExternalUrlClassification | null {
+  const raw = String(rawUrl || '').trim()
+
+  if (!raw) {
+    return null
+  }
+
+  let url: URL
+
+  try {
+    url = new URL(raw)
+  } catch {
+    return null
+  }
+
+  if (
+    url.protocol === 'file:' &&
+    (!url.hostname || url.hostname.toLowerCase() === 'localhost') &&
+    !url.username &&
+    !url.password &&
+    !url.port &&
+    !url.pathname.startsWith('//')
+  ) {
+    return { kind: 'file', url }
+  }
+
+  if (['http:', 'https:', 'mailto:'].includes(url.protocol)) {
+    return { kind: 'external', url }
+  }
+
+  if (
+    url.protocol === 'obsidian:' &&
+    url.hostname.toLowerCase() === 'open' &&
+    !url.username &&
+    !url.password &&
+    !url.port &&
+    (!url.pathname || url.pathname === '/') &&
+    !url.hash
+  ) {
+    return { kind: 'external', url }
+  }
+
+  return null
+}

--- a/apps/desktop/electron/external-url-policy.ts
+++ b/apps/desktop/electron/external-url-policy.ts
@@ -1,36 +1,123 @@
+const SAFE_RESPONSE_FILE_EXTENSIONS = new Set([
+  '.bmp',
+  '.csv',
+  '.docx',
+  '.flac',
+  '.gif',
+  '.heic',
+  '.jpeg',
+  '.jpg',
+  '.json',
+  '.log',
+  '.m4a',
+  '.m4v',
+  '.markdown',
+  '.md',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.odp',
+  '.ods',
+  '.odt',
+  '.ogg',
+  '.pdf',
+  '.png',
+  '.pptx',
+  '.rtf',
+  '.tif',
+  '.tiff',
+  '.toml',
+  '.txt',
+  '.wav',
+  '.webm',
+  '.webp',
+  '.xlsx',
+  '.yaml',
+  '.yml',
+  '.zip'
+])
+
+function hasSafeResponseFileExtension(url: URL): boolean {
+  try {
+    const pathname = decodeURIComponent(url.pathname).toLowerCase()
+    const extensionIndex = pathname.lastIndexOf('.')
+
+    return extensionIndex >= 0 && SAFE_RESPONSE_FILE_EXTENSIONS.has(pathname.slice(extensionIndex))
+  } catch {
+    return false
+  }
+}
+
 export type ExternalUrlClassification = {
   kind: 'external' | 'file'
   url: URL
 }
 
-export function classifyExternalUrl(rawUrl: unknown): ExternalUrlClassification | null {
+export type WslExternalOpenCommand = {
+  executable: 'rundll32.exe'
+  args: ['url.dll,FileProtocolHandler', string]
+}
+
+export function wslExternalOpenCommand(url: string): WslExternalOpenCommand {
+  return {
+    executable: 'rundll32.exe',
+    args: ['url.dll,FileProtocolHandler', url]
+  }
+}
+
+function parseExternalUrl(rawUrl: unknown): URL | null {
   const raw = String(rawUrl || '').trim()
 
   if (!raw) {
     return null
   }
 
-  let url: URL
-
   try {
-    url = new URL(raw)
+    return new URL(raw)
   } catch {
     return null
   }
+}
 
-  if (
+function isValidatedLocalFileUrl(url: URL): boolean {
+  return (
     url.protocol === 'file:' &&
     (!url.hostname || url.hostname.toLowerCase() === 'localhost') &&
     !url.username &&
     !url.password &&
     !url.port &&
-    !url.pathname.startsWith('//')
-  ) {
+    !url.pathname.startsWith('//') &&
+    !/%2f|%5c/i.test(url.pathname)
+  )
+}
+
+export function classifyExternalUrl(rawUrl: unknown): ExternalUrlClassification | null {
+  const url = parseExternalUrl(rawUrl)
+
+  if (!url) {
+    return null
+  }
+
+  if (isValidatedLocalFileUrl(url)) {
     return { kind: 'file', url }
   }
 
   if (['http:', 'https:', 'mailto:'].includes(url.protocol)) {
     return { kind: 'external', url }
+  }
+
+  return null
+}
+
+export function classifyResponseLinkUrl(rawUrl: unknown): ExternalUrlClassification | null {
+  const url = parseExternalUrl(rawUrl)
+
+  if (!url) {
+    return null
+  }
+
+  if (isValidatedLocalFileUrl(url) && hasSafeResponseFileExtension(url)) {
+    return { kind: 'file', url }
   }
 
   if (

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -90,6 +90,7 @@ import {
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
+import { classifyExternalUrl } from './external-url-policy'
 import { findGitBash as _findGitBash } from './find-git-bash'
 import { installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
 import { createFirstRunSetupGate } from './first-run-setup-gate'
@@ -1277,19 +1278,13 @@ function loadWindowUrl(win, url, label) {
 }
 
 function openExternalUrl(rawUrl) {
-  const raw = String(rawUrl || '').trim()
+  const target = classifyExternalUrl(rawUrl)
 
-  if (!raw) {
+  if (!target) {
     return false
   }
 
-  let parsed
-
-  try {
-    parsed = new URL(raw)
-  } catch {
-    return false
-  }
+  const parsed = target.url
 
   // `file://` URLs come from the artifacts panel (the renderer can't open
   // them itself because Chromium blocks file:// navigation from the app
@@ -1323,10 +1318,6 @@ function openExternalUrl(rawUrl) {
       .catch(error => rememberLog(`[file] openPath rejected: ${error.message}`))
 
     return true
-  }
-
-  if (!['http:', 'https:', 'mailto:'].includes(parsed.protocol)) {
-    return false
   }
 
   const url = parsed.toString()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -90,7 +90,7 @@ import {
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
-import { classifyExternalUrl } from './external-url-policy'
+import { classifyExternalUrl, classifyResponseLinkUrl, wslExternalOpenCommand } from './external-url-policy'
 import { findGitBash as _findGitBash } from './find-git-bash'
 import { installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
 import { createFirstRunSetupGate } from './first-run-setup-gate'
@@ -1277,8 +1277,8 @@ function loadWindowUrl(win, url, label) {
   win.loadURL(url).catch(error => rememberLog(`${label} failed to load: ${describeCrashReason(error)}`))
 }
 
-function openExternalUrl(rawUrl) {
-  const target = classifyExternalUrl(rawUrl)
+function openExternalUrl(rawUrl, classify = classifyExternalUrl) {
+  const target = classify(rawUrl)
 
   if (!target) {
     return false
@@ -1325,14 +1325,16 @@ function openExternalUrl(rawUrl) {
   if (IS_WSL) {
     rememberLog(`[link] opening via WSL→Windows: ${url}`)
 
-    const proc = spawn('cmd.exe', ['/c', 'start', '""', url], {
+    const command = wslExternalOpenCommand(url)
+
+    const proc = spawn(command.executable, command.args, {
       detached: true,
       stdio: 'ignore',
       windowsHide: true
     })
 
     proc.on('error', error => {
-      rememberLog(`[link] cmd.exe start failed: ${error.message}; falling back to xdg-open`)
+      rememberLog(`[link] rundll32 URL dispatch failed: ${error.message}; falling back to xdg-open`)
       shell.openExternal(url).catch(fallback => rememberLog(`[link] xdg-open failed: ${fallback.message}`))
     })
     proc.unref()
@@ -10629,6 +10631,12 @@ ipcMain.on('hermes:quick-entry:dismiss', () => hideQuickEntryWindow())
 ipcMain.handle('hermes:openExternal', (_event, url) => {
   if (!openExternalUrl(url)) {
     throw new Error('Invalid external URL')
+  }
+})
+
+ipcMain.handle('hermes:openResponseLink', (_event, url) => {
+  if (!openExternalUrl(url, classifyResponseLinkUrl)) {
+    throw new Error('Invalid response link URL')
   }
 })
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -128,6 +128,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setKeepAwake: on => ipcRenderer.send('hermes:keep-awake', on),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
+  openResponseLink: url => ipcRenderer.invoke('hermes:openResponseLink', url),
   openPreviewInBrowser: url => ipcRenderer.invoke('hermes:openPreviewInBrowser', url),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
   sanitizeWorkspaceCwd: cwd => ipcRenderer.invoke('hermes:workspace:sanitize', cwd),

--- a/apps/desktop/src/components/assistant-ui/markdown-local-link.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-local-link.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { MarkdownTextContent } from './markdown-text'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+
+  if (initialHermesDesktop) {
+    desktopWindow.hermesDesktop = initialHermesDesktop
+  } else {
+    delete desktopWindow.hermesDesktop
+  }
+})
+
+it.each([
+  ['local file', 'file:///C:/Users/example/My%20Note.md'],
+  ['Obsidian note', 'obsidian://open?vault=Personal&file=00%20Inbox%2FMy%20Note.md']
+])('opens a %s response link through the controlled desktop bridge', async (_label, href) => {
+  const openExternal = vi.fn().mockResolvedValue(undefined)
+
+  desktopWindow.hermesDesktop = { openExternal } as unknown as Window['hermesDesktop']
+
+  render(<MarkdownTextContent isRunning={false} text={`[Open note](${href})`} />)
+
+  const link = await screen.findByRole('link', { name: 'Open note' })
+  fireEvent.click(link)
+
+  await waitFor(() => expect(openExternal).toHaveBeenCalledWith(href))
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-local-link.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-local-link.test.tsx
@@ -22,13 +22,15 @@ it.each([
   ['Obsidian note', 'obsidian://open?vault=Personal&file=00%20Inbox%2FMy%20Note.md']
 ])('opens a %s response link through the controlled desktop bridge', async (_label, href) => {
   const openExternal = vi.fn().mockResolvedValue(undefined)
+  const openResponseLink = vi.fn().mockResolvedValue(undefined)
 
-  desktopWindow.hermesDesktop = { openExternal } as unknown as Window['hermesDesktop']
+  desktopWindow.hermesDesktop = { openExternal, openResponseLink } as unknown as Window['hermesDesktop']
 
   render(<MarkdownTextContent isRunning={false} text={`[Open note](${href})`} />)
 
   const link = await screen.findByRole('link', { name: 'Open note' })
   fireEvent.click(link)
 
-  await waitFor(() => expect(openExternal).toHaveBeenCalledWith(href))
+  await waitFor(() => expect(openResponseLink).toHaveBeenCalledWith(href))
+  expect(openExternal).not.toHaveBeenCalled()
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -262,7 +262,15 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
 
   if (desktopTarget) {
     return (
-      <ExternalLink className={cn('wrap-anywhere', className)} href={desktopTarget} {...props}>
+      <ExternalLink
+        className={cn('wrap-anywhere', className)}
+        href={desktopTarget}
+        onClick={event => {
+          event.preventDefault()
+          void window.hermesDesktop?.openResponseLink?.(desktopTarget)
+        }}
+        {...props}
+      >
         {children}
       </ExternalLink>
     )

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -15,7 +15,8 @@ import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { detectArtifact } from '@/lib/artifact-detect'
-import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
+import { desktopTargetFromMarkdownHref, remarkDesktopLinks } from '@/lib/desktop-links'
+import { ExternalLink, normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
@@ -51,6 +52,7 @@ import { detectEmbed, extractAlert, MarkdownAlert, RichCodeBlock, UrlEmbed } fro
 // `singleDollarTextMath: true` enables `$x^2$` for inline math (de-facto
 // LLM convention). The default false-setting only accepts `$$...$$`.
 const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
+const remarkPlugins = [remarkDesktopLinks]
 
 // `@streamdown/code` statically imports ALL of shiki (every grammar + theme —
 // the single largest chunk in the renderer), so it must never sit on the
@@ -254,6 +256,16 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
 
   if (mediaPath) {
     return <MediaAttachment path={mediaPath} />
+  }
+
+  const desktopTarget = desktopTargetFromMarkdownHref(href)
+
+  if (desktopTarget) {
+    return (
+      <ExternalLink className={cn('wrap-anywhere', className)} href={desktopTarget} {...props}>
+        {children}
+      </ExternalLink>
+    )
   }
 
   const previewTarget = previewTargetFromMarkdownHref(href)
@@ -612,6 +624,7 @@ function MarkdownTextSurface({
       parseMarkdownIntoBlocksFn={parseMarkdownIntoBlocksCached}
       plugins={plugins}
       preprocess={preprocessWithTailRepair}
+      remarkPlugins={remarkPlugins}
     />
   )
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -143,6 +143,7 @@ declare global {
       setKeepAwake?: (on: boolean) => void
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
+      openResponseLink?: (url: string) => Promise<void>
       openPreviewInBrowser?: (url: string) => Promise<void>
       fetchLinkTitle: (url: string) => Promise<string>
       sanitizeWorkspaceCwd: (cwd?: null | string) => Promise<{ cwd: string; sanitized: boolean }>

--- a/apps/desktop/src/lib/desktop-links.test.ts
+++ b/apps/desktop/src/lib/desktop-links.test.ts
@@ -22,7 +22,18 @@ describe('desktop response links', () => {
     'file://///attacker/share/note.md',
     'file://localhost//attacker/share/note.md',
     'obsidian://open@attacker?vault=Personal',
-    'obsidian://open/other-action?vault=Personal'
+    'obsidian://open/other-action?vault=Personal',
+    'file:///C:/Users/example/payload.exe',
+    'file:///C:/Users/example/payload.cmd',
+    'file:///C:/Users/example/payload.bat',
+    'file:///C:/Users/example/installer.msi',
+    'file:///C:/Users/example/shortcut.lnk',
+    'file:///C:/Users/example/website.url',
+    'file:///C:/Users/example/script.ps1',
+    'file:///C:/Users/example/document.pdf.exe',
+    'file:///C:/Users/example/encoded%2Eexe',
+    'file:///C:/Users/example/note%2Fescape.md',
+    'file:///C:/Users/example/note%5Cescape.md'
   ])('does not wrap a disallowed target: %s', target => {
     expect(desktopMarkdownHref(target)).toBeNull()
   })

--- a/apps/desktop/src/lib/desktop-links.test.ts
+++ b/apps/desktop/src/lib/desktop-links.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { desktopMarkdownHref, desktopTargetFromMarkdownHref, remarkDesktopLinks } from './desktop-links'
+
+describe('desktop response links', () => {
+  it.each(['file:///C:/Users/example/My%20Note.md', 'obsidian://open?vault=Personal&file=00%20Inbox%2FMy%20Note.md'])(
+    'round-trips an allowed target through a safe fragment: %s',
+    target => {
+      const href = desktopMarkdownHref(target)
+
+      expect(href).toMatch(/^#desktop-open\//)
+      expect(desktopTargetFromMarkdownHref(href ?? undefined)).toBe(target)
+    }
+  )
+
+  it.each([
+    'javascript:alert(1)',
+    'vscode://file/C:/Users/example/note.md',
+    'obsidian://new?vault=Personal&name=Injected',
+    'file://attacker/share/note.md',
+    'file:////attacker/share/note.md',
+    'file://///attacker/share/note.md',
+    'file://localhost//attacker/share/note.md',
+    'obsidian://open@attacker?vault=Personal',
+    'obsidian://open/other-action?vault=Personal'
+  ])('does not wrap a disallowed target: %s', target => {
+    expect(desktopMarkdownHref(target)).toBeNull()
+  })
+
+  it('rewrites link AST nodes without changing image AST nodes', () => {
+    const link = { type: 'link', url: 'file:///C:/tmp/a_(b).md' }
+    const image = { type: 'image', url: 'file:///C:/tmp/diagram.png' }
+    const tree = { children: [link, image], type: 'root' }
+
+    remarkDesktopLinks()(tree)
+
+    expect(link.url).toMatch(/^#desktop-open\//)
+    expect(image.url).toBe('file:///C:/tmp/diagram.png')
+  })
+
+  it('rejects malformed and forged safe fragments', () => {
+    expect(desktopTargetFromMarkdownHref('#desktop-open/%E0%A4%A')).toBeNull()
+    expect(desktopTargetFromMarkdownHref(`#desktop-open/${encodeURIComponent('javascript:alert(1)')}`)).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/desktop-links.ts
+++ b/apps/desktop/src/lib/desktop-links.ts
@@ -1,0 +1,80 @@
+const DESKTOP_OPEN_PREFIX = '#desktop-open/'
+
+type MarkdownNode = {
+  children?: MarkdownNode[]
+  type?: string
+  url?: unknown
+}
+
+function isLocalFileUrl(url: URL): boolean {
+  const hostname = url.hostname.toLowerCase()
+
+  return (
+    url.protocol === 'file:' &&
+    (!hostname || hostname === 'localhost') &&
+    !url.username &&
+    !url.password &&
+    !url.port &&
+    !url.pathname.startsWith('//')
+  )
+}
+
+function isObsidianOpenUrl(url: URL): boolean {
+  return (
+    url.protocol === 'obsidian:' &&
+    url.hostname.toLowerCase() === 'open' &&
+    !url.username &&
+    !url.password &&
+    !url.port &&
+    (!url.pathname || url.pathname === '/') &&
+    !url.hash
+  )
+}
+
+function isAllowedDesktopTarget(value: string): boolean {
+  let url: URL
+
+  try {
+    url = new URL(value)
+  } catch {
+    return false
+  }
+
+  return isLocalFileUrl(url) || isObsidianOpenUrl(url)
+}
+
+export function desktopMarkdownHref(target: string): string | null {
+  return isAllowedDesktopTarget(target) ? `${DESKTOP_OPEN_PREFIX}${encodeURIComponent(target)}` : null
+}
+
+export function desktopTargetFromMarkdownHref(href?: string): string | null {
+  if (!href?.startsWith(DESKTOP_OPEN_PREFIX)) {
+    return null
+  }
+
+  try {
+    const target = decodeURIComponent(href.slice(DESKTOP_OPEN_PREFIX.length))
+
+    return isAllowedDesktopTarget(target) ? target : null
+  } catch {
+    return null
+  }
+}
+
+export function remarkDesktopLinks() {
+  return (tree: MarkdownNode) => {
+    const visit = (node: MarkdownNode) => {
+      if (node.type === 'link' && typeof node.url === 'string') {
+        const href = desktopMarkdownHref(node.url)
+
+        if (href) {
+          node.url = href
+        }
+      }
+
+      node.children?.forEach(visit)
+    }
+
+    visit(tree)
+  }
+}

--- a/apps/desktop/src/lib/desktop-links.ts
+++ b/apps/desktop/src/lib/desktop-links.ts
@@ -1,5 +1,55 @@
 const DESKTOP_OPEN_PREFIX = '#desktop-open/'
 
+const SAFE_RESPONSE_FILE_EXTENSIONS = new Set([
+  '.bmp',
+  '.csv',
+  '.docx',
+  '.flac',
+  '.gif',
+  '.heic',
+  '.jpeg',
+  '.jpg',
+  '.json',
+  '.log',
+  '.m4a',
+  '.m4v',
+  '.markdown',
+  '.md',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.odp',
+  '.ods',
+  '.odt',
+  '.ogg',
+  '.pdf',
+  '.png',
+  '.pptx',
+  '.rtf',
+  '.tif',
+  '.tiff',
+  '.toml',
+  '.txt',
+  '.wav',
+  '.webm',
+  '.webp',
+  '.xlsx',
+  '.yaml',
+  '.yml',
+  '.zip'
+])
+
+function hasSafeResponseFileExtension(url: URL): boolean {
+  try {
+    const pathname = decodeURIComponent(url.pathname).toLowerCase()
+    const extensionIndex = pathname.lastIndexOf('.')
+
+    return extensionIndex >= 0 && SAFE_RESPONSE_FILE_EXTENSIONS.has(pathname.slice(extensionIndex))
+  } catch {
+    return false
+  }
+}
+
 type MarkdownNode = {
   children?: MarkdownNode[]
   type?: string
@@ -15,7 +65,9 @@ function isLocalFileUrl(url: URL): boolean {
     !url.username &&
     !url.password &&
     !url.port &&
-    !url.pathname.startsWith('//')
+    !url.pathname.startsWith('//') &&
+    !/%2f|%5c/i.test(url.pathname) &&
+    hasSafeResponseFileExtension(url)
   )
 }
 


### PR DESCRIPTION
## Summary

- enable approved local document/media links and `obsidian://open` links in assistant response Markdown
- validate links independently in the renderer and Electron main process
- preserve the existing trusted artifact opener through a separate response-link IPC route
- avoid command-shell parsing on WSL by invoking `rundll32.exe` directly

## Security boundaries

- rejects UNC/network and credentialed `file:` URLs
- permits only a passive local-file extension allowlist for model-authored response links
- rejects encoded path separators and active/double-extension targets
- restricts Obsidian links to the `open` action
- keeps renderer checks for UX and main-process checks as the security boundary

## Verification

- `npm run check:lint` — passed (0 errors; existing warnings only)
- focused Vitest suite — 39/39 passed
- `git diff --check origin/main..HEAD` — passed
- `npm run build` — passed
- independent fail-closed review — passed with no security concerns or logic errors

The broader UI run passed 3,164/3,172 tests. Six transient failures passed in isolation; the remaining two Billing failures were reproduced unchanged on a pristine `origin/main` baseline and are unrelated to this patch.
