### PR TITLE
fix(agent): wire ProviderProfile hooks into the Anthropic transport

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -198,10 +198,12 @@ def _provider_preferences_for_agent(agent) -> Dict[str, Any]:
 def _merge_nous_portal_messages_extra_body(agent, anthropic_kwargs: dict) -> dict:
     """Merge Portal ``tags`` / ``session_id`` onto an Anthropic Messages kwargs dict.
 
-    The Nous provider profile is only consulted by the OpenAI-wire transport;
-    anthropic_messages callers must merge it themselves. Passes ``session_id``
-    only — not ``provider_preferences`` (those become a top-level ``provider``
-    routing object on the OpenAI wire). Never blocks a turn on tagging.
+    Used by callers that construct Anthropic kwargs outside the transport's
+    ProviderProfile pipeline (iteration-limit summary and retry). The main
+    request path applies the same fields through the transport hooks
+    (GH-75445). Passes ``session_id`` only — not ``provider_preferences``
+    (those become a top-level ``provider`` routing object on the OpenAI wire).
+    Never blocks a turn on tagging.
     """
     if getattr(agent, "provider", None) not in {"nous", "nous-portal", "nousresearch"}:
         return anthropic_kwargs
@@ -1132,7 +1134,20 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
         if ephemeral_out is not None:
             agent._ephemeral_max_output_tokens = None  # consume immediately
-        anthropic_kwargs = _transport.build_kwargs(
+        # ProviderProfile path — the same hooks as the chat_completions
+        # transport. ``prepare_messages``, ``build_api_kwargs_extras`` and
+        # ``build_extra_body`` run inside the transport with
+        # ``api_mode="anthropic_messages"``. This replaces the Nous-only
+        # special case: registered provider profiles now contribute their
+        # portal fields (e.g. Nous ``tags`` / ``session_id``) through the
+        # generic pipeline instead of a per-provider merge (GH-75445).
+        try:
+            from providers import get_provider_profile
+
+            _profile = get_provider_profile(agent.provider)
+        except Exception:
+            _profile = None
+        return _transport.build_kwargs(
             model=agent.model,
             messages=anthropic_messages,
             tools=tools_for_api,
@@ -1144,13 +1159,10 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             base_url=getattr(agent, "_anthropic_base_url", None),
             fast_mode=(agent.request_overrides or {}).get("speed") == "fast",
             drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
+            provider_profile=_profile,
+            session_id=getattr(agent, "session_id", None),
+            supports_reasoning=agent._supports_reasoning_extra_body(),
         )
-        # Nous Portal reads ``tags`` and ``session_id`` as top-level body fields
-        # on its Messages route the same way it does on /chat/completions, but
-        # the profile hook that produces them is only consulted by the
-        # OpenAI-wire transport. Merge them here so Messages traffic keeps
-        # product attribution and sticky routing.
-        return _merge_nous_portal_messages_extra_body(agent, anthropic_kwargs)
 
     # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
     # The adapter handles message/tool conversion and boto3 calls directly.

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -9,6 +9,35 @@ from typing import Any, Dict, List, Optional
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse
 
+# Top-level Python keyword arguments accepted by the Anthropic Messages SDK
+# 0.87.0 ``messages.create()`` and ``messages.stream()`` (the intersection of
+# both signatures). Any other key a ProviderProfile hook returns at top level
+# is an extension field: it is projected onto ``extra_body`` so it reaches the
+# JSON wire without raising ``TypeError`` at dispatch time. See GH-75445.
+_ANTHROPIC_MESSAGES_TOP_LEVEL_KWARGS = frozenset({
+    "model",
+    "messages",
+    "max_tokens",
+    "cache_control",
+    "container",
+    "inference_geo",
+    "metadata",
+    "output_config",
+    "service_tier",
+    "stop_sequences",
+    "system",
+    "temperature",
+    "thinking",
+    "tool_choice",
+    "tools",
+    "top_k",
+    "top_p",
+    "extra_headers",
+    "extra_query",
+    "extra_body",
+    "timeout",
+})
+
 
 class AnthropicTransport(ProviderTransport):
     """Transport for api_mode='anthropic_messages'.
@@ -59,10 +88,27 @@ class AnthropicTransport(ProviderTransport):
             base_url: str | None
             fast_mode: bool
             drop_context_1m_beta: bool
+            provider_profile: ProviderProfile | None
+            session_id: str | None
+            supports_reasoning: bool
+
+        When ``provider_profile`` is present the ProviderProfile request hooks
+        run with the same semantics as the chat_completions transport:
+        ``prepare_messages()`` before Anthropic message conversion, then
+        ``build_api_kwargs_extras()`` and ``build_extra_body()`` applied after
+        the adapter defaults. Hooks receive ``api_mode="anthropic_messages"``
+        so dual-wire profiles can emit protocol-appropriate fields (GH-75445).
         """
         from agent.anthropic_adapter import build_anthropic_kwargs
 
-        return build_anthropic_kwargs(
+        provider_profile = params.get("provider_profile")
+
+        # Message preprocessing hook — must run before the adapter converts
+        # OpenAI-format messages to Anthropic-format messages.
+        if provider_profile is not None:
+            messages = provider_profile.prepare_messages(messages)
+
+        api_kwargs = build_anthropic_kwargs(
             model=model,
             messages=messages,
             tools=tools,
@@ -76,6 +122,81 @@ class AnthropicTransport(ProviderTransport):
             fast_mode=params.get("fast_mode", False),
             drop_context_1m_beta=params.get("drop_context_1m_beta", False),
         )
+
+        if provider_profile is None:
+            return api_kwargs
+
+        return self._apply_provider_profile(
+            api_kwargs,
+            model=model,
+            tools=tools,
+            provider_profile=provider_profile,
+            reasoning_config=params.get("reasoning_config"),
+            session_id=params.get("session_id"),
+            supports_reasoning=params.get("supports_reasoning", False),
+            base_url=params.get("base_url"),
+        )
+
+    def _apply_provider_profile(
+        self,
+        api_kwargs: Dict[str, Any],
+        *,
+        model: str,
+        tools: Optional[List[Dict[str, Any]]],
+        provider_profile: Any,
+        reasoning_config: Optional[Dict[str, Any]],
+        session_id: Optional[str],
+        supports_reasoning: bool,
+        base_url: Optional[str],
+    ) -> Dict[str, Any]:
+        """Merge ProviderProfile hook output onto Anthropic SDK kwargs.
+
+        Merge order inside ``extra_body``:
+          adapter extras < build_extra_body < build_api_kwargs_extras body
+          < extension fields projected from the top-level result.
+
+        For ordinary SDK top-level fields, profile output replaces the adapter
+        value. ``extra_headers`` dictionaries merge shallowly so the adapter's
+        beta headers are retained and profile headers win on key conflicts.
+        """
+        extra_body_from_profile, top_level_from_profile = (
+            provider_profile.build_api_kwargs_extras(
+                reasoning_config=reasoning_config,
+                supports_reasoning=supports_reasoning,
+                session_id=session_id,
+                model=model,
+                base_url=base_url,
+                api_mode=self.api_mode,
+            )
+        )
+        profile_body = provider_profile.build_extra_body(
+            session_id=session_id,
+            model=model,
+            base_url=base_url,
+            reasoning_config=reasoning_config,
+            api_mode=self.api_mode,
+        )
+
+        extra_body = dict(api_kwargs.get("extra_body") or {})
+        if profile_body:
+            extra_body.update(profile_body)
+        if extra_body_from_profile:
+            extra_body.update(extra_body_from_profile)
+
+        for key, value in (top_level_from_profile or {}).items():
+            if key == "extra_headers" and isinstance(value, dict):
+                merged_headers = dict(api_kwargs.get("extra_headers") or {})
+                merged_headers.update(value)
+                api_kwargs["extra_headers"] = merged_headers
+            elif key in _ANTHROPIC_MESSAGES_TOP_LEVEL_KWARGS:
+                api_kwargs[key] = value
+            else:
+                extra_body[key] = value
+
+        if extra_body:
+            api_kwargs["extra_body"] = extra_body
+
+        return api_kwargs
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
         """Normalize Anthropic response to NormalizedResponse.

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -51,6 +51,14 @@ class CustomProfile(ProviderProfile):
         # Ollama-only flag and thinking is already server-default-on for these
         # backends, so forcing it risks a 400 on GLM/vLLM endpoints that don't
         # recognize it. Mirrors the DeepSeek/Zai profile precedent.
+        #
+        # On the Anthropic Messages wire the adapter owns reasoning
+        # (``thinking`` / ``output_config``); ``reasoning_effort``,
+        # ``think`` and ``options.num_ctx`` are OpenAI/Ollama-shaped and would
+        # be unknown fields. The transport passes ``api_mode="anthropic_messages"``,
+        # under which this hook contributes nothing (GH-75445).
+        if ctx.get("api_mode") == "anthropic_messages":
+            return {}, {}
         if reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -68,7 +68,16 @@ class KimiProfile(ProviderProfile):
         'reasoning_effort'" (HTTP 400). This mirrors the kimi-k2 handling on the
         opencode-go relay: send effort when one is requested, otherwise fall
         back to ``extra_body.thinking`` — never both.
+
+        On the Anthropic Messages wire (``api.kimi.com/coding``) the adapter
+        translates Hermes reasoning into native ``thinking.type="adaptive"``
+        plus ``output_config.effort``. This hook's OpenAI-shaped output would
+        either be an unknown body field or an unsupported top-level kwarg, so
+        it contributes nothing when the transport passes
+        ``api_mode="anthropic_messages"`` (GH-75445).
         """
+        if context.get("api_mode") == "anthropic_messages":
+            return {}, {}
         extra_body = {}
         top_level = {}
 

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -43,8 +43,11 @@ class NousProfile(ProviderProfile):
         sticky_key = get_conversation_context() or session_id
         if sticky_key:
             body["session_id"] = sticky_key
+        # ``provider`` is an OpenAI-wire routing object. On the Anthropic
+        # Messages wire it would be an unknown body field, so emit it only for
+        # chat_completions callers (GH-75445).
         provider_preferences = context.get("provider_preferences")
-        if provider_preferences:
+        if provider_preferences and context.get("api_mode") != "anthropic_messages":
             body["provider"] = provider_preferences
         return body
 
@@ -55,7 +58,16 @@ class NousProfile(ProviderProfile):
         supports_reasoning: bool = False,
         **context,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Nous: passes full reasoning_config, but OMITS when disabled."""
+        """Nous: passes full reasoning_config, but OMITS when disabled.
+
+        On the Anthropic Messages wire the ``extra_body.reasoning`` dict is an
+        OpenAI-shaped control the native adapter translates into ``thinking`` /
+        ``output_config``; emitting it would duplicate reasoning controls. The
+        transport passes ``api_mode="anthropic_messages"``, under which this
+        hook contributes nothing and lets the adapter own reasoning (GH-75445).
+        """
+        if context.get("api_mode") == "anthropic_messages":
+            return {}, {}
         extra_body = {}
         if supports_reasoning:
             if reasoning_config is not None:

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -88,6 +88,9 @@ class ZaiProfile(ProviderProfile):
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
     ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if context.get("api_mode") == "anthropic_messages":
+            return {}, {}
+
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
 

--- a/tests/agent/test_nous_portal_anthropic_wire.py
+++ b/tests/agent/test_nous_portal_anthropic_wire.py
@@ -285,6 +285,7 @@ class TestPortalBodyFields:
             _get_transport=lambda: transport,
             _prepare_anthropic_messages_for_api=lambda msgs: msgs,
             _anthropic_preserve_dots=lambda: False,
+            _supports_reasoning_extra_body=lambda: False,
         )
         return build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
 
@@ -522,3 +523,91 @@ class TestAuxiliaryDualWire:
             )
 
         assert captured["model"] == "anthropic/claude-opus-4.8"
+
+
+# ── 7. Generic ProviderProfile wiring on the main Anthropic path ─────────────
+
+
+class TestGenericProfileWiring:
+    """The main ``anthropic_messages`` request path applies ProviderProfile
+    hooks generically instead of the Nous-only special case (GH-75445)."""
+
+    def _agent(self, **over):
+        from agent.transports.anthropic import AnthropicTransport
+
+        transport = AnthropicTransport()
+        base = dict(
+            api_mode="anthropic_messages",
+            provider="nous",
+            model="anthropic/claude-opus-4.8",
+            session_id="sess-abc123",
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            request_overrides={},
+            context_compressor=None,
+            _ephemeral_max_output_tokens=None,
+            _is_anthropic_oauth=False,
+            _anthropic_base_url=PORTAL_URL,
+            _oauth_1m_beta_disabled=False,
+            _get_transport=lambda: transport,
+            _prepare_anthropic_messages_for_api=lambda msgs: msgs,
+            _anthropic_preserve_dots=lambda: False,
+            _supports_reasoning_extra_body=lambda: False,
+        )
+        base.update(over)
+        return SimpleNamespace(**base)
+
+    def test_nous_profile_fields_flow_through_generic_pipeline(self):
+        from agent.chat_completion_helpers import build_api_kwargs
+
+        kw = build_api_kwargs(self._agent(), [{"role": "user", "content": "hi"}])
+        assert kw["extra_body"]["session_id"] == "sess-abc123"
+        assert "tags" in kw["extra_body"]
+
+    def test_nous_reasoning_stays_with_the_adapter(self):
+        from agent.chat_completion_helpers import build_api_kwargs
+
+        agent = self._agent(reasoning_config={"enabled": True, "effort": "high"})
+        kw = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+        assert "reasoning" not in kw.get("extra_body", {})
+        assert "provider" not in kw.get("extra_body", {})
+        assert kw.get("thinking") is not None
+
+    def test_synthetic_profile_reaches_the_request(self, monkeypatch):
+        from agent.chat_completion_helpers import build_api_kwargs
+        from providers.base import ProviderProfile
+
+        class _PluginProfile(ProviderProfile):
+            def prepare_messages(self, messages):
+                return [{"role": "user", "content": "plugin-prep"}]
+
+            def build_extra_body(self, *, session_id=None, **context):
+                return {"plugin": "body"}
+
+            def build_api_kwargs_extras(
+                self, *, reasoning_config=None, **context
+            ):
+                return {"plugin_extra": "x"}, {"service_tier": "standard_only"}
+
+        monkeypatch.setattr(
+            "providers.get_provider_profile",
+            lambda provider: _PluginProfile(name="plugin"),
+        )
+        kw = build_api_kwargs(
+            self._agent(provider="plugin"), [{"role": "user", "content": "hi"}]
+        )
+        assert kw["messages"][0]["content"] == "plugin-prep"
+        assert kw["extra_body"]["plugin"] == "body"
+        assert kw["extra_body"]["plugin_extra"] == "x"
+        assert kw["service_tier"] == "standard_only"
+
+    def test_no_profile_preserves_adapter_shape(self, monkeypatch):
+        from agent.chat_completion_helpers import build_api_kwargs
+
+        monkeypatch.setattr("providers.get_provider_profile", lambda provider: None)
+        kw = build_api_kwargs(
+            self._agent(provider="anthropic"), [{"role": "user", "content": "hi"}]
+        )
+        assert "extra_body" not in kw
+        assert {"model", "messages", "max_tokens"} <= set(kw)

--- a/tests/providers/test_anthropic_transport_profile.py
+++ b/tests/providers/test_anthropic_transport_profile.py
@@ -313,3 +313,32 @@ class TestBundledProfileProtocolGates:
         )
         assert top_disabled == {"reasoning_effort": "none"}
         assert extras_disabled == {"think": False}
+
+    def test_zai_profile_messages_wire_shape(self):
+        from providers import get_provider_profile
+
+        zai = get_provider_profile("zai")
+        extras, top = zai.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+            api_mode="anthropic_messages",
+        )
+        assert extras == {}
+        assert top == {}
+
+    def test_zai_messages_request_uses_adapter_reasoning_shape(self):
+        from providers import get_provider_profile
+
+        zai = get_provider_profile("zai")
+        kw = AnthropicTransport().build_kwargs(
+            model="glm-5.2",
+            messages=_simple_messages(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config={"enabled": True, "effort": "high"},
+            provider_profile=zai,
+            base_url="https://open.bigmodel.cn/api/anthropic",
+        )
+        assert "thinking" in kw
+        assert "reasoning_effort" not in kw.get("extra_body", {})
+        assert "thinking" not in kw.get("extra_body", {})

--- a/tests/providers/test_anthropic_transport_profile.py
+++ b/tests/providers/test_anthropic_transport_profile.py
@@ -1,0 +1,315 @@
+"""Anthropic transport ProviderProfile hook wiring tests (GH-75445).
+
+Pin the contract between ``AnthropicTransport.build_kwargs()`` and the three
+ProviderProfile request hooks, mirroring the chat_completions transport:
+
+1. ``prepare_messages()`` runs once before Anthropic message conversion.
+2. ``build_api_kwargs_extras()`` / ``build_extra_body()`` run once each with
+   ``api_mode="anthropic_messages"`` in their context.
+3. SDK-supported top-level fields stay top-level; unknown fields are projected
+   onto ``extra_body`` so the Anthropic SDK never raises ``TypeError``.
+4. Merge precedence is deterministic and ``provider_profile=None`` preserves
+   the adapter-only request shape.
+"""
+
+import pytest
+
+from agent.anthropic_adapter import build_anthropic_kwargs
+from agent.transports.anthropic import AnthropicTransport
+from providers.base import ProviderProfile
+
+
+class _SyntheticProfile(ProviderProfile):
+    """Recordable profile whose hooks return fixed payloads."""
+
+    def __init__(
+        self,
+        *,
+        body=None,
+        api_extra=None,
+        api_top=None,
+        prepare=None,
+        hook_error=None,
+    ):
+        super().__init__(name="synthetic-test")
+        self.body = body or {}
+        self.api_extra = api_extra or {}
+        self.api_top = api_top or {}
+        self._prepare = prepare
+        self.hook_error = hook_error
+        self.prepare_calls = 0
+        self.body_calls = 0
+        self.api_kwargs_calls = 0
+        self.body_context = None
+        self.body_session_id = None
+        self.api_context = None
+        self.api_reasoning_config = None
+
+    def prepare_messages(self, messages):
+        self.prepare_calls += 1
+        if self._prepare is not None:
+            return self._prepare(messages)
+        return messages
+
+    def build_extra_body(self, *, session_id=None, **context):
+        self.body_calls += 1
+        self.body_context = context
+        self.body_session_id = session_id
+        if self.hook_error == "body":
+            raise RuntimeError("body hook boom")
+        return self.body
+
+    def build_api_kwargs_extras(self, *, reasoning_config=None, **context):
+        self.api_kwargs_calls += 1
+        self.api_context = context
+        self.api_reasoning_config = reasoning_config
+        if self.hook_error == "api":
+            raise RuntimeError("api hook boom")
+        return self.api_extra, self.api_top
+
+
+def _simple_messages():
+    return [{"role": "user", "content": "hello"}]
+
+
+class TestHookExecution:
+    """Each ProviderProfile hook runs exactly once in the documented order."""
+
+    def test_prepare_messages_runs_once_before_conversion(self):
+        profile = _SyntheticProfile(
+            prepare=lambda msgs: [{"role": "user", "content": "prepared"}]
+        )
+        kw = AnthropicTransport().build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=_simple_messages(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            provider_profile=profile,
+        )
+        assert profile.prepare_calls == 1
+        assert kw["messages"][0]["content"] == "prepared"
+
+    def test_kwargs_hooks_run_once_with_api_mode_context(self):
+        profile = _SyntheticProfile(
+            body={"x_tag": "b"},
+            api_extra={"x_extra": "e"},
+            api_top={"service_tier": "standard_only"},
+        )
+        kw = AnthropicTransport().build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=_simple_messages(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config={"enabled": True, "effort": "high"},
+            session_id="sess-1",
+            provider_profile=profile,
+        )
+        assert profile.body_calls == 1
+        assert profile.api_kwargs_calls == 1
+        assert profile.body_context["api_mode"] == "anthropic_messages"
+        assert profile.api_context["api_mode"] == "anthropic_messages"
+        assert profile.body_session_id == "sess-1"
+        assert profile.api_context["session_id"] == "sess-1"
+        assert profile.api_reasoning_config["effort"] == "high"
+        assert kw["extra_body"]["x_tag"] == "b"
+        assert kw["extra_body"]["x_extra"] == "e"
+
+
+class TestSdkProjection:
+    """Profile top-level output lands on valid SDK kwargs or extra_body."""
+
+    def test_sdk_top_level_field_stays_top_level(self):
+        profile = _SyntheticProfile(api_top={"service_tier": "standard_only"})
+        kw = AnthropicTransport().build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=_simple_messages(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            provider_profile=profile,
+        )
+        assert kw["service_tier"] == "standard_only"
+        assert "service_tier" not in kw.get("extra_body", {})
+
+    def test_unknown_top_level_field_moves_to_extra_body(self):
+        profile = _SyntheticProfile(api_top={"parallel_tool_calls": True})
+        kw = AnthropicTransport().build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=_simple_messages(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            provider_profile=profile,
+        )
+        assert "parallel_tool_calls" not in kw
+        assert kw["extra_body"]["parallel_tool_calls"] is True
+
+    def test_extra_headers_merge_with_adapter_beta_headers(self):
+        profile = _SyntheticProfile(
+            api_top={"extra_headers": {"x-custom": "1"}}
+        )
+        kw = AnthropicTransport().build_kwargs(
+            model="claude-opus-4-6",
+            messages=_simple_messages(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            fast_mode=True,
+            provider_profile=profile,
+        )
+        assert kw["extra_headers"]["x-custom"] == "1"
+        assert "anthropic-beta" in kw["extra_headers"]
+
+
+class TestMergePrecedence:
+    """Adapter defaults < build_extra_body < build_api_kwargs_extras body
+    < extension fields projected from the top-level result."""
+
+    def test_api_kwargs_extras_body_overrides_build_extra_body(self):
+        profile = _SyntheticProfile(body={"dup": "body"}, api_extra={"dup": "api"})
+        kw = AnthropicTransport().build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=_simple_messages(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            provider_profile=profile,
+        )
+        assert kw["extra_body"]["dup"] == "api"
+
+    def test_projected_extension_overrides_profile_body(self):
+        profile = _SyntheticProfile(body={"dup": "body"}, api_top={"dup": "top"})
+        kw = AnthropicTransport().build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=_simple_messages(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            provider_profile=profile,
+        )
+        assert kw["extra_body"]["dup"] == "top"
+
+
+class TestBaselineAndFailures:
+    """No-profile parity and visible hook failures."""
+
+    def test_no_profile_matches_adapter_result(self):
+        transport = AnthropicTransport()
+        messages = _simple_messages()
+        assert transport.build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=messages,
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        ) == build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=messages,
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        )
+
+    def test_hook_exception_propagates(self):
+        profile = _SyntheticProfile(hook_error="body")
+        with pytest.raises(RuntimeError, match="body hook boom"):
+            AnthropicTransport().build_kwargs(
+                model="claude-sonnet-4-6",
+                messages=_simple_messages(),
+                tools=None,
+                max_tokens=1024,
+                reasoning_config=None,
+                provider_profile=profile,
+            )
+
+
+class TestBundledProfileProtocolGates:
+    """Dual-wire bundled profiles stay OpenAI-shaped on chat_completions and
+    contribute nothing OpenAI-specific under api_mode='anthropic_messages'."""
+
+    def test_nous_profile_messages_wire_shape(self):
+        from providers import get_provider_profile
+
+        nous = get_provider_profile("nous")
+        prefs = {"only": ["anthropic"]}
+        body = nous.build_extra_body(
+            session_id="sess-1",
+            provider_preferences=prefs,
+            api_mode="anthropic_messages",
+        )
+        assert body["session_id"] == "sess-1"
+        assert "tags" in body
+        assert "provider" not in body
+        extras, top = nous.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            supports_reasoning=True,
+            api_mode="anthropic_messages",
+        )
+        assert extras == {}
+        assert top == {}
+
+    def test_nous_profile_keeps_chat_completions_shape(self):
+        from providers import get_provider_profile
+
+        nous = get_provider_profile("nous")
+        prefs = {"only": ["anthropic"]}
+        body = nous.build_extra_body(
+            session_id="sess-1", provider_preferences=prefs
+        )
+        assert body["provider"] == prefs
+        extras, top = nous.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            supports_reasoning=True,
+        )
+        assert extras == {"reasoning": {"enabled": True, "effort": "high"}}
+        assert top == {}
+
+    def test_kimi_profile_messages_wire_shape(self):
+        from providers import get_provider_profile
+
+        kimi = get_provider_profile("kimi-coding")
+        extras, top = kimi.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            api_mode="anthropic_messages",
+        )
+        assert extras == {}
+        assert top == {}
+
+    def test_kimi_profile_keeps_chat_completions_shape(self):
+        from providers import get_provider_profile
+
+        kimi = get_provider_profile("kimi-coding")
+        extras, top = kimi.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}
+        )
+        assert top == {"reasoning_effort": "high"}
+        assert extras == {}
+        extras_disabled, _ = kimi.build_api_kwargs_extras(reasoning_config=None)
+        assert extras_disabled == {"thinking": {"type": "enabled"}}
+
+    def test_custom_profile_messages_wire_shape(self):
+        from providers import get_provider_profile
+
+        custom = get_provider_profile("custom")
+        extras, top = custom.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            api_mode="anthropic_messages",
+        )
+        assert extras == {}
+        assert top == {}
+
+    def test_custom_profile_keeps_chat_completions_shape(self):
+        from providers import get_provider_profile
+
+        custom = get_provider_profile("custom")
+        extras, top = custom.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}
+        )
+        assert top == {"reasoning_effort": "high"}
+        assert extras == {}
+        extras_disabled, top_disabled = custom.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}
+        )
+        assert top_disabled == {"reasoning_effort": "none"}
+        assert extras_disabled == {"think": False}


### PR DESCRIPTION
## What does this PR do?

Fixes #75445. The `anthropic_messages` transport bypasses every `ProviderProfile` request hook that fires on the `chat_completions` path, silently dropping provider-specific behavior (message preprocessing, reasoning/thinking controls, service tiers, extra body params) for any plugin offering an Anthropic-compatible endpoint.

This PR wires the three hooks — `prepare_messages()`, `build_api_kwargs_extras()`, `build_extra_body()` — into `AnthropicTransport.build_kwargs()` with semantics consistent with the chat_completions transport, and routes the active main-agent request through the generic profile pipeline.

## Related Issue

Fixes #75445

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

**Transport wiring** — `agent/transports/anthropic.py`
- `build_kwargs()` accepts an optional `provider_profile` (plus `session_id` / `supports_reasoning` context) through `**params`.
- `prepare_messages()` runs once before the adapter converts OpenAI-format messages to Anthropic-format messages.
- `build_api_kwargs_extras()` and `build_extra_body()` each run once after the adapter defaults, with `api_mode="anthropic_messages"` in their context so dual-wire profiles can branch per protocol.
- Field projection (`_apply_provider_profile`): SDK-supported top-level fields (intersection of the Anthropic SDK 0.87.0 `messages.create()` / `messages.stream()` signatures) stay top-level; any other top-level key is an extension field and is projected onto `extra_body`, so dispatch never raises `TypeError`. `extra_headers` dictionaries merge shallowly, preserving the adapter's beta headers.
- Merge precedence inside `extra_body`: adapter extras < `build_extra_body()` < `build_api_kwargs_extras()` body < extension fields projected from the top-level result.
- `provider_profile=None` returns the adapter-only result unchanged.

**Main-agent call site** — `agent/chat_completion_helpers.py`
- The `anthropic_messages` branch resolves the active `ProviderProfile` and passes it to the transport, replacing the Nous-only special case. `_merge_nous_portal_messages_extra_body()` is kept for the iteration-limit summary/retry callers, which are out of scope.

**Bundled dual-wire profile guards** — required so activating the hooks does not regress existing Anthropic request shapes:
- `plugins/model-providers/nous/__init__.py`: on the Messages wire, keeps `tags` / `session_id` but omits the OpenAI-wire `provider` routing object and OpenAI-shaped `reasoning`.
- `plugins/model-providers/kimi-coding/__init__.py`: on the Messages wire, contributes nothing; the adapter owns `thinking` / `output_config`.
- `plugins/model-providers/custom/__init__.py`: on the Messages wire, contributes nothing, preventing `reasoning_effort` / `think` / `options.num_ctx` from leaking onto an Anthropic-compatible endpoint (`provider="custom"` is the generic endpoint users most often point at Anthropic-compatible gateways).

**Tests**
- `tests/providers/test_anthropic_transport_profile.py` (new): hook call order/count, `api_mode` context, SDK top-level vs `extra_body` projection, merge precedence, `extra_headers` merge, no-profile parity, hook-failure propagation, and the three bundled profile protocol gates.
- `tests/agent/test_nous_portal_anthropic_wire.py`: adapted the existing stub to the new call site and added a generic-wiring regression class (main path routes the Nous profile through the pipeline, reasoning stays with the adapter, a synthetic plugin profile reaches the request, no-profile preserves the adapter shape).

## How to Test

1. `scripts/run_tests.sh tests/providers/test_anthropic_transport_profile.py tests/providers/test_transport_parity.py tests/agent/test_nous_portal_anthropic_wire.py tests/agent/test_anthropic_kwargs_sanitize.py`
2. Ruff: `ruff check agent/transports/anthropic.py agent/chat_completion_helpers.py plugins/model-providers/nous plugins/model-providers/kimi-coding plugins/model-providers/custom tests/providers/test_anthropic_transport_profile.py tests/agent/test_nous_portal_anthropic_wire.py`
3. Before the fix, a plugin profile's hooks were silently skipped on `anthropic_messages`; after the fix, a synthetic profile's `prepare_messages`, `build_extra_body` and `build_api_kwargs_extras` all reach the constructed request (covered by the new transport tests).

## Scope notes

Following the one-PR-one-issue rule, the adjacent gaps below are intentionally **not** addressed here and remain follow-up candidates:
- Auxiliary client partially invokes hooks and drops some top-level output.
- Iteration-limit summary builds separate Anthropic kwargs and keeps only the Nous special case.
- Anthropic main requests still lack generic `request_overrides` parity.
- Preventive `api_mode` gates for chat-only bundled profiles (ollama-cloud, upstage, ai-gateway, etc.) that never route to Messages.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` (target files) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — covered by the new automated tests.
