### PR TITLE
fix(slack): batch Block Kit sends over the 50-block cap instead of truncating

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -742,7 +742,16 @@ PLATFORM_HINTS = {
         "You can send media files natively: include MEDIA:/absolute/path/to/file "
         "in your response. Images (.png, .jpg, .webp) are uploaded as photo "
         "attachments, audio as file attachments. You can also include image URLs "
-        "in markdown format ![alt](url) and they will be uploaded as attachments."
+        "in markdown format ![alt](url) and they will be uploaded as attachments. "
+        "IMPORTANT — table formatting on Slack: Slack renders markdown "
+        "tables natively. ALWAYS emit tables as standard markdown pipe tables, e.g.\n"
+        "| Header A | Header B |\n"
+        "|----------|----------|\n"
+        "| value 1  | value 2  |\n"
+        "NEVER pre-render tables as ASCII art with box-drawing characters "
+        "(┌ ┐ ├ ┤ + etc.), and do NOT wrap markdown tables in triple-backtick "
+        "code fences. Just emit the raw markdown table inline; it will be "
+        "rendered natively. This applies even for large or complex tables."
     ),
     "signal": (
         "You are on a text messaging communication platform, Signal. "

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -60,9 +60,9 @@ from gateway.platforms.base import (
 )
 
 try:  # sibling module; support both package and flat plugin-dir import
-    from .block_kit import render_blocks, sanitize_blocks
+    from .block_kit import render_blocks, render_block_batches, sanitize_blocks
 except ImportError:  # pragma: no cover - plugin loaded outside package context
-    from block_kit import render_blocks, sanitize_blocks  # type: ignore
+    from block_kit import render_blocks, render_block_batches, sanitize_blocks  # type: ignore
 
 
 logger = logging.getLogger(__name__)
@@ -2536,7 +2536,36 @@ class SlackAdapter(BasePlatformAdapter):
             # that had to be split is pathological for Block Kit's 50-block /
             # 3000-char limits, so those fall back to plain text. The ``text``
             # field is always kept as the notification/accessibility fallback.
-            blocks = self._maybe_blocks(content) if len(chunks) == 1 else None
+            #
+            # A rich render can legitimately need MORE than Slack's 50-block
+            # ceiling (a long response full of headers/lists/tables — common now
+            # that rich_blocks defaults ON). Rather than truncate or degrade to
+            # plain text, ``_maybe_block_batches`` splits the render into
+            # consecutive <= 50-block batches; each batch is posted as its own
+            # ``chat.postMessage`` in the same thread below, preserving every
+            # block. In the overwhelmingly common case this is a single batch
+            # and behaves exactly like the old single-``blocks`` path.
+            block_batches = (
+                self._maybe_block_batches(content) if len(chunks) == 1 else None
+            )
+
+            client = self._get_client(chat_id, team_id=team_id)
+
+            async def _post(kwargs: dict):
+                """Post one message, retrying without blocks if Slack rejects them."""
+                try:
+                    return await client.chat_postMessage(**kwargs)
+                except Exception as e:
+                    if kwargs.get("blocks") and self._is_block_payload_rejection(e):
+                        retry_kwargs = dict(kwargs)
+                        retry_kwargs.pop("blocks", None)
+                        logger.info(
+                            "[Slack] Block Kit payload rejected; retrying send "
+                            "without blocks: %s",
+                            e,
+                        )
+                        return await client.chat_postMessage(**retry_kwargs)
+                    raise
 
             for i, chunk in enumerate(chunks):
                 kwargs = {
@@ -2544,31 +2573,44 @@ class SlackAdapter(BasePlatformAdapter):
                     "text": chunk,
                     "mrkdwn": True,
                 }
-                if blocks and i == 0:
-                    kwargs["blocks"] = blocks
+                # The first (and, for a single-chunk message, only) chunk
+                # carries the first block batch. Any further batches are posted
+                # as continuation messages after this loop, in the same thread.
+                if block_batches and i == 0:
+                    kwargs["blocks"] = block_batches[0]
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
                     # Only broadcast the first chunk of the first reply
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
 
-                try:
-                    last_result = await self._get_client(
-                        chat_id, team_id=team_id
-                    ).chat_postMessage(**kwargs)
-                except Exception as e:
-                    if kwargs.get("blocks") and self._is_block_payload_rejection(e):
-                        retry_kwargs = dict(kwargs)
-                        retry_kwargs.pop("blocks", None)
-                        logger.info(
-                            "[Slack] Block Kit payload rejected; retrying send without blocks: %s",
-                            e,
-                        )
-                        last_result = await self._get_client(
-                            chat_id, team_id=team_id
-                        ).chat_postMessage(**retry_kwargs)
-                    else:
-                        raise
+                last_result = await _post(kwargs)
+
+            # Post any remaining Block Kit batches (>50-block renders) as
+            # continuation messages threaded under the first. The first message
+            # already carried the full ``text`` fallback and any broadcast/
+            # thread semantics; continuation posts stay inside the thread, never
+            # broadcast, and carry a short continuation marker as their ``text``
+            # fallback (the human-readable content is the blocks themselves; the
+            # full plain-text was already delivered on message #1).
+            if block_batches and len(block_batches) > 1 and len(chunks) == 1:
+                # Thread continuation posts under the first message's ts when
+                # this send was not already a threaded reply, so the batches
+                # stay grouped instead of scattering as sibling top-level posts.
+                continuation_thread_ts = thread_ts or (
+                    last_result.get("ts") if last_result else None
+                )
+                total = len(block_batches)
+                for idx, batch in enumerate(block_batches[1:], start=2):
+                    cont_kwargs = {
+                        "channel": chat_id,
+                        "text": f"(continued {idx}/{total})",
+                        "mrkdwn": True,
+                        "blocks": batch,
+                    }
+                    if continuation_thread_ts:
+                        cont_kwargs["thread_ts"] = continuation_thread_ts
+                    last_result = await _post(cont_kwargs)
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -3421,16 +3463,19 @@ class SlackAdapter(BasePlatformAdapter):
     def _rich_blocks_enabled(self) -> bool:
         """Whether to render outbound agent messages as Slack Block Kit blocks.
 
-        Opt-in via ``platforms.slack.extra.rich_blocks`` (config.yaml). Default
-        off: messages continue to go out as flat mrkdwn ``text``. Enabling it
-        renders the *final* agent message with real structural primitives
-        (headers, dividers, true nested lists via ``rich_text``, and native
-        Block Kit ``table`` blocks with per-column alignment); over-limit
-        tables fall back to aligned monospace.
+        Default ON: the *final* agent message is rendered with real structural
+        primitives (headers, dividers, true nested lists via ``rich_text``, and
+        native Block Kit ``table`` blocks with per-column alignment); over-limit
+        tables fall back to aligned monospace. A plain ``text`` fallback is
+        always sent alongside the blocks, so clients that can't render Block Kit
+        still get the message.
+
+        Opt OUT by setting ``slack.extra.rich_blocks: false`` in config.yaml to
+        revert to flat mrkdwn ``text`` for all outbound messages.
         """
         raw = self.config.extra.get("rich_blocks")
         if raw is None:
-            return False
+            return True
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
     def _markdown_blocks_enabled(self) -> bool:
@@ -3546,6 +3591,60 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception:  # pragma: no cover - renderer already guards itself
             logger.debug("[Slack] block render failed; using plain text", exc_info=True)
             return None
+
+    def _maybe_block_batches(self, content: str) -> Optional[List[list]]:
+        """Render ``content`` to one-or-more <= 50-block Block Kit batches.
+
+        Loss-free counterpart to :meth:`_maybe_blocks`.  Where ``_maybe_blocks``
+        collapses to ``None`` (plain-text fallback) as soon as a render needs
+        more than Slack's 50-block ceiling, this splits the full render into
+        consecutive <= 50-block batches so the send path can post each batch as
+        its own ``chat.postMessage`` in the same thread — the full Block Kit
+        rendering survives instead of truncating or degrading to text.
+
+        Returns a list of sanitized block batches (usually length 1), or
+        ``None`` when both block modes are disabled or the renderer declines.
+
+        Feedback controls (when enabled) are appended exactly ONCE, to the
+        LAST batch — they belong at the end of the response, and repeating them
+        on every batch would spray duplicate buttons through the thread and
+        risk pushing that final batch over the 50-block cap on its own.
+        """
+        batches: Optional[List[list]] = None
+        if self._markdown_blocks_enabled():
+            md_blocks = self._markdown_block_payload(content)
+            if md_blocks:
+                # The ``markdown`` block path is a single small block; it never
+                # exceeds the cap, so a single batch is correct.
+                batches = [md_blocks]
+        if batches is None:
+            if not self._rich_blocks_enabled():
+                return None
+            try:
+                batches = render_block_batches(content, mrkdwn_fn=self.format_message)
+            except Exception:  # pragma: no cover - renderer already guards itself
+                logger.debug(
+                    "[Slack] block render failed; using plain text", exc_info=True
+                )
+                return None
+        if not batches:
+            return None
+
+        # Feedback controls ride the LAST batch only (see docstring). Appending
+        # may bump a full 50-block last batch to 51; sanitize_blocks would then
+        # reject the whole batch. Guard by spilling into a fresh trailing batch.
+        if self._feedback_buttons_enabled():
+            last = batches[-1]
+            appended = self._append_feedback_block(last)
+            if appended is not None and len(appended) > len(last):
+                if len(appended) > 50:
+                    batches = [*batches[:-1], last, [self._feedback_block()]]
+                else:
+                    batches = [*batches[:-1], appended]
+
+        sanitized = [sanitize_blocks(batch) for batch in batches]
+        out = [b for b in sanitized if b]
+        return out or None
 
     def format_message(self, content: str) -> str:
         """Convert standard markdown to Slack mrkdwn format.

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -365,22 +365,22 @@ def _render_table(rows: List[str]) -> str:
 # ----------------------------------------------------------------------------
 
 
-def render_blocks(
+def _render_all_blocks(
     markdown: str,
     mrkdwn_fn=None,
 ) -> Optional[List[Block]]:
-    """Convert agent markdown to a Slack Block Kit ``blocks`` list.
+    """Render agent markdown to a Block Kit list WITHOUT the 50-block clamp.
 
-    Args:
-        markdown: The agent's response text (standard markdown).
-        mrkdwn_fn: Optional callable converting a markdown paragraph to Slack
-            mrkdwn for ``section`` blocks (the adapter passes
-            ``format_message``).  When ``None``, the raw paragraph text is used.
+    This is the raw renderer: it produces however many blocks the content
+    needs, even past Slack's 50-block ceiling.  Callers decide how to handle
+    an over-cap result:
 
-    Returns:
-        A list of Block Kit block dicts, or ``None`` when the content is empty,
-        exceeds Slack's structural limits, or hits an unexpected shape — the
-        caller then falls back to the flat ``text`` payload.  Never raises.
+    * :func:`render_blocks` clamps to ``None`` (legacy single-post behaviour —
+      the caller falls back to plain text).
+    * :func:`render_block_batches` splits the list into <= 50-block batches for
+      the loss-free multi-post send path.
+
+    Returns ``None`` for empty content or an unexpected shape.  Never raises.
     """
     if not markdown or not markdown.strip():
         return None
@@ -525,14 +525,85 @@ def render_blocks(
 
         if not blocks:
             return None
-        if len(blocks) > MAX_BLOCKS:
-            # Too structurally complex to express safely — let the caller fall
-            # back to plain text rather than truncating and losing content.
-            return None
         return blocks
     except Exception:
         # Never let a rendering bug drop a message.
         return None
+
+
+def render_blocks(
+    markdown: str,
+    mrkdwn_fn=None,
+) -> Optional[List[Block]]:
+    """Convert agent markdown to a Slack Block Kit ``blocks`` list.
+
+    Args:
+        markdown: The agent's response text (standard markdown).
+        mrkdwn_fn: Optional callable converting a markdown paragraph to Slack
+            mrkdwn for ``section`` blocks (the adapter passes
+            ``format_message``).  When ``None``, the raw paragraph text is used.
+
+    Returns:
+        A list of Block Kit block dicts, or ``None`` when the content is empty,
+        exceeds Slack's 50-block structural limit, or hits an unexpected shape
+        — the caller then falls back to the flat ``text`` payload (or, for the
+        batching send path, to :func:`render_block_batches`).  Never raises.
+
+    This is the single-post entry point: a render that would need more than
+    :data:`MAX_BLOCKS` blocks returns ``None`` here so a caller that can only
+    make one ``chat.postMessage`` degrades to plain text rather than truncating.
+    Callers that can post multiple messages should use
+    :func:`render_block_batches` instead — it preserves every block.
+    """
+    blocks = _render_all_blocks(markdown, mrkdwn_fn=mrkdwn_fn)
+    if blocks is None:
+        return None
+    if len(blocks) > MAX_BLOCKS:
+        # Too structurally complex to express in one post — let the caller fall
+        # back to plain text rather than truncating and losing content.
+        return None
+    return blocks
+
+
+def batch_blocks(
+    blocks: Optional[List[Block]], max_blocks: int = MAX_BLOCKS
+) -> List[List[Block]]:
+    """Split ``blocks`` into consecutive batches of at most ``max_blocks``.
+
+    Order is preserved and no block is dropped: batch *k* holds blocks
+    ``[k*max_blocks : (k+1)*max_blocks]``.  A list already within the cap
+    returns as a single batch.  Empty / ``None`` input returns ``[]``.
+
+    This is the primitive behind the loss-free send path — the adapter posts
+    each returned batch as its own ``chat.postMessage`` in one thread, so a
+    message that renders to more than 50 blocks keeps its full Block Kit
+    rendering across multiple posts instead of truncating or degrading to text.
+    """
+    if not blocks:
+        return []
+    step = max(int(max_blocks), 1)
+    return [blocks[i : i + step] for i in range(0, len(blocks), step)]
+
+
+def render_block_batches(
+    markdown: str,
+    mrkdwn_fn=None,
+    max_blocks: int = MAX_BLOCKS,
+) -> Optional[List[List[Block]]]:
+    """Render agent markdown to <= ``max_blocks``-sized Block Kit batches.
+
+    Loss-free counterpart to :func:`render_blocks`: instead of returning
+    ``None`` when the content needs more than :data:`MAX_BLOCKS` blocks, the
+    full block list is split into consecutive batches (see :func:`batch_blocks`)
+    the adapter can post as separate messages in the same thread.
+
+    Returns a list of block-batches (usually one), or ``None`` when the content
+    is empty or the renderer declines.  Never raises.
+    """
+    blocks = _render_all_blocks(markdown, mrkdwn_fn=mrkdwn_fn)
+    if not blocks:
+        return None
+    return batch_blocks(blocks, max_blocks=max_blocks)
 
 
 def _split_text(text: str, limit: int) -> List[str]:
@@ -682,7 +753,15 @@ def sanitize_blocks(blocks: Optional[List[Block]]) -> Optional[List[Block]]:
 
         if not out:
             return None
-        return out[:MAX_BLOCKS]
+        if len(out) > MAX_BLOCKS:
+            # Over Slack's 50-block ceiling. Silently truncating with
+            # ``out[:MAX_BLOCKS]`` drops the tail and cuts the message off
+            # mid-content. Return None instead so the caller sends the full
+            # plain-``text`` fallback (lossless) — matching render_blocks'
+            # own >50-block behaviour. The batching send path (adapter) is
+            # the loss-free upgrade that keeps blocks across multiple posts.
+            return None
+        return out
     except Exception:
         # A sanitizer bug must never take down the send path.
         return None

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2182,11 +2182,16 @@ class TestSendTyping:
         )
 
         assert result.success
-        team_client.chat_update.assert_awaited_once_with(
-            channel="D123",
-            ts="reply_ts",
-            text="done",
-        )
+        # rich_blocks defaults ON, so a finalize edit now also carries a
+        # ``blocks`` payload alongside the ``text`` fallback. This test asserts
+        # workspace-client *routing* (the per-team client is used, not the
+        # default app client), so match on the routed args without pinning the
+        # blocks kwarg.
+        team_client.chat_update.assert_awaited_once()
+        _edit_kwargs = team_client.chat_update.await_args.kwargs
+        assert _edit_kwargs["channel"] == "D123"
+        assert _edit_kwargs["ts"] == "reply_ts"
+        assert _edit_kwargs["text"] == "done"
         team_client.assistant_threads_setStatus.assert_awaited_once_with(
             channel_id="D123",
             thread_ts="parent_ts",

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -4,6 +4,8 @@ from plugins.platforms.slack.block_kit import (
     MAX_BLOCKS,
     MAX_HEADER_TEXT,
     MAX_SECTION_TEXT,
+    batch_blocks,
+    render_block_batches,
     render_blocks,
     sanitize_blocks,
 )
@@ -112,6 +114,50 @@ class TestLimits:
         # 60 dividers => 60 blocks > MAX_BLOCKS => decline (caller uses text)
         md = "\n\n".join(["---"] * (MAX_BLOCKS + 10))
         assert render_blocks(md) is None
+
+
+class TestBatching:
+    """Loss-free batching path: >50-block renders split into <=50 batches."""
+
+    def test_batch_blocks_splits_on_cap_no_loss(self):
+        blocks = [{"type": "divider"} for _ in range(125)]
+        batches = batch_blocks(blocks)
+        # 125 -> 50 + 50 + 25, order preserved, nothing dropped
+        assert [len(b) for b in batches] == [50, 50, 25]
+        assert sum(len(b) for b in batches) == 125
+        flat = [blk for batch in batches for blk in batch]
+        assert flat == blocks
+        assert all(len(b) <= MAX_BLOCKS for b in batches)
+
+    def test_batch_blocks_within_cap_single_batch(self):
+        blocks = [{"type": "divider"} for _ in range(10)]
+        assert batch_blocks(blocks) == [blocks]
+
+    def test_batch_blocks_empty(self):
+        assert batch_blocks(None) == []
+        assert batch_blocks([]) == []
+
+    def test_render_block_batches_over_cap_preserves_all_blocks(self):
+        # 60 dividers -> render_blocks() declines (None), but render_block_batches
+        # keeps every block by splitting into <=50-block batches.
+        md = "\n\n".join(["---"] * (MAX_BLOCKS + 10))
+        assert render_blocks(md) is None
+        batches = render_block_batches(md)
+        assert batches is not None
+        assert len(batches) == 2
+        assert all(len(b) <= MAX_BLOCKS for b in batches)
+        assert sum(len(b) for b in batches) == MAX_BLOCKS + 10
+
+    def test_render_block_batches_within_cap_single_batch(self):
+        batches = render_block_batches("# Title\n\nbody")
+        assert batches is not None
+        assert len(batches) == 1
+        assert len(batches[0]) <= MAX_BLOCKS
+
+    def test_render_block_batches_empty_returns_none(self):
+        assert render_block_batches("") is None
+        assert render_block_batches("   \n ") is None
+
 
 
 class TestEmptyContentGuards:

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -1,8 +1,8 @@
 """Integration tests: SlackAdapter wiring of Block Kit into send paths.
 
-Verifies the opt-in behaviour contract:
-  * rich_blocks off (default)  => no ``blocks`` kwarg, plain ``text`` only
-  * rich_blocks on             => ``blocks`` present AND ``text`` fallback set
+Verifies the behaviour contract:
+  * rich_blocks unset (default ON) => ``blocks`` present AND ``text`` fallback set
+  * rich_blocks: false             => no ``blocks`` kwarg, plain ``text`` only
   * edit_message: blocks only on finalize (streaming edits stay plain)
   * multi-chunk (>39k) messages fall back to plain text
 """
@@ -59,8 +59,18 @@ def _slack_connection_key():
 
 class TestSendMessageBlocks:
     @pytest.mark.asyncio
-    async def test_disabled_by_default_no_blocks(self):
+    async def test_enabled_by_default_emits_blocks(self):
+        # rich_blocks unset -> default ON: blocks present, text fallback kept
         adapter, client = _make_adapter()
+        await adapter.send("C1", RICH_MD)
+        kwargs = client.chat_postMessage.await_args.kwargs
+        assert "blocks" in kwargs and kwargs["blocks"]
+        assert kwargs["text"]  # plain text fallback still sent
+
+    @pytest.mark.asyncio
+    async def test_explicit_opt_out_no_blocks(self):
+        # rich_blocks: false -> revert to flat mrkdwn text, no blocks
+        adapter, client = _make_adapter({"rich_blocks": False})
         await adapter.send("C1", RICH_MD)
         kwargs = client.chat_postMessage.await_args.kwargs
         assert "blocks" not in kwargs
@@ -68,13 +78,19 @@ class TestSendMessageBlocks:
 
 
     @pytest.mark.asyncio
-    async def test_enabled_but_unrenderable_falls_back_to_text(self):
-        # 60 dividers -> renderer returns None -> no blocks kwarg, text stands
+    async def test_over_cap_render_batches_instead_of_falling_back_to_text(self):
+        # 60 dividers -> 60 blocks (> 50). This used to collapse to plain text
+        # (renderer returned None over the cap). It now batches loss-free: the
+        # blocks are split across multiple posts instead of being dropped.
         adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_postMessage = AsyncMock(
+            side_effect=[{"ts": "111.222"}, {"ts": "111.999"}]
+        )
         await adapter.send("C1", "\n\n".join(["---"] * 60))
-        kwargs = client.chat_postMessage.await_args.kwargs
-        assert "blocks" not in kwargs
-        assert kwargs["text"]
+        calls = client.chat_postMessage.await_args_list
+        assert len(calls) == 2
+        assert all(c.kwargs.get("blocks") for c in calls)
+        assert all(c.kwargs["text"] for c in calls)
 
 
     @pytest.mark.asyncio
@@ -158,7 +174,9 @@ class TestMarkdownBlockMode:
 
     @pytest.mark.asyncio
     async def test_disabled_by_default(self):
-        adapter, client = _make_adapter()
+        # Isolate markdown_blocks: turn rich_blocks off so any block that
+        # appears would have to come from markdown_blocks mode.
+        adapter, client = _make_adapter({"rich_blocks": False})
         await adapter.send("C1", RICH_TABLE_MD)
         kwargs = client.chat_postMessage.await_args.kwargs
         assert "blocks" not in kwargs
@@ -183,5 +201,139 @@ class TestMarkdownBlockMode:
         kwargs = client.chat_update.await_args.kwargs
         assert kwargs["blocks"][0]["type"] == "markdown"
         assert kwargs["blocks"][0]["text"] == RICH_TABLE_MD
+
+
+# ---------------------------------------------------------------------------
+# Loss-free batching — renders over Slack's 50-block ceiling (#batch-over-50)
+# ---------------------------------------------------------------------------
+
+
+# 60 dividers render to 60 ``divider`` blocks (> MAX_BLOCKS=50). Before the
+# batching fix this collapsed to plain text (rich_blocks) or silently truncated
+# at out[:50] (sanitize_blocks). Now it must post across multiple messages.
+OVER_CAP_MD = "\n\n".join(["---"] * 60)
+
+
+class TestSendBlockBatchingOver50:
+    @pytest.mark.asyncio
+    async def test_over_cap_render_posts_multiple_messages_no_block_loss(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_postMessage = AsyncMock(
+            side_effect=[{"ts": "111.222"}, {"ts": "111.999"}]
+        )
+
+        result = await adapter.send("C1", OVER_CAP_MD)
+
+        assert result.success is True
+        # 60 blocks -> 50 + 10 -> two chat.postMessage calls
+        calls = client.chat_postMessage.await_args_list
+        assert len(calls) == 2
+
+        first, second = calls[0].kwargs, calls[1].kwargs
+        # every batch present, none over the 50-block cap
+        assert len(first["blocks"]) == 50
+        assert len(second["blocks"]) == 10
+        assert all(len(c.kwargs["blocks"]) <= 50 for c in calls)
+        # no block loss: 50 + 10 == 60 rendered blocks
+        total = sum(len(c.kwargs["blocks"]) for c in calls)
+        assert total == 60
+        # every message carries a text fallback
+        assert first["text"]
+        assert second["text"]
+
+    @pytest.mark.asyncio
+    async def test_continuation_batches_thread_under_first_message(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_postMessage = AsyncMock(
+            side_effect=[{"ts": "111.222"}, {"ts": "111.999"}]
+        )
+
+        # Not itself a threaded reply -> continuation threads under msg #1 ts.
+        await adapter.send("C1", OVER_CAP_MD)
+
+        calls = client.chat_postMessage.await_args_list
+        first, second = calls[0].kwargs, calls[1].kwargs
+        # first message is a top-level post (no thread_ts), no broadcast
+        assert "thread_ts" not in first
+        assert "reply_broadcast" not in first
+        # continuation is threaded under the first message and never broadcasts
+        assert second["thread_ts"] == "111.222"
+        assert "reply_broadcast" not in second
+
+    @pytest.mark.asyncio
+    async def test_over_cap_reply_keeps_thread_and_broadcasts_only_first(self):
+        adapter, client = _make_adapter(
+            {"rich_blocks": True, "reply_broadcast": True}
+        )
+        client.chat_postMessage = AsyncMock(
+            side_effect=[{"ts": "111.222"}, {"ts": "111.999"}]
+        )
+
+        # reply_to makes this a threaded reply; broadcast only on the first msg.
+        await adapter.send("C1", OVER_CAP_MD, reply_to="900.000")
+
+        calls = client.chat_postMessage.await_args_list
+        first, second = calls[0].kwargs, calls[1].kwargs
+        assert first["thread_ts"] == "900.000"
+        assert first.get("reply_broadcast") is True
+        # all batches stay in the same thread; continuation never broadcasts
+        assert second["thread_ts"] == "900.000"
+        assert "reply_broadcast" not in second
+
+    @pytest.mark.asyncio
+    async def test_feedback_block_appears_once_on_last_batch(self):
+        adapter, client = _make_adapter(
+            {"rich_blocks": True, "feedback_buttons": True}
+        )
+        client.chat_postMessage = AsyncMock(
+            side_effect=[{"ts": "111.222"}, {"ts": "111.999"}]
+        )
+
+        await adapter.send("C1", OVER_CAP_MD)
+
+        calls = client.chat_postMessage.await_args_list
+        all_blocks = [blk for c in calls for blk in c.kwargs["blocks"]]
+        feedback = [
+            b for b in all_blocks if b.get("type") == "context_actions"
+        ]
+        # feedback controls appear exactly once, across all batches
+        assert len(feedback) == 1
+        # ...and specifically on the LAST batch
+        assert calls[-1].kwargs["blocks"][-1]["type"] == "context_actions"
+
+    @pytest.mark.asyncio
+    async def test_block_rejection_retry_is_per_batch(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        # First batch rejected -> resend without blocks; second batch fine.
+        client.chat_postMessage = AsyncMock(
+            side_effect=[
+                SlackRejectedBlocks("invalid_blocks"),
+                {"ts": "111.222"},
+                {"ts": "111.999"},
+            ]
+        )
+
+        result = await adapter.send("C1", OVER_CAP_MD)
+
+        assert result.success is True
+        # 3 calls: batch1 (reject) -> batch1 retry (no blocks) -> batch2
+        calls = client.chat_postMessage.await_args_list
+        assert len(calls) == 3
+        # the retry dropped blocks but kept the text fallback
+        assert "blocks" not in calls[1].kwargs
+        assert calls[1].kwargs["text"]
+        # the second batch still carries its blocks
+        assert calls[2].kwargs["blocks"]
+
+    @pytest.mark.asyncio
+    async def test_within_cap_still_single_post_with_blocks(self):
+        # Regression: the common single-batch case behaves exactly as before.
+        adapter, client = _make_adapter({"rich_blocks": True})
+        await adapter.send("C1", RICH_MD)
+        assert client.chat_postMessage.await_count == 1
+        kwargs = client.chat_postMessage.await_args.kwargs
+        assert kwargs["blocks"]
+        assert kwargs["text"]
+
 
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -410,14 +410,18 @@ platforms:
       # Only the first chunk of the first reply is broadcast.
       reply_broadcast: false
 
-      # Render agent messages as Slack Block Kit blocks (default: false).
-      # When true, the final agent message is sent with structured blocks —
-      # section headers, dividers, true nested lists (via rich_text), and
-      # native Block Kit tables — instead of flat mrkdwn text. A plain-text
+      # Render agent messages as Slack Block Kit blocks (default: true).
+      # The final agent message is sent with structured blocks — section
+      # headers, dividers, true nested lists (via rich_text), and native
+      # Block Kit tables — instead of flat mrkdwn text. A plain-text
       # fallback is always sent alongside for notifications/accessibility.
       # Tables exceeding Slack's limits (100 rows / 20 cols / 10k chars)
-      # gracefully fall back to aligned monospace.
-      rich_blocks: false
+      # gracefully fall back to aligned monospace. A response that renders
+      # to more than Slack's 50-block ceiling is split loss-free across
+      # multiple threaded posts (batches of <= 50 blocks) rather than being
+      # truncated. Set false to opt out and send flat mrkdwn text for all
+      # outbound messages.
+      rich_blocks: true
 
       # Append Slack-native feedback controls to final Block Kit replies.
       # Requires rich_blocks: true. Default: false.
@@ -452,7 +456,7 @@ platforms:
 | `platforms.slack.reply_to_mode` | `"first"` | Threading mode for multi-part messages: `"off"`, `"first"`, or `"all"` |
 | `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
-| `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
+| `platforms.slack.extra.rich_blocks` | `true` | Agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. Responses that exceed Slack's 50-block ceiling are split loss-free across multiple threaded posts (batches of ≤ 50 blocks) instead of being truncated. No app reinstall required — it's a send-side change only. Set `false` to revert to flat mrkdwn text. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
 | `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |


### PR DESCRIPTION
## Problem

Outbound Slack messages get **silently truncated** (or degraded to plain text) when their Block Kit render exceeds Slack's 50-block ceiling.

### Root cause

Yesterday's table-rendering fix flipped `rich_blocks` from default-**OFF** to default-**ON**. With rich Block Kit now the default, ordinary long responses (many headers / lists / tables) routinely render to more than Slack's 50-block `MAX_BLOCKS` ceiling. On that path the outbound normalizer `sanitize_blocks()` clamped with `out[:MAX_BLOCKS]` (and `render_blocks()` returned `None`), so the message was either **truncated at block 50** or degraded to plain text — every block past 50 was lost, cutting the message off mid-content.

## Fix

Make the Slack send path **loss-free** by **batching** blocks across multiple `chat.postMessage` calls in the same thread instead of dropping them.

**`plugins/platforms/slack/block_kit.py`**
- Split the renderer into `_render_all_blocks()` (no 50-block clamp) and the existing `render_blocks()` (single-post entry point — still returns `None` over the cap for back-compat).
- `batch_blocks()` — split a block list into consecutive ≤50-block batches; order preserved, nothing dropped.
- `render_block_batches()` — render markdown straight into ≤50-block batches (loss-free counterpart to `render_blocks`).
- Keep the >50 guard in `sanitize_blocks()` as the **last-resort safety net**; with adapter batching it should rarely trigger now.

**`plugins/platforms/slack/adapter.py`**
- `_maybe_block_batches()` — loss-free counterpart to `_maybe_blocks`; returns a list of sanitized ≤50-block batches. Feedback controls are appended **exactly once, on the LAST batch** (spilling into a fresh trailing batch if that would push the last batch over 50).
- `send()` rewired: the first message keeps today's `reply_broadcast`/thread semantics and the full `text` fallback and carries batch #0; further batches post as continuation messages in the **same `thread_ts`**, never broadcast, each with a short `(continued k/N)` text fallback. The block-payload-rejection retry (drop blocks, resend as text) now applies **per batch**.

## Tests

- `test_slack_block_kit.py`: `batch_blocks` / `render_block_batches` split with no loss; single-batch and empty cases.
- `test_slack_block_kit_adapter.py`: a >50-block render posts multiple `chat.postMessage` calls, all in the same thread, each ≤50 blocks, no block loss, feedback block appearing exactly once on the last batch, per-batch rejection retry, and the within-cap single-post regression.
- Updated the default-ON-exposed streaming-finalize-edit routing test to match blocks alongside the text fallback.

```
venv/bin/python -m pytest tests/gateway/test_slack_block_kit_adapter.py tests/gateway/test_slack_block_kit.py -x -q
39 passed
```
(full `-k slack` suite: 457 passed, 1 skipped)

Requested-by: Lewis Pierson