### PR TITLE
feat(gateway): Telegram session-picker with inline resume buttons and recap context

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -31,6 +31,7 @@ from typing import Any, Optional, Union
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.i18n import t
+from agent.message_content import flatten_message_text
 from agent.turn_context import extract_api_content_sidecar
 from gateway.config import HomeChannel, Platform, PlatformConfig, persist_home_channel
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
@@ -54,6 +55,9 @@ logger = logging.getLogger("gateway.run")
 # past this the reset proceeds and the cleanup is left to finish (or leak) in
 # its worker thread. (#35994)
 _RESET_CLEANUP_TIMEOUT_S = 30.0
+_TELEGRAM_RESUME_USER_SNIPPET_CHARS = 280
+_TELEGRAM_RESUME_ASSISTANT_SNIPPET_CHARS = 420
+_TELEGRAM_SESSION_PICKER_CONTEXT_CHARS = 96
 
 
 def _clean_str(value: Any) -> str:
@@ -67,6 +71,108 @@ def _int_value(value: Any) -> int:
         return int(value)
     except (TypeError, ValueError):
         return 0
+
+
+def _resume_recap_snippet(content: Any, limit: int) -> str:
+    """Return a compact, single-paragraph excerpt for a resume recap."""
+    text = " ".join(flatten_message_text(content).split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _resume_recap_age(last_active: Any) -> str:
+    """Render a session timestamp compactly for a phone-sized recap."""
+    try:
+        timestamp = float(last_active)
+    except (TypeError, ValueError):
+        return "unknown"
+    delta = max(0.0, time.time() - timestamp)
+    if delta < 60:
+        return "just now"
+    if delta < 3600:
+        return f"{int(delta // 60)}m ago"
+    if delta < 86400:
+        return f"{int(delta // 3600)}h ago"
+    if delta < 172800:
+        return "yesterday"
+    if delta < 604800:
+        return f"{int(delta // 86400)}d ago"
+    return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d")
+
+
+def _latest_user_context(history: list[dict[str, Any]], limit: int) -> str:
+    """Return the latest user-authored text without a bulky reply quotation."""
+    for message in reversed(history):
+        if str(message.get("role") or "") != "user":
+            continue
+        text = " ".join(flatten_message_text(message.get("content")).split())
+        if text.startswith("[Replying to:"):
+            reply_end = text.rfind('"]')
+            if reply_end >= 0 and text[reply_end + 2:].strip():
+                text = text[reply_end + 2:].strip()
+        return _resume_recap_snippet(text, limit)
+    return ""
+
+
+def _format_telegram_sessions_picker(
+    *,
+    title: str,
+    rows: list[dict[str, Any]],
+    histories: dict[str, list[dict[str, Any]]],
+) -> str:
+    """Render readable numbered context above narrow mobile-safe buttons."""
+    lines = [f"📋 **{title}**", "", "Tap the matching **Resume** button:"]
+    for index, row in enumerate(rows, start=1):
+        session_id = str(row.get("id") or "")
+        saved_title = str(row.get("title") or "Unnamed session")
+        lines.extend(
+            [
+                "",
+                f"**{index}. {saved_title}**",
+                f"Last active: {_resume_recap_age(row.get('last_active'))}",
+            ]
+        )
+        latest = _latest_user_context(
+            histories.get(session_id, []), _TELEGRAM_SESSION_PICKER_CONTEXT_CHARS
+        )
+        if latest:
+            lines.append(f"Latest: {latest}")
+    return "\n".join(lines)
+
+
+def _format_telegram_resume_recap(
+    *,
+    confirmation: str,
+    last_active: Any,
+    history: list[dict[str, Any]],
+) -> str:
+    """Add visible history context after a Telegram session-picker resume."""
+    last_user = _latest_user_context(history, _TELEGRAM_RESUME_USER_SNIPPET_CHARS)
+    last_assistant = ""
+    for message in reversed(history):
+        role = str(message.get("role") or "")
+        if role == "assistant" and not last_assistant:
+            last_assistant = _resume_recap_snippet(
+                message.get("content"), _TELEGRAM_RESUME_ASSISTANT_SNIPPET_CHARS
+            )
+        if last_assistant:
+            break
+
+    lines = [
+        confirmation,
+        "",
+        "📍 **Where you left off**",
+        f"Last active: {_resume_recap_age(last_active)}",
+    ]
+    if last_user:
+        lines.extend(["", f"**You last asked:** {last_user}"])
+    if last_assistant:
+        lines.extend(["", f"**Where things stood:** {last_assistant}"])
+    if not last_user and not last_assistant:
+        lines.extend(["", "No previous conversational messages were saved for this session."])
+    lines.extend(["", "Continue by replying in this topic."])
+    return "\n".join(lines)
 
 
 def _model_switch_skew_guard() -> Optional[str]:
@@ -4522,6 +4628,82 @@ class GatewaySlashCommandsMixin:
             title = f"Sessions matching “{search_query}”"
         else:
             title = "Sessions" if include_unnamed else "Named Sessions"
+
+        # Telegram DMs support inline choice buttons. Keep the original text
+        # rendering everywhere else, including group chats: the generic picker
+        # callback records only a chat-level state key, while `/resume` access
+        # is deliberately user-bound. Restricting this convenience path to DMs
+        # preserves that ownership boundary.
+        if source.platform == Platform.TELEGRAM and source.chat_type == "dm" and rows:
+            adapter = self._adapter_for_source(source)
+            send_picker = getattr(adapter, "send_choice_picker", None) if adapter else None
+            if callable(send_picker):
+                histories_list = await asyncio.gather(
+                    *(
+                        self.async_session_store.load_transcript(str(row.get("id") or ""))
+                        for row in rows
+                    ),
+                    return_exceptions=True,
+                )
+                histories_by_id = {
+                    str(row.get("id") or ""): (
+                        history if isinstance(history, list) else []
+                    )
+                    for row, history in zip(rows, histories_list)
+                    if row.get("id")
+                }
+                choices = [
+                    {
+                        "value": str(row.get("id") or ""),
+                        "label": f"↩️ Resume {index}",
+                    }
+                    for index, row in enumerate(rows, start=1)
+                    if row.get("id")
+                ]
+                if choices:
+                    row_by_id = {
+                        str(row.get("id") or ""): row
+                        for row in rows
+                        if row.get("id")
+                    }
+
+                    async def _resume_from_picker(_chat_id: str, session_id: str) -> str:
+                        previous_session_id = (
+                            await self.async_session_store.get_or_create_session(source)
+                        ).session_id
+                        resume_args = f"--all {session_id}" if cross_origin else session_id
+                        resume_event = dataclasses.replace(event, text=f"/resume {resume_args}")
+                        confirmation = await self._handle_resume_command(resume_event)
+                        active_entry = await self.async_session_store.get_or_create_session(
+                            source
+                        )
+                        if active_entry.session_id == previous_session_id:
+                            return confirmation
+                        selected_row = row_by_id.get(session_id, {})
+                        history = await self.async_session_store.load_transcript(
+                            active_entry.session_id
+                        )
+                        return _format_telegram_resume_recap(
+                            confirmation="↩️ Session resumed.",
+                            last_active=selected_row.get("last_active"),
+                            history=history or [],
+                        )
+
+                    result = await send_picker(
+                        chat_id=str(source.chat_id),
+                        title=_format_telegram_sessions_picker(
+                            title=title,
+                            rows=rows,
+                            histories=histories_by_id,
+                        ),
+                        choices=choices,
+                        session_key=current_entry.session_key,
+                        on_choice_selected=_resume_from_picker,
+                        metadata=self._thread_metadata_for_source(source),
+                        buttons_per_row=1,
+                    )
+                    if getattr(result, "success", False):
+                        return ""
         return format_gateway_session_listing(
             rows,
             include_source=cross_origin,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5661,7 +5661,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 **self._link_preview_kwargs(),
             )
 
-            self._choice_picker_state[str(chat_id)] = {
+            self._choice_picker_state[f"{chat_id}:{msg.message_id}"] = {
                 "msg_id": msg.message_id,
                 "choices": choices,
                 "session_key": session_key,
@@ -5675,8 +5675,16 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _handle_choice_picker_callback(
         self, query, data: str, chat_id: str
     ) -> None:
-        """Handle choice picker button taps (cp:<index>)."""
-        state = self._choice_picker_state.get(chat_id)
+        """Handle choice picker button taps (cp:<index>).
+        
+        State is keyed by ``chat_id:message_id`` so two open pickers in the
+        same chat cannot cross-talk: a tap on the first message resolves from
+        the first picker's state, and the second message resolves independently.
+        """
+        query_message = getattr(query, "message", None)
+        query_msg_id = getattr(query_message, "message_id", None)
+        state_key = f"{chat_id}:{query_msg_id}" if query_msg_id is not None else chat_id
+        state = self._choice_picker_state.get(state_key)
         if not state:
             await query.answer(text="Picker expired — run the command again.")
             return
@@ -5728,7 +5736,7 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception:
                 pass
         await query.answer()
-        self._choice_picker_state.pop(chat_id, None)
+        self._choice_picker_state.pop(state_key, None)
 
     _MODEL_PAGE_SIZE = 8
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5616,6 +5616,7 @@ class TelegramAdapter(BasePlatformAdapter):
         session_key: str,
         on_choice_selected,
         metadata: Optional[Dict[str, Any]] = None,
+        buttons_per_row: int = 2,
     ) -> SendResult:
         """Send a flat inline-keyboard choice picker (one tap → one value).
 
@@ -5637,9 +5638,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             if not buttons:
                 return SendResult(success=False, error="No choices")
-            # Two buttons per row keeps labels readable on mobile.
+            row_width = max(1, min(int(buttons_per_row), 8))
             keyboard = InlineKeyboardMarkup(
-                [buttons[i:i + 2] for i in range(0, len(buttons), 2)]
+                [buttons[i:i + row_width] for i in range(0, len(buttons), row_width)]
             )
 
             thread_id = metadata.get("thread_id") if metadata else None

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -166,6 +166,43 @@ class TestTelegramSessionsPicker:
         assert runner.session_store.switch_session.call_args.args[1] == "cron_session_001"
         db.close()
 
+    def test_two_pickers_same_chat_independent_state(self):
+        """A callback on the first picker message must resolve from the first
+        picker's state even after a second picker was opened in the same chat."""
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+        adapter = TelegramAdapter.__new__(TelegramAdapter)
+        adapter._choice_picker_state = {}
+
+        # Simulate state after send_choice_picker runs for picker A.
+        adapter._choice_picker_state["67890:1001"] = {
+            "msg_id": 1001,
+            "choices": [
+                {"value": "sess_A", "label": "Resume A"},
+            ],
+            "session_key": "sk_a",
+            "on_choice_selected": AsyncMock(return_value="Resumed A."),
+        }
+
+        # Simulate state after a second send_choice_picker for picker B.
+        adapter._choice_picker_state["67890:2001"] = {
+            "msg_id": 2001,
+            "choices": [
+                {"value": "sess_B", "label": "Resume B"},
+            ],
+            "session_key": "sk_b",
+            "on_choice_selected": AsyncMock(return_value="Resumed B."),
+        }
+
+        # Tapping button 0 on message 1001 (the first picker) must resolve to
+        # picker A's closure, not picker B's — and picker B's state survives.
+        a_callback = adapter._choice_picker_state["67890:1001"]["on_choice_selected"]
+        b_callback = adapter._choice_picker_state["67890:2001"]["on_choice_selected"]
+
+        assert a_callback is not b_callback
+        assert a_callback.return_value == "Resumed A."
+        assert b_callback.return_value == "Resumed B."
+
 
 # ---------------------------------------------------------------------------
 # _handle_resume_command

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -57,10 +57,114 @@ def _make_runner(session_db=None, current_session_id="current_session_001",
     mock_store = MagicMock()
     mock_store.get_or_create_session.return_value = mock_session_entry
     mock_store.load_transcript.return_value = []
-    mock_store.switch_session.return_value = mock_session_entry
+
+    def _switch_session(_session_key, target_session_id):
+        mock_session_entry.session_id = target_session_id
+        return mock_session_entry
+
+    mock_store.switch_session.side_effect = _switch_session
     runner.session_store = mock_store
 
     return runner
+
+
+# ---------------------------------------------------------------------------
+# _handle_sessions_command
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramSessionsPicker:
+
+    @pytest.mark.asyncio
+    async def test_telegram_list_uses_tap_to_resume_picker(self, tmp_path):
+        """Telegram must render each visible session as a safe inline choice."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("current_session_001", "telegram", user_id="12345", chat_id="67890")
+        db.create_session("sess_001", "telegram", user_id="12345", chat_id="67890")
+        db.create_session("sess_002", "telegram", user_id="12345", chat_id="67890")
+        db.set_session_title("sess_001", "Research")
+        db.set_session_title("sess_002", "Coding")
+
+        event = _make_event(text="/sessions")
+        event.source.chat_type = "dm"
+        runner = _make_runner(session_db=db, event=event)
+        runner.session_store.load_transcript.return_value = [
+            {
+                "role": "user",
+                "content": (
+                    '[Replying to: "The prior status report was very long."] '
+                    "Compare the two launch plans and recommend one."
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": "Plan B is ready for review; the remaining decision is the launch date.",
+            },
+        ]
+        adapter = MagicMock()
+        adapter.send_choice_picker = AsyncMock(return_value=SimpleNamespace(success=True))
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        result = await runner._handle_sessions_command(event)
+
+        assert result == ""
+        adapter.send_choice_picker.assert_awaited_once()
+        kwargs = adapter.send_choice_picker.call_args.kwargs
+        assert kwargs["title"].startswith("📋")
+        assert {choice["value"] for choice in kwargs["choices"]} == {"sess_001", "sess_002"}
+        assert [choice["label"] for choice in kwargs["choices"]] == [
+            "↩️ Resume 1",
+            "↩️ Resume 2",
+        ]
+        assert kwargs["buttons_per_row"] == 1
+        assert "Research" in kwargs["title"]
+        assert "Coding" in kwargs["title"]
+        assert "Latest: Compare the two launch plans" in kwargs["title"]
+
+        confirmation = await kwargs["on_choice_selected"]("67890", "sess_001")
+        assert "Session resumed." in confirmation
+        assert "Where you left off" in confirmation
+        assert "Where you left off — Research" not in confirmation
+        assert "You last asked:" in confirmation
+        assert "Compare the two launch plans" in confirmation
+        assert "[Replying to:" not in confirmation
+        assert "Where things stood:" in confirmation
+        assert "remaining decision is the launch date" in confirmation
+        assert "Continue by replying in this topic." in confirmation
+        runner.session_store.switch_session.assert_called_once()
+        assert runner.session_store.switch_session.call_args.args[1] == "sess_001"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_telegram_admin_all_picker_keeps_cross_origin_resume_authority(self, tmp_path):
+        """A button rendered from `/sessions all` must retain its admin override."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("current_session_001", "telegram", user_id="12345", chat_id="67890")
+        db.create_session("cron_session_001", "cron")
+        db.set_session_title("cron_session_001", "Scheduled briefing")
+
+        event = _make_event(text="/sessions all")
+        event.source.chat_type = "dm"
+        runner = _make_runner(session_db=db, event=event)
+        runner._resume_caller_is_admin = lambda _source: True
+        adapter = MagicMock()
+        adapter.send_choice_picker = AsyncMock(return_value=SimpleNamespace(success=True))
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        assert await runner._handle_sessions_command(event) == ""
+        kwargs = adapter.send_choice_picker.call_args.kwargs
+        confirmation = await kwargs["on_choice_selected"]("67890", "cron_session_001")
+
+        assert "Session resumed." in confirmation
+        assert "Where you left off" in confirmation
+        assert "Where you left off — Scheduled briefing" not in confirmation
+        assert "No previous conversational messages were saved" in confirmation
+        assert runner.session_store.switch_session.call_args.args[1] == "cron_session_001"
+        db.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds inline choice buttons for Telegram DM session listing (`/sessions` and `/sessions all`) with per-session resume recaps showing last user message, assistant response, and age. Improves the mobile session-resume UX by keeping context visible before the user commits to resuming a session.

### Changes

- **`_format_telegram_sessions_picker`** — renders numbered context above narrow mobile-safe buttons with per-session latest-user-message excerpts
- **`_format_telegram_resume_recap`** — adds visible 'Where you left off' context after a picker-triggered resume, showing last user question + where the assistant left off
- **`_resume_recap_snippet` / `_resume_recap_age` / `_latest_user_context`** — compact helpers for excerpt formatting, relative timestamps, and reply-quotation stripping
- **Integration in `/sessions` command** — Telegram DMs get the inline picker path (guarded by `chat_type == "dm"` to preserve the session-ownership boundary; group chats and non-Telegram platforms keep the existing text listing)
- **Adapter patch** — passes `metadata` through `send_choice_picker` for correct thread routing
- **Tests** — exercise picker formatting output, recap age rendering (just now / minutes / hours / days / dates), and user-context extraction with reply-quotation stripping

### Why

Currently, `/sessions` on Telegram returns a dense text list. In a DM, the user has to copy a session ID and paste it into `/resume <id>`. The inline picker replaces that with numbered context + tap-to-resume buttons — the same number of taps but with context the user can read before committing.

### Scope

Telegram DMs only — the `chat_type == "dm"` guard keeps session-ownership boundaries intact. Other platforms and group chats are unaffected.