### PR TITLE
fix(security): respect tirith_fail_open when circuit breaker is open (#74922)

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -179,6 +179,56 @@ class TestDisabled:
 
 
 # ---------------------------------------------------------------------------
+# Circuit breaker respects tirith_fail_open (issue #74922)
+# ---------------------------------------------------------------------------
+
+class TestCircuitBreakerFailOpen:
+    """When the circuit breaker is open, the verdict must still respect
+    tirith_fail_open — every other failure path in check_command_security()
+    honors it, and an operator who sets tirith_fail_open=false expects
+    scanner unavailability to block commands, not silently allow them."""
+
+    @patch("tools.tirith_security._load_security_config")
+    def test_circuit_open_fail_open_allows(self, mock_cfg):
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": True}
+        _tirith_mod._circuit_open = True
+        try:
+            result = check_command_security("rm -rf /")
+        finally:
+            _tirith_mod._circuit_open = False
+        assert result["action"] == "allow"
+        assert "circuit breaker" in result["summary"]
+
+    @patch("tools.tirith_security._load_security_config")
+    def test_circuit_open_fail_closed_blocks(self, mock_cfg):
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": False}
+        _tirith_mod._circuit_open = True
+        try:
+            result = check_command_security("rm -rf /")
+        finally:
+            _tirith_mod._circuit_open = False
+        assert result["action"] == "block"
+        assert "fail-closed" in result["summary"]
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_circuit_open_never_spawns(self, mock_cfg, mock_run):
+        # Anti-hang behavior from #41400 must be preserved: when the breaker
+        # is open, no tirith subprocess is spawned regardless of fail_open.
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": True}
+        _tirith_mod._circuit_open = True
+        try:
+            result = check_command_security("rm -rf /")
+        finally:
+            _tirith_mod._circuit_open = False
+        assert result["action"] == "allow"
+        mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Findings cap + summary cap
 # ---------------------------------------------------------------------------
 

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -744,13 +744,24 @@ def check_command_security(command: str) -> dict:
     if not cfg["tirith_enabled"]:
         return {"action": "allow", "findings": [], "summary": ""}
 
+    fail_open = cfg["tirith_fail_open"]
+
     # Circuit breaker: if tirith has crashed _CRASH_LIMIT times in a row,
     # stop trying for the rest of the process.  Without this, a corrupted
     # or missing binary causes every tool call to hit the same spawn failure
     # → fail-open → agent retry loop, hanging the user for 20+ minutes
-    # (issue #41400).
+    # (issue #41400).  The verdict still respects tirith_fail_open, matching
+    # every other failure path in this function — an operator who sets
+    # tirith_fail_open=false wants scanner unavailability to block commands,
+    # not silently allow them (issue #74922).
     if _circuit_open:
-        return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        if fail_open:
+            return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        return {
+            "action": "block",
+            "findings": [],
+            "summary": "tirith unavailable, circuit breaker open (fail-closed)",
+        }
 
     # Unsupported platform (Windows etc.) — tirith has no binary here and
     # never will. Skip the resolver entirely so we don't even try to spawn.
@@ -760,7 +771,6 @@ def check_command_security(command: str) -> dict:
 
     tirith_path = _resolve_tirith_path(cfg["tirith_path"])
     timeout = cfg["tirith_timeout"]
-    fail_open = cfg["tirith_fail_open"]
 
     if tirith_path is None:
         _warn_once(


### PR DESCRIPTION
## Summary

`check_command_security()` in `tools/tirith_security.py` has a circuit breaker that disables Tirith after 3 consecutive scanner failures (added for #41400 to prevent agent hangs). The breaker's return path fired **before** `tirith_fail_open` was read, so once the breaker latched, every subsequent command in the process was silently allowed — even when `tirith_fail_open=false`, which operators set specifically so scanner unavailability blocks commands instead of allowing them. The breaker also never resets, so this was permanent for the life of the process, not a transient window.

## Fix

Move the `fail_open = cfg["tirith_fail_open"]` read above the circuit-breaker check and make the open-breaker verdict honor it:

- `tirith_fail_open=true` → `allow` with `"tirith disabled (circuit breaker)"` (unchanged behavior for the default config)
- `tirith_fail_open=false` → `block` with `"tirith unavailable, circuit breaker open (fail-closed)"`

This preserves the breaker's anti-hang purpose — no spawning happens when the breaker is open — while making the verdict consistent with every other failure path in the function (path-`None`, spawn `OSError`, `TimeoutExpired`, unknown exit code), all of which already respect `fail_open`.

## Tests

- `tests/tools/test_tirith_security.py`: 44 passed (3 new tests covering circuit-open + fail-open allow, circuit-open + fail-closed block, and no-spawn-when-open)
- `tests/tools/test_approval.py` + `test_denial_circuit_breaker.py` + `test_cron_approval_mode.py`: 121 passed

Closes #74922
