### PR TITLE
fix(profiles): reject path-traversal manifest entries (security)

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -61,17 +61,20 @@ Update semantics:
 
 from __future__ import annotations
 
+import logging
 import re
 import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
 from hermes_cli._subprocess_compat import noninteractive_git_env
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -182,6 +185,14 @@ class DistributionManifest:
     # ``list`` can show when a distribution landed on disk.  Empty for
     # manifests that ship in a repo (authors don't populate this).
     installed_at: str = ""
+    # Full set of relative file paths (POSIX-style, e.g. "skills/demo/SKILL.md")
+    # that THIS install/update's owned-paths copy actually wrote, tracked so
+    # a LATER update can tell a stale distributed file (present in this
+    # revision, absent from the next one -- must be deleted) apart from a
+    # genuine target-only user file (never in this list -- must be
+    # preserved). Populated by _copy_dist_payload() itself after each
+    # successful copy; not meant to be hand-authored (issue #74409 review).
+    installed_files: List[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: Any) -> "DistributionManifest":
@@ -211,6 +222,12 @@ class DistributionManifest:
             distribution_owned=distribution_owned,
             source=str(data.get("source") or ""),
             installed_at=str(data.get("installed_at") or ""),
+            installed_files=[
+                p2
+                for p in (data.get("installed_files") or [])
+                if (p2 := str(p).strip().replace("\\", "/").lstrip("/"))
+                and _is_safe_manifest_relative_path(p2)
+            ],
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -234,6 +251,8 @@ class DistributionManifest:
             out["source"] = self.source
         if self.installed_at:
             out["installed_at"] = self.installed_at
+        if self.installed_files:
+            out["installed_files"] = sorted(self.installed_files)
         return out
 
     def owned_paths(self) -> List[str]:
@@ -545,6 +564,46 @@ def plan_install(
     )
 
 
+def _is_safe_manifest_relative_path(path_str: str) -> bool:
+    """Reject anything that isn't a normalized, purely-relative path
+    confined to its own subtree once joined to a root directory.
+
+    Used to validate BOTH manifest.owned_paths() entries (attacker-
+    controlled: a crafted distribution.yaml's distribution_owned list)
+    and persisted installed_files entries (which, if ever written
+    unsafely by an earlier/compromised revision of this code, would
+    otherwise be blindly trusted on a later update's stale-file prune).
+    A value like "skills/../../auth.json" passes a naive
+    ``top_level in USER_OWNED_EXCLUDE`` check (top_level == "skills")
+    but escapes both the staged and target roots once joined --
+    reachable well outside the profile directory (review of #75351).
+
+    Rejects:
+    - Empty strings.
+    - Absolute paths (leading "/", or a Windows drive/UNC form).
+    - Any path component that is "." or ".." -- not just a leading one;
+      "skills/../../auth.json" has its traversal in the MIDDLE, and
+      PurePosixPath.parts flattens it out for inspection either way.
+    - Backslashes, which some filesystems (Windows) treat as separators
+      but Path.joinpath on POSIX would treat as a literal filename
+      character -- reject to avoid any interpretation ambiguity.
+    """
+    if not path_str:
+        return False
+    if "\\" in path_str:
+        return False
+    if path_str.startswith("/") or path_str.startswith("~"):
+        return False
+    # Windows drive ("C:") or UNC ("\\\\host") forms -- backslash form
+    # already rejected above; catch the drive-letter form too.
+    if len(path_str) >= 2 and path_str[1] == ":":
+        return False
+    parts = PurePosixPath(path_str).parts
+    if not parts:
+        return False
+    return all(p not in (".", "..") for p in parts)
+
+
 def _copy_dist_payload(
     staged: Path,
     target: Path,
@@ -557,37 +616,133 @@ def _copy_dist_payload(
     ``preserve_config`` is False (fresh install or ``--force-config`` update).
     ``.env.template`` is renamed to ``.env.EXAMPLE`` in the target to avoid
     shadowing a real ``.env``.
+
+    Each entry in ``manifest.owned_paths()`` is a manifest-relative path
+    (POSIX-style, e.g. ``"SOUL.md"``, ``"skills"``, or the narrower
+    ``"skills/research"`` / ``"cron/digest.json"`` forms the docs promise
+    are supported) resolved directly against staged/target -- NOT a bare
+    top-level name compared against ``staged.iterdir()``, which could only
+    ever match root entries and silently skipped any nested owned path
+    (issue #74409 review). A top-level path component in
+    ``USER_OWNED_EXCLUDE`` is rejected regardless of what the manifest
+    claims -- that floor cannot be overridden by an owned_paths entry.
+
+    An owned directory is merge-copied (new/changed content overlaid, never
+    an upfront wholesale delete of the directory) so content the manifest
+    doesn't track as distributed -- including a genuine user addition sitting
+    INSIDE an otherwise-owned directory like the default ``skills`` -- is
+    never destroyed by the copy step itself. To still honor the documented
+    "replaced from the new clone" contract and correctly distinguish a
+    STALE distributed file (shipped in an earlier revision, removed from
+    this one -- must be deleted) from that target-only user file (never
+    distributed -- must survive), this function tracks every file path it
+    writes in ``manifest.installed_files`` and, before overwriting the
+    on-disk manifest, diffs against the PREVIOUS installation's own
+    tracked list: anything that was tracked before but isn't part of this
+    copy is surgically removed (that file only, plus now-empty parent
+    directories up to the profile root); anything never tracked is left
+    alone regardless of where it lives.
     """
     target.mkdir(parents=True, exist_ok=True)
+    owned = manifest.owned_paths()
+    newly_installed: set[str] = set()
 
-    for entry in staged.iterdir():
-        name = entry.name
+    # Read the PREVIOUS installation's tracked file list before any
+    # copying happens. This must happen first: distribution.yaml
+    # (MANIFEST_FILENAME) is itself one of DEFAULT_DIST_OWNED, so the
+    # owned-path copy loop below overwrites target's manifest with the
+    # raw staged source's version (no installed_files) as part of normal
+    # processing -- reading this any later would always see that
+    # just-copied, untracked version instead of what a prior
+    # install/update actually wrote.
+    try:
+        previous_installed = set(read_manifest(target).installed_files)
+    except Exception:
+        previous_installed = set()
 
-        if name in USER_OWNED_EXCLUDE:
-            continue
-        if name == ENV_TEMPLATE_FILENAME:
-            shutil.copy2(entry, target / ENV_EXAMPLE_FILENAME)
-            continue
-        if name == "config.yaml" and preserve_config and (target / "config.yaml").exists():
-            # Leave user's config.yaml alone on update
-            continue
+    if (staged / ENV_TEMPLATE_FILENAME).is_file():
+        # .env.template ships alongside the payload to document required
+        # variables; it is not itself a content path subject to the
+        # owned_paths() allowlist.
+        shutil.copy2(staged / ENV_TEMPLATE_FILENAME, target / ENV_EXAMPLE_FILENAME)
 
-        dest = target / name
-        if entry.is_dir():
-            if dest.exists():
-                shutil.rmtree(dest)
-            staged_resolved = staged.resolve()
-            shutil.copytree(
-                entry,
-                dest,
-                ignore=lambda d, names: (
-                    [n for n in names if n in USER_OWNED_EXCLUDE]
-                    if Path(d).resolve() == staged_resolved
-                    else []
-                ),
+    for owned_path in owned:
+        owned_path = owned_path.strip().strip("/")
+        if not owned_path:
+            continue
+        if not _is_safe_manifest_relative_path(owned_path):
+            logger.warning(
+                "Ignoring unsafe distribution_owned entry %r (must be a "
+                "normalized relative path with no '..' traversal)",
+                owned_path,
             )
+            continue
+        top_level = owned_path.split("/", 1)[0]
+        if top_level in USER_OWNED_EXCLUDE:
+            continue
+
+        src = staged / owned_path
+        if not src.exists():
+            continue  # nothing staged for this owned entry
+        if owned_path == "config.yaml" and preserve_config and (target / "config.yaml").exists():
+            # Leave user's config.yaml alone on update -- but still count
+            # it as present in this revision, or the stale-file prune
+            # below (which only sees what's newly_installed) would treat
+            # the intentionally-untouched file as removed and delete it.
+            newly_installed.add(owned_path)
+            continue
+
+        dest = target / owned_path
+        if src.is_dir():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            # Merge, don't rmtree-then-copy: an upfront rmtree of the
+            # WHOLE owned directory (e.g. the default "skills") would
+            # wipe out any content inside it that was never part of any
+            # distributed revision (a genuine user addition), before the
+            # installed_files diff below even runs. dirs_exist_ok=True
+            # here is safe -- unlike the ORIGINAL bug this review flagged
+            # (a blanket merge with no cleanup at all), staleness is
+            # handled correctly afterward by the surgical per-file prune,
+            # which only removes files this function itself tracked as
+            # distributed in a PREVIOUS revision.
+            shutil.copytree(src, dest, dirs_exist_ok=True)
+            for f in src.rglob("*"):
+                if f.is_file():
+                    newly_installed.add(
+                        (Path(owned_path) / f.relative_to(src)).as_posix()
+                    )
         else:
-            shutil.copy2(entry, dest)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+            newly_installed.add(owned_path)
+
+    # Prune stale distributed files: present in the PREVIOUS on-disk
+    # manifest's own installed_files (i.e. this profile's state before we
+    # overwrite the manifest below) but absent from what was just
+    # installed. A file never tracked as distributed (a genuine user
+    # addition inside an owned directory) is never in this set and is
+    # therefore never touched.
+    for stale_rel in previous_installed - newly_installed:
+        if not _is_safe_manifest_relative_path(stale_rel):
+            logger.warning(
+                "Ignoring unsafe persisted installed_files entry %r during "
+                "stale-file cleanup (must be a normalized relative path "
+                "with no '..' traversal)",
+                stale_rel,
+            )
+            continue
+        stale_path = target / stale_rel
+        try:
+            if stale_path.is_file():
+                stale_path.unlink()
+                parent = stale_path.parent
+                while parent != target and parent.exists() and not any(parent.iterdir()):
+                    parent.rmdir()
+                    parent = parent.parent
+        except Exception:
+            pass  # best-effort cleanup — never fail the install/update over this
+
+    manifest.installed_files = sorted(newly_installed)
 
     # Emit .env.EXAMPLE from manifest if the staged tree didn't ship one
     if manifest.env_requires and not (target / ENV_EXAMPLE_FILENAME).exists():

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -394,9 +394,17 @@ class TestSecurity:
 class TestNestedUserOwnedExcludeNotFiltered:
 
     def test_nested_bin_dir_is_preserved(self, profile_env):
-        """"A distribution shipping tools/bin/ must not have tools/bin/ dropped
-        during install even though 'bin' is in USER_OWNED_EXCLUDE."""
-        staged = _make_staging_dir(profile_env, "src")
+        """A distribution shipping tools/bin/ must not have tools/bin/ dropped
+        during install even though 'bin' is in USER_OWNED_EXCLUDE -- that
+        exclusion only applies to TOP-LEVEL entries, not nested ones that
+        happen to share a name. ('tools' itself must be explicitly opted
+        into distribution_owned per the #74409 allowlist enforcement,
+        since it isn't one of the DEFAULT_DIST_OWNED entries.)"""
+        mf = DistributionManifest(
+            name="nested_bin", version="0.1.0",
+            distribution_owned=list(DEFAULT_DIST_OWNED) + ["tools"],
+        )
+        staged = _make_staging_dir(profile_env, "src", manifest=mf)
         (staged / "tools" / "bin").mkdir(parents=True)
         (staged / "tools" / "bin" / "tool.py").write_text("# tool\n")
 
@@ -405,7 +413,13 @@ class TestNestedUserOwnedExcludeNotFiltered:
         assert (plan.target_dir / "tools" / "bin" / "tool.py").exists()
 
     def test_nested_logs_dir_is_preserved(self, profile_env):
-        staged = _make_staging_dir(profile_env, "src")
+        """Same regression for a nested 'logs' dir, under an explicitly
+        owned 'scripts' entry (not a DEFAULT_DIST_OWNED path)."""
+        mf = DistributionManifest(
+            name="nested_logs", version="0.1.0",
+            distribution_owned=list(DEFAULT_DIST_OWNED) + ["scripts"],
+        )
+        staged = _make_staging_dir(profile_env, "src", manifest=mf)
         (staged / "scripts" / "logs").mkdir(parents=True)
         (staged / "scripts" / "logs" / "run.log").write_text("ok\n")
 
@@ -518,6 +532,278 @@ class TestProfileInfoDistribution:
 # Error surfaces: validation failures should propagate as DistributionError
 # or ValueError (both caught and rendered cleanly by the CLI handler)
 # ===========================================================================
+
+
+class TestDistributionOwnedNestedPaths:
+    """Regression tests for issue #74409's review: distribution_owned must
+    support nested manifest-relative paths (skills/research/,
+    cron/digest.json), not just root-level directory/file names, and an
+    update must distinguish a STALE distributed file (shipped before,
+    removed from the new revision -- must be deleted) from a genuine
+    TARGET-ONLY user file placed inside an owned directory (never
+    distributed -- must survive), instead of either silently skipping
+    nested entries or retaining every stale file forever via a merge.
+    """
+
+    def test_nested_directory_entry_is_installed(self, profile_env):
+        """distribution_owned: ['skills/research'] must actually copy
+        staged/skills/research/, not be silently skipped because
+        'skills/research' != the root entry 'skills'."""
+        mf = DistributionManifest(
+            name="nested", version="0.1.0",
+            distribution_owned=["SOUL.md", "skills/research"],
+        )
+        staged = _make_staging_dir(profile_env, "src", manifest=mf)
+        (staged / "skills" / "research").mkdir(parents=True, exist_ok=True)
+        (staged / "skills" / "research" / "SKILL.md").write_text(
+            "---\nname: research\n---\n# Research\n"
+        )
+
+        plan = install_distribution(str(staged), name="nested_test")
+
+        assert (plan.target_dir / "skills" / "research" / "SKILL.md").exists()
+
+    def test_nested_file_entry_is_installed(self, profile_env):
+        """distribution_owned: ['cron/digest.json'] must copy that exact
+        file, not require the whole 'cron' directory to be owned."""
+        mf = DistributionManifest(
+            name="nested_file", version="0.1.0",
+            distribution_owned=["SOUL.md", "cron/digest.json"],
+        )
+        staged = _make_staging_dir(profile_env, "src", manifest=mf)
+        (staged / "cron").mkdir(exist_ok=True)
+        (staged / "cron" / "digest.json").write_text('{"schedule": "0 8 * * *"}')
+
+        plan = install_distribution(str(staged), name="nested_file_test")
+
+        assert (plan.target_dir / "cron" / "digest.json").exists()
+        assert (
+            plan.target_dir / "cron" / "digest.json"
+        ).read_text() == '{"schedule": "0 8 * * *"}'
+
+    def test_narrow_owned_entry_leaves_sibling_content_untouched(self, profile_env):
+        """distribution_owned: ['skills/research'] must not touch a
+        sibling skills/other-skill/ directory that isn't part of the
+        owned allowlist -- narrower than the default whole-'skills' entry."""
+        mf = DistributionManifest(
+            name="narrow", version="0.1.0",
+            distribution_owned=["SOUL.md", "skills/research"],
+        )
+        staged = _make_staging_dir(profile_env, "src", manifest=mf)
+        (staged / "skills" / "research").mkdir(parents=True, exist_ok=True)
+        (staged / "skills" / "research" / "SKILL.md").write_text("# Research\n")
+
+        plan = install_distribution(str(staged), name="narrow_test")
+
+        # User (or a prior install) has an unrelated skill sitting alongside.
+        (plan.target_dir / "skills" / "user-added").mkdir(parents=True, exist_ok=True)
+        (plan.target_dir / "skills" / "user-added" / "SKILL.md").write_text(
+            "# Mine\n"
+        )
+
+        (staged / "skills" / "research" / "SKILL.md").write_text("# Research v2\n")
+        update_distribution("narrow_test", force_config=False)
+
+        assert (
+            plan.target_dir / "skills" / "research" / "SKILL.md"
+        ).read_text() == "# Research v2\n"
+        assert (plan.target_dir / "skills" / "user-added" / "SKILL.md").exists()
+
+    def test_stale_distributed_file_is_removed_on_update(self, profile_env):
+        """A file that WAS part of the distribution's owned content in an
+        earlier revision, and is removed from the source in a later one,
+        must actually be deleted on update -- not retained forever by a
+        dirs_exist_ok=True-style merge. Matches the documented 'replaced
+        from the new clone' contract."""
+        staged = _make_staging_dir(profile_env, "src")
+        (staged / "skills" / "old-skill").mkdir(parents=True, exist_ok=True)
+        (staged / "skills" / "old-skill" / "SKILL.md").write_text("# Old\n")
+
+        plan = install_distribution(str(staged), name="stale_test")
+        assert (plan.target_dir / "skills" / "old-skill" / "SKILL.md").exists()
+
+        # Author removes the skill from the distribution's source entirely.
+        import shutil as _shutil
+        _shutil.rmtree(staged / "skills" / "old-skill")
+        (staged / "SOUL.md").write_text("I am Source v2.\n")
+
+        update_distribution("stale_test", force_config=False)
+
+        assert not (plan.target_dir / "skills" / "old-skill").exists(), (
+            "A file removed from a newer distribution revision must be "
+            "deleted on update, not retained"
+        )
+        # The still-current demo skill (present in both revisions) survives.
+        assert (plan.target_dir / "skills" / "demo" / "SKILL.md").exists()
+
+    def test_target_only_file_inside_owned_directory_survives_update(
+        self, profile_env
+    ):
+        """A file the USER placed inside a distribution-owned directory
+        (never part of any distributed revision) must survive an update
+        -- it's never in installed_files, so the stale-file prune never
+        touches it, even though it lives inside an otherwise distribution-
+        owned tree."""
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="user_addition_test")
+
+        (plan.target_dir / "skills" / "my-local-only").mkdir(parents=True, exist_ok=True)
+        (plan.target_dir / "skills" / "my-local-only" / "SKILL.md").write_text(
+            "# Mine, never distributed\n"
+        )
+
+        (staged / "SOUL.md").write_text("I am Source v2.\n")
+        update_distribution("user_addition_test", force_config=False)
+
+        assert (
+            plan.target_dir / "skills" / "my-local-only" / "SKILL.md"
+        ).read_text() == "# Mine, never distributed\n"
+        # And the actually-distributed skill is still correctly replaced.
+        assert (plan.target_dir / "SOUL.md").read_text() == "I am Source v2.\n"
+
+    def test_installed_files_tracked_in_manifest(self, profile_env):
+        """installed_files must be populated and persisted so a later
+        update can correctly diff against it."""
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="tracked_test")
+
+        mf = read_manifest(plan.target_dir)
+        assert mf is not None
+        assert "SOUL.md" in mf.installed_files
+        assert "skills/demo/SKILL.md" in mf.installed_files
+        assert "cron/daily.json" in mf.installed_files
+        # User-owned exclusions and the .env.EXAMPLE derivative are never
+        # tracked as distributed content.
+        assert not any(f.startswith("memories/") for f in mf.installed_files)
+
+
+class TestDistributionOwnedPathTraversal:
+    """Security regression tests (review of #75351): a crafted or
+    corrupted manifest path (distribution_owned entry, or a persisted
+    installed_files entry) must never escape the staged/target roots via
+    '..' traversal, absolute paths, or other non-normalized forms. A
+    naive top-level USER_OWNED_EXCLUDE check alone doesn't catch this --
+    'skills/../../auth.json' has top_level == 'skills' (not excluded),
+    but resolves outside both roots once joined.
+    """
+
+    def test_traversal_owned_path_does_not_escape_target(self, profile_env):
+        """A crafted distribution_owned entry like 'skills/../../auth.json'
+        must not write outside the target profile directory, even though
+        its top-level component ('skills') isn't in USER_OWNED_EXCLUDE.
+        staged/"skills/../../auth.json" resolves to staged.parent/auth.json
+        (i.e. the shared profiles/ directory, one level above this specific
+        profile's own staging dir) -- verified directly below."""
+        mf = DistributionManifest(
+            name="traversal_test", version="0.1.0",
+            distribution_owned=["SOUL.md", "skills/../../auth.json"],
+        )
+        staged = _make_staging_dir(profile_env, "src", manifest=mf)
+        resolved_src = (staged / "skills/../../auth.json").resolve()
+        assert resolved_src == staged.parent / "auth.json", resolved_src
+        resolved_src.parent.mkdir(parents=True, exist_ok=True)
+        resolved_src.write_text('{"malicious": "payload"}')
+
+        # The corresponding DEST traversal target -- shared across every
+        # profile, one level above where THIS profile's own target_dir
+        # would be -- must never receive a copy.
+        outside_marker = profile_env / ".hermes" / "profiles" / "auth.json"
+
+        install_distribution(str(staged), name="traversal_test")
+
+        assert not outside_marker.exists(), (
+            "the traversal entry must not have written outside the "
+            "target profile directory"
+        )
+
+    def test_traversal_owned_path_rejected_not_silently_ignored(self, profile_env, caplog):
+        """The unsafe entry must be explicitly rejected (logged and
+        skipped), not silently swallowed by an unrelated 'nothing staged'
+        check -- verifies the validator actually runs."""
+        import logging
+        mf = DistributionManifest(
+            name="traversal_logged", version="0.1.0",
+            distribution_owned=["SOUL.md", "../../etc/passwd"],
+        )
+        staged = _make_staging_dir(profile_env, "src", manifest=mf)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.profile_distribution"):
+            install_distribution(str(staged), name="traversal_logged")
+
+        assert any(
+            "unsafe" in r.message.lower() and "distribution_owned" in r.message.lower()
+            for r in caplog.records
+        ), [r.message for r in caplog.records]
+
+    def test_traversal_persisted_installed_files_entry_ignored_on_prune(
+        self, profile_env, caplog, monkeypatch
+    ):
+        """A corrupted/tainted installed_files entry from an earlier
+        revision (e.g. a bug in an older version of this code, before the
+        from_dict()-level filter existed) must not be used to delete
+        files outside the target profile directory during stale-file
+        cleanup. from_dict() already filters unsafe entries on every
+        normal read (defense-in-depth, verified separately below) -- this
+        test patches read_manifest for the one call inside
+        _copy_dist_payload to simulate a manifest that bypassed that
+        filter, isolating and directly exercising the SEPARATE guard at
+        the actual deletion site.
+        """
+        import logging
+        import hermes_cli.profile_distribution as dist_mod
+
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="corrupted_manifest_test")
+
+        outside_target = profile_env / "OUTSIDE_MARKER.txt"
+        outside_target.write_text("must survive")
+
+        real_manifest = read_manifest(plan.target_dir)
+        tainted_files = list(real_manifest.installed_files) + [
+            "../../../OUTSIDE_MARKER.txt"
+        ]
+
+        _real_read_manifest = dist_mod.read_manifest
+        call_count = [0]
+
+        def _tainted_read_manifest(profile_dir):
+            call_count[0] += 1
+            result = _real_read_manifest(profile_dir)
+            if call_count[0] == 1 and result is not None and profile_dir == plan.target_dir:
+                # Only taint the FIRST call inside _copy_dist_payload
+                # (reading previous_installed) -- bypassing from_dict's
+                # own filter to simulate an unfiltered legacy manifest.
+                result.installed_files = tainted_files
+            return result
+
+        monkeypatch.setattr(dist_mod, "read_manifest", _tainted_read_manifest)
+
+        (staged / "SOUL.md").write_text("I am Source v2.\n")
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.profile_distribution"):
+            update_distribution("corrupted_manifest_test", force_config=False)
+
+        assert outside_target.exists() and outside_target.read_text() == "must survive", (
+            "a corrupted installed_files traversal entry must not delete "
+            "files outside the target profile directory"
+        )
+        # Best-effort: a warning SHOULD be logged when this happens, but
+        # the core security property above (nothing gets deleted outside
+        # target) is the assertion that actually matters here.
+        if caplog.records:
+            assert any("unsafe" in r.message.lower() for r in caplog.records), (
+                [r.message for r in caplog.records]
+            )
+
+    def test_from_dict_strips_traversal_entries_at_parse_time(self):
+        """Defense-in-depth: DistributionManifest.from_dict() itself must
+        never construct a manifest object carrying an unsafe
+        installed_files entry, independent of the _copy_dist_payload-level
+        guard."""
+        mf = DistributionManifest.from_dict({
+            "name": "x", "version": "0.1.0",
+            "installed_files": ["SOUL.md", "../../etc/passwd", "skills/../../auth.json"],
+        })
+        assert mf.installed_files == ["SOUL.md"]
 
 
 class TestErrorSurfaces:


### PR DESCRIPTION
## Context

Supersedes #75351 per @teknium1's review -- two blocking security issues.

## Vulnerabilities fixed

1. `owned_path` only had a leading/trailing `/` stripped. A crafted `distribution_owned` entry like `skills/../../auth.json` passes the top-level `USER_OWNED_EXCLUDE` check but resolves outside both `staged` and `target` once joined. **Confirmed exploitable**: reverting the fix and running the new test shows the traversal payload actually lands in the shared `profiles/` directory.
2. `installed_files` persists the same way, and stale-file pruning joins/unlinks entries without validation -- a corrupted manifest could delete files outside the target profile directory.

## Fix

Added `_is_safe_manifest_relative_path()`: rejects empty strings, absolute paths, backslashes, Windows drive forms, and any `.`/`..` path component anywhere in the path. Applied at three points: the owned_path loop, the stale-file prune loop, and `DistributionManifest.from_dict()` itself (defense-in-depth, filtering unsafe entries at parse time).

## Verification

Added the requested traversal regression tests. Verified the vulnerability was genuinely exploitable by temporarily reverting the fix and confirming the payload wrote outside the target directory, then restored the fix and confirmed it's blocked.

53/53 pass in the full test file (no regression).