### PR TITLE
fix(redact): pass interrupt_debug.log messages through redact_sensitive_text (#75461)

### DIFF
--- a/hermes_cli/cli_chat_turn_mixin.py
+++ b/hermes_cli/cli_chat_turn_mixin.py
@@ -396,7 +396,7 @@ class CLIChatTurnMixin:
             try:
                 from agent.redact import redact_sensitive_text
                 with open(_hermes_home / "interrupt_debug.log", "a", encoding="utf-8") as _f:
-                    _f.write(f"{time.strftime('%H:%M:%S')} interrupt fired: msg={redact_sensitive_text(str(interrupt_msg))[:60]!r}, "
+                    _f.write(f"{time.strftime('%H:%M:%S')} interrupt fired: msg={redact_sensitive_text(str(interrupt_msg), force=True)[:60]!r}, "
                              f"children={len(self.agent._active_children)}, "
                              f"parent._interrupt={self.agent._interrupt_requested}\n")
                     for _ci, _ch in enumerate(self.agent._active_children):

--- a/hermes_cli/cli_chat_turn_mixin.py
+++ b/hermes_cli/cli_chat_turn_mixin.py
@@ -396,7 +396,7 @@ class CLIChatTurnMixin:
             try:
                 from agent.redact import redact_sensitive_text
                 with open(_hermes_home / "interrupt_debug.log", "a", encoding="utf-8") as _f:
-                    _f.write(f"{time.strftime('%H:%M:%S')} interrupt fired: msg={redact_sensitive_text(str(interrupt_msg), force=True)[:60]!r}, "
+                    _f.write(f"{time.strftime('%H:%M:%S')} interrupt fired: msg={redact_sensitive_text(str(interrupt_msg), force=True, redact_url_credentials=True)[:60]!r}, "
                              f"children={len(self.agent._active_children)}, "
                              f"parent._interrupt={self.agent._interrupt_requested}\n")
                     for _ci, _ch in enumerate(self.agent._active_children):

--- a/hermes_cli/cli_chat_turn_mixin.py
+++ b/hermes_cli/cli_chat_turn_mixin.py
@@ -394,8 +394,9 @@ class CLIChatTurnMixin:
             self._clear_active_overlays_for_interrupt()
             # Debug log to file (stdout may be devnull under redirect_stdout).
             try:
+                from agent.redact import redact_sensitive_text
                 with open(_hermes_home / "interrupt_debug.log", "a", encoding="utf-8") as _f:
-                    _f.write(f"{time.strftime('%H:%M:%S')} interrupt fired: msg={str(interrupt_msg)[:60]!r}, "
+                    _f.write(f"{time.strftime('%H:%M:%S')} interrupt fired: msg={redact_sensitive_text(str(interrupt_msg))[:60]!r}, "
                              f"children={len(self.agent._active_children)}, "
                              f"parent._interrupt={self.agent._interrupt_requested}\n")
                     for _ci, _ch in enumerate(self.agent._active_children):

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -1430,7 +1430,7 @@ class CLITuiMixin:
                     from agent.redact import redact_sensitive_text
                     with open(_hermes_home / "interrupt_debug.log", "a", encoding="utf-8") as _f:
                         _f.write(
-                            f"{time.strftime('%H:%M:%S')} ENTER: queued interrupt msg={redact_sensitive_text(str(payload))[:60]!r}, "
+                            f"{time.strftime('%H:%M:%S')} ENTER: queued interrupt msg={redact_sensitive_text(str(payload), force=True)[:60]!r}, "
                             f"agent_running={self._agent_running}\n")
                 except Exception:
                     pass

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -1430,7 +1430,7 @@ class CLITuiMixin:
                     from agent.redact import redact_sensitive_text
                     with open(_hermes_home / "interrupt_debug.log", "a", encoding="utf-8") as _f:
                         _f.write(
-                            f"{time.strftime('%H:%M:%S')} ENTER: queued interrupt msg={redact_sensitive_text(str(payload), force=True)[:60]!r}, "
+                            f"{time.strftime('%H:%M:%S')} ENTER: queued interrupt msg={redact_sensitive_text(str(payload), force=True, redact_url_credentials=True)[:60]!r}, "
                             f"agent_running={self._agent_running}\n")
                 except Exception:
                     pass

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -1427,9 +1427,10 @@ class CLITuiMixin:
             else:
                 self._interrupt_queue.put(payload)
                 try:
+                    from agent.redact import redact_sensitive_text
                     with open(_hermes_home / "interrupt_debug.log", "a", encoding="utf-8") as _f:
                         _f.write(
-                            f"{time.strftime('%H:%M:%S')} ENTER: queued interrupt msg={str(payload)[:60]!r}, "
+                            f"{time.strftime('%H:%M:%S')} ENTER: queued interrupt msg={redact_sensitive_text(str(payload))[:60]!r}, "
                             f"agent_running={self._agent_running}\n")
                 except Exception:
                     pass

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -339,6 +339,48 @@ class TestTelegramTokens:
         assert "ABCDEfghij" not in result
 
 
+class TestInterruptDebugLogRedaction:
+    """#75461: both interrupt_debug.log write sites in cli.py route their
+    message values through redact_sensitive_text(force=True) before the
+    existing 60-char truncation. force=True is mandatory because the file
+    is persistent and must never hold a raw credential even when the user
+    has disabled global logging redaction (security.redact_secrets: false)."""
+
+    # Telegram bot token shape that triggered the original leak.
+    TOKEN = "1234567890:" + "A" * 35
+
+    def test_force_masks_token(self):
+        """The contract both CLI write sites rely on: force=True masks a
+        Telegram-token-shaped payload."""
+        result = redact_sensitive_text(self.TOKEN, force=True)
+        assert "A" * 35 not in result
+        assert "1234567890:***" in result
+
+    def test_force_masks_even_when_redaction_disabled(self, monkeypatch):
+        """Crucial: the persistent debug file must not leak a credential when
+        the user has turned off global redaction. Without force=True the
+        function returns the input unchanged (agent/redact.py:687-688)."""
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        result = redact_sensitive_text(self.TOKEN, force=True)
+        assert "A" * 35 not in result
+        assert "1234567890:***" in result
+
+    def test_truncation_happens_after_redaction(self):
+        """Both CLI sites apply [:60] after redaction. A long payload whose
+        secret sits near the start must still be masked — the secret cannot
+        survive merely because it falls within the first 60 chars."""
+        payload = self.TOKEN + " trailing context " + "x" * 80
+        truncated = redact_sensitive_text(payload, force=True)[:60]
+        assert "A" * 35 not in truncated
+
+    def test_non_string_payload_coerced_and_masked(self):
+        """Both CLI sites call str() on the payload before redacting; the
+        dict payload path (interrupt queue) must not leak either."""
+        payload = {"msg": self.TOKEN}
+        result = redact_sensitive_text(str(payload), force=True)
+        assert "A" * 35 not in result
+
+
 class TestPassthrough:
     def test_empty_string(self):
         assert redact_sensitive_text("") == ""

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -380,6 +380,31 @@ class TestInterruptDebugLogRedaction:
         result = redact_sensitive_text(str(payload), force=True)
         assert "A" * 35 not in result
 
+    def test_url_userinfo_credentials_masked(self):
+        """P2 follow-up: URL userinfo credentials (``user:pass@``) survive
+        force=True alone. The write sites now pass redact_url_credentials=True,
+        which masks the password portion of the userinfo."""
+        text = "https://alice:CorrectHorseBatteryStaple@example.com/path"
+        result = redact_sensitive_text(text, force=True, redact_url_credentials=True)
+        assert "CorrectHorseBatteryStaple" not in result
+        assert "alice:***@example.com" in result
+
+    def test_url_credential_named_query_param_masked(self):
+        """Credential-named query parameters (OAuth ``code=``, ``token=``, ...)
+        are masked under the same call shape used at the write sites."""
+        text = "https://example.com/oauth/cb?code=abc123xyz789&state=ok"
+        result = redact_sensitive_text(text, force=True, redact_url_credentials=True)
+        assert "abc123xyz789" not in result
+        assert "code=***&state=ok" in result
+
+    def test_url_redaction_truncation_still_works(self):
+        """[:60] is still applied after redaction: a long URL whose credential
+        sits near the start must not survive merely because it falls within the
+        first 60 chars."""
+        payload = "https://alice:secret@example.com/" + "x" * 80
+        truncated = redact_sensitive_text(payload, force=True, redact_url_credentials=True)[:60]
+        assert "secret" not in truncated
+
 
 class TestPassthrough:
     def test_empty_string(self):


### PR DESCRIPTION
Fixes #75461

## Summary  `~/.hermes/interrupt_debug.log` recorded raw user input in plaintext. When a user pasted a credential into the prompt (e.g. a Telegram bot token `1234567890:<35 chars>` during platform setup), the value was written to that file unmasked and stayed there indefinitely.  **Root cause:** both `interrupt_debug.log` write sites in `cli.py` used `open(...).write()` directly with `str(interrupt_msg)` / `str(payload)`, so they never passed through the redaction layer (`RedactingFormatter` covers everything that goes through the `logging` module; these two writes bypass it entirely).  **Fix:** wrap both message values in `redact_sensitive_text()` (from `agent.redact`) before the existing 60-char truncation, preserving the same log format, the local-import convention already used at `cli.py:10098`, and the existing `try/except Exception: pass` guards.  Verified: a Telegram-token-shaped payload `1234567890:` + `"A"*35` now writes as `1234567890:***` — matching the masked form already produced in `agent.log` (see issue evidence).  **NOT doing X:** - No change to the redactor itself (`agent/redact.py` already masks this shape via the Telegram regex at lines 783–789). - No change to what is logged, only that the value is masked before writing. - The `try/except Exception: pass` guards are preserved — a redaction failure cannot break the interrupt path. - Single-file change. No new dependencies (import is local, same pattern as the existing one in this file).  ## Test plan  1. Syntax: `python -c "import ast; ast.parse(open('cli.py', encoding='utf-8').read())"` — passes. 2. Redaction shape check (independent of cli.py):    ```python    from agent.redact import redact_sensitive_text    payload = "1234567890:" + "A" * 35    assert "A" * 35 not in redact_sensitive_text(payload)    # → '1234567890:***'    ``` 3. `git diff` review: exactly the 2 write-site changes (+2 local imports), 1 file, +4/-2. 