### PR TITLE
fix(desktop): show sidebar Cron section in Projects view

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-section-visibility.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/cron-section-visibility.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldShowCronSection } from './cron-section-visibility'
+
+describe('shouldShowCronSection', () => {
+  it('shows with jobs and no active search', () => {
+    expect(shouldShowCronSection({ cronJobsCount: 1, trimmedQuery: '' })).toBe(true)
+  })
+
+  it('hides when there are no jobs', () => {
+    expect(shouldShowCronSection({ cronJobsCount: 0, trimmedQuery: '' })).toBe(false)
+  })
+
+  it('hides while a session search is active, same as the other non-search sections', () => {
+    expect(shouldShowCronSection({ cronJobsCount: 5, trimmedQuery: 'foo' })).toBe(false)
+  })
+
+  // The contract that regressed: cron jobs aren't project-scoped, so unlike
+  // agent sessions and messaging threads, Projects view has no equivalent
+  // place to show them — the section must not depend on grouping mode.
+  it('does not depend on worktree/Projects grouping', () => {
+    expect(shouldShowCronSection({ cronJobsCount: 3, trimmedQuery: '' })).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/cron-section-visibility.ts
+++ b/apps/desktop/src/app/chat/sidebar/cron-section-visibility.ts
@@ -1,0 +1,17 @@
+// Whether the sidebar's dedicated "Cron jobs" section should render.
+//
+// Deliberately independent of `worktreeGroupingActive` (Projects view): unlike
+// agent sessions and messaging threads, a cron job has no project/worktree of
+// its own to be grouped under, so hiding it in Projects view left no
+// equivalent way to reach it there at all — the overlay (Cmd/Ctrl+K → "Cron")
+// still worked, but the persistent sidebar entry point silently disappeared
+// for anyone using Projects view.
+export function shouldShowCronSection({
+  cronJobsCount,
+  trimmedQuery
+}: {
+  cronJobsCount: number
+  trimmedQuery: string
+}): boolean {
+  return !trimmedQuery && cronJobsCount > 0
+}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -145,6 +145,7 @@ import {
 import type { SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
+import { shouldShowCronSection } from './cron-section-visibility'
 import { SidebarFilterMenu } from './filter-menu'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
@@ -1870,7 +1871,7 @@ export function ChatSidebar({
                 )
               })}
 
-            {!trimmedQuery && !worktreeGroupingActive && cronJobs.length > 0 && (
+            {shouldShowCronSection({ cronJobsCount: cronJobs.length, trimmedQuery }) && (
               <SidebarCronJobsSection
                 jobs={cronJobs}
                 label={s.cronJobs}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -109,6 +109,7 @@ import {
 import type { SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
+import { shouldShowCronSection } from './cron-section-visibility'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
 import { ProfileRail } from './profile-switcher'
@@ -1497,7 +1498,7 @@ export function ChatSidebar({
                 )
               })}
 
-            {!trimmedQuery && !worktreeGroupingActive && cronJobs.length > 0 && (
+            {shouldShowCronSection({ cronJobsCount: cronJobs.length, trimmedQuery }) && (
               <SidebarCronJobsSection
                 jobs={cronJobs}
                 label={s.cronJobs}


### PR DESCRIPTION
## Summary
- The sidebar's dedicated "Cron jobs" section (added in 488ae376db, "render backend-authoritative projects sidebar") renders behind `!trimmedQuery && !worktreeGroupingActive && cronJobs.length > 0`, the same `worktreeGroupingActive` guard used for the Messaging platform sections.
- Agent sessions and messaging threads have a project/worktree they can be grouped under in Projects view, so hiding them from the flat list there and letting them surface in the project tree instead makes sense. A cron job has no project/worktree of its own — there's no equivalent place for it to reappear in Projects view, so gating it the same way just removes it from the sidebar entirely for anyone using Projects view. The Cmd/Ctrl+K "Cron" command-palette overlay still works and still shows the jobs, but the persistent sidebar entry point silently disappears.
- Fix is narrow: extracted the visibility check into `shouldShowCronSection()` (drops the `worktreeGroupingActive` condition, keeps the search-query and jobs-exist conditions) and wired the sidebar to call it directly, so there's no inline duplicate of the condition left to drift out of sync. Messaging's identical guard is deliberately left untouched — that's a separate product question (messaging threads plausibly *do* have a project affinity) and out of scope for this fix.

## Test plan
- [x] `npx eslint` and `npx tsc -b --noEmit` clean on all three touched/added files
- [x] New `cron-section-visibility.test.ts`: covers shows-with-jobs, hides-with-zero-jobs, hides-during-active-search, and explicitly documents (via a dedicated case) that the result doesn't depend on grouping mode
- [x] `npx vitest run src/app/chat/sidebar` (full directory, to check for interference): 14 files, 109 tests passed