### PR TITLE
fix(gemini): give each native tool call its own streaming slot

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -715,6 +715,24 @@ def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
                 yield payload
 
 
+def _tool_call_slot_accepts(slot: Dict[str, Any], args_str: str) -> bool:
+    """Whether ``args_str`` belongs to an existing streaming tool call slot.
+
+    A continuation extends the arguments already accumulated in the slot and a
+    resend repeats them verbatim, so both are prefix matches. A slot still
+    holding half-sent JSON is mid-stream and keeps whatever follows it.
+    Anything else arriving after a complete JSON object is a different call.
+    """
+    previous = str(slot.get("last_arguments") or "")
+    if not previous or args_str.startswith(previous):
+        return True
+    try:
+        json.loads(previous)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return True
+    return False
+
+
 def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices: Dict[str, Dict[str, Any]]) -> List[_GeminiStreamChunk]:
     candidates = event.get("candidates") or []
     if not candidates:
@@ -748,22 +766,22 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
                 sort_keys=True,
             )
             slot = tool_call_indices.get(call_key)
-            if slot is not None:
+            if slot is not None and not _tool_call_slot_accepts(slot, args_str):
                 # ``part_index`` restarts at 0 on every stream event, so two
                 # *different* calls to the same tool arriving in separate
                 # events collide on one slot and their arguments get
-                # concatenated into unparseable JSON. A continuation always
-                # extends what we already have; anything else that follows a
-                # complete JSON object is a new call and needs its own slot.
-                _prev = str(slot.get("last_arguments") or "")
-                if _prev and not args_str.startswith(_prev):
-                    try:
-                        json.loads(_prev)
-                    except (json.JSONDecodeError, TypeError, ValueError):
-                        pass
-                    else:
-                        call_key = f"{call_key}#{len(tool_call_indices)}"
-                        slot = tool_call_indices.get(call_key)
+                # concatenated into unparseable JSON. Each call gets its own
+                # slot, and the slots opened that way stay reachable, so a
+                # later continuation or resend still lands on the one it
+                # opened instead of allocating yet another.
+                slot = None
+                for previous_key, previous_slot in tool_call_indices.items():
+                    if previous_key.startswith(f"{call_key}#") and _tool_call_slot_accepts(previous_slot, args_str):
+                        call_key = previous_key
+                        slot = previous_slot
+                        break
+                if slot is None:
+                    call_key = f"{call_key}#{len(tool_call_indices)}"
             if slot is None:
                 slot = {
                     "index": len(tool_call_indices),

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -899,6 +899,24 @@ def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
                 yield payload
 
 
+def _tool_call_slot_accepts(slot: Dict[str, Any], args_str: str) -> bool:
+    """Whether ``args_str`` belongs to an existing streaming tool call slot.
+
+    A continuation extends the arguments already accumulated in the slot and a
+    resend repeats them verbatim, so both are prefix matches. A slot still
+    holding half-sent JSON is mid-stream and keeps whatever follows it.
+    Anything else arriving after a complete JSON object is a different call.
+    """
+    previous = str(slot.get("last_arguments") or "")
+    if not previous or args_str.startswith(previous):
+        return True
+    try:
+        json.loads(previous)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return True
+    return False
+
+
 def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices: Dict[str, Dict[str, Any]]) -> List[_GeminiStreamChunk]:
     candidates = event.get("candidates") or []
     if not candidates:
@@ -932,6 +950,22 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
                 sort_keys=True,
             )
             slot = tool_call_indices.get(call_key)
+            if slot is not None and not _tool_call_slot_accepts(slot, args_str):
+                # ``part_index`` restarts at 0 on every stream event, so two
+                # *different* calls to the same tool arriving in separate
+                # events collide on one slot and their arguments get
+                # concatenated into unparseable JSON. Each call gets its own
+                # slot, and the slots opened that way stay reachable, so a
+                # later continuation or resend still lands on the one it
+                # opened instead of allocating yet another.
+                slot = None
+                for previous_key, previous_slot in tool_call_indices.items():
+                    if previous_key.startswith(f"{call_key}#") and _tool_call_slot_accepts(previous_slot, args_str):
+                        call_key = previous_key
+                        slot = previous_slot
+                        break
+                if slot is None:
+                    call_key = f"{call_key}#{len(tool_call_indices)}"
             if slot is None:
                 slot = {
                     "index": len(tool_call_indices),

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -902,10 +902,11 @@ def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
 def _tool_call_slot_accepts(slot: Dict[str, Any], args_str: str) -> bool:
     """Whether ``args_str`` belongs to an existing streaming tool call slot.
 
-    A continuation extends the arguments already accumulated in the slot and a
-    resend repeats them verbatim, so both are prefix matches. A slot still
-    holding half-sent JSON is mid-stream and keeps whatever follows it.
-    Anything else arriving after a complete JSON object is a different call.
+    Only used for events that carry no provider call id. A continuation extends
+    the arguments already accumulated in the slot and a resend repeats them
+    verbatim, so both are prefix matches. A slot still holding half-sent JSON is
+    mid-stream and keeps whatever follows it. Anything else arriving after a
+    complete JSON object is a different call.
     """
     previous = str(slot.get("last_arguments") or "")
     if not previous or args_str.startswith(previous):
@@ -941,39 +942,52 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
             except (TypeError, ValueError):
                 args_str = "{}"
             thought_signature = part.get("thoughtSignature") if isinstance(part.get("thoughtSignature"), str) else ""
-            call_key = json.dumps(
-                {
-                    "part_index": part_index,
-                    "name": name,
-                    "thought_signature": thought_signature,
-                },
-                sort_keys=True,
-            )
-            slot = tool_call_indices.get(call_key)
-            if slot is not None and not _tool_call_slot_accepts(slot, args_str):
-                # ``part_index`` restarts at 0 on every stream event, so two
-                # *different* calls to the same tool arriving in separate
-                # events collide on one slot and their arguments get
-                # concatenated into unparseable JSON. Each call gets its own
-                # slot, and the slots opened that way stay reachable, so a
-                # later continuation or resend still lands on the one it
-                # opened instead of allocating yet another.
-                slot = None
-                for previous_key, previous_slot in tool_call_indices.items():
-                    if previous_key.startswith(f"{call_key}#") and _tool_call_slot_accepts(previous_slot, args_str):
-                        call_key = previous_key
-                        slot = previous_slot
-                        break
-                if slot is None:
-                    call_key = f"{call_key}#{len(tool_call_indices)}"
+            provider_call_id = str(fc["id"]) if isinstance(fc.get("id"), str) and fc.get("id") else ""
+            if provider_call_id:
+                # Gemini 3 assigns one id per tool call, so it is the
+                # authoritative slot identity: two calls that differ only by id
+                # are two calls even when their arguments are equal, and the
+                # same id arriving again is the same call. ``part_index`` and
+                # the thought signature are deliberately left out of the key --
+                # both drift across events of one call (only the first call of
+                # a turn carries a signature), and neither distinguishes calls
+                # the id already separates.
+                call_key = json.dumps(
+                    {"name": name, "provider_call_id": provider_call_id},
+                    sort_keys=True,
+                )
+                slot = tool_call_indices.get(call_key)
+            else:
+                # Gemini 2.5 sends no call id. ``part_index`` restarts at 0 on
+                # every stream event, so two *different* calls to the same tool
+                # arriving in separate events collide on one slot and their
+                # arguments get concatenated into unparseable JSON. Fall back to
+                # telling them apart by value: each call gets its own slot, and
+                # the slots opened that way stay reachable, so a later
+                # continuation or resend still lands on the one it opened
+                # instead of allocating yet another.
+                call_key = json.dumps(
+                    {
+                        "part_index": part_index,
+                        "name": name,
+                        "thought_signature": thought_signature,
+                    },
+                    sort_keys=True,
+                )
+                slot = tool_call_indices.get(call_key)
+                if slot is not None and not _tool_call_slot_accepts(slot, args_str):
+                    slot = None
+                    for previous_key, previous_slot in tool_call_indices.items():
+                        if previous_key.startswith(f"{call_key}#") and _tool_call_slot_accepts(previous_slot, args_str):
+                            call_key = previous_key
+                            slot = previous_slot
+                            break
+                    if slot is None:
+                        call_key = f"{call_key}#{len(tool_call_indices)}"
             if slot is None:
                 slot = {
                     "index": len(tool_call_indices),
-                    "id": (
-                        str(fc["id"])
-                        if isinstance(fc.get("id"), str) and fc.get("id")
-                        else f"call_{uuid.uuid4().hex[:12]}"
-                    ),
+                    "id": provider_call_id or f"call_{uuid.uuid4().hex[:12]}",
                     "last_arguments": "",
                 }
                 tool_call_indices[call_key] = slot

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -748,6 +748,22 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
                 sort_keys=True,
             )
             slot = tool_call_indices.get(call_key)
+            if slot is not None:
+                # ``part_index`` restarts at 0 on every stream event, so two
+                # *different* calls to the same tool arriving in separate
+                # events collide on one slot and their arguments get
+                # concatenated into unparseable JSON. A continuation always
+                # extends what we already have; anything else that follows a
+                # complete JSON object is a new call and needs its own slot.
+                _prev = str(slot.get("last_arguments") or "")
+                if _prev and not args_str.startswith(_prev):
+                    try:
+                        json.loads(_prev)
+                    except (json.JSONDecodeError, TypeError, ValueError):
+                        pass
+                    else:
+                        call_key = f"{call_key}#{len(tool_call_indices)}"
+                        slot = tool_call_indices.get(call_key)
             if slot is None:
                 slot = {
                     "index": len(tool_call_indices),

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -259,10 +259,9 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
 
 
 
-# Bloque de tests para anadir al final de
-# tests/agent/test_gemini_native_adapter.py del repo hermes-agent.
-# Estilo copiado del fichero destino: funciones sueltas, import dentro,
-# docstring explicando el porque.
+# ---------------------------------------------------------------------------
+# Parallel function call slot tests
+# ---------------------------------------------------------------------------
 
 
 def _fc_event(*calls):
@@ -283,7 +282,7 @@ def _fc_event(*calls):
 
 def _accumulate(events):
     """Replay events through translate_stream_event the way the streaming loop
-    in run_agent.py does, and return {index: concatenated arguments}."""
+    in ``_stream_completion`` does, and return {index: concatenated arguments}."""
     from agent.gemini_native_adapter import translate_stream_event
 
     tool_call_indices: dict = {}
@@ -366,6 +365,35 @@ def test_identical_resend_is_still_deduplicated_into_one_slot():
 
     assert len(acc) == 1, acc
     assert acc[0] == '{"query": "A"}'
+
+
+def test_resend_of_the_second_call_reuses_its_collision_created_slot():
+    """A slot opened by the collision must stay reachable. Replaying ``[A, B,
+    B]``, the resent B starts its lookup from the shared key, whose arguments
+    are A's, so it has to be matched against the slot B already opened instead
+    of opening a third one and duplicating the call."""
+    import json
+
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices: dict = {}
+    deltas = []
+    for event in [
+        _fc_event(("web_search", {"query": "A"})),
+        _fc_event(("web_search", {"query": "B"})),
+        _fc_event(("web_search", {"query": "B"})),
+    ]:
+        for chunk in translate_stream_event(
+            event, model="gemini-2.5-flash", tool_call_indices=tool_call_indices
+        ):
+            deltas.append(chunk.choices[0].delta.tool_calls[0])
+
+    assert len(tool_call_indices) == 2, tool_call_indices
+    assert [d.index for d in deltas] == [0, 1, 1]
+    # The resend carries no new arguments and keeps the id of the call it repeats.
+    assert deltas[2].function.arguments == ""
+    assert deltas[2].id == deltas[1].id
+    assert [json.loads(d.function.arguments)["query"] for d in deltas[:2]] == ["A", "B"]
 
 
 def test_partial_json_arguments_keep_accumulating_in_one_slot():

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -683,7 +683,12 @@ def test_text_only_tool_result_has_no_parts():
 
 
 def _fc_event(*calls):
-    """Build a native Gemini SSE event carrying one functionCall part per call."""
+    """Build a native Gemini SSE event carrying one functionCall part per call.
+
+    Deliberately id-less: this is the shape Gemini 2.5 produces, and it is what
+    exercises the value-based fallback. Tests for the id-carrying path build
+    their events with ``_live_fc_event``.
+    """
     return {
         "candidates": [
             {
@@ -899,3 +904,82 @@ def test_signed_first_call_then_unsigned_calls_each_get_their_own_slot():
     ]
     # Each slot keeps the id the model assigned to the call that opened it.
     assert [d.id for d in deltas] == ["call_371934", "call_371938", "call_371942"]
+
+
+def test_calls_with_equal_arguments_but_distinct_ids_get_distinct_slots():
+    """Two calls to one tool with byte-identical arguments and different
+    provider ids are two calls, not a resend.
+
+    Value equality cannot tell them apart -- the second payload is a prefix of
+    the first, which is what a resend looks like -- so on an adapter that keys
+    slots by value the second call is erased and rewritten as an empty delta on
+    the first. The provider id is the only discriminator available, so it wins
+    whenever the model supplies one.
+    """
+    import json
+
+    from agent.gemini_native_adapter import translate_stream_event
+
+    events = [
+        _live_fc_event("web_search", {"query": "A"}, call_id="call_1"),
+        _live_fc_event("web_search", {"query": "A"}, call_id="call_2"),
+    ]
+
+    tool_call_indices: dict = {}
+    deltas = []
+    for event in events:
+        for chunk in translate_stream_event(
+            event, model="gemini-3.5-flash", tool_call_indices=tool_call_indices
+        ):
+            deltas.append(chunk.choices[0].delta.tool_calls[0])
+
+    assert len(tool_call_indices) == 2, tool_call_indices
+    assert [d.index for d in deltas] == [0, 1]
+    assert [d.id for d in deltas] == ["call_1", "call_2"]
+    # Both slots carry the full argument payload; neither is emptied as a resend.
+    assert [json.loads(d.function.arguments) for d in deltas] == [
+        {"query": "A"},
+        {"query": "A"},
+    ]
+
+
+def test_repeated_provider_id_is_one_slot_even_when_the_signature_drifts():
+    """The same provider id arriving again is the same call, and a
+    ``thoughtSignature`` that appears, changes or disappears between events
+    does not split it.
+
+    Only the first call of a turn carries a signature, so the signature drifts
+    across the events of a stream by design. Keying an id-carrying call by
+    ``(name, id)`` alone keeps it in one slot; the repeat is emitted as an empty
+    argument delta, the way a resend should be.
+    """
+    from agent.gemini_native_adapter import translate_stream_event
+
+    events = [
+        _live_fc_event(
+            "web_search",
+            {"query": "A"},
+            call_id="call_1",
+            thought_signature="Ep8JCpwJARFNMg9geVAyMFMIa5ND0OFd",
+        ),
+        _live_fc_event("web_search", {"query": "A"}, call_id="call_1"),
+        _live_fc_event(
+            "web_search",
+            {"query": "A"},
+            call_id="call_1",
+            thought_signature="ZZZZZZZZdifferentsignatureZZZZZZ",
+        ),
+    ]
+
+    tool_call_indices: dict = {}
+    deltas = []
+    for event in events:
+        for chunk in translate_stream_event(
+            event, model="gemini-3.5-flash", tool_call_indices=tool_call_indices
+        ):
+            deltas.append(chunk.choices[0].delta.tool_calls[0])
+
+    assert len(tool_call_indices) == 1, tool_call_indices
+    assert [d.index for d in deltas] == [0, 0, 0]
+    assert [d.id for d in deltas] == ["call_1", "call_1", "call_1"]
+    assert [d.function.arguments for d in deltas] == ['{"query": "A"}', "", ""]

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -675,3 +675,227 @@ def test_text_only_tool_result_has_no_parts():
     )
     fr = request["contents"][1]["parts"][0]["functionResponse"]
     assert "parts" not in fr
+
+
+# ---------------------------------------------------------------------------
+# Parallel function call slot tests
+# ---------------------------------------------------------------------------
+
+
+def _fc_event(*calls):
+    """Build a native Gemini SSE event carrying one functionCall part per call."""
+    return {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": name, "args": args}}
+                        for name, args in calls
+                    ]
+                }
+            }
+        ]
+    }
+
+
+def _accumulate(events):
+    """Replay events through translate_stream_event the way the streaming loop
+    in ``_stream_completion`` does, and return {index: concatenated arguments}."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices: dict = {}
+    acc: dict = {}
+    for event in events:
+        for chunk in translate_stream_event(
+            event, model="gemini-2.5-flash", tool_call_indices=tool_call_indices
+        ):
+            delta = chunk.choices[0].delta.tool_calls[0]
+            acc[delta.index] = acc.get(delta.index, "") + (delta.function.arguments or "")
+    return acc
+
+
+def test_same_tool_called_twice_across_events_gets_distinct_slots():
+    """``call_key`` is built from ``part_index``, which restarts at 0 on every
+    stream event. Two *different* calls to the same tool arriving in separate
+    events therefore hash to the same key and used to share one slot, so their
+    arguments were emitted under the same index and concatenated downstream
+    into unparseable JSON (`{"query": "A"}{"query": "B"}`)."""
+    import json
+
+    acc = _accumulate(
+        [
+            _fc_event(("web_search", {"query": "A"})),
+            _fc_event(("web_search", {"query": "B"})),
+        ]
+    )
+
+    assert len(acc) == 2, acc
+    assert sorted(json.loads(v)["query"] for v in acc.values()) == ["A", "B"]
+
+
+def test_three_calls_to_same_tool_across_events_each_get_a_slot():
+    """The collision compounds: every extra call lands in the same slot."""
+    import json
+
+    acc = _accumulate(
+        [
+            _fc_event(("write_file", {"path": "a"})),
+            _fc_event(("write_file", {"path": "b"})),
+            _fc_event(("write_file", {"path": "c"})),
+        ]
+    )
+
+    assert len(acc) == 3, acc
+    assert sorted(json.loads(v)["path"] for v in acc.values()) == ["a", "b", "c"]
+
+
+def test_parallel_calls_in_one_event_keep_working():
+    """Regression guard: same-event parallel calls already worked, because each
+    part gets its own ``part_index``. This is also the tell that the collision
+    is Hermes-side — if the model were concatenating, this would fail too."""
+    acc = _accumulate([_fc_event(("web_search", {"query": "A"}), ("web_search", {"query": "B"}))])
+
+    assert len(acc) == 2, acc
+
+
+def test_different_tools_across_events_keep_working():
+    """Regression guard: distinct tool names never collided, since ``name`` is
+    part of ``call_key``."""
+    acc = _accumulate(
+        [
+            _fc_event(("read_file", {"path": "a"})),
+            _fc_event(("write_file", {"path": "b"})),
+        ]
+    )
+
+    assert len(acc) == 2, acc
+
+
+def test_identical_resend_is_still_deduplicated_into_one_slot():
+    """Regression guard for the existing dedup path: an identical resend of the
+    same part is the same call, not a new one, and must not open a slot."""
+    acc = _accumulate(
+        [
+            _fc_event(("web_search", {"query": "A"})),
+            _fc_event(("web_search", {"query": "A"})),
+        ]
+    )
+
+    assert len(acc) == 1, acc
+    assert acc[0] == '{"query": "A"}'
+
+
+def test_resend_of_the_second_call_reuses_its_collision_created_slot():
+    """A slot opened by the collision must stay reachable. Replaying ``[A, B,
+    B]``, the resent B starts its lookup from the shared key, whose arguments
+    are A's, so it has to be matched against the slot B already opened instead
+    of opening a third one and duplicating the call."""
+    import json
+
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices: dict = {}
+    deltas = []
+    for event in [
+        _fc_event(("web_search", {"query": "A"})),
+        _fc_event(("web_search", {"query": "B"})),
+        _fc_event(("web_search", {"query": "B"})),
+    ]:
+        for chunk in translate_stream_event(
+            event, model="gemini-2.5-flash", tool_call_indices=tool_call_indices
+        ):
+            deltas.append(chunk.choices[0].delta.tool_calls[0])
+
+    assert len(tool_call_indices) == 2, tool_call_indices
+    assert [d.index for d in deltas] == [0, 1, 1]
+    # The resend carries no new arguments and keeps the id of the call it repeats.
+    assert deltas[2].function.arguments == ""
+    assert deltas[2].id == deltas[1].id
+    assert [json.loads(d.function.arguments)["query"] for d in deltas[:2]] == ["A", "B"]
+
+
+def test_partial_json_arguments_keep_accumulating_in_one_slot():
+    """The `json.loads` guard is what keeps a genuinely partial argument string
+    in its slot: a half-sent object does not parse, so it is treated as a
+    continuation rather than as a new call. The native path always serializes a
+    complete dict, so this exercises the guard directly on the accumulator
+    state to keep the protective behaviour pinned."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices: dict = {}
+    translate_stream_event(
+        _fc_event(("search", {"q": "A"})),
+        model="gemini-2.5-flash",
+        tool_call_indices=tool_call_indices,
+    )
+    # Simulate an incomplete payload already sitting in the slot.
+    slot = next(iter(tool_call_indices.values()))
+    slot["last_arguments"] = '{"q": "A'
+
+    translate_stream_event(
+        _fc_event(("search", {"q": "AB"})),
+        model="gemini-2.5-flash",
+        tool_call_indices=tool_call_indices,
+    )
+
+    assert len(tool_call_indices) == 1, "incomplete JSON must not open a new slot"
+
+
+def _live_fc_event(name, args, *, call_id, thought_signature=None):
+    """Build the event shape native Gemini 3 traffic actually produces: one
+    ``functionCall`` part per event, carrying the id the model assigned it, and
+    a ``thoughtSignature`` sibling on the first call only."""
+    part = {"functionCall": {"name": name, "args": args, "id": call_id}}
+    if thought_signature is not None:
+        part["thoughtSignature"] = thought_signature
+    return {"candidates": [{"content": {"parts": [part]}}]}
+
+
+def test_signed_first_call_then_unsigned_calls_each_get_their_own_slot():
+    """Replay of a capture from the native endpoint, in the shape real traffic
+    has: three sequential calls to one tool, and only the first part carries a
+    ``thoughtSignature``.
+
+    That asymmetry is why the defect looks intermittent.
+    ``thought_signature`` is part of ``call_key``, so the signed call is
+    disambiguated by accident: a two-call capture replays cleanly even on the
+    unfixed adapter, and the collision only begins with the *second unsigned*
+    call. Synthetic events carrying no signature at all collide one call
+    earlier, so they reproduce a different arrangement of the same bug -- this
+    sequence is the one the reporter hit. On the unfixed adapter it yields two
+    slots, with ``{"query": "weather in Lisbon"}{"query": "weather in Porto"}``
+    concatenated under the second.
+    """
+    import json
+
+    from agent.gemini_native_adapter import translate_stream_event
+
+    events = [
+        _live_fc_event(
+            "web_search",
+            {"query": "weather in Madrid"},
+            call_id="call_371934",
+            # Truncated; the captured signature is ~1.5 kB.
+            thought_signature="Ep8JCpwJARFNMg9geVAyMFMIa5ND0OFd",
+        ),
+        _live_fc_event("web_search", {"query": "weather in Lisbon"}, call_id="call_371938"),
+        _live_fc_event("web_search", {"query": "weather in Porto"}, call_id="call_371942"),
+    ]
+
+    tool_call_indices: dict = {}
+    deltas = []
+    for event in events:
+        for chunk in translate_stream_event(
+            event, model="gemini-3.5-flash", tool_call_indices=tool_call_indices
+        ):
+            deltas.append(chunk.choices[0].delta.tool_calls[0])
+
+    assert len(tool_call_indices) == 3, tool_call_indices
+    assert [d.index for d in deltas] == [0, 1, 2]
+    assert [json.loads(d.function.arguments)["query"] for d in deltas] == [
+        "weather in Madrid",
+        "weather in Lisbon",
+        "weather in Porto",
+    ]
+    # Each slot keeps the id the model assigned to the call that opened it.
+    assert [d.id for d in deltas] == ["call_371934", "call_371938", "call_371942"]

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -259,3 +259,137 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
 
 
 
+# Bloque de tests para anadir al final de
+# tests/agent/test_gemini_native_adapter.py del repo hermes-agent.
+# Estilo copiado del fichero destino: funciones sueltas, import dentro,
+# docstring explicando el porque.
+
+
+def _fc_event(*calls):
+    """Build a native Gemini SSE event carrying one functionCall part per call."""
+    return {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": name, "args": args}}
+                        for name, args in calls
+                    ]
+                }
+            }
+        ]
+    }
+
+
+def _accumulate(events):
+    """Replay events through translate_stream_event the way the streaming loop
+    in run_agent.py does, and return {index: concatenated arguments}."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices: dict = {}
+    acc: dict = {}
+    for event in events:
+        for chunk in translate_stream_event(
+            event, model="gemini-2.5-flash", tool_call_indices=tool_call_indices
+        ):
+            delta = chunk.choices[0].delta.tool_calls[0]
+            acc[delta.index] = acc.get(delta.index, "") + (delta.function.arguments or "")
+    return acc
+
+
+def test_same_tool_called_twice_across_events_gets_distinct_slots():
+    """``call_key`` is built from ``part_index``, which restarts at 0 on every
+    stream event. Two *different* calls to the same tool arriving in separate
+    events therefore hash to the same key and used to share one slot, so their
+    arguments were emitted under the same index and concatenated downstream
+    into unparseable JSON (`{"query": "A"}{"query": "B"}`)."""
+    import json
+
+    acc = _accumulate(
+        [
+            _fc_event(("web_search", {"query": "A"})),
+            _fc_event(("web_search", {"query": "B"})),
+        ]
+    )
+
+    assert len(acc) == 2, acc
+    assert sorted(json.loads(v)["query"] for v in acc.values()) == ["A", "B"]
+
+
+def test_three_calls_to_same_tool_across_events_each_get_a_slot():
+    """The collision compounds: every extra call lands in the same slot."""
+    import json
+
+    acc = _accumulate(
+        [
+            _fc_event(("write_file", {"path": "a"})),
+            _fc_event(("write_file", {"path": "b"})),
+            _fc_event(("write_file", {"path": "c"})),
+        ]
+    )
+
+    assert len(acc) == 3, acc
+    assert sorted(json.loads(v)["path"] for v in acc.values()) == ["a", "b", "c"]
+
+
+def test_parallel_calls_in_one_event_keep_working():
+    """Regression guard: same-event parallel calls already worked, because each
+    part gets its own ``part_index``. This is also the tell that the collision
+    is Hermes-side — if the model were concatenating, this would fail too."""
+    acc = _accumulate([_fc_event(("web_search", {"query": "A"}), ("web_search", {"query": "B"}))])
+
+    assert len(acc) == 2, acc
+
+
+def test_different_tools_across_events_keep_working():
+    """Regression guard: distinct tool names never collided, since ``name`` is
+    part of ``call_key``."""
+    acc = _accumulate(
+        [
+            _fc_event(("read_file", {"path": "a"})),
+            _fc_event(("write_file", {"path": "b"})),
+        ]
+    )
+
+    assert len(acc) == 2, acc
+
+
+def test_identical_resend_is_still_deduplicated_into_one_slot():
+    """Regression guard for the existing dedup path: an identical resend of the
+    same part is the same call, not a new one, and must not open a slot."""
+    acc = _accumulate(
+        [
+            _fc_event(("web_search", {"query": "A"})),
+            _fc_event(("web_search", {"query": "A"})),
+        ]
+    )
+
+    assert len(acc) == 1, acc
+    assert acc[0] == '{"query": "A"}'
+
+
+def test_partial_json_arguments_keep_accumulating_in_one_slot():
+    """The `json.loads` guard is what keeps a genuinely partial argument string
+    in its slot: a half-sent object does not parse, so it is treated as a
+    continuation rather than as a new call. The native path always serializes a
+    complete dict, so this exercises the guard directly on the accumulator
+    state to keep the protective behaviour pinned."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices: dict = {}
+    translate_stream_event(
+        _fc_event(("search", {"q": "A"})),
+        model="gemini-2.5-flash",
+        tool_call_indices=tool_call_indices,
+    )
+    # Simulate an incomplete payload already sitting in the slot.
+    slot = next(iter(tool_call_indices.values()))
+    slot["last_arguments"] = '{"q": "A'
+
+    translate_stream_event(
+        _fc_event(("search", {"q": "AB"})),
+        model="gemini-2.5-flash",
+        tool_call_indices=tool_call_indices,
+    )
+
+    assert len(tool_call_indices) == 1, "incomplete JSON must not open a new slot"


### PR DESCRIPTION
## What does this PR do?

Two *different* calls to the same tool arriving in **separate** stream events collide in one
accumulator slot in the native Gemini adapter. Their arguments are emitted under the same
`index` and concatenated downstream into unparseable JSON (`{"query": "A"}{"query": "B"}`),
and the call is dropped.

This is the source-side defect pointed at when #72489 was closed under the standing
`model-output-repair` policy:

> The linked discussion on #72488 usefully identifies an upstream native-Gemini
> slot-collision candidate in `agent/gemini_native_adapter.py:726-765`; a narrowly scoped
> source-side fix for a verified deterministic adapter defect would be the appropriate
> re-scope rather than reconstructing malformed arguments downstream.

That is what this PR is. **No repair or reconstruction pass is added** — the call boundary is
simply never discarded in the first place.

The branch is rebased onto `0dfba37b1` (`main`, 2026-08-27), so every line number below is a
line number in this PR's own merge base.

### Where it manifests

In `translate_stream_event` (`agent/gemini_native_adapter.py:902`), the slot key is built from
`part_index` (**926-933**):

```python
call_key = json.dumps(
    {
        "part_index": part_index,
        "name": name,
        "thought_signature": thought_signature,
    },
    sort_keys=True,
)
```

`part_index` comes from `for part_index, part in enumerate(parts)` (**910**) — it **restarts at 0
on every stream event**. Two different calls to the same tool, arriving in two events, produce an
identical `call_key` and land in the same slot.

The accumulator (**947-952**) then emits both under one index:

```python
last_arguments = str(slot.get("last_arguments") or "")
if last_arguments:
    if args_str == last_arguments:
        emitted_arguments = ""
    elif args_str.startswith(last_arguments):
        emitted_arguments = args_str[len(last_arguments):]
```

A genuinely different call is neither equal nor a prefix extension, so the full
`{"query": "B"}` is emitted under the same `index` as `{"query": "A"}`.

**The tell:** same-event parallel calls work fine — each part gets its own `part_index`,
hence a distinct key. Only calls split across events collide. If the model were the one
concatenating, both cases would fail identically.

`functionCall.id` is read at **938-942**, but only *after* the slot has already been chosen, so
it never participates in slot identity. That is the second half of the defect; see below.

**Why it looks intermittent, and why a live reproduction needs three calls.** In real native
Gemini 3 traffic only the *first* function call carries a `thoughtSignature` (~1.5 kB); the calls
after it arrive without one. `thought_signature` is part of `call_key` above, so that first call
is disambiguated by accident. A captured two-call sequence therefore replays cleanly on stock
`main` and looks healthy — the collision begins with the *second unsigned* call:

```
two calls   (signed, then unsigned):   slots=2 -> {0: '{"query": "weather in Madrid"}',
                                                   1: '{"query": "weather in Lisbon"}'}
three calls (signed, then 2 unsigned): slots=2 -> {0: '{"query": "weather in Madrid"}',
                                                   1: '{"query": "weather in Lisbon"}{"query": "weather in Porto"}'}
```

Synthetic events carrying no signature at all collide one call earlier, so they reproduce a
different arrangement of the same defect than the one reported. Both shapes are pinned.
Measured on `gemini-3.1-pro-preview` and `gemini-3.5-flash`; capture and method in
[this comment](https://github.com/NousResearch/hermes-agent/issues/72488#issuecomment-5413174403).

### The approach: the provider call id decides, value comparison is the fallback

**When the model sends `functionCall.id`, that id is the slot identity.** Gemini 3 assigns one id
per call, so the key becomes `(name, provider_call_id)` and only that exact key is reused.
`part_index` and the thought signature are deliberately left out of it: both drift across the
events of a single call — only the first call of a turn is signed — and neither distinguishes
calls the id already separates.

**When there is no id, arguments decide.** Gemini 2.5 sends no `functionCall.id` at all, so that
path keeps the value-based rule: a payload that neither extends nor repeats the arguments a slot
already holds belongs to a different call and gets its own slot, and slots opened that way stay
reachable so a later resend lands back on the slot it opened instead of allocating yet another.
That rule lives in one helper, `_tool_call_slot_accepts`.

This two-path shape is what @andrexibiza's review asked for, and it closes a case the value-based
rule alone cannot decide:

```python
# separate native Gemini stream events
{"functionCall": {"id": "call_1", "name": "web_search", "args": {"query": "A"}}}
{"functionCall": {"id": "call_2", "name": "web_search", "args": {"query": "A"}}}
```

Byte-identical arguments, different ids. The second payload is a prefix of the first, which is
exactly what a resend looks like, so a value-only matcher folds the second call into the first
slot and emits it as an empty delta — the call is erased.

**For the record, that case is not a regression this PR introduced.** Stock `main` collapses it
in precisely the same way, through the `args_str == last_arguments` branch at **949-950**, and
emits the same single slot with the same id:

```
main (0dfba37b1), no patch:  slots=1 -> (0, 'call_1', '{"query": "A"}')
                                        (0, 'call_1', '')
this PR:                     slots=2 -> (0, 'call_1', '{"query": "A"}')
                                        (1, 'call_2', '{"query": "A"}')
```

Earlier revisions of this branch left it as it was on `main`; this one fixes it too.

The id-less fallback mirrors the existing Ollama workaround in
`agent/chat_completion_helpers.py` (`_last_id_at_idx` / `_active_slot_by_idx`, declared at
**3948-3949** and applied at **4244-4254**), which solves the sibling problem of an endpoint
reusing index 0 for a whole parallel batch.

### Scope — what this deliberately does not claim

- **The OpenAI-compat path is already covered** by that Ollama workaround: a differing `id` on
  the same raw index already redirects to a fresh slot. This PR does not touch it. Whether
  Gemini's OpenAI-compat endpoint can still collide when it sends `index=None` *and* omits ids
  is not something I can demonstrate — I run the native provider and have no trace of that
  endpoint, so I am not asserting it.
- **This does not prove the model never concatenates.** It proves there is a path inside Hermes
  that produces the symptom on its own, from well-formed input. Both causes can coexist.
- **`functionCall.id` cannot replace the value-based rule while 2.5 is supported.** I probed the
  live endpoint: the id is populated and distinct per call on `gemini-3.1-pro-preview` and
  `gemini-3.5-flash`, and **absent** on `gemini-2.5-flash`, where it would degrade to a constant
  `""` for every call. Hence two paths rather than one.
- **The `elif args_str.startswith(...)` branch on `main` is unreachable**, as @Eneasf demonstrates
  in [#72488](https://github.com/NousResearch/hermes-agent/issues/72488): both operands are
  `json.dumps` of a `functionCall.args` Struct, and a serialized object cannot be a *strict*
  prefix of another, while the equality case is consumed by the branch above it. This does not
  change the fix. The prefix test in `_tool_call_slot_accepts` is a *slot membership* test with no
  `==` in front of it, so an identical id-less resend does match there and stays in its slot;
  that path is exercised by `test_identical_resend_is_still_deduplicated_into_one_slot`. What the
  same argument does touch is the "half-sent JSON keeps accumulating" guard: if `args` can never
  arrive partially serialized on this path, that guard is defensive rather than load-bearing, and
  `test_partial_json_arguments_keep_accumulating_in_one_slot` pins behaviour that current Gemini
  traffic may never produce. I am happy to drop both if a maintainer prefers the narrower change;
  none of the cross-event regressions depend on them.
- **Overlap with #24676.** That PR targets the same cluster and is earlier (2026-05-13). It is a
  value-only matcher, so it fixes the cross-event collision and the `[A, B, B]` reachability case,
  but it cannot decide equal arguments with distinct `functionCall.id`s — the case the review on
  this PR flagged as a blocker. Replayed through the same eight-case bench, no network: `main`
  `0dfba37b1` fails 5, #24676 (`45914ab`) fails 1 (case 7), this branch fails 0. The id-keyed
  branch here grafts onto #24676 cleanly if a maintainer prefers that implementation; I am happy
  to open it there instead. Not a criticism of #24676 — it predates Gemini 3, when there was no id
  to key on.
- Behaviour changes only in cases that currently lose a call; every case that works today still
  works.

## Related Issue

Fixes #72488

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/gemini_native_adapter.py` — +62 / −14. A `_tool_call_slot_accepts` helper holding the
  id-less membership rule, and, in `translate_stream_event`, slot selection split into the
  id-keyed path and the value-based fallback. The emitted tool-call id is the provider's whenever
  there is one; a synthetic id is generated only on the id-less path, as before.
- `tests/agent/test_gemini_native_adapter.py` — +309 / −0, ten tests covering the defect and the
  behaviours that must not regress.

Two commits: the first is the cross-event slot fix as previously reviewed and green-lit, the
second is the id-identity correction from review, so the delta of this round can be read on its
own.

## How to Test

Deterministic, no network and no model — synthetic well-formed stream events, each carrying one
valid `functionCall` part.

1. Check out this branch and revert *only* the adapter, keeping the new tests:
   `git checkout $(git merge-base HEAD origin/main) -- agent/gemini_native_adapter.py`
   (not `HEAD~1` — that is this PR's own first commit, which fixes four of the six cases.)
2. `pytest tests/agent/test_gemini_native_adapter.py -q` → **6 failed, 33 passed**.
3. `git checkout HEAD -- agent/gemini_native_adapter.py` and re-run → **39 passed**.

Test matrix (behaviour on `main`, without this change):

| Test | On `main` |
|---|---|
| `test_same_tool_called_twice_across_events_gets_distinct_slots` | **fails** |
| `test_three_calls_to_same_tool_across_events_each_get_a_slot` | **fails** |
| `test_resend_of_the_second_call_reuses_its_collision_created_slot` | **fails** |
| `test_signed_first_call_then_unsigned_calls_each_get_their_own_slot` | **fails** |
| `test_calls_with_equal_arguments_but_distinct_ids_get_distinct_slots` | **fails** |
| `test_repeated_provider_id_is_one_slot_even_when_the_signature_drifts` | **fails** |
| `test_parallel_calls_in_one_event_keep_working` | passes (regression guard) |
| `test_different_tools_across_events_keep_working` | passes (regression guard) |
| `test_identical_resend_is_still_deduplicated_into_one_slot` | passes (regression guard) |
| `test_partial_json_arguments_keep_accumulating_in_one_slot` | passes (regression guard) |

The four regressions the review asked for map onto that table as: equal arguments with distinct
ids → `test_calls_with_equal_arguments_but_distinct_ids_get_distinct_slots`; a repeated id
across events including signature drift → `test_repeated_provider_id_is_one_slot_even_when_the_signature_drifts`;
id-less differing arguments → `test_same_tool_called_twice_across_events_gets_distinct_slots`;
id-less identical resend → `test_identical_resend_is_still_deduplicated_into_one_slot`. The
helper that builds id-less events (`_fc_event`) is documented as such so it is clear which path
each test exercises.

Sibling files, on this branch: `pytest tests/agent/test_gemini*.py tests/agent/test_stream*.py
tests/agent/test_*tool_call*.py -q` → **162 passed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially, see note**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

> **Note on the box above:** I ran `scripts/run_tests.sh tests/agent/` — the directory this change
> lives in — on an earlier revision of this branch: **325 files, 3351 tests passed, 1 failed** in
> 38.7 min. The one failure,
> `test_credential_pool_routing.py::TestFailureAttribution::test_unmatched_key_does_not_retry_only_pool_entry`,
> reproduces identically on `main` — same assertion, `1 failed, 14 passed` on both sides — so it is
> pre-existing and unrelated. My box has 2 cores and also runs a production gateway; I have not run
> the full ~20k-test suite locally, so I am leaving the box unchecked rather than checking it on a
> partial run.
>
> **On exact-head CI evidence:** every workflow on this PR is `action_required` and always has been
> — `CI`, `Docker Build, Test, and Publish`, `Nix flake check` and `Label rerun`, with
> `check-runs` = 0 at every head this branch has had. That is GitHub's fork gate, not a failure:
> it needs a maintainer to approve the run. I cannot produce exact-head workflow evidence myself;
> approving the run on this head is all it takes and I will act on whatever it reports.
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11, native Gemini provider via the Telegram gateway

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Eight synthetic cases replayed through `translate_stream_event`, no network and no model. Cases
1-6 carry **no** `functionCall.id` (the Gemini 2.5 shape, which exercises the value-based
fallback); cases 7-8 carry one (the Gemini 3 shape). Case 8 is the captured signed-then-unsigned
sequence.

Stock `main` at `0dfba37b1`:

```
  FAIL  1. two web_search, separate events:      slots=1 (expected 2) -> {0: '{"query": "A"}{"query": "B"}'}
  ok    2. two web_search, same event:           slots=2 (expected 2) -> {0: '{"query": "A"}', 1: '{"query": "B"}'}
  ok    3. different tools:                      slots=2 (expected 2) -> {0: '{"path": "a"}', 1: '{"path": "b"}'}
  FAIL  4. three write_file, separate events:    slots=1 (expected 3) -> {0: '{"path": "a"}{"path": "b"}{"path": "c"}'}
  ok    5. identical resend (dedup) -> 1 slot:   slots=1 (expected 1) -> {0: '{"query": "A"}'}
  FAIL  6. A, B, B: resend of B returns to ITS slot: slots=1 (expected 2) -> {0: '{"query": "A"}{"query": "B"}'}
  FAIL  7. WITH id: equal args, distinct ids:    slots=1 (expected 2) -> {0: '{"query": "A"}'}
  FAIL  8. WITH id: three calls, signature on the 1st only: slots=2 (expected 3) -> {0: '{"query": "Madrid"}', 1: '{"query": "Lisbon"}{"query": "Porto"}'}
```

Same file with this PR applied:

```
  ok    1. two web_search, separate events:      slots=2 (expected 2) -> {0: '{"query": "A"}', 1: '{"query": "B"}'}
  ok    2. two web_search, same event:           slots=2 (expected 2) -> {0: '{"query": "A"}', 1: '{"query": "B"}'}
  ok    3. different tools:                      slots=2 (expected 2) -> {0: '{"path": "a"}', 1: '{"path": "b"}'}
  ok    4. three write_file, separate events:    slots=3 (expected 3) -> {0: '{"path": "a"}', 1: '{"path": "b"}', 2: '{"path": "c"}'}
  ok    5. identical resend (dedup) -> 1 slot:   slots=1 (expected 1) -> {0: '{"query": "A"}'}
  ok    6. A, B, B: resend of B returns to ITS slot: slots=2 (expected 2) -> {0: '{"query": "A"}', 1: '{"query": "B"}'}
  ok    7. WITH id: equal args, distinct ids:    slots=2 (expected 2) -> {0: '{"query": "A"}', 1: '{"query": "A"}'}
  ok    8. WITH id: three calls, signature on the 1st only: slots=3 (expected 3) -> {0: '{"query": "Madrid"}', 1: '{"query": "Lisbon"}', 2: '{"query": "Porto"}'}
```

Case 7 is the one the review found: on `main` the second call is erased and rewritten as an empty
delta on the first slot.

The cross-event fix has been running in production here since 2026-07-29 (Telegram gateway, native
Gemini provider), on the previously reviewed revision since 2026-08-01, with no regressions
observed. The id-identity change in the second commit is new as of today and has not yet run in
production.

