### PR TITLE
test(lazy_deps): guard the anchor-distinctiveness convention active_features() relies on

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -361,3 +361,55 @@ class TestInstallSpecs:
         result = ld.install_specs(["honcho-ai==2.2.0"])
         assert result.ok is False
         assert "disk on fire" in result.stderr
+
+
+class TestAnchorDistinctiveness:
+    """Guard the convention active_features() depends on: LAZY_DEPS[f][0]
+    is the feature's *anchor* — a package distinctive enough that its
+    presence proves the user enabled that feature.
+
+    Nothing else enforces this. If a future feature lists a shared floor
+    first (aiohttp, numpy, sounddevice, starlette, qrcode all appear in
+    multiple features' spec lists), activation keyed on ``specs[0]`` would
+    silently regress to the pre-#72361 behaviour for that feature: any
+    unrelated install of the shared package would mark it active and
+    ``hermes update`` would start refreshing (and potentially installing)
+    a backend the user never enabled — the #58458 false-activation bug,
+    back with no test failing.
+
+    Exception: a feature whose *every* spec is shared (today
+    ``tts.mistral`` / ``stt.mistral``, both only ``mistralai``) has no
+    distinctive package to lead with. That case is benign — if the shared
+    package is present the feature is complete, so ``feature_missing()``
+    is empty and the refresh is a no-op ``"current"``.
+    """
+
+    @staticmethod
+    def _norm(spec: str) -> str:
+        # PEP 503 name normalization, so "foo_bar" and "foo-bar" collide.
+        import re
+        return re.sub(r"[-_.]+", "-", ld._pkg_name_from_spec(spec)).lower()
+
+    def test_every_anchor_is_distinctive_or_feature_is_all_shared(self):
+        from collections import Counter
+
+        counts = Counter(
+            self._norm(spec)
+            for specs in ld.LAZY_DEPS.values()
+            for spec in specs
+        )
+        for feature, specs in ld.LAZY_DEPS.items():
+            if not specs:
+                continue
+            names = {self._norm(spec) for spec in specs}
+            if all(counts[name] > 1 for name in names):
+                # All-shared feature: no distinctive package exists to be
+                # the anchor; presence == complete, refresh is a no-op.
+                continue
+            anchor = self._norm(specs[0])
+            assert counts[anchor] == 1, (
+                f"{feature}: anchor {specs[0]!r} is also declared by another "
+                "feature, so its presence cannot prove this feature was "
+                "enabled — active_features() would false-positive. Put the "
+                "feature's distinctive package first in LAZY_DEPS."
+            )


### PR DESCRIPTION
## What does this PR do?

Adds the missing guard for the convention #72361's fix depends on: `active_features()` keys activation on `LAZY_DEPS[feature][0]` — the *anchor* package — but nothing enforces that anchors are distinctive. This test does.

**Why it matters:** six packages are now declared by more than one feature (`aiohttp` ×4, `numpy` ×4, `sounddevice` ×4, `mistralai`, `qrcode`, `starlette`). The anchor convention only works because every feature happens to list a distinctive package first. One future feature added with its shared floor first — say a new platform leading with `aiohttp` — silently regresses that feature to any-present activation: any unrelated install of the shared package marks it active, and `hermes update` starts refreshing (and potentially installing) a backend the user never enabled. That's the #58458 false-activation bug returning with no test failing and nothing visible in review.

This was flagged in the six-way comparison on #58458 ("the fix is correct-by-convention… one future feature added with its shared floor listed first silently restores this bug — with no test failing"), with an offer to contribute the guard once a design was chosen. #72361 chose the anchor design; its lockstep invariant covers pin *versions* vs `uv.lock`, a different axis — anchor *distinctiveness* remained unguarded.

**Design notes:**
- PEP 503 name normalization (`foo_bar` / `foo-bar` / `foo.bar` collide), reusing `_pkg_name_from_spec` so extras blocks like `mautrix[encryption]` resolve to the bare name.
- Features whose *every* spec is shared (today `tts.mistral` / `stt.mistral`, both declaring only `mistralai`) are exempt: no distinctive package exists to lead with, and the case is benign — if the shared package is present the feature is complete, so `feature_missing()` is empty and the refresh is a no-op `"current"`.
- The failure message names the feature and the offending spec and says exactly what to do ("put the feature's distinctive package first").
- One test, no fixtures, no mocks — mindful of the recent suite-wide pruning (`6b81590c5`); this is a table-shape invariant, not behaviour duplication.

## Related Issue

Refs #58458 (the false-activation bug #72361 fixed — this guards the fix's load-bearing assumption). No standalone issue; happy to file one if preferred.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/tools/test_lazy_deps.py`: new `TestAnchorDistinctiveness` class with `test_every_anchor_is_distinctive_or_feature_is_all_shared`.

## How to Test

1. `pytest tests/tools/test_lazy_deps.py -q` — 56 pass on current `main` (8f8bee94f).
2. Verify the guard fires on the exact regression shape: reorder `platform.discord`'s specs so `aiohttp==…` is first, rerun — the test fails naming `platform.discord`, the shared anchor, and the fix ("put the feature's distinctive package first in LAZY_DEPS").
3. Verify the exemption: `tts.mistral` / `stt.mistral` (all-shared) pass untouched.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (module suite: 56/56; full suite has pre-existing environment-dependent failures unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (CachyOS), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (the test's docstring documents the convention)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure table introspection, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
