### PR TITLE
fix(buzz): require @ for display-name mentions

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1113,42 +1113,42 @@ class BuzzAdapter(BasePlatformAdapter):
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
 
     def _is_mentioned(self, content: str) -> bool:
-        """True when the message addresses this agent (npub, hex, or name)."""
+        """True for a raw npub/hex identity or literal @display-name mention."""
         lowered = content.lower()
         if self._self_pubkey and self._self_pubkey in lowered:
             return True
         if self._self_npub and self._self_npub in lowered:
             return True
         if self._display_name:
-            pattern = rf"(?<!\w)@?{re.escape(self._display_name.lower())}(?!\w)"
+            pattern = rf"(?<!\w)@{re.escape(self._display_name.lower())}(?!\w)"
             if re.search(pattern, lowered):
                 return True
         return False
 
     def _strip_mention(self, content: str) -> str:
-        """Remove a leading @mention of this agent so the remaining text can be
+        """Remove a leading explicit identity so the remaining text can be
         recognized as a slash command or clean prompt.
 
         Mirrors the Discord adapter, which strips its own ``<@id>`` mention
         before dispatch. Without this a channel message like ``@Chip /whoami``
         arrives with a leading ``@Chip``; the gateway's ``is_command()`` checks
         ``text.lstrip().startswith("/")`` and never fires the command. Only a
-        LEADING mention is stripped (case-insensitive); mentions mid-sentence
-        are left intact so normal prose is unaffected.
+        LEADING literal @display-name mention or raw/optional-@ npub/hex identity
+        is stripped (case-insensitive); mentions mid-sentence are left intact.
         """
         text = content.strip()
         candidates = []
         if self._display_name:
-            candidates.append(re.escape(self._display_name))
+            candidates.append(rf"@{re.escape(self._display_name)}(?!\w)")
         if self._self_npub:
-            candidates.append(re.escape(self._self_npub))
+            candidates.append(rf"@?{re.escape(self._self_npub)}")
         if self._self_pubkey:
-            candidates.append(re.escape(self._self_pubkey))
+            candidates.append(rf"@?{re.escape(self._self_pubkey)}")
         if not candidates:
             return text
-        # Optional leading '@', one of the identity forms, optional trailing
-        # ':' or ',' and surrounding whitespace.
-        pattern = rf"^@?(?:{'|'.join(candidates)})[\s:,]*"
+        # Each candidate carries its own @ policy; trailing punctuation and
+        # surrounding whitespace remain optional for every identity form.
+        pattern = rf"^(?:{'|'.join(candidates)})[\s:,]*"
         stripped = re.sub(pattern, "", text, count=1, flags=re.IGNORECASE)
         return stripped.strip()
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -239,9 +239,63 @@ class TestMentionGating:
         assert adapter._dispatched == []
 
     @pytest.mark.asyncio
-    async def test_name_mention_dispatched(self, adapter):
-        await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
+    @pytest.mark.parametrize("content", ["@chip can you help?", "hey @CHIP, can you help?"])
+    async def test_name_mention_dispatched_case_insensitively(self, adapter, content):
+        await self._poll_with(adapter, _event("e1", content=content, created_at=10))
         assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "Chip can handle this",
+            "ask chip about the task",
+            "Chip's plan looks fine",
+            "CHIP CAN HANDLE THIS",
+        ],
+    )
+    async def test_bare_display_name_does_not_dispatch(self, adapter, content):
+        await self._poll_with(adapter, _event("e1", content=content, created_at=10))
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("content", ["ask @Chipotle about it", "chip@example.com replied"])
+    async def test_display_name_lookalikes_do_not_dispatch(self, adapter, content):
+        await self._poll_with(adapter, _event("e1", content=content, created_at=10))
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("identity", [SELF_NPUB, SELF_PUBKEY])
+    async def test_npub_and_hex_addressing_still_dispatch(self, adapter, identity):
+        await self._poll_with(adapter, _event("e1", content=f"ask {identity} for help", created_at=10))
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_dm_bare_display_name_dispatches_with_text_unchanged(self, adapter):
+        adapter._channel_state[CHANNEL]["chat_type"] = "dm"
+        content = "Chip is handling this"
+        await self._poll_with(adapter, _event("e1", content=content, created_at=10))
+        assert adapter._dispatched[0]["text"] == content
+
+    @pytest.mark.asyncio
+    async def test_dm_display_name_lookalike_dispatches_with_text_unchanged(self, adapter):
+        adapter._channel_state[CHANNEL]["chat_type"] = "dm"
+        content = "@Chipotle says hi"
+        await self._poll_with(adapter, _event("e1", content=content, created_at=10))
+        assert adapter._dispatched[0]["text"] == content
+
+    @pytest.mark.asyncio
+    async def test_require_mention_false_dispatches_unaddressed_message(self, adapter):
+        adapter.require_mention = False
+        await self._poll_with(adapter, _event("e1", content="just chatting", created_at=10))
+        assert adapter._dispatched[0]["text"] == "just chatting"
+
+    @pytest.mark.asyncio
+    async def test_require_mention_false_display_name_lookalike_preserves_text(self, adapter):
+        adapter.require_mention = False
+        content = "@Chipotle says hi"
+        await self._poll_with(adapter, _event("e1", content=content, created_at=10))
+        assert adapter._dispatched[0]["text"] == content
 
 
     @pytest.mark.asyncio
@@ -249,6 +303,27 @@ class TestMentionGating:
         adapter._allowed_pubkeys = {"b" * 64}
         await self._poll_with(adapter, _event("e1", content="@Chip hello", created_at=10))
         assert adapter._dispatched == []
+
+
+class TestMentionStripping:
+
+    def test_bare_leading_display_name_is_preserved(self):
+        adapter = _make_adapter()
+        assert adapter._strip_mention("Chip is handling this") == "Chip is handling this"
+
+    def test_display_name_with_regex_characters_does_not_strip_word_prefix(self):
+        adapter = _make_adapter()
+        adapter._display_name = "C++ Bot (QA)"
+        content = "@C++ Bot (QA)Extra"
+        assert adapter._strip_mention(content) == content
+
+    @pytest.mark.parametrize(
+        "identity",
+        ["@Chip", SELF_NPUB, f"@{SELF_NPUB}", SELF_PUBKEY, f"@{SELF_PUBKEY}"],
+    )
+    def test_leading_explicit_identity_is_stripped(self, identity):
+        adapter = _make_adapter()
+        assert adapter._strip_mention(f"{identity}: handle this") == "handle this"
 
 
 # ── DM classification via p-tags (issue #68871) ──────────────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes Buzz shared-channel mention gating so a display name only counts as an address when it has a literal `@` prefix.

On current `main`, the display-name regex makes `@` optional. With `require_mention: true`, ordinary prose such as `Chip can handle this` can therefore wake an agent named `Chip`. The same optional-prefix logic in `_strip_mention()` can also remove a bare leading display name—or partially strip a lookalike such as `@Chipotle`—from DMs and channels where mentions are not required.

This change keeps the fix identity-specific:

- display-name matching and stripping require a literal `@` and a terminal word boundary;
- npub and 64-character hex addressing retain their existing raw/optional-`@` behavior;
- DM classification, allowlists, thread behavior, and `require_mention: false` dispatch remain unchanged.

## Related Issue

No issue filed. Related but not duplicative: #75049 expands active-thread mention policy, while this PR fixes what qualifies as a display-name mention in the existing gate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `plugins/platforms/buzz/adapter.py` so `_is_mentioned()` requires literal `@DisplayName`, case-insensitively.
- Give `_strip_mention()` identity-specific candidates: literal `@` for display names; existing raw/optional-`@` behavior for npub and hex identities.
- Add the display-name terminal `(?!\w)` boundary to prevent prefix corruption such as stripping `@Chip` from `@Chipotle`.
- Add behavioral regression coverage in `tests/gateway/test_buzz_adapter.py` for bare-name prose, case-insensitive explicit mentions, lookalikes, email-like text, DMs, `require_mention: false`, npub/hex addressing, and regex-bearing display names.

## How to Test

1. Run:
   ```bash
   scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q
   ```
   Result: **47 passed, 0 failed**.
2. Run:
   ```bash
   python -m py_compile plugins/platforms/buzz/adapter.py
   python -m ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py
   python scripts/check-windows-footguns.py plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py
   git diff --check origin/main...HEAD
   ```
   Result: all passed.
3. Live validation on macOS 26.5.1 and 26.5.2:
   - bare display-name prose in shared channels stayed silent;
   - explicit `@DisplayName` dispatched;
   - a DM beginning with the bare display name preserved the exact original text;
   - the same negative/positive channel checks passed on a second host/profile and another shared channel.

## Scope and limitations

- No new configuration, environment variable, dependency, core change, or documentation behavior.
- Does not change existing punctuation consumption after a real mention.
- Does not define new hyphen/dot/plus display-name boundary policy.
- #75049 may require a small textual rebase in the same adapter/test area, but its active-thread policy is conceptually compatible with this stricter display-name boundary.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 and macOS 26.5.2

The focused Buzz adapter and websocket suites passed; the repository-wide Python suite was not run, so that checkbox is intentionally left unchecked.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Documentation, example config, architecture guidance, and tool schemas are N/A. The Windows-footgun scan passed for both touched files.

## Screenshots / Logs

N/A. Automated behavior tests and two-host live canaries cover the reported failure and preserved paths.

## AI assistance

AI assistance was used to help implement and test the change. The final diff was independently reviewed, rebased unchanged onto current `main`, and live-validated by the contributor.
