### PR TITLE
test(update): de-flake the EOL-churn fixture's racy-clean stat cache

### DIFF
--- a/tests/hermes_cli/test_update_eol_churn.py
+++ b/tests/hermes_cli/test_update_eol_churn.py
@@ -13,6 +13,7 @@ the whole tree as modified. These tests pin down that coupling.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -59,6 +60,20 @@ def _managed_repo(tmp_path: Path, files: dict[str, bytes]) -> Path:
     for name in files:
         (repo / name).unlink()
     _git(repo, "checkout", "--", ".")
+    # Age the checked-out files past git's "racy clean" window. ``checkout``
+    # records the freshly written (CRLF) worktree stat in the index; any file
+    # whose mtime lands in the same clock tick as that index write is resolved
+    # by content on the next ``diff``, but the rest are trusted from stat alone
+    # and their CRLF-vs-LF churn is silently missed. That makes a dirty count
+    # over the whole tree nondeterministic — observed anywhere from a couple
+    # hundred paths up to all of them across runs. A real managed checkout's
+    # files aged past that window long ago; do the same here so every path is
+    # reliably visible to the ``autocrlf=false`` probe. This changes nothing the
+    # code under test sees: under ``autocrlf=true`` the tree still reads clean
+    # via content normalization, independent of mtime.
+    stale = (1_000_000_000, 1_000_000_000)
+    for name in files:
+        os.utime(repo / name, stale)
     return repo
 
 


### PR DESCRIPTION
While CI was running my other PRs I hit an intermittent failure in this file that is unrelated to those changes and reproduces on `main`:

```
FAILED tests/hermes_cli/test_update_eol_churn.py::test_churn_across_more_files_than_fit_in_one_argv
assert len(_dirty(repo)) == len(files)   # AssertionError: assert 733 == 1200
```

### Root cause
`_managed_repo` builds the broken state with `git checkout -- .`, which writes the CRLF files and records their stat in the index. A file whose mtime lands in the same clock tick as that index write is *racily clean* — git resolves it by content on the next `diff` — but the rest are trusted from stat alone, so their CRLF-vs-LF churn is silently missed by `git diff` under `autocrlf=false`. How many paths fall in the racy window is timing-dependent, so the dirty count is nondeterministic.

Reproduced with a standalone git-only script (20 runs of the exact fixture):

| variant | under-counted runs | range |
|---|---|---|
| current | **13 / 20** | 231 – 1200 |
| aged (this PR) | **0 / 20** | 1200 |

### Fix
Age the checked-out files past the racy window (`os.utime` to a fixed past time), matching a real managed checkout whose files aged long ago. The dirty count then becomes deterministic.

This changes nothing the code under test sees: under `autocrlf=true` the tree still reads clean via **content normalization**, independent of mtime (verified: `git -c core.autocrlf=true diff` still reports 0), and the full normalize path still ends with a clean tree pinned to `autocrlf=false`. Test-only; the fixture is shared, but the other cases use a single file and are unaffected.