### PR TITLE
fix(codex): stabilize Bedrock Mantle multi-turn sessions

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1427,8 +1427,17 @@ class _CodexCompletionsAdapter:
         # build_kwargs, so they need the same guard applied independently.
         _host_for_input = str(getattr(self._client, "base_url", "") or "")
         _is_github_for_input = base_url_host_matches(_host_for_input, "githubcopilot.com")
+        # Bedrock Mantle accepts replayed encrypted reasoning but degrades
+        # the model (hidden-reasoning-only turns, repeated tool calls —
+        # Issue #75471). Suppress historical encrypted reasoning replay for
+        # Mantle the same way the main transport does, so auxiliary context
+        # compression / memory consumers follow one Mantle contract.
+        from agent.transports.codex import _is_bedrock_mantle_base_url
+        _is_mantle_for_input = _is_bedrock_mantle_base_url(_host_for_input)
         input_items = _chat_messages_to_responses_input(
-            replay_messages, is_github_responses=_is_github_for_input,
+            replay_messages,
+            is_github_responses=_is_github_for_input,
+            replay_encrypted_reasoning=not _is_mantle_for_input,
         )
 
         resp_kwargs: Dict[str, Any] = {
@@ -1479,7 +1488,8 @@ class _CodexCompletionsAdapter:
                         "effort": effort,
                         "summary": "auto",
                     }
-                    resp_kwargs["include"] = ["reasoning.encrypted_content"]
+                    if not _is_mantle_for_input:
+                        resp_kwargs["include"] = ["reasoning.encrypted_content"]
 
         # Tools support for auxiliary callers (e.g. skills_hub) that pass function schemas
         tools = kwargs.get("tools")

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -266,6 +266,50 @@ def _deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
     return deterministic_call_id(fn_name, arguments, index)
 
 
+# Mantle (Amazon Bedrock's Responses surface) mints response-local indexed
+# tool pairing IDs of the shape ``call_0`` / ``fc_1`` and reuses the same
+# index on every response in a conversation. Hermes stores the value as the
+# canonical pairing key, so a second turn reusing ``call_0`` collides with
+# the first and the pre-call duplicate sanitizer drops the later
+# call/result pair (Issue #75471). The grammar is deliberately narrow —
+# provider-issued global IDs (``call_<uuid>``, composite ``fc_`` ids, etc.)
+# are response-unique and must pass through untouched.
+_MANTLE_INDEXED_CALL_ID_RE = re.compile(r"^(?:call|fc)_\d{1,6}$")
+
+
+def _remint_mantle_indexed_call_id(
+    raw_call_id: str,
+    *,
+    request_scope: str,
+    provider_response_id: str,
+    output_ordinal: int,
+) -> str:
+    """Map a Mantle response-local indexed pairing ID to a session-safe one.
+
+    Returns ``call_mtl_<40 hex>`` (49 chars, inside the Responses 64-char
+    cap) that is byte-identical for the same
+    (request_scope, provider_response_id, raw_call_id, output_ordinal) tuple
+    and distinct across Hermes Request Scopes even when Mantle repeats,
+    omits, or malforms ``response.id``. The caller's Hermes-generated
+    ``request_scope`` is the primary identity input; a non-empty provider
+    ``response.id`` contributes additional separation. Values outside the
+    indexed grammar are returned unchanged so non-Mantle and global IDs keep
+    their existing identity contract.
+    """
+    if not isinstance(raw_call_id, str) or not raw_call_id.strip():
+        return raw_call_id
+    value = raw_call_id.strip()
+    if not _MANTLE_INDEXED_CALL_ID_RE.fullmatch(value):
+        return raw_call_id
+
+    seed = (
+        f"mantle-call-v1\x00{request_scope}\x00{provider_response_id}\x00"
+        f"{value}\x00{output_ordinal}"
+    )
+    digest = hashlib.sha256(seed.encode("utf-8", errors="replace")).hexdigest()[:40]
+    return f"call_mtl_{digest}"
+
+
 def _clamp_responses_call_id(call_id: str) -> str:
     """Keep a ``call_id`` within the Responses API's 64-char limit (#73492).
 
@@ -702,6 +746,7 @@ def _preflight_codex_input_items(
     *,
     is_github_responses: bool = False,
     sanitize_harmony_tokens: bool = False,
+    allow_encrypted_reasoning_replay: bool = True,
 ) -> List[Dict[str, Any]]:
     if not isinstance(raw_items, list):
         raise ValueError("Codex Responses input must be a list of input items.")
@@ -795,6 +840,12 @@ def _preflight_codex_input_items(
             continue
 
         if item_type == "reasoning":
+            if not allow_encrypted_reasoning_replay:
+                # Bedrock Mantle accepts replayed encrypted reasoning but
+                # degrades the model (Issue #75471). This final-preflight
+                # boundary runs after request_overrides merge, closing the
+                # override bypass that history conversion alone cannot.
+                continue
             encrypted = item.get("encrypted_content")
             if isinstance(encrypted, str) and encrypted:
                 item_id = item.get("id")
@@ -947,6 +998,7 @@ def _preflight_codex_api_kwargs(
     allow_stream: bool = False,
     is_github_responses: bool = False,
     sanitize_harmony_tokens: bool = False,
+    allow_encrypted_reasoning_replay: bool = True,
 ) -> Dict[str, Any]:
     if not isinstance(api_kwargs, dict):
         raise ValueError("Codex Responses request must be a dict.")
@@ -974,6 +1026,7 @@ def _preflight_codex_api_kwargs(
         api_kwargs.get("input"),
         is_github_responses=is_github_responses,
         sanitize_harmony_tokens=sanitize_harmony_tokens,
+        allow_encrypted_reasoning_replay=allow_encrypted_reasoning_replay,
     )
 
     tools = api_kwargs.get("tools")
@@ -1059,7 +1112,18 @@ def _preflight_codex_api_kwargs(
         normalized["reasoning"] = reasoning
     include = api_kwargs.get("include")
     if isinstance(include, list):
-        normalized["include"] = include
+        if allow_encrypted_reasoning_replay:
+            normalized["include"] = include
+        else:
+            # Mantle final-preflight gate (Issue #75471): remove the exact
+            # ``reasoning.encrypted_content`` include value while preserving
+            # other supported include values in their original order. Omit
+            # ``include`` entirely when filtering leaves an empty list.
+            filtered_include = [
+                value for value in include if value != "reasoning.encrypted_content"
+            ]
+            if filtered_include:
+                normalized["include"] = filtered_include
     service_tier = api_kwargs.get("service_tier")
     if isinstance(service_tier, str) and service_tier.strip():
         normalized["service_tier"] = service_tier.strip()
@@ -1247,10 +1311,59 @@ def _format_responses_error(error_obj: Any, response_status: str) -> str:
 # Full response normalization
 # ---------------------------------------------------------------------------
 
+_MANTLE_SCOPE_WARN_EMITTED = False
+
+
+def _resolve_mantle_pairing_call_id(
+    call_id: str,
+    *,
+    is_bedrock_mantle: bool,
+    request_scope: Optional[str],
+    provider_response_id: str,
+    output_ordinal: int,
+) -> str:
+    """Resolve the canonical pairing ID for one normalized tool call.
+
+    For Mantle responses, an indexed pairing ID (``call_0`` / ``fc_1``) is
+    reminted into a session-safe surrogate. The primary identity input is
+    the caller Request Scope; when absent, one ingestion scope is generated
+    and a single diagnostic warning is emitted. Non-Mantle endpoints and IDs
+    outside the indexed grammar pass through unchanged.
+    """
+    value = call_id.strip() if isinstance(call_id, str) else ""
+    if not is_bedrock_mantle:
+        return call_id
+    if not _MANTLE_INDEXED_CALL_ID_RE.fullmatch(value):
+        return call_id
+
+    resolved_scope = request_scope
+    if not isinstance(resolved_scope, str) or not resolved_scope.strip():
+        global _MANTLE_SCOPE_WARN_EMITTED
+        if not _MANTLE_SCOPE_WARN_EMITTED:
+            logger.warning(
+                "Mantle response normalization received no Request Scope; "
+                "generating an ingestion scope so reminted pairing IDs remain "
+                "distinct across responses. Callers should pass the current "
+                "api_request_id to keep scope derivation explicit.",
+            )
+            _MANTLE_SCOPE_WARN_EMITTED = True
+        resolved_scope = f"ingest-{uuid.uuid4().hex}"
+    if isinstance(provider_response_id, str):
+        provider_response_id = provider_response_id.strip()
+    return _remint_mantle_indexed_call_id(
+        value,
+        request_scope=resolved_scope,
+        provider_response_id=provider_response_id if provider_response_id else "",
+        output_ordinal=output_ordinal,
+    )
+
+
 def _normalize_codex_response(
     response: Any,
     *,
     issuer_kind: Optional[str] = None,
+    is_bedrock_mantle: bool = False,
+    request_scope: Optional[str] = None,
 ) -> tuple[Any, str]:
     """Normalize a Responses API object to an assistant_message-like object.
 
@@ -1258,6 +1371,14 @@ def _normalize_codex_response(
     response yields, so future replays can detect when the active endpoint
     differs from the one that minted the encrypted_content blob and drop
     the item instead of triggering HTTP 400 invalid_encrypted_content.
+
+    ``is_bedrock_mantle`` enables Issue #75471 reminting: Mantle-issued
+    response-local indexed pairing IDs (``call_0`` / ``fc_1``) are replaced
+    with a session-safe surrogate before the value enters canonical history.
+    ``request_scope`` is the caller's per-request identity used as the
+    primary remint seed; when omitted, one ingestion scope is generated and
+    a diagnostic warning is emitted (the generated pairing ID then persists
+    in Durable History and stays stable on replay).
     """
     response_status = getattr(response, "status", None)
     if isinstance(response_status, str):
@@ -1464,7 +1585,13 @@ def _normalize_codex_response(
             call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id.strip() else embedded_call_id
             if not isinstance(call_id, str) or not call_id.strip():
                 call_id = _deterministic_call_id(fn_name, arguments, len(tool_calls))
-            call_id = call_id.strip()
+            call_id = _resolve_mantle_pairing_call_id(
+                call_id.strip(),
+                is_bedrock_mantle=is_bedrock_mantle,
+                request_scope=request_scope,
+                provider_response_id=getattr(response, "id", ""),
+                output_ordinal=len(tool_calls),
+            )
             response_item_id = raw_item_id if isinstance(raw_item_id, str) else None
             response_item_id = _derive_responses_function_call_id(call_id, response_item_id)
             tool_calls.append(SimpleNamespace(
@@ -1485,7 +1612,13 @@ def _normalize_codex_response(
             call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id.strip() else embedded_call_id
             if not isinstance(call_id, str) or not call_id.strip():
                 call_id = _deterministic_call_id(fn_name, arguments, len(tool_calls))
-            call_id = call_id.strip()
+            call_id = _resolve_mantle_pairing_call_id(
+                call_id.strip(),
+                is_bedrock_mantle=is_bedrock_mantle,
+                request_scope=request_scope,
+                provider_response_id=getattr(response, "id", ""),
+                output_ordinal=len(tool_calls),
+            )
             response_item_id = raw_item_id if isinstance(raw_item_id, str) else None
             response_item_id = _derive_responses_function_call_id(call_id, response_item_id)
             tool_calls.append(SimpleNamespace(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2523,6 +2523,7 @@ def run_conversation(
                         allow_stream=False,
                         is_github_responses=agent._is_copilot_url(),
                         sanitize_harmony_tokens=agent._is_codex_backend(),
+                        base_url=agent.base_url,
                     )
                 # Copilot x-initiator: the first API call of a user turn is
                 # marked "user" so Copilot bills a premium request; tool-loop
@@ -2683,6 +2684,7 @@ def run_conversation(
                             allow_stream=False,
                             is_github_responses=agent._is_copilot_url(),
                             sanitize_harmony_tokens=agent._is_codex_backend(),
+                            base_url=agent.base_url,
                         )
                     if _use_streaming:
                         return agent._interruptible_streaming_api_call(
@@ -6075,6 +6077,12 @@ def run_conversation(
             _normalize_kwargs = {}
             if agent.api_mode == "anthropic_messages":
                 _normalize_kwargs["strip_tool_prefix"] = agent._is_anthropic_oauth
+            elif agent.api_mode == "codex_responses":
+                # Mantle response normalization needs the endpoint URL for
+                # capability detection and the current api_request_id as the
+                # remint seed for response-local indexed pairing IDs (#75471).
+                _normalize_kwargs["base_url"] = agent.base_url
+                _normalize_kwargs["request_scope"] = api_request_id
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
             finish_reason = normalized.finish_reason

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -111,21 +111,34 @@ _EXTENDED_PROMPT_CACHE_MODEL_RE = re.compile(
 )
 
 
-def _default_prompt_cache_retention_for_request(
-    model: str,
-    base_url: Any,
-) -> Optional[str]:
-    """Return ``24h`` for supported models on Amazon Bedrock Mantle."""
+def _is_bedrock_mantle_base_url(base_url: Any) -> bool:
+    """Return True when ``base_url`` targets an Amazon Bedrock Mantle endpoint.
+
+    Matches the exact hostname family ``bedrock-mantle.<region>.api.aws`` with
+    exactly four labels, a non-empty region label, and the ``api.aws`` suffix.
+    ``base_url_hostname`` already lowercases and strips a trailing DNS dot, so
+    uppercase hostnames and trailing dots normalize correctly; ports, paths,
+    queries, and fragments never reach the hostname. Look-alike hosts such as
+    ``bedrock-mantle.us-west-2.api.aws.example`` or a Mantle string buried in
+    a path stay classified as general Responses endpoints.
+    """
     from utils import base_url_hostname
 
     hostname_parts = base_url_hostname(str(base_url or "")).split(".")
-    is_bedrock_mantle = (
+    return (
         len(hostname_parts) == 4
         and hostname_parts[0] == "bedrock-mantle"
         and bool(hostname_parts[1])
         and hostname_parts[2:] == ["api", "aws"]
     )
-    if not is_bedrock_mantle:
+
+
+def _default_prompt_cache_retention_for_request(
+    model: str,
+    base_url: Any,
+) -> Optional[str]:
+    """Return ``24h`` for supported models on Amazon Bedrock Mantle."""
+    if not _is_bedrock_mantle_base_url(base_url):
         return None
 
     normalized = str(model or "").strip().lower().replace("_", "-")
@@ -268,9 +281,18 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
+        # Bedrock Mantle accepts replayed encrypted reasoning but degrades
+        # the model (hidden-reasoning-only turns, repeated tool calls, leaked
+        # tool-call scaffolding — Issue #75471). The HTTP 400
+        # ``invalid_encrypted_content`` recovery switch cannot catch
+        # accepted-but-degraded responses, so decide the capability here.
+        # The effective switch controls both history conversion and the
+        # encrypted-content include value; the reasoning effort object stays
+        # when reasoning is enabled.
+        is_bedrock_mantle = _is_bedrock_mantle_base_url(params.get("base_url"))
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
-        )
+        ) and not is_bedrock_mantle
         # Native server-side compaction (gpt-5.6 on direct OpenAI/Codex routes
         # only). The caller resolves eligibility via
         # agent.native_compaction.native_compaction_context_management();
@@ -541,7 +563,16 @@ class ResponsesApiTransport(ProviderTransport):
         return kwargs
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
-        """Normalize Codex Responses API response to NormalizedResponse."""
+        """Normalize Codex Responses API response to NormalizedResponse.
+
+        kwargs:
+            issuer_kind: str | None — explicit endpoint issuer (falls back to
+                the stash from the matching build_kwargs/convert_messages call)
+            base_url: str | None — endpoint URL used for Mantle capability
+                detection (Issue #75471 reminting)
+            request_scope: str | None — caller per-request identity used as
+                the primary remint seed for Mantle indexed pairing IDs
+        """
         from agent.codex_responses_adapter import (
             _normalize_codex_response,
         )
@@ -551,8 +582,15 @@ class ResponsesApiTransport(ProviderTransport):
         # call. Either way it gets stamped onto reasoning items so future
         # turns can detect a model swap and drop foreign-issuer blobs.
         issuer_kind = kwargs.get("issuer_kind") or self._last_issuer_kind
+        base_url = kwargs.get("base_url")
+        request_scope = kwargs.get("request_scope")
         # _normalize_codex_response returns (SimpleNamespace, finish_reason_str)
-        msg, finish_reason = _normalize_codex_response(response, issuer_kind=issuer_kind)
+        msg, finish_reason = _normalize_codex_response(
+            response,
+            issuer_kind=issuer_kind,
+            is_bedrock_mantle=_is_bedrock_mantle_base_url(base_url),
+            request_scope=request_scope,
+        )
 
         tool_calls = None
         if msg and msg.tool_calls:
@@ -626,12 +664,16 @@ class ResponsesApiTransport(ProviderTransport):
         allow_stream: bool = False,
         is_github_responses: bool = False,
         sanitize_harmony_tokens: bool = False,
+        base_url: Any = None,
     ) -> dict:
         """Validate and sanitize Codex API kwargs before the call.
 
         Normalizes input items, strips unsupported fields, validates structure.
         ``sanitize_harmony_tokens`` is enabled only for the ChatGPT Codex
         backend, which rejects literal reserved Harmony wire tokens in text.
+        ``base_url`` enables the Mantle reasoning gate (Issue #75471): the
+        final preflight removes override-injected encrypted reasoning items
+        and the ``reasoning.encrypted_content`` include value for Mantle.
         """
         from agent.codex_responses_adapter import _preflight_codex_api_kwargs
 
@@ -640,6 +682,7 @@ class ResponsesApiTransport(ProviderTransport):
             allow_stream=allow_stream,
             is_github_responses=is_github_responses,
             sanitize_harmony_tokens=sanitize_harmony_tokens,
+            allow_encrypted_reasoning_replay=not _is_bedrock_mantle_base_url(base_url),
         )
         if "prompt_cache_key" in normalized:
             bounded = _bounded_prompt_cache_key(normalized["prompt_cache_key"])

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3067,6 +3067,99 @@ class TestCodexAdapterGithubResponsesMessageIdDrop:
         assert message_item["id"] == "msg_short_but_connection_scoped"
 
 
+class TestCodexAdapterMantleReasoningGate:
+    """_CodexCompletionsAdapter must suppress historical encrypted reasoning
+    replay and the ``reasoning.encrypted_content`` include value when
+    targeting Bedrock Mantle (Issue #75471). Auxiliary calls (context
+    compression, flush_memories, MoA aggregation) route through this adapter
+    instead of agent/transports/codex.py, so they need the same gate applied
+    independently — Mantle accepts replayed encrypted reasoning but degrades
+    the model (hidden-reasoning-only turns, repeated tool calls).
+    """
+
+    @staticmethod
+    def _build_adapter(base_url):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+        from types import SimpleNamespace
+
+        message_item = SimpleNamespace(
+            type="message", role="assistant", status="completed",
+            content=[SimpleNamespace(type="output_text", text="hi")],
+        )
+        events = [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    status="completed", id="resp_test",
+                    usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+                ),
+            ),
+        ]
+
+        class _FakeCreateStream:
+            def __iter__(self): return iter(events)
+            def close(self): pass
+
+        captured_kwargs = {}
+
+        def _create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _FakeCreateStream()
+
+        real_client = MagicMock()
+        real_client.base_url = base_url
+        real_client.responses.create = _create
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.6")
+        return adapter, captured_kwargs
+
+    @staticmethod
+    def _reasoning_messages():
+        return [
+            {"role": "system", "content": "You are helpful."},
+            {
+                "role": "assistant",
+                "content": "thinking",
+                "codex_reasoning_items": [
+                    {"type": "reasoning", "encrypted_content": "opaque-blob", "summary": []},
+                ],
+            },
+            {"role": "user", "content": "continue"},
+        ]
+
+    def test_mantle_suppresses_historical_reasoning_and_include(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://bedrock-mantle.us-west-2.api.aws/v1"
+        )
+        adapter.create(
+            messages=self._reasoning_messages(),
+            extra_body={"reasoning": {"effort": "high", "enabled": True}},
+        )
+        reasoning_input = [
+            item for item in captured["input"] if item.get("type") == "reasoning"
+        ]
+        assert reasoning_input == []
+        assert "reasoning.encrypted_content" not in (captured.get("include") or [])
+        # Visible messages remain and reasoning effort is preserved.
+        assert captured["reasoning"] == {"effort": "high", "summary": "auto"}
+        assert any("continue" in str(item) for item in captured["input"])
+
+    def test_non_mantle_replays_reasoning_and_requests_encrypted_content(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://chatgpt.com/backend-api/codex"
+        )
+        adapter.create(
+            messages=self._reasoning_messages(),
+            extra_body={"reasoning": {"effort": "high", "enabled": True}},
+        )
+        reasoning_input = [
+            item for item in captured["input"] if item.get("type") == "reasoning"
+        ]
+        assert len(reasoning_input) == 1
+        assert captured.get("include") == ["reasoning.encrypted_content"]
+
+
 class TestVisionAutoSkipsKimiCoding:
     """_resolve_auto vision branch skips providers that have no vision on
     their main endpoint (e.g. Kimi Coding Plan /coding) and falls through

--- a/tests/agent/test_bedrock_mantle_responses.py
+++ b/tests/agent/test_bedrock_mantle_responses.py
@@ -1,0 +1,416 @@
+"""Regression tests for Bedrock Mantle multi-turn stability (Issue #75471).
+
+Two provider-scoped defects on the Mantle Responses endpoint:
+
+1. Mantle reuses response-local indexed pairing IDs (``call_0``) across
+   responses. Hermes stores them verbatim, so the pre-call duplicate
+   sanitizer drops later call/result pairs and freezes the tool trajectory.
+
+2. Mantle accepts replayed ``encrypted_content`` reasoning items but
+   degrades the model (hidden-reasoning-only turns, repeated tool calls,
+   leaked tool-call scaffolding). The HTTP 400 ``invalid_encrypted_content``
+   recovery switch cannot catch accepted-but-degraded responses, so the
+   capability must be decided before dispatch.
+
+These tests pin the strict repair boundary: remint indexed pairing IDs at
+Mantle response ingestion, suppress encrypted reasoning replay at history
+conversion and final preflight, and preserve every non-Mantle contract.
+"""
+
+import re
+from types import SimpleNamespace
+
+import pytest
+
+from agent.agent_runtime_helpers import sanitize_api_messages
+from agent.chat_completion_helpers import build_assistant_message
+from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
+    _preflight_codex_api_kwargs,
+    _preflight_codex_input_items,
+)
+from agent.transports import get_transport
+
+MANTLE_URL = "https://bedrock-mantle.us-west-2.api.aws/v1"
+
+
+@pytest.fixture
+def transport():
+    import agent.transports.codex  # noqa: F401
+    return get_transport("codex_responses")
+
+
+def _mantle_response(call_id: str = "call_0", item_id: str = "fc_1", name: str = "terminal", arguments: str = "{}"):
+    return SimpleNamespace(
+        status="completed",
+        id="resp_mantle",
+        output=[
+            SimpleNamespace(
+                type="function_call",
+                id=item_id,
+                call_id=call_id,
+                name=name,
+                arguments=arguments,
+            )
+        ],
+    )
+
+
+class _StubAgent:
+    """Minimal agent stub for ``build_assistant_message`` (Issue #75471)."""
+
+    verbose_logging = False
+    reasoning_callback = None
+    stream_delta_callback = None
+    _stream_callback = None
+
+    @staticmethod
+    def _extract_reasoning(assistant_message):
+        return getattr(assistant_message, "reasoning", None)
+
+    @staticmethod
+    def _needs_thinking_reasoning_pad():
+        return False
+
+    @staticmethod
+    def _strip_think_blocks(content):
+        return content
+
+    @staticmethod
+    def _split_responses_tool_id(raw_id):
+        from agent.codex_responses_adapter import _split_responses_tool_id
+        return _split_responses_tool_id(raw_id)
+
+    @staticmethod
+    def _derive_responses_function_call_id(call_id, response_item_id=None):
+        from agent.codex_responses_adapter import _derive_responses_function_call_id
+        return _derive_responses_function_call_id(call_id, response_item_id)
+
+    @staticmethod
+    def _deterministic_call_id(fn_name, arguments, index=0):
+        from agent.codex_responses_adapter import _deterministic_call_id
+        return _deterministic_call_id(fn_name, arguments, index)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint predicate (Requirement 1)
+# ---------------------------------------------------------------------------
+
+
+def _mantle_predicate():
+    from agent.transports.codex import _is_bedrock_mantle_base_url
+    return _is_bedrock_mantle_base_url
+
+
+def test_mantle_predicate_positive_matches():
+    predicate = _mantle_predicate()
+    for base_url in (
+        "https://bedrock-mantle.us-west-2.api.aws/v1",
+        "https://bedrock-mantle.eu-central-1.api.aws",
+        "https://bedrock-mantle.ap-southeast-2.api.aws/responses",
+    ):
+        assert predicate(base_url) is True, base_url
+
+
+def test_mantle_predicate_ignores_port_path_query_fragment_case_trailing_dot():
+    predicate = _mantle_predicate()
+    assert predicate("https://bedrock-mantle.us-west-2.api.aws:8443/v1") is True
+    assert predicate("BEDROCK-MANTLE.US-WEST-2.API.AWS/v1") is True
+    assert predicate("https://bedrock-mantle.us-west-2.api.aws./v1") is True
+    assert predicate("https://bedrock-mantle.us-west-2.api.aws/v1?x=1#frag") is True
+
+
+def test_mantle_predicate_rejects_lookalikes():
+    predicate = _mantle_predicate()
+    for base_url in (
+        "https://api.openai.com/v1",
+        "https://bedrock-mantle..api.aws/v1",
+        "https://bedrock-mantle.api.aws/v1",
+        "https://bedrock-mantle.us-west-2.api.aws.example/v1",
+        "https://example.com/bedrock-mantle.us-west-2.api.aws/v1",
+        "https://bedrock-mantle.us-west-2.example.com/v1",
+        "https://my-bedrock-mantle.us-west-2.api.aws/v1",
+        "https://us-west-2.bedrock-mantle.api.aws/v1",
+    ):
+        assert predicate(base_url) is False, base_url
+
+
+def test_mantle_predicate_empty_and_invalid_inputs():
+    predicate = _mantle_predicate()
+    assert predicate(None) is False
+    assert predicate("") is False
+    assert predicate("not a url") is False
+
+
+# ---------------------------------------------------------------------------
+# Remint unit tests (Requirement 2 / Requirement 3)
+# ---------------------------------------------------------------------------
+
+
+def _remint(*args, **kwargs):
+    from agent.codex_responses_adapter import _remint_mantle_indexed_call_id
+    return _remint_mantle_indexed_call_id(*args, **kwargs)
+
+
+@pytest.mark.parametrize("raw_call_id", ["call_0", "call_999999", "fc_1"])
+def test_remint_indexed_ids_produce_mantle_surrogate(raw_call_id):
+    reminted = _remint(
+        raw_call_id,
+        request_scope="req-scope-1",
+        provider_response_id="resp_mantle",
+        output_ordinal=0,
+    )
+    assert reminted.startswith("call_mtl_")
+    assert len(reminted) <= 64
+    assert re.fullmatch(r"call_mtl_[0-9a-f]{40}", reminted), reminted
+
+
+def test_remint_ignores_outside_indexed_grammar():
+    for raw_call_id in ("call_1000000", "call_ab", "fc_", "call_", "msg_abc", "call_mtl_x"):
+        assert _remint(
+            raw_call_id,
+            request_scope="req-scope-1",
+            provider_response_id="resp_mantle",
+            output_ordinal=0,
+        ) == raw_call_id
+
+
+def test_remint_same_input_produces_same_output():
+    a = _remint("call_0", request_scope="scope", provider_response_id="resp", output_ordinal=0)
+    b = _remint("call_0", request_scope="scope", provider_response_id="resp", output_ordinal=0)
+    assert a == b
+
+
+def test_remint_distinct_scopes_produce_distinct_output():
+    a = _remint("call_0", request_scope="scope-1", provider_response_id="resp", output_ordinal=0)
+    b = _remint("call_0", request_scope="scope-2", provider_response_id="resp", output_ordinal=0)
+    assert a != b
+
+
+def test_remint_scope_separates_even_when_response_id_repeats():
+    a = _remint("call_0", request_scope="scope-1", provider_response_id="same", output_ordinal=0)
+    b = _remint("call_0", request_scope="scope-2", provider_response_id="same", output_ordinal=0)
+    assert a != b
+
+
+def test_remint_ordinal_distinguishes_malformed_duplicates_in_one_response():
+    a = _remint("call_0", request_scope="scope", provider_response_id="resp", output_ordinal=0)
+    b = _remint("call_0", request_scope="scope", provider_response_id="resp", output_ordinal=1)
+    assert a != b
+
+
+def test_remint_missing_or_blank_response_id_keeps_scope_separation():
+    a = _remint("call_0", request_scope="scope", provider_response_id="", output_ordinal=0)
+    b = _remint("call_0", request_scope="scope-2", provider_response_id="", output_ordinal=0)
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn round-trip through the real chain (Requirement 4)
+# ---------------------------------------------------------------------------
+
+
+def test_mantle_multiturn_preserves_both_call_result_pairs(transport):
+    """Two Mantle responses each reusing ``call_0`` must survive
+    normalization, assistant-message building, pre-call sanitization, and
+    Responses serialization with BOTH call/result pairs intact.
+
+    Pre-fix: both normalize to ``call_0``, the sanitizer drops the later
+    pair, and only one call/output survives. Post-fix: the reminted pairing
+    keys are distinct, so both pairs replay.
+    """
+    result_a = transport.normalize_response(
+        _mantle_response(call_id="call_0", item_id="fc_1", name="terminal", arguments="{}"),
+        base_url=MANTLE_URL,
+        request_scope="scope-a",
+    )
+    result_b = transport.normalize_response(
+        _mantle_response(call_id="call_0", item_id="fc_1", name="read_file", arguments="{}"),
+        base_url=MANTLE_URL,
+        request_scope="scope-b",
+    )
+
+    stub = _StubAgent()
+    msg_a = build_assistant_message(stub, result_a, result_a.finish_reason)
+    msg_b = build_assistant_message(stub, result_b, result_b.finish_reason)
+
+    call_a = msg_a["tool_calls"][0]
+    call_b = msg_b["tool_calls"][0]
+
+    history = [
+        {"role": "user", "content": "task A"},
+        msg_a,
+        {"role": "tool", "tool_call_id": call_a["id"], "content": "result A"},
+        {"role": "user", "content": "task B"},
+        msg_b,
+        {"role": "tool", "tool_call_id": call_b["id"], "content": "result B"},
+    ]
+
+    sanitized = sanitize_api_messages(history)
+
+    assistant_calls = [
+        m["tool_calls"][0]["id"]
+        for m in sanitized
+        if m.get("role") == "assistant" and m.get("tool_calls")
+    ]
+    result_ids = [m["tool_call_id"] for m in sanitized if m.get("role") == "tool"]
+
+    assert len(assistant_calls) == 2
+    assert len(result_ids) == 2
+    assert set(assistant_calls) == set(result_ids)
+
+    items = _chat_messages_to_responses_input(sanitized)
+    function_calls = [i for i in items if i.get("type") == "function_call"]
+    function_outputs = [i for i in items if i.get("type") == "function_call_output"]
+
+    assert len(function_calls) == 2
+    assert len(function_outputs) == 2
+    assert {i["call_id"] for i in function_calls} == {i["call_id"] for i in function_outputs}
+
+
+def test_mantle_normalized_tool_call_preserves_response_item_id(transport):
+    """A valid non-empty ``fc_*`` provider item id survives reminting as
+    ``response_item_id``; the canonical pairing key is the surrogate."""
+    result = transport.normalize_response(
+        _mantle_response(call_id="call_0", item_id="fc_1", name="terminal", arguments="{}"),
+        base_url=MANTLE_URL,
+        request_scope="scope-a",
+    )
+    tc = result.tool_calls[0]
+    assert tc.call_id.startswith("call_mtl_")
+    assert tc.call_id != "call_0"
+    assert tc.response_item_id == "fc_1"
+
+
+def test_non_mantle_response_keeps_indexed_call_id(transport):
+    """A generic relay or OpenAI-style endpoint supplying ``call_0`` must
+    keep the provider ID untouched (Requirement 7)."""
+    result = transport.normalize_response(
+        _mantle_response(call_id="call_0", item_id="fc_1", name="terminal", arguments="{}"),
+        base_url="https://responses.example.com/v1",
+    )
+    tc = result.tool_calls[0]
+    assert tc.call_id == "call_0"
+
+
+def test_sanitizer_still_cleans_damaged_duplicate_pairing_ids(transport):
+    """The generic duplicate-defense must remain active for genuinely
+    damaged history that already contains raw duplicate pairing IDs."""
+    history = [
+        {"role": "user", "content": "task"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_x", "call_id": "call_x", "response_item_id": "fc_1",
+                "type": "function",
+                "function": {"name": "a", "arguments": "{}"},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_x", "content": "A"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_x", "call_id": "call_x", "response_item_id": "fc_1",
+                "type": "function",
+                "function": {"name": "b", "arguments": "{}"},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_x", "content": "B"},
+    ]
+    sanitized = sanitize_api_messages(history)
+    calls = [m for m in sanitized if m.get("role") == "assistant" and m.get("tool_calls")]
+    results = [m for m in sanitized if m.get("role") == "tool"]
+    assert len(calls) == 1
+    assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Encrypted reasoning gate (Requirement 5)
+# ---------------------------------------------------------------------------
+
+
+def _reasoning_history():
+    return [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "thinking",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "opaque-blob", "summary": []},
+            ],
+        },
+        {"role": "user", "content": "follow up"},
+    ]
+
+
+def test_mantle_request_omits_historical_encrypted_reasoning(transport):
+    kw = transport.build_kwargs(
+        model="gpt-5.6",
+        messages=_reasoning_history(),
+        tools=[],
+        base_url=MANTLE_URL,
+        reasoning_config={"effort": "high", "enabled": True},
+    )
+    reasoning_input = [i for i in kw["input"] if i.get("type") == "reasoning"]
+    include = kw.get("include") or []
+    assert reasoning_input == []
+    assert "reasoning.encrypted_content" not in include
+    # Visible context and reasoning effort are preserved.
+    assert kw["reasoning"]["effort"] == "high"
+    assert any("follow up" in str(i) for i in kw["input"])
+
+
+def test_openai_codex_request_keeps_reasoning_replay(transport):
+    kw = transport.build_kwargs(
+        model="gpt-5.6",
+        messages=_reasoning_history(),
+        tools=[],
+        base_url="https://chatgpt.com/backend-api/codex",
+        reasoning_config={"effort": "high", "enabled": True},
+    )
+    reasoning_input = [i for i in kw["input"] if i.get("type") == "reasoning"]
+    include = kw.get("include") or []
+    assert len(reasoning_input) == 1
+    assert "reasoning.encrypted_content" in include
+
+
+def test_mantle_preflight_filters_override_injected_reasoning(transport):
+    """request_overrides merge after history conversion; the final preflight
+    boundary must remove injected reasoning and the encrypted include value
+    while preserving other include values (Requirement 5.5 / 5.6)."""
+    api_kwargs = {
+        "model": "gpt-5.6",
+        "instructions": "You are Hermes.",
+        "store": False,
+        "input": [
+            {"role": "user", "content": "hi"},
+            {"type": "reasoning", "encrypted_content": "injected", "summary": []},
+        ],
+        "include": ["reasoning.encrypted_content", "reasoning.summary_text"],
+    }
+    normalized = transport.preflight_kwargs(api_kwargs, base_url=MANTLE_URL)
+    assert not [i for i in normalized["input"] if i.get("type") == "reasoning"]
+    assert "reasoning.encrypted_content" not in (normalized.get("include") or [])
+    assert "reasoning.summary_text" in (normalized.get("include") or [])
+    # Visible assistant/user content stays.
+    assert normalized["input"][0]["role"] == "user"
+
+
+def test_non_mantle_preflight_keeps_override_reasoning(transport):
+    api_kwargs = {
+        "model": "gpt-5.6",
+        "instructions": "You are Hermes.",
+        "store": False,
+        "input": [
+            {"role": "user", "content": "hi"},
+            {"type": "reasoning", "encrypted_content": "injected", "summary": []},
+        ],
+        "include": ["reasoning.encrypted_content", "reasoning.summary_text"],
+    }
+    normalized = transport.preflight_kwargs(
+        api_kwargs, base_url="https://chatgpt.com/backend-api/codex"
+    )
+    assert len([i for i in normalized["input"] if i.get("type") == "reasoning"]) == 1
+    assert "reasoning.encrypted_content" in (normalized.get("include") or [])

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -418,7 +418,7 @@ class TestCodexBuildKwargs:
 
         monkeypatch.setattr(
             "agent.codex_responses_adapter._normalize_codex_response",
-            lambda resp, issuer_kind=None: (msg, "tool_calls"),
+            lambda resp, **kwargs: (msg, "tool_calls"),
         )
         normalized = transport.normalize_response(response)
 


### PR DESCRIPTION
## What does this PR do?

Stabilizes multi-turn Bedrock Mantle Responses sessions in two places:

- Remints Mantle's short indexed pairing IDs such as `call_0` and `fc_12` into request-scoped IDs before they enter conversation history. This prevents later rounds from colliding with earlier tool-call pairs.
- Suppresses encrypted reasoning replay for Mantle at both history conversion and final request preflight boundaries. Visible messages, tool calls, tool outputs, and reasoning effort remain available.

The endpoint detection and behavior changes are scoped to `bedrock-mantle.<region>.api.aws`. Existing Responses relay behavior is preserved for other providers.

## Related Issue

Fixes #75471

## Type of Change

- [x] Bug fix

## Changes Made

- Added a shared Bedrock Mantle endpoint predicate in `agent/transports/codex.py`.
- Added deterministic request-scoped reminting for Mantle indexed call IDs in `agent/codex_responses_adapter.py`.
- Propagated endpoint and request-scope context through `agent/conversation_loop.py`.
- Added encrypted-reasoning gates for main and auxiliary Mantle requests.
- Added regression coverage for endpoint matching, ID reminting, multi-round pairing, provider isolation, sanitizer behavior, and reasoning replay.

## How to Test

1. Run the focused regression suite:

   ```bash
   scripts/run_tests.sh tests/agent/test_bedrock_mantle_responses.py tests/agent/test_auxiliary_client.py tests/agent/test_codex_responses_adapter.py tests/agent/test_message_sanitization_policy.py tests/run_agent/test_run_agent_codex_responses.py -q
   ```

2. Confirm all 271 focused tests pass.

3. Run Ruff and whitespace validation:

   ```bash
   ruff check agent/ tests/agent/ tests/run_agent/
   git diff --check origin/main...HEAD
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing PRs for duplicates.
- [x] My PR contains only changes related to this fix.
- [ ] I've run the complete test suite and all tests pass. The complete suite has environment-dependent failures in existing `tests/tools/`, `tests/tui_gateway/`, and unrelated `tests/agent/` tests; representative failures reproduce on the unmodified base commit.
- [x] I've added tests for the changes.
- [x] I've tested in the Linux development environment.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration changes.
- [x] `cli-config.yaml.example` update: N/A; no configuration keys changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A; no project workflow changed.
- [x] Cross-platform impact considered; the implementation uses provider metadata and standard-library hashing only.
- [x] Tool schema update: N/A; tool behavior and schemas are unchanged.

## Screenshots / Logs

```text
=== Summary: 5 files, 271 tests passed, 0 failed (100% complete) ===
All checks passed!
```
