### PR TITLE
fix(voice): rebuild inactive recorder streams

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -424,6 +424,60 @@ class TestAudioRecorder:
         mock_sd.InputStream.assert_called_once()
         mock_stream.start.assert_called_once()
 
+    def test_ensure_stream_reuses_active_stream(self, mock_sd):
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        active_stream = MagicMock()
+        active_stream.active = True
+        recorder._stream = active_stream
+
+        recorder._ensure_stream()
+
+        mock_sd.InputStream.assert_not_called()
+        active_stream.close.assert_not_called()
+        assert recorder._stream is active_stream
+
+    def test_ensure_stream_rebuilds_inactive_stream(self, mock_sd):
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        inactive_stream = MagicMock()
+        inactive_stream.active = False
+        inactive_stream.stop.side_effect = RuntimeError("stream already stopped")
+        replacement_stream = MagicMock()
+        mock_sd.InputStream.return_value = replacement_stream
+        recorder._stream = inactive_stream
+
+        recorder._ensure_stream()
+
+        inactive_stream.close.assert_called_once_with()
+        replacement_stream.start.assert_called_once_with()
+        assert recorder._stream is replacement_stream
+
+    def test_ensure_stream_rebuilds_when_liveness_probe_fails(self, mock_sd):
+        from tools.voice_mode import AudioRecorder
+
+        class BrokenStream:
+            stop = MagicMock()
+            close = MagicMock()
+
+            @property
+            def active(self):
+                raise RuntimeError("CoreAudio stream state unavailable")
+
+        recorder = AudioRecorder()
+        broken_stream = BrokenStream()
+        replacement_stream = MagicMock()
+        mock_sd.InputStream.return_value = replacement_stream
+        recorder._stream = broken_stream
+
+        recorder._ensure_stream()
+
+        broken_stream.close.assert_called_once_with()
+        replacement_stream.start.assert_called_once_with()
+        assert recorder._stream is replacement_stream
+
 class TestAudioRecorderStop:
     def test_stop_writes_wav_file(self, mock_sd, temp_voice_dir):
         np = pytest.importorskip("numpy")

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -716,10 +716,24 @@ class AudioRecorder(_RecorderBase):
             self._fire_silence_callback()
 
     def _ensure_stream(self) -> None:
-        """Create the InputStream once and keep it alive (between recordings the callback
-        discards chunks): re-opening an InputStream hangs on macOS CoreAudio."""
+        """Create the audio InputStream and keep it alive while usable.
+
+        The stream stays open for the lifetime of the recorder.  Between
+        recordings the callback simply discards audio chunks (``_recording``
+        is ``False``).  This avoids the CoreAudio bug where closing and
+        re-opening an ``InputStream`` hangs indefinitely on macOS. CoreAudio
+        can still deactivate the stream when another input stream opens; in
+        that case the dead object must be closed and rebuilt before capture.
+        """
         if self._stream is not None:
-            return
+            try:
+                if self._stream.active:
+                    return
+            except Exception:
+                logger.debug("Audio input stream liveness probe failed", exc_info=True)
+
+            logger.debug("Rebuilding inactive audio input stream")
+            self._close_stream_with_timeout()
         sd, np = _import_audio()
 
         def _callback(indata, frames, time_info, status):  # noqa: ARG001
@@ -776,7 +790,10 @@ class AudioRecorder(_RecorderBase):
         def _do_close():
             with suppress(Exception):
                 stream.stop()
+            try:
                 stream.close()
+            except Exception:
+                pass
 
         t = threading.Thread(target=_do_close, daemon=True)
         t.start()

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -886,15 +886,24 @@ class AudioRecorder:
     # -- public methods ------------------------------------------------------
 
     def _ensure_stream(self) -> None:
-        """Create the audio InputStream once and keep it alive.
+        """Create the audio InputStream and keep it alive while usable.
 
         The stream stays open for the lifetime of the recorder.  Between
         recordings the callback simply discards audio chunks (``_recording``
         is ``False``).  This avoids the CoreAudio bug where closing and
-        re-opening an ``InputStream`` hangs indefinitely on macOS.
+        re-opening an ``InputStream`` hangs indefinitely on macOS. CoreAudio
+        can still deactivate the stream when another input stream opens; in
+        that case the dead object must be closed and rebuilt before capture.
         """
         if self._stream is not None:
-            return  # already alive
+            try:
+                if self._stream.active:
+                    return
+            except Exception:
+                logger.debug("Audio input stream liveness probe failed", exc_info=True)
+
+            logger.debug("Rebuilding inactive audio input stream")
+            self._close_stream_with_timeout()
 
         sd, np = _import_audio()
 
@@ -1096,6 +1105,9 @@ class AudioRecorder:
         def _do_close():
             try:
                 stream.stop()
+            except Exception:
+                pass
+            try:
                 stream.close()
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

- reuse the recorder's cached `InputStream` only while its `active` liveness signal remains true
- close and rebuild inactive or unprobeable streams before the next recording, using the existing timeout-bounded shutdown path
- still attempt `close()` when `stop()` rejects an already-inactive stream
- add behavioral regression coverage for active reuse, inactive replacement, and failed liveness probes

This addresses the dead cached recorder mechanism isolated in #75417. It is intentionally complementary to #74152, which covers the separate manual push-to-talk wake-listener handoff and does not touch `tools/voice_mode.py`.

Refs #75417

## Validation

- `scripts/run_tests.sh tests/tools/test_voice_mode.py -q -k 'ensure_stream'` — 3 passed
- related voice/wake/STT suites — 118 passed
- four unrelated platform-specific failures were excluded from that related-suite run after reproducing each on clean `upstream/main` (two WSL playback mocks, the macOS beep gate, and the missing local TFLite runtime case)
- `uv run ruff check tools/voice_mode.py tests/tools/test_voice_mode.py`
- `python -m py_compile tools/voice_mode.py tests/tools/test_voice_mode.py`
- `git diff upstream/main...HEAD --check`
