### PR TITLE
fix(projects): return global projects.db path independent of active profile (#75308)

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import shutil
 import re
 import secrets
 import sqlite3
@@ -34,7 +35,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing, write_txn
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_process_hermes_home
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -42,12 +43,105 @@ from hermes_constants import get_hermes_home
 
 
 def projects_db_path() -> Path:
-    """The per-profile projects DB path (``$HERMES_HOME/projects.db``).
+    """The machine-level projects DB path (``<process HERMES_HOME>/projects.db``).
 
-    Profile-aware: ``get_hermes_home()`` already points at the active profile's
-    home. Tests pass an explicit ``db_path`` to :func:`connect`.
+    Projects are intentionally shared across profiles (a Project may *bind*
+    a kanban board and span every profile's session history) so the store
+    resolves the *process* Hermes home — the value the gateway / agent
+    backend / CLI subprocess were launched with — instead of the active
+    profile's home. ``get_process_hermes_home()`` ignores the per-request
+    ``set_hermes_home_override()`` context so a profile-switch mid-session
+    does not move the projects DB on disk (#75308).
+
+    On startup, if a legacy per-profile DB already has projects and the
+    machine-level DB is empty, copy the legacy store into place so existing
+    installs (which created Projects before this fix) keep their data.
+    The copy runs lazily on first access; subsequent reads land on the
+    machine-level file. Idempotent — second call is a no-op.
+
+    Tests pass an explicit ``db_path`` to :func:`connect` to skip resolution.
     """
-    return get_hermes_home() / "projects.db"
+    path = get_process_hermes_home() / "projects.db"
+    _migrate_legacy_per_profile_db(path)
+    return path
+
+# Cache migration attempts per process so subsequent calls are a cheap no-op.
+_LEGACY_MIGRATION_DONE: set[str] = set()
+
+
+def _legacy_per_profile_db_path() -> Path | None:
+    """Return the legacy per-profile projects DB path, if it differs from the
+    machine-level path. ``None`` when the active profile IS the process home
+    (no migration needed) so a test running with the default profile never
+    moves its own DB on disk.
+    """
+    try:
+        process_home = get_process_hermes_home()
+    except Exception:
+        return None
+    try:
+        profile_home = get_hermes_home()
+    except Exception:
+        return None
+    if process_home.resolve() == profile_home.resolve():
+        return None
+    return profile_home / "projects.db"
+
+
+def _migrate_legacy_per_profile_db(target: Path) -> None:
+    """Copy a legacy per-profile ``projects.db`` into the machine-level home
+    the first time it is needed (#75308). Safe to call repeatedly: the
+    ``_LEGACY_MIGRATION_DONE`` cache, the empty-target check, and the
+    ``shutil.copy2`` short-circuit make repeat calls a cheap no-op.
+
+    Only copies when:
+      * the legacy file exists and is non-empty, and
+      * the target file does not exist, and
+      * the legacy DB has at least one row in ``projects`` (skips empty
+        legacy stores — those would just shadow a populated machine-level
+        store created by another profile).
+    """
+    # ``os.path.realpath`` follows symlinks so /tmp vs /private/tmp land on
+    # the same cache entry (macOS resolves /tmp -> /private/tmp); a plain
+    # ``Path.resolve()`` would produce two different keys for the same file
+    # and re-trigger the copy.
+    target_key = os.path.realpath(target)
+    if target_key in _LEGACY_MIGRATION_DONE:
+        return
+    legacy = _legacy_per_profile_db_path()
+    if legacy is None:
+        _LEGACY_MIGRATION_DONE.add(target_key)
+        return
+    try:
+        if not legacy.exists() or legacy.stat().st_size == 0:
+            _LEGACY_MIGRATION_DONE.add(target_key)
+            return
+        if target.exists():
+            _LEGACY_MIGRATION_DONE.add(target_key)
+            return
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Cheap row-count probe BEFORE the copy so empty legacy stores do
+        # not shadow a populated machine-level one. ``SELECT 1 FROM projects
+        # LIMIT 1`` short-circuits on the first row, no schema awareness
+        # required.
+        probe = sqlite3.connect(f"file:{legacy}?mode=ro", uri=True)
+        try:
+            has_rows = probe.execute(
+                "SELECT 1 FROM projects LIMIT 1"
+            ).fetchone() is not None
+        finally:
+            probe.close()
+        if not has_rows:
+            _LEGACY_MIGRATION_DONE.add(target_key)
+            return
+        shutil.copy2(str(legacy), str(target))
+    except Exception:
+        # Migration is best-effort: a failure must not block the caller
+        # from opening an empty machine-level DB. The next call retries
+        # until it succeeds.
+        return
+    _LEGACY_MIGRATION_DONE.add(target_key)
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_projects_db.py
+++ b/tests/hermes_cli/test_projects_db.py
@@ -1,12 +1,28 @@
-"""Tests for the per-profile Projects store (hermes_cli/projects_db)."""
+"""Tests for the Projects store (hermes_cli/projects_db).
+
+The Projects store is machine-level (shared across profiles) per #75308:
+``projects_db_path()`` resolves the *process* Hermes home — not the active
+profile — so a profile switch never moves the DB on disk.
+"""
 
 from __future__ import annotations
 
 import os
 
+from unittest.mock import patch
+
 import pytest
 
 from hermes_cli import projects_db as pdb
+from hermes_constants import get_process_hermes_home
+
+
+@pytest.fixture(autouse=True)
+def _reset_legacy_migration_cache():
+    """Reset module-level migration cache between tests so each one starts clean."""
+    pdb._LEGACY_MIGRATION_DONE.clear()
+    yield
+    pdb._LEGACY_MIGRATION_DONE.clear()
 
 
 @pytest.fixture
@@ -16,8 +32,6 @@ def conn(tmp_path):
         yield c
     finally:
         c.close()
-
-
 
 
 
@@ -32,8 +46,6 @@ def test_discovery_policy_change_clears_only_discovered_rows(conn):
     assert pdb.list_discovered_repos(conn) == []
     assert pdb.get_project(conn, project_id) is not None
     assert pdb.get_discovery_policy_key(conn) == "policy-b"
-
-
 
 
 
@@ -57,14 +69,6 @@ def test_create_get_list(conn):
 
 
 
-
-
-
-
-
-
-
-
 def test_project_for_path_skips_archived(conn):
     pid = pdb.create_project(conn, name="P", folders=["/www/app"])
     pdb.archive_project(conn, pid)
@@ -76,8 +80,6 @@ def test_project_for_path_skips_archived(conn):
 
     pdb.restore_project(conn, pid)
     assert pdb.project_for_path(conn, "/www/app/src").id == pid
-
-
 
 
 
@@ -101,3 +103,154 @@ def test_per_profile_isolation(tmp_path):
         b.close()
 
 
+# ── #75308: projects_db_path resolves process HERMES_HOME, not profile ──────
+
+
+def test_projects_db_path_uses_process_hermes_home(tmp_path, monkeypatch):
+    """With the active profile scoped via ``set_hermes_home_override``,
+    projects_db_path() still resolves the *process* Hermes home — the
+    value of ``HERMES_HOME`` at process launch, before any profile
+    override. The legacy per-profile DB lookup only happens when the
+    profile home differs from the process home."""
+    process_home = tmp_path / "machine"
+    profile_home = tmp_path / "profiles" / "staging"
+    process_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        # process home = the env var; profile home = the override. With
+        # the override active, ``get_hermes_home()`` returns the profile
+        # path but ``get_process_hermes_home()`` still returns the
+        # process path — projects_db_path() must take the process path.
+        path = pdb.projects_db_path()
+        assert path.resolve() == (process_home / "projects.db").resolve()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_projects_db_path_returns_process_home_when_only_env_var(monkeypatch, tmp_path):
+    """When HERMES_HOME is the process home (default install), no migration is
+    attempted and the path resolves normally."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = pdb.projects_db_path()
+    assert path == (tmp_path / "projects.db").resolve()
+
+
+def test_legacy_per_profile_db_is_migrated_on_first_access(tmp_path, monkeypatch):
+    """A legacy per-profile DB that has rows is copied to the machine-level
+    path on the first call to projects_db_path(). Subsequent calls are a
+    no-op (#75308)."""
+    process_home = tmp_path / "machine"
+    profile_home = tmp_path / "profiles" / "staging"
+    process_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    # Profile home differs from process home: this is the case the issue
+    # describes (gateway launched with --profile in app-global mode).
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        # Seed a legacy per-profile DB with one project.
+        legacy_conn = pdb.connect(db_path=profile_home / "projects.db")
+        try:
+            pdb.create_project(legacy_conn, name="Legacy Project", folders=["/legacy/path"])
+        finally:
+            legacy_conn.close()
+        assert (profile_home / "projects.db").exists()
+
+        # The machine-level path must not exist yet.
+        assert not (process_home / "projects.db").exists()
+
+        # First call migrates.
+        target = pdb.projects_db_path()
+        assert target.resolve() == (process_home / "projects.db").resolve()
+        assert (process_home / "projects.db").exists()
+
+        # The migrated DB is readable and carries the legacy row.
+        new_conn = pdb.connect(db_path=target)
+        try:
+            rows = pdb.list_projects(new_conn)
+        finally:
+            new_conn.close()
+        assert [r.slug for r in rows] == ["legacy-project"]
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_legacy_empty_db_is_not_migrated(tmp_path, monkeypatch):
+    """An empty legacy per-profile DB does not shadow the machine-level home;
+    the copy is skipped and a fresh machine-level DB is opened."""
+    process_home = tmp_path / "machine"
+    profile_home = tmp_path / "profiles" / "staging"
+    process_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        # Create an empty legacy DB (no rows, just schema).
+        legacy_conn = pdb.connect(db_path=profile_home / "projects.db")
+        legacy_conn.close()
+        assert (profile_home / "projects.db").exists()
+
+        target = pdb.projects_db_path()
+        assert target.resolve() == (process_home / "projects.db").resolve()
+
+        # Empty legacy must NOT shadow: machine-level DB must be opened fresh
+        # (still empty), the legacy file is left untouched.
+        new_conn = pdb.connect(db_path=target)
+        try:
+            assert pdb.list_projects(new_conn) == []
+        finally:
+            new_conn.close()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_legacy_migration_is_idempotent(tmp_path, monkeypatch):
+    """Second call to projects_db_path() must NOT re-copy the legacy DB over
+    a populated machine-level one."""
+    process_home = tmp_path / "machine"
+    profile_home = tmp_path / "profiles" / "staging"
+    process_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        legacy_conn = pdb.connect(db_path=profile_home / "projects.db")
+        try:
+            pdb.create_project(legacy_conn, name="Legacy", folders=["/legacy"])
+        finally:
+            legacy_conn.close()
+
+        # First call migrates.
+        pdb.projects_db_path()
+
+        # Now mutate the machine-level DB; the second call must not clobber it.
+        target_conn = pdb.connect(db_path=process_home / "projects.db")
+        try:
+            pdb.create_project(target_conn, name="Machine", folders=["/machine"])
+        finally:
+            target_conn.close()
+
+        # Re-resolve; the legacy file should not be copied over the machine store.
+        # The first call already migrated "Legacy"; the second call must leave
+        # both "Legacy" (from the initial copy) and the new "Machine" alone.
+        pdb.projects_db_path()
+        target_conn = pdb.connect(db_path=process_home / "projects.db")
+        try:
+            slugs = sorted(p.slug for p in pdb.list_projects(target_conn))
+        finally:
+            target_conn.close()
+        assert slugs == ["legacy", "machine"]
+        # Idempotency check: the machine store's mtime must be newer than the
+        # legacy store's, i.e. the second call did not re-copy legacy over
+        # machine and clobber the "Machine" addition.
+        legacy_mtime = (profile_home / "projects.db").stat().st_mtime
+        machine_mtime = (process_home / "projects.db").stat().st_mtime
+        assert machine_mtime > legacy_mtime
+    finally:
+        reset_hermes_home_override(token)


### PR DESCRIPTION
## Summary

`projects_db_path()` resolved `get_hermes_home()`, which honors the active profile's home and any `set_hermes_home_override()` mid-session. The desktop app correctly reads from `~/.hermes/projects.db` (the launch-time `HERMES_HOME`, machine-level), but the agent tools (`project_list`/`project_switch`/`project_create`) and the `projects.tree` gateway RPC used the per-profile copy and saw an empty store under non-default profiles — projects disappeared and every session fell into the `__no_project__` ("Home") bucket. Projects and Profiles are many-to-many by design.

This switches `projects_db_path()` to `get_process_hermes_home()` so the same machine-level file is opened regardless of the active profile, with a one-time lazy migration of any legacy per-profile `projects.db` that has rows so existing installs do not lose data.

## Files

- `hermes_cli/projects_db.py` — `projects_db_path()` now resolves the process Hermes home. New helpers `_legacy_per_profile_db_path()` and `_migrate_legacy_per_profile_db()` copy a populated legacy store into the machine-level home on first call (idempotent, row-count gated, realpath-cached). Empty legacy stores do not shadow a populated machine-level one.
- `tests/hermes_cli/test_projects_db.py` — five new regressions pinning the process-home resolution, the legacy → machine migration, the empty-legacy no-shadow rule, and the idempotency contract (second call never clobbers a mutated machine store).

## Repro

1. Create a Project in the Hermes desktop app (writes global `~/.hermes/projects.db`).
2. Switch to a non-default profile (e.g. `--profile my-custom-profile`).
3. Call `project_list` via the agent → returns `[]` on current `main`; after this fix it returns the project from the machine-level store.
4. Sessions whose `cwd` matches the project's primary path stay under the project in the sidebar instead of dropping into Home.

## Why migrate

A straight path switch would silently lose any projects created before this fix landed. The lazy migration copies once on first access, gated by a row-count probe (`SELECT 1 FROM projects LIMIT 1`) so empty legacy stores do not clobber a populated machine-level one. A `realpath`-keyed `_LEGACY_MIGRATION_DONE` cache (autouse test fixture resets it) plus a `target.exists()` short-circuit make repeated calls a no-op.

## Test Plan

- [x] `bash scripts/run_tests.sh tests/hermes_cli/test_projects_db.py tests/hermes_cli/test_projects_cli.py tests/tui_gateway/test_projects_rpc.py -q` (30/30 passed)
- [x] `git diff --check`
- [ ] CI: `Python tests / Run tests slice *`, `ruff enforcement`, `ruff + ty diff`, `Windows footguns`, `Deny unrelated histories`, `All required checks`

Closes #75308
