### PR TITLE
fix(bedrock): repair persisted bare foundation-model IDs at agent init (#58185)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -688,6 +688,38 @@ def init_agent(
     except Exception:
         pass
 
+    # Bedrock load-time repair: bare foundation-model IDs persisted by older
+    # pickers/config flows (``anthropic.claude-fable-5``) fail every call on
+    # on-demand accounts with HTTP 400 "on-demand throughput isn't supported"
+    # (#58185). Discovery/picker fixes stop NEW bare IDs, but IDs already
+    # persisted in config files and session rows keep failing on every resume.
+    # Upgrade to the covering inference profile when live discovery confirms
+    # one exists — the same model, invokable ID form. No-ops instantly (pure
+    # string check, no AWS call) for already-prefixed IDs; fails open when
+    # discovery is unavailable.
+    if agent.provider == "bedrock" or agent.api_mode == "bedrock_converse":
+        try:
+            from agent.bedrock_adapter import repair_bedrock_model_id
+
+            _region_match = re.search(
+                r"bedrock-runtime\.([a-z0-9-]+)\.", agent._base_url_lower or ""
+            )
+            _repaired = repair_bedrock_model_id(
+                agent.model,
+                region=_region_match.group(1) if _region_match else "",
+            )
+            if _repaired != agent.model:
+                logger.warning(
+                    "bedrock: repaired bare foundation-model ID %r -> inference "
+                    "profile %r (bare IDs are not invokable on on-demand "
+                    "accounts; update the persisted config/session value).",
+                    agent.model,
+                    _repaired,
+                )
+                agent.model = _repaired
+        except Exception:
+            pass
+
     # GPT-5.x models usually require the Responses API path, but some
     # providers have exceptions (for example Copilot's gpt-5-mini still
     # uses chat completions). Also auto-upgrade for direct OpenAI URLs

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -407,7 +407,8 @@ def bedrock_model_ids_or_none() -> Optional[List[str]]:
 # Full inference-profile prefix roster for repair checks: repair must never
 # re-prefix an already-prefixed ID from ANY geography.
 _REPAIR_PROFILE_PREFIXES = (
-    "global.", "us.", "eu.", "ap.", "apac.", "jp.", "ca.", "sa.", "me.", "af.",
+    "global.", "us.", "eu.", "ap.", "apac.", "au.", "jp.", "ca.", "sa.", "me.",
+    "af.",
 )
 
 
@@ -425,14 +426,18 @@ def repair_bedrock_model_id(model_id: str, region: str = "") -> str:
     This helper is the load-time repair: given a model ID, return the
     inference-profile ID that covers it when live discovery confirms one
     exists, preferring the region's own geo prefix, then ``global.``, then
-    the first covering profile discovered. The result is the SAME model —
+    the first covering profile that is routable from the endpoint's
+    geography. The result is the SAME model —
     only the ID form changes — so applying it silently at load is a repair,
     not a model substitution.
 
     Fail-open: returns *model_id* unchanged when it is already
     profile-prefixed or an ARN, does not look like a Bedrock foundation-model
     ID, discovery is unavailable (no IAM ``bedrock:ListInferenceProfiles``,
-    no network), or no covering profile exists. Discovery results are cached
+    no network), no covering profile exists, or every covering profile
+    belongs to a foreign geography AWS would reject from this endpoint
+    (a broken bare ID is better than a differently-broken foreign one).
+    Discovery results are cached
     (1h per region), and already-prefixed IDs return without any AWS call.
     """
     mid = (model_id or "").strip()
@@ -461,18 +466,30 @@ def repair_bedrock_model_id(model_id: str, region: str = "") -> str:
         return model_id
 
     geo = ""
+    routable = candidates
     try:
-        from hermes_cli.model_setup_flows import bedrock_region_geo_prefix
+        from hermes_cli.model_setup_flows import (
+            bedrock_model_routable_from_region,
+            bedrock_region_geo_prefix,
+        )
         geo = bedrock_region_geo_prefix(region)
+        routable = [
+            c for c in candidates
+            if bedrock_model_routable_from_region(c, region)
+        ]
     except Exception:
         pass
     for preferred in (geo, "global."):
         if not preferred:
             continue
-        for candidate in candidates:
+        for candidate in routable:
             if candidate.startswith(preferred):
                 return candidate
-    return candidates[0]
+    # Never repair onto a profile AWS would reject from this endpoint's
+    # geography (e.g. jp.* from a us-east-1 endpoint) — fail open instead.
+    if routable:
+        return routable[0]
+    return model_id
 
 
 # ---------------------------------------------------------------------------

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -404,6 +404,77 @@ def bedrock_model_ids_or_none() -> Optional[List[str]]:
     return None
 
 
+# Full inference-profile prefix roster for repair checks: repair must never
+# re-prefix an already-prefixed ID from ANY geography.
+_REPAIR_PROFILE_PREFIXES = (
+    "global.", "us.", "eu.", "ap.", "apac.", "jp.", "ca.", "sa.", "me.", "af.",
+)
+
+
+def repair_bedrock_model_id(model_id: str, region: str = "") -> str:
+    """Upgrade a bare foundation-model ID to its covering inference profile.
+
+    Older ``/model`` pickers and setup flows persisted bare foundation-model
+    IDs (``anthropic.claude-fable-5``) into config files and session rows.
+    On on-demand Bedrock accounts those IDs are not invokable — every call
+    fails with HTTP 400 "Invocation of model ID ... with on-demand throughput
+    isn't supported" (#58185). The picker/discovery fixes stop NEW bare IDs
+    from being offered, but IDs already persisted keep failing on every
+    resumed session until repaired.
+
+    This helper is the load-time repair: given a model ID, return the
+    inference-profile ID that covers it when live discovery confirms one
+    exists, preferring the region's own geo prefix, then ``global.``, then
+    the first covering profile discovered. The result is the SAME model —
+    only the ID form changes — so applying it silently at load is a repair,
+    not a model substitution.
+
+    Fail-open: returns *model_id* unchanged when it is already
+    profile-prefixed or an ARN, does not look like a Bedrock foundation-model
+    ID, discovery is unavailable (no IAM ``bedrock:ListInferenceProfiles``,
+    no network), or no covering profile exists. Discovery results are cached
+    (1h per region), and already-prefixed IDs return without any AWS call.
+    """
+    mid = (model_id or "").strip()
+    if (
+        not mid
+        or mid.startswith(_REPAIR_PROFILE_PREFIXES)
+        or mid.startswith("arn:")
+        or "." not in mid
+    ):
+        return model_id
+
+    region = (region or "").strip() or resolve_bedrock_region()
+    try:
+        discovered = discover_bedrock_models(region)
+    except Exception:
+        return model_id
+    if not discovered:
+        return model_id
+
+    candidates = [
+        m["id"] for m in discovered
+        if m["id"].startswith(_REPAIR_PROFILE_PREFIXES)
+        and m["id"].split(".", 1)[1] == mid
+    ]
+    if not candidates:
+        return model_id
+
+    geo = ""
+    try:
+        from hermes_cli.model_setup_flows import bedrock_region_geo_prefix
+        geo = bedrock_region_geo_prefix(region)
+    except Exception:
+        pass
+    for preferred in (geo, "global."):
+        if not preferred:
+            continue
+        for candidate in candidates:
+            if candidate.startswith(preferred):
+                return candidate
+    return candidates[0]
+
+
 # ---------------------------------------------------------------------------
 # Tool-calling capability detection
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1157,3 +1157,182 @@ class TestBearerTokenRoutesToConverse:
         runtime = self._resolve(monkeypatch, bearer=False)
         assert runtime["api_mode"] == "anthropic_messages"
         assert runtime.get("bedrock_anthropic") is True
+# ---------------------------------------------------------------------------
+# repair_bedrock_model_id — load-time bare-ID repair (#58185)
+# ---------------------------------------------------------------------------
+
+class TestRepairBedrockModelId:
+    """Load-time repair of persisted bare foundation-model IDs."""
+
+    def _discovered(self, *ids):
+        return [{"id": i} for i in ids]
+
+    def test_repairs_bare_id_to_global_profile(self):
+        from agent import bedrock_adapter
+
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            return_value=self._discovered(
+                "global.anthropic.claude-fable-5",
+                "anthropic.claude-fable-5",
+            ),
+        ):
+            result = bedrock_adapter.repair_bedrock_model_id(
+                "anthropic.claude-fable-5", region="us-east-1"
+            )
+        assert result == "global.anthropic.claude-fable-5"
+
+    def test_prefers_region_geo_prefix_over_global(self):
+        from agent import bedrock_adapter
+
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            return_value=self._discovered(
+                "global.anthropic.claude-fable-5",
+                "eu.anthropic.claude-fable-5",
+            ),
+        ):
+            result = bedrock_adapter.repair_bedrock_model_id(
+                "anthropic.claude-fable-5", region="eu-west-1"
+            )
+        assert result == "eu.anthropic.claude-fable-5"
+
+    def test_falls_back_to_first_candidate_without_geo_or_global(self):
+        from agent import bedrock_adapter
+
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            return_value=self._discovered("jp.anthropic.claude-fable-5"),
+        ):
+            result = bedrock_adapter.repair_bedrock_model_id(
+                "anthropic.claude-fable-5", region="us-east-1"
+            )
+        assert result == "jp.anthropic.claude-fable-5"
+
+    def test_already_prefixed_id_is_untouched_without_aws_call(self):
+        from agent import bedrock_adapter
+
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            side_effect=AssertionError("must not call discovery"),
+        ):
+            for mid in (
+                "global.anthropic.claude-fable-5",
+                "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+                "apac.anthropic.claude-fable-5",
+                "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2",
+            ):
+                assert bedrock_adapter.repair_bedrock_model_id(
+                    mid, region="us-east-1"
+                ) == mid
+
+    def test_non_bedrock_shapes_are_untouched(self):
+        from agent import bedrock_adapter
+
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            side_effect=AssertionError("must not call discovery"),
+        ):
+            assert bedrock_adapter.repair_bedrock_model_id("", region="x") == ""
+            assert bedrock_adapter.repair_bedrock_model_id(
+                "gpt-4o", region="us-east-1"
+            ) == "gpt-4o"
+
+    def test_fails_open_when_discovery_raises(self):
+        from agent import bedrock_adapter
+
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            side_effect=RuntimeError("AccessDenied"),
+        ):
+            result = bedrock_adapter.repair_bedrock_model_id(
+                "anthropic.claude-fable-5", region="us-east-1"
+            )
+        assert result == "anthropic.claude-fable-5"
+
+    def test_fails_open_when_no_covering_profile(self):
+        from agent import bedrock_adapter
+
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            return_value=self._discovered(
+                "global.anthropic.claude-opus-5",
+                "amazon.titan-text-express-v1",
+            ),
+        ):
+            result = bedrock_adapter.repair_bedrock_model_id(
+                "anthropic.claude-fable-5", region="us-east-1"
+            )
+        assert result == "anthropic.claude-fable-5"
+
+    def test_fails_open_when_discovery_empty(self):
+        from agent import bedrock_adapter
+
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models", return_value=[]
+        ):
+            result = bedrock_adapter.repair_bedrock_model_id(
+                "anthropic.claude-fable-5", region="us-east-1"
+            )
+        assert result == "anthropic.claude-fable-5"
+
+    def test_resolves_region_when_not_supplied(self):
+        from agent import bedrock_adapter
+
+        with patch.object(
+            bedrock_adapter, "resolve_bedrock_region", return_value="eu-central-1"
+        ) as mock_region, patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            return_value=self._discovered("eu.anthropic.claude-fable-5"),
+        ) as mock_discover:
+            result = bedrock_adapter.repair_bedrock_model_id(
+                "anthropic.claude-fable-5"
+            )
+        assert result == "eu.anthropic.claude-fable-5"
+        mock_region.assert_called_once()
+        mock_discover.assert_called_once_with("eu-central-1")
+
+    def test_agent_init_repairs_bare_bedrock_pin(self, monkeypatch):
+        """A persisted bare Bedrock ID is upgraded during AIAgent init."""
+        from agent import bedrock_adapter
+
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            return_value=self._discovered(
+                "global.anthropic.claude-fable-5",
+            ),
+        ), patch("run_agent.ContextCompressor") as mock_compressor:
+            mock_compressor.return_value = MagicMock(
+                context_length=200000, threshold_tokens=100000
+            )
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                model="anthropic.claude-fable-5",
+                provider="bedrock",
+                api_key="unused",
+                base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
+            )
+        assert agent.model == "global.anthropic.claude-fable-5"
+
+    def test_agent_init_leaves_prefixed_pin_alone(self, monkeypatch):
+        from agent import bedrock_adapter
+
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            side_effect=AssertionError("must not call discovery"),
+        ), patch("run_agent.ContextCompressor") as mock_compressor:
+            mock_compressor.return_value = MagicMock(
+                context_length=200000, threshold_tokens=100000
+            )
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                model="global.anthropic.claude-fable-5",
+                provider="bedrock",
+                api_key="unused",
+                base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
+            )
+        assert agent.model == "global.anthropic.claude-fable-5"

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1197,7 +1197,13 @@ class TestRepairBedrockModelId:
             )
         assert result == "eu.anthropic.claude-fable-5"
 
-    def test_falls_back_to_first_candidate_without_geo_or_global(self):
+    def test_fails_open_instead_of_foreign_geo_profile(self):
+        """A US endpoint must not be repaired onto a jp.* profile.
+
+        AWS rejects geo-prefixed profiles invoked from endpoints outside
+        their geography, so swapping a broken bare ID for a foreign profile
+        trades one failure for another. Fail open instead.
+        """
         from agent import bedrock_adapter
 
         with patch.object(
@@ -1206,6 +1212,19 @@ class TestRepairBedrockModelId:
         ):
             result = bedrock_adapter.repair_bedrock_model_id(
                 "anthropic.claude-fable-5", region="us-east-1"
+            )
+        assert result == "anthropic.claude-fable-5"
+
+    def test_falls_back_to_routable_candidate_without_geo_or_global(self):
+        """jp.* IS routable from ap-* endpoints, so fallback may use it."""
+        from agent import bedrock_adapter
+
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models",
+            return_value=self._discovered("jp.anthropic.claude-fable-5"),
+        ):
+            result = bedrock_adapter.repair_bedrock_model_id(
+                "anthropic.claude-fable-5", region="ap-northeast-1"
             )
         assert result == "jp.anthropic.claude-fable-5"
 
@@ -1220,6 +1239,7 @@ class TestRepairBedrockModelId:
                 "global.anthropic.claude-fable-5",
                 "us.anthropic.claude-haiku-4-5-20251001-v1:0",
                 "apac.anthropic.claude-fable-5",
+                "au.anthropic.claude-fable-5",
                 "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2",
             ):
                 assert bedrock_adapter.repair_bedrock_model_id(


### PR DESCRIPTION
## Problem

#58185 has two halves. The prevention half — stop the `/model` picker and discovery from offering bare foundation-model IDs — is covered by #58201 and #65810. This PR addresses the second half those PRs explicitly leave open: **IDs already persisted** in config files and session rows.

A session (or config) that pinned `anthropic.claude-fable-5` while the picker still offered bare IDs keeps failing on **every resumed turn** with:

```
HTTP 400: Invocation of model ID anthropic.claude-fable-5 with on-demand throughput isn't supported.
Retry your request with the ID or ARN of an inference profile that contains this model.
```

…even after the picker/discovery fixes land, because nothing ever rewrites the persisted value. Today the only remedy is hand-editing config/state (as #65810's description notes: bad persisted IDs "survive config corrections"). We hit exactly this in production: a session created minutes before a config fix kept crash-looping for hours afterward.

## Fix

`repair_bedrock_model_id(model_id, region)` in `agent/bedrock_adapter.py`:

- Pure string short-circuit (no AWS call) when the ID is already profile-prefixed (`global.`, `us.`, `eu.`, `ap.`, `apac.`, `jp.`, `ca.`, `sa.`, `me.`, `af.`) or an ARN, or doesn't look like a Bedrock foundation-model ID.
- Otherwise consult live discovery (existing 1h-cached `discover_bedrock_models()`) for an inference profile whose base ID matches; prefer the region's own geo prefix (via the existing `bedrock_region_geo_prefix`), then `global.`, then the first covering profile.
- **Fail-open**: on discovery failure (no `bedrock:ListInferenceProfiles` IAM, offline) or no covering profile, the ID passes through unchanged and the call proceeds as before.

Wired into `init_agent()` right after `normalize_model_for_provider`, gated on `provider == "bedrock"` / `api_mode == "bedrock_converse"`. A repair is logged at WARNING with both IDs so operators can fix the persisted value.

This is deliberately a **repair, not a substitution** — the covering inference profile routes to the same model, so silently applying it at load changes only the ID form, never the model. (An alternative failsafe — falling back to the config default model on this 400 — was considered and rejected: it silently changes the model mid-conversation, and doesn't help when the default itself is a bare ID.)

## Tests

11 new tests in `tests/agent/test_bedrock_adapter.py` (`TestRepairBedrockModelId`): geo-prefix preference, global fallback, first-candidate fallback, prefixed/ARN/non-Bedrock no-op without any AWS call, fail-open on discovery error/empty/no-cover, region auto-resolution, and two `AIAgent` init integration tests (bare pin repaired; prefixed pin untouched with discovery asserted un-called).

```
python -m pytest tests/agent/test_bedrock_adapter.py -q
73 passed
```

Complements #58201 and #65810; no overlap — this PR touches neither the picker nor discovery filtering.

Fixes the persisted-ID half of #58185.