### PR TITLE
fix(sessions): filter compression tips before pagination

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4984,6 +4984,58 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             current = child_id
         return current
 
+    @staticmethod
+    def _compression_projection_ctes(seed_where_sql: str) -> str:
+        """Return CTEs that resolve each listable row's compression tip in SQL.
+
+        ``seed_where_sql`` must filter only properties of the surfaced root
+        (source, archive state, child visibility, etc.), never its raw message
+        count.  Consumers can then filter/count against ``projection_tips``'
+        effective count before applying their own LIMIT/OFFSET.
+        """
+        return f"""
+            projection_chain(root_id, cur_id, depth) AS (
+                SELECT s.id, s.id, 0 FROM sessions s {seed_where_sql}
+                UNION ALL
+                SELECT chain.root_id, child.id, chain.depth + 1
+                FROM projection_chain chain
+                JOIN sessions parent ON parent.id = chain.cur_id
+                JOIN sessions child ON child.id = (
+                    SELECT candidate.id
+                    FROM sessions candidate
+                    WHERE candidate.parent_session_id = parent.id
+                      AND json_extract(COALESCE(candidate.model_config, '{{}}'), '$._branched_from') IS NULL
+                      AND json_extract(COALESCE(candidate.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND COALESCE(candidate.source, '') != 'tool'
+                    ORDER BY
+                      CASE
+                        WHEN candidate.end_reason = 'compression' THEN 0
+                        WHEN candidate.ended_at IS NULL THEN 1
+                        ELSE 2
+                      END,
+                      COALESCE(
+                        (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = candidate.id),
+                        candidate.started_at
+                      ) DESC,
+                      candidate.started_at DESC,
+                      candidate.id DESC
+                    LIMIT 1
+                )
+                WHERE parent.end_reason = 'compression'
+                  AND chain.depth < 100
+            ),
+            projection_tips AS (
+                SELECT chain.root_id, tip.message_count AS effective_message_count
+                FROM projection_chain chain
+                JOIN (
+                    SELECT root_id, MAX(depth) AS depth
+                    FROM projection_chain
+                    GROUP BY root_id
+                ) latest ON latest.root_id = chain.root_id AND latest.depth = chain.depth
+                JOIN sessions tip ON tip.id = chain.cur_id
+            )
+        """
+
     # Columns excluded from compact_rows projections: only the payload-heavy
     # blob no list consumer renders. Everything else — including gateway
     # routing fields and desktop sidebar fields like git_branch — stays, and
@@ -5096,7 +5148,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clause, clause_params = _cwd_prefix_clause(cwd_prefix)
             where_clauses.append(clause)
             params.extend(clause_params)
-        if min_message_count > 0:
+        filter_by_projected_message_count = (
+            min_message_count > 0 and project_compression_tips and not include_children
+        )
+        if min_message_count > 0 and not filter_by_projected_message_count:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
         if archived_only:
@@ -5105,6 +5160,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.archived = 0")
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+        effective_message_count_sql = (
+            "COALESCE(projection_tips.effective_message_count, s.message_count) >= ?"
+            if filter_by_projected_message_count
+            else ""
+        )
         # Snapshot the filter params before the query builders below extend
         # them with LIMIT/OFFSET — the pinned back-fill reuses the same WHERE.
         base_where_params = list(params)
@@ -5183,6 +5243,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 outer_where = (
                     f"{where_sql} AND {combined}" if where_sql else f"WHERE {combined}"
                 )
+            if effective_message_count_sql:
+                outer_where = (
+                    f"{outer_where} AND {effective_message_count_sql}"
+                    if outer_where
+                    else f"WHERE {effective_message_count_sql}"
+                )
             _sel = self._compact_session_cols() if compact_rows else "s.*"
             query = f"""
                 WITH RECURSIVE chain(root_id, cur_id) AS (
@@ -5206,7 +5272,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         )) AS effective_last_active
                     FROM chain
                     GROUP BY root_id
-                )
+                ),
+                {self._compression_projection_ctes(where_sql)}
                 SELECT {_sel},
                     COALESCE(
                         (SELECT {_PREVIEW_RAW_SELECT}
@@ -5222,16 +5289,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     COALESCE(cm.effective_last_active, s.started_at) AS _effective_last_active
                 FROM sessions s
                 LEFT JOIN chain_max cm ON cm.root_id = s.id
+                LEFT JOIN projection_tips ON projection_tips.root_id = s.id
                 {outer_where}
                 ORDER BY _effective_last_active DESC, s.started_at DESC, s.id DESC
                 LIMIT ? OFFSET ?
             """
-            # WHERE params apply twice (CTE seed + outer select); the id filter
-            # only applies to the outer select.
-            params = params + params + id_params + [limit, offset]
+            # WHERE params apply to both chain CTE seeds and the outer select;
+            # id/effective-count filters only apply to the outer select.
+            params = (
+                params + params + params + id_params
+                + ([min_message_count] if effective_message_count_sql else [])
+                + [limit, offset]
+            )
         else:
             _sel = self._compact_session_cols() if compact_rows else "s.*"
+            effective_where = where_sql
+            if effective_message_count_sql:
+                effective_where = (
+                    f"{effective_where} AND {effective_message_count_sql}"
+                    if effective_where
+                    else f"WHERE {effective_message_count_sql}"
+                )
             query = f"""
+                WITH RECURSIVE {self._compression_projection_ctes(where_sql)}
                 SELECT {_sel},
                     COALESCE(
                         (SELECT {_PREVIEW_RAW_SELECT}
@@ -5245,11 +5325,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         s.started_at
                     ) AS last_active
                 FROM sessions s
-                {where_sql}
+                LEFT JOIN projection_tips ON projection_tips.root_id = s.id
+                {effective_where}
                 ORDER BY s.started_at DESC
                 LIMIT ? OFFSET ?
             """
-            params.extend([limit, offset])
+            params = (
+                params + params
+                + ([min_message_count] if effective_message_count_sql else [])
+                + [limit, offset]
+            )
         with self._read_ctx() as conn:
             cursor = conn.execute(query, params)
             rows = cursor.fetchall()
@@ -5272,7 +5357,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 f"{where_sql} AND s.pinned = 1" if where_sql else "WHERE s.pinned = 1"
             )
             _sel = self._compact_session_cols() if compact_rows else "s.*"
+            pinned_effective_where = pinned_where
+            if effective_message_count_sql:
+                pinned_effective_where += f" AND {effective_message_count_sql}"
             pinned_query = f"""
+                WITH RECURSIVE {self._compression_projection_ctes(where_sql)}
                 SELECT {_sel},
                     COALESCE(
                         (SELECT {_PREVIEW_RAW_SELECT}
@@ -5286,11 +5375,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         s.started_at
                     ) AS last_active
                 FROM sessions s
-                {pinned_where}
+                LEFT JOIN projection_tips ON projection_tips.root_id = s.id
+                {pinned_effective_where}
                 ORDER BY s.started_at DESC
             """
             with self._read_ctx() as conn:
-                pinned_cursor = conn.execute(pinned_query, base_where_params)
+                pinned_params = (
+                    base_where_params + base_where_params
+                    + ([min_message_count] if effective_message_count_sql else [])
+                )
+                pinned_cursor = conn.execute(pinned_query, pinned_params)
                 pinned_rows = pinned_cursor.fetchall()
             for row in pinned_rows:
                 s = dict(row)
@@ -6879,7 +6973,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clause, clause_params = _cwd_prefix_clause(cwd_prefix)
             where_clauses.append(clause)
             params.extend(clause_params)
-        if min_message_count > 0:
+        filter_by_projected_message_count = min_message_count > 0 and exclude_children
+        if min_message_count > 0 and not filter_by_projected_message_count:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
         if archived_only:
@@ -6888,9 +6983,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.archived = 0")
 
         where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+        if filter_by_projected_message_count:
+            query = f"""
+                WITH RECURSIVE {self._compression_projection_ctes(where_sql)}
+                SELECT COUNT(*)
+                FROM sessions s
+                LEFT JOIN projection_tips ON projection_tips.root_id = s.id
+                {where_sql} AND COALESCE(projection_tips.effective_message_count, s.message_count) >= ?
+            """
+            query_params = params + params + [min_message_count]
+        else:
+            query = f"SELECT COUNT(*) FROM sessions s{where_sql}"
+            query_params = params
 
         with self._lock:
-            cursor = self._conn.execute(f"SELECT COUNT(*) FROM sessions s{where_sql}", params)
+            cursor = self._conn.execute(query, query_params)
             return cursor.fetchone()[0]
 
     def session_count_by_source(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1551,6 +1551,71 @@ class TestCompressionChainProjection:
         assert tip_row["ended_at"] is None  # tip is still live
         assert tip_row["end_reason"] is None
 
+    def _build_empty_root_filter_fixture(self, db):
+        """Create a projected tip plus listable and hidden child controls."""
+        db.create_session("filtered-root", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = ? WHERE id = ?",
+            (100.0, 110.0, "compression", "filtered-root"),
+        )
+        # A normal child created while the parent was live remains hidden.
+        db.create_session("ordinary-child", "cli", parent_session_id="filtered-root")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?", (105.0, "ordinary-child")
+        )
+        db.append_message("ordinary-child", "user", "hidden delegate-like child")
+
+        db.create_session("filtered-tip", "cli", parent_session_id="filtered-root")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?", (120.0, "filtered-tip")
+        )
+        db.append_message("filtered-tip", "user", "live continuation")
+
+        # Explicit branches stay independently listable.
+        db.create_session("branch-parent", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = ? WHERE id = ?",
+            (200.0, 210.0, "branched", "branch-parent"),
+        )
+        db.create_session(
+            "branch-child",
+            "cli",
+            parent_session_id="branch-parent",
+            model_config={"_branched_from": "branch-parent"},
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?", (220.0, "branch-child")
+        )
+        db.append_message("branch-child", "user", "listable branch")
+        db._conn.commit()
+
+    def test_list_filters_compression_roots_by_projected_tip_message_count(self, db):
+        self._build_empty_root_filter_fixture(db)
+
+        rows = db.list_sessions_rich(min_message_count=1, order_by_last_active=True)
+
+        assert [row["id"] for row in rows] == ["branch-child", "filtered-tip"]
+        assert rows[1]["message_count"] == 1
+        assert rows[1]["_lineage_root_id"] == "filtered-root"
+        assert "ordinary-child" not in [row["id"] for row in rows]
+
+    def test_session_count_filters_compression_roots_by_projected_tip_message_count(self, db):
+        self._build_empty_root_filter_fixture(db)
+
+        assert db.session_count(min_message_count=1, exclude_children=True) == 2
+
+    def test_pagination_applies_after_projected_tip_message_count_filter(self, db):
+        self._build_empty_root_filter_fixture(db)
+
+        rows = db.list_sessions_rich(
+            min_message_count=1,
+            order_by_last_active=False,
+            limit=1,
+            offset=1,
+        )
+
+        assert [row["id"] for row in rows] == ["filtered-tip"]
+
 
 
 


### PR DESCRIPTION
## Summary
- evaluates `min_message_count` against the projected compression tip, not the hidden root
- keeps `list_sessions_rich` pagination and `session_count(exclude_children=True)` consistent
- preserves branch and ordinary-child visibility rules

## Reproduction / tests
- RED: a compression root with zero messages and a live tip with one message was hidden at `min_message_count=1`; count and second page were also wrong
- GREEN: `scripts/run_tests.sh tests/test_hermes_state.py` — 140 passed
- `scripts/run_tests.sh tests/hermes_cli/test_web_server_session_search.py` — 1 passed
- `ruff check hermes_state.py tests/test_hermes_state.py` and `git diff --check` passed

No user state database was opened or mutated.