### PR TITLE
fix(web): restore UI package lock consistency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18734,7 +18734,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hermes/shared": "file:../apps/shared",
-        "@nous-research/ui": "0.16.0",
+        "@nous-research/ui": "0.18.2",
         "@observablehq/plot": "0.6.17",
         "@react-three/fiber": "9.6.1",
         "@tailwindcss/vite": "4.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@hermes/shared": "file:../apps/shared",
-    "@nous-research/ui": "0.16.0",
+    "@nous-research/ui": "0.18.2",
     "@observablehq/plot": "0.6.17",
     "@react-three/fiber": "9.6.1",
     "@tailwindcss/vite": "4.3.3",


### PR DESCRIPTION
## Summary
- restore the Web workspace's `@nous-research/ui` pin to `0.18.2`
- align the workspace manifest with the existing lockfile package entry
- make a clean `npm ci` pass `npm ls --depth=0`

## Problem
Upstream `main` declares `0.16.0` in `web/package.json` and the workspace metadata in `package-lock.json`, while the same lockfile installs `web/node_modules/@nous-research/ui` as `0.18.2`. A clean install succeeds but `npm ls --depth=0` exits with `ELSPROBLEMS` and marks the package invalid.

The previous upstream base already used `0.18.2`, and the lockfile still resolves that version, so this restores the manifest rather than rewriting the resolved dependency.

## Verification
- `npm ci`
- `npm ls --depth=0`
- `npm --prefix web run typecheck`
- `npm --prefix web test` (21 files, 144 tests)
- `git diff --check`
