### PR TITLE
fix(desktop): create sessions in non-git projects

### DIFF
--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -94,6 +94,31 @@ test('switchBranch: switches a normal checkout branch', async () => {
   }
 })
 
+test('switchBranch: no-ops on a project folder that is not a repo', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-switch-plain-'))
+
+  try {
+    // The sidebar switches before starting a session; a plain folder has no
+    // branch to leave, so this must not fail the session creation behind it.
+    assert.deepEqual(await switchBranch(dir, 'main', 'git'), { branch: 'main' })
+    assert.equal(fs.existsSync(path.join(dir, '.git')), false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('switchBranch: a real repo still reports a failed switch', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-switch-missing-'))
+
+  try {
+    await ensureGitRepo('git', dir)
+
+    await assert.rejects(() => switchBranch(dir, 'no-such-branch', 'git'))
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('listBranches: lists locals and flags the checked-out branch', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-branches-'))
 

--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -11,6 +11,7 @@ import {
   ensureGitRepo,
   listBaseBranches,
   listBranches,
+  listWorktrees,
   parseWorktrees,
   sanitizeBranch,
   switchBranch
@@ -104,6 +105,33 @@ test('switchBranch: no-ops on a project folder that is not a repo', async () => 
     assert.equal(fs.existsSync(path.join(dir, '.git')), false)
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('switchBranch: a failed probe still fails instead of passing as a plain folder', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-switch-nogit-'))
+
+  try {
+    await ensureGitRepo('git', dir)
+
+    // git itself is unusable here. Silently "succeeding" would strand the
+    // session on whatever branch the checkout happens to sit on.
+    await assert.rejects(() => switchBranch(dir, 'main', path.join(dir, 'no-such-git')))
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('listWorktrees: empty means "not a repository", never a broken probe', async () => {
+  const plain = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-wt-plain-'))
+
+  try {
+    // The sidebar reads an empty list as confirmed evidence the folder is not a
+    // repo, so a probe that never ran must not answer with one.
+    assert.deepEqual(await listWorktrees(plain, 'git'), [])
+    await assert.rejects(() => listWorktrees(plain, path.join(plain, 'no-such-git')))
+  } finally {
+    fs.rmSync(plain, { recursive: true, force: true })
   }
 })
 

--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -11,6 +11,7 @@ import {
   ensureGitRepo,
   listBaseBranches,
   listBranches,
+  listWorktrees,
   parseWorktrees,
   sanitizeBranch,
   switchBranch
@@ -94,16 +95,30 @@ test('switchBranch: switches a normal checkout branch', async () => {
   }
 })
 
-test('switchBranch: no-ops on a project folder that is not a repo', async () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-switch-plain-'))
+test('switchBranch: a failed probe still fails instead of passing as a plain folder', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-switch-nogit-'))
 
   try {
-    // The sidebar switches before starting a session; a plain folder has no
-    // branch to leave, so this must not fail the session creation behind it.
-    assert.deepEqual(await switchBranch(dir, 'main', 'git'), { branch: 'main' })
-    assert.equal(fs.existsSync(path.join(dir, '.git')), false)
+    await ensureGitRepo('git', dir)
+
+    // git itself is unusable here. Silently "succeeding" would strand the
+    // session on whatever branch the checkout happens to sit on.
+    await assert.rejects(() => switchBranch(dir, 'main', path.join(dir, 'no-such-git')))
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('listWorktrees: empty means "not a repository", never a broken probe', async () => {
+  const plain = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-wt-plain-'))
+
+  try {
+    // The sidebar reads an empty list as confirmed evidence the folder is not a
+    // repo, so a probe that never ran must not answer with one.
+    assert.deepEqual(await listWorktrees(plain, 'git'), [])
+    await assert.rejects(() => listWorktrees(plain, path.join(plain, 'no-such-git')))
+  } finally {
+    fs.rmSync(plain, { recursive: true, force: true })
   }
 })
 

--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -63,14 +63,15 @@ function parseWorktrees(out) {
   return trees
 }
 
-async function listWorktrees(repoPath, gitBin) {
-  let resolved
+// git's own "there is no repository here" verdict, as opposed to a probe that
+// never got an answer (missing binary, unreadable dir, timeout). Callers must
+// keep the two apart: only the first is EVIDENCE about the directory.
+function isNotARepository(err) {
+  return /not a git repository|not a working tree/i.test(`${String(err?.stderr || '')}\n${String(err?.message || '')}`)
+}
 
-  try {
-    resolved = resolveRequestedPathForIpc(repoPath, { purpose: 'Worktree list' })
-  } catch {
-    return []
-  }
+async function listWorktrees(repoPath, gitBin) {
+  const resolved = resolveRequestedPathForIpc(repoPath, { purpose: 'Worktree list' })
 
   try {
     const out = await runGit(gitBin, ['worktree', 'list', '--porcelain'], resolved)
@@ -82,8 +83,15 @@ async function listWorktrees(repoPath, gitBin) {
       detached: tree.detached,
       locked: tree.locked
     }))
-  } catch {
-    return []
+  } catch (err) {
+    // A repo always lists at least its main worktree, so an empty list is only
+    // ever "not a repository" — the sidebar reads it as exactly that. Any other
+    // failure must surface instead of impersonating that verdict.
+    if (isNotARepository(err)) {
+      return []
+    }
+
+    throw err
   }
 }
 
@@ -349,14 +357,18 @@ async function listBranches(repoPath, gitBin) {
   }
 }
 
-// True when `dir` sits inside a git work tree. A plain project folder answers
-// "no" — as does a missing/broken git binary, which degrades the same way every
-// other op in this module does.
+// Whether `dir` sits inside a git work tree, as three outcomes: git said yes,
+// git said no, or the probe itself failed. A failed probe is NOT a "no" — the
+// caller has to keep failing loudly rather than assume a plain folder.
 async function isInsideWorkTree(gitBin, dir) {
   try {
     return (await runGit(gitBin, ['rev-parse', '--is-inside-work-tree'], dir)).trim() === 'true'
-  } catch {
-    return false
+  } catch (err) {
+    if (isNotARepository(err)) {
+      return false
+    }
+
+    throw err
   }
 }
 
@@ -368,11 +380,11 @@ async function switchBranch(repoPath, branch, gitBin) {
     throw new Error('Branch name is required.')
   }
 
-  // A project folder that isn't a repo has no branch to leave, so there is
-  // nothing to switch — succeed quietly rather than failing the caller's real
-  // work (the sidebar switches before starting a session). Never `git init`
-  // here: creating a repo behind the user's back is not a branch switch.
-  // Matches the rest of this module, which degrades to empty on a non-repo.
+  // A project folder that git confirms is not a repo has no branch to leave, so
+  // there is nothing to switch — succeed quietly rather than failing the
+  // caller's real work (the sidebar switches before starting a session). Never
+  // `git init` here: creating a repo behind the user's back is not a branch
+  // switch. A probe that FAILS still throws, so a broken git stays visible.
   if (!(await isInsideWorkTree(gitBin, resolved))) {
     return { branch: target }
   }

--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -349,12 +349,32 @@ async function listBranches(repoPath, gitBin) {
   }
 }
 
+// True when `dir` sits inside a git work tree. A plain project folder answers
+// "no" — as does a missing/broken git binary, which degrades the same way every
+// other op in this module does.
+async function isInsideWorkTree(gitBin, dir) {
+  try {
+    return (await runGit(gitBin, ['rev-parse', '--is-inside-work-tree'], dir)).trim() === 'true'
+  } catch {
+    return false
+  }
+}
+
 async function switchBranch(repoPath, branch, gitBin) {
   const resolved = resolveRequestedPathForIpc(repoPath, { purpose: 'Branch switch' })
   const target = sanitizeBranch(branch)
 
   if (!target) {
     throw new Error('Branch name is required.')
+  }
+
+  // A project folder that isn't a repo has no branch to leave, so there is
+  // nothing to switch — succeed quietly rather than failing the caller's real
+  // work (the sidebar switches before starting a session). Never `git init`
+  // here: creating a repo behind the user's back is not a branch switch.
+  // Matches the rest of this module, which degrades to empty on a non-repo.
+  if (!(await isInsideWorkTree(gitBin, resolved))) {
+    return { branch: target }
   }
 
   await runGit(gitBin, ['switch', target], resolved)

--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -435,6 +435,17 @@ async function listBranches(repoPath, gitBin) {
   }
 }
 
+// True when `dir` sits inside a git work tree. A plain project folder answers
+// "no" — as does a missing/broken git binary, which degrades the same way every
+// other op in this module does.
+async function isInsideWorkTree(gitBin, dir) {
+  try {
+    return (await runGit(gitBin, ['rev-parse', '--is-inside-work-tree'], dir)).trim() === 'true'
+  } catch {
+    return false
+  }
+}
+
 async function switchBranch(repoPath, branch, gitBin) {
   const resolved = resolveRequestedPathForIpc(repoPath, { purpose: 'Branch switch' })
 
@@ -460,6 +471,15 @@ async function switchBranch(repoPath, branch, gitBin) {
 
   if (!target) {
     throw new Error('Branch name is required.')
+  }
+
+  // A project folder that isn't a repo has no branch to leave, so there is
+  // nothing to switch — succeed quietly rather than failing the caller's real
+  // work (the sidebar switches before starting a session). Never `git init`
+  // here: creating a repo behind the user's back is not a branch switch.
+  // Matches the rest of this module, which degrades to empty on a non-repo.
+  if (!(await isInsideWorkTree(gitBin, resolved))) {
+    return { branch: target }
   }
 
   await runGit(gitBin, ['switch', target], resolved)

--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -63,14 +63,15 @@ function parseWorktrees(out) {
   return trees
 }
 
-async function listWorktrees(repoPath, gitBin) {
-  let resolved
+// git's own "there is no repository here" verdict, as opposed to a probe that
+// never got an answer (missing binary, unreadable dir, timeout). Callers must
+// keep the two apart: only the first is EVIDENCE about the directory.
+function isNotARepository(err) {
+  return /not a git repository|not a working tree/i.test(`${String(err?.stderr || '')}\n${String(err?.message || '')}`)
+}
 
-  try {
-    resolved = resolveRequestedPathForIpc(repoPath, { purpose: 'Worktree list' })
-  } catch {
-    return []
-  }
+async function listWorktrees(repoPath, gitBin) {
+  const resolved = resolveRequestedPathForIpc(repoPath, { purpose: 'Worktree list' })
 
   try {
     const out = await runGit(gitBin, ['worktree', 'list', '--porcelain'], resolved)
@@ -82,8 +83,15 @@ async function listWorktrees(repoPath, gitBin) {
       detached: tree.detached,
       locked: tree.locked
     }))
-  } catch {
-    return []
+  } catch (err) {
+    // A repo always lists at least its main worktree, so an empty list is only
+    // ever "not a repository" — the sidebar reads it as exactly that. Any other
+    // failure must surface instead of impersonating that verdict.
+    if (isNotARepository(err)) {
+      return []
+    }
+
+    throw err
   }
 }
 
@@ -435,14 +443,18 @@ async function listBranches(repoPath, gitBin) {
   }
 }
 
-// True when `dir` sits inside a git work tree. A plain project folder answers
-// "no" — as does a missing/broken git binary, which degrades the same way every
-// other op in this module does.
+// Whether `dir` sits inside a git work tree, as three outcomes: git said yes,
+// git said no, or the probe itself failed. A failed probe is NOT a "no" — the
+// caller has to keep failing loudly rather than assume a plain folder.
 async function isInsideWorkTree(gitBin, dir) {
   try {
     return (await runGit(gitBin, ['rev-parse', '--is-inside-work-tree'], dir)).trim() === 'true'
-  } catch {
-    return false
+  } catch (err) {
+    if (isNotARepository(err)) {
+      return false
+    }
+
+    throw err
   }
 }
 
@@ -459,8 +471,14 @@ async function switchBranch(repoPath, branch, gitBin) {
 
   try {
     inside = (await runGit(gitBin, ['rev-parse', '--is-inside-work-tree'], resolved)).trim()
-  } catch {
-    // Not a git repo (or git unavailable): fall through to the short-circuit.
+  } catch (err) {
+    // Only git's own "not a repository" verdict is evidence about the folder. A
+    // probe that never got an answer (missing binary, unreadable dir, timeout)
+    // must surface: reporting success would strand the session on whatever
+    // branch the checkout happens to sit on.
+    if (!isNotARepository(err)) {
+      throw err
+    }
   }
 
   if (inside !== 'true') {
@@ -473,11 +491,11 @@ async function switchBranch(repoPath, branch, gitBin) {
     throw new Error('Branch name is required.')
   }
 
-  // A project folder that isn't a repo has no branch to leave, so there is
-  // nothing to switch — succeed quietly rather than failing the caller's real
-  // work (the sidebar switches before starting a session). Never `git init`
-  // here: creating a repo behind the user's back is not a branch switch.
-  // Matches the rest of this module, which degrades to empty on a non-repo.
+  // A project folder that git confirms is not a repo has no branch to leave, so
+  // there is nothing to switch — succeed quietly rather than failing the
+  // caller's real work (the sidebar switches before starting a session). Never
+  // `git init` here: creating a repo behind the user's back is not a branch
+  // switch. A probe that FAILS still throws, so a broken git stays visible.
   if (!(await isInsideWorkTree(gitBin, resolved))) {
     return { branch: target }
   }

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -47,7 +47,7 @@ export function EnteredProjectContent({
   project: SidebarProjectTree
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
   onNewSession?: (path: null | string) => void
-  repoWorktrees?: Record<string, HermesGitWorktree[]>
+  repoWorktrees?: Record<string, HermesGitWorktree[] | null>
   liveSessions?: SessionInfo[]
   removedSessionIds?: ReadonlySet<string>
 }) {
@@ -67,7 +67,9 @@ export function EnteredProjectContent({
     <>
       {project.repos.map(repo => (
         <RepoFlatSection
-          discoveredWorktrees={repo.path ? repoWorktrees?.[repo.path] : undefined}
+          // `null` (the probe failed) collapses to "not probed" — only a real
+          // answer from git is allowed to reshape the lanes.
+          discoveredWorktrees={(repo.path ? repoWorktrees?.[repo.path] : undefined) ?? undefined}
           key={repo.id}
           liveSessions={liveSessions}
           onNewSession={onNewSession}

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -43,7 +43,8 @@ export function EnteredProjectContent({
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
   onNewSession?: (path: null | string) => void
   onNewSessionSplit?: NewSessionSplitHandler
-  repoWorktrees?: Record<string, HermesGitWorktree[]>
+  // null = the probe never answered, which is NOT evidence of a plain folder.
+  repoWorktrees?: Record<string, HermesGitWorktree[] | null>
   liveSessions?: SessionInfo[]
   removedSessionIds?: ReadonlySet<string>
 }) {
@@ -63,7 +64,9 @@ export function EnteredProjectContent({
     <>
       {project.repos.map(repo => (
         <RepoFlatSection
-          discoveredWorktrees={repo.path ? repoWorktrees?.[repo.path] : undefined}
+          // `null` (the probe failed) collapses to "not probed" — only a real
+          // answer from git is allowed to reshape the lanes.
+          discoveredWorktrees={(repo.path ? repoWorktrees?.[repo.path] : undefined) ?? undefined}
           key={repo.id}
           liveSessions={liveSessions}
           onNewSession={onNewSession}

--- a/apps/desktop/src/app/chat/sidebar/projects/model.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 
-import { orderProjectsByIds, sortProjectsForOverview } from './model'
+import { desktopGit } from '@/lib/desktop-git'
+
+import { orderProjectsByIds, sortProjectsForOverview, useRepoWorktreeMap } from './model'
 import { NO_PROJECT_ID, type SidebarProjectTree } from './workspace-groups'
+
+vi.mock('@/lib/desktop-git', () => ({ desktopGit: vi.fn() }))
 
 function makeProject(id: string, sessionCount: number): SidebarProjectTree {
   return {
@@ -74,5 +79,32 @@ describe('sortProjectsForOverview', () => {
     const projects = [makeProject('scanned', 0), active, home()]
 
     expect(ids(sortProjectsForOverview(projects, 'active'))).toEqual([NO_PROJECT_ID, 'active', 'scanned'])
+  })
+})
+
+const withProbe = (worktreeList: (repoPath: string) => Promise<unknown>) =>
+  vi.mocked(desktopGit).mockReturnValue({ worktreeList } as unknown as ReturnType<typeof desktopGit>)
+
+// The lane layer treats an EMPTY worktree list as git's own "this folder is not
+// a repository" verdict. A probe that never got an answer must therefore stay
+// distinguishable from it, or a transient git failure silently restructures a
+// real repo's lanes.
+describe('useRepoWorktreeMap', () => {
+  it('records a failed probe as unknown, not as an empty repo', async () => {
+    withProbe(() => Promise.reject(new Error('git invocation failed')))
+
+    const { result } = renderHook(() => useRepoWorktreeMap(['/repo'], true))
+
+    await waitFor(() => expect(result.current[1]).toBe(false))
+    expect(result.current[0]['/repo']).toBeNull()
+  })
+
+  it("keeps git's empty answer as an empty list", async () => {
+    withProbe(() => Promise.resolve([]))
+
+    const { result } = renderHook(() => useRepoWorktreeMap(['/plain'], true))
+
+    await waitFor(() => expect(result.current[1]).toBe(false))
+    expect(result.current[0]['/plain']).toEqual([])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/model.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/model.ts
@@ -120,11 +120,15 @@ export function orderProjectsByIds(projects: SidebarProjectTree[], orderIds: str
 // Project drill-in lanes are git-driven: source them from `git worktree list` so
 // linked worktrees still appear even when their sessions aren't in the recents
 // payload currently loaded in memory.
+// A repo's entry is the probe's THREE possible answers: the worktrees git
+// listed, `[]` for git's own "not a repository" verdict, and `null` when the
+// probe failed and we know nothing (missing binary, remote backend error).
+// Lane rendering keys off that difference, so it must not be flattened here.
 export function useRepoWorktreeMap(
   repoPaths: string[],
   enabled: boolean
-): [Record<string, HermesGitWorktree[]>, boolean] {
-  const [map, setMap] = useState<Record<string, HermesGitWorktree[]>>({})
+): [Record<string, HermesGitWorktree[] | null>, boolean] {
+  const [map, setMap] = useState<Record<string, HermesGitWorktree[] | null>>({})
   const [loading, setLoading] = useState(false)
   const key = useMemo(() => pathListKey(repoPaths), [repoPaths])
   // Refetch when a worktree is added/removed so a new lane shows immediately.
@@ -148,7 +152,7 @@ export function useRepoWorktreeMap(
       try {
         return [repoPath, await git.worktreeList(repoPath)] as const
       } catch {
-        return [repoPath, []] as const
+        return [repoPath, null] as const
       }
     })
       .then(entries => void (cancelled || setMap(Object.fromEntries(entries))))

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
@@ -1,0 +1,113 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type * as ProjectsStore from '@/store/projects'
+
+import type * as Model from './model'
+import { SidebarWorkspaceGroup } from './workspace-group'
+import type { SidebarSessionGroup } from './workspace-groups'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        noSessions: 'No sessions yet',
+        newSessionIn: (label: string) => `New session in ${label}`,
+        projects: {
+          copyPath: 'Copy path',
+          menu: 'Actions',
+          removeWorktree: 'Remove worktree',
+          reveal: 'Reveal in file manager',
+          startWork: 'New worktree'
+        },
+        showMoreIn: (n: number, label: string) => `Show ${n} more in ${label}`
+      },
+      statusStack: { coding: { switchFailed: (branch: string) => `Could not switch to ${branch}` } }
+    }
+  })
+}))
+
+vi.mock('@/store/layout', () => ({ setWorkspaceNodeOpen: vi.fn() }))
+vi.mock('@/store/profile', () => ({ newSessionInProfile: vi.fn() }))
+// Partial mocks: `@/store/projects` and `./model` pull in the coding-status
+// store's subscriptions, so replacing either module wholesale breaks the import
+// graph rather than the behavior under test.
+vi.mock('@/store/projects', async importOriginal => ({
+  ...(await importOriginal<typeof ProjectsStore>()),
+  copyPath: vi.fn(),
+  revealPath: vi.fn(),
+  switchBranchInRepo: vi.fn(() => Promise.resolve())
+}))
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+vi.mock('./model', async importOriginal => ({
+  ...(await importOriginal<typeof Model>()),
+  useWorkspaceNodeOpen: () => [true, vi.fn()] as const
+}))
+
+const { notifyError } = await import('@/store/notifications')
+const { switchBranchInRepo } = await import('@/store/projects')
+
+const lane = (over: Partial<SidebarSessionGroup> & Pick<SidebarSessionGroup, 'id' | 'label'>): SidebarSessionGroup => ({
+  path: null,
+  sessions: [],
+  ...over
+})
+
+const renderGroup = (group: SidebarSessionGroup, onNewSession = vi.fn()) => {
+  render(<SidebarWorkspaceGroup group={group} onNewSession={onNewSession} renderRows={() => null} />)
+
+  return onNewSession
+}
+
+const clickAdd = (label: string) => fireEvent.click(screen.getByRole('button', { name: `New session in ${label}` }))
+
+describe('SidebarWorkspaceGroup "+"', () => {
+  it('starts a session directly in a folder lane, without touching git', async () => {
+    const onNewSession = renderGroup(
+      lane({
+        id: '/docs/notes::folder',
+        label: 'notes',
+        isFolder: true,
+        isHome: true,
+        isMain: true,
+        path: '/docs/notes'
+      })
+    )
+
+    clickAdd('notes')
+
+    // A plain folder has no branch behind the label; switching would fail on
+    // `git switch` and take the new session down with it.
+    await waitFor(() => expect(onNewSession).toHaveBeenCalledWith('/docs/notes'))
+    expect(switchBranchInRepo).not.toHaveBeenCalled()
+  })
+
+  it('switches to the lane branch first in a real repo', async () => {
+    const onNewSession = renderGroup(
+      lane({ id: '/repo::branch::main', label: 'main', isHome: true, isMain: true, path: '/repo' })
+    )
+
+    clickAdd('main')
+
+    await waitFor(() => expect(switchBranchInRepo).toHaveBeenCalledWith('/repo', 'main'))
+    expect(onNewSession).toHaveBeenCalledWith('/repo')
+  })
+
+  it('blocks creation and reports when a real switch fails', async () => {
+    vi.mocked(switchBranchInRepo).mockRejectedValueOnce(new Error('dirty tree'))
+
+    const onNewSession = renderGroup(
+      lane({ id: '/repo::branch::main', label: 'main', isHome: true, isMain: true, path: '/repo' })
+    )
+
+    clickAdd('main')
+
+    await waitFor(() => expect(notifyError).toHaveBeenCalledWith(expect.any(Error), 'Could not switch to main'))
+    expect(onNewSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
@@ -1,6 +1,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type * as LayoutStore from '@/store/layout'
+import type * as ProfileStore from '@/store/profile'
 import type * as ProjectsStore from '@/store/projects'
 
 import type * as Model from './model'
@@ -32,8 +34,14 @@ vi.mock('@/i18n', () => ({
   })
 }))
 
-vi.mock('@/store/layout', () => ({ setWorkspaceNodeOpen: vi.fn() }))
-vi.mock('@/store/profile', () => ({ newSessionInProfile: vi.fn() }))
+vi.mock('@/store/layout', async importOriginal => ({
+  ...(await importOriginal<typeof LayoutStore>()),
+  setWorkspaceNodeOpen: vi.fn()
+}))
+vi.mock('@/store/profile', async importOriginal => ({
+  ...(await importOriginal<typeof ProfileStore>()),
+  newSessionInProfile: vi.fn()
+}))
 // Partial mocks: `@/store/projects` and `./model` pull in the coding-status
 // store's subscriptions, so replacing either module wholesale breaks the import
 // graph rather than the behavior under test.

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -94,8 +94,10 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
 
     // Main-checkout lanes are branch-labeled views over the same repo root path.
     // Clicking "+" on `main` should open on `main`, not whatever branch the root
-    // currently sits on (`test0`, etc.), so explicitly switch first.
-    if (group.isMain && group.path && group.label) {
+    // currently sits on (`test0`, etc.), so explicitly switch first. A folder
+    // lane is a plain directory with no branch behind its label — switching
+    // there would fail on `git switch` and swallow the new session with it.
+    if (group.isMain && !group.isFolder && group.path && group.label) {
       try {
         await switchBranchInRepo(group.path, group.label)
       } catch (err) {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -93,8 +93,10 @@ export function SidebarWorkspaceGroup({
 
     // Main-checkout lanes are branch-labeled views over the same repo root path.
     // Clicking "+" on `main` should open on `main`, not whatever branch the root
-    // currently sits on (`test0`, etc.), so explicitly switch first.
-    if (group.isMain && group.path && group.label) {
+    // currently sits on (`test0`, etc.), so explicitly switch first. A folder
+    // lane is a plain directory with no branch behind its label — switching
+    // there would fail on `git switch` and swallow the new session with it.
+    if (group.isMain && !group.isFolder && group.path && group.label) {
       try {
         await switchBranchInRepo(group.path, group.label)
       } catch (err) {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -12,6 +12,7 @@ import {
   NO_PROJECT_ID,
   overlayLiveLanes,
   overlayLivePreviews,
+  overlayRepoLanes,
   sessionProjectColor,
   type SidebarProjectTree,
   type SidebarSessionGroup,
@@ -435,6 +436,100 @@ describe('mergeRepoWorktreeGroups (visual enhancer)', () => {
 
     expect(merged.map(g => g.label)).toEqual(['main'])
     expect(merged[0].isHome).toBeFalsy()
+    expect(merged[0].isFolder).toBeFalsy()
+  })
+
+  it("folds a NON-repo folder's fabricated branch lanes into one folder lane", () => {
+    const repo = {
+      id: '/docs/interview prep',
+      path: '/docs/interview prep',
+      groups: [
+        // What a plain folder actually produces: the backend's path fallback
+        // lane (dir name) plus a `main` lane minted from a null git_branch.
+        lane({
+          id: '/docs/interview prep::branch::interview prep',
+          label: 'interview prep',
+          isMain: true,
+          path: '/docs/interview prep',
+          sessions: [makeSession('/docs/interview prep', { id: 'a' })]
+        }),
+        lane({
+          id: '/docs/interview prep::branch::main',
+          label: 'main',
+          isMain: true,
+          path: '/docs/interview prep',
+          sessions: [makeSession('/docs/interview prep', { id: 'a' }), makeSession('/docs/interview prep', { id: 'b' })]
+        })
+      ]
+    }
+
+    // The probe RAN and git found nothing: not a work tree.
+    const merged = mergeRepoWorktreeGroups(repo, [])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].label).toBe('interview prep')
+    expect(merged[0].isFolder).toBe(true)
+    expect(merged[0].isHome).toBe(true)
+    expect(merged[0].path).toBe('/docs/interview prep')
+    // Each session lands once, not once per fabricated lane.
+    expect(merged[0].sessions.map(s => s.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it("does not flag a real repo's home lane as a folder", () => {
+    const repo = {
+      id: '/repo',
+      path: '/repo',
+      groups: [lane({ id: '/repo::branch::main', label: 'main', isMain: true, path: '/repo' })]
+    }
+
+    const discovered: HermesGitWorktree[] = [
+      { branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' }
+    ]
+
+    expect(mergeRepoWorktreeGroups(repo, discovered).find(g => g.isHome)?.isFolder).toBeFalsy()
+  })
+})
+
+describe('overlayRepoLanes (optimistic placement)', () => {
+  it('places a branchless new session in the existing root lane instead of minting "main"', () => {
+    const repo = {
+      id: '/docs/interview prep',
+      label: 'interview prep',
+      path: '/docs/interview prep',
+      sessionCount: 0,
+      groups: [
+        lane({
+          id: '/docs/interview prep::folder',
+          label: 'interview prep',
+          isMain: true,
+          isHome: true,
+          isFolder: true,
+          path: '/docs/interview prep'
+        })
+      ]
+    }
+
+    // A fresh row in a non-repo folder records no branch.
+    const fresh = makeSession('/docs/interview prep', { git_branch: null, id: 'new' })
+    const { groups } = overlayRepoLanes(repo, [fresh])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].id).toBe('/docs/interview prep::folder')
+    expect(groups[0].sessions.map(s => s.id)).toEqual(['new'])
+  })
+
+  it('still mints a branch lane for a session that records one', () => {
+    const repo = {
+      id: '/repo',
+      label: 'repo',
+      path: '/repo',
+      sessionCount: 0,
+      groups: [lane({ id: '/repo::branch::main', label: 'main', isMain: true, path: '/repo' })]
+    }
+
+    const { groups } = overlayRepoLanes(repo, [makeSession('/repo', { git_branch: 'feature', id: 'new' })])
+
+    expect(groups.map(g => g.label).sort()).toEqual(['feature', 'main'])
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -443,14 +443,17 @@ describe('mergeRepoWorktreeGroups (visual enhancer)', () => {
           label: 'interview prep',
           isMain: true,
           path: '/docs/interview prep',
-          sessions: [makeSession('/docs/interview prep', { id: 'a' })]
+          sessions: [makeCwdSession('/docs/interview prep', { id: 'a' })]
         }),
         lane({
           id: '/docs/interview prep::branch::main',
           label: 'main',
           isMain: true,
           path: '/docs/interview prep',
-          sessions: [makeSession('/docs/interview prep', { id: 'a' }), makeSession('/docs/interview prep', { id: 'b' })]
+          sessions: [
+            makeCwdSession('/docs/interview prep', { id: 'a' }),
+            makeCwdSession('/docs/interview prep', { id: 'b' })
+          ]
         })
       ]
     }
@@ -502,7 +505,7 @@ describe('overlayRepoLanes (optimistic placement)', () => {
     }
 
     // A fresh row in a non-repo folder records no branch.
-    const fresh = makeSession('/docs/interview prep', { git_branch: null, id: 'new' })
+    const fresh = makeCwdSession('/docs/interview prep', { git_branch: null, id: 'new' })
     const { groups } = overlayRepoLanes(repo, [fresh])
 
     expect(groups).toHaveLength(1)
@@ -519,7 +522,7 @@ describe('overlayRepoLanes (optimistic placement)', () => {
       groups: [lane({ id: '/repo::branch::main', label: 'main', isMain: true, path: '/repo' })]
     }
 
-    const { groups } = overlayRepoLanes(repo, [makeSession('/repo', { git_branch: 'feature', id: 'new' })])
+    const { groups } = overlayRepoLanes(repo, [makeCwdSession('/repo', { git_branch: 'feature', id: 'new' })])
 
     expect(groups.map(g => g.label).sort()).toEqual(['feature', 'main'])
   })

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -13,6 +13,7 @@ import {
   NO_PROJECT_ID,
   overlayLiveLanes,
   overlayLivePreviews,
+  overlayRepoLanes,
   reconcileEnteredProjectSessions,
   sessionMatchesProjectFilter,
   sessionProjectColor,
@@ -427,6 +428,100 @@ describe('mergeRepoWorktreeGroups (visual enhancer)', () => {
 
     expect(merged.map(g => g.label)).toEqual(['main'])
     expect(merged[0].isHome).toBeFalsy()
+    expect(merged[0].isFolder).toBeFalsy()
+  })
+
+  it("folds a NON-repo folder's fabricated branch lanes into one folder lane", () => {
+    const repo = {
+      id: '/docs/interview prep',
+      path: '/docs/interview prep',
+      groups: [
+        // What a plain folder actually produces: the backend's path fallback
+        // lane (dir name) plus a `main` lane minted from a null git_branch.
+        lane({
+          id: '/docs/interview prep::branch::interview prep',
+          label: 'interview prep',
+          isMain: true,
+          path: '/docs/interview prep',
+          sessions: [makeSession('/docs/interview prep', { id: 'a' })]
+        }),
+        lane({
+          id: '/docs/interview prep::branch::main',
+          label: 'main',
+          isMain: true,
+          path: '/docs/interview prep',
+          sessions: [makeSession('/docs/interview prep', { id: 'a' }), makeSession('/docs/interview prep', { id: 'b' })]
+        })
+      ]
+    }
+
+    // The probe RAN and git found nothing: not a work tree.
+    const merged = mergeRepoWorktreeGroups(repo, [])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].label).toBe('interview prep')
+    expect(merged[0].isFolder).toBe(true)
+    expect(merged[0].isHome).toBe(true)
+    expect(merged[0].path).toBe('/docs/interview prep')
+    // Each session lands once, not once per fabricated lane.
+    expect(merged[0].sessions.map(s => s.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it("does not flag a real repo's home lane as a folder", () => {
+    const repo = {
+      id: '/repo',
+      path: '/repo',
+      groups: [lane({ id: '/repo::branch::main', label: 'main', isMain: true, path: '/repo' })]
+    }
+
+    const discovered: HermesGitWorktree[] = [
+      { branch: 'main', detached: false, isMain: true, locked: false, path: '/repo' }
+    ]
+
+    expect(mergeRepoWorktreeGroups(repo, discovered).find(g => g.isHome)?.isFolder).toBeFalsy()
+  })
+})
+
+describe('overlayRepoLanes (optimistic placement)', () => {
+  it('places a branchless new session in the existing root lane instead of minting "main"', () => {
+    const repo = {
+      id: '/docs/interview prep',
+      label: 'interview prep',
+      path: '/docs/interview prep',
+      sessionCount: 0,
+      groups: [
+        lane({
+          id: '/docs/interview prep::folder',
+          label: 'interview prep',
+          isMain: true,
+          isHome: true,
+          isFolder: true,
+          path: '/docs/interview prep'
+        })
+      ]
+    }
+
+    // A fresh row in a non-repo folder records no branch.
+    const fresh = makeSession('/docs/interview prep', { git_branch: null, id: 'new' })
+    const { groups } = overlayRepoLanes(repo, [fresh])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].id).toBe('/docs/interview prep::folder')
+    expect(groups[0].sessions.map(s => s.id)).toEqual(['new'])
+  })
+
+  it('still mints a branch lane for a session that records one', () => {
+    const repo = {
+      id: '/repo',
+      label: 'repo',
+      path: '/repo',
+      sessionCount: 0,
+      groups: [lane({ id: '/repo::branch::main', label: 'main', isMain: true, path: '/repo' })]
+    }
+
+    const { groups } = overlayRepoLanes(repo, [makeSession('/repo', { git_branch: 'feature', id: 'new' })])
+
+    expect(groups.map(g => g.label).sort()).toEqual(['feature', 'main'])
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -22,6 +22,11 @@ export interface SidebarSessionGroup {
   // collapses all main-checkout sessions, labeled by the worktree's LIVE branch
   // (defaulting to `main`). Renders a home glyph and pins to the top.
   isHome?: boolean
+  // True when the lane is a plain DIRECTORY, not a git branch — the project
+  // folder isn't a repo, so there is no branch to switch to and no branch name
+  // to label it with. Set only when the local git probe actually ran and came
+  // back empty; a lane the probe never saw (remote backend) stays unflagged.
+  isFolder?: boolean
   // True for the synthetic lane that collapses all of a repo's kanban task
   // worktrees (`<repo>/.worktrees/t_*`) into one row, so a heavy board doesn't
   // spray hundreds of throwaway branch lanes across the sidebar.
@@ -130,6 +135,9 @@ export const isDetachedSession = (session: SessionInfo): boolean =>
 /** The one definition of a main-checkout lane id (must match the backend tree). */
 export const branchLaneId = (repoRoot: string, branch?: string): string =>
   `${repoRoot}::branch::${(branch ?? '').trim()}`
+
+/** Id of the single lane a NON-repo project folder collapses to. */
+export const folderLaneId = (repoRoot: string): string => `${repoRoot}::folder`
 
 /** A session's recency stamp (last activity, falling back to creation). */
 export const sessionRecency = (session: SessionInfo): number => session.last_active || session.started_at || 0
@@ -255,6 +263,12 @@ export function mergeRepoWorktreeGroups(
   // backends (no probe → no homeBranch) keep their main lanes untouched.
   const mainGroups = repo.groups.filter(group => group.isMain)
   const reconciled = repo.groups.filter(group => !group.isMain).map(reconcile)
+  // The probe RAN and git reported no worktree at all → the folder is not a
+  // repo. Its "main" lanes are fabrications — a session with a null branch
+  // renders as `main`, the backend's path fallback as the dir name — so the
+  // same fold applies, just labeled by the folder instead of a branch. An
+  // UNDEFINED probe (remote backend, still loading) is not evidence of that.
+  const folderRoot = discoveredWorktrees?.length === 0 ? repo.path : null
 
   if (homeBranch) {
     reconciled.push({
@@ -263,6 +277,16 @@ export function mergeRepoWorktreeGroups(
       path: repo.path,
       isMain: true,
       isHome: true,
+      sessions: dedupeById(mainGroups.flatMap(group => group.sessions))
+    })
+  } else if (folderRoot && mainGroups.length) {
+    reconciled.push({
+      id: folderLaneId(repo.id),
+      label: baseName(folderRoot) ?? folderRoot,
+      path: repo.path,
+      isMain: true,
+      isHome: true,
+      isFolder: true,
       sessions: dedupeById(mainGroups.flatMap(group => group.sessions))
     })
   } else {
@@ -475,9 +499,20 @@ function liveLaneForRepo(repoRoot: string, session: SessionInfo): null | Sidebar
       : { id: worktreeRoot, isMain: false, label: slug, path: worktreeRoot, sessions: [] }
   }
 
-  const branch = (session.git_branch || '').trim() || DEFAULT_BRANCH_LABEL
+  const branch = (session.git_branch || '').trim()
 
-  return { id: branchLaneId(repoRoot, branch), isMain: true, label: branch, path: repoRoot, sessions: [] }
+  // No recorded branch: the row may be in a plain folder, or just predate the
+  // backend's probe. `isFolder` marks the label as a GUESS so the placer can
+  // join an existing root lane (a real branch lane, or the folded folder lane)
+  // instead of minting a second "main" beside it.
+  return {
+    id: branchLaneId(repoRoot, branch || DEFAULT_BRANCH_LABEL),
+    isFolder: !branch,
+    isMain: true,
+    label: branch || DEFAULT_BRANCH_LABEL,
+    path: repoRoot,
+    sessions: []
+  }
 }
 
 const NO_REMOVED: ReadonlySet<string> = new Set()
@@ -560,6 +595,9 @@ export function overlayRepoLanes(
 
       lane =
         lanes.find(g => g.id === placed.id) ??
+        // A branchless row belongs to whatever single lane already holds the
+        // repo root — its `main` label is a placeholder, not a match key.
+        (placed.isFolder ? lanes.find(g => g.isMain && pathKey(g.path) === repoRootKey) : undefined) ??
         (placed.isMain
           ? lanes.find(g => g.isMain && g.label.toLowerCase() === placed.label.toLowerCase())
           : undefined) ??

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -24,6 +24,11 @@ export interface SidebarSessionGroup {
   // collapses all main-checkout sessions, labeled by the worktree's LIVE branch
   // (defaulting to `main`). Renders a home glyph and pins to the top.
   isHome?: boolean
+  // True when the lane is a plain DIRECTORY, not a git branch — the project
+  // folder isn't a repo, so there is no branch to switch to and no branch name
+  // to label it with. Set only when the local git probe actually ran and came
+  // back empty; a lane the probe never saw (remote backend) stays unflagged.
+  isFolder?: boolean
   // True for the synthetic lane that collapses all of a repo's kanban task
   // worktrees (`<repo>/.worktrees/t_*`) into one row, so a heavy board doesn't
   // spray hundreds of throwaway branch lanes across the sidebar.
@@ -133,6 +138,9 @@ export const isDetachedSession = (session: SessionInfo): boolean =>
 /** The one definition of a main-checkout lane id (must match the backend tree). */
 export const branchLaneId = (repoRoot: string, branch?: string): string =>
   `${repoRoot}::branch::${(branch ?? '').trim()}`
+
+/** Id of the single lane a NON-repo project folder collapses to. */
+export const folderLaneId = (repoRoot: string): string => `${repoRoot}::folder`
 
 /** A session's recency stamp (last activity, falling back to creation). */
 export const sessionRecency = (session: SessionInfo): number => session.last_active || session.started_at || 0
@@ -258,6 +266,12 @@ export function mergeRepoWorktreeGroups(
   // backends (no probe → no homeBranch) keep their main lanes untouched.
   const mainGroups = repo.groups.filter(group => group.isMain)
   const reconciled = repo.groups.filter(group => !group.isMain).map(reconcile)
+  // The probe RAN and git reported no worktree at all → the folder is not a
+  // repo. Its "main" lanes are fabrications — a session with a null branch
+  // renders as `main`, the backend's path fallback as the dir name — so the
+  // same fold applies, just labeled by the folder instead of a branch. An
+  // UNDEFINED probe (remote backend, still loading) is not evidence of that.
+  const folderRoot = discoveredWorktrees?.length === 0 ? repo.path : null
 
   if (homeBranch) {
     reconciled.push({
@@ -266,6 +280,16 @@ export function mergeRepoWorktreeGroups(
       path: repo.path,
       isMain: true,
       isHome: true,
+      sessions: dedupeById(mainGroups.flatMap(group => group.sessions))
+    })
+  } else if (folderRoot && mainGroups.length) {
+    reconciled.push({
+      id: folderLaneId(repo.id),
+      label: baseName(folderRoot) ?? folderRoot,
+      path: repo.path,
+      isMain: true,
+      isHome: true,
+      isFolder: true,
       sessions: dedupeById(mainGroups.flatMap(group => group.sessions))
     })
   } else {
@@ -516,9 +540,20 @@ function liveLaneForRepo(repoRoot: string, session: SessionInfo): null | Sidebar
       : { id: worktreeRoot, isMain: false, label: slug, path: worktreeRoot, sessions: [] }
   }
 
-  const branch = (session.git_branch || '').trim() || DEFAULT_BRANCH_LABEL
+  const branch = (session.git_branch || '').trim()
 
-  return { id: branchLaneId(repoRoot, branch), isMain: true, label: branch, path: repoRoot, sessions: [] }
+  // No recorded branch: the row may be in a plain folder, or just predate the
+  // backend's probe. `isFolder` marks the label as a GUESS so the placer can
+  // join an existing root lane (a real branch lane, or the folded folder lane)
+  // instead of minting a second "main" beside it.
+  return {
+    id: branchLaneId(repoRoot, branch || DEFAULT_BRANCH_LABEL),
+    isFolder: !branch,
+    isMain: true,
+    label: branch || DEFAULT_BRANCH_LABEL,
+    path: repoRoot,
+    sessions: []
+  }
 }
 
 const NO_REMOVED: ReadonlySet<string> = new Set()
@@ -601,6 +636,9 @@ export function overlayRepoLanes(
 
       lane =
         lanes.find(g => g.id === placed.id) ??
+        // A branchless row belongs to whatever single lane already holds the
+        // repo root — its `main` label is a placeholder, not a match key.
+        (placed.isFolder ? lanes.find(g => g.isMain && pathKey(g.path) === repoRootKey) : undefined) ??
         (placed.isMain
           ? lanes.find(g => g.isMain && g.label.toLowerCase() === placed.label.toLowerCase())
           : undefined) ??

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -121,7 +121,7 @@ interface SidebarSessionsSectionProps {
   projectContent?: SidebarProjectTree
   // Live git lanes (`git worktree list`) for repos in the entered project —
   // a VISUAL enhancer only (empty lanes), never session membership.
-  projectRepoWorktrees?: Record<string, HermesGitWorktree[]>
+  projectRepoWorktrees?: Record<string, HermesGitWorktree[] | null>
   // Live session cache used for optimistic placement inside entered-project lanes.
   liveSessions?: SessionInfo[]
   // Client-side optimistic eviction layer (deleted/archived ids).

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -142,7 +142,7 @@ interface SidebarSessionsSectionProps {
   projectContent?: SidebarProjectTree
   // Live git lanes (`git worktree list`) for repos in the entered project —
   // a VISUAL enhancer only (empty lanes), never session membership.
-  projectRepoWorktrees?: Record<string, HermesGitWorktree[]>
+  projectRepoWorktrees?: Record<string, HermesGitWorktree[] | null>
   // Live session cache used for optimistic placement inside entered-project lanes.
   liveSessions?: SessionInfo[]
   // Client-side optimistic eviction layer (deleted/archived ids).

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -61,6 +61,14 @@ def _git_out(cwd: str, args: list[str]) -> str:
     return out if code == 0 else ""
 
 
+def _is_not_a_repo(stderr: str) -> bool:
+    """git's own "there is no repository here" verdict, as opposed to a probe
+    that never got an answer (missing binary, unreadable dir, timeout). Only the
+    former is EVIDENCE about the directory."""
+    lowered = stderr.lower()
+    return "not a git repository" in lowered or "not a working tree" in lowered
+
+
 def _git_ok(cwd: str, args: list[str]) -> None:
     """Run a git mutation, raising RuntimeError with stderr on failure."""
     code, _, err = _git(cwd, args)
@@ -503,7 +511,14 @@ def _parse_worktrees(out: str) -> list[dict]:
 
 
 def worktree_list(cwd: str) -> list[dict]:
-    out = _git_out(cwd, ["worktree", "list", "--porcelain"])
+    code, out, err = _git(cwd, ["worktree", "list", "--porcelain"])
+    if code != 0:
+        # A repo always lists at least its main worktree, so an empty list is
+        # only ever "not a repository" — the sidebar reads it as exactly that.
+        # Any other failure must surface instead of impersonating that verdict.
+        if not _is_not_a_repo(err):
+            raise RuntimeError(err.strip() or "git worktree list failed")
+        return []
     if not out:
         return []
     return [
@@ -666,11 +681,15 @@ def branch_switch(cwd: str, branch: str) -> dict:
     target = _sanitize_branch(branch)
     if not target:
         raise RuntimeError("Branch name is required.")
-    # A project folder that isn't a repo has no branch to leave, so there is
-    # nothing to switch — succeed quietly rather than failing the caller's real
-    # work (the sidebar switches before starting a session). Never init a repo
-    # here: creating one behind the user's back is not a branch switch.
-    if _git_out(cwd, ["rev-parse", "--is-inside-work-tree"]).strip() != "true":
+    # A project folder that git confirms is not a repo has no branch to leave,
+    # so there is nothing to switch — succeed quietly rather than failing the
+    # caller's real work (the sidebar switches before starting a session). Never
+    # init a repo here: creating one behind the user's back is not a branch
+    # switch. A probe that FAILS still raises, so a broken git stays visible.
+    code, inside, err = _git(cwd, ["rev-parse", "--is-inside-work-tree"])
+    if code != 0 and not _is_not_a_repo(err):
+        raise RuntimeError(err.strip() or "git rev-parse failed")
+    if inside.strip() != "true":
         return {"branch": target}
     _git_ok(cwd, ["switch", target])
     return {"branch": target}

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -666,6 +666,12 @@ def branch_switch(cwd: str, branch: str) -> dict:
     target = _sanitize_branch(branch)
     if not target:
         raise RuntimeError("Branch name is required.")
+    # A project folder that isn't a repo has no branch to leave, so there is
+    # nothing to switch — succeed quietly rather than failing the caller's real
+    # work (the sidebar switches before starting a session). Never init a repo
+    # here: creating one behind the user's back is not a branch switch.
+    if _git_out(cwd, ["rev-parse", "--is-inside-work-tree"]).strip() != "true":
+        return {"branch": target}
     _git_ok(cwd, ["switch", target])
     return {"branch": target}
 

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -677,6 +677,12 @@ def branch_switch(cwd: str, branch: str) -> dict:
     target = _sanitize_branch(branch)
     if not target:
         raise RuntimeError("Branch name is required.")
+    # A project folder that isn't a repo has no branch to leave, so there is
+    # nothing to switch — succeed quietly rather than failing the caller's real
+    # work (the sidebar switches before starting a session). Never init a repo
+    # here: creating one behind the user's back is not a branch switch.
+    if _git_out(cwd, ["rev-parse", "--is-inside-work-tree"]).strip() != "true":
+        return {"branch": target}
     _git_ok(cwd, ["switch", target])
     return {"branch": target}
 

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -59,6 +59,14 @@ def _git_line(cwd: str, args: list[str]) -> str:
     return _git_out(cwd, args).strip()
 
 
+def _is_not_a_repo(stderr: str) -> bool:
+    """git's own "there is no repository here" verdict, as opposed to a probe
+    that never got an answer (missing binary, unreadable dir, timeout). Only the
+    former is EVIDENCE about the directory."""
+    lowered = stderr.lower()
+    return "not a git repository" in lowered or "not a working tree" in lowered
+
+
 def _git_ok(cwd: str, args: list[str]) -> None:
     """Run a git mutation, raising RuntimeError with stderr on failure."""
     code, _, err = _git(cwd, args)
@@ -501,9 +509,19 @@ def review_create_pr(cwd: str) -> dict:
 
 
 def worktree_list(cwd: str) -> list[dict]:
-    """``git worktree list --porcelain`` -> one dict per tree (main tree first)."""
+    """``git worktree list --porcelain`` -> one dict per tree (main tree first).
+
+    A repo always lists at least its main worktree, so an empty list is only
+    ever "not a repository" — the sidebar reads it as exactly that verdict. Any
+    other failure must surface instead of impersonating it.
+    """
+    code, out, err = _git(cwd, ["worktree", "list", "--porcelain"])
+    if code != 0:
+        if not _is_not_a_repo(err):
+            raise RuntimeError(err.strip() or "git worktree list failed")
+        return []
     trees: list[dict] = []
-    for line in _git_out(cwd, ["worktree", "list", "--porcelain"]).split("\n"):
+    for line in out.split("\n"):
         if line.startswith("worktree "):
             trees.append({"path": line[9:].strip(), "branch": None, "isMain": not trees,
                           "detached": False, "locked": False})
@@ -677,11 +695,15 @@ def branch_switch(cwd: str, branch: str) -> dict:
     target = _sanitize_branch(branch)
     if not target:
         raise RuntimeError("Branch name is required.")
-    # A project folder that isn't a repo has no branch to leave, so there is
-    # nothing to switch — succeed quietly rather than failing the caller's real
-    # work (the sidebar switches before starting a session). Never init a repo
-    # here: creating one behind the user's back is not a branch switch.
-    if _git_out(cwd, ["rev-parse", "--is-inside-work-tree"]).strip() != "true":
+    # A project folder that git confirms is not a repo has no branch to leave,
+    # so there is nothing to switch — succeed quietly rather than failing the
+    # caller's real work (the sidebar switches before starting a session). Never
+    # init a repo here: creating one behind the user's back is not a branch
+    # switch. A probe that FAILS still raises, so a broken git stays visible.
+    code, inside, err = _git(cwd, ["rev-parse", "--is-inside-work-tree"])
+    if code != 0 and not _is_not_a_repo(err):
+        raise RuntimeError(err.strip() or "git rev-parse failed")
+    if inside.strip() != "true":
         return {"branch": target}
     _git_ok(cwd, ["switch", target])
     return {"branch": target}

--- a/tests/hermes_cli/test_web_server_git.py
+++ b/tests/hermes_cli/test_web_server_git.py
@@ -98,6 +98,28 @@ def test_worktree_add_initializes_plain_folder(client, tmp_path):
 
 
 
+def test_branch_switch_no_ops_on_a_plain_folder(client, tmp_path):
+    folder = tmp_path / "plain-project"
+    folder.mkdir()
+
+    # The sidebar switches to a lane's branch before starting a session there. A
+    # folder that is not a repo has no branch to leave, so this must succeed
+    # quietly instead of failing the session behind it — and must not init a repo.
+    assert client.post(
+        "/api/git/branch/switch", json={"path": str(folder), "branch": "main"}
+    ).json() == {"branch": "main"}
+    assert not (folder / ".git").exists()
+
+
+def test_branch_switch_still_switches_a_real_repo(client, repo):
+    _git(repo, "branch", "feature")
+
+    assert client.post(
+        "/api/git/branch/switch", json={"path": str(repo), "branch": "feature"}
+    ).json() == {"branch": "feature"}
+    assert client.get("/api/git/status", params={"path": str(repo)}).json()["branch"] == "feature"
+
+
 def test_git_endpoints_require_auth(repo):
     unauth = TestClient(web_server.app)
 

--- a/tests/hermes_cli/test_web_server_git.py
+++ b/tests/hermes_cli/test_web_server_git.py
@@ -111,6 +111,33 @@ def test_branch_switch_no_ops_on_a_plain_folder(client, tmp_path):
     assert not (folder / ".git").exists()
 
 
+def test_branch_switch_surfaces_a_failed_probe(client, repo, monkeypatch):
+    from hermes_cli import web_git
+
+    # git is unusable, not absent-of-repo. Reporting success here would strand
+    # the session on whatever branch the checkout happens to sit on.
+    monkeypatch.setattr(web_git, "_git", lambda *a, **k: (1, "", "git invocation failed"))
+
+    response = client.post(
+        "/api/git/branch/switch", json={"path": str(repo), "branch": "main"}
+    )
+    assert response.status_code == 400
+
+
+def test_worktrees_empty_only_means_not_a_repository(client, tmp_path, monkeypatch):
+    from hermes_cli import web_git
+
+    plain = tmp_path / "plain-project"
+    plain.mkdir()
+
+    # The sidebar reads an empty list as confirmed evidence the folder is not a
+    # repo, so a probe that never ran must not answer with one.
+    assert client.get("/api/git/worktrees", params={"path": str(plain)}).json()["worktrees"] == []
+
+    monkeypatch.setattr(web_git, "_git", lambda *a, **k: (1, "", "git invocation failed"))
+    assert client.get("/api/git/worktrees", params={"path": str(plain)}).status_code == 400
+
+
 def test_branch_switch_still_switches_a_real_repo(client, repo):
     _git(repo, "branch", "feature")
 


### PR DESCRIPTION
## What does this PR do?

Creating another chat in a Project whose folder is **not** a git repository fails, and the
same folder lists its sessions twice.

Clicking `+` on the lane inside such a project produces:

```
Could not switch to main
Error invoking remote method 'hermes:git:branchSwitch': Error: Command failed:
/usr/bin/git switch main fatal: not a git repository (or any of the parent directories): .git
```

…and the session is never created (`workspace-group.tsx` returns before `onNewSession`).

Both symptoms come from one defect: the sidebar invents a **git branch identity** for a
folder that was never probed as a repo.

- `liveLaneForRepo` mints `{label: 'main', isMain: true}` from a **null** `session.git_branch`.
- The backend's path fallback (`project_tree.py::_place_by_heuristic`) emits another
  `is_main` lane labeled by the directory → the same sessions render under two lanes.
- `mergeRepoWorktreeGroups` folds all `isMain` lanes into one home lane **only** when the
  git probe found a main worktree. For a non-repo the probe returns `[]`, so every
  fabricated lane survives.
- `switchBranch` (`git-worktree-ops.ts`) was the only op in that module with no repo guard —
  `listWorktrees`, `listBranches` and `listBaseBranches` all degrade to `[]` on a non-repo.
  `web_git.branch_switch` has the same gap for the web/remote backend.

The fix keeps git as the source of truth and does not add any new backend snapshot field:
a **probed-empty** `git worktree list` is treated as the evidence it is ("git ran, this is
not a work tree"), while an **unprobed** repo (remote backend, still loading) keeps today's
behavior.

Real repos are untouched: a branch lane still switches the checkout before creating the
session, and a genuine switch failure (dirty tree, unknown branch) still blocks creation
with the existing toast.

### Relation to existing PRs

- #61393 turns the raw stderr into a friendlier error, but the error still aborts chat
  creation, and the duplicate lanes remain.
- #68414 fixes it by adding repo-level `gitKind` metadata to the backend project tree
  (654 additions across backend + renderer).

This PR is smaller (+123/-6 excluding tests, no new snapshot fields, no Python protocol
change) and covers both the creation failure and the duplicate lanes. Happy to close it if
maintainers prefer either of the others.

## Related Issue

Fixes #68192
Fixes #61362
Fixes #53329
Fixes #57715
Fixes #62165

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/git-worktree-ops.ts` — `switchBranch` probes
  `git rev-parse --is-inside-work-tree` and returns without switching when the path is not a
  work tree. Nothing is initialized (`ensureGitRepo` is deliberately **not** reused — it
  would `git init` a plain folder behind the user's back); real `git switch` failures still
  propagate.
- `hermes_cli/web_git.py` — same guard in `branch_switch`, so the web/remote backend
  (`POST /api/git/branch/switch`) behaves identically.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts` — new `isFolder` lane
  flag; a probed-empty worktree list folds a non-repo's fabricated `isMain` lanes into ONE
  directory-labeled lane (mirroring the existing home-lane fold); `liveLaneForRepo` no
  longer passes a null branch off as `main`, and the optimistic overlay joins the lane that
  already holds the repo root instead of minting a second one. `isHome` on the folded lane
  gives it the existing home glyph, so the phantom branch icon goes away with no new UI code.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx` — `+` skips the branch
  switch for a folder lane.
- Tests: `electron/git-worktree-ops.test.ts` (+2), `workspace-groups.test.ts` (+5), new
  `workspace-group.test.tsx` (3 click-path cases), `tests/hermes_cli/test_web_server_git.py` (+2).

## How to Test

1. Add a Project pointing at a folder that is **not** a git repo, and start a chat in it.
2. Enter the Project in the sidebar. Before: a `main` lane with a branch glyph plus a
   folder-named lane, both listing the same sessions. After: one lane named after the
   folder, each session once.
3. Click `+` on that lane. Before: `Could not switch to main` and no new chat. After: the
   chat opens.
4. Enter a real git Project: branch lanes are still branch-labeled, `+` still switches the
   checkout first, and a switch that genuinely fails still blocks creation with the toast.

Automated:

```bash
cd apps/desktop
npm run test:desktop:platforms   # 901 passed | 2 skipped
npm run test:ui                  # 3169 passed
npm run typecheck && npm run lint # clean (0 errors)
pytest tests/hermes_cli/test_web_server_git.py -q   # 5 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #61393 and #68414 are open on the same bug; the difference is described above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — full `scripts/run_tests.sh`: 22860
      passed, 75 failed. Every failure is pre-existing on this machine, not from this PR:
      running the same files against `upstream/main` in a clean worktree produces the
      **identical** 24-failure set (`comm` diff of both `FAILED` lists is empty), and the
      rest are optional extras this venv doesn't have (`acp`, `anthropic`, daytona, fal,
      modal, hindsight, parallel search). `tests/hermes_cli/test_web_server_git.py` passes
      7/7 inside that run.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing API or config change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the added probe is plain
      `git rev-parse`; lane labels go through the existing `baseName` helper, which already
      handles `\` separators. No new path, process or signal handling.

