### PR TITLE
fix(gateway): apply provider_routing and service_tier on the api_server platform

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2401,6 +2401,7 @@ class APIServerAdapter(BasePlatformAdapter):
             _resolve_runtime_agent_kwargs,
             _resolve_gateway_model,
             _load_gateway_config,
+            _load_gateway_runtime_config,
             GatewayRunner,
         )
         from hermes_cli.tools_config import _get_platform_tools
@@ -2435,7 +2436,27 @@ class APIServerAdapter(BasePlatformAdapter):
         request_reasoning_config = _request_reasoning_config(model_options)
         if request_reasoning_config is not None:
             reasoning_config = request_reasoning_config
+
+        # OpenRouter provider-routing prefs from config.yaml. Read through the
+        # runtime loader so profile-scoped configs and ``${VAR}`` refs resolve,
+        # matching gateway/run.py's own runtime reads.
+        runtime_config = _load_gateway_runtime_config()
+        raw_provider_routing = runtime_config.get("provider_routing")
+        if raw_provider_routing is None:
+            provider_routing = {}
+        elif isinstance(raw_provider_routing, dict):
+            provider_routing = raw_provider_routing
+        else:
+            logger.warning(
+                "Ignoring invalid provider_routing config: expected an object, got %s",
+                type(raw_provider_routing).__name__,
+            )
+            provider_routing = {}
+
+        service_tier = GatewayRunner._load_service_tier()
         request_service_tier = _request_service_tier(model_options)
+        if request_service_tier is not _REQUEST_OPTION_MISSING:
+            service_tier = request_service_tier
 
         request_model = _clean_request_string(requested_model)
         request_provider = _clean_request_string(requested_provider)
@@ -2639,6 +2660,19 @@ class APIServerAdapter(BasePlatformAdapter):
             else GatewayRunner._load_fallback_model()
         )
 
+        # ``service_tier`` stays on the agent for turn reporting, but the
+        # attribute alone is inert: provider transports read
+        # ``request_overrides``. Translate through the shared resolver so an
+        # unsupported model doesn't advertise a tier it can't use.
+        request_overrides = {}
+        if service_tier == "priority":
+            try:
+                from hermes_cli.models import resolve_fast_mode_overrides
+
+                request_overrides = resolve_fast_mode_overrides(model) or {}
+            except Exception:
+                request_overrides = {}
+
         agent_kwargs = {
             "model": model,
             **runtime_kwargs,
@@ -2657,10 +2691,18 @@ class APIServerAdapter(BasePlatformAdapter):
             "session_db": self._ensure_session_db(),
             "fallback_model": fallback_model,
             "reasoning_config": reasoning_config,
+            "service_tier": service_tier,
+            "request_overrides": request_overrides,
+            "providers_allowed": provider_routing.get("only"),
+            "providers_ignored": provider_routing.get("ignore"),
+            "providers_order": provider_routing.get("order"),
+            "provider_sort": provider_routing.get("sort"),
+            "provider_require_parameters": provider_routing.get(
+                "require_parameters", False
+            ),
+            "provider_data_collection": provider_routing.get("data_collection"),
             "gateway_session_key": gateway_session_key,
         }
-        if request_service_tier is not _REQUEST_OPTION_MISSING:
-            agent_kwargs["service_tier"] = request_service_tier
 
         agent = AIAgent(**agent_kwargs)
         agent._hermes_api_runtime = {

--- a/tests/gateway/test_api_server_provider_routing.py
+++ b/tests/gateway/test_api_server_provider_routing.py
@@ -49,9 +49,9 @@ def _create_adapter(
         "_load_reasoning_config",
         staticmethod(lambda: None),
     )
-    # The messaging gateway reads routing via _load_provider_routing(), which
-    # parses raw yaml. api_server must use the runtime loader instead so
-    # profile-scoped configs and ${VAR} refs resolve; fail loudly if it doesn't.
+    # Both gateway paths use runtime config. Keep the api_server path direct so
+    # profile-scoped configs and ${VAR} refs resolve without relying on the
+    # messaging gateway's _load_provider_routing() helper.
     monkeypatch.setattr(
         GatewayRunner,
         "_load_provider_routing",

--- a/tests/gateway/test_api_server_provider_routing.py
+++ b/tests/gateway/test_api_server_provider_routing.py
@@ -1,0 +1,261 @@
+"""Coverage for provider_routing / service_tier propagation on the api_server platform."""
+
+import logging
+
+import pytest
+
+from agent.chat_completion_helpers import _provider_preferences_for_agent
+from agent.transports.chat_completions import ChatCompletionsTransport
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+class _FakeAgent:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _create_adapter(
+    monkeypatch,
+    *,
+    provider_routing=None,
+    service_tier=None,
+    model="test/model",
+    use_real_config=False,
+):
+    """Build an adapter with deterministic _create_agent dependencies."""
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("run_agent.AIAgent", _FakeAgent)
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_key": "sk-test",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: model)
+    if not use_real_config:
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_runtime_config",
+            lambda: {"provider_routing": provider_routing or {}},
+        )
+    monkeypatch.setattr("gateway.run._current_max_iterations", lambda: 10)
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_load_reasoning_config",
+        staticmethod(lambda: None),
+    )
+    # The messaging gateway reads routing via _load_provider_routing(), which
+    # parses raw yaml. api_server must use the runtime loader instead so
+    # profile-scoped configs and ${VAR} refs resolve; fail loudly if it doesn't.
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_load_provider_routing",
+        staticmethod(
+            lambda: (_ for _ in ()).throw(
+                AssertionError("api_server must use profile-scoped runtime config")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_load_service_tier",
+        staticmethod(lambda: service_tier),
+    )
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_load_fallback_model",
+        staticmethod(lambda: None),
+    )
+    monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+    monkeypatch.setattr(adapter, "_session_model_override_for", lambda *_: None)
+    return adapter
+
+
+def _emitted_provider_body(agent):
+    preferences = _provider_preferences_for_agent(agent)
+    kwargs = ChatCompletionsTransport().build_kwargs(
+        model=agent.model,
+        messages=[{"role": "user", "content": "hello"}],
+        is_openrouter=True,
+        provider_preferences=preferences,
+    )
+    return kwargs.get("extra_body", {})
+
+
+def _built_chat_completion_body(agent):
+    return ChatCompletionsTransport().build_kwargs(
+        model=agent.model,
+        messages=[{"role": "user", "content": "hello"}],
+        request_overrides=agent.request_overrides,
+    )
+
+
+def test_config_provider_routing_reaches_agent_and_openrouter_body(monkeypatch):
+    routing = {
+        "only": ["anthropic", "google"],
+        "ignore": ["deepinfra"],
+        "order": ["deepseek", "anthropic"],
+        "sort": "price",
+        "require_parameters": True,
+        "data_collection": "deny",
+    }
+    adapter = _create_adapter(
+        monkeypatch,
+        provider_routing=routing,
+        service_tier="priority",
+    )
+
+    agent = adapter._create_agent(session_id="config-routing")
+
+    assert agent.providers_allowed == routing["only"]
+    assert agent.providers_ignored == routing["ignore"]
+    assert agent.providers_order == routing["order"]
+    assert agent.provider_sort == "price"
+    assert agent.provider_require_parameters is True
+    assert agent.provider_data_collection == "deny"
+    assert agent.service_tier == "priority"
+    assert _emitted_provider_body(agent)["provider"] == routing
+
+
+def test_unset_config_does_not_emit_provider_routing(monkeypatch):
+    adapter = _create_adapter(monkeypatch)
+
+    agent = adapter._create_agent(session_id="no-routing")
+
+    assert agent.providers_allowed is None
+    assert agent.providers_ignored is None
+    assert agent.providers_order is None
+    assert agent.provider_sort is None
+    assert agent.provider_require_parameters is False
+    assert agent.provider_data_collection is None
+    assert agent.service_tier is None
+    assert "provider" not in _emitted_provider_body(agent)
+
+
+@pytest.mark.parametrize("malformed_config", ["enabled", ["deepseek"]])
+def test_non_object_config_routing_warns_and_falls_back_to_empty(
+    monkeypatch,
+    caplog,
+    malformed_config,
+):
+    adapter = _create_adapter(monkeypatch, provider_routing=malformed_config)
+
+    with caplog.at_level(logging.WARNING):
+        agent = adapter._create_agent(session_id="malformed-config-routing")
+
+    assert agent.providers_allowed is None
+    assert agent.providers_order is None
+    assert agent.provider_sort is None
+    assert "provider" not in _emitted_provider_body(agent)
+    assert "Ignoring invalid provider_routing config: expected an object" in caplog.text
+
+
+def test_config_routing_uses_profile_runtime_config_with_env_expansion(
+    monkeypatch,
+    tmp_path,
+):
+    import yaml
+
+    import gateway.run as gateway_run
+
+    default_home = tmp_path / "default"
+    profile_home = tmp_path / "profiles" / "secondary"
+    default_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+    (default_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {"provider_routing": {"order": ["default-provider"], "sort": "price"}}
+        ),
+        encoding="utf-8",
+    )
+    (profile_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "provider_routing": {
+                    "order": ["${PROFILE_ROUTING_PROVIDER}"],
+                    "sort": "${PROFILE_ROUTING_SORT}",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PROFILE_ROUTING_PROVIDER", "profile-provider")
+    monkeypatch.setenv("PROFILE_ROUTING_SORT", "latency")
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+    adapter = _create_adapter(monkeypatch, use_real_config=True)
+
+    with gateway_run._profile_runtime_scope(profile_home):
+        agent = adapter._create_agent(session_id="secondary-profile-routing")
+
+    assert agent.providers_order == ["profile-provider"]
+    assert agent.provider_sort == "latency"
+
+
+def test_config_service_tier_reaches_supported_provider_request(monkeypatch):
+    adapter = _create_adapter(
+        monkeypatch,
+        service_tier="priority",
+        model="gpt-5.4",
+    )
+
+    agent = adapter._create_agent(session_id="config-fast-mode")
+
+    assert agent.service_tier == "priority"
+    assert agent.request_overrides == {"service_tier": "priority"}
+    assert _built_chat_completion_body(agent)["service_tier"] == "priority"
+
+
+@pytest.mark.parametrize(
+    "model_options",
+    [{"service_tier": "priority"}, {"fast": True}],
+    ids=["service-tier", "fast-flag"],
+)
+def test_request_service_tier_reaches_supported_provider_request(
+    monkeypatch,
+    model_options,
+):
+    adapter = _create_adapter(monkeypatch, model="gpt-5.4")
+
+    agent = adapter._create_agent(
+        session_id="request-fast-mode",
+        model_options=model_options,
+    )
+
+    assert agent.service_tier == "priority"
+    assert agent.request_overrides == {"service_tier": "priority"}
+    assert _built_chat_completion_body(agent)["service_tier"] == "priority"
+
+
+def test_request_non_priority_service_tier_does_not_enable_fast_mode(monkeypatch):
+    adapter = _create_adapter(monkeypatch, model="gpt-5.4")
+
+    agent = adapter._create_agent(
+        session_id="request-flex-tier",
+        model_options={"service_tier": "flex"},
+    )
+
+    assert agent.service_tier == "flex"
+    assert agent.request_overrides == {}
+    assert "service_tier" not in _built_chat_completion_body(agent)
+
+
+def test_config_service_tier_is_inert_for_unsupported_model(monkeypatch):
+    adapter = _create_adapter(
+        monkeypatch,
+        service_tier="priority",
+        model="deepseek/deepseek-chat",
+    )
+
+    agent = adapter._create_agent(session_id="unsupported-fast-mode")
+
+    assert agent.service_tier == "priority"
+    assert agent.request_overrides == {}
+    assert "service_tier" not in _built_chat_completion_body(agent)


### PR DESCRIPTION
## What

`_create_agent()` in the api_server platform never passed **any** of the six `providers_*` kwargs to `AIAgent`, so `provider_routing` in `config.yaml` was read by nothing on this platform.

The messaging gateway supplies them on both run paths:

```python
providers_allowed=pr.get("only"),
providers_ignored=pr.get("ignore"),
providers_order=pr.get("order"),
provider_sort=pr.get("sort"),
provider_require_parameters=pr.get("require_parameters", False),
provider_data_collection=pr.get("data_collection"),
```

From there the chain is `agent.providers_order` → `_provider_preferences_for_agent()` → the OpenRouter `provider` block. On the api_server platform that chain started with an unset attribute, so a configured provider pin, ignore list, `sort`, `require_parameters` or `data_collection` preference was silently discarded on every `/v1/chat/completions` request. Nothing warns — the config parses fine and is simply never consulted.

`agent.service_tier` had two related gaps:

1. It was **never loaded from config** here. `GatewayRunner._load_service_tier()` exists and the messaging paths use it; api_server only honoured a tier when a *request* supplied one via `model_options`.
2. Setting the attribute is **by itself inert** — provider transports read `agent.request_overrides`, not `agent.service_tier`. So Priority Processing was dead on this platform *even when explicitly requested per-request*: `{"model_options": {"fast": true}}` on an OpenAI-family model set the attribute and emitted nothing to the provider.

This PR passes the six routing kwargs, loads `agent.service_tier` from config, and translates `"priority"` through `resolve_fast_mode_overrides(model)` — the same resolver the CLI uses — so the tier reaches the provider request and an unsupported model no longer advertises a tier it cannot use.

Routing is read via `_load_gateway_runtime_config()` rather than raw yaml, so profile-scoped configs and `${VAR}` references resolve. The messaging gateway's `_load_provider_routing()` reads raw yaml and does not; a test asserts api_server keeps using the runtime loader rather than regressing to the raw one.

## Why this matters beyond tidiness

`provider_routing` is most often configured precisely because *some* providers serving a model are unacceptable — a pin to the first-party provider because third-party hosts mangle a model's tool-call format, an `ignore` list after a bad experience, `require_parameters` so tool requests don't land on a provider that drops them. Discarding it doesn't degrade gracefully; it routes traffic to exactly the providers the operator excluded, and the resulting failures look like model or agent bugs rather than routing.

Anyone driving Hermes through the API server (rather than a messaging platform) has been running unrouted this whole time.

## How to test

Reproduce on current `main`: set a `provider_routing` block in `config.yaml` with a distinctive `order`, drive a completion through the api_server platform, and inspect the outgoing OpenRouter request — there is no `provider` key in `extra_body`. The same config on a messaging platform emits it. For the tier: set `agent.service_tier: priority` (or send `model_options: {"fast": true}`) with an OpenAI-family model and observe no `service_tier` on the provider request.

Ten regression tests in `tests/gateway/test_api_server_provider_routing.py`:

- `test_config_provider_routing_reaches_agent_and_openrouter_body` — all six keys reach the agent and the emitted OpenRouter `provider` block.
- `test_unset_config_does_not_emit_provider_routing` — no config, no `provider` key (and `require_parameters` defaults to `False`, not `None`).
- `test_non_object_config_routing_warns_and_falls_back_to_empty` — a string or list where an object belongs warns and falls back to empty rather than raising.
- `test_config_routing_uses_profile_runtime_config_with_env_expansion` — a profile-scoped `config.yaml` with `${VAR}` refs resolves through the runtime loader; `_load_provider_routing` is patched to raise, so a regression to the raw-yaml read fails loudly.
- `test_config_service_tier_reaches_supported_provider_request` / `test_request_service_tier_reaches_supported_provider_request` (parametrised over `service_tier: priority` and `fast: true`) — the tier reaches `request_overrides` and the built request body.
- `test_request_non_priority_service_tier_does_not_enable_fast_mode` — `flex` stays on the agent without being upgraded to priority.
- `test_config_service_tier_is_inert_for_unsupported_model` — `priority` on a non-supporting model emits nothing.

All ten fail on `main` before the change, with failure modes that name the bug directly (`'_FakeAgent' object has no attribute 'providers_allowed'` / `'request_overrides'`).

Ran per-file with the project venv (`uv run --extra dev python -m pytest <file>`): `test_api_server_provider_routing.py` (10), `test_api_server_runs.py` (16), `test_api_server_toolset.py` (5) — all passing. `test_api_server.py` is 91 passed / 1 failed, but `TestHealthDetailedEndpoint::test_health_detailed_returns_ok` (`assert 'degraded' == 'ok'`) fails identically on unmodified `main` in this environment, so it is pre-existing and unrelated. Both `test_api_server.py` and `test_api_server_runs.py` need `aiohttp`, which isn't in the `dev` extra — I ran them with `--with aiohttp`.

## Platforms tested

macOS (Apple Silicon, Python 3.13). The change is confined to kwarg assembly in `gateway/platforms/api_server.py` plus one config read — no file I/O, process management, or terminal handling touched.

## Related

Same class of bug, fixed path by path: #72643 (routing prefs not forwarded via the profile path), #69733 (`require_parameters` + `data_collection` not forwarded to scheduled agents). The api_server platform is another instance — it drops the whole block rather than individual keys.

## Backward compatibility

**Backward compatible.** No wire, schema, configuration or persisted-state contract changes: no new config keys, no new request fields, and no change to any response shape. Old and new clients work unchanged against either version.

There is an intended **behaviour** change for deployments that already have `provider_routing` or `agent.service_tier` in `config.yaml` and drive Hermes through the api_server platform: that configuration now takes effect, so provider selection can shift and Priority Processing can start billing at priority rates. That is the point of the fix — the values were already declared and intended to apply — but it's worth calling out for anyone who has since tuned around the silent no-op. Deployments with neither key set see no change.
