### PR TITLE
fix(discord): keep free models visible in /model picker

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8570,6 +8570,14 @@ def _define_discord_view_classes() -> None:
                 return
 
             models = provider.get("models", [])
+            # Discord Select menus cap at 25 options. Stable-sort free models
+            # first so they stay reachable for providers whose catalog exceeds
+            # the cap (e.g. nous: 35 models, free ones at the tail). The
+            # relative order of everything else is preserved.
+            models = sorted(
+                models,
+                key=lambda m: 0 if m.lower().endswith(":free") else 1,
+            )
             options = []
             for model_id in models[:25]:
                 short = model_id.split("/")[-1] if "/" in model_id else model_id

--- a/tests/gateway/test_discord_model_picker.py
+++ b/tests/gateway/test_discord_model_picker.py
@@ -83,3 +83,48 @@ async def test_model_picker_clears_controls_before_running_switch_callback():
     interaction.edit_original_response.assert_awaited_once()
 
 
+def test_model_picker_keeps_free_tail_models_inside_25_option_cap():
+    """Regression: Discord Select menus cap at 25 options.
+
+    Providers whose catalog exceeds the cap (e.g. nous: 35 models) used to
+    lose tail ``:free`` models to the ``models[:25]`` slice, making them
+    unreachable in the picker. Free models must be stable-sorted to the front
+    so they stay selectable, and the relative order of non-free models must be
+    preserved.
+    """
+    non_free = [f"provider/model-{i:02d}" for i in range(30)]
+    free = [f"provider/free-{i:02d}:free" for i in range(5)]
+    models = non_free + free  # free models at the tail, like a real catalog
+
+    view = ModelPickerView(
+        providers=[
+            {
+                "slug": "provider",
+                "name": "Provider",
+                "models": models,
+                "total_models": len(models),
+                "is_current": False,
+            }
+        ],
+        current_model="provider/model-00",
+        current_provider="provider",
+        session_key="session-1",
+        on_model_selected=AsyncMock(return_value="ok"),
+        allowed_user_ids={"123"},
+    )
+
+    view._build_model_select("provider")
+    model_select = view.children[0]
+    options = model_select.options
+
+    assert len(options) == 25  # Discord cap
+    selected = [o.value for o in options]
+
+    # Every free model is reachable despite the 25-option cap.
+    assert all(m in selected for m in free)
+    # Free models float to the front.
+    assert selected[: len(free)] == free
+    # Non-free models keep their original relative order, truncated at the cap.
+    assert selected[len(free):] == non_free[: 25 - len(free)]
+
+


### PR DESCRIPTION
## Problem

The Discord `/model` picker shows at most **25 options per provider** (`models[:25]`), because Discord Select menus cap at 25. Providers with larger catalogs (e.g. **nous: 35 models**) had their free (`:free`) models at the **tail** of the model list, so they fell outside the slice and were **unreachable in the picker** — even though the backend payload included them.

## Fix

Stable-sort models so `:free` entries come first, keeping them inside the visible 25 while preserving the relative order of all other models:

```python
models = sorted(
    models,
    key=lambda m: 0 if m.lower().endswith(":free") else 1,
)
```

## Verification

- Reproduced: nous provider catalog = 35 models, free ones at positions 25-30 → cut off by `[:25]`.
- After fix: all 5 free models sort before the 25-option cap → always selectable.
- `py_compile` passes; lint OK (pre-existing Pyright noise unrelated).
