### PR TITLE
fix(streaming): ignore null chat completion chunks

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -56,6 +56,7 @@ _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 # billing reasons keep their own 60s cooldown (set above); this is the
 # narrower non-rate-limit case.  See issue #24996.
 _FALLBACK_EXHAUSTED_COOLDOWN_S = 5.0
+_MAX_CONSECUTIVE_NULL_CHAT_CHUNKS = 32
 
 
 def _context_thread_target(callback):
@@ -3092,7 +3093,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # prevents the stale watchdog from cancelling a live stream while
             # an interceptor or codec is still handling an already-received
             # event.
-            last_chunk_time["t"] = time.time()
+            if _chunk is not None:
+                last_chunk_time["t"] = time.time()
             return True
 
         def _relay_final_response() -> dict[str, Any]:
@@ -3144,29 +3146,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Hermes interrupts the managed stream; Relay retains sole
             # ownership of closing the underlying provider stream.
             _set_request_stream_handle(stream)
+        consecutive_null_chunks = 0
         for chunk in stream:
-            last_chunk_time["t"] = time.time()
-            agent._touch_activity("receiving stream response")
-
-            # Update per-attempt diagnostic counters.  Best-effort —
-            # failures are swallowed so the streaming hot path is never
-            # interrupted by diagnostic accounting.
-            try:
-                _diag["chunks"] = int(_diag.get("chunks", 0)) + 1
-                if _diag.get("first_chunk_at") is None:
-                    _diag["first_chunk_at"] = last_chunk_time["t"]
-                # Approximate byte size from the chunk's delta payload —
-                # exact wire bytes aren't exposed by the SDK. A full
-                # repr() per chunk was 5.5-8.8 µs of pure CPU on the
-                # hottest loop in the agent; the delta-length estimate
-                # is ~3x cheaper and stays proportional to traffic.
-                try:
-                    _diag["bytes"] = int(_diag.get("bytes", 0)) + _estimate_chunk_bytes(chunk)
-                except Exception:
-                    pass
-            except Exception:
-                pass
-
             if agent._interrupt_requested:
                 # Abandoning a half-read SSE response leaves its connection
                 # permanently checked out of the httpx pool — and the partial
@@ -3197,7 +3178,36 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # Some OpenAI-compatible proxies emit a literal null SSE item,
             # which the SDK surfaces as None rather than a completion chunk.
             if chunk is None:
+                consecutive_null_chunks += 1
+                if consecutive_null_chunks >= _MAX_CONSECUTIVE_NULL_CHAT_CHUNKS:
+                    raise EmptyStreamError(
+                        "Provider returned too many consecutive null chat-completion "
+                        "chunks (possible malformed SSE response)."
+                    )
                 continue
+            consecutive_null_chunks = 0
+
+            last_chunk_time["t"] = time.time()
+            agent._touch_activity("receiving stream response")
+
+            # Update per-attempt diagnostic counters.  Best-effort —
+            # failures are swallowed so the streaming hot path is never
+            # interrupted by diagnostic accounting.
+            try:
+                _diag["chunks"] = int(_diag.get("chunks", 0)) + 1
+                if _diag.get("first_chunk_at") is None:
+                    _diag["first_chunk_at"] = last_chunk_time["t"]
+                # Approximate byte size from the chunk's delta payload —
+                # exact wire bytes aren't exposed by the SDK. A full
+                # repr() per chunk was 5.5-8.8 µs of pure CPU on the
+                # hottest loop in the agent; the delta-length estimate
+                # is ~3x cheaper and stays proportional to traffic.
+                try:
+                    _diag["bytes"] = int(_diag.get("bytes", 0)) + _estimate_chunk_bytes(chunk)
+                except Exception:
+                    pass
+            except Exception:
+                pass
 
             if not chunk.choices:
                 if hasattr(chunk, "model") and chunk.model:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3194,6 +3194,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _discard_stale_stream_chunk(stream_attempt_id, chunk)
                 continue
 
+            # Some OpenAI-compatible proxies emit a literal null SSE item,
+            # which the SDK surfaces as None rather than a completion chunk.
+            if chunk is None:
+                continue
+
             if not chunk.choices:
                 if hasattr(chunk, "model") and chunk.model:
                     model_name = chunk.model

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -123,11 +123,52 @@ class TestStreamingAccumulator:
         )
         agent.api_mode = "chat_completions"
         agent._interrupt_requested = False
+        agent._touch_activity = MagicMock()
 
         response = agent._interruptible_streaming_api_call({})
 
         assert response.choices[0].message.content == "Hello world"
         assert response.choices[0].finish_reason == "stop"
+        receiving_calls = [
+            call for call in agent._touch_activity.call_args_list
+            if call.args == ("receiving stream response",)
+        ]
+        assert len(receiving_calls) == 2
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_consecutive_null_chunks_abort_as_empty_stream(
+        self,
+        mock_close,
+        mock_create,
+    ):
+        """An endless null stream becomes retryable instead of hanging forever."""
+        from agent.errors import EmptyStreamError
+        from run_agent import AIAgent
+
+        def endless_nulls():
+            while True:
+                yield None
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda **kwargs: endless_nulls()
+        )
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.com/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        with pytest.raises(EmptyStreamError, match="consecutive null"):
+            agent._interruptible_streaming_api_call({})
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -98,6 +98,39 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_null_chunks_are_ignored(self, mock_close, mock_create):
+        """Literal null items from compatible proxies do not abort the stream."""
+        from run_agent import AIAgent
+
+        chunks = [
+            None,
+            _make_stream_chunk(content="Hello"),
+            None,
+            _make_stream_chunk(content=" world", finish_reason="stop"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.com/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].message.content == "Hello world"
+        assert response.choices[0].finish_reason == "stop"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_chat_stream_closes_original_provider_resource(
         self,
         mock_close,


### PR DESCRIPTION
## What does this PR do?

Some OpenAI-compatible proxies can emit a literal `null` SSE item. The OpenAI SDK surfaces that item as Python `None`, and the chat-completions streaming loop currently dereferences `chunk.choices`, raising `AttributeError: 'NoneType' object has no attribute 'choices'` after the upstream has already produced a response.

Occasional null items are skipped before reading `choices`, without counting them as provider activity. If a malformed upstream sends 32 consecutive null items, Hermes raises the retryable `EmptyStreamError` instead of hanging indefinitely. Valid empty-choice usage chunks keep their existing handling.

## Related Issue

Related to #39978, but covers a distinct wire shape: the stream item itself is `None`. That PR guards `None` values inside choices/events; this PR reproduces and covers literal null chat-completion chunks on current `main`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Skip occasional literal `None` items in the chat-completions stream accumulator.
- Do not refresh stream activity or diagnostics for null items.
- Abort 32 consecutive null items as a retryable malformed empty stream.
- Cover both interleaved null/valid chunks and an endless null generator.

## How to Test

1. Run `scripts/run_tests.sh tests/run_agent/test_streaming.py`.
2. Confirm all streaming accumulator and provider callback tests pass.
3. Run `ruff check agent/chat_completion_helpers.py tests/run_agent/test_streaming.py`.

Result on Windows 11 / Python 3.11: `34 passed, 0 failed`; Ruff passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and linked the related one above
- [x] My PR contains only changes related to this fix
- [ ] I've run the full repository test suite
- [x] I've added regression tests
- [x] I've tested on Windows 11 with Python 3.11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] Config example update: N/A
- [x] Architecture/workflow documentation update: N/A
- [x] Cross-platform impact considered; the guard is platform-independent
- [x] Tool descriptions/schemas update: N/A
