### PR TITLE
fix(desktop): retain SSH backend ownership across launcher replacement

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict'
+import { exec as execCommand, spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { promisify } from 'node:util'
 
 import { test } from 'vitest'
 
@@ -31,6 +34,7 @@ import {
 
 const OWNERSHIP_ID = '0123456789abcdef0123456789abcdef'
 const SPAWN_NONCE = '0123456789abcdef'
+const execLocal = promisify(execCommand)
 
 function ownedLock(over: any = {}) {
   return {
@@ -224,37 +228,42 @@ test('metadata and process proof transport failures remain indeterminate', async
     (error: any) => error.kind === 'transient-transport-error'
   )
   await assert.rejects(
-    () => pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, failure]]), 5, SPAWN_NONCE, '/x/hermes'),
+    () => pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, failure]]), 5, OWNERSHIP_ID, SPAWN_NONCE),
     (error: any) => error.kind === 'transient-transport-error'
   )
 })
 
 test('pidIsOurDashboard requires the exact serve ownership nonce', async () => {
-  const ours = `/x/hermes serve --isolated --ssh-owner-nonce ${SPAWN_NONCE}`
-  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'OWNED\n']]), 5, SPAWN_NONCE, '/x/hermes'), true)
+  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'OWNED\n']]), 5, OWNERSHIP_ID, SPAWN_NONCE), true)
   assert.equal(
     await pidIsOurDashboard(
       fakeSsh([[/print\("OWNED"/, command => (command.includes('fedcba9876543210') ? 'FOREIGN\n' : 'OWNED\n')]]),
       5,
-      'fedcba9876543210',
-      '/x/hermes'
+      OWNERSHIP_ID,
+      'fedcba9876543210'
     ),
     false
   )
-  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']]), 5, SPAWN_NONCE, '/x/hermes'), false)
+  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']]), 5, OWNERSHIP_ID, SPAWN_NONCE), false)
 })
 
-test('cleanupStale kills ONLY a provably-ours pid, always drops the lockfile', async () => {
+test('cleanupStale preserves the lock when a live pid cannot be proven owned', async () => {
   const notOurs = fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']])
-  await cleanupStale(notOurs, OWNERSHIP_ID, {
-    pid: 5,
-    spawnNonce: SPAWN_NONCE,
-    hermesPath: '/x/hermes',
-    logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
-  })
+  await assert.rejects(
+    () =>
+      cleanupStale(notOurs, OWNERSHIP_ID, {
+        pid: 5,
+        spawnNonce: SPAWN_NONCE,
+        hermesPath: '/x/hermes',
+        logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE)
+      }),
+    (error: any) => error.kind === 'ownership-mismatch'
+  )
   assert.ok(!notOurs.calls.some(c => /kill 5\b/.test(c)), 'must not kill a pid that is not our dashboard')
-  assert.ok(notOurs.calls.some(c => /rm -f/.test(c)))
+  assert.ok(!notOurs.calls.some(c => /rm -f/.test(c)), 'must retain ownership metadata for an indeterminate pid')
+})
 
+test('cleanupStale kills a provably-owned pid before dropping the lockfile', async () => {
   const ours = fakeSsh([[/print\("OWNED"/, 'OWNED\n']])
   await cleanupStale(ours, OWNERSHIP_ID, {
     pid: 9,
@@ -265,6 +274,52 @@ test('cleanupStale kills ONLY a provably-ours pid, always drops the lockfile', a
   assert.ok(ours.calls.some(c => /kill 9\b/.test(c)))
   assert.ok(ours.calls.some(c => /rm -f/.test(c)))
 })
+
+test('pidIsOurDashboard keys ownership to token path, not executable path', async () => {
+  const ssh = fakeSsh([[/print\("OWNED"/, 'OWNED\n']])
+  assert.equal(await pidIsOurDashboard(ssh, 5, OWNERSHIP_ID, SPAWN_NONCE), true)
+  const proof = ssh.calls.find(command => /print\("OWNED"/.test(command)) || ''
+  assert.ok(proof.includes(`${OWNERSHIP_ID}/${SPAWN_NONCE}.token`))
+  assert.doesNotMatch(proof, /expected=.*hermes/)
+})
+
+test.skipIf(process.platform === 'win32')(
+  'pidIsOurDashboard recognizes a wrapper-replaced process through its real local cmdline',
+  async () => {
+    const tokenPath = `${process.env.HOME}/.hermes/desktop-ssh/${OWNERSHIP_ID}/${SPAWN_NONCE}.token`
+
+    const child = spawn(
+      process.execPath,
+      [
+        '-e',
+        'setInterval(()=>{},1000)',
+        'serve',
+        '--isolated',
+        '--ssh-session-token-file',
+        tokenPath,
+        '--ssh-owner-nonce',
+        SPAWN_NONCE
+      ],
+      { stdio: 'ignore' }
+    )
+
+    await once(child, 'spawn')
+
+    const ssh = {
+      async exec(command) {
+        return (await execLocal(command)).stdout
+      }
+    }
+
+    try {
+      assert.equal(await pidIsOurDashboard(ssh, child.pid, OWNERSHIP_ID, SPAWN_NONCE), true)
+      assert.equal(await pidIsOurDashboard(ssh, child.pid, 'f'.repeat(32), SPAWN_NONCE), false)
+    } finally {
+      child.kill('SIGTERM')
+      await once(child, 'exit')
+    }
+  }
+)
 
 test('buildSpawnCommand is headless serve, detached, token not in argv', () => {
   const cmd = buildSpawnCommand('/x/hermes', 'work', { logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE) })
@@ -525,7 +580,7 @@ test('connect() respawns when the lockfile hermesPath differs from the resolved 
     [/\[ -x/, 'OK'],
     [/cat .*lock\.json/, JSON.stringify(lock)],
     [/kill -0/, 'ALIVE'],
-    [/print\("OWNED"/, 'FOREIGN\n'],
+    [/print\("OWNED"/, 'OWNED\n'],
     [/--version/, 'Hermes Agent v0.18.2\n'],
     [/grep -q ssh-session-token-file/, 'YES\n'],
     [/python3 -c/, ''],
@@ -987,10 +1042,8 @@ test('cleanupStale never deletes a lock-supplied unexpected log path', async () 
 })
 
 test('pidIsOurDashboard requires an exact nonce option value', async () => {
-  const prefix = `/x/hermes serve --isolated --ssh-owner-nonce ${SPAWN_NONCE}ff`
-  const suffix = `/x/hermes serve --isolated --ssh-owner-nonce xx${SPAWN_NONCE}`
-  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']]), 5, SPAWN_NONCE, '/x/hermes'), false)
-  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']]), 5, SPAWN_NONCE, '/x/hermes'), false)
+  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']]), 5, OWNERSHIP_ID, SPAWN_NONCE), false)
+  assert.equal(await pidIsOurDashboard(fakeSsh([[/print\("OWNED"/, 'FOREIGN\n']]), 5, OWNERSHIP_ID, SPAWN_NONCE), false)
 })
 
 test('connect removes the token file when a fresh backend fails after returning a pid', async () => {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -367,17 +367,26 @@ async function remotePidAlive(ssh, pid) {
 }
 
 // A pid is "provably ours" only if its remote cmdline carries our dashboard
-// args — never kill a pid we can't positively identify as our dashboard.
-async function pidIsOurDashboard(ssh, pid, spawnNonce, hermesPath = '') {
-  if (!pid || !/^[0-9a-f]{16}$/.test(String(spawnNonce || '')) || !hermesPath) {
+// args — never kill a pid we can't positively identify as our dashboard.  The
+// proof is the installation/profile-scoped token path plus its matching random
+// nonce, not argv[0]: executable wrappers legitimately replace themselves with
+// Python or a venv entrypoint.
+async function pidIsOurDashboard(ssh, pid, ownershipId, spawnNonce) {
+  if (
+    !pid ||
+    !/^[0-9a-f]{32}$/.test(String(ownershipId || '')) ||
+    !/^[0-9a-f]{16}$/.test(String(spawnNonce || ''))
+  ) {
     return false
   }
 
   try {
+    const expectedTokenPath = `${ownershipDirectory(ownershipId)}/${validateSpawnNonce(spawnNonce)}.token`
+
     const script =
       'import os,shlex,subprocess,sys\n' +
       `pid=${Number(pid)}\n` +
-      `expected=os.path.expanduser(${shq(hermesPath)})\n` +
+      `expected_token=os.path.expanduser(${shq(expectedTokenPath)})\n` +
       `nonce=${shq(spawnNonce)}\n` +
       'try:\n' +
       ' raw=open(f"/proc/{pid}/cmdline","rb").read()\n' +
@@ -389,9 +398,8 @@ async function pidIsOurDashboard(ssh, pid, spawnNonce, hermesPath = '') {
       'try:\n' +
       ' serve=args.index("serve")\n' +
       ' owner=args.index("--ssh-owner-nonce",serve+1)\n' +
-      ' direct=args[0]==expected\n' +
-      ' python_entry=len(args)>1 and args[1]==expected and os.path.basename(args[0]).startswith("python")\n' +
-      ' ok=(direct or python_entry) and "--isolated" in args[serve+1:] and args[owner+1]==nonce\n' +
+      ' token=args.index("--ssh-session-token-file",serve+1)\n' +
+      ' ok=("--isolated" in args[serve+1:] and args[owner+1]==nonce and args[token+1]==expected_token)\n' +
       'except (ValueError,IndexError):pass\n' +
       'print("OWNED" if ok else "FOREIGN")'
 
@@ -406,9 +414,19 @@ async function pidIsOurDashboard(ssh, pid, spawnNonce, hermesPath = '') {
   }
 }
 
-// Kill the stale dashboard ONLY if provably ours, then drop the lockfile.
+// Kill the stale dashboard ONLY if provably ours, then drop the lockfile.  A
+// live but unverified pid is indeterminate: preserve its ownership record and
+// fail closed instead of forgetting it and spawning an unbounded replacement.
 async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
-  if (pidAlive && lock && (await pidIsOurDashboard(ssh, lock.pid, lock.spawnNonce, lock.hermesPath))) {
+  if (pidAlive && lock) {
+    const owned = await pidIsOurDashboard(ssh, lock.pid, ownershipId, lock.spawnNonce)
+
+    if (!owned) {
+      const error: any = new Error('Could not prove that the stale SSH backend belongs to this Desktop installation.')
+      error.kind = 'ownership-mismatch'
+      throw error
+    }
+
     try {
       const result = (
         await ssh.exec(
@@ -707,7 +725,7 @@ async function connect(deps) {
 
   if (lock) {
     const pidAlive = await remotePidAlive(ssh, lock.pid)
-    const owned = pidAlive && (await pidIsOurDashboard(ssh, lock.pid, lock.spawnNonce, lock.hermesPath))
+    const owned = pidAlive && (await pidIsOurDashboard(ssh, lock.pid, ownershipId, lock.spawnNonce))
 
     const reusable =
       pidAlive &&
@@ -866,7 +884,7 @@ async function connect(deps) {
       void 0
     }
 
-    await cleanupStale(ssh, ownershipId, ownedSpawn)
+    await cleanupStale(ssh, ownershipId, ownedSpawn, await remotePidAlive(ssh, pid))
     throw error
   }
 }


### PR DESCRIPTION
## Summary

- prove a detached SSH backend belongs to Desktop using its installation/profile-scoped token path and matching spawn nonce, rather than `argv[0]`
- preserve the lock and log when a live PID cannot be proven owned, preventing an unbounded replacement spawn
- re-check liveness when cleaning up a failed fresh spawn so an already-exited process does not mask the original startup error
- add a real POSIX cmdline regression test for a process whose launcher has been replaced

## Root cause

Desktop intentionally detaches the remote `serve` process so it survives the SSH channel. Launcher wrappers may then `exec` Python or a venv entrypoint, making the live process path differ from the path recorded in `backend.lock.json`.

The old ownership check rejected that otherwise exact owned process. `cleanupStale()` then deleted its lock and log without terminating it, so the next connection spawned another detached backend and the previous process became a lockless orphan.

The secure bootstrap already gives every process two stronger ownership signals: `--ssh-session-token-file` contains the installation/profile ownership ID and spawn nonce, and `--ssh-owner-nonce` must match that path. This change uses that pair as the process identity and fails closed if it cannot be verified.

This also keeps the lifecycle compatible with launcher-wrapper preservation work in #74425 without weakening cross-installation isolation.

Fixes #58619.
Related: #74411, #74425.

## Validation

- `npm run test:desktop:platforms` — 78 files passed, 1 skipped; 929 tests passed, 2 skipped
- `npm run typecheck`
- `npm exec eslint -- electron/remote-lifecycle.ts electron/remote-lifecycle.test.ts`
- real Linux SSH target with default and named profiles: both detached backends retained the same PID and were reported as `connection REUSED` across a full Desktop quit/relaunch
