### PR TITLE
fix(mcp): collapse multi-type `type` arrays in MCP tool input schemas

### DIFF
--- a/contributors/emails/117359338+marcovillar-br@users.noreply.github.com
+++ b/contributors/emails/117359338+marcovillar-br@users.noreply.github.com
@@ -1,0 +1,1 @@
+marcovillar-br

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -326,6 +326,59 @@ class TestSchemaConversion:
         assert "$defs" not in schema["parameters"]
         assert "definitions" not in schema["parameters"]
 
+    def test_multitype_array_is_collapsed_to_anyof(self):
+        """A multi-type ``type`` array must become an ``anyOf`` of single-type schemas.
+
+        Anthropic's tool ``input_schema`` validator rejects an array-valued ``type``
+        with "JSON schema is invalid. It must match JSON Schema draft 2020-12", 400ing
+        every Claude-backed provider. This is not hypothetical: GitHub's hosted MCP ships
+        ``issue_write`` with ``issue_fields[].value`` typed exactly this way. Before this
+        fix the array survived ingestion untouched (``_strip_nullable_union`` only handles
+        the ``[X, "null"]`` two-element case), and the tool 400d on first use.
+        """
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "value": {"type": ["string", "number", "boolean"]},
+            },
+        })
+
+        value = schema["properties"]["value"]
+        assert "type" not in value or not isinstance(value["type"], list)
+        assert value["anyOf"] == [
+            {"type": "string"},
+            {"type": "number"},
+            {"type": "boolean"},
+        ]
+
+    def test_nested_multitype_array_under_array_items_is_collapsed(self):
+        """The real GitHub ``issue_write`` shape: the array type is nested two levels deep
+        under ``properties.<field>.items.properties.<sub>``. The sanitizer must recurse."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "issue_fields": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": ["string", "number", "boolean"]},
+                        },
+                    },
+                },
+            },
+        })
+
+        value = schema["properties"]["issue_fields"]["items"]["properties"]["value"]
+        assert value["anyOf"] == [
+            {"type": "string"},
+            {"type": "number"},
+            {"type": "boolean"},
+        ]
 
     def test_optional_nullable_field_is_collapsed_to_non_null_schema(self):
         """Anthropic rejects MCP/Pydantic anyOf-null optional parameter schemas."""

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -380,6 +380,48 @@ class TestSchemaConversion:
             {"type": "boolean"},
         ]
 
+    def test_wire_property_keys_survive_ingestion_for_dispatch_round_trip(self):
+        """Ingestion must collapse the ``type`` array WITHOUT renaming property keys.
+
+        The registry holds the schema this function returns, and dispatch depends
+        on it keeping the server's wire names: ``sanitize_tool_schemas`` renames
+        provider-hostile keys only on the copy sent to the model, and
+        ``unrename_tool_args`` maps the model's arguments back by recomputing
+        those renames from the registry's original schema. Renaming during
+        ingestion would make that reverse map an identity, and a tool from a
+        server with keys such as Cloudflare's ``issue_class~neq`` would be
+        dispatched under the sanitized key instead of the wire key.
+        """
+        from tools.mcp_tool import _normalize_mcp_input_schema
+        from tools.schema_sanitizer import sanitize_tool_schemas, unrename_tool_args
+
+        registry_params = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "issue_class~neq": {"type": ["string", "number"]},
+            },
+        })
+
+        # The type array is collapsed; the wire key is untouched.
+        assert list(registry_params["properties"]) == ["issue_class~neq"]
+        assert registry_params["properties"]["issue_class~neq"]["anyOf"] == [
+            {"type": "string"},
+            {"type": "number"},
+        ]
+
+        # The model sees the sanitized copy, with the key renamed...
+        outgoing = sanitize_tool_schemas([{
+            "type": "function",
+            "function": {"name": "query", "parameters": registry_params},
+        }])
+        model_key, = outgoing[0]["function"]["parameters"]["properties"]
+        assert model_key == "issue_class_neq"
+
+        # ...and its arguments map back to the wire key before dispatch.
+        assert unrename_tool_args(registry_params, {model_key: "bug"}) == {
+            "issue_class~neq": "bug",
+        }
+
     def test_optional_nullable_field_is_collapsed_to_non_null_schema(self):
         """Anthropic rejects MCP/Pydantic anyOf-null optional parameter schemas."""
         from tools.mcp_tool import _normalize_mcp_input_schema
@@ -1881,6 +1923,50 @@ class TestSamplingCallbackText:
                 "parameters": {"type": "object", "properties": {}},
             },
         }]
+
+    def test_server_tools_with_multitype_array_are_collapsed(self):
+        """Sampling hands server tools to the LLM without the global sanitizer.
+
+        A normal agent request goes through ``get_tool_definitions``, which
+        applies ``sanitize_tool_schemas`` to the outgoing copy. This path builds
+        the tool list here and passes it straight to ``call_llm``, so an
+        array-valued ``type`` reaches the provider verbatim unless MCP ingestion
+        collapses it — and Anthropic 400s the whole request when it does.
+        """
+        server_tool = SimpleNamespace(
+            name="issue_write",
+            description="Write an issue",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "issue_fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "value": {"type": ["string", "number", "boolean"]},
+                            },
+                        },
+                    },
+                },
+            },
+        )
+
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=_make_llm_response(),
+        ) as mock_call:
+            params = _make_sampling_params(tools=[server_tool])
+            asyncio.run(self.handler(None, params))
+
+        parameters = mock_call.call_args.kwargs["tools"][0]["function"]["parameters"]
+        value = parameters["properties"]["issue_fields"]["items"]["properties"]["value"]
+        assert "type" not in value or not isinstance(value["type"], list)
+        assert value["anyOf"] == [
+            {"type": "string"},
+            {"type": "number"},
+            {"type": "boolean"},
+        ]
 
 # ---------------------------------------------------------------------------
 # 7. Tool use sampling callback

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5330,6 +5330,19 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
     normalized = _rewrite_local_refs(schema)
     normalized = _strip_nullable_union(normalized)
     normalized = _repair_object_shape(normalized)
+    # Collapse multi-type ``type`` arrays (e.g. ``["string", "number", "boolean"]``)
+    # into an ``anyOf`` of single-type schemas. ``_strip_nullable_union`` above only
+    # handles the two-element ``[X, "null"]`` case; a genuine multi-type array survives
+    # it untouched, and Anthropic's tool ``input_schema`` validator rejects any array
+    # ``type`` with "JSON schema is invalid. It must match JSON Schema draft 2020-12"
+    # (observed via GitHub's hosted MCP: the ``issue_write`` tool declares
+    # ``issue_fields[].value`` as ``type: ["string", "number", "boolean"]``, which 400s
+    # on every Claude-backed provider). ``_sanitize_node`` is the same routine
+    # ``sanitize_tool_schemas`` applies to non-MCP tools, so this makes MCP ingestion
+    # share that behaviour instead of diverging from it.
+    from tools.schema_sanitizer import _sanitize_node
+
+    normalized = _sanitize_node(normalized, path="<mcp>")
 
     # Ensure top-level is a well-formed object schema
     if not isinstance(normalized, dict):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5337,12 +5337,21 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
     # ``type`` with "JSON schema is invalid. It must match JSON Schema draft 2020-12"
     # (observed via GitHub's hosted MCP: the ``issue_write`` tool declares
     # ``issue_fields[].value`` as ``type: ["string", "number", "boolean"]``, which 400s
-    # on every Claude-backed provider). ``_sanitize_node`` is the same routine
-    # ``sanitize_tool_schemas`` applies to non-MCP tools, so this makes MCP ingestion
-    # share that behaviour instead of diverging from it.
-    from tools.schema_sanitizer import _sanitize_node
+    # on every Claude-backed provider).
+    #
+    # Deliberately ``normalize_type_arrays`` and NOT the full ``_sanitize_node``:
+    # this function feeds the tool *registry*, which must keep the server's wire
+    # property names. The global sanitizer renames non-conforming keys only on the
+    # copy sent to the model (``model_tools.get_tool_definitions``), and
+    # ``unrename_tool_args`` maps the model's arguments back by recomputing those
+    # renames from the registry's original schema. Renaming here would make that
+    # reverse map an identity and dispatch tools from servers with keys such as
+    # ``issue_class~neq`` under the sanitized key. Both routines share one
+    # implementation of the ``type``-array rule (``collapse_type_array``), the same
+    # way ``_strip_nullable_union`` above shares ``strip_nullable_unions``.
+    from tools.schema_sanitizer import normalize_type_arrays
 
-    normalized = _sanitize_node(normalized, path="<mcp>")
+    normalized = normalize_type_arrays(normalized)
 
     # Ensure top-level is a well-formed object schema
     if not isinstance(normalized, dict):

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -302,6 +302,109 @@ def strip_nullable_unions(
     return stripped
 
 
+def collapse_type_array(value: list) -> dict:
+    """Return the keys that replace a JSON Schema ``type`` array on one node.
+
+    JSON Schema ``type`` arrays (e.g. ``["number", "string"]``, common in MCP
+    tool schemas) are rejected by several tool-call backends:
+
+      * llama.cpp's grammar generator only accepts a singular string type.
+      * Gemini (including OpenAI-compatible transports such as GitHub Copilot
+        proxying to Gemini) rejects the array form outright — plain
+        @ai-sdk/google rewrites it, but the OpenAI-compatible path forwards it
+        verbatim and the backend 400s.
+      * Anthropic's tool ``input_schema`` validator rejects it with "JSON
+        schema is invalid. It must match JSON Schema draft 2020-12".
+
+    Normalize per the SDK's behavior:
+
+      * single non-null type → ``type: X`` (+ ``nullable: true`` if the array
+        also contained "null"). No data lost.
+      * multiple non-null types → ``anyOf`` of single-type schemas, so EVERY
+        branch survives instead of silently dropping all but the first.
+        ``null`` is lifted into ``nullable: true``.
+      * all-null / empty → ``type: "null"`` (or object fallback).
+
+    Ported from anomalyco/opencode#31877. Callers merge the returned keys into
+    the node they are building; ``nullable`` is a hint and should be merged
+    with ``setdefault`` so an explicit sibling ``nullable`` wins.
+    """
+    has_null = "null" in value
+    non_null = [t for t in value if isinstance(t, str) and t != "null"]
+    if len(non_null) == 1:
+        out: dict = {"type": non_null[0]}
+    elif len(non_null) >= 2:
+        # Preserve all branches as a union instead of dropping them.
+        out = {"anyOf": [{"type": t} for t in non_null]}
+    else:
+        # No usable non-null type: all-null array → type: "null";
+        # otherwise an empty/garbage array → object fallback.
+        return {"type": "null" if has_null else "object"}
+    if has_null:
+        out["nullable"] = True
+    return out
+
+
+def normalize_type_arrays(node: Any) -> Any:
+    """Recursively collapse ``type`` arrays, leaving every other key untouched.
+
+    This is the ``type``-array rule of :func:`_sanitize_node` and nothing else
+    — in particular it does NOT rename property keys.
+
+    MCP ingestion needs exactly this narrow pass. ``_normalize_mcp_input_schema``
+    populates the tool *registry*, and the registry must keep the server's wire
+    property names: ``sanitize_tool_schemas`` renames keys only on the copy sent
+    to the model, and ``unrename_tool_args`` maps the model's arguments back by
+    recomputing the renames from the registry's original schema. A rename
+    applied during ingestion would make that reverse map an identity, and tools
+    from servers with keys such as ``issue_class~neq`` would be dispatched with
+    the sanitized key instead of the wire key.
+
+    Structural walk mirrors :func:`_sanitize_node`: ``properties`` /
+    ``patternProperties`` / ``$defs`` / ``definitions`` values are schemas
+    (keys are names and are preserved verbatim), ``items`` /
+    ``additionalProperties`` / ``anyOf`` / ``oneOf`` / ``allOf`` are recursed
+    into, and the non-schema sibling keywords pass through unchanged.
+    """
+    if isinstance(node, list):
+        return [normalize_type_arrays(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+
+    out: dict = {}
+    for key, value in node.items():
+        if key == "type" and isinstance(value, list):
+            for repl_key, repl_value in collapse_type_array(value).items():
+                if repl_key == "nullable":
+                    out.setdefault(repl_key, repl_value)
+                else:
+                    out[repl_key] = repl_value
+        elif (
+            key in {"properties", "patternProperties", "$defs", "definitions"}
+            and isinstance(value, dict)
+        ):
+            out[key] = {
+                sub_key: normalize_type_arrays(sub_value)
+                for sub_key, sub_value in value.items()
+            }
+        elif key in {"items", "additionalProperties"}:
+            # Bool ``additionalProperties`` (and non-standard ``items: true``)
+            # is a valid form — preserve rather than walk into it.
+            out[key] = value if isinstance(value, bool) else normalize_type_arrays(value)
+        elif key in {"anyOf", "oneOf", "allOf"} and isinstance(value, list):
+            out[key] = [normalize_type_arrays(item) for item in value]
+        elif key in {"required", "enum", "examples", "dependentRequired"}:
+            # Values here are literals / property-name lists, not schemas.
+            out[key] = value
+        else:
+            out[key] = (
+                normalize_type_arrays(value)
+                if isinstance(value, (dict, list))
+                else value
+            )
+    return out
+
+
 def _sanitize_node(node: Any, path: str) -> Any:
     """Recursively sanitize a JSON-Schema fragment.
 
@@ -351,39 +454,16 @@ def _sanitize_node(node: Any, path: str) -> Any:
 
     out: dict = {}
     for key, value in node.items():
-        # JSON Schema ``type`` arrays (e.g. ``["number", "string"]``, common
-        # in MCP tool schemas) are rejected by several tool-call backends:
-        #   * llama.cpp's grammar generator only accepts a singular string type.
-        #   * Gemini (including OpenAI-compatible transports such as GitHub
-        #     Copilot proxying to Gemini) rejects the array form outright —
-        #     plain @ai-sdk/google rewrites it, but the OpenAI-compatible path
-        #     forwards it verbatim and the backend 400s.
-        #
-        # Normalize per the SDK's behavior:
-        #   * single non-null type → ``type: X`` (+ ``nullable: true`` if the
-        #     array also contained "null"). No data lost.
-        #   * multiple non-null types → ``anyOf`` of single-type schemas, so
-        #     EVERY branch survives instead of silently dropping all but the
-        #     first. ``null`` is lifted into ``nullable: true``.
-        #   * all-null / empty → ``type: "null"`` (or object fallback).
-        # Ported from anomalyco/opencode#31877.
+        # ``type`` arrays are rejected by several tool-call backends; see
+        # ``collapse_type_array`` for the per-backend rationale and the mapping.
+        # ``nullable`` is merged with ``setdefault`` so an explicit sibling
+        # ``nullable`` later in this dict still wins.
         if key == "type" and isinstance(value, list):
-            has_null = "null" in value
-            non_null = [t for t in value if isinstance(t, str) and t != "null"]
-            if len(non_null) == 1:
-                out["type"] = non_null[0]
-                if has_null:
-                    out.setdefault("nullable", True)
-                continue
-            if len(non_null) >= 2:
-                # Preserve all branches as a union instead of dropping them.
-                out["anyOf"] = [{"type": t} for t in non_null]
-                if has_null:
-                    out.setdefault("nullable", True)
-                continue
-            # No usable non-null type: all-null array → type: "null";
-            # otherwise an empty/garbage array → object fallback.
-            out["type"] = "null" if has_null else "object"
+            for repl_key, repl_value in collapse_type_array(value).items():
+                if repl_key == "nullable":
+                    out.setdefault(repl_key, repl_value)
+                else:
+                    out[repl_key] = repl_value
             continue
 
         if key in {"properties", "$defs", "definitions"} and isinstance(value, dict):


### PR DESCRIPTION
### Summary

`_normalize_mcp_input_schema` (`tools/mcp_tool.py`) runs `_rewrite_local_refs`, `_strip_nullable_union` and `_repair_object_shape`, but nothing that handles a genuine multi-type `type` array such as `["string", "number", "boolean"]`. `_strip_nullable_union` only collapses the two-element `[X, "null"]` form, so a real union survives ingestion untouched.

Anthropic's tool `input_schema` validator rejects **any** array-valued `type` with `JSON schema is invalid. It must match JSON Schema draft 2020-12`, which 400s the request on every Claude-backed provider (direct, Bedrock, Vertex, Azure).

### Why this is reachable on a default install

GitHub's hosted MCP (`https://api.githubcopilot.com/mcp/`) ships `issue_write` with `issue_fields[].value` typed exactly this way, nested two levels deep under `properties.issue_fields.items.properties.value`. With that server configured, the first turn that offers the full tool list to a Claude model fails with `tools.<N>.custom.input_schema: JSON schema is invalid`, and the tool is unusable.

### The fix

**Revised after review — the first revision of this PR was wrong about the mechanism.** It routed ingestion through `_sanitize_node`, which also renames non-conforming property keys, and this PR body claimed that routine was "a no-op for schemas that are already well-formed". That claim was false: it was taken from a comment describing the outgoing-copy path, not the ingestion path. See the review discussion below.

The current revision narrows the repair to the `type`-array rule alone:

* `collapse_type_array()` (`tools/schema_sanitizer.py`) extracts the per-node `type`-array mapping that `_sanitize_node` had inline. Behavior is unchanged — `_sanitize_node` now calls it, and the `nullable` hint is still merged with `setdefault` so an explicit sibling `nullable` still wins.
* `normalize_type_arrays()` applies that rule and nothing else: the same structural walk, **no property-key renaming**, and no shape repairs (MCP ingestion already does those in `_repair_object_shape`).
* `_normalize_mcp_input_schema` calls `normalize_type_arrays`, the same way it already shares `strip_nullable_unions` with the global sanitizer.

Keeping the rename out of ingestion is what preserves dispatch: `_normalize_mcp_input_schema` feeds the tool registry, `get_tool_definitions` sanitizes only the outgoing copy, and `unrename_tool_args` maps the model's arguments back by recomputing the renames from the registry's original schema.

`tools/mcp_tool.py` +22, `tools/schema_sanitizer.py` +112/−32 (the deletions are the inline block moved into `collapse_type_array`).

### Tests

Four tests in `tests/tools/test_mcp_tool.py`:

| Test | Covers |
|---|---|
| `test_multitype_array_is_collapsed_to_anyof` | the flat case |
| `test_nested_multitype_array_under_array_items_is_collapsed` | the real nested GitHub `issue_write` shape |
| `test_server_tools_with_multitype_array_are_collapsed` | the **sampling path** — `SamplingHandler.__call__` builds its tool list and calls `call_llm` directly, never passing through `sanitize_tool_schemas`, so ingestion is the only place that can collapse the array on that route |
| `test_wire_property_keys_survive_ingestion_for_dispatch_round_trip` | the **wire-key round trip** — ingestion keeps `issue_class~neq`, `sanitize_tool_schemas` renames it to `issue_class_neq` on the outgoing copy, `unrename_tool_args` maps it back |

Measured, not asserted:

- All four **fail** against current `main` and **pass** with this change.
- The round-trip test also **fails against this PR's previous revision**, reporting `issue_class_neq` where the registry must hold `issue_class~neq` — it is a regression test for exactly the defect the review found.
- `tests/tools/test_mcp_tool.py` + `tests/tools/test_schema_sanitizer.py`: **111 passed**, and `test_schema_sanitizer.py` is unchanged, so it also covers the `_sanitize_node` extraction being behavior-preserving.
- Across all of `tests/tools/`, the set of pre-existing failures is **identical** with and without this change (optional-extra environment failures in `daytona`, `modal`, `voice`, `video`, `termux`, `image_generation`, `managed_media_gateways`, `web_tools_config`).
- `ruff check` passes on all three touched files.

### Relationship to #55643

Complementary, not a duplicate. #55643 fixes a `TypeError: unhashable type: 'list'` crash in `sanitize_gemini_schema` (`agent/gemini_schema.py`) when an array-typed schema also carries an `enum` — and its description notes that `_normalize_mcp_input_schema` "does not touch the array-`type` form". This PR is that missing half: it fixes the MCP ingestion path so the array form never reaches a provider validator in the first place. The two touch different files and neither subsumes the other.

Searched open and merged PRs and issues per CONTRIBUTING before opening; #67266 (`schema_sanitizer` combinator refs) and #43419 (memory-provider tool injection) are adjacent but touch different code paths.

### Contributor mapping

`contributors/emails/117359338+marcovillar-br@users.noreply.github.com`, added per `contributors/README.md`.
