### PR TITLE
fix(pricing): authenticate endpoint metadata probes

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1172,6 +1172,56 @@ def _pricing_entry_from_metadata(
     )
 
 
+def _configured_endpoint_api_key(
+    provider: Optional[str],
+    base_url: Optional[str],
+) -> str:
+    """Resolve a configured route's key without crossing endpoint boundaries.
+
+    Pricing is also recomputed outside live inference (for example by
+    ``hermes insights``), where callers only retain provider/base URL metadata.
+    Resolve the current profile's credential only when its configured endpoint
+    is exactly the route being probed. This prevents a stale or attacker-chosen
+    billing URL from receiving a credential for another provider.
+    """
+    if not base_url:
+        return ""
+    try:
+        from hermes_cli.config import (
+            get_compatible_custom_providers,
+            get_env_value_prefer_dotenv,
+            load_config,
+        )
+        from hermes_cli.providers import resolve_provider_full
+        from hermes_cli.route_identity import normalize_route_base_url
+
+        config = load_config()
+        if not isinstance(config, dict) or not provider:
+            return ""
+        user_providers = config.get("providers")
+        if not isinstance(user_providers, dict):
+            user_providers = {}
+        resolved = resolve_provider_full(
+            provider,
+            user_providers=user_providers,
+            custom_providers=get_compatible_custom_providers(config),
+        )
+        if resolved is None or (
+            normalize_route_base_url(resolved.base_url)
+            != normalize_route_base_url(base_url)
+        ):
+            return ""
+        for env_name in resolved.api_key_env_vars:
+            secret = str(get_env_value_prefer_dotenv(env_name) or "").strip()
+            if secret:
+                return secret
+    except Exception:
+        # Pricing lookup is best-effort and must never break the agent or
+        # insights generation because config/credential resolution failed.
+        return ""
+    return ""
+
+
 def get_pricing_entry(
     model_name: str,
     provider: Optional[str] = None,
@@ -1191,8 +1241,12 @@ def get_pricing_entry(
     if route.provider == "openrouter":
         return _openrouter_pricing_entry(route)
     if route.base_url:
+        endpoint_api_key = api_key or _configured_endpoint_api_key(
+            provider or route.provider,
+            route.base_url,
+        )
         entry = _pricing_entry_from_metadata(
-            fetch_endpoint_model_metadata(route.base_url, api_key=api_key or ""),
+            fetch_endpoint_model_metadata(route.base_url, api_key=endpoint_api_key),
             route.model,
             source_url=f"{route.base_url.rstrip('/')}/models",
             pricing_version="openai-compatible-models-api",

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -9,10 +9,101 @@ from agent.usage_pricing import (
 )
 
 
+class _EndpointModelsResponse:
+    ok = True
+
+    def __init__(self, model: str | None):
+        self._model = model
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        if self._model is None:
+            return {"data": []}
+        return {
+            "data": [
+                {
+                    "id": self._model,
+                    "pricing": {
+                        "prompt": "0.000001",
+                        "completion": "0.000002",
+                    },
+                }
+            ]
+        }
 
 
+def test_endpoint_pricing_resolves_configured_route_api_key(monkeypatch):
+    base_url = "http://litellm-proxy:4000/v1"
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "litellm-proxy",
+                    "base_url": base_url,
+                    "key_env": "LITELLM_API_KEY",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value_prefer_dotenv",
+        lambda name: "proxy-secret" if name == "LITELLM_API_KEY" else None,
+    )
+
+    def fake_get(url, *, headers, **_kwargs):
+        captured.update(url=url, headers=headers)
+        return _EndpointModelsResponse("some-model")
+
+    monkeypatch.setattr("agent.model_metadata.requests.get", fake_get)
+
+    entry = get_pricing_entry(
+        "some-model",
+        provider="custom:litellm-proxy",
+        base_url=base_url,
+    )
+
+    assert entry is not None
+    assert captured["url"] == f"{base_url}/models"
+    assert captured["headers"] == {"Authorization": "Bearer proxy-secret"}
 
 
+def test_endpoint_pricing_does_not_send_key_to_different_route(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "litellm-proxy",
+                    "base_url": "https://trusted.example/v1",
+                    "key_env": "LITELLM_API_KEY",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value_prefer_dotenv",
+        lambda _name: "must-not-leak",
+    )
+    captured = {}
+
+    def fake_get(url, *, headers, **_kwargs):
+        captured.update(url=url, headers=headers)
+        return _EndpointModelsResponse(None)
+
+    monkeypatch.setattr("agent.model_metadata.requests.get", fake_get)
+
+    get_pricing_entry(
+        "some-model",
+        provider="custom:litellm-proxy",
+        base_url="https://untrusted.example/v1",
+    )
+
+    assert captured["headers"] == {}
 
 
 def test_normalize_usage_reads_deepseek_native_cache_hit_tokens():


### PR DESCRIPTION
Fixes #75479

## Summary
- resolve the active profile credential when pricing probes an authenticated configured endpoint without an explicit key
- apply the fallback centrally in `get_pricing_entry`, covering auxiliary accounting, insights, and other callers that only retain provider/base URL metadata
- require an exact normalized route match before attaching the credential, so a stale or unrelated billing URL cannot receive another endpoint's key

## Tests
- verifies the real `/models` request receives the configured bearer authentication header for a LiteLLM-style custom provider
- verifies the credential is not sent when the pricing route differs from the configured endpoint
- `scripts/run_tests.sh tests/agent/test_usage_pricing.py tests/hermes_state/test_aux_usage_accounting.py -q` (22 passed)
- `uv run ruff check agent/usage_pricing.py tests/agent/test_usage_pricing.py`
- `python -m py_compile agent/usage_pricing.py tests/agent/test_usage_pricing.py`
- `git diff --check`
