### PR TITLE
feat(agent): model-scoped credential pool exhaustion for 429s

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1027,6 +1027,13 @@ def recover_with_credential_pool(
         # ``effective_reason`` is resolved below; this closure runs after.
         if effective_reason is not None:
             kwargs["failure_reason"] = effective_reason.value
+        _agent_model = getattr(agent, "model", None) or None
+        if rotate_status == 429 and _agent_model:
+            # A 429 is model-scoped: bench only the (key, model) pair so the
+            # key stays selectable for other models.  Mirrors the auxiliary
+            # client's model threading; non-429 statuses (and 429s with no
+            # known model) keep key-level exhaustion semantics.
+            kwargs["model"] = _agent_model
         return pool.mark_exhausted_and_rotate(**kwargs)
 
     effective_reason = classified_reason

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1037,8 +1037,12 @@ def _to_openai_base_url(base_url: str) -> str:
     return url
 
 
-def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
-    """Return (pool_exists_for_provider, selected_entry)."""
+def _select_pool_entry(provider: str, model: Optional[str] = "") -> Tuple[bool, Optional[Any]]:
+    """Return (pool_exists_for_provider, selected_entry).
+
+    ``model`` is forwarded to ``pool.select(model=model)`` so pool entries
+    exhausted for this specific model are skipped during selection.
+    """
     try:
         pool = load_pool(provider)
     except Exception as exc:
@@ -1047,6 +1051,11 @@ def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
     if not pool or not pool.has_credentials():
         return False, None
     try:
+        if model:
+            try:
+                return True, pool.select(model=model)
+            except TypeError:
+                return True, pool.select()
         return True, pool.select()
     except Exception as exc:
         logger.debug("Auxiliary client: could not select pool entry for %s: %s", provider, exc)
@@ -2349,7 +2358,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 pass
             return _try_anthropic()
 
-        pool_present, entry = _select_pool_entry(provider_id)
+        model = _get_aux_model_for_provider(provider_id) or None
+        pool_present, entry = _select_pool_entry(provider_id, model)
         if pool_present:
             api_key = _pool_runtime_api_key(entry)
             if not api_key:
@@ -2357,7 +2367,6 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
             raw_base_url = _pool_runtime_base_url(entry, pconfig.inference_base_url) or pconfig.inference_base_url
             base_url = _to_openai_base_url(raw_base_url)
-            model = _get_aux_model_for_provider(provider_id) or None
             if model is None:
                 continue  # skip provider if we don't know a valid aux model
             logger.debug("Auxiliary text client: %s (%s) via pool", pconfig.name, model)
@@ -2493,7 +2502,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
     if not _is_free_model(or_model):
         _warn_paid_lane_once(or_model)
 
-    pool_present, entry = _select_pool_entry("openrouter")
+    pool_present, entry = _select_pool_entry("openrouter", model)
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
         if or_key:
@@ -3344,7 +3353,7 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
             "pass model explicitly (auxiliary.<task>.model in config.yaml)."
         )
         return None, None
-    pool_present, entry = _select_pool_entry("openai-codex")
+    pool_present, entry = _select_pool_entry("openai-codex", model)
     if pool_present:
         codex_token = _pool_runtime_api_key(entry)
         if codex_token:
@@ -3488,7 +3497,8 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
     except ImportError:
         return None, None
 
-    pool_present, entry = _select_pool_entry("anthropic")
+    model = _get_aux_model_for_provider("anthropic") or "claude-haiku-4-5-20251001"
+    pool_present, entry = _select_pool_entry("anthropic", model)
     if pool_present and entry is not None:
         token = explicit_api_key or _pool_runtime_api_key(entry)
     else:
@@ -3533,7 +3543,6 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
 
     from agent.anthropic_adapter import _is_oauth_token
     is_oauth = _is_oauth_token(token)
-    model = _get_aux_model_for_provider("anthropic") or "claude-haiku-4-5-20251001"
     logger.debug("Auxiliary client: Anthropic native (%s) at %s (oauth=%s)", model, base_url, is_oauth)
     try:
         real_client = build_anthropic_client(token, base_url)
@@ -4212,13 +4221,16 @@ def _recoverable_pool_provider(
     return None
 
 
-def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str = "") -> bool:
+def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str = "", model: str = "") -> bool:
     """Try same-provider credential-pool recovery for auxiliary calls.
 
     ``failed_api_key`` is the API key that was actually used for the failing
     request.  Passing it lets mark_exhausted_and_rotate identify the correct
     pool entry even when another process has already rotated the pool (which
     would leave current() as None, causing the wrong entry to be marked).
+
+    ``model`` scopes the exhaustion marking to the model that actually failed
+    so sibling entries are not punished for another model's quota wall.
     """
     normalized = _normalize_aux_provider(provider)
     try:
@@ -4242,6 +4254,7 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
             status_code=status_code if status_code is not None else 401,
             error_context=error_context,
             api_key_hint=hint,
+            model=model or None,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)
@@ -4254,6 +4267,7 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
             status_code=status_code if status_code is not None else fallback_status,
             error_context=error_context,
             api_key_hint=hint,
+            model=model or None,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)
@@ -5865,7 +5879,7 @@ def resolve_provider_client(
 
     # ── OpenRouter ───────────────────────────────────────────
     if provider == "openrouter":
-        client, default = _try_openrouter(explicit_api_key=explicit_api_key)
+        client, default = _try_openrouter(explicit_api_key=explicit_api_key, model=model)
         if client is None:
             logger.warning(
                 "resolve_provider_client: openrouter requested but %s",
@@ -9141,7 +9155,12 @@ def _call_llm_impl(
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
-            if _recover_provider_pool(pool_provider, recovery_err, failed_api_key=_client_api_key):
+            if _recover_provider_pool(
+                pool_provider,
+                recovery_err,
+                failed_api_key=_client_api_key,
+                model=resolved_model or final_model or "",
+            ):
                 logger.info(
                     "Auxiliary %s: recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
@@ -9173,7 +9192,11 @@ def _call_llm_impl(
                     # alternative providers can still serve the request.
                     if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
                             or _is_rate_limit_error(retry2_err)):
-                        _recover_provider_pool(pool_provider, retry2_err)
+                        _recover_provider_pool(
+                            pool_provider,
+                            retry2_err,
+                            model=resolved_model or final_model or "",
+                        )
                         first_err = retry2_err
                     else:
                         raise
@@ -9817,7 +9840,12 @@ async def _async_call_llm_impl(
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
-            if _recover_provider_pool(pool_provider, recovery_err, failed_api_key=_client_api_key):
+            if _recover_provider_pool(
+                pool_provider,
+                recovery_err,
+                failed_api_key=_client_api_key,
+                model=resolved_model or final_model or "",
+            ):
                 logger.info(
                     "Auxiliary %s (async): recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
@@ -9842,7 +9870,11 @@ async def _async_call_llm_impl(
                 except Exception as retry2_err:
                     if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
                             or _is_rate_limit_error(retry2_err)):
-                        _recover_provider_pool(pool_provider, retry2_err)
+                        _recover_provider_pool(
+                            pool_provider,
+                            retry2_err,
+                            model=resolved_model or final_model or "",
+                        )
                         first_err = retry2_err
                     else:
                         raise

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -9,7 +9,7 @@ import threading
 import time
 import uuid
 import re
-from dataclasses import dataclass, fields, replace
+from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -198,6 +198,11 @@ class PooledCredential:
     last_error_reason: Optional[str] = None
     last_error_message: Optional[str] = None
     last_error_reset_at: Optional[float] = None
+    # Per-model 429 rate-limit benchings, keyed by exact model string. A key
+    # benched for one model stays selectable for other models. Each value:
+    # {"until": epoch seconds, "status_code": 429, "reason": Optional[str],
+    # "reset_at": Optional[float]}.
+    model_exhaustions: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     base_url: Optional[str] = None
     expires_at: Optional[str] = None
     expires_at_ms: Optional[int] = None
@@ -211,6 +216,8 @@ class PooledCredential:
     def __post_init__(self):
         if self.extra is None:
             self.extra = {}
+        if self.model_exhaustions is None:
+            self.model_exhaustions = {}
         self.auth_type = _normalize_pool_auth_type(
             self.provider,
             self.access_token,
@@ -247,6 +254,7 @@ class PooledCredential:
             "last_error_reason",
             "last_error_message",
             "last_error_reset_at",
+            "model_exhaustions",
         }
         result: Dict[str, Any] = {}
         for field_def in fields(self):
@@ -420,19 +428,33 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
     return normalized
 
 
-def _exhausted_until(entry: PooledCredential, *, sole_credential: bool = False) -> Optional[float]:
+def _exhausted_until(entry: PooledCredential, *, sole_credential: bool = False, model: Optional[str] = None) -> Optional[float]:
+    """Return when *entry* can next be used, or None if it is not benched.
+
+    With *model*, the later of the key-level cooldown and any per-model
+    rate-limit benching for that model wins.  Without *model*, only the
+    key-level cooldown applies (legacy behavior).
+    """
     if entry.last_status != STATUS_EXHAUSTED:
-        return None
-    reset_at = _parse_absolute_timestamp(getattr(entry, "last_error_reset_at", None))
-    if reset_at is not None:
-        return reset_at
-    if entry.last_status_at:
-        return entry.last_status_at + _exhausted_ttl(
-            entry.last_error_code,
-            sole_credential=sole_credential,
-            failure_reason=getattr(entry, "failure_reason", None),
-        )
-    return None
+        until: Optional[float] = None
+    else:
+        reset_at = _parse_absolute_timestamp(getattr(entry, "last_error_reset_at", None))
+        if reset_at is not None:
+            until = reset_at
+        elif entry.last_status_at:
+            until = entry.last_status_at + _exhausted_ttl(
+                entry.last_error_code,
+                sole_credential=sole_credential,
+                failure_reason=getattr(entry, "failure_reason", None),
+            )
+        else:
+            until = None
+    if model:
+        model_info = (entry.model_exhaustions or {}).get(model)
+        model_until = model_info.get("until") if isinstance(model_info, dict) else None
+        if model_until:
+            until = model_until if until is None else max(until, model_until)
+    return until
 
 
 def _normalize_custom_pool_name(name: str) -> str:
@@ -1766,13 +1788,12 @@ class CredentialPool:
             return False
         return False
 
-    def select(self) -> Optional[PooledCredential]:
-        entry, pending_refresh = self._select_under_lock()
+    def select(self, model: Optional[str] = None) -> Optional[PooledCredential]:
+        entry, pending_refresh = self._select_under_lock(model=model)
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
         if entry is not None:
             self._unmatched_rotation_streak = 0
-            return entry
         # If no entry was available but we just refreshed some, re-select
         # now that the refreshed entries are back in the pool.
         if pending_refresh:
@@ -1781,10 +1802,10 @@ class CredentialPool:
                 self._unmatched_rotation_streak = 0
         return entry
 
-    def _select_under_lock(self) -> Tuple[Optional[PooledCredential], List[tuple]]:
+    def _select_under_lock(self, model: Optional[str] = None) -> Tuple[Optional[PooledCredential], List[tuple]]:
         """Run selection under the lock, returning entry + pending refreshes."""
         with self._lock:
-            return self._select_unlocked()
+            return self._select_unlocked(model=model)
 
     def _refresh_pending_entries(self, pending: List[tuple]) -> None:
         """Refresh deferred single-use-token entries outside the lock.
@@ -1803,13 +1824,16 @@ class CredentialPool:
             self._refresh_entry(entry, force=False)
 
     def _available_entries(
-        self, *, clear_expired: bool = False, refresh: bool = False,
+        self, *, clear_expired: bool = False, refresh: bool = False, model: Optional[str] = None,
     ) -> Tuple[List[PooledCredential], List[tuple]]:
         """Return (available, pending_refresh) for entries not in cooldown.
 
         When *clear_expired* is True, entries whose cooldown has elapsed are
         reset to STATUS_OK and persisted.  When *refresh* is True, entries
-        that need a token refresh are refreshed (skipped on failure).
+        that need a token refresh are refreshed (skipped on failure).  When
+        *model* is given, entries with an active per-model rate-limit benching
+        for that model are skipped; with *clear_expired*, expired per-model
+        benchings for *model* are pruned too.
 
         Single-use-token refreshes (openai-codex, xai-oauth) are returned as
         *pending_refresh* tuples so the caller can execute them outside the
@@ -1911,7 +1935,7 @@ class CredentialPool:
                 # the re-auth case for OAuth singletons.
                 continue
             if entry.last_status == STATUS_EXHAUSTED:
-                exhausted_until = _exhausted_until(entry, sole_credential=sole_credential)
+                exhausted_until = _exhausted_until(entry, sole_credential=sole_credential, model=model)
                 if exhausted_until is not None and now < exhausted_until:
                     # Codex quota windows can reopen EARLY: the user redeems a
                     # banked rate-limit reset (Codex CLI / ChatGPT UI), upgrades
@@ -1937,6 +1961,20 @@ class CredentialPool:
                     )
                     self._replace_entry(entry, cleared)
                     entry = cleared
+                    cleared_any = True
+            if model is not None and entry.last_status != STATUS_EXHAUSTED:
+                # Key-level status is fine, but this model may still be
+                # rate-limited on the key: bench only the (key, model) pair.
+                model_info = (entry.model_exhaustions or {}).get(model)
+                model_until = model_info.get("until") if isinstance(model_info, dict) else None
+                if model_until is not None and model_until > now:
+                    continue
+                if clear_expired and model_until is not None:
+                    pruned = dict(entry.model_exhaustions or {})
+                    pruned.pop(model, None)
+                    cleared_entry = replace(entry, model_exhaustions=pruned)
+                    self._replace_entry(entry, cleared_entry)
+                    entry = cleared_entry
                     cleared_any = True
             if refresh and self._entry_needs_refresh(entry):
                 if self.provider in ("openai-codex", "xai-oauth"):
@@ -1975,13 +2013,13 @@ class CredentialPool:
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
 
-    def _select_unlocked(self, *, refresh: bool = True) -> Tuple[Optional[PooledCredential], List[tuple]]:
+    def _select_unlocked(self, *, refresh: bool = True, model: Optional[str] = None) -> Tuple[Optional[PooledCredential], List[tuple]]:
         """Select the best available credential entry.
 
         Returns ``(entry, pending_refresh)`` where *pending_refresh* contains
         single-use-token entries that must be refreshed outside the lock.
         """
-        available, pending_refresh = self._available_entries(clear_expired=True, refresh=refresh)
+        available, pending_refresh = self._available_entries(clear_expired=True, refresh=refresh, model=model)
         if not available:
             self._current_id = None
             self._log_no_available_entries()
@@ -2036,8 +2074,12 @@ class CredentialPool:
         api_key_hint: Optional[str] = None,
         credential_id: Optional[str] = None,
         failure_reason: Optional[str] = None,
+        model: Optional[str] = None,
     ) -> Optional[PooledCredential]:
         with self._lock:
+            # A 429 with a known model benches only the (key, model) pair;
+            # every other status keeps the legacy key-level behavior.
+            rotate_model = model if status_code == 429 else None
             entry = None
             identity_supplied = bool(credential_id or api_key_hint)
             if credential_id:
@@ -2095,7 +2137,7 @@ class CredentialPool:
                     self.provider,
                 )
                 self._current_id = None
-                next_entry, _pending = self._select_unlocked(refresh=False)
+                next_entry, _pending = self._select_unlocked(refresh=False, model=rotate_model)
                 avail, _ = self._available_entries()
                 if next_entry is not None and len(avail) == 1:
                     # A single-entry pool cannot rotate. Returning its only
@@ -2110,10 +2152,55 @@ class CredentialPool:
             # streak is stale (this mark WILL advance pool state).
             self._unmatched_rotation_streak = 0
             if entry is None:
-                entry = self._current_unlocked() or self._select_unlocked(refresh=False)[0]
+                entry = self._current_unlocked() or self._select_unlocked(refresh=False, model=rotate_model)[0]
             if entry is None:
                 return None
             _label = entry.label or entry.id[:8]
+            if rotate_model is not None:
+                # Per-model 429 rate limit: bench only the (key, model) pair.
+                # The key-level status is left untouched so the key stays
+                # selectable for other models.
+                normalized = _normalize_error_context(error_context)
+                reset_at = normalized.get("reset_at")
+                until = reset_at if reset_at is not None else time.time() + EXHAUSTED_TTL_429_SECONDS
+                bench = {
+                    "until": until,
+                    "status_code": 429,
+                    "reason": normalized.get("reason"),
+                    "reset_at": reset_at,
+                }
+                # The same key can back more than one pool entry (an explicit
+                # pool entry plus a ``model_config`` entry auto-seeded from
+                # ``model.api_key``).  Bench every entry sharing the failed
+                # key for this model, or model-aware rotation would reselect
+                # the same depleted key through its sibling entry.
+                failed_runtime_key = getattr(entry, "runtime_api_key", None)
+                targets = [entry]
+                if identity_supplied and failed_runtime_key:
+                    targets.extend(
+                        sibling
+                        for sibling in self._entries
+                        if sibling.id != entry.id
+                        and sibling.runtime_api_key == failed_runtime_key
+                    )
+                for target in targets:
+                    target_exhaustions = dict(target.model_exhaustions or {})
+                    target_exhaustions[rotate_model] = dict(bench)
+                    self._replace_entry(
+                        target, replace(target, model_exhaustions=target_exhaustions)
+                    )
+                self._persist()
+                sibling_note = f" (+{len(targets) - 1} sibling)" if len(targets) > 1 else ""
+                logger.info(
+                    "credential pool: marking %s model-limited for %s%s, rotating for that model",
+                    _label, rotate_model, sibling_note,
+                )
+                self._current_id = None
+                next_entry, _ = self._select_unlocked(refresh=False, model=rotate_model)
+                if next_entry:
+                    _next_label = next_entry.label or next_entry.id[:8]
+                    logger.info("credential pool: rotated to %s", _next_label)
+                return next_entry
             self._mark_exhausted(
                 entry, status_code, error_context, failure_reason=failure_reason
             )
@@ -2161,7 +2248,7 @@ class CredentialPool:
                     _label, status_code,
                 )
             self._current_id = None
-            next_entry, _pending = self._select_unlocked(refresh=False)
+            next_entry, _pending = self._select_unlocked(refresh=False, model=rotate_model)
             if next_entry:
                 _next_label = next_entry.label or next_entry.id[:8]
                 logger.info("credential pool: rotated to %s", _next_label)
@@ -2285,7 +2372,7 @@ class CredentialPool:
             count = 0
             new_entries = []
             for entry in self._entries:
-                if entry.last_status or entry.last_status_at or entry.last_error_code:
+                if entry.last_status or entry.last_status_at or entry.last_error_code or entry.model_exhaustions:
                     new_entries.append(
                         replace(
                             entry,
@@ -2295,6 +2382,7 @@ class CredentialPool:
                             last_error_reason=None,
                             last_error_message=None,
                             last_error_reset_at=None,
+                            model_exhaustions={},
                         )
                     )
                     count += 1

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -132,33 +132,57 @@ def _classify_exhausted_status(entry) -> tuple[str, bool]:
 
 
 
+def _format_model_limited(entry) -> str:
+    """Compact marker when a key is rate-limited for specific models (per-model 429s)."""
+    model_exhaustions = getattr(entry, "model_exhaustions", None) or {}
+    if not isinstance(model_exhaustions, dict):
+        return ""
+    now = time.time()
+    active = sorted(
+        model
+        for model, info in model_exhaustions.items()
+        if isinstance(info, dict)
+        and isinstance(info.get("until"), (int, float))
+        and info["until"] > now
+    )
+    if not active:
+        return ""
+    if len(active) == 1:
+        return f" model-limited ({active[0]})"
+    return f" model-limited ({len(active)} models)"
+
+
 def _format_exhausted_status(entry) -> str:
     if entry.last_status != STATUS_EXHAUSTED:
-        return ""
+        return _format_model_limited(entry)
     label, show_retry_window = _classify_exhausted_status(entry)
     reason = getattr(entry, "last_error_reason", None)
     reason_text = f" {reason}" if isinstance(reason, str) and reason.strip() else ""
     code = f" ({entry.last_error_code})" if entry.last_error_code else ""
     if not show_retry_window:
-        return f" {label}{reason_text}{code} (re-auth may be required)"
-    exhausted_until = _exhausted_until(entry)
-    if exhausted_until is None:
-        return f" {label}{reason_text}{code}"
-    remaining = max(0, int(math.ceil(exhausted_until - time.time())))
-    if remaining <= 0:
-        return f" {label}{reason_text}{code} (ready to retry)"
-    minutes, seconds = divmod(remaining, 60)
-    hours, minutes = divmod(minutes, 60)
-    days, hours = divmod(hours, 24)
-    if days:
-        wait = f"{days}d {hours}h"
-    elif hours:
-        wait = f"{hours}h {minutes}m"
-    elif minutes:
-        wait = f"{minutes}m {seconds}s"
+        status = f" {label}{reason_text}{code} (re-auth may be required)"
     else:
-        wait = f"{seconds}s"
-    return f" {label}{reason_text}{code} ({wait} left)"
+        exhausted_until = _exhausted_until(entry)
+        if exhausted_until is None:
+            status = f" {label}{reason_text}{code}"
+        else:
+            remaining = max(0, int(math.ceil(exhausted_until - time.time())))
+            if remaining <= 0:
+                status = f" {label}{reason_text}{code} (ready to retry)"
+            else:
+                minutes, seconds = divmod(remaining, 60)
+                hours, minutes = divmod(minutes, 60)
+                days, hours = divmod(hours, 24)
+                if days:
+                    wait = f"{days}d {hours}h"
+                elif hours:
+                    wait = f"{hours}h {minutes}m"
+                elif minutes:
+                    wait = f"{minutes}m {seconds}s"
+                else:
+                    wait = f"{seconds}s"
+                status = f" {label}{reason_text}{code} ({wait} left)"
+    return status + _format_model_limited(entry)
 
 
 def auth_add_command(args) -> None:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1868,7 +1868,10 @@ def resolve_runtime_provider(
     except Exception:
         pool = None
     if pool and pool.has_credentials():
-        entry = pool.select()
+        if target_model:
+            entry = pool.select(model=target_model)
+        else:
+            entry = pool.select()
         pool_api_key = ""
         if entry is not None:
             pool_api_key = (

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2045,8 +2045,10 @@ def test_model_scoped_429_keeps_key_level_status_and_rotates_for_that_model(
         api_key_hint="***",
         model="gemini-3.5-flash-lite",
     )
-    assert next_entry is not None
-    assert next_entry.id == "cred-2"
+    # Both entries share the same runtime key ("***"), so the per-model
+    # bench propagates to the sibling: nothing is left to rotate to for the
+    # rate-limited model.
+    assert next_entry is None
 
     cred_1 = pool.entries()[0]
     assert cred_1.id == "cred-1"
@@ -2055,13 +2057,18 @@ def test_model_scoped_429_keeps_key_level_status_and_rotates_for_that_model(
     assert bench is not None
     assert bench["status_code"] == 429
     assert bench["until"] > time.time()
+    # Sibling sharing the failed key is benched for the model too, so
+    # model-aware rotation cannot reselect the same depleted key.
+    cred_2 = pool.entries()[1]
+    assert cred_2.last_status == "ok"
+    assert "gemini-3.5-flash-lite" in cred_2.model_exhaustions
 
     sel_x = pool.select(model="gemini-3.5-flash-lite")
-    assert sel_x is not None and sel_x.id == "cred-2"
+    assert sel_x is None  # every same-key entry benched for that model
     sel_y = pool.select(model="gemini-3.5-pro")
-    assert sel_y is not None and sel_y.id == "cred-1"
+    assert sel_y is not None and sel_y.id in {"cred-1", "cred-2"}
     sel_none = pool.select()
-    assert sel_none is not None and sel_none.id == "cred-1"  # no-model callers ignore benches
+    assert sel_none is not None and sel_none.id in {"cred-1", "cred-2"}  # no-model callers ignore benches
 
 
 def test_peek_and_has_available_ignore_model_benches(tmp_path, monkeypatch):

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2024,3 +2024,95 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+def test_model_scoped_429_keeps_key_level_status_and_rotates_for_that_model(
+    tmp_path, monkeypatch
+):
+    """A 429 with a known model benches only (key, model), not the key.
+
+    The failing entry's key-level ``last_status`` must stay untouched so the
+    key remains selectable for every other model; rotation picks the next key
+    only for the rate-limited model.  Regression: before model-scoped
+    exhaustion, a 429 on one model marked the whole key exhausted until
+    ``reset_at`` (up to 24h), killing it for all models.
+    """
+    pool = _load_two_ok_pool(tmp_path, monkeypatch)
+
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={"message": "quota exceeded for model"},
+        api_key_hint="***",
+        model="gemini-3.5-flash-lite",
+    )
+    assert next_entry is not None
+    assert next_entry.id == "cred-2"
+
+    cred_1 = pool.entries()[0]
+    assert cred_1.id == "cred-1"
+    assert cred_1.last_status == "ok"  # key-level status NOT flipped
+    bench = cred_1.model_exhaustions.get("gemini-3.5-flash-lite")
+    assert bench is not None
+    assert bench["status_code"] == 429
+    assert bench["until"] > time.time()
+
+    sel_x = pool.select(model="gemini-3.5-flash-lite")
+    assert sel_x is not None and sel_x.id == "cred-2"
+    sel_y = pool.select(model="gemini-3.5-pro")
+    assert sel_y is not None and sel_y.id == "cred-1"
+    sel_none = pool.select()
+    assert sel_none is not None and sel_none.id == "cred-1"  # no-model callers ignore benches
+
+
+def test_peek_and_has_available_ignore_model_benches(tmp_path, monkeypatch):
+    """The model-agnostic surfaces keep seeing a model-benched key as usable.
+
+    ``peek()`` and ``has_available()`` take no model, so a key that is only
+    benched for one model must still count as available there; only
+    model-aware selection skips it.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "custom": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "tok-1",
+                        "last_status": "ok",
+                        "model_exhaustions": {
+                            "gemini-x": {
+                                "until": time.time() + 3600,
+                                "status_code": 429,
+                                "reason": None,
+                                "reset_at": None,
+                            }
+                        },
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "secondary",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "tok-2",
+                        "last_status": "ok",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("custom")
+    assert pool.has_available() is True
+    assert pool.peek().id == "cred-1"
+    # The model-aware path skips the benched key for that model.
+    assert pool.select(model="gemini-x").id == "cred-2"

--- a/tests/agent/test_credential_pool_model_exhaustion.py
+++ b/tests/agent/test_credential_pool_model_exhaustion.py
@@ -1,0 +1,320 @@
+"""Tests for model-scoped exhaustion in the credential pool.
+
+A 429 rate limit on a known model must bench only the (key, model) pair so
+the key stays selectable for other models.  Callers that do not pass a
+model keep the exact legacy key-level behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+
+
+def _write_auth_store(tmp_path, payload: dict) -> None:
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _two_key_pool_payload() -> dict:
+    """Two healthy manual api_key entries with distinct access tokens."""
+    return {
+        "version": 1,
+        "credential_pool": {
+            "custom": [
+                {
+                    "id": "cred-a",
+                    "label": "key-a",
+                    "auth_type": "api_key",
+                    "priority": 0,
+                    "source": "manual",
+                    "access_token": "tok-a",
+                    "last_status": "ok",
+                    "last_status_at": None,
+                    "last_error_code": None,
+                },
+                {
+                    "id": "cred-b",
+                    "label": "key-b",
+                    "auth_type": "api_key",
+                    "priority": 1,
+                    "source": "manual",
+                    "access_token": "tok-b",
+                    "last_status": "ok",
+                    "last_status_at": None,
+                    "last_error_code": None,
+                },
+            ]
+        },
+    }
+
+
+def _load_pool(tmp_path, monkeypatch, payload: Optional[dict] = None):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, payload or _two_key_pool_payload())
+    from agent.credential_pool import load_pool
+
+    return load_pool("custom")
+
+
+def _entry(pool, entry_id: str):
+    return next(e for e in pool.entries() if e.id == entry_id)
+
+
+def _selected_id(pool, model=None) -> str:
+    """select() returns Optional; tests here always expect an entry."""
+    entry = pool.select(model=model)
+    assert entry is not None
+    return entry.id
+
+
+def test_model_scoped_429_benches_pair_only_and_rotates_for_that_model(tmp_path, monkeypatch):
+    """A 429 with a known model must not flip the key-level status.
+
+    The failing key is benched only for that model; rotation for the model
+    lands on the other key, and the failing key stays selectable for other
+    models.
+    """
+    pool = _load_pool(tmp_path, monkeypatch)
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        api_key_hint="tok-a",
+        model="gemini-3.5-flash-lite",
+    )
+    assert next_entry is not None
+    assert next_entry.id == "cred-b"
+
+    key_a = _entry(pool, "cred-a")
+    # Key-level status untouched: the key is not exhausted for other models.
+    assert key_a.last_status == "ok"
+    bench = key_a.model_exhaustions["gemini-3.5-flash-lite"]
+    assert bench["status_code"] == 429
+    assert bench["until"] > time.time()
+
+    # The benched model is routed to the other key...
+    assert _selected_id(pool, "gemini-3.5-flash-lite") == "cred-b"
+    # ...but another model may still use key A.
+    assert _selected_id(pool, "gemini-3.5-pro") == "cred-a"
+
+
+def test_select_skips_model_benched_key_for_that_model_only(tmp_path, monkeypatch):
+    """Active per-model benching blocks only that model, not others."""
+    payload = _two_key_pool_payload()
+    payload["credential_pool"]["custom"][0]["model_exhaustions"] = {
+        "gemini-x": {
+            "until": time.time() + 3600,
+            "status_code": 429,
+            "reason": None,
+            "reset_at": None,
+        }
+    }
+    pool = _load_pool(tmp_path, monkeypatch, payload)
+
+    assert _selected_id(pool, "gemini-x") == "cred-b"
+    assert _selected_id(pool, "gemini-y") == "cred-a"
+    # No-model selection ignores per-model benchings entirely.
+    assert _selected_id(pool) == "cred-a"
+
+def test_model_429_prefers_provider_reset_at_over_default_ttl(tmp_path, monkeypatch):
+    """The provider's reset_at from error_context wins over the 1h TTL."""
+    pool = _load_pool(tmp_path, monkeypatch)
+    reset_at = time.time() + 4 * 3600  # clearly beyond the 1h default TTL
+
+    pool.mark_exhausted_and_rotate(
+        status_code=429,
+        api_key_hint="tok-a",
+        model="gemini-x",
+        error_context={"reset_at": reset_at, "reason": "rate_limit_exceeded"},
+    )
+
+    bench = _entry(pool, "cred-a").model_exhaustions["gemini-x"]
+    assert bench["until"] == pytest.approx(reset_at, abs=2)
+    assert bench["reset_at"] == pytest.approx(reset_at, abs=2)
+    assert bench["reason"] == "rate_limit_exceeded"
+
+
+def test_expired_model_bench_clears_and_is_pruned(tmp_path, monkeypatch):
+    """A past-until bench no longer blocks selection and is pruned on clear."""
+    payload = _two_key_pool_payload()
+    payload["credential_pool"]["custom"][0]["model_exhaustions"] = {
+        "gemini-x": {
+            "until": time.time() - 60,
+            "status_code": 429,
+            "reason": None,
+            "reset_at": None,
+        }
+    }
+    pool = _load_pool(tmp_path, monkeypatch, payload)
+
+    # The expired bench no longer blocks the model.
+    assert _selected_id(pool, "gemini-x") == "cred-a"
+
+    # Selection runs with clear_expired=True, which pruned the stale entry.
+    key_a = _entry(pool, "cred-a")
+    assert "gemini-x" not in key_a.model_exhaustions
+
+
+def test_model_bench_survives_persist_and_reload(tmp_path, monkeypatch):
+    """Model benchings round-trip through auth.json with a real reload."""
+    pool = _load_pool(tmp_path, monkeypatch)
+    pool.mark_exhausted_and_rotate(
+        status_code=429,
+        api_key_hint="tok-a",
+        model="gemini-x",
+    )
+
+    stored = json.loads((tmp_path / "hermes" / "auth.json").read_text(encoding="utf-8"))
+    stored_a = next(
+        e for e in stored["credential_pool"]["custom"] if e["id"] == "cred-a"
+    )
+    assert stored_a["model_exhaustions"]["gemini-x"]["status_code"] == 429
+
+    from agent.credential_pool import load_pool
+
+    pool2 = load_pool("custom")
+    assert _entry(pool2, "cred-a").model_exhaustions["gemini-x"]["until"] > time.time()
+    assert _selected_id(pool2, "gemini-x") == "cred-b"
+    assert _selected_id(pool2, "gemini-y") == "cred-a"
+
+
+def test_auth_reset_clears_model_exhaustions(tmp_path, monkeypatch):
+    """`hermes auth reset` clears per-model benchings for every entry."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "tok-1",
+                        "last_status": "ok",
+                        "last_status_at": None,
+                        "last_error_code": None,
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "secondary",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "tok-2",
+                        "last_status": "ok",
+                        "last_status_at": None,
+                        "last_error_code": None,
+                    },
+                ]
+            },
+        },
+    )
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    pool.mark_exhausted_and_rotate(
+        status_code=429,
+        api_key_hint="tok-1",
+        model="gemini-x",
+    )
+    assert _entry(pool, "cred-1").model_exhaustions
+
+    from hermes_cli.auth_commands import auth_reset_command
+
+    auth_reset_command(SimpleNamespace(provider="anthropic"))
+
+    pool2 = load_pool("anthropic")
+    assert _entry(pool2, "cred-1").model_exhaustions == {}
+    # The key is usable again for the previously benched model.
+    assert _selected_id(pool2, "gemini-x") == "cred-1"
+
+
+def test_429_without_model_keeps_key_level_behavior(tmp_path, monkeypatch):
+    """model=None callers keep the exact legacy key-level exhaustion."""
+    pool = _load_pool(tmp_path, monkeypatch)
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        api_key_hint="tok-a",
+    )
+    assert next_entry is not None
+    assert next_entry.id == "cred-b"
+
+    key_a = _entry(pool, "cred-a")
+    assert key_a.last_status == "exhausted"
+    assert key_a.model_exhaustions == {}
+
+    # Key-level exhaustion blocks the key for every model.
+    assert _selected_id(pool) == "cred-b"
+    assert _selected_id(pool, "gemini-x") == "cred-b"
+    assert _selected_id(pool, "gemini-y") == "cred-b"
+
+
+def test_non_429_with_model_keeps_key_level_behavior(tmp_path, monkeypatch):
+    """Only 429 with a model benches per-model; 401 stays key-level."""
+    pool = _load_pool(tmp_path, monkeypatch)
+    pool.mark_exhausted_and_rotate(
+        status_code=401,
+        api_key_hint="tok-a",
+        model="gemini-x",
+    )
+
+    key_a = _entry(pool, "cred-a")
+    assert key_a.last_status == "exhausted"
+    assert key_a.model_exhaustions == {}
+    assert _selected_id(pool, "gemini-x") == "cred-b"
+
+
+def test_model_bench_dominates_when_key_level_cooldown_expired(tmp_path, monkeypatch):
+    """The later of key-level cooldown and per-model bench gates selection.
+
+    Key A's key-level 429 cooldown has elapsed, so a plain selection would
+    reset it to OK; the still-active per-model bench for gemini-x must keep
+    blocking that model while other models see the key as healthy.
+    """
+    payload = _two_key_pool_payload()
+    entry_a = payload["credential_pool"]["custom"][0]
+    entry_a["last_status"] = "exhausted"
+    entry_a["last_status_at"] = time.time() - 4000  # beyond the 1h TTL
+    entry_a["last_error_code"] = 429
+    entry_a["model_exhaustions"] = {
+        "gemini-x": {
+            "until": time.time() + 3600,
+            "status_code": 429,
+            "reason": None,
+            "reset_at": None,
+        }
+    }
+    pool = _load_pool(tmp_path, monkeypatch, payload)
+
+    assert _selected_id(pool, "gemini-x") == "cred-b"
+    assert _selected_id(pool, "gemini-y") == "cred-a"
+
+
+def test_resolve_provider_client_threads_model_into_openrouter_select(monkeypatch):
+    """The main openrouter client-build path must select the pool with the
+    model so per-model benches are honored at selection time, not only at
+    rotation time (review fix: model was in scope but not passed)."""
+    from agent import auxiliary_client as mod
+
+    captured = {}
+
+    def fake_try_openrouter(*, explicit_api_key=None, model=None):
+        captured["model"] = model
+        return object(), "some-default-model"
+
+    monkeypatch.setattr(mod, "_try_openrouter", fake_try_openrouter)
+
+    client, final_model = mod.resolve_provider_client(
+        "openrouter", "google/gemini-3-flash-preview", False,
+    )
+    assert client is not None
+    assert captured["model"] == "google/gemini-3-flash-preview"
+    assert final_model is not None

--- a/tests/agent/test_credential_pool_model_exhaustion.py
+++ b/tests/agent/test_credential_pool_model_exhaustion.py
@@ -318,3 +318,36 @@ def test_resolve_provider_client_threads_model_into_openrouter_select(monkeypatc
     assert client is not None
     assert captured["model"] == "google/gemini-3-flash-preview"
     assert final_model is not None
+
+
+def test_per_model_bench_propagates_to_same_key_siblings(tmp_path, monkeypatch):
+    """A per-model bench must cover every entry sharing the failed key.
+
+    Duplicate entries (an explicit pool entry plus a model_config entry
+    auto-seeded from the same model.api_key) carry the identical runtime
+    key. Benching only the matched entry would let model-aware rotation
+    reselect the same depleted key through its sibling.
+    """
+    payload = _two_key_pool_payload()
+    # cred-b shares cred-a's runtime key.
+    payload["credential_pool"]["custom"][1]["access_token"] = "tok-a"
+    pool = _load_pool(tmp_path, monkeypatch, payload)
+
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        api_key_hint="tok-a",
+        model="gemini-x",
+    )
+    # Both entries benched for gemini-x: nothing left to rotate to.
+    assert next_entry is None
+
+    key_a = _entry(pool, "cred-a")
+    key_b = _entry(pool, "cred-b")
+    assert key_a.last_status == "ok"
+    assert key_b.last_status == "ok"
+    assert "gemini-x" in key_a.model_exhaustions
+    assert "gemini-x" in key_b.model_exhaustions
+    # No entry selectable for the benched model...
+    assert pool.select(model="gemini-x") is None
+    # ...but both remain selectable for other models.
+    assert _selected_id(pool, "gemini-y") in {"cred-a", "cred-b"}

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -471,6 +471,41 @@ class TestFailureAttribution:
         assert swapped.id == "cred-0"
 
 
+    def test_429_rotates_model_scoped_with_agent_model(self, tmp_path, monkeypatch):
+        """Primary-agent 429 recovery forwards agent.model.
+
+        The bench must be per-(key, model): the failing key keeps its
+        key-level status and stays selectable for other models, matching the
+        auxiliary client's model threading.
+        """
+        pool = self._make_pool(
+            tmp_path, monkeypatch,
+            [self._entry(0, "key-a"), self._entry(1, "key-b")],
+        )
+        agent = self._agent(pool, failing_key="key-a")
+        agent.model = "claude-sonnet-x"
+
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        # First 429: retry-same semantics, no rotation yet.
+        recovered, has_retried = recover_with_credential_pool(
+            agent, status_code=429, has_retried_429=False
+        )
+        assert recovered is False
+        assert has_retried is True
+        # Second consecutive 429: rotate, benching (key-a, model) only.
+        recovered, has_retried = recover_with_credential_pool(
+            agent, status_code=429, has_retried_429=True
+        )
+        assert recovered is True
+        assert has_retried is False
+        statuses = self._statuses(pool)
+        assert statuses["cred-0"] != "exhausted"  # key-level status untouched
+        key_a = next(e for e in pool.entries() if e.id == "cred-0")
+        assert "claude-sonnet-x" in key_a.model_exhaustions
+        swapped = agent._swap_credential.call_args[0][0]
+        assert swapped.id == "cred-1"
+
     def test_unmatched_key_does_not_retry_only_pool_entry(
         self, tmp_path, monkeypatch
     ):

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -149,6 +149,8 @@ Provider-supplied `reset_at` timestamps override these default cooldowns.
 
 The `has_retried_429` flag resets on every successful API call, so a single transient 429 doesn't trigger rotation.
 
+When the failing request's model is known, 429 exhaustion is tracked per (key, model), so a key rate-limited for one model stays usable for other models.
+
 ## Custom Endpoint Pools
 
 Custom OpenAI-compatible endpoints (Together.ai, RunPod, local servers) get their own pools, keyed by the endpoint name from the `providers:` dict in config.yaml (or the legacy `custom_providers` list, which is auto-migrated).


### PR DESCRIPTION
## What does this PR do?

Credential pool exhaustion is currently key-scoped: a 429 rate limit for one model benches the whole key for up to 24 hours (or until the provider `reset_at`), so a single model's quota wall silently kills the key for every other model it serves. With free-tier Gemini keys sharing a pool, one exhausted model makes the whole pool unselectable for the models that still have quota.

This PR makes exhaustion model-scoped for the 429 case:

- `PooledCredential` gains a `model_exhaustions` dict that benches only the `(key, model)` pair that actually hit the rate limit. The key-level status stays untouched, so the key remains selectable for every other model.
- `CredentialPool.select(model=...)`, `_available_entries(model=...)`, and `_exhausted_until(entry, model=...)` filter and prune per-model benchings; `mark_exhausted_and_rotate(model=...)` records a per-model benching only for 429s with a known model, and rotates for that model only.
- All other status codes (401, 402, 403, ...) keep the exact legacy key-level behavior.
- Callers with no model (`select()`, `peek()`, `has_available()`, and all existing single-argument call sites) are byte-for-byte unaffected: `model=None` is the legacy path.
- The auxiliary client threads the failing model through `_select_pool_entry` and `_recover_provider_pool` at all four recovery sites in `call_llm` / `async_call_llm`; `runtime_provider` selects pool entries with the target model.
- `hermes auth list` shows a `model-limited (<model>)` or `model-limited (N models)` marker when a key is only benched for specific models.

Why per-model benching and not a plugin: the credential pool is core harness infrastructure at the provider-resolution layer (`agent/credential_pool.py`). There is no plugin hook that intercepts `select()` or `mark_exhausted_and_rotate()`, so the change has to land in the core pool itself.

## Related Issue

No dedicated issue was filed for this work. Prior art that informed the design: #73380, #50960, #38804 (credential pool exhaustion and rotation behavior).

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/credential_pool.py`: `PooledCredential.model_exhaustions` field (serialized in `to_dict`, cleared by `reset_statuses`); `select(model=)`, `_select_unlocked(model=)`, `_available_entries(model=)` with per-model skip + expired-bench pruning; `mark_exhausted_and_rotate(model=)` benches `(key, model)` on 429 only and rotates per-model; `_exhausted_until(entry, model=)` takes the later of key-level cooldown and per-model benching.
- `agent/auxiliary_client.py`: `_select_pool_entry(provider, model="")` forwards the model to `pool.select()` (with a TypeError compat fallback for legacy no-kwargs fake pools in tests); `_recover_provider_pool(..., model="")` passes the failing model to `mark_exhausted_and_rotate` at all four recovery sites; `_resolve_api_key_provider`, `_try_openrouter`, `_try_anthropic`, `_build_codex_client`, and the `resolve_provider_client` openrouter client-build path select with the resolved aux model.
- `hermes_cli/runtime_provider.py`: pool selection passes `target_model` to `select(model=...)`.
- `hermes_cli/auth_commands.py`: `_format_model_limited()` renders a compact `model-limited` marker in `hermes auth list` output.
- `website/docs/user-guide/features/credential-pools.md`: documents per-(key, model) 429 tracking.
- `tests/agent/test_credential_pool_model_exhaustion.py`: new, 10 tests (key-level status preservation, per-model rotation, model-agnostic surfaces, expired-bench pruning, persistence round-trip against a temp `HERMES_HOME`, `hermes auth reset` clearing, legacy `model=None` and non-429-with-model behavior, and model threading through the `resolve_provider_client` openrouter client-build path).
- `tests/agent/test_credential_pool.py`: 2 additive tests (existing tests byte-identical).

## How to Test

1. Run the pool test family: `scripts/run_tests.sh tests/agent/test_credential_pool.py tests/agent/test_credential_pool_model_exhaustion.py`
2. Run the aux client wiring tests: `scripts/run_tests.sh tests/agent/test_auxiliary_client_resolve_dedup.py tests/agent/test_auxiliary_main_first.py tests/agent/test_set_runtime_main_custom_provider.py tests/run_agent/test_63425_credential_pool_auto_detect.py`
3. Result: 66/66 pool tests and 22/22 aux wiring tests pass; the full credential-pool family (routing, unmatched rotation bound, oauth writethrough, no-entries log throttle, run_agent interrupt) passes 26/26.
4. Manual: `hermes auth list` on a pool where one key has a per-model bench shows `model-limited (<model>)` while the key-level status stays `ok`.
5. Windows footgun scan is clean on all touched files.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Screenshots / Logs

Test evidence:

```
$ scripts/run_tests.sh tests/agent/test_credential_pool.py tests/agent/test_credential_pool_model_exhaustion.py
66 passed (56 + 10)

$ scripts/run_tests.sh tests/agent/test_auxiliary_client_resolve_dedup.py tests/agent/test_auxiliary_main_first.py tests/agent/test_set_runtime_main_custom_provider.py tests/run_agent/test_63425_credential_pool_auto_detect.py
22 passed
```
