### PR TITLE
fix(kanban): reject completion artifacts that do not exist

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5001,12 +5001,48 @@ def _merge_completion_prose_artifacts(
     return updated
 
 
+def _validate_durable_artifact(artifact: str) -> None:
+    """Reject a declared durable artifact that cannot be handed off.
+
+    Completion may reference artifacts outside the scratch workspace;
+    they are handed off by path alone, so each must exist, be a regular
+    file, be readable, and be non-empty, or the task must not complete.
+    """
+    path = Path(artifact)
+    if not path.exists():
+        raise ArtifactPreservationError(
+            f"declared durable artifact does not exist: {artifact}"
+        )
+    if not path.is_file():
+        raise ArtifactPreservationError(
+            f"declared durable artifact is not a regular file: {artifact}"
+        )
+    if not os.access(path, os.R_OK):
+        raise ArtifactPreservationError(
+            f"declared durable artifact is not readable: {artifact}"
+        )
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise ArtifactPreservationError(
+            f"declared durable artifact is not readable: {artifact}"
+        ) from exc
+    if size == 0:
+        raise ArtifactPreservationError(
+            f"declared durable artifact is empty: {artifact}"
+        )
+
+
 def _persist_scratch_completion_artifacts(
     conn: sqlite3.Connection,
     task_id: str,
     metadata: dict,
 ) -> None:
-    """Copy scratch-workspace completion artifacts before cleanup removes them."""
+    """Copy scratch-workspace completion artifacts before cleanup removes them.
+
+    Artifacts outside the scratch workspace are validated (not copied) so
+    completion cannot reference a file that does not exist or cannot be read.
+    """
     raw_artifacts = metadata.get("artifacts")
     if not isinstance(raw_artifacts, (list, tuple)):
         return
@@ -5015,7 +5051,13 @@ def _persist_scratch_completion_artifacts(
         "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
-    if not row or row["workspace_kind"] != "scratch" or not row["workspace_path"]:
+    if not row:
+        return
+    if row["workspace_kind"] != "scratch" or not row["workspace_path"]:
+        for item in raw_artifacts:
+            artifact = str(item).strip() if isinstance(item, str) else ""
+            if artifact:
+                _validate_durable_artifact(artifact)
         return
 
     workspace = Path(row["workspace_path"]).expanduser()
@@ -5052,10 +5094,12 @@ def _persist_scratch_completion_artifacts(
         try:
             resolved_src = src.resolve()
         except OSError:
+            _validate_durable_artifact(artifact)
             persisted.append(artifact)
             continue
 
         if not resolved_src.is_relative_to(workspace_root):
+            _validate_durable_artifact(artifact)
             persisted.append(artifact)
             continue
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -604,6 +604,88 @@ def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
     ]
 
 
+# ---------------------------------------------------------------------------
+# Durable artifact validation on completion (#53699)
+# ---------------------------------------------------------------------------
+
+
+
+def test_complete_task_rejects_missing_durable_artifact(kanban_home, tmp_path):
+    """Completion referencing a nonexistent durable artifact is rejected.
+
+    Regression for #53699: a declared artifact outside the scratch
+    workspace was handed off by path alone, so a path that never existed
+    was accepted and the task silently completed.
+    """
+    workspace = tmp_path / "persistent"
+    workspace.mkdir()
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn, title="review doc", workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        with pytest.raises(kb.ArtifactPreservationError):
+            kb.complete_task(
+                conn,
+                t,
+                result="done",
+                metadata={"artifacts": [str(workspace / "missing.md")]},
+            )
+        task = kb.get_task(conn, t)
+    assert task is not None
+    assert task.status == "ready", "task must stay open when the artifact is rejected"
+
+
+def test_complete_task_rejects_empty_and_directory_durable_artifacts(kanban_home, tmp_path):
+    """Durable artifacts must be non-empty regular files, not dirs or 0-byte paths."""
+    workspace = tmp_path / "persistent"
+    workspace.mkdir()
+    empty_file = workspace / "empty.txt"
+    empty_file.write_bytes(b"")
+    subdir = workspace / "subdir"
+    subdir.mkdir()
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn, title="collect outputs", workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        with pytest.raises(kb.ArtifactPreservationError, match="empty"):
+            kb.complete_task(
+                conn, t, result="done",
+                metadata={"artifacts": [str(empty_file)]},
+            )
+        with pytest.raises(kb.ArtifactPreservationError, match="regular file"):
+            kb.complete_task(
+                conn, t, result="done",
+                metadata={"artifacts": [str(subdir)]},
+            )
+
+
+def test_complete_task_accepts_existing_durable_artifact(kanban_home, tmp_path):
+    """An existing readable durable artifact is carried through completion."""
+    workspace = tmp_path / "persistent"
+    workspace.mkdir()
+    deliverable = workspace / "report.md"
+    deliverable.write_text("finished\n", encoding="utf-8")
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn, title="write report", workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        assert kb.complete_task(
+            conn, t, result="done",
+            metadata={"artifacts": [str(deliverable)]},
+        )
+        completed = [e for e in kb.list_events(conn, t) if e.kind == "completed"][-1]
+        assert completed is not None
+        payload = completed.payload
+        assert payload is not None
+        assert payload["artifacts"] == [str(deliverable)]
+        task = kb.get_task(conn, t)
+    assert task is not None
+    assert task.status == "done"
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -125,9 +125,15 @@ async def test_gateway_create_autosubscribes_on_explicit_board(kanban_home):
 
 @pytest.mark.asyncio
 async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_path, monkeypatch):
-    """Missing artifact paths are silently skipped — they may have been
-    referenced by name only. The notifier must not crash and must still
-    deliver any artifacts that do exist."""
+    """Missing artifact paths are silently skipped at delivery time.
+
+    Complete-time validation now rejects worker-declared durable paths that
+    never existed, so this test injects a ghost path into the stored completed
+    event after a successful complete — modeling the race where a file vanishes
+    between complete and notify. The notifier must not crash and must still
+    deliver any artifacts that do exist.
+    """
+    import json
     import hermes_cli.kanban_db as kb
     from gateway.run import GatewayRunner
     from gateway.config import Platform
@@ -150,12 +156,37 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
     import os
     os.environ["HERMES_KANBAN_TASK"] = tid
     try:
-        kt._handle_complete({
-            "summary": "one real, one ghost",
-            "artifacts": [str(real_pdf), "/tmp/definitely-does-not-exist.pdf"],
+        result = kt._handle_complete({
+            "summary": "one real artifact",
+            "artifacts": [str(real_pdf)],
         })
     finally:
         os.environ.pop("HERMES_KANBAN_TASK", None)
+    assert "error" not in json.loads(result)
+
+    # Simulate a path that disappears (or was only named for reference) after
+    # completion by patching the stored completed event payload.
+    conn = kb.connect()
+    try:
+        row = conn.execute(
+            "SELECT id, payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'completed' "
+            "ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        assert row is not None
+        payload = json.loads(row["payload"] or "{}")
+        payload["artifacts"] = [
+            str(real_pdf),
+            "/tmp/definitely-does-not-exist.pdf",
+        ]
+        conn.execute(
+            "UPDATE task_events SET payload = ? WHERE id = ?",
+            (json.dumps(payload), row["id"]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
     runner = object.__new__(GatewayRunner)
     runner._running = True

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -160,6 +160,32 @@ def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
         conn.close()
 
 
+def test_complete_rejects_missing_durable_artifact(worker_env, tmp_path):
+    """kanban_complete must reject a nonexistent durable artifact.
+
+    Regression for #53699 at the worker-facing boundary: the worker gets
+    the structured in-flight error and the task stays open, so the worker
+    can fix the path and retry the same handoff.
+    """
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    out = json.loads(kt._handle_complete({
+        "summary": "done",
+        "artifacts": [str(tmp_path / "missing.md")],
+    }))
+    assert out.get("error")
+    assert "still in-flight" in out["error"]
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status != "done"
+    finally:
+        conn.close()
+
+
 def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     """Goal-mode tasks must pass the auxiliary judge before completion.
     Regression for #38367: workers bypassing the judge via early kanban_complete."""


### PR DESCRIPTION
## What does this PR do?

`kanban_complete` accepted declared artifacts that live outside the scratch workspace without checking them at all. A completion referencing a path that never existed was recorded as done, and the artifact was reported as persisted even though no file existed to hand off. This PR validates durable artifact paths for non-scratch workspaces via `_validate_durable_artifact`, rejecting completions that reference nonexistent files.

## Related Issue

Fixes #53699

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` — when `_scratch_workspace` returns `None` (non-scratch or missing workspace), durable artifacts are now validated via `_validate_durable_artifact` before the completion is recorded.
- Tests cover nonexistent artifact rejection, non-scratch workspace validation, and notifier alignment with complete-time validation.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_notify.py tests/tools/test_kanban_tools.py` — all pass.
2. Full project checker passes.
3. Manual: create a kanban task with a non-scratch workspace, complete it with an artifact path that doesn't exist — verify the completion is rejected.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing
- [x] No new core tools or env vars introduced
- [x] Prompt caching and role alternation preserved