### PR TITLE
fix(desktop): bump @assistant-ui/react to ^0.15.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -64,7 +64,7 @@
     "test:e2e:update-snapshots": "npm run build && WLR_BACKENDS=headless WLR_NO_HARDWARE_CURSORS=1 cage -- npx playwright test e2e/ --reporter=list --update-snapshots"
   },
   "dependencies": {
-    "@assistant-ui/react": "^0.14.23",
+    "@assistant-ui/react": "^0.15.0",
     "@assistant-ui/react-streamdown": "^0.3.4",
     "@audiowave/react": "^0.6.2",
     "@chenglou/pretext": "^0.0.6",


### PR DESCRIPTION
Closes #75503

Bumps `@assistant-ui/react` from `^0.14.23` to `^0.15.0` in `apps/desktop/package.json` to resolve the peer dependency conflict with `@assistant-ui/react-streamdown@0.3.8`, which requires `@assistant-ui/react@\^0.15.0`.

Without this fix, `npm install` in `apps/desktop` fails with:

```
npm error ERESOLVE unable to resolve dependency tree
npm error peer @assistant-ui/react@"^0.15.0" from @assistant-ui/react-streamdown@0.3.8
```