### PR TITLE
fix(kanban): isolate ad-hoc test harness environments

### DIFF
--- a/hermes_cli/kanban_test_context.py
+++ b/hermes_cli/kanban_test_context.py
@@ -1,0 +1,73 @@
+"""Hermetic environment for ad-hoc Kanban regression and E2E harnesses.
+
+This module deliberately imports no Kanban code at module load time.  Worker
+processes inherit board/database pins from their dispatcher, so those variables
+must be removed before a harness imports or resolves ``hermes_cli.kanban_db``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+_KANBAN_ENV_PREFIX = "HERMES_KANBAN_"
+
+
+@dataclass(frozen=True)
+class IsolatedKanbanTestEnvironment:
+    """Resolved paths for a hermetic Kanban harness run."""
+
+    home: Path
+    db_path: Path
+
+
+def _restore_kanban_environment(previous: dict[str, str]) -> None:
+    for name in list(os.environ):
+        if name == "HERMES_HOME" or name.startswith(_KANBAN_ENV_PREFIX):
+            os.environ.pop(name, None)
+    os.environ.update(previous)
+
+
+@contextmanager
+def isolated_kanban_test_context() -> Iterator[IsolatedKanbanTestEnvironment]:
+    """Run an ad-hoc Kanban harness against a fresh temporary Hermes home.
+
+    All inherited ``HERMES_KANBAN_*`` variables are cleared before importing
+    the Kanban DB module.  The resolved default DB path is then required to be
+    below the temporary ``HERMES_HOME``; otherwise the context fails closed
+    before yielding to the harness.
+
+    Import and use ``hermes_cli.kanban_db`` only inside this context.
+    """
+    previous = {
+        name: value
+        for name, value in os.environ.items()
+        if name == "HERMES_HOME" or name.startswith(_KANBAN_ENV_PREFIX)
+    }
+
+    with tempfile.TemporaryDirectory(prefix="hermes-kanban-test-") as tmpdir:
+        home = Path(tmpdir).resolve()
+        for name in list(os.environ):
+            if name.startswith(_KANBAN_ENV_PREFIX):
+                os.environ.pop(name, None)
+        os.environ["HERMES_HOME"] = str(home)
+
+        try:
+            from hermes_cli import kanban_db
+
+            db_path = kanban_db.kanban_db_path().expanduser().resolve()
+            try:
+                db_path.relative_to(home)
+            except ValueError as exc:
+                raise RuntimeError(
+                    "isolated Kanban test DB resolved outside its temporary "
+                    f"HERMES_HOME: {db_path} (home: {home})"
+                ) from exc
+
+            yield IsolatedKanbanTestEnvironment(home=home, db_path=db_path)
+        finally:
+            _restore_kanban_environment(previous)

--- a/tests/hermes_cli/test_kanban_test_context.py
+++ b/tests/hermes_cli/test_kanban_test_context.py
@@ -1,0 +1,74 @@
+"""Regression tests for hermetic Kanban E2E/probe harnesses."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _create_sentinel_db(path: Path) -> bytes:
+    path.parent.mkdir(parents=True)
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE production_sentinel (value TEXT NOT NULL)")
+        conn.execute("INSERT INTO production_sentinel VALUES ('untouched')")
+    return path.read_bytes()
+
+
+def test_isolated_context_ignores_worker_pins_and_preserves_pinned_db(
+    tmp_path, monkeypatch
+):
+    production_db = tmp_path / "production" / "kanban.db"
+    production_before = _create_sentinel_db(production_db)
+    worker_env = {
+        "HERMES_HOME": str(tmp_path / "worker-profile"),
+        "HERMES_KANBAN_DB": str(production_db),
+        "HERMES_KANBAN_BOARD": "pascas-labs",
+        "HERMES_KANBAN_HOME": str(production_db.parent),
+        "HERMES_KANBAN_WORKSPACES_ROOT": str(production_db.parent / "workspaces"),
+        "HERMES_KANBAN_LOGS_ROOT": str(production_db.parent / "logs"),
+        "HERMES_KANBAN_TASK": "t_production_worker",
+        "HERMES_KANBAN_FUTURE_ROUTING_PIN": str(production_db.parent),
+    }
+    for name, value in worker_env.items():
+        monkeypatch.setenv(name, value)
+
+    from hermes_cli.kanban_test_context import isolated_kanban_test_context
+
+    with isolated_kanban_test_context() as isolated:
+        assert not any(name.startswith("HERMES_KANBAN_") for name in os.environ)
+        assert Path(os.environ["HERMES_HOME"]).resolve() == isolated.home
+
+        from hermes_cli import kanban_db as kb
+
+        assert kb.kanban_db_path().resolve() == isolated.db_path
+        isolated.db_path.relative_to(isolated.home)
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn,
+                title="regression probe",
+                assignee="probe-profile",
+            )
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            assert task.title == "regression probe"
+
+    assert production_db.read_bytes() == production_before
+    for name, value in worker_env.items():
+        assert os.environ[name] == value
+
+
+def test_isolated_context_fails_closed_when_db_resolves_outside_temp_home(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.kanban_test_context import isolated_kanban_test_context
+
+    outside_db = tmp_path / "outside" / "kanban.db"
+    monkeypatch.setattr(kb, "kanban_db_path", lambda: outside_db)
+
+    with pytest.raises(RuntimeError, match="outside its temporary HERMES_HOME"):
+        with isolated_kanban_test_context():
+            pass


### PR DESCRIPTION
## Summary

- Add an explicit `isolated_kanban_test_context` for ad-hoc Kanban regression and E2E harnesses.
- Clear inherited `HERMES_KANBAN_*` routing pins before importing or resolving the Kanban database.
- Restore the caller environment after the run and fail closed if the resolved database is not below the temporary `HERMES_HOME`.

## Incident and root cause

An ad-hoc Kanban harness started from a worker process can inherit the dispatcher’s database and board pins. Setting a temporary `HERMES_HOME` alone is insufficient because explicit `HERMES_KANBAN_*` values take precedence, so a probe can resolve the worker’s live database instead of a disposable test database.

## Scope and design

This is an opt-in harness helper, not a production execution-path change. A core guard was intentionally avoided because normal dispatcher-to-worker routing must preserve inherited board and database pins. Isolation belongs at the test-harness boundary where those pins are unambiguously unsafe.

## Safety invariant

The context does not yield until the resolved database path is component-wise below a freshly created temporary Hermes home. Tests also verify that a pinned sentinel database remains byte-for-byte unchanged and that the inherited environment is restored.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_test_context.py tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_db.py --tb=short`
- 53 passed, 0 failed
- `git diff --check`