### PR TITLE
docs: note macOS installer is Apple Silicon only

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -17,6 +17,10 @@ platform-gated features are supported), see **[Platform Support](./platform-supp
 ### With the Hermes Desktop installer on macOS or Windows (recommended)
 To easily install the command-line and desktop applications, [download the Hermes Desktop installer](https://hermes-agent.nousresearch.com/) from our website and run it.
 
+:::note
+The macOS installer is **Apple Silicon only**. macOS on x86 (Intel) processors is [not a supported platform](./platform-support.md#unsupported).
+:::
+
 ### Without Hermes Desktop:
 For a command-line only install without Hermes Desktop, run:
 

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -8,7 +8,7 @@ description: "The native Hermes desktop app — a polished experience for chatti
 
 The Hermes desktop app is a native app built around the **same** agent you get from the CLI and the gateway — same config, same API keys, same sessions, same skills, same memory. It is not a separate product or a lightweight clone; it uses the same Hermes Agent core and settings, and drives it through a modern & thoughtfully designed UI. If you have used `hermes` in a terminal, everything you set up there is already here, and anything you do here shows up there.
 
-It runs on **macOS, Windows, and Linux**.
+It runs on **macOS (Apple Silicon), Windows, and Linux** — see [Platform Support](../getting-started/platform-support.md) for the full matrix.
 
 :::tip Which interface is which?
 Hermes has several front ends that all talk to the same agent:


### PR DESCRIPTION
## What does this PR do?

`getting-started/platform-support.md` already lists **macOS on x86 (Intel) processors** under **Unsupported**. But the two pages a new user actually lands on don't reflect that policy:

- `getting-started/installation.md` recommends the macOS Desktop installer with no architecture qualifier.
- `user-guide/desktop.md` states the app "runs on **macOS, Windows, and Linux**".

So an Intel Mac user follows the documented happy path, downloads the DMG, and only discovers the platform is unsupported when the app fails with `Bad CPU type in executable` — after which the usual next step is to open an issue.

That has now happened repeatedly: #37505, #40456, #40471, #42199, #42928, #48322, #52381, and #60054 are all the same discovery. #48322 and #60054 were labeled `duplicate`.

This PR cross-references the existing policy from those two pages so the information is available *before* the download rather than after the failure.

**No change in platform support is proposed or implied.** This documents the decision already made in 772cf847b (`feat(docs): clarify platform support`); the wording deliberately reuses that page's own phrasing.

## Related Issue

No single issue — this addresses the recurring-report pattern behind #37505, #40456, #40471, #42199, #42928, #48322, #52381, #60054. Those requests ask for Intel *builds*, which this PR does not provide, so it does not close them.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/getting-started/installation.md` — added a `:::note` under the recommended-installer section stating the macOS installer is Apple Silicon only, linking to `platform-support.md#unsupported`.
- `website/docs/user-guide/desktop.md` — qualified "runs on macOS, Windows, and Linux" as "macOS (Apple Silicon), Windows, and Linux", linking to the full support matrix.

Net change: 2 files, +5 / -1.

## How to Test

1. `cd website && npm run build` (or `npm start`) — the Docusaurus build resolves both relative links.
2. Open **Getting Started → Installation**; the note appears directly under the recommended macOS/Windows installer section.
3. Open **User Guide → Desktop App**; the first line links to **Platform Support**.
4. Confirm the `#unsupported` anchor resolves to the existing `## Unsupported` heading in `platform-support.md`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs:`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run**; this PR touches only Markdown under `website/docs/` and no Python code paths.
- [ ] I've added tests for my changes — N/A for a documentation change.
- [x] I've tested on my platform: macOS 26.5.2, x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this PR *is* the documentation change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — documentation only; no behavioral or platform-gated code touched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Rendered text after this change:

**installation.md**
> ### With the Hermes Desktop installer on macOS or Windows (recommended)
> To easily install the command-line and desktop applications, download the Hermes Desktop installer from our website and run it.
>
> > **Note**
> > The macOS installer is **Apple Silicon only**. macOS on x86 (Intel) processors is [not a supported platform](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/getting-started/platform-support.md).

**desktop.md**
> It runs on **macOS (Apple Silicon), Windows, and Linux** — see [Platform Support](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/getting-started/platform-support.md) for the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
