### PR TITLE
fix(gateway): show the active fallback route in /status and /usage (#75535)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -69,6 +69,33 @@ def _int_value(value: Any) -> int:
         return 0
 
 
+def _parse_gateway_runtime(raw_model_config: Any) -> dict:
+    """Return the persisted live-routing snapshot from a session's model_config.
+
+    The gateway records the route actually serving a session — including any
+    active fallback provider — into ``model_config.gateway_runtime`` on every
+    provider switch (``provider``/``base_url``/``api_mode``/``fallback_active``).
+    ``billing_provider`` can lag that route (no accounting has landed yet, or an
+    upstream proxy omits streaming usage), so status/usage read this snapshot to
+    reflect the live provider rather than the configured default (#75535).
+
+    Accepts the raw ``model_config`` column (a JSON string or already-decoded
+    dict) and always returns a dict, empty when absent or unparseable.
+    """
+    config: Any = raw_model_config
+    if isinstance(config, str):
+        import json
+
+        try:
+            config = json.loads(config) if config else {}
+        except Exception:
+            return {}
+    if not isinstance(config, dict):
+        return {}
+    runtime = config.get("gateway_runtime")
+    return runtime if isinstance(runtime, dict) else {}
+
+
 def _model_switch_skew_guard() -> Optional[str]:
     """Refuse a model switch when the gateway is running stale code.
 
@@ -630,6 +657,17 @@ class GatewaySlashCommandsMixin:
         provider_name = provider_name or _clean_str(session_row.get("billing_provider"))
         base_url = base_url or _clean_str(session_row.get("billing_base_url"))
         context_used = context_used or _int_value(getattr(session_entry, "last_prompt_tokens", 0))
+
+        # Before the configured default, fall back to the persisted live-routing
+        # snapshot: when a session runs on a fallback provider, billing_provider
+        # is often still empty, so /status would otherwise show the configured
+        # default instead of the provider actually serving the session (#75535).
+        if not provider_name or not base_url:
+            gateway_runtime = _parse_gateway_runtime(session_row.get("model_config"))
+            if not provider_name:
+                provider_name = _clean_str(gateway_runtime.get("provider"))
+            if not base_url:
+                base_url = _clean_str(gateway_runtime.get("base_url"))
 
         user_config: dict[str, Any] = {}
         if not model_name or not provider_name or not context_total:
@@ -4788,6 +4826,12 @@ class GatewaySlashCommandsMixin:
                 persisted = {}
             provider = provider or persisted.get("billing_provider")
             base_url = base_url or persisted.get("billing_base_url")
+            # billing_provider lags a fallback route, so prefer the persisted
+            # live-routing snapshot for /usage too, before it gives up (#75535).
+            if not provider or not base_url:
+                gateway_runtime = _parse_gateway_runtime(persisted.get("model_config"))
+                provider = provider or gateway_runtime.get("provider")
+                base_url = base_url or gateway_runtime.get("base_url")
 
         if wants_reset:
             normalized_provider = str(provider or "").strip().lower()

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4818,7 +4818,7 @@ class GatewaySlashCommandsMixin:
         provider = getattr(agent, "provider", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
         base_url = getattr(agent, "base_url", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
         api_key = getattr(agent, "api_key", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
-        if not provider and getattr(self, "_session_db", None) is not None:
+        if (not provider or not base_url) and getattr(self, "_session_db", None) is not None:
             try:
                 _entry_for_billing = await self.async_session_store.get_or_create_session(source)
                 persisted = await self._session_db.get_session(_entry_for_billing.session_id) or {}

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -2,6 +2,7 @@ from hermes_state import AsyncSessionDB
 """Tests for gateway /status behavior and token persistence."""
 
 from datetime import datetime
+import json
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -486,5 +487,61 @@ async def test_context_all_appends_expanded_listings():
     assert "hermes-agent" in result
     # Expanded view drops the hint
     assert "Use /context all" not in result
+
+
+def test_parse_gateway_runtime_reads_snapshot():
+    from gateway.slash_commands import _parse_gateway_runtime
+
+    runtime = {"provider": "custom:freellmapi", "base_url": "https://x/v1"}
+    # JSON string (the raw model_config column shape).
+    assert _parse_gateway_runtime(json.dumps({"gateway_runtime": runtime})) == runtime
+    # Already-decoded dict.
+    assert _parse_gateway_runtime({"gateway_runtime": runtime}) == runtime
+    # Absent / malformed / wrong-typed inputs all yield an empty dict.
+    assert _parse_gateway_runtime(None) == {}
+    assert _parse_gateway_runtime("") == {}
+    assert _parse_gateway_runtime("not json") == {}
+    assert _parse_gateway_runtime({"gateway_runtime": "nope"}) == {}
+    assert _parse_gateway_runtime({}) == {}
+
+
+@pytest.mark.asyncio
+async def test_status_command_uses_active_fallback_route_over_config_default():
+    """When a session runs on a fallback provider, billing_provider is often
+    still empty; /status must surface the persisted live route rather than
+    falling through to the configured default (#75535)."""
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    # No live/cached agent and no billing_provider yet — only the persisted
+    # gateway_runtime snapshot records the active fallback route.
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "model": "custom/free-model",
+        "billing_provider": None,
+        "model_config": json.dumps(
+            {
+                "gateway_runtime": {
+                    "provider": "custom:freellmapi",
+                    "base_url": "https://freellmapi.example/v1",
+                    "fallback_active": True,
+                }
+            }
+        ),
+    }
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "(custom:freellmapi)" in result
+    # It must NOT be left provider-less nor show a stale configured default.
+    assert "`custom/free-model`" in result
 
 

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -162,6 +162,70 @@ class TestUsageAccountSection:
         assert "📊 **Session Info**" in result
         assert "📈 **Account limits**" in result
 
+    @pytest.mark.asyncio
+    async def test_usage_command_uses_gateway_runtime_base_url_when_agent_omits_it(self, monkeypatch):
+        """A live agent can expose a provider but no base_url; the account fetch
+        must still recover the base_url from the persisted live-routing snapshot
+        (model_config.gateway_runtime). Regresses the guard that previously only
+        consulted persisted data when the provider itself was missing (#75535)."""
+        import json
+
+        # Resident agent: provider set, base_url None (the mock's default).
+        agent = _make_mock_agent(provider="custom:freellmapi", base_url=None)
+        runner = _make_runner(SK, agent=agent)
+        runner._session_db = AsyncSessionDB(MagicMock())
+        # No billing metadata has landed yet; the only record of the live route's
+        # base_url is the gateway_runtime snapshot persisted on every switch.
+        runner._session_db._db.get_session.return_value = {
+            "billing_provider": "",
+            "billing_base_url": "",
+            "model_config": json.dumps(
+                {
+                    "gateway_runtime": {
+                        "provider": "custom:freellmapi",
+                        "base_url": "https://freellmapi.example/v1",
+                        "fallback_active": True,
+                    }
+                }
+            ),
+        }
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-1"
+        runner.session_store.get_or_create_session.return_value = session_entry
+        runner.session_store.load_transcript.return_value = [
+            {"role": "user", "content": "earlier"},
+        ]
+
+        calls = []
+
+        async def _fake_to_thread(fn, *args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr("gateway.run.asyncio.to_thread", _fake_to_thread)
+        monkeypatch.setattr(
+            "gateway.slash_commands.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "gateway.slash_commands.render_account_usage_lines",
+            lambda snapshot, markdown=False: [
+                "📈 **Account limits**",
+                "Provider: custom:freellmapi",
+            ],
+        )
+        monkeypatch.setattr("agent.account_usage.nous_credits_lines", lambda markdown=False: [])
+
+        event = MagicMock()
+        with patch("agent.rate_limit_tracker.format_rate_limit_compact", return_value="RPM: 50/60"), \
+             patch("agent.usage_pricing.estimate_usage_cost") as mock_cost:
+            mock_cost.return_value = MagicMock(amount_usd=None, status="unknown")
+            result = await runner._handle_usage_command(event)
+
+        account_call = next(c for c in calls if c["args"] == ("custom:freellmapi",))
+        assert account_call["kwargs"]["base_url"] == "https://freellmapi.example/v1"
+        assert "📈 **Account limits**" in result
+
 
 class TestUsageReset:
     """`/usage reset [--force]` — banked Codex reset redemption via the gateway."""


### PR DESCRIPTION
## Summary
`/status` (and `/usage`) resolved the session provider as **live agent → `billing_provider` → config default**. `billing_provider` is frequently empty — no accounting has landed yet on a fresh session, or an upstream proxy omits streaming usage — so a session running on a *fallback* provider fell through to the configured default and displayed the wrong provider (e.g. `opencode-go` instead of the active `custom:freellmapi`).

The gateway already persists the live route into `model_config.gateway_runtime` on every provider switch (`provider`/`base_url`/`api_mode`/`fallback_active`, written in `gateway/run.py`). `/status` and `/usage` simply never read it.

## Fix
- Add a shared `_parse_gateway_runtime(model_config)` helper (accepts the raw JSON string or a decoded dict; always returns a dict).
- In `_handle_status_command` and the `/usage` provider resolution, consult that snapshot **between** `billing_provider` and the config default — so both surface the provider actually serving the session, including an active fallback.

Insertion order is preserved: a live agent and a landed `billing_provider` still win; the snapshot only fills the gap that previously skipped straight to the default.

## Tests
- `test_parse_gateway_runtime_reads_snapshot` — parsing of JSON/dict/absent/malformed inputs.
- `test_status_command_uses_active_fallback_route_over_config_default` — `/status` surfaces the persisted fallback provider when there's no live agent and no `billing_provider`.
- Full `tests/gateway/test_status_command.py`, `test_usage_command.py`, `test_status.py` pass (67). Preflight gates (windows-footguns, ruff, affected tests) pass.

## Notes
`/usage` shares the fix via the same helper; its account-usage fetch path is harder to exercise in isolation, so it's covered by the helper unit test plus the shared code path rather than a separate integration test. The issue also mentions the billing dashboard — that's a separate surface (not slash_commands) and is out of scope here.

Fixes #75535
