### PR TITLE
feat(cli): allow forcing Ctrl+Enter/Ctrl+J newline via config.yaml

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -512,6 +512,13 @@ def load_cli_config() -> Dict[str, Any]:
             "busy_input_mode": "interrupt",
             "persistent_output": True,
             "persistent_output_max_lines": 200,
+            # When true, Ctrl+Enter / Ctrl+J inserts a newline in the classic CLI
+            # instead of submitting. Default false; Hermes auto-enables this on
+            # terminals that are known to distinguish the keystroke (Windows
+            # Terminal, WSL, SSH, Ghostty). Set true to force the behavior on a
+            # local POSIX terminal where Ctrl+Enter would otherwise submit.
+            # See `cli.py::_preserve_ctrl_enter_newline()`.
+            "ctrl_enter_newline": False,
             # Print a one-line summary of resolved modal prompts (approval /
             # clarify) into scrollback so the decision survives the repaint.
             "persist_prompts": True,
@@ -3596,11 +3603,13 @@ def _preserve_ctrl_enter_newline() -> bool:
 
     Windows Terminal, WSL, SSH sessions, Ghostty, and some modern terminals
     deliver Ctrl+Enter/Ctrl+J as bare LF (c-j). On those terminals c-j must
-    NOT be bound to submit;
-    binding it to submit makes Ctrl+Enter (intended as 'newline like Alt+Enter')
-    submit instead. Local POSIX TTYs that deliver Enter as LF (docker exec,
-    some thin PTYs without SSH) still need c-j bound to submit, so we keep
-    that binding for those.
+    NOT be bound to submit; binding it to submit makes Ctrl+Enter (intended
+    as 'newline like Alt+Enter') submit instead. Local POSIX TTYs that
+    deliver Enter as LF (docker exec, some thin PTYs without SSH) still need
+    c-j bound to submit, so we keep that binding for those.
+
+    A user can also force newline behavior on any terminal by setting
+    ``display.ctrl_enter_newline: true`` in ``config.yaml``.
 
     See issue #22379.
     """
@@ -3626,7 +3635,27 @@ def _preserve_ctrl_enter_newline() -> bool:
                     return True
         except OSError:
             continue
+
+    # Config override: user can force Ctrl+Enter/Ctrl+J to insert a newline
+    # on local POSIX terminals where it would otherwise submit.
+    if _ctrl_enter_newline_config():
+        return True
+
     return False
+
+
+def _ctrl_enter_newline_config() -> bool:
+    """Return the user-configured ``display.ctrl_enter_newline`` value.
+
+    Uses the CLI-specific config loader so ``--ignore-user-config`` is honored
+    (``HERMES_IGNORE_USER_CONFIG=1`` skips the user config.yaml). Falls back
+    to false if config is not yet available.
+    """
+    try:
+        cfg = CLI_CONFIG
+        return bool(cfg.get("display", {}).get("ctrl_enter_newline"))
+    except Exception:
+        return False
 
 
 def _bind_prompt_submit_keys(kb, handler) -> None:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1174,6 +1174,14 @@ DEFAULT_CONFIG = {
         # responses and content messages are never touched.  Default 0
         # (disabled) preserves prior behavior.
         "ephemeral_system_ttl": 0,
+        # When true, Ctrl+Enter / Ctrl+J inserts a newline in the classic CLI
+        # instead of submitting. Default false; Hermes auto-enables this on
+        # terminals that are known to distinguish the keystroke (Windows
+        # Terminal, WSL, SSH, Ghostty). Set true to force the behavior on a
+        # local POSIX terminal where Ctrl+Enter would otherwise submit.
+        # See `cli.py::_preserve_ctrl_enter_newline()`.
+        "ctrl_enter_newline": False,
+
         # Per-platform display/streaming overrides. Each key is a gateway
         # platform ("telegram", "discord", "slack", …) mapping to a dict of
         # display settings that override the global value for that platform

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -11,9 +11,46 @@ These tests pin the gating predicate and the resulting binding behavior.
 
 from __future__ import annotations
 
+import builtins
 import os
 import sys
+import tempfile
+from pathlib import Path
 from unittest.mock import patch
+
+
+def _hermes_home_with_config(config_text: str) -> Path:
+    """Create a temp HERMES_HOME, write config.yaml, point HERMES_HOME at it.
+
+    Returns the temp config path.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="hermes-test-"))
+    config_path = tmp / "config.yaml"
+    config_path.write_text(config_text, encoding="utf-8")
+    os.environ["HERMES_HOME"] = str(tmp)
+    return config_path
+
+
+def _clear_stale_env() -> None:
+    """Remove env vars that would otherwise trigger preserve-newline."""
+    for k in list(os.environ.keys()):
+        if k.startswith(("SSH_", "WT")) or k in (
+            "WSL_DISTRO_NAME",
+            "GHOSTTY_RESOURCES_DIR",
+            "GHOSTTY_BIN_DIR",
+            "TERM_PROGRAM",
+        ):
+            os.environ.pop(k, None)
+
+
+def _no_proc_open():
+    """Patch builtins.open so /proc reads fail (WSL fallback probe)."""
+    real_open = builtins.open
+    def _fake_open(path, *args, **kwargs):
+        if "/proc/version" in str(path) or "/proc/sys/kernel/osrelease" in str(path):
+            raise OSError("no /proc")
+        return real_open(path, *args, **kwargs)
+    return patch("builtins.open", side_effect=_fake_open)
 
 
 def test_native_windows_preserves_newline():
@@ -59,15 +96,54 @@ def test_proc_version_microsoft_marker_preserves_newline():
     """WSL detection via /proc when env vars are scrubbed (sudo etc.)."""
     import cli as cli_mod
     from io import StringIO
+
     with patch.object(sys, "platform", "linux"):
         with patch.dict(os.environ, {}, clear=True):
-            real_open = open
+            real_open = builtins.open
             def _fake_open(path, *args, **kwargs):
                 if "/proc/version" in str(path) or "/proc/sys/kernel/osrelease" in str(path):
                     return StringIO("Linux version 5.15.167.4-microsoft-standard-WSL2")
                 return real_open(path, *args, **kwargs)
             with patch("builtins.open", side_effect=_fake_open):
                 assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
+def test_pure_local_linux_does_not_preserve():
+    """A bare local Linux TTY (no SSH/WSL/WT/Ghostty) keeps c-j → submit so docker exec
+    style Enter-as-LF stays usable."""
+    import cli as cli_mod
+    # Stub out /proc reads — those are the WSL fallback signal.
+    with patch.object(sys, "platform", "linux"):
+        with patch.dict(os.environ, {}, clear=True):
+            with _no_proc_open():
+                assert cli_mod._preserve_ctrl_enter_newline() is False
+
+
+def test_config_override_preserves_ctrl_j_newline():
+    """display.ctrl_enter_newline: true forces newline behavior on local POSIX."""
+    _clear_stale_env()
+    _hermes_home_with_config("display:\n  ctrl_enter_newline: true\n")
+
+    with patch.object(sys, "platform", "linux"):
+        with _no_proc_open():
+            if "cli" in sys.modules:
+                del sys.modules["cli"]
+            import cli as cli_mod
+            assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
+def test_config_override_respects_ignore_user_config():
+    """HERMES_IGNORE_USER_CONFIG=1 must ignore a user config enabling the setting."""
+    _clear_stale_env()
+    _hermes_home_with_config("display:\n  ctrl_enter_newline: true\n")
+    os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
+
+    with patch.object(sys, "platform", "linux"):
+        with _no_proc_open():
+            if "cli" in sys.modules:
+                del sys.modules["cli"]
+            import cli as cli_mod
+            assert cli_mod._preserve_ctrl_enter_newline() is False
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -242,6 +242,16 @@ Most terminals send the same byte sequence for `Enter` and `Shift+Enter` by defa
 
 Where the terminal cannot distinguish them, `Alt+Enter` and `Ctrl+J` continue to work everywhere. **On Windows Terminal specifically, `Alt+Enter` is captured by the terminal (toggles fullscreen) and never reaches Hermes — use `Ctrl+Enter` (delivered as `Ctrl+J`) or `Ctrl+J` directly for a newline.**
 
+On a local Linux terminal where `Ctrl+J` is bound to **submit** (so that thin PTYs that send `Enter` as LF still work), you can force newline behavior by setting:
+
+```yaml
+# ~/.hermes/config.yaml
+display:
+  ctrl_enter_newline: true
+```
+
+This makes `Ctrl+Enter` / `Ctrl+J` insert a newline even when Hermes would otherwise treat LF as Enter. It is applied automatically on Windows, WSL, SSH, Windows Terminal, and Ghostty, so the config is only needed for other local POSIX terminals.
+
 ## Redirecting the Agent Mid-Turn
 
 While the agent is working, you can send a correction without starting a new turn:


### PR DESCRIPTION
Add `display.ctrl_enter_newline` (default false). When true, the classic CLI treats Ctrl+Enter / Ctrl+J as newline even on local POSIX terminals that would otherwise bind LF to submit to keep thin PTYs working.

The existing auto-detection for Windows, WSL, SSH, Windows Terminal, and Ghostty is unchanged; the config is an opt-in escape hatch for other local terminals.

- Add `ctrl_enter_newline` to `DEFAULT_CONFIG` display section
- Read it from `cli.py::_preserve_ctrl_enter_newline()`
- Add `_ctrl_enter_newline_config()` helper for testability
- Extend `tests/cli/test_ctrl_enter_newline.py`
- Document in `website/docs/user-guide/cli.md`

Refs #22379