### PR TITLE
perf(ci): drop per-job ripgrep/uv/Python setup, use the baked runner image

### DIFF
--- a/.github/actions/uv-cache/action.yml
+++ b/.github/actions/uv-cache/action.yml
@@ -1,0 +1,24 @@
+name: Cache uv downloads
+description: >-
+  Persist uv's download/wheel cache (~/.cache/uv) across runs, keyed on the
+  dependency manifests. This is the half of astral-sh/setup-uv we still need:
+  uv itself and CPython 3.11 are baked into the nousresearch/nous-gke-runner
+  image (see hermes-agent-ci-infra runner/Dockerfile), but the wheel cache is
+  per-workspace and must still be restored. Without it `uv sync` re-downloads
+  and re-builds every wheel on every job — the toolchain would be faster to
+  set up and the sync dramatically slower, a net loss.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/uv
+        # runner.arch in the key: the cache holds built wheels, which are
+        # arch-specific — the docker workflow runs this on arm64 too.
+        key: uv-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+        # Fall back to any older cache for this arch: a stale wheel set still
+        # saves most of the download, and `uv sync --locked` re-resolves from
+        # uv.lock regardless, so a partial hit can't produce a wrong env.
+        restore-keys: |
+          uv-cache-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -154,16 +154,11 @@ jobs:
       # than the build itself.  Reusing the existing daemon state is the
       # cheapest path to coverage on every PR that touches docker code.
       # ---------------------------------------------------------------------
-      - name: Install uv (for docker tests)
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
-          # raw.githubusercontent.com every job; transient fetch failures
-          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
-          version: '0.9.28'
-
-      - name: Set up Python 3.11 (for docker tests)
-        run: uv python install 3.11
+      # uv and CPython 3.11 are baked into the nousresearch/nous-gke-runner
+      # image (hermes-agent-ci-infra runner/Dockerfile) — no setup-uv, no
+      # `uv python install`.
+      - name: Restore uv cache (for docker tests)
+        uses: ./.github/actions/uv-cache
 
       - name: Install Python dependencies (for docker tests)
         # ``dev`` extra pulls in pytest, pytest-asyncio —

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -59,20 +59,11 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
 
       # ── Python (for the hermes serve backend) ──────────────────────────
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pin the uv version: unpinned, setup-uv resolves "latest" by
-          # fetching a manifest from raw.githubusercontent.com on EVERY job —
-          # a transient fetch failure fails the whole job (2026-07-28 slice-5
-          # incident). Pinned, the binary downloads directly; no manifest hop.
-          version: "0.9.28"
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-      - name: Set up Python 3.11
-        run: uv python install 3.11
+      # uv and CPython 3.11 are baked into the nousresearch/nous-gke-runner
+      # image (hermes-agent-ci-infra runner/Dockerfile) — no setup-uv, no
+      # `uv python install`.
+      - name: Restore uv cache
+        uses: ./.github/actions/uv-cache
       - name: Install Python dependencies
         uses: ./.github/actions/retry
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,13 +38,9 @@ jobs:
         with:
           fetch-depth: 0 # need full history for merge-base + worktree
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
-          # raw.githubusercontent.com every job; transient fetch failures
-          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
-          version: "0.9.28"
+      # uv and CPython 3.11 are baked into the nousresearch/nous-gke-runner
+      # image (hermes-agent-ci-infra runner/Dockerfile) — no setup-uv, no
+      # `uv python install`.
 
       - name: Install ruff + ty
         uses: ./.github/actions/retry
@@ -132,13 +128,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
-          # raw.githubusercontent.com every job; transient fetch failures
-          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
-          version: "0.9.28"
+      # uv and CPython 3.11 are baked into the nousresearch/nous-gke-runner
+      # image (hermes-agent-ci-infra runner/Dockerfile) — no setup-uv, no
+      # `uv python install`.
 
       - name: Install ruff
         uses: ./.github/actions/retry

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,40 +57,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install ripgrep (prebuilt binary)
-        run: |
-          set -euo pipefail
-          RG_VERSION=15.1.0
-          RG_SHA256=1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599
-          RG_TARBALL=ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz
-          curl -sSfL --retry 3 --retry-delay 5 -o "$RG_TARBALL" \
-            "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TARBALL}"
-          echo "${RG_SHA256}  ${RG_TARBALL}" | sha256sum -c -
-          tar -xzf "$RG_TARBALL"
-          sudo mv "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl/rg" /usr/local/bin/rg
-          rm -rf "$RG_TARBALL" "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl"
-          rg --version
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pin the uv version: unpinned, setup-uv resolves "latest" by
-          # fetching a manifest from raw.githubusercontent.com on EVERY job —
-          # a transient fetch failure fails the whole job (2026-07-28 slice-5
-          # incident). Pinned, the binary downloads directly; no manifest hop.
-          version: "0.9.28"
-          # Persist uv's download/wheel cache (~/.cache/uv) across runs.
-          # Keyed on the dependency manifests, so the cache is reused until
-          # pyproject.toml or uv.lock changes. `uv sync` still runs every
-          # time, but resolves from the warm cache instead of re-downloading
-          # and re-building wheels.
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Set up Python 3.11
-        run: uv python install 3.11
+      # uv and CPython 3.11 are baked into the nousresearch/nous-gke-runner
+      # image (hermes-agent-ci-infra runner/Dockerfile) — no setup-uv, no
+      # `uv python install`. Only the wheel cache still needs restoring.
+      - name: Restore uv cache
+        uses: ./.github/actions/uv-cache
 
       - name: Install dependencies
         # `uv sync --locked` installs the exact pinned set from uv.lock (and
@@ -188,40 +159,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install ripgrep (prebuilt binary)
-        run: |
-          set -euo pipefail
-          RG_VERSION=15.1.0
-          RG_SHA256=1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599
-          RG_TARBALL=ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz
-          curl -sSfL --retry 3 --retry-delay 5 -o "$RG_TARBALL" \
-            "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TARBALL}"
-          echo "${RG_SHA256}  ${RG_TARBALL}" | sha256sum -c -
-          tar -xzf "$RG_TARBALL"
-          sudo mv "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl/rg" /usr/local/bin/rg
-          rm -rf "$RG_TARBALL" "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl"
-          rg --version
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pin the uv version: unpinned, setup-uv resolves "latest" by
-          # fetching a manifest from raw.githubusercontent.com on EVERY job —
-          # a transient fetch failure fails the whole job (2026-07-28 slice-5
-          # incident). Pinned, the binary downloads directly; no manifest hop.
-          version: "0.9.28"
-          # Persist uv's download/wheel cache (~/.cache/uv) across runs.
-          # Keyed on the dependency manifests, so the cache is reused until
-          # pyproject.toml or uv.lock changes. `uv sync` still runs every
-          # time, but resolves from the warm cache instead of re-downloading
-          # and re-building wheels.
-          enable-cache: true
-          cache-dependency-glob: |
-            pyproject.toml
-            uv.lock
-
-      - name: Set up Python 3.11
-        run: uv python install 3.11
+      # uv and CPython 3.11 are baked into the nousresearch/nous-gke-runner
+      # image (hermes-agent-ci-infra runner/Dockerfile) — no setup-uv, no
+      # `uv python install`. Only the wheel cache still needs restoring.
+      - name: Restore uv cache
+        uses: ./.github/actions/uv-cache
 
       - name: Install dependencies
         # `uv sync --locked` installs the exact pinned set from uv.lock (and

--- a/.github/workflows/uv-lockfile-check.yml
+++ b/.github/workflows/uv-lockfile-check.yml
@@ -68,13 +68,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
-          # raw.githubusercontent.com every job; transient fetch failures
-          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
-          version: "0.9.28"
+      # uv and CPython 3.11 are baked into the nousresearch/nous-gke-runner
+      # image (hermes-agent-ci-infra runner/Dockerfile) — no setup-uv, no
+      # `uv python install`.
 
       # `uv lock --check` re-resolves the project from pyproject.toml and
       # compares the result to uv.lock, exiting non-zero if they disagree.


### PR DESCRIPTION
> **Stacked on `feat/arc-runner-migration`** — review only the top commit; the diff below is against that branch, not `main`.
>
> **Blocked on** NousResearch/hermes-agent-ci-infra#3, which bakes the toolchain into the runner image. Pods pull `:latest` on start, so **that must merge and push before this does** — the reverse order breaks every runner.

Eleven jobs on every push repeat the same three network round-trips before doing any work: download ripgrep from GitHub releases, run `astral-sh/setup-uv`, then `uv python install 3.11`. The 8 test slices, e2e, lint ×2, docker tests, and uv-lockfile-check all pay it, all for identical bytes.

Each hop is also a failure mode — the 2026-07-28 slice-5 incident was a transient `setup-uv` manifest fetch failing a whole job, and pinning the version narrowed that window without closing it.

The runner image now bakes ripgrep 15.1.0, uv 0.9.28, and CPython 3.11 (**same versions**, so this is a move rather than an upgrade), which makes these steps pure overhead. Remove them.

## Keeping the wheel cache

The one part of `setup-uv` still worth having is `enable-cache`. It's per-workspace, not per-image, and without it `uv sync` re-downloads and re-builds every wheel — the toolchain would be faster to set up and the sync dramatically slower, a **net loss**.

Replaced with a small `.github/actions/uv-cache` composite doing the same `actions/cache` on `~/.cache/uv`, keyed on `pyproject.toml` + `uv.lock`:

- `runner.arch` is in the key because the cache holds **built wheels** and `docker.yml` runs on `arc-runner-arm64` too
- the `restore-keys` prefix means a stale hit still saves most of the download
- `uv sync --locked` re-resolves from `uv.lock` regardless, so a partial hit **cannot** produce a wrong environment

`lint.yml` and `uv-lockfile-check.yml` only `uv tool install` / `uv lock --check` and never build a project venv, so they drop the setup step without needing the cache action at all.

## Verification

Not a test suite — there isn't one for CI config. Verified with a self-contained script that builds the runner image on both arches from cold and probes it. **23/23 pass.**

The load-bearing flag is `--network none`, which proves the tools are genuinely baked rather than lazily fetched. Probes run as the unprivileged `runner` user, as real jobs do.

- `rg` 15.1.0, `uv` 0.9.28, and `uv python find 3.11` all resolve on **amd64 and arm64** with no network
- With this repo's real `pyproject.toml` + `uv.lock` and **no setup step of any kind**, `uv sync --locked --python 3.11 --extra dev` completes in **3s** into a working 3.11.14 venv
- Every local `uses:` in the touched workflows resolves on disk; no stripped-step remnants remain
- The `uv-cache` composite parses, caches the right path, keys on arch + both manifests, has a fallback, and is SHA-pinned

`actionlint` reports **7 findings on the base branch and 7 on this branch** — zero introduced.

## Note on the rebase

This branch previously carried its own copy of the sparse-checkout commit. `feat/arc-runner-migration` has a superset version of that change (same sparse-checkout plus a `needs:` reformat), so the duplicate was dropped and only the toolchain commit was replayed on top.

## Caveat

This validates the image and the workflow YAML, but **not** a real ARC pod pulling `:latest` — that only gets exercised once the ci-infra PR merges and the image is pushed.
