### PR TITLE
fix(gateway): resolve session_key in shutdown-flush recovery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25446,7 +25446,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Recover any pending messages flushed during a previous shutdown (#72680).
     try:
         from gateway.shutdown_flush import recover_pending_to_db
-        recovered = recover_pending_to_db()
+        recovered = recover_pending_to_db(
+            session_resolver=runner.session_store.peek_session_id,
+        )
         if recovered:
             logger.info(
                 "Recovered %d pending message(s) from shutdown flush", recovered,

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -168,6 +168,8 @@ def _serialise_value(value: Any) -> Optional[dict]:
 
 def recover_pending_to_db(
     session_db=None,
+    *,
+    session_resolver=None,
 ) -> int:
     """Recover flushed pending messages into state.db via SessionDB.
 
@@ -181,6 +183,13 @@ def recover_pending_to_db(
     session_db:
         An existing ``SessionDB`` instance.  If ``None``, a new one is
         opened on the default ``state.db`` path.
+    session_resolver:
+        Optional callable mapping ``session_key -> session_id`` (e.g.
+        ``SessionStore.peek_session_id``).  Real flush files carry no
+        ``session_id`` — adapter ``MessageEvent`` objects have no such
+        attribute — so without a resolver every recovery lands in the
+        "no session_id" skip branch and the message is silently never
+        re-ingested.
 
     Returns
     -------
@@ -227,11 +236,13 @@ def recover_pending_to_db(
             # session_key in the source column.
             session_id = data.get("session_id", "")
 
+            if not session_id and session_resolver is not None:
+                try:
+                    session_id = session_resolver(session_key) or ""
+                except Exception:
+                    session_id = ""
+
             if not session_id:
-                # Try to extract from the session_key itself — gateway
-                # session keys contain the session_id as the last segment
-                # in some formats, but that's not guaranteed.  Log and
-                # skip if we can't resolve it.
                 logger.warning(
                     "Cannot recover pending message for %s: no session_id "
                     "in flush file and session_key-to-id resolution is not "

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -132,3 +132,113 @@ def test_get_flush_dir_uses_get_hermes_home(tmp_path, monkeypatch):
     assert result == tmp_path / "pending_messages"
 
 
+
+
+def test_recover_resolves_session_key_via_resolver(tmp_path, monkeypatch):
+    """Real flush files carry only `text` (MessageEvent has no session_id
+    attribute). Without a resolver they were skipped forever; with one,
+    the message must be recovered and the file cleaned up."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    ts = int(time.time())
+    payload = {
+        "session_key": "agent:main:telegram:dm:42",
+        "ts": ts,
+        "data": {"text": "are you there?"},  # what _serialise_value actually produces
+    }
+    flush_file = flush_dir / "pending-test.json"
+    flush_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    mock_db = MagicMock()
+    count = recover_pending_to_db(
+        mock_db,
+        session_resolver=lambda key: "20260731_abc123" if key == "agent:main:telegram:dm:42" else None,
+    )
+
+    assert count == 1
+    mock_db.append_message.assert_called_once_with(
+        session_id="20260731_abc123",
+        role="user",
+        content="are you there?",
+        timestamp=ts,
+    )
+    assert not flush_file.exists()
+
+
+def test_recover_without_resolver_skips_text_only_payload(tmp_path, monkeypatch):
+    """Without a resolver, a text-only (real MessageEvent) payload is
+    skipped and the file preserved — the pre-fix behavior for every real
+    flush. Documents why the call site wires peek_session_id."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    payload = {
+        "session_key": "agent:main:telegram:dm:42",
+        "ts": int(time.time()),
+        "data": {"text": "are you there?"},
+    }
+    flush_file = flush_dir / "pending-test.json"
+    flush_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    mock_db = MagicMock()
+    count = recover_pending_to_db(mock_db)
+
+    assert count == 0
+    mock_db.append_message.assert_not_called()
+    assert flush_file.exists()
+
+
+def test_recover_via_real_session_store_routing_reload(tmp_path, monkeypatch):
+    """Integration through the real startup boundary: persist a session-key
+    mapping in boot 1, construct a fresh SessionStore in boot 2, and recover
+    a text-only payload via peek_session_id — the exact wiring run.py:25449
+    installs (not a mocked resolver)."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    from gateway.config import GatewayConfig, Platform
+    from gateway.session import SessionSource, SessionStore
+
+    # Boot 1: persist a session_key -> session_id mapping.
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    store1 = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    src = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="42", chat_type="dm", user_id="u1",
+    )
+    entry = store1.get_or_create_session(src)
+
+    # Flush file with a real MessageEvent-shaped (text-only) payload.
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    ts = int(time.time())
+    flush_file = flush_dir / "pending-x.json"
+    flush_file.write_text(
+        json.dumps({
+            "session_key": entry.session_key,
+            "ts": ts,
+            "data": {"text": "are you there?"},
+        }),
+        encoding="utf-8",
+    )
+
+    # Boot 2: fresh store — peek_session_id must reload the mapping from disk.
+    store2 = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    assert store2.peek_session_id(entry.session_key) == entry.session_id
+
+    db = hermes_state.SessionDB(db_path=tmp_path / "state.db")
+    try:
+        count = recover_pending_to_db(
+            db, session_resolver=store2.peek_session_id,
+        )
+        assert count == 1
+        convo = db.get_messages_as_conversation(entry.session_id)
+        assert any(m["content"] == "are you there?" for m in convo)
+        assert not flush_file.exists()
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?

Fixes the #72680 pending-message recovery never recovering anything: every real shutdown-flush file is silently skipped at startup.

The mechanism was built so a message arriving while the gateway is draining ("⏳ queued for the next turn after it comes back") is written to `<hermes_home>/pending_messages/` and re-ingested on the next boot. But the data path is broken end-to-end:

1. `_serialise_value` captures only `text` from adapter `_pending_messages` values — they are `MessageEvent` objects, which have **no `session_id` attribute** (that lives on `event.source`, which isn't serialised).
2. `recover_pending_to_db` therefore always lands in the "no session_id in flush file" branch: warning logged, message skipped, file preserved — on every boot, forever.

The existing tests masked it by hand-writing `session_id` into flush payloads that real `MessageEvent`s never produce.

The fix adds an optional `session_resolver` parameter to `recover_pending_to_db` and wires it at the startup call site to `SessionStore.peek_session_id` (the existing lock-held session_key → session_id accessor). Files with genuinely unresolvable keys keep the current preserve-and-warn behavior.

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Changes Made

- `gateway/shutdown_flush.py`: `recover_pending_to_db` gains `session_resolver`; when `session_id` is absent from the payload it tries `session_resolver(session_key)` before falling back to the preserve-and-warn skip. Docstring documents why real flush files lack `session_id`.
- `gateway/run.py`: the startup recovery call passes `session_resolver=runner.session_store.peek_session_id`.
- `tests/gateway/test_shutdown_flush.py`: three regression tests — a text-only (real-`MessageEvent`-shaped) payload is recovered via the resolver and the file deleted; the same payload without a resolver is skipped with the file preserved; and an integration test through the real startup boundary — a mapping persisted by one `SessionStore`, reloaded by a fresh one, recovered via `peek_session_id` (the exact `run.py` wiring, no mocks).

## How to Test

Reproduction (against pre-fix code, real `MessageEvent` through the real serialiser):

```python
payload = _serialise_value(message_event)          # -> {"text": "are you there?"}  (no session_id)
# flush file written with that payload, then on next boot:
recover_pending_to_db(db)                          # pre-fix:  0 recovered, file preserved (message silently lost)
recover_pending_to_db(db, session_resolver=store.peek_session_id)
                                                   # post-fix: 1 recovered, correct row, file cleaned up
```

Focused validation completed:

1. `bash scripts/run_tests.sh tests/gateway/test_shutdown_flush.py` — 8/8 pass.
2. Sabotage check: reverting the fix makes both the resolver test and the integration test fail (6 pass); restoring returns to 8/8.
3. Related suites: `test_gateway_shutdown.py test_13121_shutdown_inflight_transcript_flush.py test_pending_drain_no_recursion.py test_bounded_adapter_teardown.py` + the flush file — 22/22 pass.
4. Full repo-wide suite, `bash scripts/run_tests.sh` (branch): 22,920 pass / 98 fail. Baseline on clean `main` (this branch's parent), same machine: 22,917 pass / 99 fail — zero branch-only failures (environment-dependent lanes only). Nothing in the shutdown/flush surface fails.
5. `uvx --from ruff==0.15.10 ruff check gateway/shutdown_flush.py gateway/run.py tests/gateway/test_shutdown_flush.py` — clean.
6. `git diff --check` — clean.
7. Adversarial cases executed: resolver returning `None` (unknown key) falls back to preserve-and-warn; payloads that DO carry `session_id` still take the direct path; resolver raising is contained (falls back, no crash).

The full repo-wide suite was run locally (item 4) with zero branch-only failures vs clean `main`; GitHub CI remains the final confirmation environment.

## Logs

Sabotage verification output:

```
# fix stashed (pre-fix behavior):
=== Summary: 1 files, 6 tests passed, 2 failed ===   (resolver + integration tests)
# fix restored:
=== Summary: 1 files, 8 tests passed, 0 failed ===
```
