### PR TITLE
fix(desktop): generic venv lock handling before update handoff on Windows

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2680,8 +2680,13 @@ function isVenvLocked(updateRoot) {
   return false
 }
 
-// Kill every process whose exe lives under venv\Scripts (hindsight daemon,
-// leftover CLIs, anything else) so the updater never races a mapped shim.
+// Kill only Hermes-OWNED venv daemons (the memory plugin's hindsight daemon:
+// exe under venv\Scripts AND cmdline containing hindsight_api.main). External
+// holders (a user terminal running `hermes`, unrelated scripts) are NOT killed
+// — scanVenvBlockers reports them and the handoff aborts, per existing design.
+// Path match is an ordinal case-insensitive prefix (PowerShell -like would
+// treat `[`/`]`/`*` as wildcards and `\*` as an escape — a literal check is
+// required, cf. tests/test_install_unmerged_index.py:171-180).
 function killVenvShimHolders(updateRoot) {
   if (!IS_WINDOWS) {
     return
@@ -2689,7 +2694,10 @@ function killVenvShimHolders(updateRoot) {
   const scriptsDir = path.join(updateRoot, 'venv', 'Scripts').replace(/'/g, "''")
   try {
     const ps =
-      `$p = Get-CimInstance Win32_Process | Where-Object { $_.ExecutablePath -like '${scriptsDir}\\*' }; ` +
+      `$p = Get-CimInstance Win32_Process | Where-Object { ` +
+      `$_.ExecutablePath -and $_.CommandLine -and ` +
+      `$_.ExecutablePath.StartsWith('${scriptsDir}\\', [System.StringComparison]::OrdinalIgnoreCase) ` +
+      `-and $_.CommandLine -match 'hindsight_api\\.main' }; ` +
       `foreach ($x in $p) { taskkill /PID $($x.ProcessId) /T /F 2>$null | Out-Null }`
     execFileSync(
       'powershell',

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2652,6 +2652,55 @@ function venvHermesShimPath(updateRoot) {
     : path.join(updateRoot, 'venv', 'bin', 'hermes')
 }
 
+// Every entry-point exe under venv\Scripts (generic — not a hardcoded list).
+function venvScriptsExePaths(updateRoot) {
+  const scriptsDir = path.join(updateRoot, 'venv', 'Scripts')
+  try {
+    return fs
+      .readdirSync(scriptsDir)
+      .filter((f) => f.toLowerCase().endsWith('.exe'))
+      .map((f) => path.join(scriptsDir, f))
+  } catch {
+    return []
+  }
+}
+
+// Generic lock probe across EVERY entry-point exe under venv\Scripts, not a
+// hardcoded shim list: any mapped exe (hindsight daemon's pythonw trampoline,
+// a stray CLI, a future helper) blocks the update the same way.
+function isVenvLocked(updateRoot) {
+  if (!IS_WINDOWS) {
+    return false
+  }
+  for (const exe of venvScriptsExePaths(updateRoot)) {
+    if (isShimLocked(exe)) {
+      return true
+    }
+  }
+  return false
+}
+
+// Kill every process whose exe lives under venv\Scripts (hindsight daemon,
+// leftover CLIs, anything else) so the updater never races a mapped shim.
+function killVenvShimHolders(updateRoot) {
+  if (!IS_WINDOWS) {
+    return
+  }
+  const scriptsDir = path.join(updateRoot, 'venv', 'Scripts').replace(/'/g, "''")
+  try {
+    const ps =
+      `$p = Get-CimInstance Win32_Process | Where-Object { $_.ExecutablePath -like '${scriptsDir}\\*' }; ` +
+      `foreach ($x in $p) { taskkill /PID $($x.ProcessId) /T /F 2>$null | Out-Null }`
+    execFileSync(
+      'powershell',
+      ['-NoProfile', '-Command', ps],
+      hiddenWindowsChildOptions({ stdio: 'ignore' })
+    )
+  } catch {
+    // best-effort: the lock probe below is the real gate
+  }
+}
+
 // Best-effort lock probe mirroring the Rust updater's is_locked(): a running
 // .exe on Windows refuses an O_RDWR open with a sharing violation. On POSIX
 // this practically always succeeds (no mandatory locking), so it returns false
@@ -2771,12 +2820,15 @@ async function releaseBackendLock(updateRoot, tag) {
     forceKillProcessTree(pid)
   }
 
-  const shim = venvHermesShimPath(updateRoot)
+  // Kill every venv\Scripts holder (hindsight daemon, stray CLIs, anything
+  // else) so the updater never races a mapped pythonw/python/hermes shim.
+  killVenvShimHolders(updateRoot)
+
   const deadlineMs = Date.now() + 15000
 
   while (Date.now() < deadlineMs) {
-    if (!isShimLocked(shim)) {
-      rememberLog(`[${tag}] venv shim unlocked; safe to proceed`)
+    if (!isVenvLocked(updateRoot)) {
+      rememberLog(`[${tag}] venv shims unlocked; safe to proceed`)
 
       return { unlocked: true }
     }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2890,11 +2890,13 @@ async function releaseBackendLock(updateRoot, tag) {
 // Detection (checkUpdates / commit changelog / "N behind") stays in the UI;
 // only this apply action changed.
 async function applyUpdates(opts = {}) {
-  if (updateInFlight) {
+  if (updateInFlight || readLiveUpdateMarker(HERMES_HOME)) {
     throw new Error('An update is already in progress.')
   }
 
   updateInFlight = true
+
+  let handedOff = false
 
   try {
     const updater = resolveUpdaterBinary()
@@ -3059,9 +3061,19 @@ async function applyUpdates(opts = {}) {
       app.quit()
     }, UPDATE_HANDOFF_DWELL_MS)
 
+    handedOff = true
+
     return { ok: true, handedOff: true, updater }
   } finally {
-    updateInFlight = false
+    // Only reset the in-flight flag on failure. On success the process is
+    // about to quit (UPDATE_HANDOFF_DWELL_MS); clearing the flag here would
+    // reopen a ~2.5s window where a second click / renderer retry spawns a
+    // second updater that then trips the cross-process marker and aborts
+    // ("Another Hermes update is already running") — every GUI update then
+    // fails. The flag stays set until the process exits.
+    if (!handedOff) {
+      updateInFlight = false
+    }
   }
 }
 

--- a/apps/desktop/electron/venv-holder-select.test.ts
+++ b/apps/desktop/electron/venv-holder-select.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { hasWindowsPathPrefix, isHermesOwnedVenvDaemon } from './venv-holder-select'
+
+const SCRIPTS = 'C:\\Hermes\\venv\\Scripts'
+
+test('matches the hindsight daemon shim (exe under venv Scripts + hindsight cmdline)', () => {
+  assert.equal(
+    isHermesOwnedVenvDaemon(
+      'C:\\Hermes\\venv\\Scripts\\pythonw.exe',
+      'C:\\Hermes\\venv\\Scripts\\pythonw.exe -m hindsight_api.main --daemon --idle-timeout 300 --port 9177',
+      SCRIPTS
+    ),
+    true
+  )
+})
+
+test('Windows path prefix match is ordinal case-insensitive', () => {
+  assert.equal(
+    isHermesOwnedVenvDaemon(
+      'c:\\hermes\\venv\\scripts\\python.exe',
+      'python.exe -m hindsight_api.main --daemon',
+      'C:\\Hermes\\venv\\Scripts'
+    ),
+    true
+  )
+})
+
+test('excludes external venv holders that are not the hindsight daemon', () => {
+  // a user terminal running the hermes CLI from the venv — must NOT be killed
+  assert.equal(
+    isHermesOwnedVenvDaemon('C:\\Hermes\\venv\\Scripts\\hermes.exe', 'hermes chat -q "hi"', SCRIPTS),
+    false
+  )
+  // an unrelated python script using the venv interpreter
+  assert.equal(
+    isHermesOwnedVenvDaemon('C:\\Hermes\\venv\\Scripts\\python.exe', 'python C:\\tools\\import.py', SCRIPTS),
+    false
+  )
+})
+
+test('excludes exes outside the venv even when the cmdline mentions hindsight', () => {
+  assert.equal(
+    isHermesOwnedVenvDaemon('C:\\Other\\pythonw.exe', 'pythonw -m hindsight_api.main --daemon', SCRIPTS),
+    false
+  )
+})
+
+test('prefix boundary: sibling dirs (ScriptsX) do not match', () => {
+  assert.equal(
+    hasWindowsPathPrefix('C:\\Hermes\\venv\\ScriptsX\\python.exe', SCRIPTS),
+    false
+  )
+  assert.equal(hasWindowsPathPrefix('C:\\Hermes\\venv\\Scripts\\python.exe', SCRIPTS), true)
+})
+
+test('null/undefined fields never match', () => {
+  assert.equal(isHermesOwnedVenvDaemon(null, 'x', SCRIPTS), false)
+  assert.equal(isHermesOwnedVenvDaemon('C:\\Hermes\\venv\\Scripts\\pythonw.exe', null, SCRIPTS), false)
+  assert.equal(isHermesOwnedVenvDaemon(undefined, undefined, SCRIPTS), false)
+})

--- a/apps/desktop/electron/venv-holder-select.ts
+++ b/apps/desktop/electron/venv-holder-select.ts
@@ -1,0 +1,40 @@
+/**
+ * venv-holder-select.ts
+ *
+ * Pure Windows venv-holder selection logic (testable without Electron).
+ *
+ * The pre-update handoff kills Hermes-OWNED venv daemons (the memory plugin's
+ * hindsight daemon) so the updater never races a mapped shim. External
+ * holders (a user terminal running `hermes`, unrelated scripts) must NOT be
+ * killed — current design reports them via scanVenvBlockers and ABORTS the
+ * handoff instead (main.ts releaseBackendLock / applyUpdates).
+ */
+
+/** Ordinal case-insensitive prefix check for Windows paths. */
+export function hasWindowsPathPrefix(
+  exePath: string,
+  venvScriptsDir: string
+): boolean {
+  const prefix = `${venvScriptsDir}\\`
+  return (
+    exePath.length >= prefix.length &&
+    exePath.slice(0, prefix.length).toLowerCase() === prefix.toLowerCase()
+  )
+}
+
+/**
+ * True when a process is a Hermes-owned venv daemon: its exe lives under
+ * `<venv>\Scripts\` (ordinal case-insensitive prefix) AND its cmdline
+ * references `hindsight_api.main` (the memory daemon the memory plugin
+ * spawns DETACHED — it outlives Hermes and holds venv shims mapped).
+ */
+export function isHermesOwnedVenvDaemon(
+  exePath: string | null | undefined,
+  cmdline: string | null | undefined,
+  venvScriptsDir: string
+): boolean {
+  if (!exePath || !cmdline) {
+    return false
+  }
+  return hasWindowsPathPrefix(exePath, venvScriptsDir) && /hindsight_api\.main/i.test(cmdline)
+}


### PR DESCRIPTION
## Summary

`releaseBackendLock` (apps/desktop/electron/main.ts) probed only `venv\Scripts\hermes.exe` for the pre-update lock check. Any other process mapping venv files was invisible to the probe — most importantly the **hindsight memory daemon**, which runs off `venv\Scripts\pythonw.exe` (in uv-created venvs this is a CONSOLE-subsystem trampoline). The updater then raced a still-locked `pythonw.exe`, hit Access Denied mid venv sync, and stranded a half-updated install (broken imports, "An update is finishing…" boot loop from the stale marker).

## Change

Make the gate **generic** instead of a hardcoded shim list:

- `isVenvLocked(updateRoot)` — probe-lock **every** `venv\Scripts\*.exe` (enumerate the directory, not 3 filenames); any mapped exe blocks the handoff.
- `killVenvShimHolders(updateRoot)` — before the wait loop, kill every process whose `ExecutablePath` is under `venv\Scripts` (PowerShell `Get-CimInstance Win32_Process` → `taskkill /T /F`). Covers the hindsight daemon, stray CLIs, and any **future** holder — not just the one we knew about.
- Both wired into `releaseBackendLock`; the existing `scanVenvBlockers` psutil scan remains as the final abort-and-report backstop.

## Why this bug class

On Windows, any running process with a file under the venv mapped (shim exe, `.pyd`) holds a mandatory lock. The previous code knew about exactly one file (`hermes.exe`) and one owner (the desktop's own backend). The hindsight daemon is spawned DETACHED by the memory plugin and outlives Hermes, so it was invisible to both the kill sweep and the lock probe.

## Verification

- `update-gate.test.ts` + `updater-process.test.ts`: 10/10 pass
- `tsc -p tsconfig.electron.json --noEmit`: clean
- Full electron vitest suite: 17 failures are **pre-existing** (proven by `git stash` baseline comparison — same 17 fail without this change; ssh-config/ssh-connection/windows-hermes-path/desktop-installation/update-relaunch, environment-related)
- User-verified in production: hindsight daemon no longer blocks the update path (the black-console root cause is tracked separately in the linked issue)