### PR TITLE
feat: add deepseek/deepseek-v4-flash-0731 to OpenRouter curated model list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -65,6 +65,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # DeepSeek
     ("deepseek/deepseek-v4-pro",               ""),
     ("deepseek/deepseek-v4-flash",             ""),
+    ("deepseek/deepseek-v4-flash-0731",        "re-post-trained 2026-07-31 build; improved agentic + coding"),
     # Qwen
     ("qwen/qwen3.7-max",                       ""),
     # MoonshotAI


### PR DESCRIPTION
## Summary

Adds the newly released **DeepSeek V4 Flash 0731** (2026-07-31) to the OpenRouter curated model list.

## What changed

- `hermes_cli/models.py`: Added `("deepseek/deepseek-v4-flash-0731", "re-post-trained 2026-07-31 build; improved agentic + coding")` to `OPENROUTER_MODELS`

## Why only this file

- `agent/model_metadata.py` — existing `deepseek-v4-flash` context window entry (1M) already matches `deepseek-v4-flash-0731` via longest-substring matching
- `agent/usage_pricing.py` — DeepSeek-direct pricing for `deepseek-v4-flash` applies to the 0731 build; OpenRouter pricing is fetched live from the API
- `agent/reasoning_timeouts.py` — pattern matching covers the dated variant
- `hermes_cli/model_normalize.py` — V-series regex (`deepseek-v\\d+([-.].+)?$`) already matches dated variants

## References

- OpenRouter model page: https://openrouter.ai/deepseek/deepseek-v4-flash-0731
- DeepSeek changelog: https://api-docs.deepseek.com/updates/
- Artificial Analysis benchmarks: https://artificialanalysis.ai/articles/deepseek-v4-flash-0731-scores-50-on-the-artificial-analysis-intelligence-index-10-points-above-previous-deepseek-v4-flash