### PR TITLE
fix(terminal): block launchctl submit inside gateway

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -90,7 +90,21 @@ _ENV_OPTIONS_WITH_VALUES = frozenset({
     "--split-string",
     "--unset",
 })
-_COMMAND_WRAPPERS = frozenset({"command", "env", "exec", "sudo", "time"})
+_COMMAND_WRAPPERS = frozenset({
+    "arch",
+    "caffeinate",
+    "command",
+    "doas",
+    "env",
+    "exec",
+    "nice",
+    "nohup",
+    "setsid",
+    "stdbuf",
+    "sudo",
+    "time",
+    "timeout",
+})
 _SUDO_OPTIONS_WITH_VALUES = frozenset({
     "-C",
     "-D",
@@ -112,6 +126,23 @@ _SUDO_OPTIONS_WITH_VALUES = frozenset({
     "--user",
 })
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "-o", "--init-file", "--rcfile"})
+_OPTION_WRAPPERS = frozenset({
+    "arch",
+    "caffeinate",
+    "doas",
+    "nice",
+    "nohup",
+    "setsid",
+    "stdbuf",
+    "timeout",
+})
+_WRAPPER_OPTIONS_WITH_VALUES = {
+    "caffeinate": frozenset({"-t", "-w"}),
+    "doas": frozenset({"-C", "-u"}),
+    "nice": frozenset({"-n", "--adjustment"}),
+    "stdbuf": frozenset({"-e", "-i", "-o"}),
+    "timeout": frozenset({"-k", "-s", "--kill-after", "--signal"}),
+}
 
 
 def contains_gateway_lifecycle_command(text: str) -> bool:
@@ -188,6 +219,8 @@ def _shell_tokens(command: str) -> Optional[list[str]]:
             tokens.append(token)
         return tokens
     except ValueError:
+        # Fail open on malformed shell text. Known cases are unbalanced quotes,
+        # which the target shell also rejects rather than executing.
         return None
 
 
@@ -238,6 +271,20 @@ def _contains_launchctl_submit_tokens(tokens: list[str], depth: int) -> bool:
                 index = _skip_assignments(tokens, index)
             if wrapper == "time" and index < len(tokens) and tokens[index] == "-p":
                 index += 1
+            if wrapper in _OPTION_WRAPPERS:
+                options_with_values = _WRAPPER_OPTIONS_WITH_VALUES.get(
+                    wrapper, frozenset()
+                )
+                while (
+                    index < len(tokens)
+                    and tokens[index].startswith("-")
+                    and tokens[index] != "--"
+                ):
+                    index += 2 if tokens[index] in options_with_values else 1
+                if wrapper == "timeout":
+                    if index < len(tokens) and tokens[index] == "--":
+                        index += 1
+                    index += index < len(tokens)
             if index < len(tokens) and tokens[index] == "--":
                 index += 1
         if index >= len(tokens) or _is_command_separator(tokens[index]):
@@ -263,7 +310,15 @@ def _contains_launchctl_submit_tokens(tokens: list[str], depth: int) -> bool:
                 and not option.startswith("--")
                 and "c" in option[1:]
             ):
-                payload = _shell_tokens(_unquote(tokens[option_index + 1]))
+                payload_index = option_index + 1
+                if (
+                    payload_index < len(tokens)
+                    and _unquote(tokens[payload_index]) == "--"
+                ):
+                    payload_index += 1
+                if payload_index >= len(tokens):
+                    break
+                payload = _shell_tokens(_unquote(tokens[payload_index]))
                 if payload and _contains_launchctl_submit_tokens(payload, depth + 1):
                     return True
                 break

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -34,6 +34,7 @@ only fail (silently) when it fires.
 from __future__ import annotations
 
 import re
+import shlex
 from pathlib import Path
 from typing import Optional
 
@@ -65,12 +66,220 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"|(?:p?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
 )
 
+_COMMAND_SEPARATOR_CHARS = frozenset(";&|()\n")
+_SHELLS = frozenset({"bash", "dash", "ksh", "sh", "zsh"})
+_SHELL_COMMAND_PREFIXES = frozenset({
+    "!",
+    "{",
+    "do",
+    "elif",
+    "else",
+    "if",
+    "then",
+    "until",
+    "while",
+})
+_ASSIGNMENT_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=.*")
+_QUOTED_ASSIGNMENT_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=([\"']).*")
+_REDIRECTION_PATTERN = re.compile(r"\d*(?:<|>).*")
+_ENV_OPTIONS_WITH_VALUES = frozenset({
+    "-C",
+    "-S",
+    "-u",
+    "--chdir",
+    "--split-string",
+    "--unset",
+})
+_COMMAND_WRAPPERS = frozenset({"command", "env", "exec", "sudo", "time"})
+_SUDO_OPTIONS_WITH_VALUES = frozenset({
+    "-C",
+    "-D",
+    "-g",
+    "-h",
+    "-p",
+    "-R",
+    "-T",
+    "-u",
+    "--chdir",
+    "--chroot",
+    "--close-from",
+    "--command-timeout",
+    "--group",
+    "--host",
+    "--prompt",
+    "--role",
+    "--type",
+    "--user",
+})
+_SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "-o", "--init-file", "--rcfile"})
+
 
 def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
     return bool(_GATEWAY_LIFECYCLE_PATTERN.search(text))
+
+
+def _is_command_separator(token: str) -> bool:
+    return bool(token) and not (set(token) - _COMMAND_SEPARATOR_CHARS)
+
+
+def _skip_assignments(tokens: list[str], index: int) -> int:
+    while index < len(tokens):
+        token = tokens[index]
+        quoted = _QUOTED_ASSIGNMENT_PATTERN.fullmatch(token)
+        if quoted:
+            quote = quoted.group(1)
+            value = token.split("=", 1)[1]
+            if len(value) >= 2 and value.endswith(quote):
+                index += 1
+                continue
+            index += 1
+            while index < len(tokens) and not tokens[index].endswith(quote):
+                index += 1
+            index += index < len(tokens)
+            continue
+        if _ASSIGNMENT_PATTERN.fullmatch(token):
+            index += 1
+            continue
+        break
+    return index
+
+
+def _skip_redirections(tokens: list[str], index: int) -> int:
+    while index < len(tokens) and _REDIRECTION_PATTERN.fullmatch(tokens[index]):
+        token = tokens[index]
+        if token.endswith(("<", ">")):
+            if index + 2 < len(tokens) and tokens[index + 1] == "&":
+                index += 3
+            else:
+                index += 2
+        else:
+            index += 1
+        index = _skip_assignments(tokens, index)
+    return index
+
+
+def _shell_tokens(command: str) -> Optional[list[str]]:
+    """Return a small, comment-aware shell token stream or ``None``."""
+    if len(command) > 16_384:
+        return None
+    try:
+        lexer = shlex.shlex(
+            command.replace("\\\n", ""),
+            posix=False,
+            punctuation_chars=";&|()\n",
+        )
+        lexer.whitespace = " \t\r"
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens: list[str] = []
+        in_comment = False
+        for token in lexer:
+            if in_comment:
+                if "\n" in token:
+                    tokens.append("\n")
+                    in_comment = False
+                continue
+            if token.startswith("#"):
+                in_comment = True
+                continue
+            tokens.append(token)
+        return tokens
+    except ValueError:
+        return None
+
+
+def _unquote(token: str) -> str:
+    try:
+        return shlex.split(token)[0]
+    except (IndexError, ValueError):
+        return token
+
+
+def _contains_launchctl_submit_tokens(tokens: list[str], depth: int) -> bool:
+    index = 0
+    while index < len(tokens):
+        if index and not _is_command_separator(tokens[index - 1]):
+            index += 1
+            continue
+        index = _skip_assignments(tokens, index)
+        while (
+            index < len(tokens) and _unquote(tokens[index]) in _SHELL_COMMAND_PREFIXES
+        ):
+            index += 1
+            index = _skip_assignments(tokens, index)
+        index = _skip_redirections(tokens, index)
+        while (
+            index < len(tokens)
+            and _unquote(tokens[index]).rsplit("/", 1)[-1] in _COMMAND_WRAPPERS
+        ):
+            wrapper = _unquote(tokens[index]).rsplit("/", 1)[-1]
+            index += 1
+            if wrapper == "command" and index < len(tokens) and tokens[index] == "-p":
+                index += 1
+            if wrapper == "env":
+                while index < len(tokens):
+                    assignment_end = _skip_assignments(tokens, index)
+                    if assignment_end != index:
+                        index = assignment_end
+                        continue
+                    if tokens[index] in _ENV_OPTIONS_WITH_VALUES:
+                        index += 2
+                        continue
+                    if tokens[index].startswith("-") and tokens[index] != "--":
+                        index += 1
+                        continue
+                    break
+            if wrapper == "sudo":
+                while index < len(tokens) and tokens[index].startswith("-"):
+                    index += 2 if tokens[index] in _SUDO_OPTIONS_WITH_VALUES else 1
+                index = _skip_assignments(tokens, index)
+            if wrapper == "time" and index < len(tokens) and tokens[index] == "-p":
+                index += 1
+            if index < len(tokens) and tokens[index] == "--":
+                index += 1
+        if index >= len(tokens) or _is_command_separator(tokens[index]):
+            index += 1
+            continue
+        name = _unquote(tokens[index]).rsplit("/", 1)[-1]
+        if (
+            name == "launchctl"
+            and index + 1 < len(tokens)
+            and _unquote(tokens[index + 1]) == "submit"
+        ):
+            return True
+        if name not in _SHELLS or depth >= 3:
+            index += 1
+            continue
+        option_index = index + 1
+        while option_index < len(tokens) - 1:
+            option = _unquote(tokens[option_index])
+            if _is_command_separator(option) or not option.startswith("-"):
+                break
+            if (
+                option.startswith("-")
+                and not option.startswith("--")
+                and "c" in option[1:]
+            ):
+                payload = _shell_tokens(_unquote(tokens[option_index + 1]))
+                if payload and _contains_launchctl_submit_tokens(payload, depth + 1):
+                    return True
+                break
+            option_index += 2 if option in _SHELL_OPTIONS_WITH_VALUES else 1
+        index += 1
+    return False
+
+
+def contains_launchctl_submit_command(command: str) -> bool:
+    """Detect an actual ``launchctl submit`` invocation in bounded shell text."""
+    if len(command) > 16_384:
+        return bool(
+            re.search(r"(?i)\blaunchctl\s+submit\b", command.replace("\\\n", ""))
+        )
+    tokens = _shell_tokens(command)
+    return bool(tokens and _contains_launchctl_submit_tokens(tokens, 0))
 
 
 def _resolve_script_path(script_path: str) -> Path:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -213,16 +213,34 @@ class TestTerminalToolGatewayLifecycleGuard:
                 raise AssertionError("execute must not be reached")
         return _FakeEnv()
 
-    def _minimal_config(self):
-        return {"env_type": "local", "cwd": "/tmp", "timeout": 60, "lifetime_seconds": 3600}
+    def _make_recording_env(self, calls):
+        class _FakeEnv:
+            env = {}
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "ok", "returncode": 0}
+        return _FakeEnv()
 
-    def _patch_env(self, monkeypatch, fake_env, *, inside_gateway: bool):
+    def _minimal_config(self, env_type="local"):
+        return {
+            "env_type": env_type,
+            "cwd": "/tmp",
+            "timeout": 60,
+            "lifetime_seconds": 3600,
+            "docker_image": "test-image",
+        }
+
+    def _patch_env(
+        self, monkeypatch, fake_env, *, inside_gateway: bool, env_type="local"
+    ):
         import tools.terminal_tool as tt
         eid = "default"
         monkeypatch.setattr(tt, "_active_environments", {eid: fake_env})
         monkeypatch.setattr(tt, "_last_activity", {eid: 0.0})
         monkeypatch.setattr(tt, "_task_env_overrides", {})
-        monkeypatch.setattr(tt, "_get_env_config", self._minimal_config)
+        monkeypatch.setattr(
+            tt, "_get_env_config", lambda: self._minimal_config(env_type)
+        )
         if inside_gateway:
             monkeypatch.setenv("_HERMES_GATEWAY", "1")
         else:
@@ -234,6 +252,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         "systemctl stop hermes-gateway.service",
         "hermes gateway restart",
         "launchctl kickstart gui/501/ai.hermes.gateway",
+        "launchctl load /Library/LaunchDaemons/ai.hermes.gateway.plist",
         "pkill -f hermes.*gateway",
     ])
     def test_blocks_lifecycle_commands_inside_gateway(self, monkeypatch, cmd):
@@ -244,6 +263,7 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
+        assert "gateway would kill this command" in result["error"]
 
     def test_force_true_cannot_bypass_block(self, monkeypatch):
         import tools.terminal_tool as tt
@@ -255,6 +275,143 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
         assert "Blocked" in result["error"]
+
+    @pytest.mark.parametrize("cmd", [
+        "launchctl submit -l ai.hermes.gateway-restart-once.test -p /bin/zsh "
+        "-- /bin/zsh /tmp/gateway-restart-once.sh",
+        "launchctl submit -l com.example.cleanup -p /does/not/exist",
+        "/bin/launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "command launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "exec /bin/launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "env MODE=test launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "env -i launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "echo ready; launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "true && /bin/launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "printf x | launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "echo ready\nlaunchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "echo ready\n\nlaunchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "echo ready;\nlaunchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "true &&\nlaunchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "echo ready # harmless comment\nlaunchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "if true; then launchctl submit -l com.example.cleanup -p /usr/bin/true; fi",
+        "{ launchctl submit -l com.example.cleanup -p /usr/bin/true; }",
+        "NOTE='one shot' launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "VAR=\"v\" launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "VAR='v' launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "env VAR=\"v\" launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "FOO=\"bar\" echo hi; launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        ">/tmp/launchctl-submit.log launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "2>&1 launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "command -p launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "sudo launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "sudo -n launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "sudo --user root launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "sudo FOO=bar launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "time launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "launchctl \\\nsubmit -l com.example.cleanup -p /usr/bin/true",
+        "launchctl submit -l com.example.cleanup -p /usr/bin/true # " + "x" * 17_000,
+        "(launchctl submit -l com.example.cleanup -p /usr/bin/true)",
+        "sh -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
+        "bash -o posix -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
+        "bash --init-file /tmp/empty -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
+    ])
+    def test_blocks_local_launchctl_submit_inside_gateway(self, monkeypatch, cmd):
+        import tools.terminal_tool as tt
+        calls = []
+        self._patch_env(
+            monkeypatch, self._make_recording_env(calls), inside_gateway=True
+        )
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+
+        result = json.loads(tt.terminal_tool(command=cmd))
+
+        assert result["exit_code"] == 1
+        assert "submitted launchd jobs can outlive or relaunch the gateway" in result["error"]
+        assert "external shell" in result["error"]
+        assert calls == []
+
+    def test_allows_launchctl_submit_outside_gateway(self, monkeypatch):
+        import tools.terminal_tool as tt
+        calls = []
+        command = "launchctl submit -l com.example.cleanup -p /usr/bin/true"
+        self._patch_env(
+            monkeypatch, self._make_recording_env(calls), inside_gateway=False
+        )
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+
+        result = json.loads(tt.terminal_tool(command=command))
+
+        assert result["exit_code"] == 0
+        assert calls == [command]
+
+    @pytest.mark.parametrize("env_type", ["docker", "ssh"])
+    def test_allows_launchctl_submit_on_nonlocal_backend(
+        self, monkeypatch, env_type
+    ):
+        import tools.terminal_tool as tt
+        calls = []
+        command = "launchctl submit -l com.example.cleanup -p /usr/bin/true"
+        self._patch_env(
+            monkeypatch,
+            self._make_recording_env(calls),
+            inside_gateway=True,
+            env_type=env_type,
+        )
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+
+        result = json.loads(tt.terminal_tool(command=command))
+
+        assert result["exit_code"] == 0
+        assert calls == [command]
+
+    @pytest.mark.parametrize("cmd", [
+        "echo 'launchctl submit -l com.example.cleanup'",
+        "echo ';' launchctl submit",
+        "echo ready # launchctl submit -l com.example.cleanup",
+        "python -c 'import sys' launchctl submit",
+        "bash --norc 'launchctl submit -l com.example.cleanup'",
+    ])
+    def test_allows_launchctl_submit_words_outside_command_position(
+        self, monkeypatch, cmd
+    ):
+        import tools.terminal_tool as tt
+        calls = []
+        self._patch_env(
+            monkeypatch, self._make_recording_env(calls), inside_gateway=True
+        )
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+
+        result = json.loads(tt.terminal_tool(command=cmd))
+
+        assert result["exit_code"] == 0
+        assert calls == [cmd]
+
+    @pytest.mark.parametrize("cmd", [
+        "launchctl bootstrap gui/501 /does/not/exist",
+        "launchctl load /does/not/exist",
+    ])
+    def test_allows_neutral_launchctl_bootstrap_and_load(self, monkeypatch, cmd):
+        import tools.terminal_tool as tt
+        calls = []
+        self._patch_env(
+            monkeypatch, self._make_recording_env(calls), inside_gateway=True
+        )
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+
+        result = json.loads(tt.terminal_tool(command=cmd))
+
+        assert result["exit_code"] == 0
+        assert calls == [cmd]
 
     def test_safe_systemctl_commands_pass_through(self, monkeypatch):
         """Non-hermes systemctl commands must not be blocked by this guard."""

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -313,6 +313,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         "(launchctl submit -l com.example.cleanup -p /usr/bin/true)",
         "sh -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
         "bash -o posix -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
+        "bash -O extglob -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
         "bash --init-file /tmp/empty -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
     ])
     def test_blocks_local_launchctl_submit_inside_gateway(self, monkeypatch, cmd):

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -308,10 +308,17 @@ class TestTerminalToolGatewayLifecycleGuard:
         "sudo --user root launchctl submit -l com.example.cleanup -p /usr/bin/true",
         "sudo FOO=bar launchctl submit -l com.example.cleanup -p /usr/bin/true",
         "time launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "caffeinate -t 60 launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "arch -arm64 launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "nice -n 5 launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "stdbuf -o L launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "timeout --signal TERM 10 launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "doas -u root launchctl submit -l com.example.cleanup -p /usr/bin/true",
         "launchctl \\\nsubmit -l com.example.cleanup -p /usr/bin/true",
         "launchctl submit -l com.example.cleanup -p /usr/bin/true # " + "x" * 17_000,
         "(launchctl submit -l com.example.cleanup -p /usr/bin/true)",
         "sh -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
+        "bash -c -- 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
         "bash -o posix -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
         "bash -O extglob -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
         "bash --init-file /tmp/empty -c 'launchctl submit -l com.example.cleanup -p /usr/bin/true'",
@@ -331,6 +338,36 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 1
         assert "submitted launchd jobs can outlive or relaunch the gateway" in result["error"]
         assert "external shell" in result["error"]
+        assert calls == []
+
+    @pytest.mark.parametrize("command", [
+        "nohup launchctl submit -l com.example.cleanup -p /usr/bin/true",
+        "setsid --wait launchctl submit -l com.example.cleanup -p /usr/bin/true",
+    ])
+    def test_blocks_background_wrapped_launchctl_submit_inside_gateway(
+        self, monkeypatch, command
+    ):
+        import tools.terminal_tool as tt
+        from tools.process_registry import process_registry
+
+        calls = []
+        self._patch_env(
+            monkeypatch, self._make_recording_env(calls), inside_gateway=True
+        )
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+
+        def fail_if_spawned(**kwargs):
+            calls.append(kwargs)
+            raise AssertionError("background process must not spawn")
+
+        monkeypatch.setattr(process_registry, "spawn_local", fail_if_spawned)
+
+        result = json.loads(tt.terminal_tool(command=command, background=True))
+
+        assert result["exit_code"] == 1
+        assert "submitted launchd jobs can outlive or relaunch the gateway" in result["error"]
         assert calls == []
 
     def test_allows_launchctl_submit_outside_gateway(self, monkeypatch):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2439,6 +2439,7 @@ def terminal_tool(
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
         # but applies unconditionally (force=True cannot help here).
         if os.environ.get("_HERMES_GATEWAY") == "1":
+            from cron.lifecycle_guard import contains_launchctl_submit_command
             from hermes_cli.cron import _contains_gateway_lifecycle_command
             if _contains_gateway_lifecycle_command(command):
                 return json.dumps({
@@ -2450,6 +2451,17 @@ def terminal_tool(
                         "it could complete (SIGTERM propagates to child processes). "
                         "Run `hermes gateway restart` from a separate shell outside "
                         "the running gateway."
+                    ),
+                    "status": "error",
+                }, ensure_ascii=False)
+            if env_type == "local" and contains_launchctl_submit_command(command):
+                return json.dumps({
+                    "output": "",
+                    "exit_code": 1,
+                    "error": (
+                        "Blocked: submitted launchd jobs can outlive or relaunch the "
+                        "gateway. Run `launchctl submit` from an external shell "
+                        "instead of the gateway-hosted terminal tool."
                     ),
                     "status": "error",
                 }, ensure_ascii=False)


### PR DESCRIPTION
## Summary

- block command-position `launchctl submit` invocations from local terminal calls running inside the Hermes gateway
- normalize common execution wrappers and the valid `bash -c -- <payload>` form before command detection
- keep the guard ahead of approval/`force=True`, so a submitted KeepAlive job cannot repeatedly restart its own gateway host
- preserve external-shell, non-local backend, neutral `launchctl bootstrap`/`load`, and existing lifecycle-command behavior

## Why

`launchctl submit` jobs can outlive the terminal command and be relaunched by launchd. In #62891, a submitted helper repeatedly ran `hermes gateway restart`, causing 263 gateway restarts before the transient job was removed.

Label-only matching is not enough: a neutral label can execute the same payload. This patch blocks the unsafe `submit` primitive at the local gateway-hosted terminal boundary while leaving Hermes' supported internal restart path and normal external-shell administration untouched.

This is intentionally a foot-gun guard, not a general shell-security boundary. Indirect execution through arbitrary scripts/interpreters remains outside scope.

Closes #62891.

## Test plan

- `HERMES_HOME=<temp> python -m pytest -q tests/hermes_cli/test_gateway_restart_loop.py tests/tools/test_terminal_tool.py tests/tools/test_terminal_tool_requirements.py tests/tools/test_terminal_tool_pty_fallback.py tests/cron` — 493 passed
- `python -m ruff check cron/lifecycle_guard.py tools/terminal_tool.py tests/hermes_cli/test_gateway_restart_loop.py`
- `git diff --check`
