### PR TITLE
fix(dashboard): slash completion double-slash, copy button overlap, WebGL black rows

### DIFF
--- a/web/src/components/SlashPopover.tsx
+++ b/web/src/components/SlashPopover.tsx
@@ -83,7 +83,19 @@ export const SlashPopover = forwardRef<SlashPopoverHandle, Props>(
 
     const apply = useCallback(
       (item: CompletionItem) => {
-        onApply(input.slice(0, replaceFrom) + item.text);
+        // The server's "extras" completions (/compact, /details, /logs, etc.)
+        // return their text WITH a leading "/" while plain commands return bare
+        // names ("exit", "help"). replaceFrom is always 1 for slash completions
+        // (the gateway's replace_from field), so the reconstructed value would
+        // be "/" + "/compact" = "//compact" without the strip below.
+        // Mirror the logic the TUI's Tab handler applies in useInputHandlers.ts.
+        const text =
+          input.startsWith("/") &&
+          item.text.startsWith("/") &&
+          replaceFrom > 0
+            ? item.text.slice(1)
+            : item.text;
+        onApply(input.slice(0, replaceFrom) + text);
       },
       [input, replaceFrom, onApply],
     );

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -786,6 +786,16 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         const webgl = new WebglAddon();
         webgl.onContextLoss(() => webgl.dispose());
         term.loadAddon(webgl);
+        // Fix #51769: force a full refresh after WebGL takes over so rows
+        // painted before the atlas was ready (which appear black) are redrawn.
+        requestAnimationFrame(() => {
+          try {
+            term.refresh(0, term.rows - 1);
+            term.scrollToBottom();
+          } catch {
+            /* ignore: term may already be disposed */
+          }
+        });
       } catch (err) {
         console.warn(
           "[hermes-chat] WebGL renderer unavailable; falling back to default",
@@ -1584,8 +1594,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               "bg-black/20",
               "opacity-70 hover:opacity-100 hover:border-current/60",
               "transition-opacity duration-150",
-              "bottom-2 right-2 px-2 py-1 text-xs sm:bottom-3 sm:right-3 sm:px-2.5 sm:py-1.5",
-              "lg:bottom-4 lg:right-4",
+              "bottom-2 right-8 px-2 py-1 text-xs sm:bottom-3 sm:right-9 sm:px-2.5 sm:py-1.5",
+              "lg:bottom-4 lg:right-9",
             )}
             style={{ color: terminalFg }}
           >


### PR DESCRIPTION
Cherry-pick of original fix — resubmitted cleanly without the reverted xterm experiments.

- SlashPopover: strip leading "/" from extras completions to prevent double-slash insertion
- ChatPage: move copy button right to avoid xterm scrollbar overlap  
- ChatPage: rAF refresh after WebGL addon loads to fix black rows

Fixes part of #52376. Closes #51769.