### PR TITLE
feat(models): add deepseek/deepseek-v4-flash-0731 to Nous portal and OpenRouter catalogs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -65,6 +65,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # DeepSeek
     ("deepseek/deepseek-v4-pro",               ""),
     ("deepseek/deepseek-v4-flash",             ""),
+    ("deepseek/deepseek-v4-flash-0731",        "dated snapshot of v4-flash"),
     # Qwen
     ("qwen/qwen3.7-max",                       ""),
     # MoonshotAI
@@ -236,6 +237,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # DeepSeek
         "deepseek/deepseek-v4-pro",
         "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash-0731",
         # Qwen
         "qwen/qwen3.7-max",
         # MoonshotAI

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-28T16:38:40Z",
+  "updated_at": "2026-07-31T15:41:39Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -95,6 +95,10 @@
         {
           "id": "deepseek/deepseek-v4-flash",
           "description": ""
+        },
+        {
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "description": "dated snapshot of v4-flash"
         },
         {
           "id": "qwen/qwen3.7-max",
@@ -229,6 +233,9 @@
         },
         {
           "id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "id": "deepseek/deepseek-v4-flash-0731"
         },
         {
           "id": "qwen/qwen3.7-max"


### PR DESCRIPTION
## Summary
`deepseek/deepseek-v4-flash-0731` (dated snapshot of v4-flash) now appears in the Nous Portal and OpenRouter model pickers.

Verified live on both endpoints before adding: OpenRouter `GET /api/v1/models` (ctx 1,048,576, $0.14/$0.28 per M) and Nous portal `/v1/models` both serve the slug.

## Changes
- `hermes_cli/models.py`: added to `OPENROUTER_MODELS` (with "dated snapshot of v4-flash" description) and `_PROVIDER_MODELS["nous"]`, directly below `deepseek-v4-flash` per family ordering.
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`.

Deliberately untouched (scoped rollout — these already resolve for the new slug):
- Context length: `deepseek-v4-flash` prefix entry in `DEFAULT_CONTEXT_LENGTHS` matches `-0731` → 1M. Verified.
- Reasoning stale-timeout floor: prefix match → 600s. Verified.
- Pricing snapshot: both requested routes bill via `official_models_api` (live pricing) — `resolve_billing_route` confirmed for openrouter and nous. No `_OFFICIAL_DOCS_PRICING` entry needed.

## Validation
| Check | Result |
|---|---|
| Targeted suites (models, picker, gmi, catalog, pricing, minimax) | 98/98 pass |
| E2E curated fallback (temp HERMES_HOME, keys stripped) | present, ordered, no dupes in both lists |
| `get_reasoning_stale_timeout_floor("deepseek/deepseek-v4-flash-0731")` | 600.0 |
| Context resolution | 1,000,000 via prefix |

## Infographic

![deepseek-v4-flash-0731 rollout](https://v3b.fal.media/files/b/0aa479ed/-A_Dxp8l_55c5NJFSwTEL_c8eKRPwz.png)
