### PR TITLE
feat(signal): support shared accounts with disjoint group ownership

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1578,6 +1578,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_policy"] = platform_cfg["group_policy"]
                 if "group_allow_from" in platform_cfg:
                     bridged["group_allow_from"] = platform_cfg["group_allow_from"]
+                if plat == Platform.SIGNAL and "shared_account_group_only" in platform_cfg:
+                    bridged["shared_account_group_only"] = platform_cfg["shared_account_group_only"]
                 if "group_allow_admin_from" in platform_cfg:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -186,6 +186,7 @@ def _str_keyed(value: Any) -> Any:
 
 _TELEGRAM = frozenset({Platform.TELEGRAM})
 _DISCORD_SLACK = frozenset({Platform.DISCORD, Platform.SLACK})
+_SIGNAL = frozenset({Platform.SIGNAL})
 
 def _plain(*keys: str) -> tuple:
     """Keys copied verbatim into ``extra`` for every platform."""
@@ -207,6 +208,7 @@ _SHARED_KEYS: tuple = (
         "dm_policy", "allow_from", "allow_admin_from", "user_allowed_commands",
         "group_policy", "group_allow_from", "group_allow_admin_from", "group_user_allowed_commands",
     ),
+    ("shared_account_group_only", _SIGNAL, None),
     ("channel_skill_bindings", _DISCORD_SLACK, None),
     ("channel_prompts", None, _str_keyed),
     *_plain("gateway_restart_notification", "typing_indicator", "typing_status_text"),

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -592,8 +592,10 @@ class SignalAdapter(BasePlatformAdapter):
                 return False
             lock_acquired = True
         except Exception as e:
-            logger.error("Signal: could not acquire routing locks: %s", e)
-            return False
+            if self.shared_account_group_only:
+                logger.error("Signal: could not acquire routing locks: %s", e)
+                return False
+            logger.warning("Signal: Could not acquire phone lock (non-fatal): %s", e)
 
         # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
         from gateway.platforms._http_client_limits import platform_httpx_limits

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -13,6 +13,7 @@ Requires:
 
 import asyncio
 import base64
+import hashlib
 import json
 import logging
 import os
@@ -57,6 +58,11 @@ from gateway.platforms.signal_rate_limit import (
     _signal_send_timeout,
     get_scheduler,
 )
+from gateway.status import (
+    acquire_scoped_lock,
+    list_scoped_locks,
+    release_scoped_lock,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,11 +76,55 @@ SSE_RETRY_DELAY_INITIAL = 2.0
 SSE_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
 HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before concern
+_SIGNAL_STARTUP_SCOPE = "signal-phone-startup"
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _signal_group_scope(account: str) -> str:
+    account_hash = hashlib.sha256(account.encode("utf-8")).hexdigest()[:16]
+    return f"signal-phone-group-{account_hash}"
+
+
+def _active_signal_scoped_lock(scope: str, identity: str) -> Optional[dict]:
+    """Return the active exact marker, including one owned by this process."""
+    identity_hash = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+    return next(
+        (
+            record
+            for record in list_scoped_locks(scope, active_only=True)
+            if record.get("identity_hash") == identity_hash
+        ),
+        None,
+    )
+
+
+def _release_signal_scoped_lock(scope: str, identity: str) -> None:
+    """Release one exact marker and verify that this process no longer owns it."""
+    release_scoped_lock(scope, identity)
+    identity_hash = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+    if any(
+        record.get("identity_hash") == identity_hash
+        and record.get("pid") == os.getpid()
+        for record in list_scoped_locks(scope)
+    ):
+        raise OSError(f"Signal scoped lock is still owned after release: {scope}")
+
+
+def _release_signal_claims(claims: List[Tuple[str, str]]) -> None:
+    """Attempt every claim release, then re-raise the first failure."""
+    first_error: Optional[Exception] = None
+    for scope, identity in claims:
+        try:
+            _release_signal_scoped_lock(scope, identity)
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+    if first_error is not None:
+        raise first_error
 
 
 def _parse_comma_list(value: str) -> List[str]:
@@ -266,6 +316,7 @@ class SignalAdapter(BasePlatformAdapter):
         self.http_url = extra.get("http_url", "http://127.0.0.1:8080").rstrip("/")
         self.account = extra.get("account", "")
         self.ignore_stories = extra.get("ignore_stories", True)
+        self.shared_account_group_only = extra.get("shared_account_group_only", False)
 
         # Parse allowlists — group policy is derived from presence of group allowlist
         group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
@@ -335,6 +386,7 @@ class SignalAdapter(BasePlatformAdapter):
         self._recipient_uuid_by_number: Dict[str, str] = {}
         self._recipient_number_by_uuid: Dict[str, str] = {}
         self._recipient_cache_lock = asyncio.Lock()
+        self._signal_group_claims: List[Tuple[str, str]] = []
 
         logger.info("Signal adapter initialized: url=%s account=%s groups=%s",
                      self.http_url, redact_phone(self.account),
@@ -344,20 +396,204 @@ class SignalAdapter(BasePlatformAdapter):
     # Lifecycle
     # ------------------------------------------------------------------
 
+    def _release_signal_routing_locks(self) -> None:
+        first_error: Optional[Exception] = None
+        claims = list(self._signal_group_claims)
+        self._signal_group_claims.clear()
+        try:
+            _release_signal_claims(claims)
+        except Exception as exc:
+            first_error = exc
+
+        try:
+            self._release_platform_lock()
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+
+        if first_error is not None:
+            raise first_error
+
+    def _acquire_signal_routing_locks(self) -> bool:
+        """Reserve this account mode and the complete assigned group set."""
+        coordinator_holder = _active_signal_scoped_lock(
+            _SIGNAL_STARTUP_SCOPE, self.account
+        )
+        if coordinator_holder is None:
+            coordinator_acquired, coordinator_holder = acquire_scoped_lock(
+                _SIGNAL_STARTUP_SCOPE,
+                self.account,
+                metadata={"platform": "signal", "signal_mode": "startup"},
+            )
+        else:
+            coordinator_acquired = False
+        if not coordinator_acquired:
+            logger.error(
+                "Signal: account listener setup is already in progress",
+            )
+            self._set_fatal_error(
+                "signal_account_coordinator_lock",
+                "Signal account listener setup is already in progress",
+                retryable=True,
+            )
+            return False
+
+        routing_acquired = False
+        try:
+            if self.shared_account_group_only:
+                normal_holder = _active_signal_scoped_lock(
+                    "signal-phone", self.account
+                )
+                if normal_holder is None:
+                    normal_available, normal_holder = acquire_scoped_lock(
+                        "signal-phone",
+                        self.account,
+                        metadata={
+                            "platform": "signal",
+                            "signal_mode": "normal-probe",
+                        },
+                    )
+                else:
+                    normal_available = False
+                if not normal_available:
+                    owner_pid = (
+                        normal_holder.get("pid")
+                        if isinstance(normal_holder, dict)
+                        else None
+                    )
+                    logger.error(
+                        "Signal: account is held by a normal or legacy listener%s",
+                        f" (PID {owner_pid})" if owner_pid else "",
+                    )
+                    self._set_fatal_error(
+                        "signal_legacy_account_lock",
+                        "Signal account is held by a normal or legacy listener",
+                        retryable=True,
+                    )
+                    return False
+                _release_signal_scoped_lock("signal-phone", self.account)
+
+                groups = sorted(set(self.group_allow_from))
+                group_scope = _signal_group_scope(self.account)
+                claims: List[Tuple[str, str]] = []
+                try:
+                    for group_id in groups:
+                        existing = _active_signal_scoped_lock(group_scope, group_id)
+                        if existing is None:
+                            acquired, _ = acquire_scoped_lock(
+                                group_scope,
+                                group_id,
+                                metadata={
+                                    "platform": "signal",
+                                    "signal_mode": "shared-group",
+                                },
+                            )
+                        else:
+                            acquired = False
+                        if not acquired:
+                            logger.error(
+                                "Signal: group is assigned to another shared profile",
+                            )
+                            self._set_fatal_error(
+                                "signal_account_group_lock",
+                                "A Signal group is assigned to another shared profile",
+                                retryable=True,
+                            )
+                            return False
+                        claims.append((group_scope, group_id))
+                finally:
+                    if len(claims) != len(groups):
+                        _release_signal_claims(claims)
+                self._signal_group_claims = claims
+                routing_acquired = True
+                return True
+
+            if list_scoped_locks(
+                _signal_group_scope(self.account), active_only=True
+            ):
+                logger.error(
+                    "Signal: account is in use by shared group-only listeners"
+                )
+                self._set_fatal_error(
+                    "signal_account_group_lock",
+                    "Signal account is in use by shared group-only listeners",
+                    retryable=True,
+                )
+                return False
+
+            # Preserve the original account-wide scope and --replace behavior.
+            if (
+                _active_signal_scoped_lock("signal-phone", self.account) is not None
+                and not getattr(self, "_platform_lock_takeover_allowed", False)
+            ):
+                self._set_fatal_error(
+                    "signal-phone_lock",
+                    "Signal account already in use. Stop the other gateway first.",
+                    retryable=True,
+                )
+                return False
+            try:
+                acquired = self._acquire_platform_lock(
+                    "signal-phone",
+                    self.account,
+                    "Signal account",
+                )
+            except Exception:
+                self._platform_lock_scope = None
+                self._platform_lock_identity = None
+                raise
+            if acquired:
+                routing_acquired = True
+            else:
+                self._platform_lock_scope = None
+                self._platform_lock_identity = None
+            return acquired
+        finally:
+            try:
+                _release_signal_scoped_lock(_SIGNAL_STARTUP_SCOPE, self.account)
+            except Exception:
+                if routing_acquired:
+                    try:
+                        self._release_signal_routing_locks()
+                    except Exception:
+                        logger.exception(
+                            "Signal: failed to roll back routing ownership after "
+                            "startup coordinator release failed"
+                        )
+                raise
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to signal-cli daemon and start SSE listener."""
+        if not isinstance(self.shared_account_group_only, bool):
+            logger.error(
+                "Signal: shared_account_group_only must be a boolean value"
+            )
+            return False
+
         if not self.http_url or not self.account:
             logger.error("Signal: SIGNAL_HTTP_URL and SIGNAL_ACCOUNT are required")
             return False
 
-        # Acquire scoped lock to prevent duplicate Signal listeners for the same phone
+        if self.shared_account_group_only:
+            if not self.group_allow_from:
+                logger.error(
+                    "Signal: shared_account_group_only requires an explicit group allowlist"
+                )
+                return False
+            if "*" in self.group_allow_from:
+                logger.error(
+                    "Signal: shared_account_group_only does not permit a wildcard group allowlist"
+                )
+                return False
+
         lock_acquired = False
         try:
-            if not self._acquire_platform_lock('signal-phone', self.account, 'Signal account'):
+            if not self._acquire_signal_routing_locks():
                 return False
             lock_acquired = True
         except Exception as e:
-            logger.warning("Signal: Could not acquire phone lock (non-fatal): %s", e)
+            logger.error("Signal: could not acquire routing locks: %s", e)
+            return False
 
         # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
         from gateway.platforms._http_client_limits import platform_httpx_limits
@@ -386,7 +622,7 @@ class SignalAdapter(BasePlatformAdapter):
                     await self.client.aclose()
                     self.client = None
                 if lock_acquired:
-                    self._release_platform_lock()
+                    self._release_signal_routing_locks()
 
     async def disconnect(self) -> None:
         """Stop SSE listener and clean up."""
@@ -415,7 +651,7 @@ class SignalAdapter(BasePlatformAdapter):
             await self.client.aclose()
             self.client = None
 
-        self._release_platform_lock()
+        self._release_signal_routing_locks()
 
         logger.info("Signal: disconnected")
 
@@ -538,9 +774,10 @@ class SignalAdapter(BasePlatformAdapter):
         # Unwrap nested envelope if present
         envelope_data = envelope.get("envelope", envelope)
 
-        # Handle syncMessage: extract "Note to Self" messages (sent to own account)
-        # while still filtering other sync events (read receipts, typing, etc.)
-        is_note_to_self = False
+        # Promote sent-message syncs for Note to Self and groups while filtering
+        # other sync events (read receipts, typing, etc.). Shared group-only
+        # mode drops Note to Self but keeps group sync-sents enabled.
+        is_promoted_sync_sent = False
         if "syncMessage" in envelope_data:
             sync_msg = envelope_data.get("syncMessage")
             if sync_msg and isinstance(sync_msg, dict):
@@ -550,14 +787,21 @@ class SignalAdapter(BasePlatformAdapter):
                     sent_ts = sent_msg.get("timestamp")
                     sent_msg_group_info = sent_msg.get("groupInfo") or {}
                     sent_msg_group_id = sent_msg_group_info.get("groupId") if sent_msg_group_info else None
+                    is_note_to_self = (
+                        dest == self._account_normalized and not sent_msg_group_id
+                    )
+                    if self.shared_account_group_only and is_note_to_self:
+                        logger.debug(
+                            "Signal: ignoring Note to Self in shared account group-only mode"
+                        )
+                        return
                     if dest == self._account_normalized or sent_msg_group_id:
                         # Check if this is an echo of our own outbound reply
                         if self._consume_sent_timestamp(sent_ts):
                             return
-                        # Genuine user Note to Self — promote to dataMessage
-                        is_note_to_self = True
+                        is_promoted_sync_sent = True
                         envelope_data = {**envelope_data, "dataMessage": sent_msg}
-            if not is_note_to_self:
+            if not is_promoted_sync_sent:
                 return
 
         # Extract sender info
@@ -574,8 +818,9 @@ class SignalAdapter(BasePlatformAdapter):
             logger.debug("Signal: ignoring envelope with no sender")
             return
 
-        # Self-message filtering — prevent reply loops (but allow Note to Self)
-        if self._account_normalized and sender == self._account_normalized and not is_note_to_self:
+        # Self-message filtering — prevent reply loops, except for promoted
+        # Note-to-Self and group sync-sent messages in normal mode.
+        if self._account_normalized and sender == self._account_normalized and not is_promoted_sync_sent:
             return
 
         # Filter stories
@@ -595,6 +840,10 @@ class SignalAdapter(BasePlatformAdapter):
         group_info = data_message.get("groupInfo")
         group_id = group_info.get("groupId") if group_info else None
         is_group = bool(group_id)
+
+        if self.shared_account_group_only and not is_group:
+            logger.debug("Signal: ignoring DM in shared account group-only mode")
+            return
 
         # Group message filtering — derived from SIGNAL_GROUP_ALLOWED_USERS:
         # - No env var set → groups disabled (default safe behavior)

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -4,6 +4,7 @@ and SIGNAL_ACCOUNT."""
 
 import asyncio
 import base64
+import hashlib
 import itertools
 import json
 import logging
@@ -38,6 +39,7 @@ from gateway.platforms.signal_rate_limit import (
     SignalRateLimitError, _extract_retry_after_seconds, _format_wait, _is_signal_rate_limit_error,
     _signal_send_timeout, get_scheduler)
 from gateway.platforms._shared import get_scoped_secret as _sig_secret
+from gateway.status import acquire_scoped_lock, list_scoped_locks, release_scoped_lock
 from utils import TRUTHY_STRINGS
 
 logger = logging.getLogger(__name__)
@@ -48,6 +50,7 @@ SSE_RETRY_DELAY_INITIAL = 2.0
 SSE_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
 HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before concern
+_SIGNAL_STARTUP_SCOPE = "signal-phone-startup"
 
 # Magic-byte prefixes checked before delegating to the shared audio/AV sniffer.
 _MAGIC_EXTENSIONS = ((b"\x89PNG", ".png"), (b"\xff\xd8", ".jpg"), (b"GIF8", ".gif"), (b"%PDF", ".pdf"))
@@ -61,6 +64,49 @@ _SKIP_IMAGE_LOG = {
     "oversize": lambda url, detail: ("Signal: image too large (%d bytes), skipping %s", detail, url)}
 _QUOTE_AUTHOR_KEYS = (
     "author", "authorNumber", "authorUuid", "authorAci", "authorServiceId", "authorServiceIdString")
+
+
+def _signal_group_scope(account: str) -> str:
+    account_hash = hashlib.sha256(account.encode("utf-8")).hexdigest()[:16]
+    return f"signal-phone-group-{account_hash}"
+
+
+def _active_signal_scoped_lock(scope: str, identity: str) -> Optional[dict]:
+    """Return the active exact marker, including one owned by this process."""
+    identity_hash = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+    return next(
+        (
+            record
+            for record in list_scoped_locks(scope, active_only=True)
+            if record.get("identity_hash") == identity_hash
+        ),
+        None,
+    )
+
+
+def _release_signal_scoped_lock(scope: str, identity: str) -> None:
+    """Release one exact marker and verify that this process no longer owns it."""
+    release_scoped_lock(scope, identity)
+    identity_hash = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+    if any(
+        record.get("identity_hash") == identity_hash
+        and record.get("pid") == os.getpid()
+        for record in list_scoped_locks(scope)
+    ):
+        raise OSError(f"Signal scoped lock is still owned after release: {scope}")
+
+
+def _release_signal_claims(claims: List[Tuple[str, str]]) -> None:
+    """Attempt every claim release, then re-raise the first failure."""
+    first_error: Optional[Exception] = None
+    for scope, identity in claims:
+        try:
+            _release_signal_scoped_lock(scope, identity)
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+    if first_error is not None:
+        raise first_error
 
 
 def _parse_comma_list(value: str) -> List[str]:
@@ -186,6 +232,7 @@ class SignalAdapter(BasePlatformAdapter):
         self.http_url = extra.get("http_url", "http://127.0.0.1:8080").rstrip("/")
         self.account = extra.get("account", "")
         self.ignore_stories = extra.get("ignore_stories", True)
+        self.shared_account_group_only = extra.get("shared_account_group_only", False)
         # Allowlists are per-profile (scoped reads); group policy derives from the group allowlist's
         # presence. The DM allowlist mirrors run.py's SIGNAL_ALLOWED_USERS so reaction hooks (which
         # fire before run.py's auth gate) can skip unauthorized senders; "*" = open.
@@ -218,20 +265,180 @@ class SignalAdapter(BasePlatformAdapter):
         self._recipient_uuid_by_number: Dict[str, str] = {}
         self._recipient_number_by_uuid: Dict[str, str] = {}
         self._recipient_cache_lock = asyncio.Lock()
+        self._signal_group_claims: List[Tuple[str, str]] = []
         logger.info("Signal adapter initialized: url=%s account=%s groups=%s", self.http_url,
                     redact_phone(self.account), "enabled" if self.group_allow_from else "disabled")
 
+    def _release_signal_routing_locks(self) -> None:
+        first_error: Optional[Exception] = None
+        claims = list(self._signal_group_claims)
+        self._signal_group_claims.clear()
+        try:
+            _release_signal_claims(claims)
+        except Exception as exc:
+            first_error = exc
+
+        try:
+            self._release_platform_lock()
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+
+        if first_error is not None:
+            raise first_error
+
+    def _acquire_signal_routing_locks(self) -> bool:
+        """Reserve this account mode and the complete assigned group set."""
+        coordinator_holder = _active_signal_scoped_lock(
+            _SIGNAL_STARTUP_SCOPE, self.account
+        )
+        if coordinator_holder is None:
+            coordinator_acquired, coordinator_holder = acquire_scoped_lock(
+                _SIGNAL_STARTUP_SCOPE,
+                self.account,
+                metadata={"platform": "signal", "signal_mode": "startup"},
+            )
+        else:
+            coordinator_acquired = False
+        if not coordinator_acquired:
+            logger.error("Signal: account listener setup is already in progress")
+            self._set_fatal_error(
+                "signal_account_coordinator_lock",
+                "Signal account listener setup is already in progress",
+                retryable=True,
+            )
+            return False
+
+        routing_acquired = False
+        try:
+            if self.shared_account_group_only:
+                normal_holder = _active_signal_scoped_lock("signal-phone", self.account)
+                if normal_holder is None:
+                    normal_available, normal_holder = acquire_scoped_lock(
+                        "signal-phone",
+                        self.account,
+                        metadata={"platform": "signal", "signal_mode": "normal-probe"},
+                    )
+                else:
+                    normal_available = False
+                if not normal_available:
+                    owner_pid = normal_holder.get("pid") if isinstance(normal_holder, dict) else None
+                    logger.error(
+                        "Signal: account is held by a normal or legacy listener%s",
+                        f" (PID {owner_pid})" if owner_pid else "",
+                    )
+                    self._set_fatal_error(
+                        "signal_legacy_account_lock",
+                        "Signal account is held by a normal or legacy listener",
+                        retryable=True,
+                    )
+                    return False
+                _release_signal_scoped_lock("signal-phone", self.account)
+
+                groups = sorted(set(self.group_allow_from))
+                group_scope = _signal_group_scope(self.account)
+                claims: List[Tuple[str, str]] = []
+                try:
+                    for group_id in groups:
+                        existing = _active_signal_scoped_lock(group_scope, group_id)
+                        if existing is None:
+                            acquired, _ = acquire_scoped_lock(
+                                group_scope,
+                                group_id,
+                                metadata={"platform": "signal", "signal_mode": "shared-group"},
+                            )
+                        else:
+                            acquired = False
+                        if not acquired:
+                            logger.error("Signal: group is assigned to another shared profile")
+                            self._set_fatal_error(
+                                "signal_account_group_lock",
+                                "A Signal group is assigned to another shared profile",
+                                retryable=True,
+                            )
+                            return False
+                        claims.append((group_scope, group_id))
+                finally:
+                    if len(claims) != len(groups):
+                        _release_signal_claims(claims)
+                self._signal_group_claims = claims
+                routing_acquired = True
+                return True
+
+            if list_scoped_locks(_signal_group_scope(self.account), active_only=True):
+                logger.error("Signal: account is in use by shared group-only listeners")
+                self._set_fatal_error(
+                    "signal_account_group_lock",
+                    "Signal account is in use by shared group-only listeners",
+                    retryable=True,
+                )
+                return False
+
+            # Preserve the original account-wide scope and --replace behavior.
+            if (
+                _active_signal_scoped_lock("signal-phone", self.account) is not None
+                and not getattr(self, "_platform_lock_takeover_allowed", False)
+            ):
+                self._set_fatal_error(
+                    "signal-phone_lock",
+                    "Signal account already in use. Stop the other gateway first.",
+                    retryable=True,
+                )
+                return False
+            try:
+                acquired = self._acquire_platform_lock(
+                    "signal-phone", self.account, "Signal account"
+                )
+            except Exception:
+                self._platform_lock_scope = None
+                self._platform_lock_identity = None
+                raise
+            if acquired:
+                routing_acquired = True
+            else:
+                self._platform_lock_scope = None
+                self._platform_lock_identity = None
+            return acquired
+        finally:
+            try:
+                _release_signal_scoped_lock(_SIGNAL_STARTUP_SCOPE, self.account)
+            except Exception:
+                if routing_acquired:
+                    try:
+                        self._release_signal_routing_locks()
+                    except Exception:
+                        logger.exception(
+                            "Signal: failed to roll back routing ownership after "
+                            "startup coordinator release failed"
+                        )
+                raise
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to signal-cli daemon and start SSE listener."""
+        if not isinstance(self.shared_account_group_only, bool):
+            logger.error("Signal: shared_account_group_only must be a boolean value")
+            return False
         if not self.http_url or not self.account:
             logger.error("Signal: SIGNAL_HTTP_URL and SIGNAL_ACCOUNT are required")
             return False
-        lock_acquired = False  # scoped lock prevents duplicate Signal listeners for the same phone
+
+        if self.shared_account_group_only:
+            if not self.group_allow_from:
+                logger.error("Signal: shared_account_group_only requires an explicit group allowlist")
+                return False
+            if "*" in self.group_allow_from:
+                logger.error("Signal: shared_account_group_only does not permit a wildcard group allowlist")
+                return False
+
+        lock_acquired = False
         try:
-            if not self._acquire_platform_lock('signal-phone', self.account, 'Signal account'):
+            if not self._acquire_signal_routing_locks():
                 return False
             lock_acquired = True
         except Exception as e:
+            if self.shared_account_group_only:
+                logger.error("Signal: could not acquire routing locks: %s", e)
+                return False
             logger.warning("Signal: Could not acquire phone lock (non-fatal): %s", e)
         # Tighter keepalive so idle CLOSE_WAIT drains promptly.
         # See #18451.
@@ -258,7 +465,7 @@ class SignalAdapter(BasePlatformAdapter):
             if not self._running:
                 await self._close_client()
                 if lock_acquired:
-                    self._release_platform_lock()
+                    self._release_signal_routing_locks()
 
     async def _close_client(self) -> None:
         if self.client:
@@ -281,7 +488,7 @@ class SignalAdapter(BasePlatformAdapter):
             task.cancel()
         self._typing_tasks.clear()
         await self._close_client()
-        self._release_platform_lock()
+        self._release_signal_routing_locks()
         logger.info("Signal: disconnected")
 
     async def _handle_sse_line(self, line: str) -> None:
@@ -371,7 +578,11 @@ class SignalAdapter(BasePlatformAdapter):
         if not sent_msg or not isinstance(sent_msg, dict):
             return None
         dest = sent_msg.get("destinationNumber") or sent_msg.get("destination")
-        if dest != self._account_normalized and not (sent_msg.get("groupInfo") or {}).get("groupId"):
+        group_id = (sent_msg.get("groupInfo") or {}).get("groupId")
+        if self.shared_account_group_only and dest == self._account_normalized and not group_id:
+            logger.debug("Signal: ignoring Note to Self in shared account group-only mode")
+            return None
+        if dest != self._account_normalized and not group_id:
             return None
         if self._consume_sent_timestamp(sent_msg.get("timestamp")):
             return None  # echo of our own outbound reply
@@ -444,6 +655,9 @@ class SignalAdapter(BasePlatformAdapter):
         group_info = data_message.get("groupInfo")
         group_id = group_info.get("groupId") if group_info else None
         is_group = bool(group_id)
+        if self.shared_account_group_only and not is_group:
+            logger.debug("Signal: ignoring DM in shared account group-only mode")
+            return
         if is_group and not self._group_allowed(group_id):
             return
         chat_id = f"group:{group_id}" if is_group else sender

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1359,6 +1359,80 @@ def remove_pid_file() -> None:
         pass
 
 
+def _scoped_lock_record_is_stale(record: dict[str, Any]) -> bool:
+    """Return whether a scoped-lock owner record is proven stale."""
+    try:
+        owner_pid = int(record["pid"])
+    except (KeyError, TypeError, ValueError):
+        return True
+
+    if not _pid_exists(owner_pid):
+        return True
+
+    current_start = _get_process_start_time(owner_pid)
+    recorded_start = record.get("start_time")
+    if owner_pid == os.getpid() and recorded_start == current_start:
+        return False
+    if (
+        recorded_start is not None
+        and current_start is not None
+        and current_start != recorded_start
+    ):
+        return True
+
+    # When start_time comparison is unavailable on either side (macOS /
+    # Windows have no /proc, so the lock record's start_time may be None;
+    # psutil may also fail to read create_time for recycled PIDs), fall back
+    # to checking the live process command line. When cmdline is also
+    # unreadable, consult the lock record's own argv. Both oracles must
+    # indicate "not a gateway" to mark stale.
+    if (
+        (recorded_start is None or current_start is None)
+        and not _looks_like_gateway_process(owner_pid)
+    ):
+        live_cmdline = _read_process_cmdline(owner_pid)
+        if live_cmdline is not None or not _record_looks_like_gateway(record):
+            return True
+
+    # Secondary defence against boot-time PID+start_time collisions.
+    if (
+        recorded_start is not None
+        and current_start is not None
+        and not _looks_like_gateway_process(owner_pid)
+    ):
+        live_cmdline = _read_process_cmdline(owner_pid)
+        if live_cmdline is not None:
+            return True
+
+    # Stopped processes still appear alive but cannot service the gateway.
+    try:
+        proc_status = Path(f"/proc/{owner_pid}/status")
+        if proc_status.exists():
+            for line in proc_status.read_text(encoding="utf-8").splitlines():
+                if line.startswith("State:"):
+                    return line.split()[1] in {"T", "t"}
+    except (OSError, PermissionError):
+        pass
+    return False
+
+
+def list_scoped_locks(
+    scope: Optional[str] = None,
+    *,
+    active_only: bool = False,
+) -> list[dict[str, Any]]:
+    """List machine-local scoped-lock records in deterministic order."""
+    records: list[dict[str, Any]] = []
+    for lock_path in sorted(_get_lock_dir().glob("*.lock")):
+        record = _read_json_file(lock_path)
+        if record is None or (scope is not None and record.get("scope") != scope):
+            continue
+        if active_only and _scoped_lock_record_is_stale(record):
+            continue
+        records.append(dict(record))
+    return records
+
+
 def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, Any]] = None) -> tuple[bool, Optional[dict[str, Any]]]:
     """Acquire a machine-local lock keyed by scope + identity.
 
@@ -1395,65 +1469,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
             _write_json_file(lock_path, record)
             return True, existing
 
-        stale = existing_pid is None
-        if not stale:
-            if not _pid_exists(existing_pid):
-                stale = True
-            else:
-                current_start = _get_process_start_time(existing_pid)
-                if (
-                    existing.get("start_time") is not None
-                    and current_start is not None
-                    and current_start != existing.get("start_time")
-                ):
-                    stale = True
-                # When start_time comparison is unavailable on either side
-                # (macOS / Windows have no /proc, so the lock record's
-                # start_time may be None; psutil may also fail to read
-                # create_time for recycled PIDs), fall back to checking the
-                # live process command line.  When cmdline is also unreadable
-                # (Windows has no ps), consult the lock record's own argv —
-                # the gateway writes it at startup and it's the only identity
-                # signal on platforms without ps.  Both oracles must indicate
-                # "not a gateway" to mark stale.
-                if (
-                    not stale
-                    and (existing.get("start_time") is None or current_start is None)
-                    and not _looks_like_gateway_process(existing_pid)
-                ):
-                    live_cmdline = _read_process_cmdline(existing_pid)
-                    if live_cmdline is not None or not _record_looks_like_gateway(existing):
-                        stale = True
-                # Secondary defence against boot-time PID+start_time collisions:
-                # systemd spawns core services deterministically, so an unrelated
-                # process (e.g. cron) can land on the exact same PID and jiffy
-                # count as a previous gateway. If both start_times are known and
-                # match but the live process is not a gateway, and we can confirm
-                # that by reading its cmdline, the lock is stale.
-                if (
-                    not stale
-                    and existing.get("start_time") is not None
-                    and current_start is not None
-                    and not _looks_like_gateway_process(existing_pid)
-                ):
-                    live_cmdline = _read_process_cmdline(existing_pid)
-                    if live_cmdline is not None:
-                        stale = True
-                # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
-                # processes still appear alive to _pid_exists but are not
-                # actually running. Treat them as stale so --replace works.
-                if not stale:
-                    try:
-                        _proc_status = Path(f"/proc/{existing_pid}/status")
-                        if _proc_status.exists():
-                            for _line in _proc_status.read_text(encoding="utf-8").splitlines():
-                                if _line.startswith("State:"):
-                                    _state = _line.split()[1]
-                                    if _state in {"T", "t"}:  # stopped or tracing stop
-                                        stale = True
-                                    break
-                    except (OSError, PermissionError):
-                        pass
+        stale = _scoped_lock_record_is_stale(existing)
         if stale:
             # Remove the stale lock ATOMICALLY by renaming it to a tombstone
             # instead of unlinking. With unlink()+O_EXCL, two racing starters

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1026,6 +1026,28 @@ def _scoped_lock_record_is_stale(existing: dict[str, Any], existing_pid: Optiona
     return _process_is_stopped(existing_pid)
 
 
+def list_scoped_locks(
+    scope: Optional[str] = None,
+    *,
+    active_only: bool = False,
+) -> list[dict[str, Any]]:
+    """List machine-local scoped-lock records in deterministic order."""
+    records: list[dict[str, Any]] = []
+    for lock_path in sorted(_get_lock_dir().glob("*.lock")):
+        record = _read_json_file(lock_path)
+        if record is None or (scope is not None and record.get("scope") != scope):
+            continue
+        owner_pid = _pid_from_record(record)
+        if (
+            active_only
+            and owner_pid != os.getpid()
+            and _scoped_lock_record_is_stale(record, owner_pid)
+        ):
+            continue
+        records.append(dict(record))
+    return records
+
+
 def _process_is_stopped(pid: int) -> bool:
     """True for a stopped / tracing-stop state (T/t) in ``/proc/<pid>/status``."""
     with contextlib.suppress(OSError):

--- a/tests/gateway/test_signal_shared_group.py
+++ b/tests/gateway/test_signal_shared_group.py
@@ -1,0 +1,767 @@
+"""Tests for Signal shared-account group-only mode."""
+
+import subprocess
+import sys
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import Platform, PlatformConfig
+
+
+@pytest.fixture(autouse=True)
+def _reset_signal_scheduler():
+    """The attachment scheduler is process-wide; drop it between tests
+    so a fresh token bucket greets each case."""
+    from gateway.platforms.signal_rate_limit import _reset_scheduler
+
+    _reset_scheduler()
+    yield
+    _reset_scheduler()
+
+
+def _make_signal_adapter(monkeypatch, account="+15551234567", **extra):
+    """Create a SignalAdapter with sensible test defaults."""
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", extra.pop("group_allowed", ""))
+    from gateway.platforms.signal import SignalAdapter
+
+    config = PlatformConfig()
+    config.enabled = True
+    config.extra = {
+        "http_url": "http://localhost:8080",
+        "account": account,
+        **extra,
+    }
+    return SignalAdapter(config)
+
+
+class TestSignalSharedConfigLoading:
+    def test_shared_account_group_only_loads_from_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "signal:\n  shared_account_group_only: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+155****4567")
+
+        from gateway.config import load_gateway_config
+
+        config = load_gateway_config()
+
+        signal_config = config.platforms[Platform.SIGNAL]
+        assert signal_config.extra["shared_account_group_only"] is True
+
+    @pytest.mark.parametrize(
+        "config_text",
+        [
+            "platforms:\n  signal:\n    shared_account_group_only: true\n",
+            "gateway:\n  platforms:\n    signal:\n      shared_account_group_only: true\n",
+        ],
+    )
+    def test_shared_account_group_only_loads_from_nested_config(
+        self, tmp_path, monkeypatch, config_text
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(config_text, encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+155****4567")
+
+        from gateway.config import load_gateway_config
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.SIGNAL].extra["shared_account_group_only"] is True
+        )
+
+
+class TestSignalSharedAdapterInit:
+    def test_shared_account_group_only_defaults_off(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        assert adapter.shared_account_group_only is False
+
+    def test_shared_account_group_only_reads_config(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, shared_account_group_only=True)
+        assert adapter.shared_account_group_only is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", ["false", 1, ["invalid"]])
+    async def test_shared_account_group_only_rejects_unsupported_values(
+        self, monkeypatch, value
+    ):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=value,
+            group_allowed="abc123==",
+        )
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+
+        result = await adapter.connect()
+
+        assert result is False
+        adapter._acquire_platform_lock.assert_not_called()
+
+
+class TestSignalSharedAccountConnectionPolicy:
+    @pytest.mark.asyncio
+    async def test_requires_explicit_group_allowlist(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, shared_account_group_only=True)
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+
+        result = await adapter.connect()
+
+        assert result is False
+        adapter._acquire_platform_lock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_wildcard_group_allowlist(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="*",
+        )
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+
+        result = await adapter.connect()
+
+        assert result is False
+        adapter._acquire_platform_lock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_connect_releases_shared_group_claims(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=MagicMock(status_code=503))
+        mock_client.aclose = AsyncMock()
+
+        with patch(
+            "gateway.platforms.signal.httpx.AsyncClient", return_value=mock_client
+        ):
+            result = await adapter.connect()
+
+        assert result is False
+        mock_client.aclose.assert_awaited_once()
+        from gateway.platforms import signal as signal_module
+
+        assert (
+            signal_module.list_scoped_locks(
+                signal_module._signal_group_scope(adapter.account), active_only=True
+            )
+            == []
+        )
+
+
+class TestSignalRoutingLocks:
+    @pytest.mark.parametrize("first_shared", [False, True])
+    def test_rejects_mixed_modes_in_either_order(
+        self, tmp_path, monkeypatch, first_shared
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+        first = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=first_shared,
+            group_allowed="group-a==" if first_shared else "",
+        )
+        assert first._acquire_signal_routing_locks() is True
+
+        try:
+            monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-b"))
+            second = _make_signal_adapter(
+                monkeypatch,
+                shared_account_group_only=not first_shared,
+                group_allowed="group-b==" if not first_shared else "",
+            )
+
+            assert second._acquire_signal_routing_locks() is False
+        finally:
+            first._release_signal_routing_locks()
+
+    def test_group_claims_are_scoped_to_account(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        first = _make_signal_adapter(
+            monkeypatch,
+            account="+15550000001",
+            shared_account_group_only=True,
+            group_allowed="same-group==",
+        )
+        second = _make_signal_adapter(
+            monkeypatch,
+            account="+15550000002",
+            shared_account_group_only=True,
+            group_allowed="same-group==",
+        )
+
+        assert first._acquire_signal_routing_locks() is True
+        try:
+            assert second._acquire_signal_routing_locks() is True
+            from gateway.status import list_scoped_locks
+
+            records = [
+                record
+                for record in list_scoped_locks(active_only=True)
+                if record.get("metadata", {}).get("signal_mode") == "shared-group"
+            ]
+            assert len(records) == 2
+            assert len({record["scope"] for record in records}) == 2
+        finally:
+            second._release_signal_routing_locks()
+            first._release_signal_routing_locks()
+
+    def test_normal_mode_preserves_legacy_account_lock(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        adapter = _make_signal_adapter(monkeypatch)
+        assert adapter._acquire_signal_routing_locks() is True
+        try:
+            assert adapter._platform_lock_scope == "signal-phone"
+            assert adapter._platform_lock_identity == adapter.account
+        finally:
+            adapter._release_signal_routing_locks()
+
+    def test_normal_replace_delegates_existing_account_lock_to_base(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.platforms import signal as signal_module
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._platform_lock_takeover_allowed = True
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+        acquired, _ = signal_module.acquire_scoped_lock(
+            "signal-phone", adapter.account
+        )
+        assert acquired is True
+
+        try:
+            assert adapter._acquire_signal_routing_locks() is True
+            adapter._acquire_platform_lock.assert_called_once_with(
+                "signal-phone",
+                adapter.account,
+                "Signal account",
+            )
+        finally:
+            signal_module._release_signal_scoped_lock(
+                "signal-phone", adapter.account
+            )
+
+    def test_startup_coordinator_contention_is_retryable(self, tmp_path, monkeypatch):
+        from gateway.platforms import signal as signal_module
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        account = "test-account"
+        acquired, _ = signal_module.acquire_scoped_lock(
+            signal_module._SIGNAL_STARTUP_SCOPE, account
+        )
+        assert acquired is True
+
+        contender = _make_signal_adapter(
+            monkeypatch,
+            account=account,
+            shared_account_group_only=True,
+            group_allowed="group-a==",
+        )
+        assert contender._acquire_signal_routing_locks() is False
+        assert contender.fatal_error_code == "signal_account_coordinator_lock"
+        assert contender.fatal_error_retryable is True
+
+        signal_module._release_signal_scoped_lock(
+            signal_module._SIGNAL_STARTUP_SCOPE, account
+        )
+        retry = _make_signal_adapter(
+            monkeypatch,
+            account=account,
+            shared_account_group_only=True,
+            group_allowed="group-a==",
+        )
+        assert retry._acquire_signal_routing_locks() is True
+        retry._release_signal_routing_locks()
+
+    def test_failed_duplicate_normal_adapter_preserves_live_legacy_lock(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+        first = _make_signal_adapter(monkeypatch)
+        second = _make_signal_adapter(monkeypatch)
+        assert first._acquire_signal_routing_locks() is True
+
+        try:
+            assert second._acquire_signal_routing_locks() is False
+            assert getattr(second, "_platform_lock_identity", None) is None
+            second._release_signal_routing_locks()
+
+            third = _make_signal_adapter(monkeypatch)
+            assert third._acquire_signal_routing_locks() is False
+        finally:
+            first._release_signal_routing_locks()
+
+        assert third._acquire_signal_routing_locks() is True
+        third._release_signal_routing_locks()
+
+    def test_shared_guard_release_failure_rolls_back_committed_group_claims(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.platforms import signal as signal_module
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        real_release = signal_module._release_signal_scoped_lock
+
+        def release_that_fails_for_startup(scope, identity):
+            real_release(scope, identity)
+            if scope == signal_module._SIGNAL_STARTUP_SCOPE:
+                raise OSError("startup guard release failed")
+
+        monkeypatch.setattr(
+            signal_module,
+            "_release_signal_scoped_lock",
+            release_that_fails_for_startup,
+        )
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-a==",
+        )
+
+        with pytest.raises(OSError, match="startup guard release failed"):
+            adapter._acquire_signal_routing_locks()
+
+        assert adapter._signal_group_claims == []
+        assert (
+            signal_module.list_scoped_locks(
+                signal_module._signal_group_scope(adapter.account), active_only=True
+            )
+            == []
+        )
+
+    def test_normal_guard_release_failure_rolls_back_committed_account_lock(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.platforms import signal as signal_module
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        real_release = signal_module._release_signal_scoped_lock
+
+        def release_that_fails_for_startup(scope, identity):
+            real_release(scope, identity)
+            if scope == signal_module._SIGNAL_STARTUP_SCOPE:
+                raise OSError("startup guard release failed")
+
+        monkeypatch.setattr(
+            signal_module,
+            "_release_signal_scoped_lock",
+            release_that_fails_for_startup,
+        )
+        adapter = _make_signal_adapter(monkeypatch)
+
+        with pytest.raises(OSError, match="startup guard release failed"):
+            adapter._acquire_signal_routing_locks()
+
+        assert adapter._platform_lock_identity is None
+        available, _ = signal_module.acquire_scoped_lock(
+            "signal-phone",
+            adapter.account,
+        )
+        assert available is True
+        signal_module._release_signal_scoped_lock("signal-phone", adapter.account)
+
+    def test_failed_duplicate_adapter_cannot_release_live_owner(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.platforms import signal as signal_module
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+        first = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="same-group==",
+        )
+        second = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="same-group==",
+        )
+        assert first._acquire_signal_routing_locks() is True
+
+        try:
+            assert second._acquire_signal_routing_locks() is False
+            second._release_signal_routing_locks()
+            assert signal_module.list_scoped_locks(
+                signal_module._signal_group_scope(first.account), active_only=True
+            )
+
+            third = _make_signal_adapter(
+                monkeypatch,
+                shared_account_group_only=True,
+                group_allowed="same-group==",
+            )
+            assert third._acquire_signal_routing_locks() is False
+        finally:
+            first._release_signal_routing_locks()
+
+    def test_allows_disjoint_shared_group_assignments(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        first = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-a==,group-b==",
+        )
+        second = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-c==,group-d==",
+        )
+
+        assert first._acquire_signal_routing_locks() is True
+        try:
+            assert second._acquire_signal_routing_locks() is True
+        finally:
+            second._release_signal_routing_locks()
+            first._release_signal_routing_locks()
+
+    def test_partial_overlap_retains_no_nonoverlapping_group(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        first = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-b==",
+        )
+        overlapping = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-a==,group-b==",
+        )
+        group_a = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-a==",
+        )
+
+        assert first._acquire_signal_routing_locks() is True
+        try:
+            assert overlapping._acquire_signal_routing_locks() is False
+            assert group_a._acquire_signal_routing_locks() is True
+            group_a._release_signal_routing_locks()
+        finally:
+            first._release_signal_routing_locks()
+
+    def test_partial_set_rollback_attempts_every_release_after_error(
+        self, tmp_path, monkeypatch
+    ):
+        import gateway.platforms.signal as signal_module
+        from gateway.status import list_scoped_locks
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        holder = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-c==",
+        )
+        overlapping = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-a==,group-b==,group-c==",
+        )
+
+        assert holder._acquire_signal_routing_locks() is True
+        real_release = signal_module._release_signal_scoped_lock
+        released = []
+
+        def flaky_release(scope, identity):
+            released.append(identity)
+            if identity == "group-a==":
+                raise OSError("first rollback release failed")
+            return real_release(scope, identity)
+
+        monkeypatch.setattr(signal_module, "_release_signal_scoped_lock", flaky_release)
+        try:
+            with pytest.raises(OSError, match="first rollback release failed"):
+                overlapping._acquire_signal_routing_locks()
+
+            assert "group-a==" in released
+            assert "group-b==" in released
+            active_hashes = {
+                record["identity_hash"]
+                for record in list_scoped_locks(
+                    signal_module._signal_group_scope(holder.account), active_only=True
+                )
+            }
+            assert (
+                signal_module.hashlib.sha256(b"group-b==").hexdigest()[:16]
+                not in active_hashes
+            )
+        finally:
+            holder._release_signal_routing_locks()
+
+
+class TestSignalSharedAccountGroupOnlyInbound:
+    @pytest.mark.asyncio
+    async def test_drops_direct_messages(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "contact-uuid",
+                "sourceUuid": "contact-uuid",
+                "timestamp": 1900000000,
+                "dataMessage": {"message": "private request"},
+            }
+        })
+
+        assert captured == []
+
+    @pytest.mark.parametrize(
+        ("group_id", "expected_count"),
+        [("abc123==", 1), ("unassigned==", 0)],
+    )
+    @pytest.mark.asyncio
+    async def test_filters_ordinary_group_messages_by_assignment(
+        self, monkeypatch, group_id, expected_count
+    ):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+15550001111",
+                "sourceUuid": "contact-uuid",
+                "timestamp": 1950000000,
+                "dataMessage": {
+                    "message": "ordinary group message",
+                    "groupInfo": {"groupId": group_id, "type": "DELIVER"},
+                },
+            }
+        })
+
+        assert len(captured) == expected_count
+
+    @pytest.mark.asyncio
+    async def test_drops_non_group_sync_sent_messages(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": adapter.account,
+                "sourceUuid": "uuid-self",
+                "timestamp": 1975000000,
+                "syncMessage": {
+                    "sentMessage": {
+                        "destinationNumber": "+15550002222",
+                        "timestamp": 1975000000,
+                        "message": "sent direct message",
+                    }
+                },
+            }
+        })
+
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_drops_note_to_self(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": adapter.account,
+                "sourceUuid": "uuid-self",
+                "timestamp": 2000000000,
+                "syncMessage": {
+                    "sentMessage": {
+                        "destinationNumber": adapter.account,
+                        "destination": adapter.account,
+                        "timestamp": 2000000000,
+                        "message": "note to self: buy milk",
+                    }
+                },
+            }
+        })
+
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_processes_allowlisted_group_sync_messages(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": adapter.account,
+                "sourceUuid": "uuid-self",
+                "timestamp": 2100000000,
+                "syncMessage": {
+                    "sentMessage": {
+                        "destinationNumber": None,
+                        "destination": None,
+                        "timestamp": 2100000000,
+                        "message": "message from my phone",
+                        "groupInfo": {
+                            "groupId": "abc123==",
+                            "type": "DELIVER",
+                        },
+                    }
+                },
+            }
+        })
+
+        assert len(captured) == 1
+        assert captured[0].text == "message from my phone"
+        assert captured[0].source.chat_id == "group:abc123=="
+
+
+def test_signal_release_detects_marker_that_remains_owned(tmp_path, monkeypatch):
+    from gateway.platforms import signal as signal_module
+
+    monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+    scope = signal_module._signal_group_scope("+15550000001")
+    acquired, _ = signal_module.acquire_scoped_lock(
+        scope,
+        "group-a",
+        metadata={"platform": "signal", "signal_mode": "shared-group"},
+    )
+    assert acquired is True
+    monkeypatch.setattr(signal_module, "release_scoped_lock", lambda *args: None)
+
+    with pytest.raises(OSError, match="still owned"):
+        signal_module._release_signal_scoped_lock(scope, "group-a")
+
+    assert signal_module._active_signal_scoped_lock(scope, "group-a") is not None
+
+
+def test_routing_cleanup_attempts_every_release_after_group_error(monkeypatch):
+    from gateway.platforms import signal as signal_module
+
+    adapter = _make_signal_adapter(monkeypatch, shared_account_group_only=True)
+    adapter._signal_group_claims = [("scope", "group-a"), ("scope", "group-b")]
+    calls = []
+
+    def release(scope, identity):
+        calls.append((scope, identity))
+        if identity == "group-a":
+            raise OSError("unlock failed")
+
+    monkeypatch.setattr(signal_module, "_release_signal_scoped_lock", release)
+    adapter._release_platform_lock = MagicMock()
+
+    with pytest.raises(OSError, match="unlock failed"):
+        adapter._release_signal_routing_locks()
+
+    assert [identity for _, identity in calls] == ["group-a", "group-b"]
+    assert adapter._signal_group_claims == []
+    adapter._release_platform_lock.assert_called_once_with()
+
+
+def test_group_claim_recovers_after_holder_process_exits(tmp_path, monkeypatch):
+    from gateway.platforms import signal as signal_module
+
+    lock_dir = str(tmp_path / "locks")
+    account = "test-account"
+    monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", lock_dir)
+    holder = tmp_path / "hermes"
+    holder.write_text(
+        "import os, sys\n"
+        "os.environ['HERMES_GATEWAY_LOCK_DIR'] = sys.argv[1]\n"
+        "from gateway.platforms.signal import _signal_group_scope\n"
+        "from gateway.status import acquire_scoped_lock\n"
+        "ok, _ = acquire_scoped_lock("
+        "_signal_group_scope(sys.argv[2]), sys.argv[3])\n"
+        "print('READY' if ok else 'FAILED', flush=True)\n"
+        "sys.stdin.readline()\n",
+        encoding="utf-8",
+    )
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(holder),
+            lock_dir,
+            account,
+            "group-a",
+            "gateway",
+            "run",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.stdout is not None
+        assert process.stdout.readline().strip() == "READY"
+        scope = signal_module._signal_group_scope(account)
+        assert (
+            signal_module.acquire_scoped_lock(scope, "group-a")[0]
+            is False
+        )
+
+        process.terminate()
+        process.wait(timeout=10)
+        assert (
+            signal_module.acquire_scoped_lock(scope, "group-a")[0]
+            is True
+        )
+        signal_module._release_signal_scoped_lock(scope, "group-a")
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=10)

--- a/tests/gateway/test_signal_shared_group.py
+++ b/tests/gateway/test_signal_shared_group.py
@@ -135,6 +135,25 @@ class TestSignalSharedAccountConnectionPolicy:
         adapter._acquire_platform_lock.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_normal_mode_lock_exception_still_checks_daemon(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._acquire_signal_routing_locks = MagicMock(
+            side_effect=OSError("lock storage unavailable")
+        )
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=MagicMock(status_code=503))
+        mock_client.aclose = AsyncMock()
+
+        with patch(
+            "gateway.platforms.signal.httpx.AsyncClient", return_value=mock_client
+        ):
+            result = await adapter.connect()
+
+        assert result is False
+        mock_client.get.assert_awaited_once()
+        mock_client.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_failed_connect_releases_shared_group_claims(
         self, tmp_path, monkeypatch
     ):

--- a/tests/gateway/test_signal_shared_group.py
+++ b/tests/gateway/test_signal_shared_group.py
@@ -1,0 +1,788 @@
+"""Tests for Signal shared-account group-only mode."""
+
+import subprocess
+import sys
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import Platform, PlatformConfig
+
+
+@pytest.fixture(autouse=True)
+def _reset_signal_scheduler():
+    """The attachment scheduler is process-wide; drop it between tests
+    so a fresh token bucket greets each case."""
+    from gateway.platforms.signal_rate_limit import _reset_scheduler
+
+    _reset_scheduler()
+    yield
+    _reset_scheduler()
+
+
+def _make_signal_adapter(monkeypatch, account="+15551234567", **extra):
+    """Create a SignalAdapter with sensible test defaults."""
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", extra.pop("group_allowed", ""))
+    from gateway.platforms.signal import SignalAdapter
+
+    config = PlatformConfig()
+    config.enabled = True
+    config.extra = {
+        "http_url": "http://localhost:8080",
+        "account": account,
+        **extra,
+    }
+    return SignalAdapter(config)
+
+
+class TestSignalSharedConfigLoading:
+    def test_shared_account_group_only_loads_from_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "signal:\n  shared_account_group_only: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+155****4567")
+
+        from gateway.config import load_gateway_config
+
+        config = load_gateway_config()
+
+        signal_config = config.platforms[Platform.SIGNAL]
+        assert signal_config.extra["shared_account_group_only"] is True
+
+    @pytest.mark.parametrize(
+        "config_text",
+        [
+            "platforms:\n  signal:\n    shared_account_group_only: true\n",
+            "gateway:\n  platforms:\n    signal:\n      shared_account_group_only: true\n",
+        ],
+    )
+    def test_shared_account_group_only_loads_from_nested_config(
+        self, tmp_path, monkeypatch, config_text
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(config_text, encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+155****4567")
+
+        from gateway.config import load_gateway_config
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.SIGNAL].extra["shared_account_group_only"] is True
+        )
+
+
+class TestSignalSharedAdapterInit:
+    def test_shared_account_group_only_defaults_off(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        assert adapter.shared_account_group_only is False
+
+    def test_shared_account_group_only_reads_config(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, shared_account_group_only=True)
+        assert adapter.shared_account_group_only is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", ["false", 1, ["invalid"]])
+    async def test_shared_account_group_only_rejects_unsupported_values(
+        self, monkeypatch, value
+    ):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=value,
+            group_allowed="abc123==",
+        )
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+
+        result = await adapter.connect()
+
+        assert result is False
+        adapter._acquire_platform_lock.assert_not_called()
+
+
+class TestSignalSharedAccountConnectionPolicy:
+    @pytest.mark.asyncio
+    async def test_requires_explicit_group_allowlist(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, shared_account_group_only=True)
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+
+        result = await adapter.connect()
+
+        assert result is False
+        adapter._acquire_platform_lock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_wildcard_group_allowlist(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="*",
+        )
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+
+        result = await adapter.connect()
+
+        assert result is False
+        adapter._acquire_platform_lock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_normal_mode_lock_exception_still_checks_daemon(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._acquire_signal_routing_locks = MagicMock(
+            side_effect=OSError("lock storage unavailable")
+        )
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=MagicMock(status_code=503))
+        mock_client.aclose = AsyncMock()
+
+        with patch(
+            "gateway.platforms.signal.httpx.AsyncClient", return_value=mock_client
+        ):
+            result = await adapter.connect()
+
+        assert result is False
+        mock_client.get.assert_awaited_once()
+        mock_client.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_failed_connect_releases_shared_group_claims(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=MagicMock(status_code=503))
+        mock_client.aclose = AsyncMock()
+
+        with patch(
+            "gateway.platforms.signal.httpx.AsyncClient", return_value=mock_client
+        ):
+            result = await adapter.connect()
+
+        assert result is False
+        mock_client.aclose.assert_awaited_once()
+        from gateway.platforms import signal as signal_module
+
+        assert (
+            signal_module.list_scoped_locks(
+                signal_module._signal_group_scope(adapter.account), active_only=True
+            )
+            == []
+        )
+
+
+class TestSignalRoutingLocks:
+    @pytest.mark.parametrize("first_shared", [False, True])
+    def test_rejects_mixed_modes_in_either_order(
+        self, tmp_path, monkeypatch, first_shared
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+        first = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=first_shared,
+            group_allowed="group-a==" if first_shared else "",
+        )
+        assert first._acquire_signal_routing_locks() is True
+
+        try:
+            monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-b"))
+            second = _make_signal_adapter(
+                monkeypatch,
+                shared_account_group_only=not first_shared,
+                group_allowed="group-b==" if not first_shared else "",
+            )
+
+            assert second._acquire_signal_routing_locks() is False
+        finally:
+            first._release_signal_routing_locks()
+
+    def test_group_claims_are_scoped_to_account(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        first = _make_signal_adapter(
+            monkeypatch,
+            account="+15550000001",
+            shared_account_group_only=True,
+            group_allowed="same-group==",
+        )
+        second = _make_signal_adapter(
+            monkeypatch,
+            account="+15550000002",
+            shared_account_group_only=True,
+            group_allowed="same-group==",
+        )
+
+        assert first._acquire_signal_routing_locks() is True
+        try:
+            assert second._acquire_signal_routing_locks() is True
+            from gateway.status import list_scoped_locks
+
+            records = [
+                record
+                for record in list_scoped_locks(active_only=True)
+                if record.get("metadata", {}).get("signal_mode") == "shared-group"
+            ]
+            assert len(records) == 2
+            assert len({record["scope"] for record in records}) == 2
+        finally:
+            second._release_signal_routing_locks()
+            first._release_signal_routing_locks()
+
+    def test_normal_mode_preserves_legacy_account_lock(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        adapter = _make_signal_adapter(monkeypatch)
+        assert adapter._acquire_signal_routing_locks() is True
+        try:
+            assert adapter._platform_lock_scope == "signal-phone"
+            assert adapter._platform_lock_identity == adapter.account
+        finally:
+            adapter._release_signal_routing_locks()
+
+    def test_normal_replace_delegates_existing_account_lock_to_base(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.platforms import signal as signal_module
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._platform_lock_takeover_allowed = True
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+        acquired, _ = signal_module.acquire_scoped_lock(
+            "signal-phone", adapter.account
+        )
+        assert acquired is True
+
+        try:
+            assert adapter._acquire_signal_routing_locks() is True
+            adapter._acquire_platform_lock.assert_called_once_with(
+                "signal-phone",
+                adapter.account,
+                "Signal account",
+            )
+        finally:
+            signal_module._release_signal_scoped_lock(
+                "signal-phone", adapter.account
+            )
+
+    def test_startup_coordinator_contention_is_retryable(self, tmp_path, monkeypatch):
+        from gateway.platforms import signal as signal_module
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        account = "test-account"
+        acquired, _ = signal_module.acquire_scoped_lock(
+            signal_module._SIGNAL_STARTUP_SCOPE, account
+        )
+        assert acquired is True
+
+        contender = _make_signal_adapter(
+            monkeypatch,
+            account=account,
+            shared_account_group_only=True,
+            group_allowed="group-a==",
+        )
+        assert contender._acquire_signal_routing_locks() is False
+        assert contender.fatal_error_code == "signal_account_coordinator_lock"
+        assert contender.fatal_error_retryable is True
+
+        signal_module._release_signal_scoped_lock(
+            signal_module._SIGNAL_STARTUP_SCOPE, account
+        )
+        retry = _make_signal_adapter(
+            monkeypatch,
+            account=account,
+            shared_account_group_only=True,
+            group_allowed="group-a==",
+        )
+        assert retry._acquire_signal_routing_locks() is True
+        retry._release_signal_routing_locks()
+
+    def test_failed_duplicate_normal_adapter_preserves_live_legacy_lock(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+        first = _make_signal_adapter(monkeypatch)
+        second = _make_signal_adapter(monkeypatch)
+        assert first._acquire_signal_routing_locks() is True
+
+        try:
+            assert second._acquire_signal_routing_locks() is False
+            assert getattr(second, "_platform_lock_identity", None) is None
+            second._release_signal_routing_locks()
+
+            third = _make_signal_adapter(monkeypatch)
+            assert third._acquire_signal_routing_locks() is False
+        finally:
+            first._release_signal_routing_locks()
+
+        assert third._acquire_signal_routing_locks() is True
+        third._release_signal_routing_locks()
+
+    def test_shared_guard_release_failure_rolls_back_committed_group_claims(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.platforms import signal as signal_module
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        real_release = signal_module._release_signal_scoped_lock
+
+        def release_that_fails_for_startup(scope, identity):
+            real_release(scope, identity)
+            if scope == signal_module._SIGNAL_STARTUP_SCOPE:
+                raise OSError("startup guard release failed")
+
+        monkeypatch.setattr(
+            signal_module,
+            "_release_signal_scoped_lock",
+            release_that_fails_for_startup,
+        )
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-a==",
+        )
+
+        with pytest.raises(OSError, match="startup guard release failed"):
+            adapter._acquire_signal_routing_locks()
+
+        assert adapter._signal_group_claims == []
+        assert (
+            signal_module.list_scoped_locks(
+                signal_module._signal_group_scope(adapter.account), active_only=True
+            )
+            == []
+        )
+
+    def test_normal_guard_release_failure_rolls_back_committed_account_lock(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.platforms import signal as signal_module
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        real_release = signal_module._release_signal_scoped_lock
+
+        def release_that_fails_for_startup(scope, identity):
+            real_release(scope, identity)
+            if scope == signal_module._SIGNAL_STARTUP_SCOPE:
+                raise OSError("startup guard release failed")
+
+        monkeypatch.setattr(
+            signal_module,
+            "_release_signal_scoped_lock",
+            release_that_fails_for_startup,
+        )
+        adapter = _make_signal_adapter(monkeypatch)
+
+        with pytest.raises(OSError, match="startup guard release failed"):
+            adapter._acquire_signal_routing_locks()
+
+        assert adapter._platform_lock_identity is None
+        available, _ = signal_module.acquire_scoped_lock(
+            "signal-phone",
+            adapter.account,
+        )
+        assert available is True
+        signal_module._release_signal_scoped_lock("signal-phone", adapter.account)
+
+    def test_failed_duplicate_adapter_cannot_release_live_owner(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.platforms import signal as signal_module
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+        first = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="same-group==",
+        )
+        second = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="same-group==",
+        )
+        assert first._acquire_signal_routing_locks() is True
+
+        try:
+            assert second._acquire_signal_routing_locks() is False
+            second._release_signal_routing_locks()
+            assert signal_module.list_scoped_locks(
+                signal_module._signal_group_scope(first.account), active_only=True
+            )
+
+            third = _make_signal_adapter(
+                monkeypatch,
+                shared_account_group_only=True,
+                group_allowed="same-group==",
+            )
+            assert third._acquire_signal_routing_locks() is False
+        finally:
+            first._release_signal_routing_locks()
+
+    def test_allows_disjoint_shared_group_assignments(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        first = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-a==,group-b==",
+        )
+        second = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-c==,group-d==",
+        )
+
+        assert first._acquire_signal_routing_locks() is True
+        try:
+            assert second._acquire_signal_routing_locks() is True
+        finally:
+            second._release_signal_routing_locks()
+            first._release_signal_routing_locks()
+
+    def test_partial_overlap_retains_no_nonoverlapping_group(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        first = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-b==",
+        )
+        overlapping = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-a==,group-b==",
+        )
+        group_a = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-a==",
+        )
+
+        assert first._acquire_signal_routing_locks() is True
+        try:
+            assert overlapping._acquire_signal_routing_locks() is False
+            assert group_a._acquire_signal_routing_locks() is True
+            group_a._release_signal_routing_locks()
+        finally:
+            first._release_signal_routing_locks()
+
+    def test_partial_set_rollback_attempts_every_release_after_error(
+        self, tmp_path, monkeypatch
+    ):
+        import gateway.platforms.signal as signal_module
+        from gateway.status import list_scoped_locks
+
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        holder = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-c==",
+        )
+        overlapping = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="group-a==,group-b==,group-c==",
+        )
+
+        assert holder._acquire_signal_routing_locks() is True
+        real_release = signal_module._release_signal_scoped_lock
+        released = []
+
+        def flaky_release(scope, identity):
+            released.append(identity)
+            if identity == "group-a==":
+                raise OSError("first rollback release failed")
+            return real_release(scope, identity)
+
+        monkeypatch.setattr(signal_module, "_release_signal_scoped_lock", flaky_release)
+        try:
+            with pytest.raises(OSError, match="first rollback release failed"):
+                overlapping._acquire_signal_routing_locks()
+
+            assert "group-a==" in released
+            assert "group-b==" in released
+            active_hashes = {
+                record["identity_hash"]
+                for record in list_scoped_locks(
+                    signal_module._signal_group_scope(holder.account), active_only=True
+                )
+            }
+            assert (
+                signal_module.hashlib.sha256(b"group-b==").hexdigest()[:16]
+                not in active_hashes
+            )
+        finally:
+            holder._release_signal_routing_locks()
+
+
+class TestSignalSharedAccountGroupOnlyInbound:
+    @pytest.mark.asyncio
+    async def test_drops_direct_messages(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "contact-uuid",
+                "sourceUuid": "contact-uuid",
+                "timestamp": 1900000000,
+                "dataMessage": {"message": "private request"},
+            }
+        })
+
+        assert captured == []
+
+    @pytest.mark.parametrize(
+        ("group_id", "expected_count"),
+        [("abc123==", 1), ("unassigned==", 0)],
+    )
+    @pytest.mark.asyncio
+    async def test_filters_ordinary_group_messages_by_assignment(
+        self, monkeypatch, group_id, expected_count
+    ):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+15550001111",
+                "sourceUuid": "contact-uuid",
+                "timestamp": 1950000000,
+                "dataMessage": {
+                    "message": "ordinary group message",
+                    "groupInfo": {"groupId": group_id, "type": "DELIVER"},
+                },
+            }
+        })
+
+        assert len(captured) == expected_count
+
+    @pytest.mark.asyncio
+    async def test_drops_non_group_sync_sent_messages(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": adapter.account,
+                "sourceUuid": "uuid-self",
+                "timestamp": 1975000000,
+                "syncMessage": {
+                    "sentMessage": {
+                        "destinationNumber": "+15550002222",
+                        "timestamp": 1975000000,
+                        "message": "sent direct message",
+                    }
+                },
+            }
+        })
+
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_drops_note_to_self(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        adapter._recent_sent_timestamps[2000000000] = 1.0
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": adapter.account,
+                "sourceUuid": "uuid-self",
+                "timestamp": 2000000000,
+                "syncMessage": {
+                    "sentMessage": {
+                        "destinationNumber": adapter.account,
+                        "destination": adapter.account,
+                        "timestamp": 2000000000,
+                        "message": "note to self: buy milk",
+                    }
+                },
+            }
+        })
+
+        assert captured == []
+        assert 2000000000 in adapter._recent_sent_timestamps
+
+    @pytest.mark.asyncio
+    async def test_processes_allowlisted_group_sync_messages(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            shared_account_group_only=True,
+            group_allowed="abc123==",
+        )
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": adapter.account,
+                "sourceUuid": "uuid-self",
+                "timestamp": 2100000000,
+                "syncMessage": {
+                    "sentMessage": {
+                        "destinationNumber": None,
+                        "destination": None,
+                        "timestamp": 2100000000,
+                        "message": "message from my phone",
+                        "groupInfo": {
+                            "groupId": "abc123==",
+                            "type": "DELIVER",
+                        },
+                    }
+                },
+            }
+        })
+
+        assert len(captured) == 1
+        assert captured[0].text == "message from my phone"
+        assert captured[0].source.chat_id == "group:abc123=="
+
+
+def test_signal_release_detects_marker_that_remains_owned(tmp_path, monkeypatch):
+    from gateway.platforms import signal as signal_module
+
+    monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+    scope = signal_module._signal_group_scope("+15550000001")
+    acquired, _ = signal_module.acquire_scoped_lock(
+        scope,
+        "group-a",
+        metadata={"platform": "signal", "signal_mode": "shared-group"},
+    )
+    assert acquired is True
+    monkeypatch.setattr(signal_module, "release_scoped_lock", lambda *args: None)
+
+    with pytest.raises(OSError, match="still owned"):
+        signal_module._release_signal_scoped_lock(scope, "group-a")
+
+    assert signal_module._active_signal_scoped_lock(scope, "group-a") is not None
+
+
+def test_routing_cleanup_attempts_every_release_after_group_error(monkeypatch):
+    from gateway.platforms import signal as signal_module
+
+    adapter = _make_signal_adapter(monkeypatch, shared_account_group_only=True)
+    adapter._signal_group_claims = [("scope", "group-a"), ("scope", "group-b")]
+    calls = []
+
+    def release(scope, identity):
+        calls.append((scope, identity))
+        if identity == "group-a":
+            raise OSError("unlock failed")
+
+    monkeypatch.setattr(signal_module, "_release_signal_scoped_lock", release)
+    adapter._release_platform_lock = MagicMock()
+
+    with pytest.raises(OSError, match="unlock failed"):
+        adapter._release_signal_routing_locks()
+
+    assert [identity for _, identity in calls] == ["group-a", "group-b"]
+    assert adapter._signal_group_claims == []
+    adapter._release_platform_lock.assert_called_once_with()
+
+
+def test_group_claim_recovers_after_holder_process_exits(tmp_path, monkeypatch):
+    from gateway.platforms import signal as signal_module
+
+    lock_dir = str(tmp_path / "locks")
+    account = "test-account"
+    monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", lock_dir)
+    holder = tmp_path / "hermes"
+    holder.write_text(
+        "import os, sys\n"
+        "os.environ['HERMES_GATEWAY_LOCK_DIR'] = sys.argv[1]\n"
+        "from gateway.platforms.signal import _signal_group_scope\n"
+        "from gateway.status import acquire_scoped_lock\n"
+        "ok, _ = acquire_scoped_lock("
+        "_signal_group_scope(sys.argv[2]), sys.argv[3])\n"
+        "print('READY' if ok else 'FAILED', flush=True)\n"
+        "sys.stdin.readline()\n",
+        encoding="utf-8",
+    )
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(holder),
+            lock_dir,
+            account,
+            "group-a",
+            "gateway",
+            "run",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.stdout is not None
+        assert process.stdout.readline().strip() == "READY"
+        scope = signal_module._signal_group_scope(account)
+        assert (
+            signal_module.acquire_scoped_lock(scope, "group-a")[0]
+            is False
+        )
+
+        process.terminate()
+        process.wait(timeout=10)
+        assert (
+            signal_module.acquire_scoped_lock(scope, "group-a")[0]
+            is True
+        )
+        signal_module._release_signal_scoped_lock(scope, "group-a")
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=10)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -334,6 +334,58 @@ class TestTerminatePid:
 
 
 class TestScopedLocks:
+    def test_list_scoped_locks_returns_only_active_exact_scope_records(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        assert status.acquire_scoped_lock(
+            "signal-groups-account-a", "group-a", metadata={"label": "a"}
+        )[0]
+        assert status.acquire_scoped_lock(
+            "signal-groups-account-a", "group-b", metadata={"label": "b"}
+        )[0]
+        assert status.acquire_scoped_lock(
+            "signal-groups-account-ab", "group-c", metadata={"label": "c"}
+        )[0]
+
+        records = status.list_scoped_locks("signal-groups-account-a", active_only=True)
+
+        assert {record["metadata"]["label"] for record in records} == {"a", "b"}
+        assert records == status.list_scoped_locks(
+            "signal-groups-account-a", active_only=True
+        )
+        assert {record["scope"] for record in records} == {"signal-groups-account-a"}
+
+    def test_list_scoped_locks_uses_acquisition_stale_owner_rules(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = status._get_scope_lock_path("signal-groups-account-a", "group-a")
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text(
+            json.dumps({
+                "pid": 99999,
+                "start_time": None,
+                "kind": "hermes-gateway",
+                "argv": ["hermes", "gateway", "run"],
+                "scope": "signal-groups-account-a",
+                "identity_hash": status._scope_hash("group-a"),
+                "metadata": {},
+            }),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "/usr/libexec/unrelated"
+        )
+
+        assert status.list_scoped_locks("signal-groups-account-a")
+        assert (
+            status.list_scoped_locks("signal-groups-account-a", active_only=True) == []
+        )
+
     def test_windows_file_lock_uses_high_offset(self, tmp_path, monkeypatch):
         lock_path = tmp_path / "gateway.lock"
         handle = open(lock_path, "a+", encoding="utf-8")

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -438,6 +438,58 @@ class TestTerminatePid:
 
 
 class TestScopedLocks:
+    def test_list_scoped_locks_returns_only_active_exact_scope_records(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        assert status.acquire_scoped_lock(
+            "signal-groups-account-a", "group-a", metadata={"label": "a"}
+        )[0]
+        assert status.acquire_scoped_lock(
+            "signal-groups-account-a", "group-b", metadata={"label": "b"}
+        )[0]
+        assert status.acquire_scoped_lock(
+            "signal-groups-account-ab", "group-c", metadata={"label": "c"}
+        )[0]
+
+        records = status.list_scoped_locks("signal-groups-account-a", active_only=True)
+
+        assert {record["metadata"]["label"] for record in records} == {"a", "b"}
+        assert records == status.list_scoped_locks(
+            "signal-groups-account-a", active_only=True
+        )
+        assert {record["scope"] for record in records} == {"signal-groups-account-a"}
+
+    def test_list_scoped_locks_uses_acquisition_stale_owner_rules(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = status._get_scope_lock_path("signal-groups-account-a", "group-a")
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text(
+            json.dumps({
+                "pid": 99999,
+                "start_time": None,
+                "kind": "hermes-gateway",
+                "argv": ["hermes", "gateway", "run"],
+                "scope": "signal-groups-account-a",
+                "identity_hash": status._scope_hash("group-a"),
+                "metadata": {},
+            }),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "/usr/libexec/unrelated"
+        )
+
+        assert status.list_scoped_locks("signal-groups-account-a")
+        assert status.list_scoped_locks(
+            "signal-groups-account-a", active_only=True
+        ) == []
+
     @pytest.mark.windows_only
     def test_windows_file_lock_uses_high_offset(self, tmp_path, monkeypatch):
         # Faking _IS_WINDOWS on POSIX could not reproduce the msvcrt

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -141,6 +141,44 @@ Group access is controlled by the `SIGNAL_GROUP_ALLOWED_USERS` env var:
 | Set with group IDs | Only listed groups are monitored (e.g., `groupId1,groupId2`). |
 | Set to `*` | The bot responds in any group it's a member of. |
 
+### Sharing One Signal Account Across Profiles
+
+Multiple Hermes profiles can use the same Signal account through the same or
+separate signal-cli HTTP daemons when each profile owns a distinct set of
+groups. Enable the safety mode in each participating profile's `config.yaml`:
+
+```yaml
+signal:
+  shared_account_group_only: true
+```
+
+Each profile must also set `SIGNAL_GROUP_ALLOWED_USERS` to an explicit,
+non-empty list of group IDs. The wildcard `*` is rejected in this mode. Group
+assignments must be disjoint: startup fails if another shared profile already
+holds a configured group.
+
+In `shared_account_group_only` mode:
+
+- an account-specific scoped lock serializes shared and normal startup, rejecting
+  mixed listeners in either startup order while allowing shared profiles with
+  disjoint group sets;
+- machine-wide generic scoped-lock markers ensure only one live profile can own
+  each group; graceful shutdown removes them, and a later startup recovers
+  markers left stale by a process exit or crash;
+- direct messages and Note to Self are ignored before agent dispatch;
+- allowlisted group messages still work, including group messages sent from
+  the account owner's phone that arrive as `syncMessage.sentMessage`;
+- other synchronized events remain filtered normally.
+
+All participating gateway processes must be upgraded to a version that supports
+this option before enabling it. Stop legacy Signal gateways during migration
+rather than running a mixed-version rolling upgrade. Normal mode retains the
+legacy account-wide `signal-phone` lock, and shared mode refuses to start while
+that legacy lock is already present.
+
+Outside this opt-in mode, Signal remains account-exclusive and its DM/Note to
+Self behavior is unchanged.
+
 ---
 
 ## Features


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `signal.shared_account_group_only` mode that allows multiple Hermes profiles to use the same Signal account when each profile is assigned a distinct set of Signal groups.

Signal accounts are normally protected by an account-wide exclusive lock. Shared group-only mode narrows ownership safely:

- each participating profile must configure an explicit, non-empty group allowlist;
- wildcard group access is rejected;
- group assignments must be disjoint across live profiles;
- normal and shared listeners cannot coexist for the same account;
- direct messages, Note to Self, malformed traffic, and messages from unassigned groups are dropped before pairing or authorization;
- assigned group messages are retained, including synchronized sent-group messages from the account owner's phone.

The implementation composes Hermes' existing machine-wide scoped-lock infrastructure rather than introducing a Signal-specific locking system. Generic scoped-lock acquisition, release, takeover, and stale-owner semantics remain unchanged. Normal Signal mode and its existing `--replace` takeover behavior are preserved.

## Related Issue

No directly matching issue was found after searching open and closed issues and pull requests.

Related context: #17080 discusses conflicts caused by profiles sharing exclusive platform credentials. This PR does not change `profile create --clone` behavior; it adds a narrowly scoped, explicit sharing mode for Signal groups.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/config_loader.py`
  - Propagates `signal.shared_account_group_only` through the current platform-specific shared-key configuration path.

- `gateway/platforms/signal.py`
  - Validates that shared mode is configured with a literal YAML boolean.
  - Requires an explicit, non-empty group allowlist and rejects `*`.
  - Coordinates normal and shared startup for the same Signal account.
  - Claims each configured group through existing scoped locks, with all-or-nothing rollback when any claim fails.
  - Rejects overlapping group ownership and mixed normal/shared listeners.
  - Filters inbound traffic to assigned groups before pairing and authorization.
  - Rejects shared-mode Note-to-Self traffic before outbound timestamp or recipient-cache state is mutated.
  - Retains assigned ordinary group messages and synchronized sent-group messages.
  - Adapts routing-lock ownership to the current upstream connect/disconnect lifecycle while preserving normal-mode fallback behavior.
  - Releases all retained claims during cleanup while preserving the first release error.

- `gateway/status.py`
  - Adds `list_scoped_locks()` for enumerating records in an exact scope.
  - Reuses the current centralized stale-owner classification for active-only listing without changing scoped-lock acquisition or release behavior.

- `tests/gateway/test_signal_shared_group.py`
  - Covers strict configuration, inbound filtering, disjoint and overlapping ownership, mixed-mode exclusion, rollback, cleanup, stale recovery, and normal `--replace` behavior.
  - Verifies that rejecting shared-mode Note-to-Self traffic does not consume outbound timestamp state.

- `tests/gateway/test_status.py`
  - Covers exact-scope listing and active-only stale-record filtering.

- `website/docs/user-guide/messaging/signal.md`
  - Documents configuration, group-assignment requirements, migration constraints, and behavior outside the opt-in mode.

## How to Test

1. Run the impacted gateway test matrix:

   ```bash
   scripts/run_tests.sh \
     tests/gateway/test_signal.py \
     tests/gateway/test_signal_shared_group.py \
     tests/gateway/test_signal_format.py \
     tests/gateway/test_signal_rate_limit.py \
     tests/gateway/test_status.py \
     tests/gateway/test_config.py \
     tests/gateway/test_platform_base.py
   ```

   Current result:

   ```text
   358 passed, 0 failed, 3 skipped
   ```

2. Configure two profiles with the same `SIGNAL_ACCOUNT`. In each profile, enable shared mode:

   ```yaml
   signal:
     shared_account_group_only: true
   ```

   Give each profile a different explicit `SIGNAL_GROUP_ALLOWED_USERS` group list, start both gateways, and verify that each profile receives messages only from its assigned groups.

3. Assign the same group to both profiles and verify that the second listener is rejected without retaining any partial group claims.

4. While a shared listener is active, start a normal listener for the same account and verify that it is rejected. Repeat in the opposite startup order.

5. Send a direct message, Note to Self message, unassigned group message, and assigned group message. Verify that only the assigned group message reaches agent dispatch.

6. Send an assigned group message from the account owner's phone and verify that the corresponding `syncMessage.sentMessage` event is retained.

7. Terminate a shared listener without graceful cleanup, then verify that a later listener recovers its stale group claims.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.12 x86_64 with Python 3.13.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — Signal user guide updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; this is a platform-specific setting documented in the Signal guide
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or contribution workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no new platform-specific lock implementation or OS primitive
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model-tool behavior changed

## Screenshots / Logs

No UI changes.

Current impacted gateway matrix:

```text
7 files, 358 tests passed, 0 failed, 3 skipped
```

The skipped cases are Windows-only and run in the Windows CI lane.
