### PR TITLE
fix(desktop): surface pins hidden by profile scope

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -167,6 +167,7 @@ import {
   revalidatePooledRemoteBackends,
   revalidateRemoteConnection
 } from './remote-liveness'
+import { countCrossProfilePins, windowSessionsIncludingPins } from './session-window'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -10079,6 +10080,20 @@ async function interceptSessionRequestForRemote(request) {
       recentsSp.set('exclude_sources', recentsExclude)
     }
 
+    // A concrete recents scope intentionally omits sibling-profile history,
+    // but the renderer still needs durable sibling pins to disclose that those
+    // conversations exist. LIMIT 1 is enough because every list endpoint
+    // back-fills pinned rows beyond its ordinary recency window.
+    const crossProfilePinsSp = recentsProfile === 'all' ? null : sliceParams('recents_limit', '1', { profile: 'all' })
+
+    if (crossProfilePinsSp) {
+      crossProfilePinsSp.set('limit', '1')
+
+      if (recentsExclude) {
+        crossProfilePinsSp.set('exclude_sources', recentsExclude)
+      }
+    }
+
     const cronSp = sliceParams('cron_limit', '50', { profile: 'all', source: 'cron' })
 
     const messagingSp = sliceParams('messaging_limit', '100', { profile: 'all' })
@@ -10088,14 +10103,16 @@ async function interceptSessionRequestForRemote(request) {
       messagingSp.set('exclude_sources', messagingExclude)
     }
 
-    const [recents, cron, messaging] = await Promise.all([
+    const [recents, crossProfilePins, cron, messaging] = await Promise.all([
       fetchProfilesSessionSlice(recentsSp, remoteProfiles),
+      crossProfilePinsSp ? fetchProfilesSessionSlice(crossProfilePinsSp, remoteProfiles) : Promise.resolve(null),
       fetchProfilesSessionSlice(cronSp, remoteProfiles),
       fetchProfilesSessionSlice(messagingSp, remoteProfiles)
     ])
 
     return {
       recents: {
+        hidden_pinned_count: crossProfilePins ? countCrossProfilePins(rowsOf(crossProfilePins), recentsProfile) : 0,
         sessions: rowsOf(recents),
         total: Number(recents?.total) || 0,
         profile_totals: recents?.profile_totals || {}
@@ -10235,7 +10252,12 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const recency = s => s?.[order] ?? s?.started_at ?? 0
   merged.sort((a, b) => recency(b) - recency(a))
 
-  return { ...(base as any), sessions: merged.slice(offset, offset + limit), total, profile_totals: profileTotals }
+  return {
+    ...(base as any),
+    sessions: windowSessionsIncludingPins(merged, offset, limit),
+    total,
+    profile_totals: profileTotals
+  }
 }
 
 ipcMain.handle('hermes:api', async (_event, request) => {

--- a/apps/desktop/electron/session-window.test.ts
+++ b/apps/desktop/electron/session-window.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { countCrossProfilePins, windowSessionsIncludingPins } from './session-window'
+
+const row = (id: string, profile: string, pinned = false) => ({ id, pinned, profile })
+
+describe('windowSessionsIncludingPins', () => {
+  it('preserves durable pins beyond the recency window', () => {
+    const rows = [row('recent', 'default'), row('old-pin', 'default', true), row('old-ordinary', 'default')]
+
+    expect(windowSessionsIncludingPins(rows, 0, 1).map(session => session.id)).toEqual(['recent', 'old-pin'])
+  })
+})
+
+describe('countCrossProfilePins', () => {
+  it('counts pinned sibling rows without conflating cloned session ids', () => {
+    const candidates = [row('same-id', 'default', true), row('same-id', 'work', true), row('latest-work', 'work')]
+
+    expect(countCrossProfilePins(candidates, 'default')).toBe(1)
+  })
+})

--- a/apps/desktop/electron/session-window.ts
+++ b/apps/desktop/electron/session-window.ts
@@ -1,0 +1,32 @@
+export interface SessionWindowRow {
+  id?: string
+  pinned?: boolean
+  profile?: string
+}
+
+const profileKey = (profile: string | undefined) => profile?.trim() || 'default'
+const sessionKey = (session: SessionWindowRow) => `${profileKey(session.profile)}\0${session.id ?? ''}`
+
+/** Keep pinned rows reachable even when recency puts them beyond the page cap. */
+export function windowSessionsIncludingPins<T extends SessionWindowRow>(rows: T[], offset: number, limit: number): T[] {
+  const window = rows.slice(offset, offset + limit)
+  const seen = new Set(window.map(sessionKey))
+
+  for (const session of rows.slice(offset + limit)) {
+    const key = sessionKey(session)
+
+    if (session.pinned && !seen.has(key)) {
+      seen.add(key)
+      window.push(session)
+    }
+  }
+
+  return window
+}
+
+/** Count durable sibling-profile pins without merging ambiguous cloned ids. */
+export function countCrossProfilePins<T extends SessionWindowRow>(candidates: T[], scopedProfile: string): number {
+  const scope = profileKey(scopedProfile)
+
+  return candidates.filter(session => session.pinned && profileKey(session.profile) !== scope).length
+}

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -39,9 +39,9 @@ import {
   $sessions,
   resolveComposerSessionKey,
   sessionMatchesStoredId,
-  sessionPinId,
   shouldMigrateComposerScope
 } from '@/store/session'
+import { createSessionPinKey, sessionPinKey } from '@/store/session-pin-key'
 import { isSecondaryWindow, isWatchWindow } from '@/store/windows'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
@@ -110,6 +110,7 @@ function ChatHeader({
   const sessions = useStore($sessions)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const profiles = useStore($profiles)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
 
   const activeStoredSession =
     (selectedSessionId && sessions.find(session => sessionMatchesStoredId(session, selectedSessionId))) || null
@@ -124,11 +125,13 @@ function ChatHeader({
   // Pins live on the durable lineage-root id, but selectedSessionId is the live
   // (tip) id — resolve through the loaded row so the menu reflects the pin
   // state after auto-compression rotates the id.
-  const selectedIsPinned = activeStoredSession
-    ? pinnedSessionIds.includes(sessionPinId(activeStoredSession))
+  const selectedPinKey = activeStoredSession
+    ? sessionPinKey(activeStoredSession)
     : selectedSessionId
-      ? pinnedSessionIds.includes(selectedSessionId)
-      : false
+      ? createSessionPinKey(activeGatewayProfile, selectedSessionId)
+      : null
+
+  const selectedIsPinned = Boolean(selectedPinKey && pinnedSessionIds.includes(selectedPinKey))
 
   // Secondary windows (new-session scratch, subagent watch, cmd-click pop-out)
   // are compact side panels — they drop the session-actions header + border

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -46,6 +46,7 @@ import {
   sessionMatchesStoredId,
   sessionPinId
 } from '@/store/session'
+import { createSessionPinKey } from '@/store/session-pin-key'
 import {
   $sessionStates,
   $sessionTiles,
@@ -428,16 +429,18 @@ export function stackSessionTilesIntoMain(): void {
  *  updates in other sessions) — for a context menu that's almost never open.
  *  Same class as the TreeGroup fix (#72245): derive narrowly, bail out unless
  *  the derived values change. */
-function useTileMenuRow(storedSessionId: string): { pinId: string; profile?: string; title: string } {
-  const cache = useRef<{ key: string; value: { pinId: string; profile?: string; title: string } } | null>(null)
+function useTileMenuRow(storedSessionId: string): { pinKey: string; profile?: string; title: string } {
+  const cache = useRef<{ key: string; value: { pinKey: string; profile?: string; title: string } } | null>(null)
 
   const subscribe = useCallback((onChange: () => void) => {
     const offSessions = $sessions.listen(onChange)
     const offTree = $projectTree.listen(onChange)
+    const offProfile = $activeGatewayProfile.listen(onChange)
 
     return () => {
       offSessions()
       offTree()
+      offProfile()
     }
   }, [])
 
@@ -446,10 +449,11 @@ function useTileMenuRow(storedSessionId: string): { pinId: string; profile?: str
     const pinId = stored ? sessionPinId(stored) : storedSessionId
     const title = tileTitle(storedSessionId)
     const profile = stored?.profile
-    const key = `${pinId}\u0000${title}\u0000${profile ?? ''}`
+    const pinKey = createSessionPinKey(profile ?? $activeGatewayProfile.get(), pinId)
+    const key = `${pinKey}\u0000${title}`
 
     if (cache.current?.key !== key) {
-      cache.current = { key, value: { pinId, profile, title } }
+      cache.current = { key, value: { pinKey, profile, title } }
     }
 
     return cache.current.value
@@ -477,9 +481,9 @@ export function SessionTabMenu({
   /** Layout-tree pane id — powers the Close-others/right/all verbs. */
   tabPaneId: string
 }) {
-  const { pinId, profile, title } = useTileMenuRow(storedSessionId)
+  const { pinKey, profile, title } = useTileMenuRow(storedSessionId)
   const pinnedSessionIds = useStore($pinnedSessionIds)
-  const pinned = pinnedSessionIds.includes(pinId)
+  const pinned = pinnedSessionIds.includes(pinKey)
 
   return (
     <span className="contents" onContextMenu={event => event.stopPropagation()}>
@@ -489,7 +493,7 @@ export function SessionTabMenu({
         onClose={onClose}
         onDelete={() => void sessionTileDelegate()?.deleteSession(storedSessionId)}
         onHideTabBar={onHideTabBar}
-        onPin={() => (pinned ? unpinSession(pinId) : pinSession(pinId))}
+        onPin={() => (pinned ? unpinSession(pinKey) : pinSession(pinKey))}
         pinned={pinned}
         profile={profile}
         sessionId={storedSessionId}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -101,9 +101,9 @@ import {
   $sessionProfilesTruncated,
   $sessions,
   $sessionsLoading,
-  sessionPinId,
   setCurrentCwd
 } from '@/store/session'
+import { sessionMatchesPinKey, sessionPinKey, sessionScopedId } from '@/store/session-pin-key'
 import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
 
 import {
@@ -144,7 +144,8 @@ import {
   SidebarPinnedEmptyState,
   SidebarSessionSkeletons
 } from './section-states'
-import { buildSessionByAnyId } from './session-index'
+import { buildSessionByPinKey } from './session-index'
+import { shouldShowSessionSections } from './session-visibility'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
@@ -410,10 +411,10 @@ export function ChatSidebar({
 
   const workingSessionIdSet = useMemo(() => new Set(workingSessionIds), [workingSessionIds])
 
-  // Index sessions by every id a pin might be stored under — recents, cron,
+  // Index sessions by every scoped key a pin might be stored under — recents, cron,
   // AND messaging, since all three can be pinned (see session-index.ts).
-  const sessionByAnyId = useMemo(
-    () => buildSessionByAnyId(visibleSessions, cronSessions, messagingSessions),
+  const sessionByPinKey = useMemo(
+    () => buildSessionByPinKey(visibleSessions, cronSessions, messagingSessions),
     [visibleSessions, cronSessions, messagingSessions]
   )
 
@@ -421,29 +422,29 @@ export function ChatSidebar({
     const seen = new Set<string>()
     const out: SessionInfo[] = []
 
-    for (const pinId of pinnedSessionIds) {
-      const session = sessionByAnyId.get(pinId)
+    for (const pinKey of pinnedSessionIds) {
+      const session = sessionByPinKey.get(pinKey)
+      const scopedId = session ? sessionScopedId(session) : null
 
-      if (session && !seen.has(session.id)) {
-        seen.add(session.id)
+      if (session && scopedId && !seen.has(scopedId)) {
+        seen.add(scopedId)
         out.push(session)
       }
     }
 
     return out
-  }, [pinnedSessionIds, sessionByAnyId])
-
-  const pinnedRealIdSet = useMemo(() => new Set(pinnedSessions.map(s => s.id)), [pinnedSessions])
-  const pinnedIdSet = useMemo(() => new Set(pinnedSessionIds), [pinnedSessionIds])
+  }, [pinnedSessionIds, sessionByPinKey])
 
   // A pinned session belongs to the Pinned section and nowhere else, so every
-  // other list filters it out (the flat recents already did). Match on the live
-  // id AND the durable pin id — a backend snapshot can surface either side of a
-  // compression tip rotation.
+  // other list filters it out (the flat recents already did). Match modern
+  // profile-qualified keys and id-only legacy entries awaiting migration.
   const isPinnedSession = useCallback(
-    (session: SessionInfo) => pinnedRealIdSet.has(session.id) || pinnedIdSet.has(sessionPinId(session)),
-    [pinnedRealIdSet, pinnedIdSet]
+    (session: SessionInfo) => pinnedSessionIds.some(key => sessionMatchesPinKey(session, key)),
+    [pinnedSessionIds]
   )
+
+  const pinRow = useCallback((session: SessionInfo) => pinSession(sessionPinKey(session)), [])
+  const unpinRow = useCallback((session: SessionInfo) => unpinSession(sessionPinKey(session)), [])
 
   // Full-text search across *all* sessions (not just the loaded page) so 699
   // sessions stay findable. Debounced; loaded sessions are matched instantly
@@ -499,12 +500,12 @@ export function ChatSidebar({
         continue
       }
 
-      const loaded = sessionByAnyId.get(match.session_id)
+      const loaded = sessionByPinKey.get(match.session_id)
       out.set(match.session_id, loaded ?? searchResultToSession(match))
     }
 
     return [...out.values()]
-  }, [trimmedQuery, sortedSessions, serverMatches, sessionByAnyId])
+  }, [trimmedQuery, sortedSessions, serverMatches, sessionByPinKey])
 
   const unpinnedAgentSessions = useMemo(
     () => sortedSessions.filter(s => !isPinnedSession(s)),
@@ -1102,7 +1103,12 @@ export function ChatSidebar({
 
   const showSessionSkeletons = sessionsLoading && sortedSessions.length === 0
 
-  const showSessionSections = showSessionSkeletons || sortedSessions.length > 0 || projectModel.length > 0
+  const showSessionSections = shouldShowSessionSections({
+    hiddenPinnedSessionCount: crossProfilePinCount,
+    projectCount: projectModel.length,
+    sessionCount: sortedSessions.length,
+    sessionsLoading: showSessionSkeletons
+  })
 
   // Each reorderable list reports its OWN new id order; persisting is a direct,
   // typed write — no id-prefix sniffing to figure out which level moved.
@@ -1115,16 +1121,7 @@ export function ChatSidebar({
   // it over the default sort, so stale/new ids reconcile on the next render.
   const reorderProjects = (ids: string[]) => setSidebarProjectOrderIds(ids)
 
-  // Sortable rows carry live session ids; the pinned store is keyed by durable
-  // (lineage-root) ids, so translate before persisting the new order.
-  const reorderPinned = (ids: string[]) =>
-    setPinnedSessionOrder(
-      ids.map(id => {
-        const session = sessionByAnyId.get(id)
-
-        return session ? sessionPinId(session) : id
-      })
-    )
+  const reorderPinned = (keys: string[]) => setPinnedSessionOrder(keys)
 
   return (
     <Sidebar
@@ -1269,7 +1266,7 @@ export function ChatSidebar({
                 onDeleteSession={onDeleteSession}
                 onResumeSession={onResumeSession}
                 onToggle={() => undefined}
-                onTogglePin={pinSession}
+                onTogglePin={pinRow}
                 open
                 pinned={false}
                 rootClassName="min-h-32 flex-1 overflow-hidden p-0"
@@ -1301,7 +1298,7 @@ export function ChatSidebar({
                 onReorderSessions={reorderPinned}
                 onResumeSession={onResumeSession}
                 onToggle={() => setSidebarPinsOpen(!pinsOpen)}
-                onTogglePin={unpinSession}
+                onTogglePin={unpinRow}
                 open={pinsOpen}
                 pinned
                 rootClassName="shrink-0 p-0 pb-1"
@@ -1453,7 +1450,7 @@ export function ChatSidebar({
                 onReorderSessions={showAllProfiles ? undefined : reorderSessions}
                 onResumeSession={onResumeSession}
                 onToggle={() => setSidebarRecentsOpen(!agentsOpen)}
-                onTogglePin={pinSession}
+                onTogglePin={pinRow}
                 open={agentsOpen}
                 pinned={false}
                 projectBackRow={
@@ -1511,7 +1508,7 @@ export function ChatSidebar({
                     onDeleteSession={onDeleteSession}
                     onResumeSession={onResumeSession}
                     onToggle={() => toggleSidebarMessagingOpen(group.sourceId)}
-                    onTogglePin={pinSession}
+                    onTogglePin={pinRow}
                     open={messagingOpenIds.includes(group.sourceId)}
                     pinned={false}
                     rootClassName="shrink-0 p-0"

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -63,7 +63,14 @@ import {
   toggleSidebarMessagingOpen,
   unpinSession
 } from '@/store/layout'
-import { $newChatProfile, $profiles, $profileScope, ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
+import {
+  $newChatProfile,
+  $profiles,
+  $profileScope,
+  ALL_PROFILES,
+  normalizeProfileKey,
+  setShowAllProfiles
+} from '@/store/profile'
 import {
   $activeProjectId,
   $projects,
@@ -87,6 +94,7 @@ import {
   $cronSessions,
   $currentCwd,
   $gatewayState,
+  $hiddenPinnedSessionCount,
   $messagingPlatformTotals,
   $messagingSessions,
   $messagingTruncated,
@@ -130,7 +138,12 @@ import {
   StartWorkButton,
   useRepoWorktreeMap
 } from './projects'
-import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
+import {
+  SidebarBlankState,
+  SidebarCrossProfilePinsNotice,
+  SidebarPinnedEmptyState,
+  SidebarSessionSkeletons
+} from './section-states'
 import { buildSessionByAnyId } from './session-index'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
@@ -302,6 +315,7 @@ export function ChatSidebar({
   const messagingTruncated = useStore($messagingTruncated)
   const sessionsLoading = useStore($sessionsLoading)
   const sessionProfilesTruncated = useStore($sessionProfilesTruncated)
+  const hiddenPinnedSessionCount = useStore($hiddenPinnedSessionCount)
   const workingSessionIds = useStore($workingSessionIds)
   const profiles = useStore($profiles)
   const profileScope = useStore($profileScope)
@@ -312,6 +326,7 @@ export function ChatSidebar({
   // profile while scope is still ALL (persisted), the rail is hidden and they'd
   // otherwise be stuck in the grouped view with no way out.
   const showAllProfiles = multiProfile && profileScope === ALL_PROFILES
+  const crossProfilePinCount = showAllProfiles ? 0 : hiddenPinnedSessionCount
   const agentOrderIds = useStore($sidebarSessionOrderIds)
   const agentOrderManual = useStore($sidebarSessionOrderManual)
   const workspaceOrderIds = useStore($sidebarWorkspaceOrderIds)
@@ -1270,7 +1285,16 @@ export function ChatSidebar({
                 contentClassName={cn('flex max-h-[50vh] flex-col gap-px rounded-lg pb-2 pt-1', GROUP_BODY)}
                 dndSensors={dndSensors}
                 emptyState={<SidebarPinnedEmptyState />}
+                footer={
+                  crossProfilePinCount > 0 ? (
+                    <SidebarCrossProfilePinsNotice
+                      count={crossProfilePinCount}
+                      onShowAll={() => setShowAllProfiles(true)}
+                    />
+                  ) : undefined
+                }
                 label={s.pinned}
+                labelMeta={crossProfilePinCount > 0 ? `+${crossProfilePinCount}` : undefined}
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}
                 onDeleteSession={onDeleteSession}

--- a/apps/desktop/src/app/chat/sidebar/section-states.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarCrossProfilePinsNotice } from './section-states'
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      profiles: { showAllProfiles: 'Show all profiles' },
+      sidebar: { shiftClickHint: 'Shift-click a chat to pin' }
+    }
+  })
+}))
+
+afterEach(cleanup)
+
+describe('SidebarCrossProfilePinsNotice', () => {
+  it('offers the all-profiles view when scoped pins are hidden', () => {
+    const onShowAll = vi.fn()
+
+    render(<SidebarCrossProfilePinsNotice count={2} onShowAll={onShowAll} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all profiles' }))
+
+    expect(screen.getByText('+2')).toBeTruthy()
+    expect(onShowAll).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/section-states.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.tsx
@@ -50,3 +50,21 @@ export function SidebarPinnedEmptyState() {
     </div>
   )
 }
+
+export function SidebarCrossProfilePinsNotice({ count, onShowAll }: { count: number; onShowAll: () => void }) {
+  const { t } = useI18n()
+
+  return (
+    <Button
+      aria-label={t.profiles.showAllProfiles}
+      className="h-7 w-full justify-start gap-1.5 px-2 text-[0.75rem] font-normal text-(--ui-text-tertiary)"
+      onClick={onShowAll}
+      size="sm"
+      variant="ghost"
+    >
+      <Codicon className="text-(--ui-text-quaternary)" name="accounts-view-bar-icon" size="0.75rem" />
+      <span className="min-w-0 flex-1 truncate text-left">{t.profiles.showAllProfiles}</span>
+      <span className="text-(--ui-text-quaternary)">+{count}</span>
+    </Button>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/session-index.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.test.ts
@@ -1,48 +1,64 @@
 import { describe, expect, it } from 'vitest'
 
+import { createSessionPinKey } from '@/store/session-pin-key'
 import type { SessionInfo } from '@/types/hermes'
 
-import { buildSessionByAnyId } from './session-index'
+import { buildSessionByPinKey } from './session-index'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
 
-describe('buildSessionByAnyId', () => {
+describe('buildSessionByPinKey', () => {
   it('resolves a pin from every slice the sidebar fetches', () => {
     // The contract that matters: a pin is looked up in this map no matter
     // which slice owns the row. Messaging is the one that regressed — a
     // pinned session is filtered out of its own section, so a miss here
     // removes it from the sidebar entirely rather than just misplacing it.
-    const index = buildSessionByAnyId([row('recent')], [row('cron_job_1')], [row('telegram_42')])
+    const index = buildSessionByPinKey([row('recent')], [row('cron_job_1')], [row('telegram_42')])
 
     for (const id of ['recent', 'cron_job_1', 'telegram_42']) {
-      expect(index.get(id)?.id).toBe(id)
+      expect(index.get(createSessionPinKey('default', id))?.id).toBe(id)
     }
   })
 
   it('resolves a pin stored on the pre-compression lineage root', () => {
-    const index = buildSessionByAnyId([], [], [row('tip', { _lineage_root_id: 'root' })])
+    const index = buildSessionByPinKey([], [], [row('tip', { _lineage_root_id: 'root' })])
 
     // Both identities point at the one live row.
-    expect(index.get('root')?.id).toBe('tip')
-    expect(index.get('tip')?.id).toBe('tip')
+    expect(index.get(createSessionPinKey('default', 'root'))?.id).toBe('tip')
+    expect(index.get(createSessionPinKey('default', 'tip'))?.id).toBe('tip')
   })
 
   it('lets a recents row win a direct id collision', () => {
-    const index = buildSessionByAnyId(
+    const index = buildSessionByPinKey(
       [row('dupe', { title: 'from recents' })],
       [],
       [row('dupe', { title: 'from messaging' })]
     )
 
-    expect(index.get('dupe')?.title).toBe('from recents')
+    expect(index.get(createSessionPinKey('default', 'dupe'))?.title).toBe('from recents')
   })
 
   it('does not let a lineage alias clobber a real row under that id', () => {
     // 'root' is a live session in its own right AND another row's lineage
     // root; the real row must win so the pin opens the right conversation.
-    const index = buildSessionByAnyId([row('root')], [], [row('tip', { _lineage_root_id: 'root' })])
+    const index = buildSessionByPinKey([row('root')], [], [row('tip', { _lineage_root_id: 'root' })])
 
-    expect(index.get('root')?.id).toBe('root')
+    expect(index.get(createSessionPinKey('default', 'root'))?.id).toBe('root')
+  })
+
+  it('keeps cloned ids independently addressable by profile', () => {
+    const index = buildSessionByPinKey(
+      [
+        row('shared', { pinned: false, profile: 'default', title: 'default copy' }),
+        row('shared', { pinned: true, profile: 'work', title: 'work copy' })
+      ],
+      [],
+      []
+    )
+
+    expect(index.get(createSessionPinKey('default', 'shared'))?.title).toBe('default copy')
+    expect(index.get(createSessionPinKey('work', 'shared'))?.title).toBe('work copy')
+    expect(index.has('shared')).toBe(false)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-index.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.ts
@@ -1,7 +1,8 @@
+import { createSessionPinKey } from '@/store/session-pin-key'
 import type { SessionInfo } from '@/types/hermes'
 
 /**
- * Index sessions by every id a pin might be stored under.
+ * Index sessions by every profile-qualified key a pin might be stored under.
  *
  * The sidebar fetches three independent slices — recents, cron, and messaging
  * — and renders the latter two in self-managed sections. Any of them can be
@@ -12,20 +13,49 @@ import type { SessionInfo } from '@/types/hermes'
  *
  * Each session is keyed under both its live id and its lineage root, so a pin
  * stored before an auto-compression still resolves to the live continuation
- * tip. Recents are indexed last and win a direct id collision.
+ * tip. Recents are indexed last and win a direct collision inside one profile.
+ * A legacy unqualified id is exposed only when it resolves to exactly one
+ * scoped identity; cloned ids stay deliberately ambiguous until migration.
  */
-export function buildSessionByAnyId(
+export function buildSessionByPinKey(
   visibleSessions: SessionInfo[],
   cronSessions: SessionInfo[],
   messagingSessions: SessionInfo[]
 ): Map<string, SessionInfo> {
   const map = new Map<string, SessionInfo>()
+  const legacyCandidates = new Map<string, Set<string>>()
+
+  const recordLegacyCandidate = (legacyId: string, qualifiedKey: string) => {
+    const candidates = legacyCandidates.get(legacyId) ?? new Set<string>()
+
+    candidates.add(qualifiedKey)
+    legacyCandidates.set(legacyId, candidates)
+  }
 
   for (const session of [...cronSessions, ...messagingSessions, ...visibleSessions]) {
-    map.set(session.id, session)
+    const directKey = createSessionPinKey(session.profile, session.id)
 
-    if (session._lineage_root_id && !map.has(session._lineage_root_id)) {
-      map.set(session._lineage_root_id, session)
+    map.set(directKey, session)
+    recordLegacyCandidate(session.id, directKey)
+
+    if (session._lineage_root_id) {
+      const rootKey = createSessionPinKey(session.profile, session._lineage_root_id)
+
+      if (!map.has(rootKey)) {
+        map.set(rootKey, session)
+      }
+
+      recordLegacyCandidate(session._lineage_root_id, rootKey)
+    }
+  }
+
+  for (const [legacyId, candidates] of legacyCandidates) {
+    if (candidates.size === 1) {
+      const row = map.get([...candidates][0])
+
+      if (row) {
+        map.set(legacyId, row)
+      }
     }
   }
 

--- a/apps/desktop/src/app/chat/sidebar/session-visibility.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-visibility.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldShowSessionSections } from './session-visibility'
+
+describe('shouldShowSessionSections', () => {
+  it('keeps recovery controls visible for an empty profile with hidden sibling pins', () => {
+    expect(
+      shouldShowSessionSections({
+        hiddenPinnedSessionCount: 1,
+        projectCount: 0,
+        sessionCount: 0,
+        sessionsLoading: false
+      })
+    ).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-visibility.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-visibility.ts
@@ -1,0 +1,15 @@
+interface SessionSectionVisibility {
+  hiddenPinnedSessionCount: number
+  projectCount: number
+  sessionCount: number
+  sessionsLoading: boolean
+}
+
+export function shouldShowSessionSections({
+  hiddenPinnedSessionCount,
+  projectCount,
+  sessionCount,
+  sessionsLoading
+}: SessionSectionVisibility): boolean {
+  return sessionsLoading || sessionCount > 0 || projectCount > 0 || hiddenPinnedSessionCount > 0
+}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -12,7 +12,7 @@ import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
 import { groupEntriesByRecency, type SidebarListRow, toSessionRows } from '@/lib/session-date-groups'
 import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
-import { sessionPinId } from '@/store/session'
+import { sessionPinKey, sessionScopedId } from '@/store/session-pin-key'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
 import {
@@ -95,7 +95,7 @@ interface SidebarSessionsSectionProps {
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
-  onTogglePin: (sessionId: string) => void
+  onTogglePin: (session: SessionInfo) => void
   onNewSessionInWorkspace?: (path: null | string) => void
   pinned: boolean
   rootClassName?: string
@@ -226,6 +226,9 @@ export function SidebarSessionsSection({
   )
 
   const renderRow = (session: SessionInfo, draggable: boolean, branchStem?: string) => {
+    const rowKey = sessionScopedId(session)
+    const sortableId = pinned ? sessionPinKey(session) : session.id
+
     const rowProps = {
       branchStem,
       isPinned: pinned,
@@ -234,7 +237,7 @@ export function SidebarSessionsSection({
       onArchive: () => onArchiveSession(session.id),
       onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
       onDelete: () => onDeleteSession(session.id),
-      onPin: () => onTogglePin(sessionPinId(session)),
+      onPin: () => onTogglePin(session),
       onResume: () => onResumeSession(session.id),
       reorderable: draggable && !branchStem,
       session,
@@ -242,9 +245,9 @@ export function SidebarSessionsSection({
     }
 
     return draggable && !branchStem ? (
-      <SortableSidebarSessionRow key={session.id} {...rowProps} />
+      <SortableSidebarSessionRow key={rowKey} sortableId={sortableId} {...rowProps} />
     ) : (
-      <SidebarSessionRow key={session.id} {...rowProps} />
+      <SidebarSessionRow key={rowKey} {...rowProps} />
     )
   }
 
@@ -383,7 +386,11 @@ export function SidebarSessionsSection({
 
     inner =
       sessionsDraggable && onReorderSessions ? (
-        <ReorderableList ids={sessions.map(s => s.id)} onReorder={onReorderSessions} sensors={dndSensors}>
+        <ReorderableList
+          ids={sessions.map(session => (pinned ? sessionPinKey(session) : session.id))}
+          onReorder={onReorderSessions}
+          sensors={dndSensors}
+        >
           {virtual}
         </ReorderableList>
       ) : (
@@ -391,7 +398,11 @@ export function SidebarSessionsSection({
       )
   } else if (sessionsDraggable && onReorderSessions) {
     inner = (
-      <ReorderableList ids={sessions.map(s => s.id)} onReorder={onReorderSessions} sensors={dndSensors}>
+      <ReorderableList
+        ids={sessions.map(session => (pinned ? sessionPinKey(session) : session.id))}
+        onReorder={onReorderSessions}
+        sensors={dndSensors}
+      >
         {flatRows.map(row => renderListRow(row, true))}
       </ReorderableList>
     )
@@ -433,10 +444,11 @@ interface SortableSessionRowProps {
   onDelete: () => void
   onPin: () => void
   onResume: () => void
+  sortableId: string
 }
 
-function SortableSidebarSessionRow(props: SortableSessionRowProps) {
-  return <SidebarSessionRow {...props} {...useSortableBindings(props.session.id)} />
+function SortableSidebarSessionRow({ sortableId, ...props }: SortableSessionRowProps) {
+  return <SidebarSessionRow {...props} {...useSortableBindings(sortableId)} />
 }
 
 function SortableProjectOverviewRow(props: React.ComponentProps<typeof ProjectOverviewRow>) {

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -8,7 +8,7 @@ import { useI18n } from '@/i18n'
 import { type SidebarListRow } from '@/lib/session-date-groups'
 import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
-import { sessionPinId } from '@/store/session'
+import { sessionPinKey, sessionScopedId } from '@/store/session-pin-key'
 
 import { SidebarDateDivider } from './chrome'
 import { SidebarSessionRow } from './session-row'
@@ -35,7 +35,7 @@ interface VirtualSessionListProps {
   onBranchSession?: (sessionId: string, profile?: string) => void
   onDeleteSession: (sessionId: string) => void
   onResumeSession: (sessionId: string) => void
-  onTogglePin: (sessionId: string) => void
+  onTogglePin: (session: SessionInfo) => void
   pinned: boolean
   showProfileTags?: boolean
   sortable: boolean
@@ -69,7 +69,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     getItemKey: index => {
       const row = listRows[index]
 
-      return row ? (row.kind === 'divider' ? row.key : row.entry.session.id) : index
+      return row ? (row.kind === 'divider' ? row.key : sessionScopedId(row.entry.session)) : index
     },
     getScrollElement: () => scrollerRef.current,
     // jsdom-friendly default; the real rect takes over on first observe.
@@ -112,7 +112,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       onArchive: () => onArchiveSession(session.id),
       onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
       onDelete: () => onDeleteSession(session.id),
-      onPin: () => onTogglePin(sessionPinId(session)),
+      onPin: () => onTogglePin(session),
       onResume: () => onResumeSession(session.id),
       reorderable,
       showProfile: showProfileTags
@@ -121,16 +121,17 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     return reorderable ? (
       <VirtualSortableRow
         index={virtualItem.index}
-        key={session.id}
+        key={sessionScopedId(session)}
         measureRef={virtualizer.measureElement}
         rowProps={commonProps}
         session={session}
+        sortableId={pinned ? sessionPinKey(session) : session.id}
       />
     ) : (
       <SidebarSessionRow
         {...commonProps}
         data-index={virtualItem.index}
-        key={session.id}
+        key={sessionScopedId(session)}
         ref={virtualizer.measureElement}
         session={session}
       />
@@ -157,10 +158,11 @@ interface VirtualSortableRowProps {
   measureRef: (node: Element | null) => void
   rowProps: SessionRowCommonProps
   session: SessionInfo
+  sortableId: string
 }
 
-function VirtualSortableRow({ index, measureRef, rowProps, session }: VirtualSortableRowProps) {
-  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id: session.id })
+function VirtualSortableRow({ index, measureRef, rowProps, session, sortableId }: VirtualSortableRowProps) {
+  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id: sortableId })
 
   // Merge dnd-kit's setNodeRef with the virtualizer's measureElement so
   // the row participates in both DnD hit-testing and TanStack height

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -29,7 +29,8 @@ import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions, sessionPinId } from '@/store/session'
+import { $sessions } from '@/store/session'
+import { sessionPinKey, sessionScopedId } from '@/store/session-pin-key'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -363,11 +364,11 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
               ) : (
                 <ul>
                   {filteredSessions.map(session => {
-                    const pinId = sessionPinId(session)
-                    const pinned = pinnedSessionIds.includes(pinId)
+                    const pinKey = sessionPinKey(session)
+                    const pinned = pinnedSessionIds.includes(pinKey)
 
                     return (
-                      <li className="group flex items-center gap-2 py-2" key={session.id}>
+                      <li className="group flex items-center gap-2 py-2" key={sessionScopedId(session)}>
                         <button
                           className="min-w-0 flex-1 text-left"
                           onClick={() => onOpenSession(session.id)}
@@ -382,7 +383,7 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                         </button>
                         <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
                           <RowIconButton
-                            onClick={() => (pinned ? unpinSession(pinId) : pinSession(pinId))}
+                            onClick={() => (pinned ? unpinSession(pinKey) : pinSession(pinKey))}
                             title={pinned ? cc.unpinSession : cc.pinSession}
                           >
                             {pinned ? <BookmarkFilled className="size-3.5" /> : <Bookmark className="size-3.5" />}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -59,11 +59,11 @@ import {
   $selectedStoredSessionId,
   $sessions,
   sessionMatchesStoredId,
-  sessionPinId,
   setAwaitingResponse,
   setBusy,
   setMessages
 } from '@/store/session'
+import { createSessionPinKey, sessionPinKey } from '@/store/session-pin-key'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord } from '@/store/wake-word'
 import { isSecondaryWindow } from '@/store/windows'
@@ -793,12 +793,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     }
 
     const session = $sessions.get().find(s => sessionMatchesStoredId(s, sessionId))
-    const pinId = session ? sessionPinId(session) : sessionId
+    const pinKey = session ? sessionPinKey(session) : createSessionPinKey($activeGatewayProfile.get(), sessionId)
 
-    if ($pinnedSessionIds.get().includes(pinId)) {
-      unpinSession(pinId)
+    if ($pinnedSessionIds.get().includes(pinKey)) {
+      unpinSession(pinKey)
     } else {
-      pinSession(pinId)
+      pinSession(pinKey)
     }
   }, [])
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -34,7 +34,6 @@ import {
   $yoloActive,
   type NewChatWorkspaceTarget,
   resolveComposerSessionKey,
-  sessionPinId,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
@@ -56,6 +55,7 @@ import {
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
+import { createSessionPinKey, sessionMatchesPinKey } from '@/store/session-pin-key'
 import {
   $sessionTiles,
   closeSessionTile,
@@ -1311,9 +1311,6 @@ export function useSessionActions({
       const closingRuntimeId = wasSelected ? activeSessionId : null
       const previousMessages = $messages.get()
       const previousPinned = $pinnedSessionIds.get()
-      // Pins are keyed on the durable lineage-root id; the stored id may be the
-      // live tip after compression. Drop both so the pin can't linger.
-      const removedPinId = removed ? sessionPinId(removed) : storedSessionId
       const removedIds = [storedSessionId, removed?.id, removed?._lineage_root_id]
 
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
@@ -1323,7 +1320,13 @@ export function useSessionActions({
       // the delete RPC is in flight, so a racing refresh can't flash it back.
       tombstoneSessions(removedIds)
       beginSessionMutation(removedIds)
-      $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== removedPinId))
+      $pinnedSessionIds.set(
+        previousPinned.filter(key =>
+          removed
+            ? !sessionMatchesPinKey(removed, key)
+            : key !== storedSessionId && key !== createSessionPinKey($activeGatewayProfile.get(), storedSessionId)
+        )
+      )
 
       // Tear down before awaiting so the route effect can't resume the
       // doomed session via the stale /<sid> URL.
@@ -1410,16 +1413,19 @@ export function useSessionActions({
       const archived = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
       const wasSelected = selectedStoredSessionId === storedSessionId
       const previousPinned = $pinnedSessionIds.get()
-      // Pins are keyed on the durable lineage-root id; the stored id may be the
-      // live tip after compression. Drop both so the pin can't linger.
-      const archivedPinId = archived ? sessionPinId(archived) : storedSessionId
       const archivedIds = [storedSessionId, archived?.id, archived?._lineage_root_id]
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       tombstoneSessions(archivedIds)
       beginSessionMutation(archivedIds)
-      $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
+      $pinnedSessionIds.set(
+        previousPinned.filter(key =>
+          archived
+            ? !sessionMatchesPinKey(archived, key)
+            : key !== storedSessionId && key !== createSessionPinKey($activeGatewayProfile.get(), storedSessionId)
+        )
+      )
 
       if (wasSelected) {
         startFreshSessionDraft(true)

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo, SidebarSessionsResponse } from '@/hermes'
+import { $pinnedSessionIds } from '@/store/layout'
 import {
   $cronSessions,
   $hiddenPinnedSessionCount,
@@ -14,6 +15,7 @@ import {
   setSessions,
   setSessionsLoading
 } from '@/store/session'
+import { createSessionPinKey } from '@/store/session-pin-key'
 
 import { useSessionListActions } from './use-session-list-actions'
 
@@ -88,6 +90,7 @@ beforeEach(() => {
   setCronSessions([])
   setHiddenPinnedSessionCount(0)
   setMessagingSessions([])
+  $pinnedSessionIds.set([])
   setSessionsLoading(false)
 })
 
@@ -96,10 +99,24 @@ afterEach(() => {
   setCronSessions([])
   setHiddenPinnedSessionCount(0)
   setMessagingSessions([])
+  $pinnedSessionIds.set([])
   setSessionsLoading(false)
 })
 
 describe('refreshSessions identity + loading hygiene', () => {
+  it('preserves only scoped pinned rows when a concrete-profile page omits them', async () => {
+    setSessions([row('kept', { profile: 'work' }), row('sibling-only', { profile: 'default' })])
+    $pinnedSessionIds.set([createSessionPinKey('work', 'kept'), createSessionPinKey('default', 'sibling-only')])
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'work' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(session => session.id)).toEqual(['kept'])
+  })
+
   it('keeps the previous $sessions array when the refresh is content-identical', async () => {
     const rows = [row('a'), row('b')]
     listSidebarSessions.mockResolvedValue(sidebar({ sessions: rows }))

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -4,10 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SessionInfo, SidebarSessionsResponse } from '@/hermes'
 import {
   $cronSessions,
+  $hiddenPinnedSessionCount,
   $messagingSessions,
   $sessions,
   $sessionsLoading,
   setCronSessions,
+  setHiddenPinnedSessionCount,
   setMessagingSessions,
   setSessions,
   setSessionsLoading
@@ -43,11 +45,19 @@ const row = (id: string, over: Partial<SessionInfo> = {}): SessionInfo =>
 // separate listAllProfileSessions calls (each of which reopened every profile
 // DB) — #66377-adjacent perf work from the desktop audit canvas.
 const sidebar = (
-  recents: { sessions: SessionInfo[]; profiles_truncated?: Record<string, boolean> },
+  recents: {
+    sessions: SessionInfo[]
+    hidden_pinned_count?: number
+    profiles_truncated?: Record<string, boolean>
+  },
   cron: SessionInfo[] = [],
   messaging: SessionInfo[] = []
 ): SidebarSessionsResponse => ({
-  recents: { sessions: recents.sessions, profiles_truncated: recents.profiles_truncated },
+  recents: {
+    hidden_pinned_count: recents.hidden_pinned_count,
+    profiles_truncated: recents.profiles_truncated,
+    sessions: recents.sessions
+  },
   cron: { sessions: cron },
   messaging: { sessions: messaging }
 })
@@ -76,6 +86,7 @@ beforeEach(() => {
   removed.ids = new Set()
   setSessions([])
   setCronSessions([])
+  setHiddenPinnedSessionCount(0)
   setMessagingSessions([])
   setSessionsLoading(false)
 })
@@ -83,6 +94,7 @@ beforeEach(() => {
 afterEach(() => {
   setSessions([])
   setCronSessions([])
+  setHiddenPinnedSessionCount(0)
   setMessagingSessions([])
   setSessionsLoading(false)
 })
@@ -209,6 +221,18 @@ describe('refreshSessions batches slices into one request', () => {
     expect($sessions.get().map(s => s.id)).toEqual(['a', 'b'])
     expect($cronSessions.get().map(s => s.id)).toEqual(['c1'])
     expect($messagingSessions.get().map(s => s.id)).toEqual(['m1'])
+  })
+
+  it('stores the number of durable pins hidden by the concrete profile scope', async () => {
+    listSidebarSessions.mockResolvedValue(sidebar({ hidden_pinned_count: 2, sessions: [row('a')] }))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($hiddenPinnedSessionCount.get()).toBe(2)
   })
 
   it('forwards the active profile scope + section limits to the batched call', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -28,6 +28,7 @@ import {
   setSessions,
   setSessionsLoading
 } from '@/store/session'
+import { sessionPinIdsForScope } from '@/store/session-pin-key'
 import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
 
 // The recents list is local-only: cron rows have their own section, kanban
@@ -50,7 +51,7 @@ const MESSAGING_EXCLUDED_SOURCES = ['cron', ...LOCAL_SESSION_SOURCE_IDS]
 function sessionsToKeep(scope?: string): Set<string> {
   const keep = new Set<string>([
     ...$workingSessionIds.get(),
-    ...$pinnedSessionIds.get(),
+    ...sessionPinIdsForScope($pinnedSessionIds.get(), scope),
     ...getRecentlySettledSessionIds()
   ])
 
@@ -199,7 +200,8 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         // identity, or every sidebar memo keyed on $sessions recomputes and the
         // whole list re-renders once per turn/broadcast for nothing.
         setSessions(prev => {
-          const next = mergeSessionPage(prev, incoming, sessionsToKeep())
+          const keepScope = profileScope === ALL_PROFILES ? undefined : profileScope
+          const next = mergeSessionPage(prev, incoming, sessionsToKeep(keepScope))
 
           return sameCronSignature(prev, next) ? prev : next
         })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -20,6 +20,7 @@ import {
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
   setCronSessions,
+  setHiddenPinnedSessionCount,
   setMessagingPlatformTotals,
   setMessagingSessions,
   setMessagingTruncated,
@@ -215,6 +216,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
             ? prev
             : next
         })
+        setHiddenPinnedSessionCount(recents.hidden_pinned_count ?? 0)
 
         // Cron section: latest N cron sessions (kept so a pinned cron run still
         // resolves via sessionByAnyId), signature-gated like above.

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -431,6 +431,8 @@ export async function listAllProfileSessions(
 // splices remote profiles per slice (see interceptSessionRequestForRemote).
 export interface SidebarSessionSlice {
   sessions: SessionInfo[]
+  /** Durable recents pins owned by profiles hidden by a concrete scope. */
+  hidden_pinned_count?: number
   /** Per-profile "the window came back full, more rows exist on disk" flags —
    *  what pagination needs, without a COUNT(*) per profile DB per refresh. */
   profiles_truncated?: Record<string, boolean>
@@ -522,6 +524,7 @@ async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<S
 
   return {
     recents: {
+      hidden_pinned_count: 0,
       profiles_truncated: profilesTruncatedFrom(recents.sessions, req.recentsLimit),
       sessions: recents.sessions
     },

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -4,12 +4,14 @@ import { $sessionsLimit, resetSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '
 import {
   $cronSessions,
   $freshDraftReady,
+  $hiddenPinnedSessionCount,
   $messagingSessions,
   $sessionProfilesTruncated,
   $sessions,
   $sessionsLoading,
   setCronSessions,
   setFreshDraftReady,
+  setHiddenPinnedSessionCount,
   setMessagingSessions,
   setSessionProfilesTruncated,
   setSessions,
@@ -28,6 +30,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     $gatewaySwitching.set(false)
     setSessions([{ id: 's1', title: 'old', profile: 'default' } as never])
     setSessionProfilesTruncated({ default: true })
+    setHiddenPinnedSessionCount(2)
     setCronSessions([{ id: 'c1', title: 'cron', profile: 'default' } as never])
     setMessagingSessions([{ id: 'm1', title: 'tg', profile: 'default' } as never])
     $stalledSessionIds.set(['s1'])
@@ -39,6 +42,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
   afterEach(() => {
     resetSessionsLimit()
     setSessions([])
+    setHiddenPinnedSessionCount(0)
     setCronSessions([])
     setMessagingSessions([])
     $stalledSessionIds.set([])
@@ -51,6 +55,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
 
     expect($sessions.get()).toEqual([])
     expect($sessionProfilesTruncated.get()).toEqual({})
+    expect($hiddenPinnedSessionCount.get()).toBe(0)
     expect($cronSessions.get()).toEqual([])
     expect($messagingSessions.get()).toEqual([])
     expect($stalledSessionIds.get()).toEqual([])

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -11,6 +11,7 @@ import {
   setActiveSessionId,
   setCronSessions,
   setFreshDraftReady,
+  setHiddenPinnedSessionCount,
   setMessages,
   setMessagingPlatformTotals,
   setMessagingSessions,
@@ -45,6 +46,7 @@ export function wipeSessionListsForGatewaySwitch(): void {
   resetSidebarBatchCapability()
   setSessions([])
   setSessionProfilesTruncated({})
+  setHiddenPinnedSessionCount(0)
   setCronSessions([])
   setMessagingSessions([])
   setMessagingPlatformTotals({})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -74,6 +74,8 @@ export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states 
   return typeof override === 'number' ? override : SIDEBAR_DEFAULT_WIDTH
 })
 
+// Ordered `profile\0lineage-root-id` keys. The storage key stays stable so
+// session-pin-sync.ts can migrate legacy id-only values in place.
 export const $pinnedSessionIds = persistentAtom(SIDEBAR_PINNED_STORAGE_KEY, [] as string[], Codecs.stringArray)
 export const $sidebarSessionOrderIds = persistentAtom(
   SIDEBAR_SESSION_ORDER_STORAGE_KEY,
@@ -403,16 +405,19 @@ export function setSidebarResizing(resizing: boolean) {
   $isSidebarResizing.set(resizing)
 }
 
-export function pinSession(sessionId: string, index?: number) {
+export function pinSession(sessionKey: string, index?: number) {
   const prev = $pinnedSessionIds.get()
 
-  setOrderIds($pinnedSessionIds, insertUniqueId(prev, sessionId, index ?? prev.filter(id => id !== sessionId).length))
-}
-
-export function unpinSession(sessionId: string) {
   setOrderIds(
     $pinnedSessionIds,
-    $pinnedSessionIds.get().filter(id => id !== sessionId)
+    insertUniqueId(prev, sessionKey, index ?? prev.filter(key => key !== sessionKey).length)
+  )
+}
+
+export function unpinSession(sessionKey: string) {
+  setOrderIds(
+    $pinnedSessionIds,
+    $pinnedSessionIds.get().filter(key => key !== sessionKey)
   )
 }
 

--- a/apps/desktop/src/store/session-pin-key.test.ts
+++ b/apps/desktop/src/store/session-pin-key.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import {
+  createSessionPinKey,
+  parseSessionPinKey,
+  sessionMatchesPinKey,
+  sessionPinIdsForScope,
+  sessionPinKey
+} from './session-pin-key'
+
+const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
+  ({ id, message_count: 1, source: 'desktop', started_at: 0, title: id, ...extra }) as SessionInfo
+
+describe('profile-qualified session pin keys', () => {
+  it('round-trips profile and durable lineage id', () => {
+    const key = createSessionPinKey('work', 'root')
+
+    expect(parseSessionPinKey(key)).toEqual({ id: 'root', profile: 'work' })
+    expect(sessionPinKey(row('tip', { _lineage_root_id: 'root', profile: 'work' }))).toBe(key)
+  })
+
+  it('treats an absent profile as default', () => {
+    expect(parseSessionPinKey(createSessionPinKey(undefined, 'chat'))).toEqual({
+      id: 'chat',
+      profile: 'default'
+    })
+  })
+
+  it('does not match a cloned id owned by another profile', () => {
+    const workKey = createSessionPinKey('work', 'shared')
+
+    expect(sessionMatchesPinKey(row('shared', { profile: 'work' }), workKey)).toBe(true)
+    expect(sessionMatchesPinKey(row('shared', { profile: 'default' }), workKey)).toBe(false)
+  })
+
+  it('unwraps only keys in the requested scope while retaining unresolved legacy ids', () => {
+    const keys = [createSessionPinKey('default', 'default-pin'), createSessionPinKey('work', 'work-pin'), 'legacy-pin']
+
+    expect(sessionPinIdsForScope(keys, 'work')).toEqual(['work-pin', 'legacy-pin'])
+    expect(sessionPinIdsForScope(keys)).toEqual(['default-pin', 'work-pin', 'legacy-pin'])
+  })
+})

--- a/apps/desktop/src/store/session-pin-key.ts
+++ b/apps/desktop/src/store/session-pin-key.ts
@@ -1,0 +1,66 @@
+import type { SessionInfo } from '@/types/hermes'
+
+import { sessionMatchesStoredId, sessionPinId } from './session'
+
+const SESSION_PIN_KEY_SEPARATOR = '\0'
+
+export interface ParsedSessionPinKey {
+  id: string
+  profile: string
+}
+
+export function normalizeSessionPinProfile(profile?: null | string): string {
+  return profile?.trim() || 'default'
+}
+
+export function createSessionPinKey(profile: null | string | undefined, id: string): string {
+  return `${normalizeSessionPinProfile(profile)}${SESSION_PIN_KEY_SEPARATOR}${id}`
+}
+
+export function parseSessionPinKey(key: string): null | ParsedSessionPinKey {
+  const separator = key.indexOf(SESSION_PIN_KEY_SEPARATOR)
+
+  if (separator <= 0 || separator === key.length - 1) {
+    return null
+  }
+
+  return {
+    id: key.slice(separator + 1),
+    profile: normalizeSessionPinProfile(key.slice(0, separator))
+  }
+}
+
+export function sessionPinKey(session: SessionInfo): string {
+  return createSessionPinKey(session.profile, sessionPinId(session))
+}
+
+export function sessionScopedId(session: SessionInfo): string {
+  return createSessionPinKey(session.profile, session.id)
+}
+
+export function sessionMatchesPinKey(session: SessionInfo, key: string): boolean {
+  const parsed = parseSessionPinKey(key)
+
+  if (!parsed) {
+    return sessionMatchesStoredId(session, key)
+  }
+
+  return normalizeSessionPinProfile(session.profile) === parsed.profile && sessionMatchesStoredId(session, parsed.id)
+}
+
+export function sessionPinIdsForScope(keys: readonly string[], scope?: string): string[] {
+  const normalizedScope = scope ? normalizeSessionPinProfile(scope) : null
+  const ids: string[] = []
+
+  for (const key of keys) {
+    const parsed = parseSessionPinKey(key)
+
+    if (!parsed) {
+      ids.push(key)
+    } else if (!normalizedScope || parsed.profile === normalizedScope) {
+      ids.push(parsed.id)
+    }
+  }
+
+  return ids
+}

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/hermes', () => ({
 import { $pinnedSessionIds } from '@/store/layout'
 import { $sessions } from '@/store/session'
 
+import { createSessionPinKey } from './session-pin-key'
 import { watchSessionPins } from './session-pin-sync'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
@@ -41,7 +42,7 @@ afterEach(() => {
 describe('watchSessionPins', () => {
   it('mirrors a new pin as pinned=true with the row profile', async () => {
     $sessions.set([row('a', { profile: 'work' })])
-    $pinnedSessionIds.set(['a'])
+    $pinnedSessionIds.set([createSessionPinKey('work', 'a')])
     await flush()
 
     expect(patch).toHaveBeenCalledWith('a', true, 'work')
@@ -49,23 +50,18 @@ describe('watchSessionPins', () => {
 
   it('mirrors an unpin as pinned=false', async () => {
     $sessions.set([row('b')])
-    $pinnedSessionIds.set(['b'])
+    $pinnedSessionIds.set([createSessionPinKey('default', 'b')])
     await flush()
     patch.mockClear()
 
     $pinnedSessionIds.set([])
     await flush()
 
-    expect(patch).toHaveBeenCalledWith('b', false, undefined)
+    expect(patch).toHaveBeenCalledWith('b', false, 'default')
   })
 
-  it('defers a pin whose row is not loaded, then flushes once it appears', async () => {
-    $pinnedSessionIds.set(['c'])
-    await flush()
-    // No row yet -> nothing sent.
-    expect(patch).not.toHaveBeenCalled()
-
-    $sessions.set([row('c', { profile: 'p2' })])
+  it('mirrors a qualified pin before its row is loaded', async () => {
+    $pinnedSessionIds.set([createSessionPinKey('p2', 'c')])
     await flush()
 
     expect(patch).toHaveBeenCalledWith('c', true, 'p2')
@@ -74,15 +70,15 @@ describe('watchSessionPins', () => {
   it('matches a pin id against the lineage root', async () => {
     // pin id is the lineage root; the live row carries it as _lineage_root_id.
     $sessions.set([row('tip', { _lineage_root_id: 'root' })])
-    $pinnedSessionIds.set(['root'])
+    $pinnedSessionIds.set([createSessionPinKey('default', 'root')])
     await flush()
 
-    expect(patch).toHaveBeenCalledWith('root', true, undefined)
+    expect(patch).toHaveBeenCalledWith('root', true, 'default')
   })
 
   it('does not re-PATCH an already-mirrored pin on unrelated session updates', async () => {
     $sessions.set([row('d')])
-    $pinnedSessionIds.set(['d'])
+    $pinnedSessionIds.set([createSessionPinKey('default', 'd')])
     await flush()
     patch.mockClear()
 
@@ -95,18 +91,30 @@ describe('watchSessionPins', () => {
 })
 
 describe('watchSessionPins remote pull', () => {
+  it('migrates an ambiguous legacy id to the cloned profile whose durable row is pinned', async () => {
+    $pinnedSessionIds.set(['shared'])
+    $sessions.set([
+      row('shared', { pinned: false, profile: 'default' }),
+      row('shared', { pinned: true, profile: 'work' })
+    ])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual([createSessionPinKey('work', 'shared')])
+    expect(patch).not.toHaveBeenCalledWith('shared', true, 'default')
+  })
+
   it('adopts a pin another app made', async () => {
     $sessions.set([row('remote', { pinned: true })])
     await flush()
 
-    expect($pinnedSessionIds.get()).toContain('remote')
+    expect($pinnedSessionIds.get()).toContain(createSessionPinKey('default', 'remote'))
   })
 
   it('adopts a remote pin on the durable lineage root, not the live tip', async () => {
     $sessions.set([row('tip', { _lineage_root_id: 'root', pinned: true })])
     await flush()
 
-    expect($pinnedSessionIds.get()).toEqual(['root'])
+    expect($pinnedSessionIds.get()).toEqual([createSessionPinKey('default', 'root')])
   })
 
   it('does not echo an adopted pin back as a redundant write', async () => {
@@ -126,16 +134,18 @@ describe('watchSessionPins remote pull', () => {
     $sessions.set([row('gone', { pinned: false })])
     await flush()
 
-    expect($pinnedSessionIds.get()).not.toContain('gone')
+    expect($pinnedSessionIds.get()).not.toContain(createSessionPinKey('default', 'gone'))
   })
 
   it('leaves the local set alone when the backend omits the flag', async () => {
-    $pinnedSessionIds.set(['legacy'])
+    const pinKey = createSessionPinKey('default', 'legacy')
+
+    $pinnedSessionIds.set([pinKey])
     // No `pinned` key at all — a runtime predating the column.
     $sessions.set([row('legacy')])
     await flush()
 
-    expect($pinnedSessionIds.get()).toContain('legacy')
+    expect($pinnedSessionIds.get()).toContain(pinKey)
   })
 
   it('does not revert a fresh local pin while the loaded row is still stale (#74570)', async () => {
@@ -146,18 +156,20 @@ describe('watchSessionPins remote pull', () => {
     await flush()
     patch.mockClear()
 
-    $pinnedSessionIds.set(['fresh'])
+    const pinKey = createSessionPinKey('default', 'fresh')
+
+    $pinnedSessionIds.set([pinKey])
     await flush()
 
-    expect($pinnedSessionIds.get()).toContain('fresh')
-    expect(patch).toHaveBeenCalledWith('fresh', true, undefined)
+    expect($pinnedSessionIds.get()).toContain(pinKey)
+    expect(patch).toHaveBeenCalledWith('fresh', true, 'default')
   })
 
   it('does not revert a fresh local unpin while the loaded row still says pinned (#74570)', async () => {
     // Adopt a server-side pin first, so it's held locally and mirrored.
     $sessions.set([row('sticky', { pinned: true })])
     await flush()
-    expect($pinnedSessionIds.get()).toContain('sticky')
+    expect($pinnedSessionIds.get()).toContain(createSessionPinKey('default', 'sticky'))
     patch.mockClear()
 
     // User unpins while the loaded row still says pinned=true.
@@ -165,10 +177,10 @@ describe('watchSessionPins remote pull', () => {
     await flush()
 
     expect($pinnedSessionIds.get()).not.toContain('sticky')
-    expect(patch).toHaveBeenCalledWith('sticky', false, undefined)
+    expect(patch).toHaveBeenCalledWith('sticky', false, 'default')
   })
 
-  it('keeps a deferred pin (row not yet loaded) when a stale page finally arrives', async () => {
+  it('migrates a unique legacy pin when its row finally appears', async () => {
     $pinnedSessionIds.set(['deferred'])
     await flush()
     expect(patch).not.toHaveBeenCalled()
@@ -177,8 +189,8 @@ describe('watchSessionPins remote pull', () => {
     $sessions.set([row('deferred', { pinned: false })])
     await flush()
 
-    expect($pinnedSessionIds.get()).toContain('deferred')
-    expect(patch).toHaveBeenCalledWith('deferred', true, undefined)
+    expect($pinnedSessionIds.get()).toContain(createSessionPinKey('default', 'deferred'))
+    expect(patch).toHaveBeenCalledWith('deferred', true, 'default')
   })
 
   it('ignores a stale page that contradicts a write still in flight', async () => {
@@ -187,16 +199,18 @@ describe('watchSessionPins remote pull', () => {
     patch.mockImplementationOnce(() => new Promise(resolve => (settle = resolve)))
 
     $sessions.set([row('race')])
-    $pinnedSessionIds.set(['race'])
+    const pinKey = createSessionPinKey('default', 'race')
+
+    $pinnedSessionIds.set([pinKey])
     await flush()
-    expect(patch).toHaveBeenCalledWith('race', true, undefined)
+    expect(patch).toHaveBeenCalledWith('race', true, 'default')
 
     // A list request issued before the PATCH lands still says pinned=false.
     // Honouring it would silently undo the pin the user just made.
     $sessions.set([row('race', { pinned: false })])
     await flush()
 
-    expect($pinnedSessionIds.get()).toContain('race')
+    expect($pinnedSessionIds.get()).toContain(pinKey)
 
     // Once the write is acked, later server truth is honoured again.
     settle({ ok: true })
@@ -206,6 +220,6 @@ describe('watchSessionPins remote pull', () => {
     $sessions.set([row('race', { pinned: false }), row('other')])
     await flush()
 
-    expect($pinnedSessionIds.get()).not.toContain('race')
+    expect($pinnedSessionIds.get()).not.toContain(pinKey)
   })
 })

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -1,162 +1,176 @@
 /**
- * Reconcile the sidebar's pins with the backend "keep" flag, both directions.
+ * Reconcile the sidebar's local pin order with each profile's durable backend
+ * `sessions.pinned` flag.
  *
- * Pins drive the sidebar UI out of `$pinnedSessionIds` (localStorage), but the
- * durable record is `sessions.pinned` in each profile's state.db. Two things
- * depend on the backend copy: the `sessions.auto_archive` sweep runs
- * server-side and would otherwise hide a pinned chat, and a second Desktop app
- * pointed at the same gateway has its own, separate localStorage.
- *
- * Push: PATCH `pinned` whenever the local set changes, and re-assert the whole
- * set at boot — which transparently migrates pre-existing pins with no user
- * action.
- *
- * Pull: session rows now carry `pinned`, and the list endpoints back-fill
- * pinned conversations past their LIMIT, so a row's absence from a page no
- * longer says anything about its pin state. That makes the server row
- * authoritative: adopt pins this app hasn't seen, and drop local pins the
- * server says are gone. Only rows actually present in the payload are
- * consulted, so a backend predating the flag (`pinned === undefined`) leaves
- * the local set untouched.
+ * Persisted keys are profile-qualified (`profile\0lineage-root-id`). Older
+ * Desktop builds stored only the unqualified id. Legacy keys migrate once the
+ * owning row is known: a unique match keeps the user's local intent, while
+ * cloned ids with conflicting server state adopt only the profile rows whose
+ * durable flag is true. Ambiguous all-false clones stay legacy until a concrete
+ * profile page makes ownership unambiguous; we never guess and pin a sibling.
  */
 
 import { setSessionPinnedRemote } from '@/hermes'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
+import { $cronSessions, $messagingSessions, $sessions } from '@/store/session'
 
-// pin ids we've successfully PATCHed pinned=true this session.
+import { parseSessionPinKey, sessionMatchesPinKey, sessionPinKey } from './session-pin-key'
+
+// Qualified keys confirmed by this app or adopted from a server row.
 const mirrored = new Set<string>()
-// pin ids awaiting their row so we can resolve the owning profile before PATCH.
-const pending = new Set<string>()
-// Writes we've issued but not yet had acked, id -> value written. A list page
-// already in flight when we PATCH still carries the old value, so it must not
-// be read as the server disagreeing with us. Cleared when the write settles —
-// the request's own lifetime is the guard, so nothing can leave one open.
+// Writes issued but not yet acknowledged. A session page already in flight may
+// carry the old value, so the local write must win until its request settles.
 const unconfirmed = new Map<string, boolean>()
 
-function profileFor(pinId: string): null | string | undefined {
-  return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
-}
+const loadedRows = () => [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()]
 
-/** PATCH the flag, guarding reads against pages that predate the write. */
-function writePin(id: string, pinned: boolean, profile?: null | string): Promise<void> {
-  unconfirmed.set(id, pinned)
+function writePin(key: string, pinned: boolean): Promise<void> {
+  const parsed = parseSessionPinKey(key)
 
-  return setSessionPinnedRemote(id, pinned, profile).then(
+  if (!parsed) {
+    return Promise.resolve()
+  }
+
+  unconfirmed.set(key, pinned)
+
+  return setSessionPinnedRemote(parsed.id, pinned, parsed.profile).then(
     () => {
-      unconfirmed.delete(id)
+      if (unconfirmed.get(key) === pinned) {
+        unconfirmed.delete(key)
+      }
     },
     (err: unknown) => {
-      unconfirmed.delete(id)
+      if (unconfirmed.get(key) === pinned) {
+        unconfirmed.delete(key)
+      }
+
       throw err
     }
   )
 }
 
-/**
- * Adopt the server's pin state for every row in the current page.
- *
- * Runs after the push pass so local intent is already fenced (`pending` /
- * `unconfirmed`) by the time the page is read — a fresh local toggle whose
- * PATCH hasn't landed yet must win over the stale row, not be reverted by it
- * (#74570). Remote pins adopted here are marked mirrored before the local set
- * changes, so the re-entrant reconcile doesn't echo them back as a PATCH.
- */
+/** Resolve old id-only entries without letting a cloned sibling claim them. */
+function migrateLegacyKeys(keys: readonly string[]): string[] {
+  const rows = loadedRows()
+  const next: string[] = []
+
+  const add = (key: string) => {
+    if (!next.includes(key)) {
+      next.push(key)
+    }
+  }
+
+  for (const key of keys) {
+    if (parseSessionPinKey(key)) {
+      add(key)
+
+      continue
+    }
+
+    const candidates = new Map<string, (typeof rows)[number]>()
+
+    for (const row of rows) {
+      if (sessionMatchesPinKey(row, key)) {
+        candidates.set(sessionPinKey(row), row)
+      }
+    }
+
+    if (candidates.size === 1) {
+      add([...candidates.keys()][0])
+
+      continue
+    }
+
+    if (candidates.size > 1) {
+      const durablePins = [...candidates].filter(([, row]) => row.pinned === true)
+
+      if (durablePins.length > 0) {
+        for (const [qualified] of durablePins) {
+          add(qualified)
+        }
+
+        continue
+      }
+    }
+
+    // No row yet, or several all-false/flagless clones: preserve the old key
+    // until a concrete profile page can resolve it without guessing.
+    add(key)
+  }
+
+  return next
+}
+
 function pullRemotePins(): void {
   const local = new Set($pinnedSessionIds.get())
 
-  for (const row of $sessions.get()) {
-    // A backend without the flag has no opinion; never act on `undefined`.
+  for (const row of loadedRows()) {
     if (typeof row.pinned !== 'boolean') {
       continue
     }
 
-    // Pins are keyed on the durable lineage root so they survive compression
-    // tip rotation; the row may surface under either identity.
-    const pinId = sessionPinId(row)
-    const heldLocally = local.has(pinId) || local.has(row.id)
-
-    // A write of ours the page hasn't caught up to yet is newer than the page.
-    const awaited = unconfirmed.has(pinId) ? unconfirmed.get(pinId) : unconfirmed.get(row.id)
+    const key = sessionPinKey(row)
+    const heldLocally = local.has(key)
+    const awaited = unconfirmed.get(key)
 
     if (awaited !== undefined && awaited !== row.pinned) {
       continue
     }
 
-    // Local intent still waiting on its PATCH (row unresolved when the push
-    // pass ran) is also newer than the page — never revert it.
-    if (pending.has(pinId) || pending.has(row.id)) {
-      continue
-    }
-
     if (row.pinned && !heldLocally) {
-      // Mark mirrored first: pinSession fires the pin listener synchronously,
-      // and the nested reconcile must not see this as a new pin to PATCH.
-      mirrored.add(pinId)
-      pinSession(pinId)
+      // Fence the synchronous pin listener before mutating the atom so an
+      // adopted server pin is not echoed back as a redundant PATCH.
+      mirrored.add(key)
+      pinSession(key)
     } else if (!row.pinned && heldLocally) {
-      // Same discipline on the way down: forget the mirror before the nested
-      // reconcile runs, or it re-PATCHes pinned=false the server already has.
-      mirrored.delete(pinId)
-      mirrored.delete(row.id)
-      unpinSession(local.has(pinId) ? pinId : row.id)
+      // Likewise, forget the mirror first so the nested reconcile does not
+      // PATCH false for a change the server already reported.
+      mirrored.delete(key)
+      unpinSession(key)
     }
   }
 }
 
 function reconcile(): void {
-  // Config/session REST is only reachable through the Electron bridge.
   if (!window.hermesDesktop) {
     return
   }
 
-  // Push before pull. The pin listener fires synchronously on a local toggle,
-  // so this reconcile runs before the PATCH for that toggle exists anywhere.
-  // The push pass below records the intent (`pending`, then `unconfirmed` via
-  // writePin) — only then may the pull read the page, where those fences stop
-  // the still-stale row from silently reverting the user's action (#74570).
-  const current = new Set($pinnedSessionIds.get())
+  const stored = $pinnedSessionIds.get()
+  const migrated = migrateLegacyKeys(stored)
 
-  // Unpinned: anything we were tracking that's no longer in the set.
-  for (const id of [...mirrored, ...pending]) {
-    if (!current.has(id)) {
-      mirrored.delete(id)
-      pending.delete(id)
-      void writePin(id, false, profileFor(id)).catch(() => {})
+  if (migrated.length !== stored.length || migrated.some((key, index) => key !== stored[index])) {
+    $pinnedSessionIds.set(migrated)
+
+    return
+  }
+
+  const current = new Set(stored.filter(key => parseSessionPinKey(key)))
+
+  for (const key of [...mirrored]) {
+    if (!current.has(key)) {
+      mirrored.delete(key)
+      void writePin(key, false).catch(() => {})
     }
   }
 
-  // Newly pinned: hold until we can resolve the row (for its profile).
-  for (const id of current) {
-    if (!mirrored.has(id)) {
-      pending.add(id)
+  for (const key of current) {
+    if (!mirrored.has(key)) {
+      mirrored.add(key)
+      void writePin(key, true).catch(() => {
+        mirrored.delete(key)
+      })
     }
-  }
-
-  // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
-  // retry on the next $sessions change.
-  for (const id of [...pending]) {
-    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
-
-    if (!row) {
-      continue
-    }
-
-    pending.delete(id)
-    mirrored.add(id)
-    void writePin(id, true, row.profile).catch(() => {
-      // Let a later reconcile retry the mirror.
-      mirrored.delete(id)
-      pending.add(id)
-    })
   }
 
   pullRemotePins()
 }
 
-// Sync once, then re-sync on pin-set and session-list changes. Call once per app.
+// Sync once, then follow every session slice that can own a sidebar pin.
 export function watchSessionPins(): void {
   reconcile()
   $pinnedSessionIds.listen(reconcile)
   $sessions.listen(reconcile)
+  $cronSessions.listen(reconcile)
+  $messagingSessions.listen(reconcile)
 }

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -391,6 +391,10 @@ export const $messagingTruncated = atom<boolean>(false)
 // "is there another page?" is what pagination actually needs and comes free
 // from the row count the query already returned.
 export const $sessionProfilesTruncated = atom<Record<string, boolean>>({})
+// Durable recents pins owned by profiles outside the active concrete scope.
+// Kept as a summary rather than session rows because cloned profiles may share
+// ids and the Desktop's persisted pin keys are intentionally unqualified.
+export const $hiddenPinnedSessionCount = atom(0)
 export const $sessionsLoading = atom(true)
 export const $activeSessionId = atom<string | null>(null)
 export const $selectedStoredSessionId = atom<string | null>(null)
@@ -475,6 +479,7 @@ export const setMessagingPlatformTotals = (next: Updater<Record<string, number>>
 export const setMessagingTruncated = (next: Updater<boolean>) => updateAtom($messagingTruncated, next)
 export const setSessionProfilesTruncated = (next: Updater<Record<string, boolean>>) =>
   updateAtom($sessionProfilesTruncated, next)
+export const setHiddenPinnedSessionCount = (next: Updater<number>) => updateAtom($hiddenPinnedSessionCount, next)
 export const setSessionsLoading = (next: Updater<boolean>) => updateAtom($sessionsLoading, next)
 export const setActiveSessionId = (next: Updater<string | null>) => updateAtom($activeSessionId, next)
 export const setActiveSessionStoredIdRotation = (next: Updater<ActiveSessionStoredIdRotation | null>) =>

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -221,7 +221,11 @@ def get_profiles_sessions_sidebar(
     from hermes_state import SessionDB
     from hermes_cli import profiles as profiles_mod
 
-    # cron + messaging are cross-profile; recents is scoped to recents_profile.
+    # cron + messaging are cross-profile; ordinary recents are scoped to
+    # recents_profile. Count durable pins in other profiles separately so the
+    # renderer can explain hidden pins without mixing profile rows. Profile
+    # clones may legitimately share session ids, so appending sibling rows to
+    # the scoped list would make the unqualified Desktop pin index ambiguous.
     # Scan every profile once regardless (each DB opened a single time).
     try:
         infos = profiles_mod.list_profiles()
@@ -241,6 +245,7 @@ def get_profiles_sessions_sidebar(
     messaging_cap = min(max(messaging_limit, 1), 500)
 
     recents_rows: List[Dict[str, Any]] = []
+    hidden_pinned_count = 0
     cron_rows: List[Dict[str, Any]] = []
     messaging_rows: List[Dict[str, Any]] = []
     recents_truncated: Dict[str, bool] = {}
@@ -297,6 +302,14 @@ def get_profiles_sessions_sidebar(
                 unpinned_count = sum(1 for s in profile_rows if not s.get("pinned"))
                 recents_truncated[name] = unpinned_count >= recents_cap
                 recents_rows.extend(_tag(profile_rows, name))
+            else:
+                hidden_pinned_count += db.session_count(
+                    exclude_sources=recents_exclude_list or None,
+                    min_message_count=1,
+                    include_archived=False,
+                    exclude_children=True,
+                    pinned_only=True,
+                )
             cron_rows.extend(_tag(_slice(db, source="cron", cap=cron_cap), name))
             messaging_rows.extend(
                 _tag(_slice(db, exclude=messaging_exclude_list, cap=messaging_cap), name)
@@ -321,6 +334,7 @@ def get_profiles_sessions_sidebar(
     return {
         "recents": {
             "sessions": _window(recents_rows, recents_cap),
+            "hidden_pinned_count": hidden_pinned_count,
             "profiles_truncated": recents_truncated,
         },
         "cron": {"sessions": _window(cron_rows, cron_cap)},

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7005,6 +7005,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         archived_only: bool = False,
         exclude_children: bool = False,
         exclude_sources: List[str] = None,
+        pinned_only: bool = False,
     ) -> int:
         """Count sessions, optionally filtered by source.
 
@@ -7019,6 +7020,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (e.g. ``["cron"]`` so the recents "load more" total matches a
         cron-excluded ``list_sessions_rich`` page and doesn't keep "load more"
         stuck on for buried scheduler sessions).
+
+        Pass ``pinned_only=True`` for a cheap durable-pin summary without
+        hydrating full session rows and previews.
         """
         where_clauses = []
         params = []
@@ -7045,6 +7049,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if min_message_count > 0:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
+        if pinned_only:
+            where_clauses.append("s.pinned = 1")
         if archived_only:
             where_clauses.append("s.archived = 1")
         elif not include_archived:

--- a/tests/hermes_cli/test_web_server_sidebar_sessions.py
+++ b/tests/hermes_cli/test_web_server_sidebar_sessions.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+from hermes_cli import profiles as profiles_mod
+from hermes_cli.web_routers import profiles as profiles_router
+from hermes_state import SessionDB
+
+
+def _seed(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    db = SessionDB(db_path=path)
+    try:
+        for row in rows:
+            db.create_session(row["id"], source=row.get("source", "desktop"))
+            db.append_message(row["id"], role="user", content=row["id"])
+            if row.get("pinned"):
+                db.set_session_pinned(row["id"], True)
+            if row.get("archived"):
+                db.set_session_archived(row["id"], True)
+    finally:
+        db.close()
+
+
+def test_sidebar_reports_sibling_pins_without_mixing_profile_rows(tmp_path, monkeypatch):
+    default_home = tmp_path / "default"
+    work_home = tmp_path / "work"
+    _seed(default_home / "state.db", [{"id": "same-id", "pinned": True}])
+    _seed(
+        work_home / "state.db",
+        [
+            {"id": "same-id", "pinned": True},
+            {"id": "work-ordinary"},
+            {"id": "work-archived-pin", "pinned": True, "archived": True},
+            {"id": "work-cron-pin", "pinned": True, "source": "cron"},
+        ],
+    )
+    monkeypatch.setattr(
+        profiles_mod,
+        "list_profiles",
+        lambda: [
+            SimpleNamespace(name="default", path=default_home),
+            SimpleNamespace(name="work", path=work_home),
+        ],
+    )
+    monkeypatch.setattr(profiles_router, "_strip_session_list_rows", lambda rows: rows)
+
+    result = profiles_router.get_profiles_sessions_sidebar(
+        recents_profile="default",
+        recents_limit=1,
+        recents_exclude="cron",
+        cron_limit=1,
+        messaging_limit=1,
+        messaging_exclude="cron,desktop",
+    )
+
+    assert [(row["id"], row["profile"]) for row in result["recents"]["sessions"]] == [
+        ("same-id", "default")
+    ]
+    assert result["recents"]["hidden_pinned_count"] == 1

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2399,6 +2399,20 @@ class TestSessionPinAndStaleArchive:
         assert with_pins[:3] == page
         assert len(with_pins) == len(page) + 1
 
+    def test_session_count_can_select_only_listable_pins(self, db):
+        self._make_idle(db, "keep", days_idle=3)
+        self._make_idle(db, "ordinary", days_idle=2)
+        self._make_idle(db, "archived", days_idle=1)
+        db.set_session_pinned("keep", True)
+        db.set_session_pinned("archived", True)
+        db.set_session_archived("archived", True)
+
+        assert db.session_count(
+            min_message_count=1,
+            exclude_children=True,
+            pinned_only=True,
+        ) == 1
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Keeps profile-scoped Desktop recents isolated while making durable pins in sibling profiles visible as a summary instead of silently making those conversations look deleted.

The sidebar returns a cheap `hidden_pinned_count`, shows `+N` beside Pinned, and offers **Show all profiles**. It deliberately does not merge sibling-profile rows into a concrete profile's recents: cloned profiles can legitimately contain identical session IDs.

Desktop pin persistence now uses profile-qualified identities, with conservative migration of legacy unqualified IDs. This lets cloned profiles sharing a session ID retain independent, opposing pin states without one profile's row overwriting or unpinning the other. Empty selected profiles also retain the hidden-pin notice and recovery action.

The Electron remote-profile merge preserves pinned backfills beyond the normal recency window and computes the same hidden-pin summary for remote configurations.

## Related Issue

Related to #51685 and #74760.

This addresses the profile-scope/remote-pagination discovery path; no session-row deletion was demonstrated. It also resolves both issues from the automated review on the first revision: empty-profile notice visibility and cloned-ID pin ambiguity.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a filtered `SessionDB.session_count(..., pinned_only=True)` summary path.
- Return sibling-profile durable pin counts separately from profile-scoped recents.
- Store and clear the hidden-pin summary with the rest of gateway-bound session state.
- Show the count in the Pinned section with a route to the all-profiles view, including when the selected profile has no local sessions or projects.
- Persist Desktop pins as `profile + lineage-root-id` identities across sidebar, tab, command-centre, drag-order, archive/delete, and sync paths.
- Migrate legacy ID-only pins when ownership is known; for ambiguous cloned IDs, adopt explicit durable pins rather than guessing a sibling profile.
- Route default-profile pin writes explicitly, so all-profile operation cannot accidentally mutate the currently active named profile.
- Preserve old pinned rows after Electron merges and windows local/remote profile results.
- Keep concrete-profile payloads scoped: sibling session objects never enter that renderer index.

## How to Test

1. Pin a session in profile A, switch to an empty profile B, and confirm Pinned shows `+1` plus **Show all profiles** without profile A's ordinary recents leaking into B.
2. Clone profiles so both contain the same session ID, pin it in one profile only, select All profiles, and confirm the two rows retain opposing states.
3. Run:
   - `scripts/run_tests.sh tests/test_hermes_state.py tests/hermes_cli/test_web_server_sidebar_sessions.py -q` — 142 passed
   - `npx vitest run --project ui` — 3,298 passed
   - `npx vitest run --project electron` — 935 passed, 2 skipped
   - `npm run typecheck` — passed (renderer, Electron, E2E)
   - `npm run lint` — 0 errors (82 existing warnings outside this change)
   - `npm run build` — passed
   - `uv run ruff check hermes_state.py hermes_cli/web_routers/profiles.py tests/test_hermes_state.py tests/hermes_cli/test_web_server_sidebar_sessions.py` — passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user configuration changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — platform-neutral Python/TypeScript plus full Electron platform suite
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The empty-profile notice, cloned-ID indexing/migration, scoped hydration, UI interaction, and Electron pagination paths have automated regression coverage. The production Desktop build completes successfully.
