### PR TITLE
Resolve a gateway approval by session_key, not just Runs-API run_id

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1515,6 +1515,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/runs/{run_id}", self._handle_get_run),
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
             ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
+            ("POST", "/v1/sessions/{session_key}/approval", self._handle_session_approval),
             ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run),
         ]
         if _CRON_AVAILABLE:
@@ -2055,6 +2056,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
+                "session_approval": {"method": "POST", "path": "/v1/sessions/{session_key}/approval"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
                 "skills": {"method": "GET", "path": "/v1/skills"},
                 "toolsets": {"method": "GET", "path": "/v1/toolsets"},
@@ -5271,6 +5273,77 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({
             "object": "hermes.run.approval_response",
             "run_id": run_id,
+            "choice": choice,
+            "resolved": resolved,
+        })
+
+    async def _handle_session_approval(self, request: "web.Request") -> "web.Response":
+        """POST /v1/sessions/{session_key}/approval — resolve a pending approval by its
+        gateway session_key directly, instead of a Runs-API run_id.
+
+        _handle_run_approval above only resolves approvals for runs started through this
+        platform's own POST /v1/runs (it looks up run_id in self._run_approval_sessions, a dict
+        this platform alone populates). Every other gateway platform - WhatsApp, Telegram,
+        Discord, the CLI - blocks on the exact same resolve_gateway_approval(session_key, choice)
+        call (see tools/approval.py's docstring: "Every existing platform ... resolves approvals
+        this same in-process way"), but until now there was no HTTP route to reach it for a
+        session that didn't originate through the Runs API. This route exists for exactly that
+        case: any caller that already knows a pending approval's session_key (e.g. a bridging
+        service like a Runs-API facade that also subscribes to the gateway's own governance/event
+        log) can resolve it here, with no run_id or Runs-API bookkeeping required at all.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_key = request.match_info["session_key"]
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        raw_choice = str(body.get("choice", "")).strip().lower()
+        aliases = {"approve": "once", "approved": "once", "allow": "once"}
+        choice = aliases.get(raw_choice, raw_choice)
+        allowed = {"once", "session", "always", "deny"}
+        if choice not in allowed:
+            return web.json_response(
+                _openai_error(
+                    "Invalid approval choice; expected one of: once, session, always, deny",
+                    code="invalid_approval_choice",
+                ),
+                status=400,
+            )
+
+        resolve_all = (
+            _coerce_request_bool(body.get("all"), default=False)
+            or _coerce_request_bool(body.get("resolve_all"), default=False)
+        )
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            resolved = resolve_gateway_approval(
+                session_key,
+                choice,
+                resolve_all=resolve_all,
+            )
+        except Exception as exc:
+            logger.exception("[api_server] approval resolution failed for session %s", session_key)
+            return web.json_response(_openai_error(str(exc)), status=500)
+
+        if resolved <= 0:
+            return web.json_response(
+                _openai_error(
+                    f"Session has no pending approval: {session_key}",
+                    code="approval_not_pending",
+                ),
+                status=409,
+            )
+
+        return web.json_response({
+            "object": "hermes.session.approval_response",
+            "session_key": session_key,
             "choice": choice,
             "resolved": resolved,
         })

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -69,6 +69,7 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_post("/v1/sessions/{session_key}/approval", adapter._handle_session_approval)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
 
@@ -836,3 +837,82 @@ class TestStopRun:
                 body = await events_resp.text()
                 # Stream should have received run.failed and closed
                 assert "run.failed" in body or "stream closed" in body
+
+
+class TestSessionApproval:
+    """POST /v1/sessions/{session_key}/approval - resolves a pending approval directly by its
+    gateway session_key, for callers that don't have (and can't get) a Runs-API run_id, e.g. an
+    approval that originated from a platform session (WhatsApp, Telegram, ...) never started
+    through this adapter's own POST /v1/runs."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_via_the_real_gateway_mechanism_no_run_id_needed(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                resp = await cli.post(
+                    "/v1/sessions/agent:main:whatsapp:dm:5511999999999/approval",
+                    json={"choice": "once"},
+                )
+
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["session_key"] == "agent:main:whatsapp:dm:5511999999999"
+                assert data["choice"] == "once"
+                assert data["resolved"] == 1
+                mock_resolve.assert_called_once_with(
+                    "agent:main:whatsapp:dm:5511999999999",
+                    "once",
+                    resolve_all=False,
+                )
+
+    @pytest.mark.asyncio
+    async def test_no_pending_approval_returns_409(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("tools.approval.resolve_gateway_approval", return_value=0):
+                resp = await cli.post(
+                    "/v1/sessions/agent:main:cli:default/approval",
+                    json={"choice": "once"},
+                )
+
+                assert resp.status == 409
+                data = await resp.json()
+                assert data["error"]["code"] == "approval_not_pending"
+
+    @pytest.mark.asyncio
+    async def test_invalid_choice_returns_400(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/sessions/agent:main:cli:default/approval",
+                json={"choice": "not-a-real-choice"},
+            )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"]["code"] == "invalid_approval_choice"
+
+    @pytest.mark.asyncio
+    async def test_resolve_all_flag_is_forwarded(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("tools.approval.resolve_gateway_approval", return_value=3) as mock_resolve:
+                resp = await cli.post(
+                    "/v1/sessions/agent:main:cli:default/approval",
+                    json={"choice": "once", "all": True},
+                )
+
+        assert resp.status == 200
+        mock_resolve.assert_called_once_with("agent:main:cli:default", "once", resolve_all=True)
+
+    @pytest.mark.asyncio
+    async def test_requires_auth_when_configured(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/sessions/agent:main:cli:default/approval",
+                json={"choice": "once"},
+            )
+
+        assert resp.status == 401


### PR DESCRIPTION
## Summary

`POST /v1/runs/{run_id}/approval` (the API Server platform's only approval-resolution route today) only works for approvals belonging to a run started through that same platform's own `POST /v1/runs` — it looks up `run_id` in `self._run_approval_sessions`, an in-memory dict this adapter alone populates.

Every other gateway platform (WhatsApp, Telegram, Discord, the CLI) resolves a pending approval the exact same way internally — `resolve_gateway_approval(session_key, choice)` (see `tools/approval.py`'s own docstring: *"Every existing platform ... resolves approvals this same in-process way"*) — but there was no HTTP-exposed way to reach that call for a session that never went through the Runs API.

This adds `POST /v1/sessions/{session_key}/approval`, mirroring `_handle_run_approval`'s logic but keyed by `session_key` directly instead of `run_id` — actually simpler, since it skips the `run_id → session_key` lookup indirection entirely.

## Motivation

We're building a durable, Postgres-backed approval inbox as a facade over the Runs API. It subscribes to the gateway's own governance event stream, which already carries every approval's `session_key` regardless of originating platform. Runs-API-originated approvals resolve fine today via the existing route; everything else (e.g. a WhatsApp-originated approval) hits a dead end with no way to resolve it externally. This endpoint closes that gap for any external service in the same position, not just ours.

## Test plan

- 5 new tests in `tests/gateway/test_api_server_runs.py::TestSessionApproval`, mirroring the existing `_handle_run_approval` coverage (resolves via the real mechanism, 409 on no pending approval, 400 on invalid choice, `resolve_all` forwarding, auth requirement).
- Full `tests/gateway/test_api_server_runs.py` suite passes (38/38) against a clean checkout of the pinned commit this PR is based on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)