### PR TITLE
fix(slack): extract files from forwarded/shared message attachments

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5919,7 +5919,30 @@ class SlackAdapter(BasePlatformAdapter):
         media_urls = list(thread_root_media_urls)
         media_types = list(thread_root_media_types)
         attachment_notices: List[str] = []
-        files = event.get("files", [])
+        files = list(event.get("files", []))
+
+        # Forwarded/shared messages do NOT put their files in the top-level
+        # ``event.files`` list. Slack represents a forward/share as an entry
+        # in the legacy ``event.attachments`` array flagged ``is_share``
+        # (also seen as ``is_msg_unfurl``/``is_reply_unfurl``), and any file
+        # that was attached to the *original* message lives nested at
+        # ``attachment.files[]`` on that entry. Without this, a forwarded
+        # message with an attachment is invisible to the bot even though
+        # direct attachments work fine (#Pepper 2026-07-31: forwarded Slack
+        # attachment not extracted).
+        for _att in event.get("attachments") or []:
+            if not isinstance(_att, dict):
+                continue
+            if not (
+                _att.get("is_share")
+                or _att.get("is_msg_unfurl")
+                or _att.get("is_reply_unfurl")
+            ):
+                continue
+            for _shared_file in _att.get("files") or []:
+                if isinstance(_shared_file, dict):
+                    files.append(_shared_file)
+
         for f in files:
             # Slack Connect channels return stub file objects with
             # file_access="check_file_info" and no URL fields. We must

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1618,6 +1618,119 @@ class TestIncomingDocumentHandling:
         assert "can you parse this" in msg_event.text
 
     @pytest.mark.asyncio
+    async def test_forwarded_message_file_is_downloaded(self, adapter):
+        """A file attached to a forwarded/shared message (Slack puts it in
+        event.attachments[].files, flagged is_share — NOT in event.files)
+        must be downloaded and processed exactly like a direct attachment
+        (Pepper 2026-07-31: forwarded Slack attachment not extracted)."""
+        pdf_bytes = b"%PDF-1.4 forwarded content"
+
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
+            dl.return_value = pdf_bytes
+            event = self._make_event(
+                text="fyi",
+                files=[],
+                attachments=[
+                    {
+                        "is_share": True,
+                        "author_name": "Alice",
+                        "text": "check this out",
+                        "files": [
+                            {
+                                "mimetype": "application/pdf",
+                                "name": "forwarded-report.pdf",
+                                "url_private_download": "https://files.slack.com/forwarded-report.pdf",
+                                "size": len(pdf_bytes),
+                            }
+                        ],
+                    }
+                ],
+            )
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.DOCUMENT
+        assert len(msg_event.media_urls) == 1
+        assert os.path.exists(msg_event.media_urls[0])
+        assert msg_event.media_types == ["application/pdf"]
+
+    @pytest.mark.asyncio
+    async def test_forwarded_message_stub_file_hydrated_via_files_info(self, adapter):
+        """A forwarded message's file reference can arrive as a Slack Connect
+        stub (file_access=check_file_info, no URL fields). The adapter must
+        call files.info to hydrate the full object before downloading it,
+        mirroring the existing top-level-attachment stub handling."""
+        pdf_bytes = b"%PDF-1.4 hydrated forwarded content"
+        adapter._app.client.files_info = AsyncMock(
+            return_value={
+                "ok": True,
+                "file": {
+                    "id": "F_STUB",
+                    "mimetype": "application/pdf",
+                    "name": "hydrated.pdf",
+                    "url_private_download": "https://files.slack.com/hydrated.pdf",
+                    "size": len(pdf_bytes),
+                },
+            }
+        )
+
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
+            dl.return_value = pdf_bytes
+            event = self._make_event(
+                text="from another workspace",
+                files=[],
+                attachments=[
+                    {
+                        "is_share": True,
+                        "files": [
+                            {
+                                "id": "F_STUB",
+                                "file_access": "check_file_info",
+                            }
+                        ],
+                    }
+                ],
+            )
+            await adapter._handle_slack_message(event)
+
+        adapter._app.client.files_info.assert_awaited_once_with(file="F_STUB")
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.DOCUMENT
+        assert len(msg_event.media_urls) == 1
+        assert msg_event.media_types == ["application/pdf"]
+
+    @pytest.mark.asyncio
+    async def test_non_share_attachment_files_are_ignored(self, adapter):
+        """Link-unfurl attachments (e.g. is_msg_unfurl=False, no share flags)
+        must not have their nested files pulled in — only genuine
+        forward/share/reply-unfurl attachments should contribute files."""
+        event = self._make_event(
+            text="check this link",
+            files=[],
+            attachments=[
+                {
+                    "title": "Some Notion page",
+                    "title_link": "https://notion.so/page",
+                    "files": [
+                        {
+                            "mimetype": "application/pdf",
+                            "name": "unrelated.pdf",
+                            "url_private_download": "https://files.slack.com/unrelated.pdf",
+                        }
+                    ],
+                }
+            ],
+        )
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.media_urls == []
+
+    @pytest.mark.asyncio
     async def test_large_txt_not_injected(self, adapter):
         """A .txt file over 100KB should be cached but NOT injected."""
         content = b"x" * (200 * 1024)


### PR DESCRIPTION
## Why
Georg forwarded a Slack message with an attachment and asked Pepper to digest it into GBrain. Pepper could not see the attachment at all.

## Root cause
Slack represents a forwarded/shared message as an entry in `event.attachments` flagged `is_share` (also seen as `is_msg_unfurl`/`is_reply_unfurl`). Any file attached to the *original* message is nested at `attachment.files[]` on that entry — it is **not** present in the top-level `event.files` list, which is the only place the Slack adapter's attachment-handling code looked. Direct attachments already work correctly (download, caching, text injection, PDF/image/audio/video handling) — the gap was specifically forwarded/shared messages.

## Fix
Walk `event.attachments` for entries flagged `is_share`/`is_msg_unfurl`/`is_reply_unfurl` and fold their nested `files[]` into the same list already processed for direct attachments, so forwarded files get identical handling — including files.info hydration for Slack Connect stub file objects (`file_access=check_file_info`) nested inside a forwarded attachment.

## Tests
- `test_forwarded_message_file_is_downloaded` — file nested in an `is_share` attachment is downloaded/cached/typed like a direct attachment.
- `test_forwarded_message_stub_file_hydrated_via_files_info` — a stub file reference inside a forwarded attachment is hydrated via `files.info` before download.
- `test_non_share_attachment_files_are_ignored` — link-unfurl attachments (no share/unfurl flag) don't leak unrelated nested files into the message.

Full `tests/gateway/test_slack.py` suite (164 tests) passes; `ruff check` clean.

Reported by Pepper (EA agent) 2026-07-31.