### PR TITLE
fix(desktop): re-arm continuous voice after speech

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -2,6 +2,8 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BargeMonitorCallbacks } from '@/lib/voice-barge-in'
+import { type SpeechStreamSession, startSpeechStream } from '@/lib/voice-playback'
+import { $voicePlayback } from '@/store/voice-playback'
 
 import type { MicRecording } from './use-mic-recorder'
 import { useVoiceConversation } from './use-voice-conversation'
@@ -262,5 +264,192 @@ describe('useVoiceConversation full-duplex barge-in', () => {
     hook.rerender({ busy: true })
 
     expect(monitorCalls.length).toBe(armed)
+  })
+
+  it('re-arms after a normally completed streamed reply', async () => {
+    let response: { id: string; pending: boolean; text: string } | null = null
+    const onBusyChange: { current: (busy: boolean) => void } = { current: () => undefined }
+    let resolveStream: (outcome: 'done' | 'fallback') => void = () => undefined
+
+    const done = new Promise<'done' | 'fallback'>(resolve => {
+      resolveStream = resolve
+    })
+
+    const stream: SpeechStreamSession = { append: vi.fn(), done, finish: vi.fn() }
+
+    vi.mocked(startSpeechStream).mockImplementation(async () => {
+      $voicePlayback.set({
+        audioElement: null,
+        messageId: null,
+        sequence: $voicePlayback.get().sequence + 1,
+        source: 'voice-conversation',
+        status: 'preparing'
+      })
+
+      return stream
+    })
+
+    $voicePlayback.set({
+      audioElement: null,
+      messageId: null,
+      sequence: 10,
+      source: null,
+      status: 'idle'
+    })
+
+    const hook = renderHook(
+      ({ busy }: HookProps) =>
+        useVoiceConversation({
+          busy,
+          consumePendingResponse: vi.fn(),
+          enabled: true,
+          onSubmit: vi.fn(async () => onBusyChange.current(true)),
+          onTranscribeAudio: vi.fn(async () => 'start the test'),
+          pendingResponse: () => response
+        }),
+      { initialProps: { busy: false } }
+    )
+
+    onBusyChange.current = busy => hook.rerender({ busy })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['q'], { type: 'audio/webm' }),
+      durationMs: 900,
+      heardSpeech: true
+    })
+    await act(async () => {
+      hook.result.current.stopTurn()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('thinking'))
+
+    response = { id: 'reply-1', pending: false, text: 'A completed streamed reply.' }
+    hook.rerender({ busy: false })
+    await waitFor(() => expect(hook.result.current.status).toBe('speaking'))
+
+    await act(async () => {
+      resolveStream('done')
+      await done
+    })
+
+    await waitFor(() => expect(micHandle.start).toHaveBeenCalledTimes(2))
+  })
+
+  it('does not re-arm when playback stops while stream startup is pending', async () => {
+    let response: { id: string; pending: boolean; text: string } | null = null
+    const onBusyChange: { current: (busy: boolean) => void } = { current: () => undefined }
+    let resolveStart: (session: SpeechStreamSession) => void = () => undefined
+
+    const start = new Promise<SpeechStreamSession>(resolve => {
+      resolveStart = resolve
+    })
+
+    let resolveStream: (outcome: 'done' | 'fallback') => void = () => undefined
+
+    const done = new Promise<'done' | 'fallback'>(resolve => {
+      resolveStream = resolve
+    })
+
+    const stream: SpeechStreamSession = { append: vi.fn(), done, finish: vi.fn() }
+
+    vi.mocked(startSpeechStream).mockImplementation(async () => start)
+    $voicePlayback.set({ audioElement: null, messageId: null, sequence: 0, source: null, status: 'idle' })
+
+    const hook = renderHook(
+      ({ busy }: HookProps) =>
+        useVoiceConversation({
+          busy,
+          consumePendingResponse: vi.fn(),
+          enabled: true,
+          onSubmit: vi.fn(async () => onBusyChange.current(true)),
+          onTranscribeAudio: vi.fn(async () => 'start the test'),
+          pendingResponse: () => response
+        }),
+      { initialProps: { busy: false } }
+    )
+
+    onBusyChange.current = busy => hook.rerender({ busy })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['q'], { type: 'audio/webm' }),
+      durationMs: 900,
+      heardSpeech: true
+    })
+    await act(async () => {
+      hook.result.current.stopTurn()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('thinking'))
+
+    response = { id: 'reply-1', pending: false, text: 'A reply.' }
+    hook.rerender({ busy: false })
+    await waitFor(() => expect(hook.result.current.status).toBe('speaking'))
+
+    await act(async () => {
+      // The user stops while resolving the stream URL; stream startup then
+      // performs its own stop before returning the session.
+      $voicePlayback.set({ audioElement: null, messageId: null, sequence: 1, source: null, status: 'idle' })
+      $voicePlayback.set({ audioElement: null, messageId: null, sequence: 2, source: null, status: 'preparing' })
+      resolveStart(stream)
+      await start
+      resolveStream('done')
+      await done
+    })
+
+    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
+    expect(micHandle.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves a startup stop when streaming falls back to whole-text playback', async () => {
+    let response: { id: string; pending: boolean; text: string } | null = null
+    const onBusyChange: { current: (busy: boolean) => void } = { current: () => undefined }
+
+    vi.mocked(startSpeechStream).mockImplementation(async () => {
+      // The user stops while the stream URL is resolving; no stream opens.
+      $voicePlayback.set({ audioElement: null, messageId: null, sequence: 1, source: null, status: 'idle' })
+
+      return null
+    })
+    $voicePlayback.set({ audioElement: null, messageId: null, sequence: 0, source: null, status: 'idle' })
+
+    const hook = renderHook(
+      ({ busy }: HookProps) =>
+        useVoiceConversation({
+          busy,
+          consumePendingResponse: vi.fn(),
+          enabled: true,
+          onSubmit: vi.fn(async () => onBusyChange.current(true)),
+          onTranscribeAudio: vi.fn(async () => 'start the test'),
+          pendingResponse: () => response
+        }),
+      { initialProps: { busy: false } }
+    )
+
+    onBusyChange.current = busy => hook.rerender({ busy })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['q'], { type: 'audio/webm' }),
+      durationMs: 900,
+      heardSpeech: true
+    })
+    await act(async () => {
+      hook.result.current.stopTurn()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('thinking'))
+
+    response = { id: 'reply-1', pending: false, text: 'A reply.' }
+    hook.rerender({ busy: false })
+
+    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
+    expect(micHandle.start).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -73,6 +73,7 @@ export function useVoiceConversation({
   const bargeCapturePendingRef = useRef(false)
   const bargedRef = useRef(false)
   const speechStartSequenceRef = useRef(0)
+  const speechStoppedDuringStartupRef = useRef(false)
   const enabledRef = useRef(enabled)
   const mutedRef = useRef(muted)
   const busyRef = useRef(busy)
@@ -286,9 +287,11 @@ export function useVoiceConversation({
       // voice-playback sequence has advanced past what we captured at speech
       // start — don't auto-start the next sentence, the user chose to stop.
       const stoppedByUser =
+        speechStoppedDuringStartupRef.current ||
         speechStartSequenceRef.current > 0 && $voicePlayback.get().sequence > speechStartSequenceRef.current
 
       speechStartSequenceRef.current = 0
+      speechStoppedDuringStartupRef.current = false
 
       if (enabledRef.current && !stoppedByUser) {
         pendingStartRef.current = true
@@ -458,9 +461,13 @@ export function useVoiceConversation({
         // this is a safety net for read-aloud-style entries into the loop.
         ensureBargeMonitor()
 
+        const playback = playSpeechText(response.text, { source: 'voice-conversation' })
+        // Starting playback stops any prior audio synchronously, which advances
+        // the sequence. Capture it after that normal initialization so only a
+        // later user stop prevents re-arming the microphone.
         speechStartSequenceRef.current = $voicePlayback.get().sequence
 
-        void playSpeechText(response.text, { source: 'voice-conversation' })
+        void playback
           .catch(error => notifyError(error, voiceCopy.playbackFailed))
           .finally(() => {
             if (responseIdRef.current === responseId) {
@@ -484,7 +491,7 @@ export function useVoiceConversation({
     (responseId: string) => {
       responseIdRef.current = responseId
       spokenSourceLengthRef.current = 0
-      speechStartSequenceRef.current = $voicePlayback.get().sequence
+      speechStoppedDuringStartupRef.current = false
       setStatus('speaking')
 
       // VAD barge-in: the user talking over the reply cuts playback, drops
@@ -494,9 +501,15 @@ export function useVoiceConversation({
       ensureBargeMonitor()
 
       void (async () => {
-        const session = await startSpeechStream({ source: 'voice-conversation' })
+        const sequenceBeforeStreamStart = $voicePlayback.get().sequence
+
+        const session = await startSpeechStream({
+          isCurrent: () => responseIdRef.current === responseId,
+          source: 'voice-conversation'
+        })
 
         // The session may resolve after the loop moved on (barge, disable).
+        // Do not let a stale startup overwrite the active reply's tracking.
         if (responseIdRef.current !== responseId) {
           if (session) {
             stopVoicePlayback()
@@ -504,6 +517,16 @@ export function useVoiceConversation({
 
           return
         }
+
+        // startSpeechStream synchronously stops prior playback before opening
+        // its socket, which advances the sequence once. If it advanced more
+        // than once while its URL was resolving, an external stop happened and
+        // must still prevent this reply from re-arming the microphone.
+        const sequenceAfterStreamStart = $voicePlayback.get().sequence
+        const expectedStartupAdvance = session ? 1 : 0
+        speechStoppedDuringStartupRef.current =
+          sequenceAfterStreamStart > sequenceBeforeStreamStart + expectedStartupAdvance
+        speechStartSequenceRef.current = sequenceAfterStreamStart
 
         if (!session) {
           // No streaming backend/provider: speak the whole reply once it lands.

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -65,6 +65,8 @@ function currentState(
 }
 
 export interface VoicePlaybackOptions {
+  /** Returns false when an async playback request has been superseded. */
+  isCurrent?: () => boolean
   messageId?: string | null
   source: VoicePlaybackSource
 }
@@ -322,16 +324,16 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
  * whole-text `playSpeechText`.
  */
 export async function startSpeechStream(options: VoicePlaybackOptions): Promise<null | SpeechStreamSession> {
-  const wsUrl = await resolveSpeakStreamUrl()
+  const url = await resolveSpeakStreamUrl()
 
-  if (!wsUrl) {
+  if (!url || options.isCurrent?.() === false) {
     return null
   }
 
   stopVoicePlayback()
   setVoicePlaybackState(currentState('preparing', options))
 
-  const session = openSpeechStream(wsUrl, options)
+  const session = openSpeechStream(url, options)
 
   void session.done.then(outcome => {
     if (outcome === 'done') {


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop continuous voice mode (Ctrl+B) failing to re-arm the microphone after a normal spoken reply. The voice indicator stayed active, but no second utterance was captured.

The fix records playback state only after normal startup, preserves genuine user stops during async stream startup and whole-text fallback, and cancels stale stream startup before it can stop newer playback.

## Related Issue

No existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Re-arm continuous listening after normal streamed and fallback TTS completion.
- Preserve intentional stops/barge-ins across async stream startup, including initial playback sequence zero and stream-unavailable fallback.
- Guard superseded stream startup before global playback mutations.
- Add regression coverage for normal completion, pending-start stop, and fallback behavior.

## How to Test

1. Enable continuous voice mode with Ctrl+B and submit a spoken request.
2. Let the assistant finish speaking, then speak a second request; the microphone should re-arm and capture it.
3. Stop/barge during stream startup; the stale reply must not restart listening or interrupt newer playback.

Validated on macOS 26.5.2 with a real two-turn Ctrl+B conversation.

Automated validation:

- `npm exec --no-install -- vitest run src/app/chat/composer/hooks/use-voice-conversation.test.tsx` (9/9)
- Focused ESLint and desktop TypeScript typecheck
- `npm run check` (full JS workspace; passed)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and current source to avoid duplication
- [x] My PR contains only changes related to this bug fix
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.2

### Documentation & Housekeeping

- [x] Relevant documentation/config/schema updates are N/A
- [x] Cross-platform impact considered: this is renderer playback state logic; no OS-specific APIs were added