### PR TITLE
fix(desktop): stop syncing session runtime model/provider to composer atoms

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -725,13 +725,11 @@ interface ApplyRuntimeInfoOptions {
 /** Mirror a session's runtime state into the composer atoms the MAIN pane
  *  renders from. Foreground sessions only — see ApplyRuntimeInfoOptions. */
 function publishRuntimeToComposer(state: SessionRuntimeStatePatch): void {
-  if (state.model !== undefined) {
-    setCurrentModel(state.model)
-  }
-
-  if (state.provider !== undefined) {
-    setCurrentProvider(state.provider)
-  }
+  // NOTE: model and provider are intentionally omitted.
+  // Composer model/provider is sticky UI state (localStorage + manual picks).
+  // Writing session runtime model/provider here made fallback providers sticky across
+  // new sessions (defeating per-turn primary restoration). See #75320.
+  // The model pill reads session runtime via primaryField(state => state.model, $currentModel).
 
   if (state.cwd !== undefined) {
     setCurrentCwd(state.cwd)

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -12,9 +12,7 @@ import {
   $messages,
   setActiveSessionStoredIdRotation,
   setCurrentFastMode,
-  setCurrentModel,
   setCurrentPersonality,
-  setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setTurnStartedAt,
@@ -36,8 +34,12 @@ interface SessionStateCacheOptions {
 }
 
 function syncRuntimeMetadataToView(state: ClientSessionState) {
-  setCurrentModel(state.model ?? '')
-  setCurrentProvider(state.provider ?? '')
+  // NOTE: setCurrentModel / setCurrentProvider are intentionally omitted here.
+  // Composer model/provider is sticky UI state (localStorage + manual picks).
+  // The session runtime model flows to the model pill via primaryField(state =>
+  // state.model, $currentModel) in session-view.tsx — no composer-atom write needed.
+  // Writing the session runtime model here made fallback providers sticky across
+  // new sessions (defeating per-turn primary restoration). See #75320.
   setCurrentReasoningEffort(state.reasoningEffort ?? '')
   setCurrentServiceTier(state.serviceTier ?? '')
   setCurrentFastMode(state.fast ?? false)


### PR DESCRIPTION
Closes #75320

## Problem

When a Desktop session hits a rate limit and the fallback chain activates, the
fallback provider/model was being written into the sticky composer atoms
(`$currentModel`/`$currentProvider`, persisted to localStorage). This caused:

1. **New sessions inherit fallback as PRIMARY**: `desktopSessionCreateParams()` reads
   from `$currentModel`/`$currentProvider`, so every new `session.create` shipped
   the fallback model as a per-session override.
2. **Per-turn primary restoration defeated**: for those sessions the "primary" IS
   the fallback, so `restore_primary_runtime` has nothing to restore.

## Root Cause

Two paths were writing session runtime model/provider to the composer atoms:

1. `syncRuntimeMetadataToView` (use-session-state-cache.ts) — called on every
   session state flush.
2. `publishRuntimeToComposer` → `applyRuntimeInfo` (use-session-actions/utils.ts) —
   called on session create/activate/resume/branch.

Note: `gateway-event.ts:371-377` already correctly avoids `setCurrentModel`/`setCurrentProvider`
for `session.info` events, but the two paths above were not guarded.

## Fix

Removed `setCurrentModel` and `setCurrentProvider` calls from both:

- `syncRuntimeMetadataToView`: the session state IS the authoritative source for
  the active session's model; the model pill reads it via
  `primaryField(state => state.model, $currentModel)` in session-view.tsx.
- `publishRuntimeToComposer`: same — the session runtime should not overwrite
  the user's sticky selection.

`$currentModel`/`$currentProvider` are still updated via `selectModel` (user manual pick)
and `applyStoredSessionPreviewRuntimeInfo` (stored session sidebar preview), which is correct.

## Verification

- Model pill still displays the correct session runtime (via `primaryField`).
- New sessions use the user's sticky selection (or profile default), not the fallback.
- Per-turn primary restoration (`restore_primary_runtime`) works correctly.