### PR TITLE
fix(desktop): retire inactive subagent history

### DIFF
--- a/apps/desktop/src/app/agents/index.tsx
+++ b/apps/desktop/src/app/agents/index.tsx
@@ -12,11 +12,13 @@ import { compactNumber } from '@/lib/format'
 import { AlertCircle, CheckCircle2 } from '@/lib/icons'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
+import { $activeSessionId } from '@/store/session'
+import { $focusedRuntimeId } from '@/store/session-states'
 import {
   $subagentsBySession,
-  allSubagents,
   buildSubagentTree,
   type SubagentNode,
+  subagentsForPanel,
   type SubagentStatus,
   type SubagentStreamEntry
 } from '@/store/subagents'
@@ -81,11 +83,16 @@ interface AgentsViewProps {
 export function AgentsView({ onClose }: AgentsViewProps) {
   const { t } = useI18n()
   const subagentsBySession = useStore($subagentsBySession)
+  const activeSessionId = useStore($activeSessionId)
+  const focusedRuntimeId = useStore($focusedRuntimeId)
 
-  // Aggregate every session, matching the status-bar indicator — a subagent
-  // running in a background session must still be visible here, or the two
-  // desync ("Agents N running" vs an empty tree).
-  const tree = useMemo(() => buildSubagentTree(allSubagents(subagentsBySession)), [subagentsBySession])
+  // Keep complete context for the focused session and any background session
+  // that still has live work. Once an inactive session is wholly terminal its
+  // historical rows no longer belong in the live Spawn tree.
+  const tree = useMemo(
+    () => buildSubagentTree(subagentsForPanel(subagentsBySession, focusedRuntimeId ?? activeSessionId)),
+    [activeSessionId, focusedRuntimeId, subagentsBySession]
+  )
 
   return (
     <Panel closeLabel={t.agents.close} onClose={onClose}>

--- a/apps/desktop/src/app/chat/session-tile-actions.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { type SessionTileDelegate, setSessionTileDelegate } from '@/store/session-states'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
+
+import { MAIN_COMPOSER_SCOPE } from './composer/scope'
+import { useSessionTileActions } from './session-tile-actions'
+
+const { requestGateway } = vi.hoisted(() => ({ requestGateway: vi.fn() }))
+
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway })
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({ t: { desktop: new Proxy({}, { get: (_target, key) => String(key) }) } })
+}))
+
+const SID = 'tile-runtime'
+
+function installDelegate() {
+  let state = createClientSessionState()
+  const noop = vi.fn(async () => undefined)
+
+  setSessionTileDelegate({
+    archiveSession: noop,
+    branchSession: noop,
+    deleteSession: noop,
+    executeSlash: noop,
+    interruptSession: noop,
+    resumeTile: vi.fn(async () => SID),
+    submitToSession: noop,
+    updateSession: (_runtimeId, updater) => (state = updater(state))
+  } satisfies SessionTileDelegate)
+}
+
+describe('useSessionTileActions Stop', () => {
+  beforeEach(() => {
+    $subagentsBySession.set({})
+    installDelegate()
+    requestGateway.mockReset().mockResolvedValue({})
+  })
+
+  it('terminalizes live rows without deleting a late-completion target', async () => {
+    upsertSubagent(SID, { goal: 'child', status: 'running', subagent_id: 'child', task_index: 0 })
+    const { result } = renderHook(() =>
+      useSessionTileActions({ requestGateway, runtimeId: SID, scope: MAIN_COMPOSER_SCOPE, storedSessionId: 'tile-stored' })
+    )
+
+    await act(async () => result.current.cancelRun())
+
+    expect($subagentsBySession.get()[SID]?.[0]?.status).toBe('interrupted')
+
+    upsertSubagent(
+      SID,
+      { status: 'completed', subagent_id: 'child', summary: 'finished after tile stop', task_index: 0 },
+      false,
+      'subagent.complete'
+    )
+
+    expect($subagentsBySession.get()[SID]?.[0]).toMatchObject({
+      status: 'completed',
+      summary: 'finished after tile stop'
+    })
+    expect(requestGateway).toHaveBeenCalledWith('session.interrupt', { session_id: SID })
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile-actions.test.tsx
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { type SessionTileDelegate, setSessionTileDelegate } from '@/store/session-states'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
+
+import { MAIN_COMPOSER_SCOPE } from './composer/scope'
+import { useSessionTileActions } from './session-tile-actions'
+
+const { requestGateway } = vi.hoisted(() => ({ requestGateway: vi.fn() }))
+
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway })
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({ t: { desktop: new Proxy({}, { get: (_target, key) => String(key) }) } })
+}))
+
+const SID = 'tile-runtime'
+
+function installDelegate() {
+  let state = createClientSessionState()
+  const noop = vi.fn(async () => undefined)
+
+  setSessionTileDelegate({
+    archiveSession: noop,
+    branchSession: noop,
+    deleteSession: noop,
+    executeSlash: noop,
+    interruptSession: noop,
+    resumeTile: vi.fn(async () => SID),
+    submitToSession: noop,
+    updateSession: (_runtimeId, updater) => (state = updater(state))
+  } satisfies SessionTileDelegate)
+}
+
+describe('useSessionTileActions Stop', () => {
+  beforeEach(() => {
+    $subagentsBySession.set({})
+    installDelegate()
+    requestGateway.mockReset().mockResolvedValue({})
+  })
+
+  it('terminalizes live rows without deleting a late-completion target', async () => {
+    upsertSubagent(SID, { goal: 'child', status: 'running', subagent_id: 'child', task_index: 0 })
+    const { result } = renderHook(() =>
+      useSessionTileActions({ runtimeId: SID, scope: MAIN_COMPOSER_SCOPE, storedSessionId: 'tile-stored' })
+    )
+
+    await act(async () => result.current.cancelRun())
+
+    expect($subagentsBySession.get()[SID]?.[0]?.status).toBe('interrupted')
+
+    upsertSubagent(
+      SID,
+      { status: 'completed', subagent_id: 'child', summary: 'finished after tile stop', task_index: 0 },
+      false,
+      'subagent.complete'
+    )
+
+    expect($subagentsBySession.get()[SID]?.[0]).toMatchObject({
+      status: 'completed',
+      summary: 'finished after tile stop'
+    })
+    expect(requestGateway).toHaveBeenCalledWith('session.interrupt', { session_id: SID })
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -36,7 +36,7 @@ import {
   sessionTileOwnerRoute
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
-import { clearSessionSubagents } from '@/store/subagents'
+import { interruptSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
 import type { SessionInfo } from '@/types/hermes'
@@ -342,7 +342,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
     }))
 
     clearSessionTodos(sessionId)
-    clearSessionSubagents(sessionId)
+    interruptSessionSubagents(sessionId)
     resetSessionBackground(sessionId)
     setSessionDraftingTool(sessionId, '')
     clearAllPrompts(sessionId)

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -27,7 +27,7 @@ import { clearAllPrompts } from '@/store/prompts'
 import { $connection, $sessions, sessionMatchesStoredId } from '@/store/session'
 import { $sessionStates, sessionTileDelegate } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
-import { clearSessionSubagents } from '@/store/subagents'
+import { interruptSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
 import type { SessionInfo } from '@/types/hermes'
@@ -257,7 +257,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     }))
 
     clearSessionTodos(sessionId)
-    clearSessionSubagents(sessionId)
+    interruptSessionSubagents(sessionId)
     resetSessionBackground(sessionId)
     setSessionDraftingTool(sessionId, '')
     clearAllPrompts(sessionId)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -848,7 +848,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           notifyWorkspaceChanged(toolChangedPath(payload))
         }
       } else if (SUBAGENT_EVENT_TYPES.has(event.type)) {
-        if (sessionId && payload && !sessionInterrupted(sessionId)) {
+        // Stop suppresses stale progress, but terminal events remain
+        // authoritative: children may finish after their parent is interrupted.
+        if (sessionId && payload && (event.type === 'subagent.complete' || !sessionInterrupted(sessionId))) {
           if (!nativeSubagentSessionsRef.current.has(sessionId)) {
             pruneDelegateFallbackSubagents(sessionId)
           }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/tools.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/tools.ts
@@ -129,7 +129,9 @@ export function handleToolEvent(ctx: GatewayEventContext): boolean {
   }
 
   if (SUBAGENT_EVENT_TYPES.has(event.type)) {
-    if (sessionId && payload && !sessionInterrupted(sessionId)) {
+    // Stop suppresses stale progress, but terminal events remain
+    // authoritative: children may finish after their parent is interrupted.
+    if (sessionId && payload && (event.type === 'subagent.complete' || !sessionInterrupted(sessionId))) {
       if (!nativeSubagentSessionsRef.current.has(sessionId)) {
         pruneDelegateFallbackSubagents(sessionId)
       }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/tool-drafting-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/tool-drafting-event.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
+import { $subagentsBySession, interruptSessionSubagents, upsertSubagent } from '@/store/subagents'
 import { $draftingToolSessions } from '@/store/tool-drafting'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -96,6 +96,7 @@ describe('drafting-tool label lifecycle', () => {
 
   it('accepts a terminal subagent update after stop without accepting progress', async () => {
     upsertSubagent(SID, { goal: 'initial', status: 'running', subagent_id: 'child', task_index: 0 })
+    interruptSessionSubagents(SID)
     sessionStates.set(SID, { ...createClientSessionState(), interrupted: true })
     await mountStream()
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/tool-drafting-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/tool-drafting-event.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
 import { $draftingToolSessions } from '@/store/tool-drafting'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -31,12 +32,14 @@ function draftedTool(sessionId = SID) {
 describe('drafting-tool label lifecycle', () => {
   beforeEach(() => {
     sessionStates.clear()
+    $subagentsBySession.set({})
     $draftingToolSessions.set({})
   })
 
   afterEach(() => {
     cleanup()
     sessionStates.clear()
+    $subagentsBySession.set({})
     $draftingToolSessions.set({})
     vi.restoreAllMocks()
   })
@@ -89,5 +92,26 @@ describe('drafting-tool label lifecycle', () => {
     emit('tool.generating', { name: 'write_file' })
 
     expect(draftedTool()).toBeUndefined()
+  })
+
+  it('accepts a terminal subagent update after stop without accepting progress', async () => {
+    upsertSubagent(SID, { goal: 'initial', status: 'running', subagent_id: 'child', task_index: 0 })
+    sessionStates.set(SID, { ...createClientSessionState(), interrupted: true })
+    await mountStream()
+
+    emit('subagent.progress', { goal: 'stale progress', status: 'running', subagent_id: 'child', task_index: 0 })
+    expect($subagentsBySession.get()[SID]?.[0]?.goal).toBe('initial')
+
+    emit('subagent.complete', {
+      status: 'completed',
+      subagent_id: 'child',
+      summary: 'finished after parent stop',
+      task_index: 0
+    })
+
+    expect($subagentsBySession.get()[SID]?.[0]).toMatchObject({
+      status: 'completed',
+      summary: 'finished after parent stop'
+    })
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/tool-drafting-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/tool-drafting-event.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
 import { $draftingToolSessions } from '@/store/tool-drafting'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -62,12 +63,14 @@ describe('drafting-tool label lifecycle', () => {
   beforeEach(() => {
     handleEvent = null
     sessionStates.clear()
+    $subagentsBySession.set({})
     $draftingToolSessions.set({})
   })
 
   afterEach(() => {
     cleanup()
     sessionStates.clear()
+    $subagentsBySession.set({})
     $draftingToolSessions.set({})
     vi.restoreAllMocks()
   })
@@ -120,5 +123,26 @@ describe('drafting-tool label lifecycle', () => {
     emit('tool.generating', { name: 'write_file' })
 
     expect(draftedTool()).toBeUndefined()
+  })
+
+  it('accepts a terminal subagent update after stop without accepting progress', async () => {
+    upsertSubagent(SID, { goal: 'initial', status: 'running', subagent_id: 'child', task_index: 0 })
+    sessionStates.set(SID, { ...createClientSessionState(), interrupted: true })
+    await mountStream()
+
+    emit('subagent.progress', { goal: 'stale progress', status: 'running', subagent_id: 'child', task_index: 0 })
+    expect($subagentsBySession.get()[SID]?.[0]?.goal).toBe('initial')
+
+    emit('subagent.complete', {
+      status: 'completed',
+      subagent_id: 'child',
+      summary: 'finished after parent stop',
+      task_index: 0
+    })
+
+    expect($subagentsBySession.get()[SID]?.[0]).toMatchObject({
+      status: 'completed',
+      summary: 'finished after parent stop'
+    })
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/tool-drafting-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/tool-drafting-event.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
+import { $subagentsBySession, interruptSessionSubagents, upsertSubagent } from '@/store/subagents'
 import { $draftingToolSessions } from '@/store/tool-drafting'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -127,6 +127,7 @@ describe('drafting-tool label lifecycle', () => {
 
   it('accepts a terminal subagent update after stop without accepting progress', async () => {
     upsertSubagent(SID, { goal: 'initial', status: 'running', subagent_id: 'child', task_index: 0 })
+    interruptSessionSubagents(SID)
     sessionStates.set(SID, { ...createClientSessionState(), interrupted: true })
     await mountStream()
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -27,6 +27,7 @@ import {
   setSessions
 } from '@/store/session'
 import { dropSessionState, publishSessionState } from '@/store/session-states'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
 import { $wakeWord, resetWakeWordState } from '@/store/wake-word'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -3659,6 +3660,38 @@ describe('usePromptActions sleep/wake session recovery', () => {
       busy: false,
       interrupted: true,
       turnStartedAt: null
+    })
+  })
+
+  it('terminalizes primary Stop rows without deleting a late-completion target', async () => {
+    $subagentsBySession.set({})
+    upsertSubagent(RUNTIME_SESSION_ID, {
+      goal: 'child',
+      status: 'running',
+      subagent_id: 'child',
+      task_index: 0
+    })
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.cancelRun()
+
+    expect($subagentsBySession.get()[RUNTIME_SESSION_ID]?.[0]?.status).toBe('interrupted')
+
+    upsertSubagent(
+      RUNTIME_SESSION_ID,
+      { status: 'completed', subagent_id: 'child', summary: 'finished after primary stop', task_index: 0 },
+      false,
+      'subagent.complete'
+    )
+
+    expect($subagentsBySession.get()[RUNTIME_SESSION_ID]?.[0]).toMatchObject({
+      status: 'completed',
+      summary: 'finished after primary stop'
     })
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -22,6 +22,7 @@ import {
   setSessions
 } from '@/store/session'
 import { dropSessionState, publishSessionState } from '@/store/session-states'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
 import { $wakeWord, resetWakeWordState } from '@/store/wake-word'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -2986,6 +2987,38 @@ describe('usePromptActions sleep/wake session recovery', () => {
       busy: false,
       interrupted: true,
       turnStartedAt: null
+    })
+  })
+
+  it('terminalizes primary Stop rows without deleting a late-completion target', async () => {
+    $subagentsBySession.set({})
+    upsertSubagent(RUNTIME_SESSION_ID, {
+      goal: 'child',
+      status: 'running',
+      subagent_id: 'child',
+      task_index: 0
+    })
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.cancelRun()
+
+    expect($subagentsBySession.get()[RUNTIME_SESSION_ID]?.[0]?.status).toBe('interrupted')
+
+    upsertSubagent(
+      RUNTIME_SESSION_ID,
+      { status: 'completed', subagent_id: 'child', summary: 'finished after primary stop', task_index: 0 },
+      false,
+      'subagent.complete'
+    )
+
+    expect($subagentsBySession.get()[RUNTIME_SESSION_ID]?.[0]).toMatchObject({
+      status: 'completed',
+      summary: 'finished after primary stop'
     })
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -40,7 +40,7 @@ import {
   setTurnStartedAt
 } from '@/store/session'
 import { $sessionStates, isSessionRemote } from '@/store/session-states'
-import { clearSessionSubagents } from '@/store/subagents'
+import { interruptSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
 
@@ -724,7 +724,7 @@ export function usePromptActions({
     })
 
     clearSessionTodos(sessionId)
-    clearSessionSubagents(sessionId)
+    interruptSessionSubagents(sessionId)
     resetSessionBackground(sessionId)
     setSessionDraftingTool(sessionId, '')
     // Stop ends the turn, so the gateway is no longer blocked on any prompt it

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -32,7 +32,7 @@ import {
   setMessages,
   setTurnStartedAt
 } from '@/store/session'
-import { clearSessionSubagents } from '@/store/subagents'
+import { interruptSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
 
@@ -616,7 +616,7 @@ export function usePromptActions({
     })
 
     clearSessionTodos(sessionId)
-    clearSessionSubagents(sessionId)
+    interruptSessionSubagents(sessionId)
     resetSessionBackground(sessionId)
     setSessionDraftingTool(sessionId, '')
     // Stop ends the turn, so the gateway is no longer blocked on any prompt it

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -38,7 +38,7 @@ import {
 } from '@/store/session'
 import { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
 import { $statusbarHiddenIds } from '@/store/statusbar-prefs'
-import { $subagentsBySession, activeSubagentCount, failedSubagentCount } from '@/store/subagents'
+import { $subagentsBySession, activeSubagentCount, failedSubagentCount, subagentsForPanel } from '@/store/subagents'
 import { $gatewayRestarting } from '@/store/system-actions'
 import {
   $backendUpdateApply,
@@ -106,19 +106,6 @@ export function useStatusbarItems({
   const primarySessionStartedAt = useStore($sessionStartedAt)
   const primaryTurnStartedAt = useStore($turnStartedAt)
 
-  // The indicator must speak the same scope as the Spawn-tree panel it opens:
-  // every session's subagents, never background system actions. Only two
-  // COUNTS are read, so select scalars — a whole-map `useStore` re-ran this
-  // hook (rebuilding all ~9 statusbar items) on every subagent progress tick
-  // in ANY session, including background ones.
-  const subagentsRunning = useStoreSelector($subagentsBySession, bySession =>
-    Object.values(bySession).reduce((sum, items) => sum + activeSubagentCount(items), 0)
-  )
-
-  const subagentsFailed = useStoreSelector($subagentsBySession, bySession =>
-    Object.values(bySession).reduce((sum, items) => sum + failedSubagentCount(items), 0)
-  )
-
   const updateStatus = useStore($updateStatus)
   const updateApply = useStore($updateApply)
   const backendUpdateStatus = useStore($backendUpdateStatus)
@@ -156,6 +143,17 @@ export function useStatusbarItems({
 
   const activeSessionId = primaryFocused ? primaryActiveSessionId : (focusedRuntimeId ?? null)
   const busy = primaryFocused ? primaryBusy : focusedBusy
+
+  // Match the panel's live scope: all sessions with active work, plus terminal
+  // history for the focused session. Scalar selectors avoid progress-tick
+  // rerenders when the two displayed counts are unchanged.
+  const subagentsRunning = useStoreSelector($subagentsBySession, bySession =>
+    activeSubagentCount(subagentsForPanel(bySession, activeSessionId))
+  )
+
+  const subagentsFailed = useStoreSelector($subagentsBySession, bySession =>
+    failedSubagentCount(subagentsForPanel(bySession, activeSessionId))
+  )
 
   // EMPTY_USAGE (module constant) keeps the fallback referentially stable —
   // a fresh `{...}` each render would bust the usage-label memos below.

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -35,7 +35,7 @@ import {
   setCurrentUsage
 } from '@/store/session'
 import { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
-import { $subagentsBySession, activeSubagentCount, failedSubagentCount } from '@/store/subagents'
+import { $subagentsBySession, activeSubagentCount, failedSubagentCount, subagentsForPanel } from '@/store/subagents'
 import { $gatewayRestarting } from '@/store/system-actions'
 import {
   $backendUpdateApply,
@@ -101,19 +101,6 @@ export function useStatusbarItems({
   const primarySessionStartedAt = useStore($sessionStartedAt)
   const primaryTurnStartedAt = useStore($turnStartedAt)
 
-  // The indicator must speak the same scope as the Spawn-tree panel it opens:
-  // every session's subagents, never background system actions. Only two
-  // COUNTS are read, so select scalars — a whole-map `useStore` re-ran this
-  // hook (rebuilding all ~9 statusbar items) on every subagent progress tick
-  // in ANY session, including background ones.
-  const subagentsRunning = useStoreSelector($subagentsBySession, bySession =>
-    Object.values(bySession).reduce((sum, items) => sum + activeSubagentCount(items), 0)
-  )
-
-  const subagentsFailed = useStoreSelector($subagentsBySession, bySession =>
-    Object.values(bySession).reduce((sum, items) => sum + failedSubagentCount(items), 0)
-  )
-
   const updateStatus = useStore($updateStatus)
   const updateApply = useStore($updateApply)
   const backendUpdateStatus = useStore($backendUpdateStatus)
@@ -151,6 +138,17 @@ export function useStatusbarItems({
 
   const activeSessionId = primaryFocused ? primaryActiveSessionId : (focusedRuntimeId ?? null)
   const busy = primaryFocused ? primaryBusy : focusedBusy
+
+  // Match the panel's live scope: all sessions with active work, plus terminal
+  // history for the focused session. Scalar selectors avoid progress-tick
+  // rerenders when the two displayed counts are unchanged.
+  const subagentsRunning = useStoreSelector($subagentsBySession, bySession =>
+    activeSubagentCount(subagentsForPanel(bySession, activeSessionId))
+  )
+
+  const subagentsFailed = useStoreSelector($subagentsBySession, bySession =>
+    failedSubagentCount(subagentsForPanel(bySession, activeSessionId))
+  )
 
   // EMPTY_USAGE (module constant) keeps the fallback referentially stable —
   // a fresh `{...}` each render would bust the usage-label memos below.

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -3,12 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   $subagentsBySession,
   activeSubagentCount,
-  allSubagents,
   buildSubagentTree,
   clearSessionSubagents,
   failedSubagentCount,
   pruneDelegateFallbackSubagents,
   pruneFinishedSessionSubagents,
+  subagentsForPanel,
   upsertSubagent
 } from './subagents'
 
@@ -102,25 +102,49 @@ describe('subagent store', () => {
     expect(listFor('s1').map(item => item.id)).toEqual(['sa-0-xyz'])
   })
 
-  // Contract: the status-bar "Agents" indicator and the Spawn-tree panel read
-  // the same scope — every session's subagents — so a count can never point at
-  // an empty tree (the desync behind "Agents (N)" vs "No live subagents").
-  it('counts running/failed across every session, matching the aggregated tree', () => {
+  it('counts running/failed across active sessions, matching the panel tree', () => {
     upsertSubagent('s1', { goal: 'a', status: 'running', subagent_id: 'a', task_index: 0 })
     upsertSubagent('s1', { goal: 'b', status: 'failed', subagent_id: 'b', task_index: 1 })
     upsertSubagent('s2', { goal: 'c', status: 'running', subagent_id: 'c', task_index: 0 })
     upsertSubagent('s2', { goal: 'd', status: 'failed', subagent_id: 'd', task_index: 1 })
 
-    const flat = allSubagents($subagentsBySession.get())
-    const indicatorRunning = Object.values($subagentsBySession.get()).reduce((n, l) => n + activeSubagentCount(l), 0)
-    const indicatorFailed = Object.values($subagentsBySession.get()).reduce((n, l) => n + failedSubagentCount(l), 0)
+    const flat = subagentsForPanel($subagentsBySession.get(), 's1')
+    const indicatorRunning = activeSubagentCount(flat)
+    const indicatorFailed = failedSubagentCount(flat)
     const tree = buildSubagentTree(flat)
 
-    // The active-session-only filter would have reported 1/1 here, not 2/2.
     expect(indicatorRunning).toBe(2)
     expect(indicatorFailed).toBe(2)
     expect(tree).toHaveLength(4)
     expect(indicatorRunning + indicatorFailed).toBe(tree.length)
+  })
+
+  it('keeps terminal history only for the current or still-active sessions', () => {
+    upsertSubagent('current', { goal: 'current done', status: 'completed', subagent_id: 'current', task_index: 0 })
+    upsertSubagent('background-live', {
+      goal: 'background live',
+      status: 'running',
+      subagent_id: 'live',
+      task_index: 0
+    })
+    upsertSubagent('background-live', {
+      goal: 'background sibling',
+      status: 'completed',
+      subagent_id: 'sibling',
+      task_index: 1
+    })
+    upsertSubagent('background-done', {
+      goal: 'old history',
+      status: 'failed',
+      subagent_id: 'old',
+      task_index: 0
+    })
+
+    expect(subagentsForPanel($subagentsBySession.get(), 'current').map(item => item.id)).toEqual([
+      'current',
+      'live',
+      'sibling'
+    ])
   })
 
   it('clears one session without touching another', () => {

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -4,8 +4,8 @@ import {
   $subagentsBySession,
   activeSubagentCount,
   buildSubagentTree,
-  clearSessionSubagents,
   failedSubagentCount,
+  interruptSessionSubagents,
   pruneDelegateFallbackSubagents,
   pruneFinishedSessionSubagents,
   subagentsForPanel,
@@ -147,14 +147,33 @@ describe('subagent store', () => {
     ])
   })
 
-  it('clears one session without touching another', () => {
-    upsertSubagent('s1', { goal: 'one', status: 'running', subagent_id: 'a1', task_index: 0 })
-    upsertSubagent('s2', { goal: 'two', status: 'running', subagent_id: 'a2', task_index: 0 })
+  it('interrupts live rows on stop without discarding terminal event targets', () => {
+    upsertSubagent('s1', { goal: 'running', status: 'running', subagent_id: 'running', task_index: 0 })
+    upsertSubagent('s1', { goal: 'queued', status: 'queued', subagent_id: 'queued', task_index: 1 })
+    upsertSubagent('s1', { goal: 'done', status: 'completed', subagent_id: 'done', task_index: 2 })
 
-    clearSessionSubagents('s1')
+    interruptSessionSubagents('s1')
 
-    expect($subagentsBySession.get().s1).toBeUndefined()
-    expect($subagentsBySession.get().s2).toHaveLength(1)
+    expect(listFor('s1').map(item => [item.id, item.status])).toEqual([
+      ['running', 'interrupted'],
+      ['queued', 'interrupted'],
+      ['done', 'completed']
+    ])
+    expect(activeSubagentCount(listFor('s1'))).toBe(0)
+  })
+
+  it('lets a late completion refine a row interrupted by stop', () => {
+    upsertSubagent('s1', { goal: 'running', status: 'running', subagent_id: 'child', task_index: 0 })
+    interruptSessionSubagents('s1')
+
+    upsertSubagent(
+      's1',
+      { status: 'completed', subagent_id: 'child', summary: 'finished after stop', task_index: 0 },
+      false,
+      'subagent.complete'
+    )
+
+    expect(listFor('s1')[0]).toMatchObject({ status: 'completed', summary: 'finished after stop' })
   })
 
   // Regression test for #64015: still-RUNNING background subagents must survive

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -321,6 +321,10 @@ export const activeSubagentCount = (items: readonly SubagentProgress[]) =>
 export const failedSubagentCount = (items: readonly SubagentProgress[]) =>
   items.filter(item => item.status === 'failed' || item.status === 'interrupted').length
 
-/** Flatten every session's subagents — the scope the Spawn-tree panel and the
- *  status-bar indicator must agree on. */
-export const allSubagents = (bySession: Record<string, SubagentProgress[]>) => Object.values(bySession).flat()
+/** Keep the focused session's history plus complete background delegations
+ * while they are active. Finished inactive sessions disappear as a unit, so
+ * parent/sibling context is preserved without accumulating stale history. */
+export const subagentsForPanel = (bySession: Record<string, SubagentProgress[]>, focusedSessionId: string | null) =>
+  Object.entries(bySession).flatMap(([sessionId, items]) =>
+    sessionId === focusedSessionId || activeSubagentCount(items) > 0 ? items : []
+  )

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -208,15 +208,26 @@ function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined
   }
 }
 
-export function clearSessionSubagents(sid: string) {
+/** End a stopped session's live rows without discarding their identity.
+ * Keeping the rows lets a terminal gateway event that was already in flight
+ * refine the final status, while the immediate interrupted status prevents
+ * the stopped session from looking active forever if no event arrives. */
+export function interruptSessionSubagents(sid: string) {
   const map = $subagentsBySession.get()
+  const list = map[sid]
 
-  if (!(sid in map)) {
+  if (!list?.some(item => !TERMINAL.has(item.status))) {
     return
   }
 
-  const { [sid]: _drop, ...rest } = map
-  $subagentsBySession.set(rest)
+  const at = Date.now()
+  const next = list.map(item =>
+    TERMINAL.has(item.status)
+      ? item
+      : { ...item, currentTool: undefined, status: 'interrupted' as const, updatedAt: at }
+  )
+
+  $subagentsBySession.set({ ...map, [sid]: next })
 }
 
 /**
@@ -226,8 +237,8 @@ export function clearSessionSubagents(sid: string) {
  * from the display while background subagents that outlived the spawning turn
  * remain visible (and still accept late progress/complete events).
  *
- * Distinct from `clearSessionSubagents` (used by the Stop action, which
- * genuinely cancels running subagents and so should drop them all) and from
+ * Distinct from `interruptSessionSubagents` (used by Stop to terminalize live
+ * rows while preserving them for in-flight completion events) and from
  * `pruneDelegateFallbackSubagents` (which filters by id prefix to remove
  * placeholder rows once the real native event arrives).
  */
@@ -277,7 +288,10 @@ export function upsertSubagent(sid: string, payload: SubagentPayload, createIfMi
 
   const prev = idx >= 0 ? list[idx] : undefined
 
-  if (prev && TERMINAL.has(prev.status)) {
+  const refinesInterruptedStop =
+    prev?.status === 'interrupted' && eventType === 'subagent.complete' && TERMINAL.has(asStatus(payload.status))
+
+  if (prev && TERMINAL.has(prev.status) && !refinesInterruptedStop) {
     return
   }
 

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -291,6 +291,10 @@ export const activeSubagentCount = (items: readonly SubagentProgress[]) =>
 export const failedSubagentCount = (items: readonly SubagentProgress[]) =>
   items.filter(item => item.status === 'failed' || item.status === 'interrupted').length
 
-/** Flatten every session's subagents — the scope the Spawn-tree panel and the
- *  status-bar indicator must agree on. */
-export const allSubagents = (bySession: Record<string, SubagentProgress[]>) => Object.values(bySession).flat()
+/** Keep the focused session's history plus complete background delegations
+ * while they are active. Finished inactive sessions disappear as a unit, so
+ * parent/sibling context is preserved without accumulating stale history. */
+export const subagentsForPanel = (bySession: Record<string, SubagentProgress[]>, focusedSessionId: string | null) =>
+  Object.entries(bySession).flatMap(([sessionId, items]) =>
+    sessionId === focusedSessionId || activeSubagentCount(items) > 0 ? items : []
+  )

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -178,15 +178,26 @@ function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined
   }
 }
 
-export function clearSessionSubagents(sid: string) {
+/** End a stopped session's live rows without discarding their identity.
+ * Keeping the rows lets a terminal gateway event that was already in flight
+ * refine the final status, while the immediate interrupted status prevents
+ * the stopped session from looking active forever if no event arrives. */
+export function interruptSessionSubagents(sid: string) {
   const map = $subagentsBySession.get()
+  const list = map[sid]
 
-  if (!(sid in map)) {
+  if (!list?.some(item => !TERMINAL.has(item.status))) {
     return
   }
 
-  const { [sid]: _drop, ...rest } = map
-  $subagentsBySession.set(rest)
+  const at = Date.now()
+  const next = list.map(item =>
+    TERMINAL.has(item.status)
+      ? item
+      : { ...item, currentTool: undefined, status: 'interrupted' as const, updatedAt: at }
+  )
+
+  $subagentsBySession.set({ ...map, [sid]: next })
 }
 
 /**
@@ -196,8 +207,8 @@ export function clearSessionSubagents(sid: string) {
  * from the display while background subagents that outlived the spawning turn
  * remain visible (and still accept late progress/complete events).
  *
- * Distinct from `clearSessionSubagents` (used by the Stop action, which
- * genuinely cancels running subagents and so should drop them all) and from
+ * Distinct from `interruptSessionSubagents` (used by Stop to terminalize live
+ * rows while preserving them for in-flight completion events) and from
  * `pruneDelegateFallbackSubagents` (which filters by id prefix to remove
  * placeholder rows once the real native event arrives).
  */
@@ -247,7 +258,10 @@ export function upsertSubagent(sid: string, payload: SubagentPayload, createIfMi
 
   const prev = idx >= 0 ? list[idx] : undefined
 
-  if (prev && TERMINAL.has(prev.status)) {
+  const refinesInterruptedStop =
+    prev?.status === 'interrupted' && eventType === 'subagent.complete' && TERMINAL.has(asStatus(payload.status))
+
+  if (prev && TERMINAL.has(prev.status) && !refinesInterruptedStop) {
     return
   }
 


### PR DESCRIPTION
## Summary

- keep the focused session's complete subagent tree visible while showing background session trees only while they still contain running or queued work
- use the same filtered scope for the Agents status-bar counts, so the indicator and panel cannot disagree
- accept authoritative `subagent.complete` events after a parent session is interrupted while continuing to suppress stale progress events
- add regression coverage for inactive-session history and post-stop completion delivery

This is complementary to #63664: that PR reconciles stale running rows through backend liveness checks, while this change fixes the client-side aggregation and interruption gate described in #75505 without adding polling.

Fixes #75505

## Validation

- `npm --prefix apps/desktop test -- --project ui src/app/session src/store/subagents.test.ts` — 406 passed
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/desktop run lint` — no errors
- `npm --prefix apps/desktop run build`
- Prettier check on all changed TypeScript files
- `git diff upstream/main...HEAD --check`
