### PR TITLE
feat: add /nocode answer-only mode skill

### DIFF
--- a/skills/autonomous-ai-agents/nocode/SKILL.md
+++ b/skills/autonomous-ai-agents/nocode/SKILL.md
@@ -2,7 +2,7 @@
 name: nocode
 description: "Use when /nocode is typed: answer only, no code or installs."
 version: 1.0.0
-author: Hermes Agent
+author: Bruno Barboza (@BrunoBza), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -11,19 +11,12 @@ metadata:
     related_skills: [plan]
 ---
 
-# Answer-Only Mode (/nocode)
+# Nocode Skill
 
-## Overview
-
-`/nocode` is an answer-only mode for the agent: when the user types it (CLI
-or messaging platform) followed by a question, the agent answers directly —
-no code, no file writes, no installs, no state changes. Read-only research
-is allowed and encouraged; mutations are not.
-
-It is the inverse of plan mode: `/plan` produces a plan document, `/nocode`
-produces an answer. Users reach for it when they want a question answered
-without the agent "helpfully" scaffolding projects, installing packages, or
-editing files along the way.
+Answer-only mode for the agent. When the user types `/nocode` followed by a
+question, the agent answers directly with read-only research — it does NOT
+write files, install packages, or mutate state. It is the mirror image of
+plan mode: `/plan` produces a plan document, `/nocode` produces an answer.
 
 ## When to Use
 
@@ -39,10 +32,22 @@ Don't use for:
   those are normal turns.
 - Planning work — use the `plan` skill instead.
 
-## How This Differs from /plan
+## Prerequisites
 
-`/plan` and `/nocode` are sibling mode skills that both restrain the agent
-from running off and doing things, but they produce different deliverables:
+- None. The mode uses only tools already available to the agent
+  (`web_search`, `web_extract`, `read_file`, `session_search`,
+  `skills_list`, read-only terminal inspection).
+
+## How to Run
+
+Type `/nocode <question>` in the CLI or any messaging platform. Installed
+skills are exposed as dynamic slash commands on both surfaces, so the skill
+loads as `/nocode`; the text after the command is the question.
+
+## Quick Reference
+
+`/plan` vs `/nocode` — both are mode skills that restrain the agent from
+running off and doing things, but they produce different deliverables:
 
 | | `/plan` | `/nocode` |
 |---|---|---|
@@ -58,43 +63,40 @@ anything done. `/nocode` is the stricter mode: it permits only read-only
 research, while `/plan` may inspect the repo and writes the plan file as its
 deliverable.
 
-## Core Behavior
+## Procedure
 
 1. **Answer directly in the same turn.** No preamble, no plan, no
    "I'll set that up for you".
-2. **Research is allowed and encouraged** when it improves the answer —
-   anything read-only: `web_search`, `web_extract`, `read_file`,
-   `session_search`, `skills_list`, and read-only terminal inspection.
-3. **Forbidden unless the user explicitly asks in the same message:**
-   - `write_file`, `patch`, or any file creation/editing.
-   - Mutating terminal commands: installs (`pip`, `apt`), `git commit/push`,
-     `rm`, `mv`, config changes, service restarts.
-   - `execute_code` with side effects (pure read-only computation is fine).
-   - `cronjob` create/update/remove, memory writes, skill management.
-   - Any "let me just test it / install it / set it up" behavior.
+2. **Research when it improves the answer** — anything read-only:
+   `web_search`, `web_extract`, `read_file`, `session_search`,
+   `skills_list`, read-only terminal inspection.
+3. **Do not mutate anything** unless the user explicitly asks in the same
+   message: no `write_file`/`patch`, no installs (`pip`, `apt`), no
+   `git commit`/`push`, no `rm`/`mv`, no config changes or service
+   restarts, no side-effecting `execute_code`, no cron/memory/skill
+   mutations.
+4. **If answering genuinely requires an action** (e.g. inspecting a live
+   service): explain briefly what you would do and why, ask permission,
+   and wait.
 
-## When Action Is Genuinely Required
-
-If answering accurately requires an action (e.g., inspecting a live server or
-checking a running service):
-
-1. Explain briefly what you would do and why.
-2. Ask permission and wait.
-
-## Common Pitfalls
+## Pitfalls
 
 1. **Treating "answer only" as "no research".** Read-only research is the
    point of the mode — don't answer from memory when a quick `web_search`
    would verify the facts.
 2. **Slipping in a "helpful" action.** The deliverable is the answer;
-   artifacts, installs, and "I went ahead and..." are failures of this mode.
+   artifacts, installs, and "I went ahead and..." are failures of this
+   mode.
 3. **Asking permission unnecessarily.** If you can answer, just answer —
    only gate when an action is truly required.
 
-## Verification Checklist
+## Verification
 
-- [ ] The user has a complete, direct answer.
-- [ ] No files were created or edited.
-- [ ] No packages were installed.
-- [ ] No config, cron, memory, or service state changed.
-- [ ] If an action was required, permission was requested before doing anything.
+The mode succeeded when:
+
+- The user has a complete, direct answer.
+- No files were created or edited.
+- No packages were installed.
+- No config, cron, memory, or service state changed.
+- If an action was required, permission was requested before doing
+  anything.

--- a/skills/autonomous-ai-agents/nocode/SKILL.md
+++ b/skills/autonomous-ai-agents/nocode/SKILL.md
@@ -39,6 +39,25 @@ Don't use for:
   those are normal turns.
 - Planning work — use the `plan` skill instead.
 
+## How This Differs from /plan
+
+`/plan` and `/nocode` are sibling mode skills that both restrain the agent
+from running off and doing things, but they produce different deliverables:
+
+| | `/plan` | `/nocode` |
+|---|---|---|
+| Deliverable | A markdown plan document saved under `.hermes/plans/` | A direct answer in the conversation |
+| Purpose | Prepare a task for later implementation | Answer a question now, without side effects |
+| File writes | Writes exactly one file — the plan | Writes nothing, ever |
+| Typical trigger | "Plan how to build X" | "Just answer, don't do anything" |
+| After the turn | The plan is meant to be executed later | The answer is the end state; nothing remains |
+
+Choose `/plan` when the user wants a roadmap for work that will happen later.
+Choose `/nocode` when the user wants information and explicitly does not want
+anything done. `/nocode` is the stricter mode: it permits only read-only
+research, while `/plan` may inspect the repo and writes the plan file as its
+deliverable.
+
 ## Core Behavior
 
 1. **Answer directly in the same turn.** No preamble, no plan, no

--- a/skills/autonomous-ai-agents/nocode/SKILL.md
+++ b/skills/autonomous-ai-agents/nocode/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: nocode
+description: "Use when /nocode is typed: answer only, no code or installs."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [answer-only, read-only, question-answering, agent-behavior, no-code]
+    related_skills: [plan]
+---
+
+# Answer-Only Mode (/nocode)
+
+## Overview
+
+`/nocode` is an answer-only mode for the agent: when the user types it (CLI
+or messaging platform) followed by a question, the agent answers directly —
+no code, no file writes, no installs, no state changes. Read-only research
+is allowed and encouraged; mutations are not.
+
+It is the inverse of plan mode: `/plan` produces a plan document, `/nocode`
+produces an answer. Users reach for it when they want a question answered
+without the agent "helpfully" scaffolding projects, installing packages, or
+editing files along the way.
+
+## When to Use
+
+- The user types `/nocode <question>` on the CLI or a messaging platform.
+- The user asks for "answer only", "just answer, don't do anything",
+  "só responde", "sem código", or an equivalent phrase.
+- You are about to reach for a mutating tool (write, install, config change)
+  in order to answer a question — stop and answer instead.
+
+Don't use for:
+
+- Requests that explicitly ask for action (edits, installs, deploys, tests) —
+  those are normal turns.
+- Planning work — use the `plan` skill instead.
+
+## Core Behavior
+
+1. **Answer directly in the same turn.** No preamble, no plan, no
+   "I'll set that up for you".
+2. **Research is allowed and encouraged** when it improves the answer —
+   anything read-only: `web_search`, `web_extract`, `read_file`,
+   `session_search`, `skills_list`, and read-only terminal inspection.
+3. **Forbidden unless the user explicitly asks in the same message:**
+   - `write_file`, `patch`, or any file creation/editing.
+   - Mutating terminal commands: installs (`pip`, `apt`), `git commit/push`,
+     `rm`, `mv`, config changes, service restarts.
+   - `execute_code` with side effects (pure read-only computation is fine).
+   - `cronjob` create/update/remove, memory writes, skill management.
+   - Any "let me just test it / install it / set it up" behavior.
+
+## When Action Is Genuinely Required
+
+If answering accurately requires an action (e.g., inspecting a live server or
+checking a running service):
+
+1. Explain briefly what you would do and why.
+2. Ask permission and wait.
+
+## Common Pitfalls
+
+1. **Treating "answer only" as "no research".** Read-only research is the
+   point of the mode — don't answer from memory when a quick `web_search`
+   would verify the facts.
+2. **Slipping in a "helpful" action.** The deliverable is the answer;
+   artifacts, installs, and "I went ahead and..." are failures of this mode.
+3. **Asking permission unnecessarily.** If you can answer, just answer —
+   only gate when an action is truly required.
+
+## Verification Checklist
+
+- [ ] The user has a complete, direct answer.
+- [ ] No files were created or edited.
+- [ ] No packages were installed.
+- [ ] No config, cron, memory, or service state changed.
+- [ ] If an action was required, permission was requested before doing anything.

--- a/tests/skills/test_nocode_skill.py
+++ b/tests/skills/test_nocode_skill.py
@@ -1,0 +1,90 @@
+"""Tests for the nocode answer-only mode skill.
+
+Structural + internal-consistency checks only (stdlib + pytest, no network).
+The behavior contract was validated live via /nocode on CLI and Telegram.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "autonomous-ai-agents"
+    / "nocode"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+REQUIRED_SECTIONS = (
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+)
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_skill_file_exists():
+    assert SKILL_MD.is_file(), f"missing {SKILL_MD}"
+
+
+def test_frontmatter_present(skill_text: str):
+    assert skill_text.startswith("---\n"), "SKILL.md must open with YAML frontmatter"
+    assert skill_text.count("---") >= 2, "frontmatter must be delimited by two '---'"
+
+
+def test_name_and_description_declared(skill_text: str):
+    assert re.search(r"^name:\s*nocode\s*$", skill_text, re.MULTILINE), "name field"
+    m = re.search(r'^description:\s*"([^"]+)"\s*$', skill_text, re.MULTILINE)
+    assert m, "description field required"
+    desc = m.group(1)
+    assert len(desc) <= 60, "new-skill descriptions must fit the 60-char budget"
+    assert desc.startswith("Use when"), "description must start with the trigger phrase"
+
+
+def test_author_credits_human_contributor_first(skill_text: str):
+    m = re.search(r"^author:\s*(.*)$", skill_text, re.MULTILINE)
+    assert m, "author field required"
+    assert "@BrunoBza" in m.group(1), "human contributor must be credited first"
+
+
+def test_platforms_declared(skill_text: str):
+    m = re.search(r"^platforms:\s*(.*)$", skill_text, re.MULTILINE)
+    assert m, "platforms field required"
+    for os_name in ("linux", "macos", "windows"):
+        assert os_name in m.group(1), f"missing {os_name} in platforms"
+
+
+def test_required_sections_present(skill_text: str):
+    for heading in REQUIRED_SECTIONS:
+        assert heading in skill_text, f"missing section: {heading}"
+
+
+def test_plan_comparison_present(skill_text: str):
+    """The /plan vs /nocode decision guidance must survive edits."""
+    assert "/plan" in skill_text and "/nocode" in skill_text
+    assert ".hermes/plans/" in skill_text
+
+
+def test_related_skills_resolve_in_repo(skill_text: str):
+    m = re.search(r"related_skills:\s*\[([^\]]*)\]", skill_text)
+    assert m, "related_skills required"
+    related = [name.strip() for name in m.group(1).split(",") if name.strip()]
+    assert "plan" in related, "plan must be listed as a related skill"
+    plan_skill = (
+        Path(__file__).resolve().parents[2]
+        / "skills"
+        / "software-development"
+        / "plan"
+        / "SKILL.md"
+    )
+    assert plan_skill.is_file(), "related_skills must reference in-repo skills only"


### PR DESCRIPTION
## Summary

Adds a new bundled skill, `nocode`, under `skills/autonomous-ai-agents/`. It turns into a dynamic `/nocode` slash command (installed skills are exposed as commands on both CLI and messaging platforms) that puts the agent in **answer-only mode**:

- Answer the user's question directly in the same turn.
- Research is allowed and encouraged — anything read-only (`web_search`, `web_extract`, `read_file`, `session_search`).
- Forbidden unless explicitly requested: file writes/edits, installs, mutating terminal commands, side-effecting `execute_code`, cron/memory/skill mutations.
- If answering genuinely requires an action (e.g. inspecting a live service), explain what you would do and ask permission first.

It is the mirror image of the bundled `plan` skill: `/plan` produces a plan document, `/nocode` produces an answer. Both are mode skills expressed purely as instructions over existing tools.

## Motivation

A recurring user pattern with agentic assistants: asking a question and having the agent "helpfully" scaffold projects, install packages, or edit files along the way. A single-word mode command (`/nocode <question>`) makes the no-action contract explicit and reusable across CLI and messaging platforms.

## What changed

- `skills/autonomous-ai-agents/nocode/SKILL.md` — new skill following the modern section order (intro, When to Use, Prerequisites, How to Run, Quick Reference, Procedure, Pitfalls, Verification), including a `/plan` vs `/nocode` comparison table in Quick Reference.
- `tests/skills/test_nocode_skill.py` — structural + internal-consistency checks (stdlib + pytest, no network): frontmatter, human-contributor credit, required sections, `/plan` comparison, in-repo `related_skills`.

## Validation

- Frontmatter passes the repo's own `tools/skill_manager_tool.py::_validate_frontmatter` with `new_skill=True`.
- `scripts/run_tests.sh tests/skills/test_nocode_skill.py -q` passes (0.7s).
- Loaded and exercised as `/nocode` on Telegram and CLI in a live Hermes install: answering a follow-up question with zero mutating tool calls.

## Checklist

- [x] Skill lives in `skills/<category>/<name>/SKILL.md` in the repo tree
- [x] Frontmatter: `name`, `description` (≤60 chars, trigger first), `version`, `author` (human contributor credited first), `license`, `platforms`, `metadata.hermes.{tags, related_skills}`
- [x] Body uses the modern section order per AGENTS.md
- [x] `related_skills` references only in-repo skills (`plan`)
- [x] Test at `tests/skills/test_nocode_skill.py` using stdlib + pytest only
- [x] No new top-level category — reuses existing `autonomous-ai-agents`
- [x] Conventional commit messages
