### PR TITLE
fix(google_chat): key /setup-files OAuth token by email, not resource name (#75492)

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1563,14 +1563,21 @@ class GoogleChatAdapter(BasePlatformAdapter):
             # Short-circuit /setup-files before the agent dispatch.
             text = (event.text or "").strip()
             if text.startswith("/setup-files") and event.source is not None:
-                # The sender's email (user_id_alt) is the per-user OAuth
-                # key — the bot stores this user's token at
-                # ${HERMES_HOME}/google_chat_user_tokens/<sanitized>.json
-                # so when User B asks for a file later in B's DM, B's
-                # token gets used (not the first person who set up files).
+                # The per-user OAuth key is the sender's EMAIL, stored at
+                # ${HERMES_HOME}/google_chat_user_tokens/<sanitized>.json so
+                # when User B asks for a file later in B's DM, B's token gets
+                # used (not the first person who set up files).
+                #
+                # ``_build_message_event`` assigns the email to ``user_id``
+                # and the ``users/{id}`` resource name to ``user_id_alt``, and
+                # ``_send_file`` reads the token back by that same email. The
+                # key MUST therefore come from ``user_id`` — reading
+                # ``user_id_alt`` here stored the token under the resource
+                # name, which the send path can never find, so native
+                # delivery failed permanently after a successful setup (#75492).
                 sender_email = (
-                    event.source.user_id_alt
-                    if event.source and event.source.user_id_alt
+                    event.source.user_id
+                    if event.source and event.source.user_id
                     else None
                 )
                 handled = await self._handle_setup_files_command(

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1130,10 +1130,10 @@ class TestUserOAuthHelper:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         users_dir = tmp_path / "google_chat_user_tokens"
         users_dir.mkdir(parents=True)
-        (users_dir / "alice@example.com.json").write_text("{}")
-        (users_dir / "bob@example.com.json").write_text("{}")
+        (users_dir / "alice@example.com.json").write_text("{}", encoding="utf-8")
+        (users_dir / "bob@example.com.json").write_text("{}", encoding="utf-8")
         # Legacy file should NOT appear in the list.
-        (tmp_path / "google_chat_user_token.json").write_text("{}")
+        (tmp_path / "google_chat_user_token.json").write_text("{}", encoding="utf-8")
 
         from plugins.platforms.google_chat.oauth import list_authorized_emails
         assert list_authorized_emails() == [
@@ -1272,7 +1272,7 @@ class TestThreadCountStore:
         as fresh, move on. The next incr() will overwrite."""
         from plugins.platforms.google_chat.adapter import _ThreadCountStore
         path = tmp_path / "counts.json"
-        path.write_text("not valid json {")
+        path.write_text("not valid json {", encoding="utf-8")
         store = _ThreadCountStore(path)
         store.load()
         assert store.get("spaces/X", "spaces/X/threads/T") == 0
@@ -1281,7 +1281,7 @@ class TestThreadCountStore:
         assert prev == 0
         # File now has valid JSON.
         import json
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         assert data == {"spaces/X": {"spaces/X/threads/T": 1}}
 
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1054,6 +1054,41 @@ class TestSetupFilesSlashCommand:
         adapter._handle_setup_files_command.assert_awaited_once()
         adapter.handle_message.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_setup_files_keys_oauth_by_email_not_resource_name(self, adapter):
+        """The per-user OAuth key must be the sender's email (``user_id``),
+        NOT the ``users/{id}`` resource name (``user_id_alt``).
+
+        Regression for #75492: ``/setup-files`` stored the token under
+        ``user_id_alt`` (always the resource name), while ``_send_file`` reads
+        it back by email, so the two keys never matched and native attachment
+        delivery failed permanently after a successful authorization.
+        """
+        adapter._handle_setup_files_command = AsyncMock(return_value=True)
+        adapter._build_message_event = AsyncMock(
+            return_value=MessageEvent(
+                text="/setup-files start",
+                message_type=MessageType.TEXT,
+                source=adapter.build_source(
+                    chat_id="spaces/S",
+                    chat_name="DM",
+                    chat_type="dm",
+                    # Email is the canonical id; resource name is the alt.
+                    user_id="ramon@example.com",
+                    user_name="Ramón",
+                    thread_id="spaces/S/threads/T",
+                    user_id_alt="users/12345",
+                ),
+                raw_message={},
+                message_id="spaces/S/messages/M",
+            )
+        )
+        await adapter._dispatch_message({}, {})
+        adapter._handle_setup_files_command.assert_awaited_once()
+        kwargs = adapter._handle_setup_files_command.await_args.kwargs
+        assert kwargs["sender_email"] == "ramon@example.com"
+        assert kwargs["sender_email"] != "users/12345"
+
 
 class TestUserOAuthHelper:
     @staticmethod


### PR DESCRIPTION
## Summary

`/setup-files` derived the per-user OAuth token key from `event.source.user_id_alt`, which `_build_message_event` **always** sets to the `users/{id}` Chat resource name. `_send_file` reads the token back by **email** (`event.source.user_id`). The two keys can never match, so native attachment delivery failed permanently even after a successful `/setup-files` authorization — and the failure was silent and self-contradictory (the bot replied `✅ Authorized!`, then every attachment failed with a message instructing the user to redo the setup they had just completed).

This keys the token by `event.source.user_id` (the email), symmetric with the send path, and corrects the misleading comment.

## Root cause

`_build_message_event` assigns identity as:

```python
user_id=(sender_email or sender_name),   # the email (canonical id)
user_id_alt=(sender_name or None),       # the users/{id} resource name
```

The `/setup-files` handler read `user_id_alt` and treated it as the email, so it stored `google_chat_user_tokens/users_{id}.json`. `_send_file` (`_load_per_user_chat_api(sender_email)`) looks the token up by the asker's email. Different key → never found → the multi-user Google Chat OAuth path never worked; installs where attachments do work rely on the legacy single-user token, which bypasses both keys.

## Fix

- `plugins/platforms/google_chat/adapter.py`: derive the OAuth key from `event.source.user_id` (email), matching the read path.

## Test

- `tests/gateway/test_google_chat.py::TestSetupFilesSlashCommand::test_setup_files_keys_oauth_by_email_not_resource_name`: builds an event whose `user_id` (email) and `user_id_alt` (resource name) differ, and asserts the handler receives the **email** as the OAuth key. This fails against the old `user_id_alt` code and passes with the fix. Full `tests/gateway/test_google_chat.py` (64 tests) passes.

Fixes #75492
