### PR TITLE
fix(update): make pre-update snapshot size cap configurable (#75411)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2679,6 +2679,13 @@ DEFAULT_CONFIG = {
         # Values below 1 are floored to 1 — the backup just created is
         # always preserved. The quick snapshot always keeps exactly 1.
         "backup_keep": 5,
+        # Per-file size cap (bytes) for the pre-update quick snapshot.
+        # Files larger than this are skipped with a warning so a bloated
+        # state.db can never stall ``hermes update`` or silently eat disk.
+        # ``None`` (default) keeps the built-in 1 GiB cap; raise it (e.g.
+        # ``5368709120`` for 5 GiB) to include a legitimately large
+        # state.db in the snapshot. Set to ``0`` for no cap.
+        "pre_update_snapshot_max_file_size": None,
         # What `hermes update` does with uncommitted local changes to the
         # source tree when it runs NON-interactively — i.e. triggered from
         # the desktop/chat app or the gateway, where there's no TTY to answer

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2231,6 +2231,47 @@ _PRE_UPDATE_SNAPSHOT_KEEP = 1
 # of wall time and silently ate 24 GB of disk per update).
 _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE = 1 << 30  # 1 GiB
 
+def _resolve_pre_update_snapshot_max_file_size(args) -> int:
+    """Resolve the per-file size cap for the pre-update quick snapshot.
+
+    ``updates.pre_update_snapshot_max_file_size`` (bytes) overrides the
+    hardcoded 1 GiB default so an operator with a legitimately large
+    state.db (issue #75411) can opt into snapshotting it. ``None`` /
+    missing keeps the default; ``0`` disables the cap; invalid or
+    non-positive values fall back to the default with a warning.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception as exc:
+        logging.getLogger(__name__).debug(
+            "Could not load config for pre-update snapshot cap: %s", exc
+        )
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+
+    updates_cfg = cfg.get("updates", {}) if isinstance(cfg, dict) else {}
+    raw = updates_cfg.get("pre_update_snapshot_max_file_size")
+    if raw is None:
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logging.getLogger(__name__).warning(
+            "Ignoring invalid updates.pre_update_snapshot_max_file_size %r "
+            "— using default 1 GiB cap",
+            raw,
+        )
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+    if value < 0:
+        logging.getLogger(__name__).warning(
+            "Ignoring negative updates.pre_update_snapshot_max_file_size %d "
+            "— using default 1 GiB cap",
+            value,
+        )
+        return _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+    return value
+
 def _resolve_pre_update_backup_mode(args) -> str:
     """Resolve the pre-update backup mode: ``"off"``, ``"quick"``, or ``"full"``.
 
@@ -2323,7 +2364,7 @@ def _run_pre_update_backup(args) -> Optional[str]:
         snapshot_id = create_quick_snapshot(
             label="pre-update",
             keep=_PRE_UPDATE_SNAPSHOT_KEEP,
-            max_file_size=_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+            max_file_size=_resolve_pre_update_snapshot_max_file_size(args),
         )
 
         # After the snapshot, verify the source state.db is still intact.
@@ -2339,7 +2380,7 @@ def _run_pre_update_backup(args) -> Optional[str]:
                     _src_path,
                     check_header=True,
                     run_pragma=True,
-                    max_bytes=_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+                    max_bytes=_resolve_pre_update_snapshot_max_file_size(args),
                 )
                 if not _integrity.get("valid"):
                     _msg = _integrity.get("message", "unknown error")

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1055,6 +1055,67 @@ class TestRunPreUpdateBackup:
         assert len(self._zips(hermes_home)) == 1
 
 
+    def _set_snapshot_cap(self, hermes_home, value):
+        import yaml
+        (hermes_home / "config.yaml").write_text(yaml.safe_dump({
+            "_config_version": 22,
+            "updates": {"pre_update_snapshot_max_file_size": value},
+        }))
+
+    def test_snapshot_max_file_size_default(self, hermes_home):
+        """#75411: no config override → built-in 1 GiB cap."""
+        from hermes_cli.update_cmd import _resolve_pre_update_snapshot_max_file_size
+        assert _resolve_pre_update_snapshot_max_file_size(Namespace()) == 1 << 30
+
+    def test_snapshot_max_file_size_override(self, hermes_home):
+        """#75411: config override raises the cap (e.g. a 5 GiB state.db)."""
+        from hermes_cli.update_cmd import _resolve_pre_update_snapshot_max_file_size
+        self._set_snapshot_cap(hermes_home, 5 * (1 << 30))
+        assert _resolve_pre_update_snapshot_max_file_size(Namespace()) == 5 * (1 << 30)
+
+    def test_snapshot_max_file_size_zero_disables_cap(self, hermes_home):
+        """#75411: ``0`` disables the cap entirely."""
+        from hermes_cli.update_cmd import _resolve_pre_update_snapshot_max_file_size
+        self._set_snapshot_cap(hermes_home, 0)
+        assert _resolve_pre_update_snapshot_max_file_size(Namespace()) == 0
+
+    def test_snapshot_max_file_size_invalid_falls_back(self, hermes_home):
+        """#75411: invalid or negative config falls back to the default cap."""
+        from hermes_cli.update_cmd import _resolve_pre_update_snapshot_max_file_size
+        self._set_snapshot_cap(hermes_home, "garbage")
+        assert _resolve_pre_update_snapshot_max_file_size(Namespace()) == 1 << 30
+        self._set_snapshot_cap(hermes_home, -1)
+        assert _resolve_pre_update_snapshot_max_file_size(Namespace()) == 1 << 30
+
+    def test_config_snapshot_cap_controls_state_db_inclusion(self, hermes_home, capsys):
+        """#75411: updates.pre_update_snapshot_max_file_size controls whether
+        a large state.db is snapshotted or skipped with a warning."""
+        db_path = hermes_home / "state.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, data TEXT)")
+        conn.execute("INSERT INTO sessions VALUES ('s1', 'hello world')")
+        conn.commit()
+        conn.close()
+
+        from hermes_cli.main import _run_pre_update_backup
+
+        # Small cap → state.db is skipped (warning printed, not snapshotted).
+        self._set_snapshot_cap(hermes_home, 1024)
+        snap_id = _run_pre_update_backup(Namespace(no_backup=False, backup=False))
+        out = capsys.readouterr().out
+        assert snap_id is not None
+        assert "skipping state.db" in out.lower()
+        assert not (hermes_home / "state-snapshots" / snap_id / "state.db").exists()
+
+        # Large cap → state.db is snapshotted.
+        self._set_snapshot_cap(hermes_home, 100 * 1024 * 1024)
+        snap_id = _run_pre_update_backup(Namespace(no_backup=False, backup=False))
+        out = capsys.readouterr().out
+        assert snap_id is not None
+        assert "skipping state.db" not in out.lower()
+        assert (hermes_home / "state-snapshots" / snap_id / "state.db").exists()
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #75411 — the pre-update quick snapshot skips any file over a hardcoded 1 GiB cap, so users with a legitimately large `state.db` (the reporter's is 5.0 GB) see `⚠ Snapshot: skipping state.db (5.0 GB exceeds 1.0 GB limit)` and get no snapshot of their database.

This makes the per-file size cap configurable via `updates.pre_update_snapshot_max_file_size` (bytes):

- `None` (default) — unchanged behavior, built-in 1 GiB cap.
- Any positive byte value (e.g. `5368709120` for 5 GiB) — files up to that size are included in the pre-update snapshot.
- `0` — disables the cap entirely.
- Invalid / negative values fall back to the default with a warning.

The resolved cap is used both for `create_quick_snapshot(max_file_size=...)` and for the post-snapshot `verify_sqlite_integrity(max_bytes=...)` probe, so the two stay consistent.

## Changes

- `hermes_cli/config_defaults.py` — document the new `updates.pre_update_snapshot_max_file_size` default (`None`).
- `hermes_cli/update_cmd.py` — add `_resolve_pre_update_snapshot_max_file_size()` and use it in `_run_pre_update_backup()`.
- `tests/hermes_cli/test_backup.py` — unit tests for default/override/zero/invalid resolution plus an integration test proving a large `state.db` is skipped under a small cap and included under a raised cap.

## Tests

`tests/hermes_cli/test_backup.py` + `tests/hermes_cli/test_cmd_update.py`: 66 passed (5 new).
