### PR TITLE
Statusbar off by default

### DIFF
--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -3,10 +3,11 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
 const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
 
-// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. Hiding it
-// unmounts the bar (its 15s status poll goes with it), so the way back is the
-// `view.toggleStatusbar` keybind or the ⌘K row — never the bar itself.
-export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, true, Codecs.bool)
+// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. Off by default
+// — the bar is opt-in. Hiding it unmounts the bar (its 15s status poll goes with
+// it), so the way back is the `view.toggleStatusbar` keybind or the ⌘K row,
+// never the bar itself.
+export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, false, Codecs.bool)
 
 export function toggleStatusbarVisible() {
   $statusbarVisible.set(!$statusbarVisible.get())


### PR DESCRIPTION
The statusbar is now opt-in. Existing users with a stored preference keep their choice; new users get a clean bottom edge. The way back is the `view.toggleStatusbar` keybind or the ⌘K row, unchanged.