### PR TITLE
fix(lsp): honor lsp.wait_timeout in baseline snapshot

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -309,8 +309,11 @@ class LSPService:
             return
         try:
             # Outer join budget must exceed the inner wait budget or a
-            # slow-but-alive server gets falsely marked broken.
-            t = max(8.0, self._wait_timeout + 3.0)
+            # slow-but-alive server gets falsely marked broken.  The
+            # floor keeps the default behavior (8s with default config)
+            # while letting larger user-configured wait_timeout values
+            # scale the join budget instead of capping it at 8s.
+            t = max(DIAGNOSTICS_DOCUMENT_WAIT + 3.0, self._wait_timeout + 3.0)
             diags = self._loop.run(self._snapshot_async(file_path), timeout=t)
             self._delta_baseline[os.path.abspath(file_path)] = diags or []
         except Exception as e:  # noqa: BLE001
@@ -483,7 +486,9 @@ class LSPService:
             return []
         try:
             version = await client.open_file(file_path, language_id=language_id_for(file_path))
-            fresh = await client.wait_for_diagnostics(file_path, version, mode=self._wait_mode)
+            fresh = await client.wait_for_diagnostics(
+                file_path, version, mode=self._wait_mode, timeout=self._wait_timeout
+            )
         except Exception as e:  # noqa: BLE001
             logger.debug("snapshot open/wait failed: %s", e)
             return []

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -117,6 +117,12 @@ def main():
                     "message": "synthetic error from mock-lsp",
                 }
             ]
+            if script == "silent":
+                # Never publishes diagnostics and the pull endpoint is
+                # rejected (below).  Models a slow server that only
+                # re-reports after a didChange it never receives — the
+                # baseline snapshot has to wait out its full budget.
+                continue
             if script == "stale":
                 # Ghost scenario: publish an error for the ORIGINAL
                 # content, then never publish again after edits.
@@ -159,7 +165,7 @@ def main():
             continue
 
         if msg.get("method") == "textDocument/diagnostic":
-            if script in {"stale", "slow_push"}:
+            if script in {"stale", "slow_push", "silent"}:
                 # These scripts model push-only servers so the ghost
                 # can't be papered over by the pull channel.
                 write_message(

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -7,6 +7,7 @@ on.
 """
 from __future__ import annotations
 
+import os
 import sys
 import time
 from pathlib import Path
@@ -75,6 +76,99 @@ def mock_pyright(monkeypatch, tmp_path):
         next(gen)
     except StopIteration:
         pass
+
+
+@pytest.fixture
+def mock_pyright_silent(monkeypatch, tmp_path):
+    """Install the silent mock as ``pyright`` (never pushes diagnostics).
+
+    The silent server accepts the open but never publishes diagnostics
+    for the pre-edit content and rejects the pull channel, so the
+    baseline snapshot has to wait out its full budget — exactly the
+    slow-server shape from the wait_timeout report.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / "pyproject.toml").write_text("")
+    monkeypatch.chdir(str(repo))
+    gen = _install_mock_server(monkeypatch, "silent", "pyright")
+    next(gen)
+    yield repo
+    try:
+        next(gen)
+    except StopIteration:
+        pass
+
+
+def test_snapshot_baseline_honors_wait_timeout(mock_pyright_silent):
+    """``snapshot_baseline`` must wait at most ``lsp.wait_timeout``, not
+    the hardcoded client fallback of 5s.
+
+    Regression for the report that a 2s wait_timeout was ignored by the
+    baseline path: the wait ran without a timeout and fell back to
+    ``DIAGNOSTICS_DOCUMENT_WAIT`` (5s).  The silent mock never pushes,
+    so the elapsed time directly exposes the effective wait budget.
+    """
+    repo = mock_pyright_silent
+    f = repo / "x.py"
+    f.write_text("print('hi')\n")
+
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=2.0,
+        install_strategy="manual",
+    )
+    try:
+        start = time.monotonic()
+        svc.snapshot_baseline(str(f))
+        elapsed = time.monotonic() - start
+
+        # The wait is deadline-based: it always runs the full budget
+        # (never less than wait_timeout) and the server never pushes,
+        # so both bounds are stable under load.
+        assert elapsed >= 1.5, f"baseline returned before the wait budget: {elapsed:.2f}s"
+        assert elapsed < 4.5, (
+            f"baseline ignored wait_timeout=2.0 and ran the 5s fallback: {elapsed:.2f}s"
+        )
+        assert svc.get_status()["broken"] == []
+        # No fresh data pre-edit -> empty (never stale) baseline.
+        assert svc._delta_baseline[os.path.abspath(str(f))] == []
+    finally:
+        svc.shutdown()
+
+
+def test_snapshot_baseline_scales_join_budget_past_8s(mock_pyright_silent):
+    """The outer join budget must scale with ``wait_timeout`` instead of
+    capping at 8s.
+
+    With wait_timeout=10.0 the inner wait takes 10s; an 8s outer cap
+    would fire first, falsely mark the server broken, and truncate the
+    snapshot.  The elapsed time must land between the inner budget and
+    the (now scaled) outer budget, with the server still healthy.
+    """
+    repo = mock_pyright_silent
+    f = repo / "x.py"
+    f.write_text("print('hi')\n")
+
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=10.0,
+        install_strategy="manual",
+    )
+    try:
+        start = time.monotonic()
+        svc.snapshot_baseline(str(f))
+        elapsed = time.monotonic() - start
+
+        assert elapsed >= 9.5, f"baseline cut short by the outer cap: {elapsed:.2f}s"
+        assert elapsed < 12.5, f"baseline overran the scaled join budget: {elapsed:.2f}s"
+        # A slow-but-alive server must not be marked broken.
+        assert svc.get_status()["broken"] == []
+    finally:
+        svc.shutdown()
 
 
 


### PR DESCRIPTION
## What does this PR do?

The pre-write baseline snapshot (`snapshot_baseline`) called
`wait_for_diagnostics(...)` without a timeout, so the client silently fell
back to its hardcoded `DIAGNOSTICS_DOCUMENT_WAIT` (5s) instead of the
user-configured `lsp.wait_timeout`. On slow servers that don't publish
diagnostics right after `didOpen` (e.g. tsserver on large projects), every
write paid a fixed 5s wait no matter what `wait_timeout` said.

This forwards `self._wait_timeout` to the wait — exactly what the sibling
`get_diagnostics_sync` path already does (manager.py L362/L514) — and
couples the outer join budget to the effective inner wait budget so a
slow-but-alive server with `wait_timeout > 5s` isn't falsely marked broken
by the previous flat 8s floor. Default behavior is unchanged:
5.0 + 3.0 = 8.0.

## Related Issue

Fixes #75551

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/lsp/manager.py`: `_snapshot_async` now passes
  `timeout=self._wait_timeout` to `wait_for_diagnostics` (matching
  `_open_and_wait_async`); `snapshot_baseline`'s outer join budget is now
  `max(DIAGNOSTICS_DOCUMENT_WAIT + 3.0, wait_timeout + 3.0)` instead of the
  flat `max(8.0, ...)`.
- `tests/agent/lsp/_mock_lsp_server.py`: new `silent` script mode — accepts
  the open but never publishes diagnostics and rejects the pull channel,
  deterministically modeling the slow-server shape from the report.
- `tests/agent/lsp/test_service.py`: two regression tests proving the
  baseline wait honors `wait_timeout` (2.0s and 10.0s budgets) and that the
  server is not marked broken.

## How to Test

1. `scripts/run_tests.sh tests/agent/lsp/test_service.py -q` — the changed
   service suite passes on this branch.
2. Regression proof: with `wait_timeout=2.0` against a silent mock LSP
   server, `snapshot_baseline` takes 5.02s on `main` and 2.02s on this
   branch; both new tests fail on `main` (5.03s elapsed) and pass here.
3. `scripts/check.sh --project hermes-agent` gates: `uv lock --check`,
   `ruff check .`, and the changed test files all pass; `ty` reports zero
   diagnostics on the changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — via the canonical
   `scripts/run_tests.sh` runner: the changed-file suite is 8/8 green; the
   full suite is CI's sharded job
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no config surface changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure asyncio timeout plumbing, same pattern as the existing sync path)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
wait_timeout=2.0, silent mock server, snapshot_baseline:
  main    (8f8bee94f): 5.02s   # ignores wait_timeout, 5s client fallback
  branch  (c8f494022): 2.02s   # honors wait_timeout
```