### PR TITLE
fix(api): persist session pin and archive flags

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3026,9 +3026,11 @@ class APIServerAdapter(BasePlatformAdapter):
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
             "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id",
+            "archived", "pinned", "_lineage_root_id",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
+        for flag in ("archived", "pinned"):
+            payload[flag] = bool(session.get(flag, False))
         # Avoid exposing full system prompts/model_config through the client API;
         # callers only need to know whether those snapshots exist.
         payload["has_system_prompt"] = bool(session.get("system_prompt"))
@@ -3238,10 +3240,16 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        allowed = {"title", "end_reason"}
+        allowed = {"title", "end_reason", "archived", "pinned"}
         unknown = sorted(set(body) - allowed)
         if unknown:
             return web.json_response(_openai_error(f"Unsupported session fields: {', '.join(unknown)}", code="unsupported_session_field"), status=400)
+        invalid_flags = [name for name in ("archived", "pinned") if name in body and not isinstance(body[name], bool)]
+        if invalid_flags:
+            return web.json_response(
+                _openai_error(f"Session fields must be booleans: {', '.join(invalid_flags)}", code="invalid_session_field"),
+                status=400,
+            )
 
         db = await self._ensure_session_db_async()
         if "title" in body:
@@ -3251,6 +3259,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response(_openai_error(str(exc), code="invalid_title"), status=400)
         if body.get("end_reason"):
             await asyncio.to_thread(db.end_session, session_id, str(body["end_reason"]))
+        if "archived" in body:
+            await asyncio.to_thread(db.set_session_archived, session_id, body["archived"])
+        if "pinned" in body:
+            await asyncio.to_thread(db.set_session_pinned, session_id, body["pinned"])
         session = await asyncio.to_thread(db.get_session, session_id) or session
         return web.json_response({"object": "hermes.session", "session": self._session_response(session)})
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -608,3 +608,65 @@ async def test_require_model_lock_hard_fails_when_global_default_would_be_used(a
     mock_run.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_patch_session_persists_pin_and_archive_flags(adapter, session_db):
+    session_id = session_db.create_session("durable-session-flags", "api_server")
+    app = _create_session_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.patch(
+            f"/api/sessions/{session_id}",
+            json={"pinned": True, "archived": True},
+        )
+        assert response.status == 200, await response.text()
+        patched = await response.json()
+
+        fetched = await cli.get(f"/api/sessions/{session_id}")
+        assert fetched.status == 200, await fetched.text()
+        fetched_session = (await fetched.json())["session"]
+
+    assert patched["session"]["pinned"] is True
+    assert patched["session"]["archived"] is True
+    assert fetched_session["pinned"] is True
+    assert fetched_session["archived"] is True
+
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.patch(f"/api/sessions/{session_id}", json={"pinned": False})
+        assert response.status == 200, await response.text()
+        patched = await response.json()
+
+        response = await cli.patch(f"/api/sessions/{session_id}", json={"archived": False})
+        assert response.status == 200, await response.text()
+        unarchived = await response.json()
+
+        listed = await cli.get("/api/sessions")
+        assert listed.status == 200, await listed.text()
+        listed_sessions = (await listed.json())["data"]
+
+    assert patched["session"]["pinned"] is False
+    assert patched["session"]["archived"] is True
+    assert unarchived["session"]["pinned"] is False
+    assert unarchived["session"]["archived"] is False
+    listed_session = next(row for row in listed_sessions if row["id"] == session_id)
+    assert listed_session["pinned"] is False
+    assert listed_session["archived"] is False
+    stored = session_db.get_session(session_id)
+    assert stored["pinned"] == 0
+    assert stored["archived"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field, value", [("pinned", 1), ("archived", "true"), ("pinned", None)])
+async def test_patch_session_rejects_non_boolean_flags(adapter, session_db, field, value):
+    session_id = session_db.create_session("invalid-session-flags", "api_server")
+    app = _create_session_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.patch(f"/api/sessions/{session_id}", json={field: value})
+        assert response.status == 400, await response.text()
+        error = (await response.json())["error"]
+
+    assert error["code"] == "invalid_session_field"
+    assert field in error["message"]
+
+


### PR DESCRIPTION
## Summary
- accept boolean `pinned` and `archived` fields on the API session PATCH endpoint
- persist the flags through SessionDB and return normalized booleans from detail and list responses
- reject non-boolean values and cover pin, unpin, archive, unarchive, and list round trips

Fixes #75468

## Tests
- `pytest -q tests/gateway/test_session_api.py`
- `ruff check gateway/platforms/api_server.py tests/gateway/test_session_api.py`