### PR TITLE
gateway: make run submission idempotent

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1248,6 +1248,9 @@ class APIServerAdapter(BasePlatformAdapter):
         self._stopping_run_ids: set[str] = set()
         # Pollable run status for dashboards and external control-plane UIs.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
+        # Idempotent /v1/runs submissions: key -> (canonical request hash, run_id).
+        # This closes the accepted-run/lost-response window for mobile clients.
+        self._run_idempotency: Dict[str, tuple[str, str]] = {}
         # Active approval session key for each run_id.  The approval core
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
@@ -2867,6 +2870,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "responses_api": True,
                 "responses_streaming": True,
                 "run_submission": True,
+                "run_submission_idempotency": True,
                 "run_status": True,
                 "run_events_sse": True,
                 "run_stop": True,
@@ -6088,16 +6092,43 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
 
-        # Enforce concurrency limit (shared across all agent-serving
-        # endpoints; configurable via gateway.api_server.max_concurrent_runs).
-        limited = self._concurrency_limited_response()
-        if limited is not None:
-            return limited
-
         try:
             body = await request.json()
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        idempotency_key = (request.headers.get("Idempotency-Key") or "").strip()
+        if len(idempotency_key) > 256:
+            return web.json_response(
+                _openai_error("Idempotency-Key exceeds 256 characters"), status=400
+            )
+        request_fingerprint = hashlib.sha256(
+            json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        if idempotency_key:
+            previous = self._run_idempotency.get(idempotency_key)
+            if previous is not None:
+                previous_fingerprint, previous_run_id = previous
+                if previous_fingerprint != request_fingerprint:
+                    return web.json_response(
+                        _openai_error(
+                            "Idempotency-Key was already used with a different /v1/runs request",
+                            code="idempotency_conflict",
+                        ),
+                        status=409,
+                    )
+                status = self._run_statuses.get(previous_run_id, {}).get(
+                    "status", "started"
+                )
+                return web.json_response(
+                    {"run_id": previous_run_id, "status": status}, status=202
+                )
+
+        # Matching idempotent replays above do not consume new capacity and
+        # must succeed even while the original run fills the final slot.
+        limited = self._concurrency_limited_response()
+        if limited is not None:
+            return limited
 
         raw_input = body.get("input")
         if not raw_input:
@@ -6168,6 +6199,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error(selection_error), status=400)
 
         run_id = f"run_{uuid.uuid4().hex}"
+        if idempotency_key:
+            self._run_idempotency[idempotency_key] = (request_fingerprint, run_id)
         session_id = session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are
@@ -6703,6 +6736,13 @@ class APIServerAdapter(BasePlatformAdapter):
         ]
         for run_id in stale_statuses:
             self._run_statuses.pop(run_id, None)
+            stale_keys = [
+                key
+                for key, (_, keyed_run_id) in self._run_idempotency.items()
+                if keyed_run_id == run_id
+            ]
+            for key in stale_keys:
+                self._run_idempotency.pop(key, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -146,6 +146,58 @@ class TestStartRun:
                 assert status["object"] == "hermes.run"
 
     @pytest.mark.asyncio
+    async def test_idempotency_key_returns_same_run_and_rejects_mismatched_reuse(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+                headers = {"Idempotency-Key": "mobile-turn-1"}
+
+                first = await cli.post("/v1/runs", json={"input": "hello"}, headers=headers)
+                replay = await cli.post("/v1/runs", json={"input": "hello"}, headers=headers)
+                conflict = await cli.post("/v1/runs", json={"input": "different"}, headers=headers)
+
+                assert first.status == 202
+                assert replay.status == 202
+                assert (await first.json())["run_id"] == (await replay.json())["run_id"]
+                assert conflict.status == 409
+                assert len(adapter._run_idempotency) == 1
+
+    @pytest.mark.asyncio
+    async def test_idempotent_replay_bypasses_saturated_concurrency_slot(self, adapter):
+        app = _create_runs_app(adapter)
+        adapter._max_concurrent_runs = 1
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent, agent_ready, interrupted = _make_slow_agent()
+                mock_create.return_value = mock_agent
+                headers = {"Idempotency-Key": "saturated-mobile-turn"}
+                first = await cli.post("/v1/runs", json={"input": "hello"}, headers=headers)
+                first_data = await first.json()
+                assert agent_ready.wait(timeout=3.0)
+                replay = await cli.post("/v1/runs", json={"input": "hello"}, headers=headers)
+                assert replay.status == 202
+                assert (await replay.json())["run_id"] == first_data["run_id"]
+                interrupted.set()
+
+    def test_terminal_status_sweep_prunes_run_idempotency_key(self, adapter):
+        run_id = "run_expired"
+        adapter._run_statuses[run_id] = {
+            "run_id": run_id,
+            "status": "completed",
+            "updated_at": 1,
+        }
+        adapter._run_idempotency["expired-key"] = ("fingerprint", run_id)
+        adapter._sweep_orphaned_runs_once(now=adapter._RUN_STATUS_TTL + 2)
+        assert run_id not in adapter._run_statuses
+        assert "expired-key" not in adapter._run_idempotency
+
+    @pytest.mark.asyncio
     async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):
         """/v1/runs must bind the raw session id as the api_server chat_id
         (like every other agent-entry route does via _run_agent): the async


### PR DESCRIPTION
## Summary

- accept an `Idempotency-Key` on `POST /v1/runs`
- replay the original accepted run for an identical key and request
- reject reuse of a key with a different request
- advertise `run_submission_idempotency` through `/v1/capabilities`
- bound the replay registry and preserve concurrent request safety

This closes the ambiguous-acceptance window for clients that must retry a lost `/v1/runs` response without starting a duplicate agent run.

## Verification

- `uv run pytest tests/gateway/test_api_server_runs.py -q`
- 19 passed on upstream base `5835201de19b099d76b8e4c64afe8af90c98af05`
