### PR TITLE
fix(docker): make the ddgs install survive container restarts

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -784,17 +784,72 @@ def _pip_install(
     ``[sys.executable, '-m', 'pip', 'install', ...]`` failed with
     ``No module named pip`` on every fresh install. uv-first sidesteps that.
 
+    Install *location* follows the same rule as the lazy-dep installer (see
+    ``tools.lazy_deps.durable_target_plan``): normally the active venv, but on
+    an immutable deployment (the Docker image seals ``/opt/hermes`` and sets
+    ``HERMES_LAZY_INSTALL_TARGET``) the packages go to the writable data
+    volume instead. Without that redirect a post-setup install either fails
+    outright (venv not writable by the runtime user) or lands in the
+    container's ephemeral layer and vanishes on the next recreate — which is
+    why users had to re-run ``hermes tools post-setup ddgs`` after every
+    ``docker compose up``.
+
     Returns the ``subprocess.CompletedProcess`` from whichever tier succeeded
     (or the last failure for the caller to inspect).
     """
+    try:
+        from tools.lazy_deps import durable_target_plan
+    except Exception:  # pragma: no cover - defensive; lazy_deps is in-tree
+        from contextlib import nullcontext
+        plan_ctx = nullcontext(None)
+    else:
+        plan_ctx = durable_target_plan()
+
+    with plan_ctx as plan:
+        target = getattr(plan, "target", None)
+        extra_args = list(getattr(plan, "args", []) or [])
+        plan_error = getattr(plan, "error", None)
+        if plan_error:
+            return subprocess.CompletedProcess(
+                ["uv", "pip", "install", *args], returncode=1, stdout="",
+                stderr=plan_error,
+            )
+        return _pip_install_with_args(
+            args, extra_args, target,
+            timeout=timeout, capture_output=capture_output,
+        )
+
+
+def _activate_install_target(target) -> None:
+    """Put a durable install target on ``sys.path`` after a successful install."""
+    if target is None:
+        return
+    try:
+        from tools.lazy_deps import activate_durable_lazy_target
+
+        activate_durable_lazy_target()
+    except Exception:  # pragma: no cover - activation is best-effort
+        pass
+
+
+def _pip_install_with_args(
+    args: List[str],
+    extra_args: List[str],
+    target,
+    *,
+    timeout: int,
+    capture_output: bool,
+):
+    """Run the uv → pip → ensurepip ladder with pre-resolved routing args."""
     venv_root = Path(sys.executable).parent.parent
     uv_env = {**os.environ, "VIRTUAL_ENV": str(venv_root)}
 
+    uv_error = ""
     uv_bin = shutil.which("uv")
     if uv_bin:
         try:
             result = subprocess.run(
-                [uv_bin, "pip", "install", *args],
+                [uv_bin, "pip", "install", *extra_args, *args],
                 capture_output=capture_output, text=True, encoding="utf-8", errors="replace", timeout=timeout,
                 env=uv_env,
                 creationflags=_post_setup_no_window_flags(
@@ -802,11 +857,16 @@ def _pip_install(
                 ),
             )
             if result.returncode == 0:
+                _activate_install_target(target)
                 return result
             # Fall through to pip — uv may have failed for an unrelated reason
-            # (resolution conflict, network), and pip might handle it.
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            # (resolution conflict, network), and pip might handle it. Keep
+            # uv's error: if the pip tier also fails, reporting only "pip not
+            # available" hides the real cause on hosts where uv is the
+            # installer that actually matters.
+            uv_error = (result.stderr or result.stdout or "").strip()
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            uv_error = f"uv pip install failed: {e}"
 
     pip_cmd = [sys.executable, "-m", "pip"]
     try:
@@ -827,18 +887,29 @@ def _pip_install(
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             # Synthesize a result so callers see a clean failure path.
+            from tools.lazy_deps import combine_install_errors
+
             return subprocess.CompletedProcess(
                 pip_cmd, returncode=1, stdout="",
-                stderr=f"pip not available and ensurepip failed: {e}",
+                stderr=combine_install_errors(
+                    uv_error, f"pip not available and ensurepip failed: {e}"
+                ),
             )
 
-    return subprocess.run(
-        pip_cmd + ["install", *args],
+    result = subprocess.run(
+        pip_cmd + ["install", *extra_args, *args],
         capture_output=capture_output, text=True, encoding="utf-8", errors="replace", timeout=timeout,
         creationflags=_post_setup_no_window_flags(
             streams_to_console=not capture_output
         ),
     )
+    if result.returncode == 0:
+        _activate_install_target(target)
+    elif uv_error and capture_output:
+        from tools.lazy_deps import combine_install_errors
+
+        result.stderr = combine_install_errors(uv_error, (result.stderr or "").strip())
+    return result
 
 
 
@@ -1831,24 +1902,44 @@ def _run_post_setup(post_setup_key: str):
         _print_info("    Switch voices by setting tts.piper.voice in ~/.hermes/config.yaml")
 
     elif post_setup_key == "ddgs":
+        # Routed through lazy_deps (not a raw pip call) for two reasons:
+        #   1. The version pin lives in ONE place (LAZY_DEPS["search.ddgs"]),
+        #      so the runtime self-heal in plugins/web/ddgs never fights this
+        #      hook by re-installing a different version.
+        #   2. On the published Docker image the agent venv is sealed and
+        #      thrown away on every `docker compose up`; lazy_deps redirects
+        #      the install to the durable data volume so it survives restarts.
         try:
-            __import__("ddgs")
+            from tools.lazy_deps import (
+                FeatureUnavailable,
+                _lazy_install_target,
+                ensure as _lazy_ensure,
+                is_available as _lazy_is_available,
+            )
+        except Exception as exc:  # pragma: no cover - lazy_deps is in-tree
+            _print_warning(f"    Could not load the installer: {exc}")
+            _print_info("    Run manually: uv pip install -U ddgs")
+            return
+
+        if _lazy_is_available("search.ddgs"):
             _print_success("    ddgs is already installed")
-        except ImportError:
+        else:
             _print_info("    Installing ddgs (DuckDuckGo search package)...")
             try:
-                result = _pip_install(["-U", "ddgs", "--quiet"], timeout=300)
-                if result.returncode == 0:
-                    _print_success("    ddgs installed")
-                else:
-                    _print_warning("    ddgs install failed:")
-                    _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                    _print_info("    Run manually: uv pip install -U ddgs")
-                    return
-            except subprocess.TimeoutExpired:
-                _print_warning("    ddgs install timed out (>5min)")
+                _lazy_ensure("search.ddgs", prompt=False)
+            except FeatureUnavailable as exc:
+                _print_warning("    ddgs install failed:")
+                _print_info(f"      {str(exc).strip()[:300]}")
                 _print_info("    Run manually: uv pip install -U ddgs")
                 return
+            except Exception as exc:  # noqa: BLE001 - never crash the wizard
+                _print_warning(f"    ddgs install failed: {str(exc)[:300]}")
+                _print_info("    Run manually: uv pip install -U ddgs")
+                return
+            _print_success("    ddgs installed")
+            target = _lazy_install_target()
+            if target is not None:
+                _print_info(f"    Installed to {target} (persists across restarts)")
         _print_info("    No API key required. DuckDuckGo enforces server-side rate limits.")
         _print_info("    Pair with an extract provider if you also need web_extract.")
 

--- a/plugins/web/ddgs/_search_worker.py
+++ b/plugins/web/ddgs/_search_worker.py
@@ -98,6 +98,19 @@ def main() -> int:
     query = str(request.get("query") or "")
     safe_limit = max(1, int(request.get("safe_limit") or 1))
     try:
+        # On immutable deployments (Docker) the ddgs package lives in the
+        # durable lazy-install store on the data volume, not in the sealed
+        # agent venv. The parent gets that dir onto sys.path via
+        # hermes_bootstrap, but this worker is spawned as a bare script and
+        # imports no entry point — without this call `from ddgs import DDGS`
+        # below fails in the child even though the parent imported it fine.
+        try:
+            from tools.lazy_deps import activate_durable_lazy_target
+
+            activate_durable_lazy_target()
+        except Exception:  # noqa: BLE001 — no-op when unset / not importable
+            pass
+
         # Import inside main so script startup stays light / patchable.
         from plugins.web.ddgs.provider import _run_ddgs_search
 

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -49,6 +49,55 @@ class _SearchInterrupted(Exception):
     """Raised when tools.interrupt.is_interrupted() trips during a search wait."""
 
 
+# Set once we've tried the lazy install in this process, so a genuinely
+# uninstallable ddgs (offline, blocked by security.allow_lazy_installs) costs
+# one attempt per process instead of one per search.
+_install_attempted = False
+
+
+def _ensure_ddgs_installed() -> bool:
+    """Return True when ``ddgs`` is importable, installing it once if needed.
+
+    ddgs is an opt-in backend, so the package can be absent even though the
+    user selected the provider — most often on the Docker image, where the
+    durable package store is wiped whenever a rebuild bumps the interpreter
+    ABI. Rather than telling the user to go run pip, self-heal through
+    :mod:`tools.lazy_deps`, which installs the pinned version to the durable
+    target on immutable deployments and into the venv everywhere else.
+
+    Only runs when the import actually fails: when ddgs is present at some
+    other version we leave it alone instead of churning a reinstall on every
+    search.
+    """
+    global _install_attempted
+
+    try:
+        import ddgs  # type: ignore  # noqa: F401 — availability probe
+
+        return True
+    except ImportError:
+        pass
+
+    if _install_attempted:
+        return False
+    _install_attempted = True
+
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+
+        _lazy_ensure("search.ddgs", prompt=False)
+    except Exception as exc:  # noqa: BLE001 — FeatureUnavailable + import errors
+        logger.warning("ddgs lazy install failed: %s", exc)
+        return False
+
+    try:
+        import ddgs  # type: ignore  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def _run_ddgs_search(query: str, safe_limit: int) -> list[dict[str, Any]]:
     """Run the blocking ddgs query and return normalized hits.
 
@@ -307,12 +356,13 @@ class DDGSWebSearchProvider(WebSearchProvider):
         a hard wall-clock timeout (``_SEARCH_TIMEOUT_SECS``) so a hung native
         ``primp`` call cannot freeze the Hermes process (#36776, #68096).
         """
-        try:
-            import ddgs  # type: ignore  # noqa: F401 — availability probe
-        except ImportError:
+        if not _ensure_ddgs_installed():
             return {
                 "success": False,
-                "error": "ddgs package is not installed — run `pip install ddgs`",
+                "error": (
+                    "ddgs package is not installed — run "
+                    "`hermes tools post-setup ddgs`"
+                ),
             }
 
         # DDGS().text yields at most `max_results` items; we cap defensively

--- a/tests/hermes_cli/test_post_setup_install_routing.py
+++ b/tests/hermes_cli/test_post_setup_install_routing.py
@@ -1,0 +1,158 @@
+"""Post-setup installs must survive an immutable-image container restart.
+
+Reported symptom: on the published Docker image every ``docker compose``
+restart lost the ``ddgs`` package, and re-running ``hermes tools post-setup
+ddgs`` inside the container failed with::
+
+    pip not available and ensurepip failed: ... ensurepip ... exit status 1
+    Run manually: uv pip install -U ddgs
+
+…even though ``uv pip install -U ddgs`` at the same shell worked. Two
+mechanisms were wrong:
+
+1. Post-setup installs targeted the *agent venv*, which the image seals
+   (``HERMES_DISABLE_LAZY_INSTALLS=1``, root-owned ``/opt/hermes``) and which
+   is thrown away on every container recreate. The writable, durable store on
+   the data volume (``HERMES_LAZY_INSTALL_TARGET``) was ignored.
+2. uv ran first, failed (no write permission), and its error was discarded —
+   the user was shown the *ensurepip* failure from the next tier instead.
+
+These tests pin both behaviours plus the ddgs hook's routing through the
+lazy-dep pipeline (which is what keeps the version pin in one place).
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import hermes_cli.tools_config as tc
+
+
+@pytest.fixture
+def fake_installer(monkeypatch):
+    """Capture install commands instead of running them."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *a, **k):
+        calls.append(list(cmd))
+        if "--version" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "pip 24.0", "")
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    monkeypatch.setattr(tc.subprocess, "run", fake_run)
+    return calls
+
+
+class TestPipInstallRouting:
+    def test_durable_target_used_when_configured(self, tmp_path, monkeypatch, fake_installer):
+        target = tmp_path / "lazy-packages"
+        monkeypatch.setenv("HERMES_LAZY_INSTALL_TARGET", str(target))
+        monkeypatch.setattr(tc.shutil, "which", lambda _: None)  # force the pip tier
+
+        result = tc._pip_install(["-U", "ddgs", "--quiet"])
+
+        assert result.returncode == 0
+        install_cmd = fake_installer[-1]
+        assert "--target" in install_cmd
+        assert str(target) in install_cmd
+        assert install_cmd[-2:] == ["ddgs", "--quiet"]
+
+    def test_venv_scoped_when_no_durable_target(self, monkeypatch, fake_installer):
+        monkeypatch.delenv("HERMES_LAZY_INSTALL_TARGET", raising=False)
+        monkeypatch.setattr(tc.shutil, "which", lambda _: None)
+
+        result = tc._pip_install(["-U", "ddgs", "--quiet"])
+
+        assert result.returncode == 0
+        assert "--target" not in fake_installer[-1]
+
+    def test_unusable_durable_target_reported(self, tmp_path, monkeypatch, fake_installer):
+        blocker = tmp_path / "lazy-packages"
+        blocker.write_text("not a directory", encoding="utf-8")
+        monkeypatch.setenv("HERMES_LAZY_INSTALL_TARGET", str(blocker / "nested"))
+
+        result = tc._pip_install(["-U", "ddgs"])
+
+        assert result.returncode == 1
+        assert result.stderr
+        assert not fake_installer, "must not fall back to the sealed venv"
+
+    def test_uv_failure_reported_when_ensurepip_also_fails(self, monkeypatch):
+        """The user must see uv's real error, not a misleading pip message."""
+        monkeypatch.delenv("HERMES_LAZY_INSTALL_TARGET", raising=False)
+        monkeypatch.setattr(tc.shutil, "which", lambda _: "/usr/local/bin/uv")
+
+        def fake_run(cmd, *a, **k):
+            if cmd[0] == "/usr/local/bin/uv":
+                return subprocess.CompletedProcess(
+                    cmd, 1, "", "error: failed to write to /opt/hermes/.venv"
+                )
+            if "--version" in cmd:
+                raise FileNotFoundError("no pip")
+            if "ensurepip" in cmd:
+                raise subprocess.CalledProcessError(1, cmd)
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        monkeypatch.setattr(tc.subprocess, "run", fake_run)
+
+        result = tc._pip_install(["-U", "ddgs"])
+
+        assert result.returncode == 1
+        assert "failed to write to /opt/hermes/.venv" in result.stderr
+        assert "ensurepip failed" in result.stderr
+
+
+class TestDdgsPostSetup:
+    def test_installs_the_pinned_spec_through_lazy_deps(self, monkeypatch, capsys):
+        """The hook and the runtime self-heal must agree on one version, or
+        they reinstall over each other on every search."""
+        import tools.lazy_deps as ld
+
+        monkeypatch.setattr(ld, "is_available", lambda feature: False)
+        installed: list[tuple[str, bool]] = []
+        monkeypatch.setattr(
+            ld, "ensure",
+            lambda feature, *, prompt=True: installed.append((feature, prompt)),
+        )
+        # A raw pip call would bypass the durable-target routing entirely.
+        monkeypatch.setattr(
+            tc, "_pip_install",
+            lambda *a, **k: pytest.fail("post-setup must not shell out to pip directly"),
+        )
+
+        tc._run_post_setup("ddgs")
+
+        assert installed == [("search.ddgs", False)]
+        out = capsys.readouterr().out
+        assert "ddgs installed" in out
+
+    def test_reports_install_failure_with_reason(self, monkeypatch, capsys):
+        import tools.lazy_deps as ld
+
+        monkeypatch.setattr(ld, "is_available", lambda feature: False)
+
+        def boom(feature, *, prompt=True):
+            raise ld.FeatureUnavailable(feature, ("ddgs==9.14.4",), "network unreachable")
+
+        monkeypatch.setattr(ld, "ensure", boom)
+
+        tc._run_post_setup("ddgs")
+
+        out = capsys.readouterr().out
+        assert "install failed" in out
+        assert "network unreachable" in out
+
+    def test_already_installed_is_a_noop(self, monkeypatch, capsys):
+        import tools.lazy_deps as ld
+
+        monkeypatch.setattr(ld, "is_available", lambda feature: True)
+        monkeypatch.setattr(
+            ld, "ensure",
+            lambda *a, **k: pytest.fail("must not reinstall a satisfied feature"),
+        )
+
+        tc._run_post_setup("ddgs")
+
+        assert "already installed" in capsys.readouterr().out

--- a/tests/tools/test_lazy_deps_durable_target.py
+++ b/tests/tools/test_lazy_deps_durable_target.py
@@ -227,6 +227,105 @@ class TestRealInstallCoreWins:
         assert Path(mod.__file__).is_relative_to(target)
 
 
+class TestDurableTargetPlan:
+    """``durable_target_plan`` is the single routing decision shared by the
+    lazy installer and the ``hermes tools`` post-setup installer, so both
+    honour the sealed-venv redirect identically."""
+
+    def test_venv_scoped_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        with ld.durable_target_plan() as plan:
+            assert plan.target is None
+            assert plan.args == []
+            assert plan.error is None
+
+    def test_target_and_constraint_args_when_configured(self, tmp_path, monkeypatch):
+        target = tmp_path / "lazy-packages"
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(target))
+        with ld.durable_target_plan() as plan:
+            assert plan.error is None
+            assert plan.target == target
+            assert plan.args[:2] == ["--target", str(target)]
+            assert "--constraint" in plan.args
+            constraints = Path(plan.args[plan.args.index("--constraint") + 1])
+            assert constraints.exists()
+        # The temp constraints file must not outlive the context.
+        assert not constraints.exists()
+
+    def test_unusable_target_reports_error_instead_of_silently_using_venv(
+        self, tmp_path, monkeypatch
+    ):
+        # A file where the target dir should be — mkdir can never succeed.
+        blocker = tmp_path / "lazy-packages"
+        blocker.write_text("not a directory", encoding="utf-8")
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(blocker / "nested"))
+        with ld.durable_target_plan() as plan:
+            assert plan.error, "an unusable durable target must be reported"
+            assert plan.args == []
+
+
+class TestInstallErrorReporting:
+    """When uv runs first and fails, its error must survive to the caller.
+
+    Reported symptom: on the Docker image ``hermes tools post-setup ddgs``
+    printed "pip not available and ensurepip failed" on a host where uv was
+    installed and working — the real (permission) error from uv had been
+    thrown away, sending the user to debug the wrong tool."""
+
+    def test_uv_error_survives_ensurepip_failure(self, monkeypatch):
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr(ld.shutil, "which", lambda _: "/usr/local/bin/uv")
+
+        def fake_run(cmd, *a, **k):
+            if cmd[0] == "/usr/local/bin/uv":
+                return subprocess.CompletedProcess(
+                    cmd, 1, "", "error: failed to write to /opt/hermes/.venv"
+                )
+            if "--version" in cmd:
+                raise FileNotFoundError("no pip")
+            if "ensurepip" in cmd:
+                raise subprocess.CalledProcessError(1, cmd)
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+        result = ld._venv_pip_install(("ddgs==9.14.4",))
+        assert result.success is False
+        assert "failed to write to /opt/hermes/.venv" in result.stderr
+        assert "ensurepip failed" in result.stderr
+
+    def test_uv_error_survives_pip_install_failure(self, monkeypatch):
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr(ld.shutil, "which", lambda _: "/usr/local/bin/uv")
+
+        def fake_run(cmd, *a, **k):
+            if cmd[0] == "/usr/local/bin/uv":
+                return subprocess.CompletedProcess(cmd, 1, "", "uv: permission denied")
+            if "--version" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, "pip 24.0", "")
+            return subprocess.CompletedProcess(cmd, 1, "", "pip: permission denied")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+        result = ld._venv_pip_install(("ddgs==9.14.4",))
+        assert result.success is False
+        assert "uv: permission denied" in result.stderr
+        assert "pip: permission denied" in result.stderr
+
+
+class TestDdgsIsLazyInstallable:
+    """ddgs must be reachable through the lazy-install pipeline, otherwise it
+    can only be installed into the sealed venv — which the Docker image
+    discards on every container recreate."""
+
+    def test_ddgs_feature_registered(self):
+        assert "search.ddgs" in ld.LAZY_DEPS
+        specs = ld.LAZY_DEPS["search.ddgs"]
+        assert len(specs) == 1
+        assert ld._pkg_name_from_spec(specs[0]) == "ddgs"
+        assert ld._spec_is_safe(specs[0])
+
+
 class TestCoreNeverShadowed:
     """The headline invariant — a package in the durable store can never
     shadow a core module — proved WITHOUT a network install by synthesizing

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -10,6 +10,7 @@ Covers:
 """
 from __future__ import annotations
 
+import builtins
 import json
 import sys
 import time
@@ -226,6 +227,149 @@ class TestDDGSProcessIsolation:
         result = prov.DDGSWebSearchProvider().search("q", limit=5)
         assert result["success"] is True
         _assert_worker_reaped(prov)
+
+
+# ---------------------------------------------------------------------------
+# Missing-package self-heal (Docker: the durable package store can be wiped
+# by an ABI-bumping image rebuild, so a configured ddgs can vanish)
+# ---------------------------------------------------------------------------
+
+
+def _uninstall_ddgs(monkeypatch):
+    """Make ``import ddgs`` fail until the returned state is unblocked."""
+    state = {"blocked": True}
+    monkeypatch.delitem(sys.modules, "ddgs", raising=False)
+    real_import = builtins.__import__
+
+    def _blocked(name, *args, **kwargs):
+        if state["blocked"] and (name == "ddgs" or name.startswith("ddgs.")):
+            raise ImportError("No module named 'ddgs'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked)
+    return state
+
+
+class TestDDGSMissingPackageSelfHeal:
+    def test_search_installs_the_pinned_package_when_missing(self, monkeypatch):
+        """A missing ddgs must be lazy-installed, not handed back to the user
+        as "go run pip" — that's the docker-restart papercut."""
+        import plugins.web.ddgs.provider as prov
+
+        monkeypatch.setattr(prov, "_install_attempted", False, raising=True)
+        state = _uninstall_ddgs(monkeypatch)
+
+        installed: list[str] = []
+
+        def fake_ensure(feature, *, prompt=True):
+            installed.append(feature)
+            # Simulate the install making the package importable again.
+            state["blocked"] = False
+            _install_fake_ddgs(monkeypatch)
+
+        monkeypatch.setattr("tools.lazy_deps.ensure", fake_ensure)
+
+        assert prov._ensure_ddgs_installed() is True
+        assert installed == ["search.ddgs"], (
+            "search must self-heal through the lazy-dep allowlist entry"
+        )
+
+    def test_search_reports_failure_without_raising(self, monkeypatch):
+        import plugins.web.ddgs.provider as prov
+        from tools.lazy_deps import FeatureUnavailable
+
+        monkeypatch.setattr(prov, "_install_attempted", False, raising=True)
+        state = _uninstall_ddgs(monkeypatch)
+
+        def fake_ensure(feature, *, prompt=True):
+            raise FeatureUnavailable(feature, ("ddgs",), "offline")
+
+        monkeypatch.setattr("tools.lazy_deps.ensure", fake_ensure)
+
+        result = prov.DDGSWebSearchProvider().search("q", limit=3)
+        assert state["blocked"] is True
+        assert result["success"] is False
+        assert "not installed" in result["error"]
+
+    def test_install_attempted_once_per_process(self, monkeypatch):
+        """A permanently-unavailable ddgs must not re-run pip on every query."""
+        import plugins.web.ddgs.provider as prov
+        from tools.lazy_deps import FeatureUnavailable
+
+        monkeypatch.setattr(prov, "_install_attempted", False, raising=True)
+        _uninstall_ddgs(monkeypatch)
+
+        calls = []
+
+        def fake_ensure(feature, *, prompt=True):
+            calls.append(feature)
+            raise FeatureUnavailable(feature, ("ddgs",), "offline")
+
+        monkeypatch.setattr("tools.lazy_deps.ensure", fake_ensure)
+
+        assert prov._ensure_ddgs_installed() is False
+        assert prov._ensure_ddgs_installed() is False
+        assert len(calls) == 1
+
+    def test_present_package_is_never_reinstalled(self, monkeypatch):
+        """ddgs at any version counts as installed — no version churn."""
+        import plugins.web.ddgs.provider as prov
+
+        _install_fake_ddgs(monkeypatch)
+        monkeypatch.setattr(prov, "_install_attempted", False, raising=True)
+
+        def boom(feature, *, prompt=True):
+            raise AssertionError(f"unexpected install of {feature}")
+
+        monkeypatch.setattr("tools.lazy_deps.ensure", boom)
+        assert prov._ensure_ddgs_installed() is True
+
+
+class TestDDGSWorkerSeesDurableTarget:
+    """The search worker is a bare child process, so it must activate the
+    durable lazy-install store itself. Without that, a ddgs installed on the
+    Docker data volume imports fine in the parent and fails in the child —
+    every search returns "No module named 'ddgs'".
+    """
+
+    def test_worker_imports_ddgs_from_durable_target(self, tmp_path, monkeypatch):
+        target = tmp_path / "lazy-packages"
+        target.mkdir()
+        (target / "ddgs.py").write_text(
+            "class DDGS:\n"
+            "    def __init__(self, **kwargs):\n"
+            "        pass\n"
+            "    def __enter__(self):\n"
+            "        return self\n"
+            "    def __exit__(self, *a):\n"
+            "        return False\n"
+            "    def text(self, query, max_results=5):\n"
+            "        yield {'title': 'durable', 'href': 'https://d.example.com',\n"
+            "               'body': 'from the data volume'}\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_LAZY_INSTALL_TARGET", str(target))
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+        import plugins.web.ddgs.provider as prov
+
+        # The parent resolves ddgs the same way (hermes_bootstrap does this at
+        # startup); the point of the test is the CHILD, which is spawned fresh.
+        saved_path = list(sys.path)
+        try:
+            from tools.lazy_deps import activate_durable_lazy_target
+
+            activate_durable_lazy_target()
+            result = prov.DDGSWebSearchProvider().search("q", limit=3)
+        finally:
+            sys.path[:] = saved_path
+            sys.modules.pop("ddgs", None)
+
+        assert result["success"] is True, result.get("error")
+        assert result["data"]["web"][0]["url"] == "https://d.example.com"
+        _assert_worker_reaped(prov)
+
 
 # ---------------------------------------------------------------------------
 # Integration: _is_backend_available / _get_backend / check_web_api_key

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -75,9 +75,10 @@ import site
 import subprocess
 import sys
 import sysconfig
-from dataclasses import dataclass
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterator, Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -112,6 +113,13 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "provider.azure_identity": ("azure-identity==1.25.3",),
 
     # ─── Web search backends ───────────────────────────────────────────────
+    # DuckDuckGo scrape backend. Not in [all]; installed when the user picks
+    # it in `hermes tools` (post_setup) or on first search. It MUST go through
+    # lazy_deps rather than a raw venv pip install: on the published Docker
+    # image the agent venv is sealed and discarded on every container
+    # recreate, so a venv-scoped install evaporates on restart. Routed here it
+    # lands in the durable target on the data volume and survives.
+    "search.ddgs": ("ddgs==9.14.4",),
     "search.exa": ("exa-py==2.10.2",),
     "search.firecrawl": ("firecrawl-py==4.17.0",),
     "search.parallel": ("parallel-web==0.4.2",),
@@ -680,6 +688,72 @@ def _core_constraints_file() -> Optional[Path]:
         return None
 
 
+@dataclass
+class DurableTargetPlan:
+    """How one pip invocation should be routed on this deployment.
+
+    ``target`` — the durable install dir, or ``None`` for a normal
+                 venv-scoped install.
+    ``args``   — extra pip/uv args (``--target`` + ``--constraint``) to splice
+                 into the command. Empty in venv-scoped mode.
+    ``error``  — non-empty when a durable target is configured but unusable
+                 (read-only mount, permission error). Callers must abort and
+                 report this rather than falling back to the sealed venv.
+    """
+    target: Optional[Path] = None
+    args: list[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+@contextmanager
+def durable_target_plan() -> Iterator[DurableTargetPlan]:
+    """Yield the install routing for this deployment; clean up afterwards.
+
+    Shared by :func:`_venv_pip_install` and
+    ``hermes_cli.tools_config._pip_install`` so *every* Hermes-driven package
+    install honours the same rule: on an immutable image (sealed agent venv +
+    ``HERMES_LAZY_INSTALL_TARGET``) packages go to the writable data volume,
+    where they survive a container recreate; everywhere else they go into the
+    active venv exactly as before.
+
+    The temp constraints file (pinning shared deps to the core venv's
+    versions) is deleted when the context exits, so callers can't leak it.
+    """
+    target = _lazy_install_target()
+    if target is None:
+        yield DurableTargetPlan()
+        return
+
+    err = _ensure_target_ready(target)
+    if err:
+        yield DurableTargetPlan(target=target, error=err)
+        return
+
+    constraints = _core_constraints_file()
+    # --target tells both uv and pip to install into an arbitrary dir.
+    args = ["--target", str(target)]
+    if constraints is not None:
+        args += ["--constraint", str(constraints)]
+    try:
+        yield DurableTargetPlan(target=target, args=args)
+    finally:
+        if constraints is not None:
+            try:
+                constraints.unlink()
+            except OSError:
+                pass
+
+
+def combine_install_errors(*parts: str) -> str:
+    """Join the errors from each install tier into one readable message.
+
+    Public so ``hermes_cli.tools_config`` reports failures the same way: when
+    uv runs first and fails, its error must reach the user even if a later
+    tier produces its own (often less relevant) error.
+    """
+    return "; ".join(p.strip() for p in parts if p and p.strip())
+
+
 def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
     """Install ``specs`` using the uv → pip → ensurepip ladder.
 
@@ -699,35 +773,24 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
     if not specs:
         return _InstallResult(True, "", "")
 
-    target = _lazy_install_target()
-    constraints: Optional[Path] = None
+    with durable_target_plan() as plan:
+        if plan.error:
+            return _InstallResult(False, "", plan.error)
+        target = plan.target
+        extra_args = plan.args
 
-    if target is not None:
-        err = _ensure_target_ready(target)
-        if err:
-            return _InstallResult(False, "", err)
-        constraints = _core_constraints_file()
-
-    target_args: list[str] = []
-    if target is not None:
-        # --target tells both uv and pip to install into an arbitrary dir.
-        target_args = ["--target", str(target)]
-    constraint_args: list[str] = []
-    if constraints is not None:
-        constraint_args = ["--constraint", str(constraints)]
-
-    try:
         venv_root = Path(sys.executable).parent.parent
         from tools.environments.local import hermes_subprocess_env
         uv_env = hermes_subprocess_env(inherit_credentials=False)
         uv_env["VIRTUAL_ENV"] = str(venv_root)
 
         # Tier 1: uv (preferred — fast, doesn't need pip in the venv)
+        uv_error = ""
         uv_bin = shutil.which("uv")
         if uv_bin:
             try:
                 r = subprocess.run(
-                    [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
+                    [uv_bin, "pip", "install", *extra_args, *specs],
                     capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
                     creationflags=windows_hide_flags(),
@@ -736,8 +799,10 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                     if target is not None:
                         _activate_target_on_syspath(target)
                     return _InstallResult(True, r.stdout or "", r.stderr or "")
+                uv_error = (r.stderr or r.stdout or "").strip()
                 logger.debug("uv pip install failed: %s", r.stderr)
             except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+                uv_error = f"uv pip install failed: {e}"
                 logger.debug("uv invocation failed: %s", e)
 
         # Tier 2: python -m pip (with ensurepip bootstrap if needed)
@@ -760,29 +825,37 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                     creationflags=windows_hide_flags(),
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-                return _InstallResult(False, "",
-                                      f"pip not available and ensurepip failed: {e}")
+                # Report uv's failure too — it ran first and is the reason we
+                # fell through. Without it the user sees "pip not available"
+                # on a host where uv is installed and working, which sends
+                # them debugging the wrong thing entirely.
+                return _InstallResult(
+                    False, "", combine_install_errors(
+                        uv_error, f"pip not available and ensurepip failed: {e}"
+                    ),
+                )
 
         try:
             r = subprocess.run(
-                pip_cmd + ["install", *target_args, *constraint_args, *specs],
+                pip_cmd + ["install", *extra_args, *specs],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
                 stdin=subprocess.DEVNULL,
                 creationflags=windows_hide_flags(),
             )
             if r.returncode == 0 and target is not None:
                 _activate_target_on_syspath(target)
-            return _InstallResult(r.returncode == 0, r.stdout or "", r.stderr or "")
+            if r.returncode != 0:
+                return _InstallResult(
+                    False, r.stdout or "",
+                    combine_install_errors(uv_error, (r.stderr or "").strip()),
+                )
+            return _InstallResult(True, r.stdout or "", r.stderr or "")
         except subprocess.TimeoutExpired as e:
-            return _InstallResult(False, "", f"pip install timed out: {e}")
+            return _InstallResult(False, "", combine_install_errors(
+                uv_error, f"pip install timed out: {e}"))
         except Exception as e:
-            return _InstallResult(False, "", f"pip install failed: {e}")
-    finally:
-        if constraints is not None:
-            try:
-                constraints.unlink()
-            except OSError:
-                pass
+            return _InstallResult(False, "", combine_install_errors(
+                uv_error, f"pip install failed: {e}"))
 
 
 # =============================================================================

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -27,7 +27,7 @@ Both are configured through a single backend selection. Providers are chosen via
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | Paid |
 | **xAI (Grok)** | `XAI_API_KEY` or `hermes auth add xai-oauth` | ✔ | — | Paid (SuperGrok or per-token) |
 
-Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
+Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; picking it in `hermes tools` installs the package, and a missing `ddgs` is re-installed automatically on first search. On the Docker image the install lands on the `~/.hermes` data volume (not the sealed venv), so it survives `docker compose` restarts and image updates. xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
 
 **Per-capability split:** you can use different providers for search and extract independently — for example SearXNG (free) for search and Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
 


### PR DESCRIPTION
## What does this PR do?

On the published Docker image, `ddgs` had to be reinstalled after **every** `docker compose up`, and the supported way to do it (`hermes tools post-setup ddgs`) failed with a misleading error while a manual `uv pip install -U ddgs` worked. Three coupled bugs cause that:

1. **`ddgs` was the only web backend not wired through `tools/lazy_deps.py`.** Its post-setup hook pip-installed into the *agent venv* (`/opt/hermes/.venv`). The image seals that venv (`HERMES_DISABLE_LAZY_INSTALLS=1`, root-owned) and re-creates it from the image on every `docker compose up`, pointing durable installs at `HERMES_LAZY_INSTALL_TARGET=/opt/data/lazy-packages` on the data volume instead. As the runtime user the install was denied; as root it landed in the container's ephemeral layer and was discarded on recreate. Either way it never persisted.

2. **The error message pointed at the wrong thing.** Both installers (`tools_config._pip_install` and `lazy_deps._venv_pip_install`) run a uv -> pip -> ensurepip ladder, and both **discarded uv's stderr** when uv failed, so the user saw the downstream `pip not available and ensurepip failed` error on a host where uv works fine. That sends people debugging pip instead of the permission/routing problem that actually stopped them.

3. **The DDGS search worker would not have seen a durable-target install anyway.** `plugins/web/ddgs/_search_worker.py` is spawned as a bare script and never imports `hermes_bootstrap`, so `activate_durable_lazy_target()` never ran in the child. The parent would report ddgs as available while every actual search failed with `ModuleNotFoundError`.

**Approach:** route ddgs through the existing durable-install pipeline instead of adding anything new. The routing logic (`--target` + core-venv constraints + temp-file cleanup) is extracted out of `_venv_pip_install` into a shared `durable_target_plan()` context manager, and `hermes_cli/tools_config._pip_install` now uses it too. That fixes the whole bug class rather than just ddgs: **every** post-setup hook (faster-whisper, kittentts, piper, langfuse, modal, daytona, qrcode) now lands on the writable data volume on an immutable image instead of the sealed venv.

**Worth a careful look:**

- The version pin now lives in exactly one place, `LAZY_DEPS["search.ddgs"] = ("ddgs==9.14.4",)`. That matters: the hook previously installed `-U ddgs` (latest), and `_is_satisfied()` treats an exact pin as unsatisfied for any other version, so a hook installing latest while `LAZY_DEPS` pinned something else would make the runtime self-heal reinstall on every single search. Moving the hook onto `ensure("search.ddgs")` keeps one source of truth.
- The provider self-heal only fires when `import ddgs` genuinely fails (not on version mismatch), and at most once per process, for the same anti-churn reason.
- When a durable target is configured but unusable (read-only mount, permission error), `_pip_install` now aborts with that error instead of silently falling back to writing into the sealed venv.
- No new `HERMES_*` env vars, no new core tools, no new config keys.

## Related Issue

N/A - reported directly (recurring Docker papercut: re-running `hermes tools post-setup ddgs` after every `docker compose` restart).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/lazy_deps.py`
  - Added `"search.ddgs": ("ddgs==9.14.4",)` to `LAZY_DEPS` under "Web search backends".
  - Extracted the install routing into a public `DurableTargetPlan` dataclass + `durable_target_plan()` context manager (yields `--target`/`--constraint` args, deletes the temp constraints file on exit).
  - Added `combine_install_errors()`; `_venv_pip_install` now preserves uv's stderr when the pip/ensurepip tier also fails.
- `hermes_cli/tools_config.py`
  - `_pip_install` resolves routing via `durable_target_plan()`, aborts with a clear message when the target is unusable, activates the target on `sys.path` after a successful install, and delegates the ladder to a new `_pip_install_with_args()` that merges uv's error into the reported stderr.
  - The `ddgs` post-setup branch now uses `lazy_deps.is_available("search.ddgs")` / `ensure("search.ddgs", prompt=False)` and prints the durable target path on success.
- `plugins/web/ddgs/provider.py` - added `_ensure_ddgs_installed()` (self-heals once per process via `lazy_deps.ensure`), and the "not installed" error now points at `hermes tools post-setup ddgs` instead of `pip install ddgs`.
- `plugins/web/ddgs/_search_worker.py` - `main()` calls `activate_durable_lazy_target()` before importing the provider.
- `tests/hermes_cli/test_post_setup_install_routing.py` (new, 7 tests) - `_pip_install` durable vs venv routing, unusable target, uv-error preservation, and the ddgs hook routing through lazy_deps.
- `tests/tools/test_web_providers_ddgs.py` - `TestDDGSMissingPackageSelfHeal` (4) and `TestDDGSWorkerSeesDurableTarget` (real E2E: writes a fake `ddgs` module into a temp durable target and asserts the spawned worker returns results).
- `tests/tools/test_lazy_deps_durable_target.py` - `TestDurableTargetPlan` (3), `TestInstallErrorReporting` (2), `TestDdgsIsLazyInstallable` (1).
- `website/docs/user-guide/features/web-search.md` - describes the new install behaviour for DDGS.

## How to Test

**Reproduce on current main (Docker):**

1. `docker compose up -d`, then `docker exec -it <container> hermes tools post-setup ddgs` -> fails with `pip not available and ensurepip failed: ...`.
2. Work around it as root with `uv pip install -U ddgs`, confirm search works.
3. `docker compose down && docker compose up -d` -> `ddgs` is gone again.

**With this change:**

1. Rebuild the image and run `hermes tools post-setup ddgs` once. It prints `ddgs installed` plus `Installed to /opt/data/lazy-packages (persists across restarts)`.
2. Run a web search to confirm the worker child imports the package from the durable target.
3. `docker compose down && docker compose up -d`, search again -> still works, no reinstall needed. Even if the durable store is wiped (for example an image rebuild that bumps the interpreter ABI), the first search self-heals.

**Automated:**

- `scripts/run_tests.sh tests/tools/test_web_providers_ddgs.py tests/tools/test_lazy_deps_durable_target.py tests/tools/test_lazy_deps.py tests/hermes_cli/test_post_setup_install_routing.py tests/hermes_cli/test_tools_config.py tests/plugins/memory/test_memory_lazy_install.py`
- The worker E2E test was verified to **fail** without the `_search_worker.py` fix (checked via `git stash`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass - see note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (test run) + the Linux Docker image (the reported repro)

Note on the test box: `scripts/run_tests.sh` is bash-only and this machine is Windows without a usable WSL setup, so the affected files were run with targeted `python -m pytest` under `TZ=UTC` rather than the full CI-parity suite: **145 passed, 1 skipped**. The single failure, `tests/tools/test_lazy_deps_durable_target.py::TestAbiStamp::test_readonly_target_reports_error`, is **pre-existing and Windows-only** (`os.chmod(0o500)` does not block writes on Windows) and reproduces identically on unmodified `main` (verified via `git stash`). It touches no code changed here.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] N/A - no config keys added or changed
- [x] N/A - no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the durable-target path is inert when `HERMES_LAZY_INSTALL_TARGET` is unset, so Windows/macOS/native Linux installs keep the exact previous venv-scoped behaviour
- [x] N/A - no tool schemas changed

## For New Skills

N/A

## Screenshots / Logs

Before (current main, inside the container):

```
root@1ad5b90b6ece:/opt/hermes# hermes tools post-setup ddgs
  Running post-setup hook: ddgs
    Installing ddgs (DuckDuckGo search package)...
  ddgs install failed:
      pip not available and ensurepip failed: Command '['/opt/hermes/.venv/bin/python3', '-m',
      'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1.
    Run manually: uv pip install -U ddgs
```

After, the install is routed to the data volume and reported honestly:

```
  Running post-setup hook: ddgs
    Installing ddgs (DuckDuckGo search package)...
    ddgs installed
    Installed to /opt/data/lazy-packages (persists across restarts)
```