### PR TITLE
fix(config): route _SECRET-suffixed keys to .env

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1159,7 +1159,7 @@ def _is_env_config_key(key: str) -> bool:
     ]
     return (
         key_upper in api_keys
-        or key_upper.endswith(('_API_KEY', '_TOKEN'))
+        or key_upper.endswith(('_API_KEY', '_TOKEN', '_SECRET'))
         or key_upper.startswith('TERMINAL_SSH')
     )
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -67,7 +67,7 @@ class TestExplicitAllowlist:
 # ---------------------------------------------------------------------------
 
 class TestCatchAllPatterns:
-    """Any key ending in _API_KEY or _TOKEN should route to .env."""
+    """Any key ending in _API_KEY, _TOKEN, or _SECRET should route to .env."""
 
     @pytest.mark.parametrize("key", [
         "DAYTONA_API_KEY",
@@ -75,6 +75,7 @@ class TestCatchAllPatterns:
         "SOME_FUTURE_SERVICE_API_KEY",
         "MY_CUSTOM_TOKEN",
         "WHATSAPP_BOT_TOKEN",
+        "CLIENT_SECRET",
     ])
     def test_api_key_suffix_routes_to_env(self, key, _isolated_hermes_home):
         set_config_value(key, "secret-456")


### PR DESCRIPTION
## Summary

`_is_env_config_key()` determines whether `hermes config set` routes a key to `.env` (safe, git-excluded) or `config.yaml`. It already routes keys ending in `_API_KEY` and `_TOKEN` to .env. This adds `_SECRET` to the suffix list.

## Before

```bash
hermes config set CLIENT_SECRET mysecret   # stored in config.yaml (plain text)
hermes config set ENCRYPTION_SECRET key     # stored in config.yaml
```

## After

```bash
hermes config set CLIENT_SECRET mysecret   # stored in .env (git-excluded)
hermes config set ENCRYPTION_SECRET key     # stored in .env
```

## Scope

One-line change adding `_SECRET` to the suffix tuple in `_is_env_config_key()`.