### PR TITLE
fix(buzz): drop channel messages p-tagged to another agent (fixes #75166)

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1008,8 +1008,12 @@ class BuzzAdapter(BasePlatformAdapter):
         is_dm = state["chat_type"] == "dm"
         # In shared channels, respond only when addressed — unless
         # require_mention is disabled, in which case respond to every message.
-        # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
+        # DMs always dispatch.  When the event p-tags another agent, the
+        # mention was resolved to them (issue #75166) — never dispatch,
+        # regardless of what the text contains.
+        if not is_dm and self.require_mention and (
+            self._event_addresses_other_agent(event) or not self._is_mentioned(content)
+        ):
             return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
@@ -1111,6 +1115,28 @@ class BuzzAdapter(BasePlatformAdapter):
         state["chat_type"] = "dm"
         self._channel_names.setdefault(channel_id, "DM")
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
+
+    def _event_addresses_other_agent(self, event: dict) -> bool:
+        """True when the event carries p-tags but none targets our pubkey.
+
+        Buzz resolves ``@Name`` into the mentioned member's pubkey and
+        emits it as a ``p`` tag, so an event p-tagged to somebody else was
+        addressed to that agent — never to us, no matter what the text
+        contains.  This only ever narrows dispatch: events with no p-tags
+        (relays or clients that omit mention tags) return False and fall
+        through to the text gate.
+        """
+        if not self._self_pubkey:
+            return False
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return False
+        p_targets = [
+            str(tag[1]).lower()
+            for tag in tags
+            if isinstance(tag, (list, tuple)) and len(tag) > 1 and tag[0] == "p"
+        ]
+        return bool(p_targets) and self._self_pubkey not in p_targets
 
     def _is_mentioned(self, content: str) -> bool:
         """True when the message addresses this agent (npub, hex, or name)."""

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -224,6 +224,17 @@ class TestMentionGating:
 
         a._dispatch_message = capture
         a._message_handler = AsyncMock()
+        # Real-channel metadata: these tests exercise the channel mention
+        # gate, so a p-tagged event must never reclassify to DM (the
+        # DM-latch path is covered by TestDmClassification).
+        a._channel_meta = {
+            CHANNEL: {
+                "channel_id": CHANNEL,
+                "name": "general",
+                "description": "General conversation and community updates.",
+            },
+        }
+        a._channel_names = {CHANNEL: "general"}
         a._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
         return a
 
@@ -248,6 +259,68 @@ class TestMentionGating:
     async def test_allowlist_blocks_unauthorized(self, adapter):
         adapter._allowed_pubkeys = {"b" * 64}
         await self._poll_with(adapter, _event("e1", content="@Chip hello", created_at=10))
+        assert adapter._dispatched == []
+
+    # ── p-tag mention disambiguation (issue #75166) ─────────────────────
+    #
+    # Buzz resolves @Name into the mentioned member's pubkey and emits it
+    # as a p-tag.  When the event p-tags another agent, the message was
+    # addressed to them — an agent whose display name merely appears in the
+    # prose must not hijack the turn.  p-tags only ever narrow the gate.
+
+    @pytest.mark.asyncio
+    async def test_mention_of_another_agent_is_not_hijacked(self, adapter):
+        """The reported bug: an agent named "Hermes" must not answer a
+        message p-tagged to another member, even though "hermes" appears
+        several times in the prose."""
+        adapter._display_name = "Hermes"
+        await self._poll_with(
+            adapter,
+            _tagged_event(
+                "e1", CHANNEL, p=OTHER_PUBKEY,
+                content="@ResearchBot how can i connect a Hermes Cloud agent to "
+                        "buzz? what does hermes offer?",
+            ),
+        )
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_p_tagged_mention_dispatches(self, adapter):
+        """A normal @mention resolves to our pubkey — dispatches."""
+        await self._poll_with(
+            adapter,
+            _tagged_event("e1", CHANNEL, p=SELF_PUBKEY, content="@Chip please summarize"),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+
+    @pytest.mark.asyncio
+    async def test_multi_mention_including_self_dispatches(self, adapter):
+        """@Other @Chip: the p-tags include ours, so the message is for us too."""
+        event = _tagged_event(
+            "e1", CHANNEL, p=SELF_PUBKEY, content="@ResearchBot @Chip thoughts?"
+        )
+        event["tags"].append(["p", OTHER_PUBKEY])
+        await self._poll_with(adapter, event)
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_name_in_prose_without_p_tags_still_dispatches(self, adapter):
+        """No p-tags (relay/client omits them): the text gate stays the
+        authority, so name-in-prose keeps dispatching — the change only
+        narrows, never widens."""
+        adapter._display_name = "Hermes"
+        await self._poll_with(adapter, _event("e1", content="what is hermes?"))
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_p_tags_never_widen_the_gate(self, adapter):
+        """p-tag alone is not sufficient: p-tagged to us but un-mentioned in
+        a real channel must stay behind the text gate (this is exactly the
+        DM-latch discriminator of #68871, asserted here for the gate)."""
+        await self._poll_with(
+            adapter,
+            _tagged_event("e1", CHANNEL, p=SELF_PUBKEY, content="thanks everyone"),
+        )
         assert adapter._dispatched == []
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Buzz channel mention gate hijack described in #75166. The gate decided "am I being addressed?" by matching the agent's display name against the message text:

```python
pattern = rf"(?<!\\w)@?{re.escape(self._display_name.lower())}(?!\\w)"
```

Any message containing that word dispatched a turn — an agent named `Hermes` answered questions addressed to a different bot, and ordinary prose about Hermes triggered it too.

Buzz resolves `@Name` into the mentioned member's pubkey and emits it as a `p` tag, so the event already records who was addressed. When a message carries `p` tags and none of them is ours, it was meant for somebody else and is now dropped.

## Related Issue

Fixes #75166

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/buzz/adapter.py`: new `_event_addresses_other_agent(event)` helper — returns True when the event carries `p` tags but none targets our pubkey — wired into the channel mention gate (`_dispatch_event`), so a message p-tagged to another agent is dropped even when the text mentions us.
- `tests/gateway/test_buzz_adapter.py`: 5 new behavioral tests in `TestMentionGating` (fixture now pins real-channel metadata so p-tagged events can't reclassify to DM):
  - `test_mention_of_another_agent_is_not_hijacked` — the reported repro (agent named "Hermes", message p-tagged to another member)
  - `test_p_tagged_mention_dispatches` — normal @mention resolved to our pubkey
  - `test_multi_mention_including_self_dispatches` — @Other @Chip
  - `test_name_in_prose_without_p_tags_still_dispatches` — fallback preserved
  - `test_p_tags_never_widen_the_gate` — over-correction guard

## Scope (only narrows, never widens)

- The text gate runs first; a `p` tag alone is still not sufficient to dispatch.
- Thread replies that `p`-tag us without naming us behave exactly as before.
- The DM-latch path (`_maybe_latch_dm` / `_is_direct_message_event`, issue #68871) is untouched.
- Events with no `p` tags fall through to the existing text check, so relays or clients that omit mention tags are unaffected.

## How to Test

1. `python -m pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q` → 32 passed.
2. Red/green proof: reverting `adapter.py` to `main` makes `test_mention_of_another_agent_is_not_hijacked` fail (1 failed, 27 passed); with the fix the suite is green.
3. Full `tests/gateway` run: 4453 passed, 7 failed — identical failure set with and without this change (pre-existing macOS-environment failures in discord send / systemd / session-store / shutdown-forensics tests, unrelated to Buzz).

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] Existing tests pass with my change
- [x] I have added tests that prove my fix is effective
- [x] I have checked that my changes don't break the rest of the test suite
