### PR TITLE
fix(cli): require closer >= opener length, prioritize fence detection over table buffering, drive real streaming methods in tests

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2861,9 +2861,48 @@ def _rich_text_from_ansi(text: str) -> _RichText:
     return _RichText.from_ansi(text or "")
 
 
+_FENCED_CODE_BLOCK_RE = re.compile(
+    r"^([ \t]{0,3})(`{3,}|~{3,})[ \t]*([^\n`~]*)\n(.*?)^\1(`{3,}|~{3,})[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+# Matches a single line that IS a fence marker (opening or closing) --
+# used by the streaming line-by-line strip-mode formatter, which processes
+# one line at a time and can't run the whole-response regex above.
+_STREAM_FENCE_LINE_RE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})[ \t]*[^\n`~]*$")
+
+
 def _strip_markdown_syntax(text: str) -> str:
     """Best-effort markdown marker removal for plain-text display."""
     plain = _rich_text_from_ansi(text or "").plain
+
+    # Extract fenced code blocks BEFORE any prose-markdown stripping below.
+    # Code content must survive byte-for-byte: the emphasis-stripping regexes
+    # further down (`__x__` -> `x`, `*x*` -> `x`) don't know Python from
+    # prose, so a real docstring/dunder like `__name__` or `__main__` was
+    # being silently corrupted into `name`/`main` when it appeared inside a
+    # fenced block in `strip` mode -- code that ran fine got displayed (and,
+    # if copied, executed) with different semantics (issue #73212). Pull
+    # each fenced block out into a placeholder, run the existing prose
+    # stripping on what's left, then splice the untouched code back in. The
+    # opening fence's language tag (e.g. "python") is dropped entirely in
+    # this plain-text mode rather than left as a stray visible line.
+    code_blocks: list[str] = []
+
+    def _extract_fence(match: "re.Match[str]") -> str:
+        opener, closer = match.group(2), match.group(5)
+        if closer[0] != opener[0] or len(closer) < len(opener):
+            # Invalid closer (wrong character type, or shorter than the
+            # opener -- e.g. a ```` opener can't be closed by ```). Leave
+            # the whole match untouched; it falls through to the ordinary
+            # prose-stripping path below, same as an unterminated fence
+            # (review of #75188).
+            return match.group(0)
+        code_blocks.append(match.group(4))
+        return f"\x00FENCE{len(code_blocks) - 1}\x00"
+
+    plain = _FENCED_CODE_BLOCK_RE.sub(_extract_fence, plain)
+
     # Avoid stripping cron-style expressions like "* * * * *" as if they were
     # Markdown horizontal rules. CommonMark treats three or more "*" as an HR,
     # but in Hermes output it's common to display cron schedules verbatim.
@@ -2888,6 +2927,20 @@ def _strip_markdown_syntax(text: str) -> str:
     plain = re.sub(r"(?<!\w)_([^_]+)_(?!\w)", r"\1", plain)
     plain = re.sub(r"~~([^~]+)~~", r"\1", plain)
     plain = re.sub(r"\n{3,}", "\n\n", plain)
+
+    # Splice the untouched code blocks back in, byte-for-byte -- no
+    # rstrip("\n") here. An earlier version trimmed trailing newlines off
+    # each captured block before splicing it back, which silently dropped
+    # trailing blank lines that were genuinely part of the fenced content
+    # (review of #73217: "trailing blank lines inside a captured block are
+    # not preserved byte-for-byte"). The block's own captured text
+    # (match.group(4) in _extract_fence above) already excludes the
+    # closing-fence line itself (the regex's trailing ^\1\2 anchor stops
+    # capture there), so there's nothing left to trim -- whatever newlines
+    # are in the captured group are genuinely part of the code content.
+    for i, code in enumerate(code_blocks):
+        plain = plain.replace(f"\x00FENCE{i}\x00", code)
+
     return plain.strip("\n")
 
 
@@ -4343,6 +4396,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # populated only while `_in_stream_table` is True.
         self._stream_table_buf: list[str] = []
         self._in_stream_table = False
+        # True while a streamed fenced code block (```/~~~) is open --
+        # i.e. we've seen the opening fence line but not yet the matching
+        # closing fence line. strip mode must skip prose-markdown
+        # stripping for every line in between, or a real code dunder like
+        # __name__ streamed line-by-line gets corrupted the same way the
+        # whole-response path was before it became fence-aware (issue
+        # #73212's fix didn't cover streaming at all -- review of #73217).
+        self._in_stream_code_fence = False
+        # The fence character ('`' or '~') that opened the current block,
+        # so a same-type closing fence is recognized and a different-type
+        # run of the other character mid-block is not mistaken for a
+        # closer.
+        self._stream_code_fence_char = ""
+        # The opener's marker LENGTH (e.g. 4 for "````"), so a closer must
+        # be at least this long to be recognized -- a shorter closer for a
+        # longer opener is invalid per CommonMark (review of #75188).
+        self._stream_code_fence_len = 0
         self._pending_edit_snapshots = {}
         self._last_input_mode_recovery = 0.0
         self._input_mode_recovery_notice_shown = False
@@ -6697,6 +6767,57 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         while "\n" in self._stream_buf:
             line, self._stream_buf = self._stream_buf.split("\n", 1)
 
+            # Fence detection must run BEFORE table-row buffering. A
+            # fenced code line can coincidentally look like a table row
+            # (e.g. a fence opener/closer, or content inside the fence
+            # like "| __name__ |"), and must never be swallowed into
+            # table buffering -- which invokes markdown stripping on
+            # flush -- while a code fence is open or transitioning
+            # (review of #75188).
+            _fence_transition = False
+            if self.final_response_markdown == "strip":
+                _fence_m = _STREAM_FENCE_LINE_RE.match(line)
+                if _fence_m:
+                    _fence_marker = _fence_m.group(1)
+                    _fence_char = _fence_marker[0]
+                    _fence_len = len(_fence_marker)
+                    if not self._in_stream_code_fence:
+                        # Opening fence: mark in-fence and remember which
+                        # character (backtick/tilde) and LENGTH close it.
+                        # This line itself (fence markers + language tag)
+                        # is left unstripped rather than reconstructed
+                        # with the language tag dropped, the way the
+                        # whole-response path does -- streaming can't
+                        # safely rewrite a line already flushed to the
+                        # terminal, so the fence markers stay visible
+                        # here (a minor, intentional difference from the
+                        # whole-response splice behavior).
+                        self._in_stream_code_fence = True
+                        self._stream_code_fence_char = _fence_char
+                        self._stream_code_fence_len = _fence_len
+                    elif (
+                        _fence_char == self._stream_code_fence_char
+                        and _fence_len >= self._stream_code_fence_len
+                    ):
+                        # Closing fence: same character type AND at least
+                        # as long as the opener (a shorter closer, e.g.
+                        # ``` closing ````, is invalid per CommonMark and
+                        # doesn't end the block).
+                        self._in_stream_code_fence = False
+                        self._stream_code_fence_char = ""
+                        self._stream_code_fence_len = 0
+                    _fence_transition = True
+
+            if self._in_stream_code_fence or _fence_transition:
+                # Inside an active fence, or this line IS a fence marker
+                # itself: never buffer as a table row (flush any table
+                # already in progress first -- the fence takes
+                # precedence), and never strip.
+                if self._in_stream_table:
+                    _flush_table_buf()
+                _emit_one(line)
+                continue
+
             # Hold table-shaped lines in a side-buffer so we can re-pad
             # the whole block once it ends.  Streaming line-by-line, we
             # cannot re-align mid-table without reflowing already-printed
@@ -6812,6 +6933,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._deferred_content = ""
         self._stream_table_buf = []
         self._in_stream_table = False
+        self._in_stream_code_fence = False
+        self._stream_code_fence_char = ""
+        self._stream_code_fence_len = 0
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -1,3 +1,4 @@
+import re
 from io import StringIO
 
 from rich.console import Console
@@ -102,3 +103,322 @@ def test_strip_mode_still_strips_boundary_underscore_emphasis():
 
     output = _render_to_text(renderable)
     assert "say hi and bold now" in output
+
+
+# -- Fenced code blocks must survive strip mode literally (issue #73212) ----
+
+def test_strip_mode_preserves_dunder_underscores_inside_fenced_code():
+    """The reporter's exact repro: __name__ must not become name."""
+    renderable = _render_final_assistant_content(
+        "```python\nprint(type(executor).__name__)\n```",
+        mode="strip",
+    )
+    output = _render_to_text(renderable)
+    assert "__name__" in output
+    # The language tag must not appear as a stray visible line.
+    lines = [l.strip() for l in output.splitlines() if l.strip()]
+    assert lines[0] != "python"
+
+
+def test_strip_mode_preserves_dunder_main_guard_inside_fenced_code():
+    renderable = _render_final_assistant_content(
+        '```python\nif __name__ == "__main__":\n    main()\n```',
+        mode="strip",
+    )
+    output = _render_to_text(renderable)
+    assert '__name__ == "__main__"' in output
+
+
+def test_strip_mode_drops_language_tag_line(monkeypatch):
+    """The opening fence's language tag must not be rendered as a plain
+    visible line of output (it was previously left behind verbatim once
+    the backtick fence markers were stripped)."""
+    from cli import _strip_markdown_syntax
+    rendered = _strip_markdown_syntax("```python\nx = 1\n```")
+    lines = [l for l in rendered.splitlines() if l.strip()]
+    assert "python" not in lines
+
+
+def test_strip_mode_preserves_asterisk_emphasis_markers_inside_fenced_code():
+    """Code that happens to contain single/double asterisks (e.g. **kwargs,
+    a docstring with *args) must not have them stripped as Markdown
+    emphasis -- only prose outside code fences gets that treatment."""
+    from cli import _strip_markdown_syntax
+    rendered = _strip_markdown_syntax(
+        "```python\ndef f(*args, **kwargs):\n    pass\n```"
+    )
+    assert "def f(*args, **kwargs):" in rendered
+
+
+def test_strip_mode_preserves_backtick_fence_markers_would_have_removed():
+    """Sanity: without fence-awareness, the bare '(```+|~~~+)' removal
+    regex would strip ALL backtick fences anywhere, including a fence
+    that legitimately appears inside another fenced block's content
+    (e.g. an assistant explaining Markdown syntax). The extracted block's
+    raw text must round-trip untouched."""
+    from cli import _strip_markdown_syntax
+    source = "```text\nUse ``` to start a code fence.\n```"
+    rendered = _strip_markdown_syntax(source)
+    assert "```" in rendered
+
+
+def test_strip_mode_prose_dunder_stripping_still_works_outside_code():
+    """Regression: this fix must not disable emphasis stripping for
+    prose outside code fences -- only protect literal code content."""
+    renderable = _render_final_assistant_content(
+        "say __bold__ now",
+        mode="strip",
+    )
+    output = _render_to_text(renderable)
+    assert "say bold now" in output
+
+
+def test_strip_mode_multiple_fenced_blocks_each_preserved_independently():
+    from cli import _strip_markdown_syntax
+    source = (
+        "First:\n```python\n__version__ = \"1.0\"\n```\n"
+        "Second:\n```python\n__author__ = \"x\"\n```"
+    )
+    rendered = _strip_markdown_syntax(source)
+    assert "__version__" in rendered
+    assert "__author__" in rendered
+
+
+# -- Follow-up fixes per review of #73217 ------------------------------------
+
+def test_strip_mode_preserves_trailing_blank_lines_inside_fenced_block():
+    """Regression: the splice-back loop used to code.rstrip("\\n") each
+    captured block before re-inserting it, silently dropping trailing
+    blank lines that were genuinely part of the fenced content (e.g. a
+    file ending in a blank line, or deliberate spacing before a closing
+    bracket). The block sits mid-response (followed by more prose) so
+    this isolates the splice-back behavior from the unrelated outer
+    plain.strip("\\n") cleanup applied to the whole response boundary."""
+    from cli import _strip_markdown_syntax
+    source = "```python\nx = 1\n\n\n```\nDone."
+    rendered = _strip_markdown_syntax(source)
+    assert "x = 1\n\n\n" in rendered, (
+        f"trailing blank lines inside the fenced block were trimmed: {rendered!r}"
+    )
+
+
+def test_strip_mode_longer_closing_fence_still_recognized():
+    """Regression: a closing fence with MORE backticks than the opener
+    (valid per CommonMark -- the closer only needs to be at least as long
+    as the opener, not exactly equal) must still be recognized as the
+    block's end, protecting the content inside."""
+    from cli import _strip_markdown_syntax
+    source = "```python\nprint(__name__)\n````"
+    rendered = _strip_markdown_syntax(source)
+    assert "__name__" in rendered
+
+
+def test_strip_mode_shorter_closing_fence_not_recognized():
+    """Regression (review of #75188): a closing fence with FEWER
+    backticks than the opener (e.g. ``` closing ````) is invalid per
+    CommonMark and must NOT be treated as ending the block -- the earlier
+    revision of this fix accepted any closer >= 3 characters regardless
+    of the opener's length. Since the too-short closer is invalid, this
+    text has no valid closer at all and falls through to the documented
+    unterminated-fence fallback (same known, accepted limitation as no
+    closer at all): __name__ IS affected here (becomes name), because
+    ordinary prose-emphasis stripping runs on it. The key distinction
+    from the bug this fix prevents: with the bug, the too-short closer
+    would be wrongly ACCEPTED, the block correctly EXTRACTED, and
+    __name__ would survive fully intact -- that must NOT happen."""
+    from cli import _strip_markdown_syntax
+    source = "````python\nprint(__name__)\n```\nmore code\n````"
+    rendered = _strip_markdown_syntax(source)
+    assert "__name__" not in rendered, (
+        "a too-short closer must not be accepted as valid -- if it were, "
+        f"the block would be extracted and __name__ would survive intact: {rendered!r}"
+    )
+
+
+def test_strip_mode_unterminated_fence_documented_fallback_behavior():
+    """Regression (review of #73217, cross-referencing #73315): an
+    unterminated fence (opening marker with no matching close anywhere in
+    the text -- e.g. a response cut off mid-code-block) cannot be
+    protected as a literal block, since there's no way to know where it
+    was meant to end. This documents the current, intentional fallback:
+    _FENCED_CODE_BLOCK_RE simply doesn't match (no closer found), so the
+    content is never extracted/protected at all -- the bare fence-marker
+    removal and ordinary prose-emphasis stripping run on it like any
+    other text. A dunder like __name__ IS still affected in this specific
+    corner case (it structurally matches the double-underscore emphasis
+    pattern), unlike a properly-closed block. This is a known, accepted
+    limitation -- not a crash, not silent data loss of the rest of the
+    response, just the pre-#73212 behavior for the one case that can't be
+    disambiguated without a closing fence. Must not raise."""
+    from cli import _strip_markdown_syntax
+    source = "```python\nprint(__name__)"  # no closing fence anywhere
+    rendered = _strip_markdown_syntax(source)  # must not raise
+    assert "```" not in rendered
+    assert "name" in rendered  # __name__ -> name, the known limitation
+
+
+class TestStreamingStripModeFenceState:
+    """Regression tests for issue #73217/#75188's review: strip mode's
+    per-line STREAMING formatter (HermesCLI._emit_stream_text) is a
+    completely separate code path from _strip_markdown_syntax()'s
+    whole-response handling -- it processes one line at a time as chunks
+    arrive and has no visibility into the full response, so the
+    fence-awareness fix didn't cover it at all. A fenced __name__
+    streamed line-by-line remained corrupted even after #73212's fix
+    landed.
+
+    Drives the REAL _emit_stream_text()/_reset_stream_state() methods
+    (not a hand-rolled duplicate of the fence-detection conditional), so
+    production-only ordering -- e.g. table-row buffering happening before
+    fence detection -- is actually covered.
+    """
+
+    def _make_cli(self):
+        """Minimal HermesCLI instance with just enough state for
+        _emit_stream_text() to run without a full construction."""
+        import cli as cli_mod
+        obj = object.__new__(cli_mod.HermesCLI)
+        obj.final_response_markdown = "strip"
+        obj._stream_buf = ""
+        obj._stream_started = True
+        obj._stream_box_opened = True
+        obj._stream_table_buf = []
+        obj._in_stream_table = False
+        obj._in_stream_code_fence = False
+        obj._stream_code_fence_char = ""
+        obj._stream_code_fence_len = 0
+        obj._reasoning_preview_buf = ""
+        obj._reasoning_box_opened = False
+        obj._reasoning_buf = ""
+        obj._deferred_content = ""
+        obj.show_reasoning = False
+        obj.show_timestamps = False
+        return obj
+
+    def _feed_and_capture(self, monkeypatch, obj, chunks):
+        """Feed `chunks` through the real _emit_stream_text(), capturing
+        every printed line via a patched cli._cprint. Strips the padding/
+        ANSI wrapper _emit_one() adds so assertions can check line content
+        directly."""
+        import cli as cli_mod
+
+        printed = []
+        monkeypatch.setattr(cli_mod, "_cprint", lambda text: printed.append(text))
+
+        for chunk in chunks:
+            obj._emit_stream_text(chunk)
+
+        lines = []
+        for text in printed:
+            # _emit_one() wraps each line as f"{_STREAM_PAD}{...}{_RST}" or
+            # f"{_STREAM_PAD}{_tc}{...}{_RST}" -- strip the pad prefix and
+            # any trailing ANSI reset/color codes to get the raw line.
+            stripped = text
+            if stripped.startswith(cli_mod._STREAM_PAD):
+                stripped = stripped[len(cli_mod._STREAM_PAD):]
+            stripped = re.sub(r"\x1b\[[0-9;]*m", "", stripped)
+            lines.append(stripped)
+        return lines
+
+    def test_dunder_survives_when_fence_and_code_arrive_in_separate_chunks(
+        self, monkeypatch
+    ):
+        """The exact scenario the review flagged: streamed content is
+        split at each newline and each line stripped independently, with
+        no memory of a fence opened on a PREVIOUS chunk."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(
+            monkeypatch, obj,
+            ["```python\n", "print(type(x).__name__)\n", "```\n"],
+        )
+        assert any("__name__" in l for l in emitted), emitted
+        assert not any(l.strip() == "__main__" for l in emitted)
+
+    def test_fence_state_persists_across_multiple_stream_chunks(self, monkeypatch):
+        """A single line of code split mid-token across two separate
+        streamed deltas (the buffer only flushes complete lines, so this
+        exercises accumulation) must still be protected once the line is
+        complete, and fence state must still be correctly open."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(monkeypatch, obj, ["```python\n"])
+        assert obj._in_stream_code_fence is True
+        assert obj._stream_code_fence_char == "`"
+        assert obj._stream_code_fence_len == 3
+
+        emitted += self._feed_and_capture(
+            monkeypatch, obj, ['if __name__ == "__main__":\n']
+        )
+        assert obj._in_stream_code_fence is True
+        assert any('__name__ == "__main__"' in l for l in emitted), emitted
+
+        self._feed_and_capture(monkeypatch, obj, ["```\n"])
+        assert obj._in_stream_code_fence is False
+
+    def test_prose_outside_stream_fence_still_stripped(self, monkeypatch):
+        """Sanity: this fix must not disable stripping for ordinary
+        streamed prose lines outside any fence."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(monkeypatch, obj, ["say __bold__ now\n"])
+        assert emitted == ["say bold now"]
+
+    def test_stream_fence_state_resets_between_responses(self, monkeypatch):
+        """A fence left open (e.g. a bug elsewhere, or an unterminated
+        block) must not leak into the NEXT response's streaming state.
+        Drives the REAL _reset_stream_state() method (per review of
+        #75188), not a hand-simulated copy of its reset assignments."""
+        obj = self._make_cli()
+        self._feed_and_capture(monkeypatch, obj, ["```python\n"])
+        assert obj._in_stream_code_fence is True
+
+        obj._reset_stream_state()
+
+        assert obj._in_stream_code_fence is False
+        assert obj._stream_code_fence_char == ""
+        assert obj._stream_code_fence_len == 0
+
+    def test_shorter_closer_does_not_close_longer_opener_while_streaming(
+        self, monkeypatch
+    ):
+        """Regression (review of #75188): the streaming fence state only
+        tracked the marker CHARACTER, not its length, so a 3-backtick
+        closer incorrectly ended a 4-backtick-opened block. A genuine
+        3-backtick line appearing mid-block (e.g. the assistant explaining
+        Markdown fence syntax inside a real code block) must not be
+        mistaken for the closer, and __name__ after it must stay
+        protected."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(
+            monkeypatch, obj,
+            [
+                "````python\n",
+                "# use ``` to start a fence\n",
+                "print(__name__)\n",
+                "````\n",
+            ],
+        )
+        assert obj._in_stream_code_fence is False  # correctly closed by ````
+        assert any("__name__" in l for l in emitted), emitted
+        assert not any(l.strip() == "__main__" for l in emitted)
+
+    def test_fenced_pipe_line_not_swallowed_by_table_buffering(self, monkeypatch):
+        """Regression (review of #75188): table-row buffering used to run
+        BEFORE fence-state detection, so a fenced line shaped like a
+        table row (e.g. a Markdown table example inside a code fence)
+        got swallowed into table buffering instead of being recognized
+        as fenced content -- and table-buffer flushing invokes markdown
+        stripping, which would corrupt a dunder the same way as before."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(
+            monkeypatch, obj,
+            [
+                "```text\n",
+                "| __name__ | value |\n",
+                "|---|---|\n",
+                "```\n",
+            ],
+        )
+        assert obj._in_stream_table is False, (
+            "the pipe-shaped fenced line must not have been buffered as a table row"
+        )
+        assert any("__name__" in l for l in emitted), emitted
+        assert not any(l.strip() == "__main__" for l in emitted)


### PR DESCRIPTION
## Context

Supersedes #75188 per @teknium1's review -- three real gaps.

## Fixes

1. **Shorter closer accepted.** The closer-length check accepted any closer >= 3 chars, including one shorter than the opener. Fixed both the whole-response regex and the streaming state (added length tracking alongside the character tracking).
2. **Table buffering before fence detection.** A fenced line shaped like a table row could be swallowed into table buffering (which invokes markdown stripping) before fence detection ever saw it. Restructured to check fence state first.
3. **Tests duplicated the conditional instead of driving real methods.** Rewrote the streaming test harness to call `_emit_stream_text()`/`_reset_stream_state()` directly, patching `cli._cprint` to capture output -- this now covers the table-buffering-order issue, which the old duplicated-logic tests couldn't.

## Verification

Added regression tests for both the shorter-closer rejection (whole-response and streaming) and the pipe-line-inside-a-fence case. Verified each fix independently by temporarily disabling it and confirming the corresponding test fails.

24/24 pass in the full `tests/cli/test_cli_markdown_rendering.py` file; 45/45 across two more dependent test files (no regression).