### PR TITLE
fix(kanban): skip blocked triage tasks in decomposer

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -653,6 +653,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         default=None,
         help="Optional reason/note — recorded as a comment before unblocking. Quote multi-word reasons.",
     )
+    p_unblock.add_argument(
+        "--recover-escalated", action="store_true",
+        help="Clear a human-reviewed triage escalation so the decomposer can retry it",
+    )
     p_unblock.add_argument("task_ids", nargs="+")
 
     p_promote = sub.add_parser(
@@ -2328,9 +2332,14 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
         for tid in ids:
             if reason:
                 kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
-            if not kb.unblock_task(conn, tid):
+            ok = (
+                kb.recover_escalated_triage_task(conn, tid)
+                if getattr(args, "recover_escalated", False)
+                else kb.unblock_task(conn, tid)
+            )
+            if not ok:
                 failed.append(tid)
-                print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
+                print(f"cannot unblock {tid} (not blocked/scheduled or escalated triage?)", file=sys.stderr)
             else:
                 print(f"Unblocked {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5751,6 +5751,19 @@ def promote_task(
     return True, None
 
 
+def recover_escalated_triage_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Acknowledge a human decision and make an escalated triage task decomposable."""
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE tasks SET block_kind = NULL WHERE id = ? AND status = 'triage' AND block_kind IS NOT NULL",
+            (task_id,),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(conn, task_id, "triage_escalation_recovered", None)
+        return True
+
+
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """Transition ``blocked``/``scheduled`` -> ready or todo.
 

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -289,6 +289,13 @@ def decompose_task(
         return DecomposeOutcome(
             task_id, False, f"task is not in triage (status={task.status!r})"
         )
+    if task.block_kind is not None:
+        return DecomposeOutcome(
+            task_id,
+            False,
+            f"task escalated to triage after repeated {task.block_kind!r} blocks; "
+            "waiting on human input — refusing to re-specify",
+        )
 
     cfg = _load_config()
     orchestrator = _resolve_orchestrator_profile(cfg)
@@ -457,12 +464,13 @@ def decompose_task(
 
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
-    """Return task ids currently in the triage column."""
+    """Return decomposable task ids currently in the triage column."""
+    query = "SELECT id FROM tasks WHERE status = 'triage' AND block_kind IS NULL"
+    params: list[str] = []
+    if tenant is not None:
+        query += " AND tenant = ?"
+        params.append(tenant)
+    query += " ORDER BY priority DESC, created_at ASC LIMIT 1000"
     with kb.connect_closing() as conn:
-        rows = kb.list_tasks(
-            conn,
-            status="triage",
-            tenant=tenant,
-            limit=1000,
-        )
-    return [row.id for row in rows]
+        rows = conn.execute(query, params).fetchall()
+    return [row["id"] for row in rows]

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -7,12 +7,14 @@ and the assignee-fallback logic.
 
 from __future__ import annotations
 
+import argparse
 import json as jsonlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hermes_cli import kanban as kc
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_decompose as decomp
 
@@ -173,28 +175,48 @@ def test_blocked_triage_tasks_are_not_decomposed_until_a_human_clears_the_block(
     assert task_id not in decomp.list_triage_ids()
     with patch("agent.auxiliary_client.call_llm") as call_llm:
         outcome = decomp.decompose_task(task_id, author="me")
-    assert outcome.ok is False
-    assert "waiting on human input" in outcome.reason
-    call_llm.assert_not_called()
+        assert outcome.ok is False
+        assert "waiting on human input" in outcome.reason
+        call_llm.assert_not_called()
 
-    with kb.connect_closing() as conn:
-        task = kb.get_task(conn, task_id)
+        parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+        subparsers = parser.add_subparsers(dest="command")
+        kc.build_parser(subparsers)
+        args = parser.parse_args(
+            [
+                "kanban",
+                "unblock",
+                "--recover-escalated",
+                "--reason",
+                "operator retry approved",
+                task_id,
+            ]
+        )
+        assert kc.kanban_command(args) == 0
+
+        with kb.connect_closing() as conn:
+            task = kb.get_task(conn, task_id)
+            events = kb.list_events(conn, task_id)
+            comments = kb.list_comments(conn, task_id)
         assert task.status == "triage"
-        assert task.block_kind == "capability"
-        assert kb.recover_escalated_triage_task(conn, task_id) is True
+        assert task.block_kind is None
+        assert task.block_recurrences == kb.BLOCK_RECURRENCE_LIMIT
+        assert any(event.kind == "triage_escalation_recovered" for event in events)
+        assert any(comment.body == "UNBLOCK: operator retry approved" for comment in comments)
+        assert task_id in decomp.list_triage_ids()
 
-    assert task_id in decomp.list_triage_ids()
-
-    patches = _patch_list_profiles(["orchestrator"])
-    for profile_patch in patches:
-        profile_patch.start()
-    try:
-        with _patch_aux_client(
-            jsonlib.dumps({"fanout": False, "title": "respecified", "body": "ready to retry"})
-        ), _patch_extra_body():
-            outcome = decomp.decompose_task(task_id, author="me")
-    finally:
+        patches = _patch_list_profiles(["orchestrator"])
         for profile_patch in patches:
-            profile_patch.stop()
+            profile_patch.start()
+        try:
+            call_llm.return_value = _fake_aux_response(
+                jsonlib.dumps({"fanout": False, "title": "respecified", "body": "ready to retry"})
+            )
+            with _patch_extra_body():
+                outcome = decomp.decompose_task(task_id, author="me")
+        finally:
+            for profile_patch in patches:
+                profile_patch.stop()
 
-    assert outcome.ok is True
+        assert outcome.ok is True
+        call_llm.assert_called_once()

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -161,3 +161,40 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def test_blocked_triage_tasks_are_not_decomposed_until_a_human_clears_the_block(kanban_home):
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="awaiting capability", triage=True)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET block_kind = ?, block_recurrences = ? WHERE id = ?",
+                ("capability", kb.BLOCK_RECURRENCE_LIMIT, task_id),
+            )
+
+    assert task_id not in decomp.list_triage_ids()
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
+        outcome = decomp.decompose_task(task_id, author="me")
+    assert outcome.ok is False
+    assert "waiting on human input" in outcome.reason
+    call_llm.assert_not_called()
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task.status == "triage"
+        assert task.block_kind == "capability"
+        assert kb.recover_escalated_triage_task(conn, task_id) is True
+
+    assert task_id in decomp.list_triage_ids()
+
+    patches = _patch_list_profiles(["orchestrator"])
+    for profile_patch in patches:
+        profile_patch.start()
+    try:
+        with _patch_aux_client(
+            jsonlib.dumps({"fanout": False, "title": "respecified", "body": "ready to retry"})
+        ), _patch_extra_body():
+            outcome = decomp.decompose_task(task_id, author="me")
+    finally:
+        for profile_patch in patches:
+            profile_patch.stop()
+
+    assert outcome.ok is True


### PR DESCRIPTION
## Summary
- keep triage tasks with a stored block reason out of auto-decomposition
- filter them in SQL before the decomposer worklist limit
- allow decomposition again once a human clears the block reason

Fixes #75444

## Tests
- `pytest -q tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_block_kinds.py`
- `ruff check hermes_cli/kanban_decompose.py tests/hermes_cli/test_kanban_decompose.py`