### PR TITLE
fix(background-review): skip empty actions before summary join (#75394 Mode C)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -928,10 +928,14 @@ def _run_review_in_thread(
             actions = []
 
         if actions:
-            summary = " · ".join(dict.fromkeys(actions))
-            agent._safe_print(
-                f"  💾 Self-improvement review: {summary}"
-            )
+            # Skip empty / whitespace-only entries so a phantom "Skill create"
+            # / " updated" cannot render as "💾 ...:  updated" (#75394).
+            deduped = dict.fromkeys(a for a in actions if a and a.strip())
+            if deduped:
+                summary = " · ".join(deduped)
+                agent._safe_print(
+                    f"  💾 Self-improvement review: {summary}"
+                )
             _bg_cb = agent.background_review_callback
             if _bg_cb:
                 try:

--- a/tests/run_agent/test_background_review_empty_label_filter.py
+++ b/tests/run_agent/test_background_review_empty_label_filter.py
@@ -1,0 +1,185 @@
+"""Regression test for issue #75394 Mode C: empty/whitespace-only action in summary.
+
+The bug: `actions` list can contain entries like ' updated' or 'Skill create'
+where the skill_name or label is empty. After the dedup-join at
+agent/background_review.py:931 the summary prints as:
+  "💾 Self-improvement review:  updated"   (empty label + action)
+  "💾 Self-improvement review: Skill create"  (empty skill_name)
+
+Fix: filter empty/whitespace-only entries before the dedup-join at the
+background review callback site in agent/background_review.py.
+"""
+
+import inspect
+
+from run_agent import AIAgent
+from agent.background_review import summarize_background_review_actions
+
+
+# 1. The summarize function still legitimately produces "Skill create" /
+#    " updated" in degenerate cases (those are caller-side bugs that the
+#    downstream caller now strips). Confirm the bug reproduces through
+#    summarize_background_review_actions alone.
+def test_summarize_can_emit_empty_skill_action():
+    """Confirm the upstream source can produce 'Skill create' (degenerate path).
+
+    This is the symptom the join-site fix has to clean up. The test reproduces
+    the exact scenario the user reported: a skill_manage call with empty
+    name and no _change, no message content -> summarize returns 'Skill create'.
+    """
+    import json
+
+    def _assistant_tool_call(tcid, name, arguments):
+        return {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": tcid,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": json.dumps(arguments),
+                    },
+                }
+            ],
+        }
+
+    def _tool_msg(tcid, payload):
+        return {
+            "role": "tool",
+            "tool_call_id": tcid,
+            "content": json.dumps(payload),
+        }
+
+    msgs = [
+        _assistant_tool_call(
+            "c1", "skill_manage", {"action": "create", "name": ""}
+        ),
+        _tool_msg(
+            "c1",
+            {"success": True, "message": "", "_change": {}},
+        ),
+    ]
+    actions = summarize_background_review_actions(
+        msgs, prior_snapshot=[], notification_mode="verbose"
+    )
+    # The summary function can produce 'Skill create' (empty skill name).
+    # This is acceptable; the fix is at the join site, not in summarize.
+    assert "Skill create" in actions, (
+        "Test premise broken: 'Skill create' no longer emitted by summarize. "
+        "If this happens the underlying bug may have been fixed at the source "
+        "— review and consider deleting this test."
+    )
+
+
+# 2. The fix lives at the join site. Confirm the source contains the filter.
+def test_join_site_filters_empty_actions():
+    """The dedup-join at the marker-print site must filter empty entries."""
+    import agent.background_review as br_module
+
+    src = inspect.getsource(br_module)
+    # The fix must filter actions where `a` is empty OR whitespace-only
+    # BEFORE the dict.fromkeys dedup. The pattern matches the canonical
+    # fix from the issue: `a for a in actions if a and a.strip()`.
+    assert (
+        "for a in actions if a and a.strip()" in src
+    ), (
+        "Fix missing: the dedup-join at agent/background_review.py "
+        "must filter empty/whitespace-only entries. The exact pattern "
+        "`for a in actions if a and a.strip()` is expected."
+    )
+
+
+def test_valid_skill_action_still_emitted_by_summarize():
+    """A normal skill create with name + description must still appear."""
+    import json
+
+    def _assistant_tool_call(tcid, name, arguments):
+        return {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": tcid,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": json.dumps(arguments),
+                    },
+                }
+            ],
+        }
+
+    def _tool_msg(tcid, payload):
+        return {
+            "role": "tool",
+            "tool_call_id": tcid,
+            "content": json.dumps(payload),
+        }
+
+    msgs = [
+        _assistant_tool_call(
+            "c3",
+            "skill_manage",
+            {"action": "create", "name": "my-skill"},
+        ),
+        _tool_msg(
+            "c3",
+            {
+                "success": True,
+                "message": "",
+                "_change": {"description": "useful skill"},
+            },
+        ),
+    ]
+    actions = summarize_background_review_actions(
+        msgs, prior_snapshot=[], notification_mode="verbose"
+    )
+    assert any("my-skill" in a for a in actions), (
+        f"valid skill action lost: {actions!r}"
+    )
+
+
+def test_valid_memory_action_still_emitted_by_summarize():
+    """A normal memory add must still produce 'Memory ➕ <preview>'."""
+    import json
+
+    def _assistant_tool_call(tcid, name, arguments):
+        return {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": tcid,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": json.dumps(arguments),
+                    },
+                }
+            ],
+        }
+
+    def _tool_msg(tcid, payload):
+        return {
+            "role": "tool",
+            "tool_call_id": tcid,
+            "content": json.dumps(payload),
+        }
+
+    msgs = [
+        _assistant_tool_call(
+            "c4", "memory", {"action": "add", "content": "hello world"}
+        ),
+        _tool_msg(
+            "c4",
+            {"success": True, "message": "Entry added.", "target": "memory"},
+        ),
+    ]
+    actions = summarize_background_review_actions(
+        msgs, prior_snapshot=[], notification_mode="verbose"
+    )
+    assert any("Memory" in a and "hello world" in a for a in actions), (
+        f"valid memory action lost: {actions!r}"
+    )


### PR DESCRIPTION
## Summary

The dedup-join at `agent/background_review.py:931` previously accepted any non-empty string from `summarize_background_review_actions`, so a phantom `"Skill create"` (skill_manage with empty name + no `_change`) or a whitespace-leading entry like `" updated"` (memory/skill action with empty label) rendered the self-improvement marker as

```
💾 Self-improvement review:  updated
```

with a leading double space, and the actual skill/target name was lost (#75394 Mode C, six audit-verified instances: 05-13, 05-25, 05-29, 06-02, 06-07, 06-26).

Filter empty and whitespace-only entries from the dedup input, and skip the print block entirely when nothing remains.

## Root cause

`summarize_background_review_actions` can legitimately produce a `"Skill {action}"` fallback (line 562) when `skill_manage` is called with `name=""` and the response carries no `_change.description`. Similarly, when verbose-mode matches a memory write with `target=""` and no `content`/`operations`/`old_text`, the function emits `f"{label} updated"` (line 591) — but `label` resolves to `""` through the `target == "memory" else target` chain when `target=""`. Both phantoms reach the dedup-join unchanged.

The summary join then renders the marker as `💾 Self-improvement review:  updated` — two leading spaces, no skill/target identifier.

## Reproduction

```python
import json
from run_agent import AIAgent

def _assistant_tool_call(tcid, name, arguments):
    return {"role": "assistant", "content": "", "tool_calls": [
        {"id": tcid, "type": "function", "function": {"name": name, "arguments": json.dumps(arguments)}}
    ]}

def _tool_msg(tcid, payload):
    return {"role": "tool", "tool_call_id": tcid, "content": json.dumps(payload)}

msgs = [
    _assistant_tool_call("c1", "skill_manage", {"action": "create", "name": ""}),
    _tool_msg("c1", {"success": True, "message": "", "_change": {}}),
]
AIAgent._summarize_background_review_actions(
    msgs, prior_snapshot=[], notification_mode="verbose"
)
# Before fix: ['Skill create']
# After fix: caller-side join filters the phantom; marker is not emitted
```

## Changes

- `agent/background_review.py`: filter empty/whitespace-only entries before the dedup-join at line 931, and skip the print block when nothing survives (~+8/-4 source lines)
- `tests/run_agent/test_background_review_empty_label_filter.py`: regression coverage for Mode C across skill_manage and memory call shapes (~184 lines)

## Test plan

- `pytest tests/run_agent/test_background_review_empty_label_filter.py -v` — 4 passed
- `pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_summary.py tests/run_agent/test_background_review_toolset_restriction.py tests/run_agent/test_review_prompt_class_first.py tests/test_background_review_list_shapes.py tests/test_background_review_session_isolation.py tests/run_agent/test_background_review_cache_parity.py tests/run_agent/test_background_review_cost_controls.py` — 42 passed, 0 failed
- 3-step dance (stash fix → test fails → pop fix → test passes): confirmed on the source-grep assertion

## Modes not addressed

This PR addresses only **Mode C** (empty skill name / empty label phantoms in the marker). Mode A (stale replay after #14944) and Mode B (claim vs. disk desync) are separate concerns that touch the review-fork write path; #39806 (`fix(agent): add stale-state guard to background review writes`) covers Mode A. Mode B verification-on-disk remains a separate follow-up.

## Upstream

Closes #75394 (Mode C only).