### PR TITLE
feat: wire up display.show_cost to show cost, tokens, cache rate, provider in status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4501,7 +4501,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._providers_order = pr.get("order")
         self._provider_require_params = pr.get("require_parameters", False)
         self._provider_data_collection = pr.get("data_collection")
-        self._provider_allow_fallbacks = pr.get("allow_fallbacks", True)
 
         # OpenRouter Pareto Code router knob — coding-score floor (0.0-1.0).
         # Only applied when model.model == "openrouter/pareto-code".
@@ -5352,37 +5351,36 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             snapshot["session_cache_rate"] = None
 
-        # Cost estimation for the status bar (only when show_cost is enabled)
+        # Cost for the status bar (only when show_cost is enabled). We render
+        # the per-call accumulator that conversation_loop already maintains:
+        # each API call is priced on its resolved route (so fallbacks, model
+        # switches, and MoA sessions are accounted correctly) and accumulated
+        # into agent.session_estimated_cost_usd / session_cost_status /
+        # session_cost_source. Repricing the cumulative lifetime totals here
+        # against the *current* model/provider would be wrong, and calling
+        # estimate_usage_cost() during synchronous status-bar rendering could
+        # cold-fetch /models metadata and block chrome repaint.
         if getattr(self, '_show_cost', False):
             try:
-                total_tok = snapshot["session_total_tokens"]
-                if total_tok > 0:
-                    from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
-                    usage = CanonicalUsage(
-                        input_tokens=snapshot["session_input_tokens"],
-                        output_tokens=snapshot["session_output_tokens"],
-                        cache_read_tokens=snapshot["session_cache_read_tokens"],
-                        cache_write_tokens=snapshot["session_cache_write_tokens"],
-                        request_count=snapshot["session_api_calls"],
-                    )
-                    cost_result = estimate_usage_cost(
-                        model_name,
-                        usage,
-                        provider=getattr(agent, "provider", None),
-                        base_url=getattr(agent, "base_url", None),
-                        api_key=getattr(agent, "api_key", None),
-                    )
-                    snapshot["session_cost_label"] = cost_result.label
-                    snapshot["session_cost_status"] = cost_result.status
+                cost_status = getattr(agent, "session_cost_status", "unknown") or "unknown"
+                cost_source = getattr(agent, "session_cost_source", "none") or "none"
+                snapshot["session_cost_status"] = cost_status
+                snapshot["session_cost_source"] = cost_source
+                amount = getattr(agent, "session_estimated_cost_usd", None)
+                if amount is not None and float(amount) > 0:
+                    snapshot["session_cost_label"] = f"~${float(amount):.2f}"
+                elif cost_status == "included":
+                    snapshot["session_cost_label"] = "included"
                 else:
                     snapshot["session_cost_label"] = ""
-                    snapshot["session_cost_status"] = "unknown"
             except Exception:
                 snapshot["session_cost_label"] = ""
                 snapshot["session_cost_status"] = "unknown"
+                snapshot["session_cost_source"] = "none"
         else:
             snapshot["session_cost_label"] = ""
             snapshot["session_cost_status"] = "unknown"
+            snapshot["session_cost_source"] = "none"
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:

--- a/cli.py
+++ b/cli.py
@@ -5368,7 +5368,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 snapshot["session_cost_source"] = cost_source
                 amount = getattr(agent, "session_estimated_cost_usd", None)
                 if amount is not None and float(amount) > 0:
-                    snapshot["session_cost_label"] = f"~${float(amount):.2f}"
+                    # 'actual' costs (OpenRouter usage.cost) are exact; only
+                    # estimates get the ~ prefix.
+                    _prefix = "~" if cost_status != "actual" else ""
+                    snapshot["session_cost_label"] = f"{_prefix}${float(amount):.2f}"
                 elif cost_status == "included":
                     snapshot["session_cost_label"] = "included"
                 else:

--- a/cli.py
+++ b/cli.py
@@ -4317,6 +4317,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # summary line out of non-interactive surfaces.
         self._interactive_turn = False
 
+        # show_cost: show estimated $ cost and token counts in the status bar
+        self._show_cost = bool(CLI_CONFIG["display"].get("show_cost", False))
+
         # Submitted multiline user-message preview (display.user_message_preview in config.yaml)
         _ump = CLI_CONFIG["display"].get("user_message_preview", {})
         if not isinstance(_ump, dict):
@@ -4498,6 +4501,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._providers_order = pr.get("order")
         self._provider_require_params = pr.get("require_parameters", False)
         self._provider_data_collection = pr.get("data_collection")
+        self._provider_allow_fallbacks = pr.get("allow_fallbacks", True)
 
         # OpenRouter Pareto Code router knob — coding-score floor (0.0-1.0).
         # Only applied when model.model == "openrouter/pareto-code".
@@ -5234,6 +5238,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             "session_completion_tokens": 0,
             "session_total_tokens": 0,
             "session_api_calls": 0,
+            "session_cost_label": "",
+            "session_cost_status": "unknown",
+            "session_provider": "",
+            "session_cache_rate": None,
             "compressions": 0,
             "active_background_tasks": 0,
             "active_background_processes": 0,
@@ -5329,6 +5337,53 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
 
+        # Provider name for the status bar
+        snapshot["session_provider"] = getattr(agent, "provider", None) or ""
+
+        # Cache rate: cache_read / (input + cache_read) * 100
+        try:
+            inp = snapshot["session_input_tokens"]
+            cache_read = snapshot["session_cache_read_tokens"]
+            cache_denom = inp + cache_read
+            if cache_denom > 0:
+                snapshot["session_cache_rate"] = round(cache_read / cache_denom * 100, 1)
+            else:
+                snapshot["session_cache_rate"] = None
+        except Exception:
+            snapshot["session_cache_rate"] = None
+
+        # Cost estimation for the status bar (only when show_cost is enabled)
+        if self._show_cost:
+            try:
+                total_tok = snapshot["session_total_tokens"]
+                if total_tok > 0:
+                    from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+                    usage = CanonicalUsage(
+                        input_tokens=snapshot["session_input_tokens"],
+                        output_tokens=snapshot["session_output_tokens"],
+                        cache_read_tokens=snapshot["session_cache_read_tokens"],
+                        cache_write_tokens=snapshot["session_cache_write_tokens"],
+                        request_count=snapshot["session_api_calls"],
+                    )
+                    cost_result = estimate_usage_cost(
+                        model_name,
+                        usage,
+                        provider=getattr(agent, "provider", None),
+                        base_url=getattr(agent, "base_url", None),
+                        api_key=getattr(agent, "api_key", None),
+                    )
+                    snapshot["session_cost_label"] = cost_result.label
+                    snapshot["session_cost_status"] = cost_result.status
+                else:
+                    snapshot["session_cost_label"] = ""
+                    snapshot["session_cost_status"] = "unknown"
+            except Exception:
+                snapshot["session_cost_label"] = ""
+                snapshot["session_cost_status"] = "unknown"
+        else:
+            snapshot["session_cost_label"] = ""
+            snapshot["session_cost_status"] = "unknown"
+
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
             # last_prompt_tokens is parked at the -1 sentinel right after a
@@ -5349,6 +5404,30 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
         return snapshot
+
+    def _format_cost_token_string(self, snapshot: Dict[str, Any]) -> str:
+        """Build a compact cost/token/cache string for the status bar.
+        
+        Returns e.g. \"$0.02 · ↓105K ↑7.5K · 95.6% cache\" or empty string.
+        """
+        if not self._show_cost:
+            return ""
+        parts = []
+        cost_label = snapshot.get("session_cost_label", "")
+        if cost_label:
+            parts.append(cost_label)
+        inp = snapshot.get("session_input_tokens", 0) or 0
+        out = snapshot.get("session_output_tokens", 0) or 0
+        if inp > 0 and out > 0:
+            parts.append(f"↓{format_token_count_compact(inp)} ↑{format_token_count_compact(out)}")
+        elif inp > 0:
+            parts.append(f"↓{format_token_count_compact(inp)}")
+        elif out > 0:
+            parts.append(f"↑{format_token_count_compact(out)}")
+        cache_rate = snapshot.get("session_cache_rate")
+        if cache_rate is not None:
+            parts.append(f"{cache_rate}% cache")
+        return " · ".join(parts)
 
     @staticmethod
     def _status_bar_display_width(text: str) -> int:
@@ -5890,9 +5969,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                # Show provider alongside model name when show_cost is on
+                provider = snapshot.get("session_provider", "")
+                if provider and self._show_cost:
+                    model_label = f"⚕ {provider} · {snapshot['model_short']}"
+                else:
+                    model_label = f"⚕ {snapshot['model_short']}"
+                parts = [model_label, percent_label]
                 if battery_label:
                     parts.insert(0, battery_label)
+                # Cost/token/rate segment (medium tier)
+                cost_token_str = self._format_cost_token_string(snapshot)
+                if cost_token_str:
+                    parts.append(cost_token_str)
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -5922,9 +6011,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            # Show provider alongside model name when show_cost is on
+            provider = snapshot.get("session_provider", "")
+            if provider and self._show_cost:
+                model_label = f"⚕ {provider} · {snapshot['model_short']}"
+            else:
+                model_label = f"⚕ {snapshot['model_short']}"
+            parts = [model_label, context_label, percent_label]
             if battery_label:
                 parts.insert(0, battery_label)
+            # Cost/token/rate segment (wide tier)
+            cost_token_str = self._format_cost_token_string(snapshot)
+            if cost_token_str:
+                parts.append(cost_token_str)
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -5996,12 +6095,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
+                    # Show provider alongside model name
+                    provider = snapshot.get("session_provider", "")
+                    if provider and self._show_cost:
+                        model_short = f"{provider} · {snapshot['model_short']}"
+                    else:
+                        model_short = snapshot["model_short"]
                     frags = [
                         ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        ("class:status-bar-strong", model_short),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    # Cost/token/rate segment (medium tier TUI)
+                    cost_token_str = self._format_cost_token_string(snapshot)
+                    if cost_token_str:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-cost", cost_token_str))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -6041,9 +6151,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
+                    # Show provider alongside model name
+                    provider = snapshot.get("session_provider", "")
+                    if provider and self._show_cost:
+                        model_short = f"{provider} · {snapshot['model_short']}"
+                    else:
+                        model_short = snapshot["model_short"]
                     frags = [
                         ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        ("class:status-bar-strong", model_short),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),
@@ -6051,6 +6167,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    # Cost/token/rate segment (wide tier TUI)
+                    cost_token_str = self._format_cost_token_string(snapshot)
+                    if cost_token_str:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-cost", cost_token_str))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -16644,6 +16765,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             'status-bar-bad': 'bg:#1a1a2e #FF8C00 bold',
             'status-bar-critical': 'bg:#1a1a2e #FF6B6B bold',
             'status-bar-yolo': 'bg:#1a1a2e #FF4444 bold',
+            'status-bar-cost': 'bg:#1a1a2e #00BFA5 bold',
             # Bronze horizontal rules around the input area
             'input-rule': '#CD7F32',
             # Clipboard image attachment badges

--- a/cli.py
+++ b/cli.py
@@ -5353,7 +5353,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             snapshot["session_cache_rate"] = None
 
         # Cost estimation for the status bar (only when show_cost is enabled)
-        if self._show_cost:
+        if getattr(self, '_show_cost', False):
             try:
                 total_tok = snapshot["session_total_tokens"]
                 if total_tok > 0:
@@ -5410,7 +5410,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         
         Returns e.g. \"$0.02 · ↓105K ↑7.5K · 95.6% cache\" or empty string.
         """
-        if not self._show_cost:
+        if not getattr(self, '_show_cost', False):
             return ""
         parts = []
         cost_label = snapshot.get("session_cost_label", "")
@@ -5971,7 +5971,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if width < 76:
                 # Show provider alongside model name when show_cost is on
                 provider = snapshot.get("session_provider", "")
-                if provider and self._show_cost:
+                if provider and getattr(self, '_show_cost', False):
                     model_label = f"⚕ {provider} · {snapshot['model_short']}"
                 else:
                     model_label = f"⚕ {snapshot['model_short']}"
@@ -6013,7 +6013,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             compressions = snapshot.get("compressions", 0)
             # Show provider alongside model name when show_cost is on
             provider = snapshot.get("session_provider", "")
-            if provider and self._show_cost:
+            if provider and getattr(self, '_show_cost', False):
                 model_label = f"⚕ {provider} · {snapshot['model_short']}"
             else:
                 model_label = f"⚕ {snapshot['model_short']}"
@@ -6097,7 +6097,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
                     # Show provider alongside model name
                     provider = snapshot.get("session_provider", "")
-                    if provider and self._show_cost:
+                    if provider and getattr(self, '_show_cost', False):
                         model_short = f"{provider} · {snapshot['model_short']}"
                     else:
                         model_short = snapshot["model_short"]
@@ -6153,7 +6153,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
                     # Show provider alongside model name
                     provider = snapshot.get("session_provider", "")
-                    if provider and self._show_cost:
+                    if provider and getattr(self, '_show_cost', False):
                         model_short = f"{provider} · {snapshot['model_short']}"
                     else:
                         model_short = snapshot["model_short"]

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -30,6 +30,9 @@ def _attach_agent(
     context_tokens: int,
     context_length: int,
     compressions: int = 0,
+    estimated_cost_usd: float = 0.0,
+    cost_status: str = "unknown",
+    cost_source: str = "none",
 ):
     cli_obj.agent = SimpleNamespace(
         model=cli_obj.model,
@@ -43,6 +46,9 @@ def _attach_agent(
         session_completion_tokens=completion_tokens,
         session_total_tokens=total_tokens,
         session_api_calls=api_calls,
+        session_estimated_cost_usd=estimated_cost_usd,
+        session_cost_status=cost_status,
+        session_cost_source=cost_source,
         get_rate_limit_state=lambda: None,
         context_compressor=SimpleNamespace(
             last_prompt_tokens=context_tokens,
@@ -333,16 +339,73 @@ class TestShowCostStatusBar:
             context_tokens=12_000,
             context_length=200_000,
             cache_read_tokens=50_000,
+            estimated_cost_usd=0.0234,
+            cost_status="estimated",
+            cost_source="official_docs_snapshot",
         )
         cli_obj._show_cost = True
         text = cli_obj._build_status_bar_text(width=120)
         # Should show provider, cost label, tokens, and cache rate
         assert "anthropic" in text  # provider from _attach_agent
+        assert "~$0.02" in text  # estimated cost label from the accumulator
         assert "↓" in text  # input tokens arrow
         assert "↑" in text  # output tokens arrow
         assert "cache" in text  # cache rate
         # Should NOT show the old "tok" suffix (replaced by ↓↑ arrows)
         assert "tok" not in text.replace("↓", "").replace("↑", "")
+
+    def test_show_cost_renders_accumulated_cost_not_reprice(self):
+        """Regression: cost must come from the per-call accumulator, not a
+        reprice of cumulative token totals against the current model/provider.
+
+        A session that fell back to a cheaper model (or switched models / ran
+        MoA) has earlier calls priced on their own resolved routes; the status
+        bar must render that accumulated value verbatim and never recompute it
+        from the lifetime token totals with the *current* model.
+        """
+        # Lifetime totals are large and would price high if repriced against
+        # the current anthropic model. The accumulated cost is small because
+        # most of the session ran on a cheap fallback model.
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=1_000_000,
+            completion_tokens=200_000,
+            total_tokens=1_200_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+            cache_read_tokens=500_000,
+            estimated_cost_usd=0.0142,
+            cost_status="estimated",
+            cost_source="official_docs_snapshot",
+        )
+        cli_obj._show_cost = True
+        text = cli_obj._build_status_bar_text(width=120)
+        # The accumulated (fallback-priced) value wins; no reprice against the
+        # current model. An estimate_usage_cost reprice of 1.2M tokens on
+        # claude-sonnet would show dollars, not cents.
+        assert "~$0.01" in text  # the exact accumulated label
+
+    def test_show_cost_included_status_shows_included_label(self):
+        """When the accumulator reports an included (bundled-plan) status, the
+        status bar must show the 'included' label rather than an empty string,
+        so a swallowed pricing error or missing label cannot pass silently."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+            estimated_cost_usd=0.0,
+            cost_status="included",
+            cost_source="none",
+        )
+        cli_obj._show_cost = True
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "included" in text
+        assert "~$" not in text
 
     def test_show_cost_disabled_hides_cost_and_tokens_default(self):
         """When show_cost is not set (default False), cost/tokens should not appear."""
@@ -354,10 +417,13 @@ class TestShowCostStatusBar:
             api_calls=5,
             context_tokens=12_000,
             context_length=200_000,
+            estimated_cost_usd=0.0234,
+            cost_status="estimated",
         )
         # _show_cost not set — defaults to False via getattr
         text = cli_obj._build_status_bar_text(width=120)
         assert "claude-sonnet-4-20250514" in text
+        assert "~$0.02" not in text
         assert "↓" not in text
         assert "↑" not in text
         assert "cache" not in text

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -407,6 +407,26 @@ class TestShowCostStatusBar:
         assert "included" in text
         assert "~$" not in text
 
+    def test_show_cost_actual_openrouter_cost_no_tilde(self):
+        """An 'actual' cost (from OpenRouter usage.cost) must render without the
+        ~ estimate prefix, so the status bar distinguishes exact from estimated."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+            estimated_cost_usd=0.1310,
+            cost_status="actual",
+            cost_source="provider_cost_api",
+        )
+        cli_obj._show_cost = True
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "$0.13" in text
+        assert "~$0.13" not in text
+
     def test_show_cost_disabled_hides_cost_and_tokens_default(self):
         """When show_cost is not set (default False), cost/tokens should not appear."""
         cli_obj = _attach_agent(

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -319,3 +319,83 @@ class TestIdleSinceLastTurn:
         assert snapshot["idle_since"].startswith("✓ ")
 
 
+class TestShowCostStatusBar:
+    """Tests for the display.show_cost feature in the status bar."""
+
+    def test_show_cost_enabled_shows_cost_and_tokens(self):
+        """When show_cost is enabled, cost, tokens, and cache rate appear."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+            cache_read_tokens=50_000,
+        )
+        cli_obj._show_cost = True
+        text = cli_obj._build_status_bar_text(width=120)
+        # Should show provider, cost label, tokens, and cache rate
+        assert "anthropic" in text  # provider from _attach_agent
+        assert "↓" in text  # input tokens arrow
+        assert "↑" in text  # output tokens arrow
+        assert "cache" in text  # cache rate
+        # Should NOT show the old "tok" suffix (replaced by ↓↑ arrows)
+        assert "tok" not in text.replace("↓", "").replace("↑", "")
+
+    def test_show_cost_disabled_hides_cost_and_tokens_default(self):
+        """When show_cost is not set (default False), cost/tokens should not appear."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+        # _show_cost not set — defaults to False via getattr
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "claude-sonnet-4-20250514" in text
+        assert "↓" not in text
+        assert "↑" not in text
+        assert "cache" not in text
+
+    def test_show_cost_cache_rate_computed_correctly(self):
+        """Cache rate should be cache_read / (input + cache_read) * 100."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            input_tokens=10_000,
+            output_tokens=2_000,
+            cache_read_tokens=90_000,
+            cache_write_tokens=0,
+            prompt_tokens=100_000,
+            completion_tokens=2_000,
+            total_tokens=102_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+        cli_obj._show_cost = True
+        snapshot = cli_obj._get_status_bar_snapshot()
+        # 90_000 / (10_000 + 90_000) * 100 = 90.0%
+        assert snapshot["session_cache_rate"] == 90.0
+
+    def test_show_cost_no_cache_returns_zero_rate(self):
+        """When no cache reads, cache_rate should be 0.0."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=5,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+        cli_obj._show_cost = True
+        snapshot = cli_obj._get_status_bar_snapshot()
+        # 0 / (10_000 + 0) * 100 = 0.0
+        assert snapshot["session_cache_rate"] == 0.0
+
+

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1588,7 +1588,7 @@ display:
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
-  show_cost: false        # Show estimated $ cost, token in/out, cache rate %, and provider in the CLI status bar
+  show_cost: false        # Show estimated $ cost, token in/out, cache rate %, and provider in the classic CLI status bar (prompt_toolkit CLI; not the Ink TUI)
   timestamps: false       # When true, prefixes user and assistant labels with timestamps in the CLI / TUI transcript
   timestamp_format: "%H:%M"  # strftime format for those timestamps (e.g. "%b-%d %H:%M" for month-day)
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1588,7 +1588,7 @@ display:
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
-  show_cost: false        # Show estimated $ cost in the CLI status bar
+  show_cost: false        # Show estimated $ cost, token in/out, cache rate %, and provider in the CLI status bar
   timestamps: false       # When true, prefixes user and assistant labels with timestamps in the CLI / TUI transcript
   timestamp_format: "%H:%M"  # strftime format for those timestamps (e.g. "%b-%d %H:%M" for month-day)
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1198,7 +1198,7 @@ display:
   bell_on_complete: false # 当 agent 完成时播放终端铃声（适合长任务）
   show_reasoning: false   # 在每次响应上方显示模型推理/思考（用 /reasoning show|hide 切换）
   streaming: false        # 将 token 实时流式传输到终端
-  show_cost: false        # 在 CLI 状态栏中显示估计 $ 成本、输入/输出 token、缓存率 % 和提供商
+  show_cost: false        # 在经典 CLI 状态栏（prompt_toolkit CLI，而非 Ink TUI）中显示估计 $ 成本、输入/输出 token、缓存率 % 和提供商
   timestamps: false       # 为 true 时，在 CLI/TUI 记录中为用户和 assistant 标签添加 [HH:MM] 时间戳前缀
   tool_preview_length: 0  # 工具调用预览的最大字符数（0 = 无限制，显示完整路径/命令）
   runtime_footer:         # Gateway：在最终回复中附加运行时上下文页脚

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1198,7 +1198,7 @@ display:
   bell_on_complete: false # 当 agent 完成时播放终端铃声（适合长任务）
   show_reasoning: false   # 在每次响应上方显示模型推理/思考（用 /reasoning show|hide 切换）
   streaming: false        # 将 token 实时流式传输到终端
-  show_cost: false        # 在 CLI 状态栏中显示估计 $ 成本
+  show_cost: false        # 在 CLI 状态栏中显示估计 $ 成本、输入/输出 token、缓存率 % 和提供商
   timestamps: false       # 为 true 时，在 CLI/TUI 记录中为用户和 assistant 标签添加 [HH:MM] 时间戳前缀
   tool_preview_length: 0  # 工具调用预览的最大字符数（0 = 无限制，显示完整路径/命令）
   runtime_footer:         # Gateway：在最终回复中附加运行时上下文页脚


### PR DESCRIPTION
## Summary

`display.show_cost` was a dead config key — defined in `config_defaults.py` but never read anywhere. This PR wires it up so it actually shows estimated cost, token usage, cache hit rate, and provider name in the CLI/TUI status bar.

## Changes

1. **Reads `display.show_cost`** in `HermesCLI.__init__` — follows the same pattern as other display settings

2. **Adds cost estimation to the snapshot** via `agent.usage_pricing.estimate_usage_cost()` — computes a cost label using the same pricing engine that `/usage` uses

3. **Adds cache rate computation** — `cache_read / (input + cache_read) * 100`

4. **Adds provider name** to the snapshot from `agent.provider`

5. **Renders all in the status bar** — both plain-text (`_build_status_bar_text`) and styled TUI (`_get_status_bar_fragments`) across narrow/medium/wide width tiers

6. **Adds `status-bar-cost` style** to the default skin (teal `#00BFA5`)

7. **Adds tests** — 4 new tests covering: enabled display, disabled default, cache rate computation, and zero-cache edge case

8. **Updates docs** — English and Chinese config docs to describe the full feature scope

## Example output

```
⚕ anthropic · claude-sonnet-4-20250514 │ 12.4K/200K · 6% │ /bin/bash.06 · ↓10K ↑2.2K · 83.3% cache │ 15m
```

## Testing

- All 31 existing status bar and turn_summary tests pass
- 4 new tests added for the show_cost feature
- Python syntax check passes
- Cost estimation verified working with `estimate_usage_cost()` for OpenRouter provider