### PR TITLE
fix(browser): give each CDP supervisor its own page target

### DIFF
--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -160,6 +160,11 @@ def _test_page_url() -> str:
     return "data:text/html;base64," + base64.b64encode(html.encode()).decode()
 
 
+def _title_page_url(title: str) -> str:
+    html = f"<!doctype html><html><head><title>{title}</title></head><body>{title}</body></html>"
+    return "data:text/html;base64," + base64.b64encode(html.encode()).decode()
+
+
 def _fire_on_page(cdp_url: str, expression: str) -> None:
     """Navigate the first page target to a data URL and fire `expression`."""
     import asyncio
@@ -235,6 +240,36 @@ def test_supervisor_start_and_snapshot(chrome_cdp, supervisor_registry):
     assert snap.pending_dialogs == ()
     # At minimum a top frame should exist after the navigate.
     assert snap.frame_tree.get("top") is not None
+
+
+def test_two_supervisors_navigate_distinct_owned_pages(chrome_cdp, supervisor_registry):
+    """Two task IDs navigate separate real Chrome tabs through owned sessions.
+
+    This is the integration boundary behind ``browser_navigate`` for shared
+    CDP browsers: each operation goes through ``CDPSupervisor.navigate_page``
+    and must remain bound to that supervisor's page session (#69727).
+    """
+    cdp_url, _port = chrome_cdp
+    first = supervisor_registry.get_or_start(task_id="pytest-nav-a", cdp_url=cdp_url)
+    second = supervisor_registry.get_or_start(task_id="pytest-nav-b", cdp_url=cdp_url)
+
+    assert first.page_target_id()
+    assert second.page_target_id()
+    assert first.page_target_id() != second.page_target_id()
+    assert first.navigate_page(_title_page_url("owned-page-a"))["ok"] is True
+    assert second.navigate_page(_title_page_url("owned-page-b"))["ok"] is True
+
+    deadline = time.monotonic() + 5
+    titles = (None, None)
+    while time.monotonic() < deadline:
+        first_title = first.evaluate_runtime("document.title")
+        second_title = second.evaluate_runtime("document.title")
+        titles = (first_title.get("result"), second_title.get("result"))
+        if titles == ("owned-page-a", "owned-page-b"):
+            break
+        time.sleep(0.05)
+
+    assert titles == ("owned-page-a", "owned-page-b")
 
 
 def test_main_frame_alert_detection_and_dismiss(chrome_cdp, supervisor_registry):

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -36,6 +36,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -165,6 +166,14 @@ def _title_page_url(title: str) -> str:
     return "data:text/html;base64," + base64.b64encode(html.encode()).decode()
 
 
+def _interactive_page_url() -> str:
+    html = """<!doctype html><html><head><title>interactive</title></head><body>
+<button id="owned-click" onclick="document.title='clicked'">Click</button>
+<input id="owned-input">
+</body></html>"""
+    return "data:text/html;base64," + base64.b64encode(html.encode()).decode()
+
+
 def _fire_on_page(cdp_url: str, expression: str) -> None:
     """Navigate the first page target to a data URL and fire `expression`."""
     import asyncio
@@ -270,6 +279,60 @@ def test_two_supervisors_navigate_distinct_owned_pages(chrome_cdp, supervisor_re
         time.sleep(0.05)
 
     assert titles == ("owned-page-a", "owned-page-b")
+
+
+@pytest.mark.skipif(not shutil.which("npx"), reason="agent-browser integration requires npx")
+def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, supervisor_registry, monkeypatch):
+    """Concurrent click/fill operations stay on their task-owned CDP pages."""
+    from tools import browser_tool
+
+    cdp_url, _port = chrome_cdp
+    first = supervisor_registry.get_or_start(task_id="pytest-action-a", cdp_url=cdp_url)
+    second = supervisor_registry.get_or_start(task_id="pytest-action-b", cdp_url=cdp_url)
+    page_url = _interactive_page_url()
+    assert first.navigate_page(page_url)["ok"] is True
+    assert second.navigate_page(page_url)["ok"] is True
+
+    sessions = {
+        "pytest-action-a": {"session_name": "pytest_action_a", "cdp_url": cdp_url},
+        "pytest-action-b": {"session_name": "pytest_action_b", "cdp_url": cdp_url},
+    }
+    monkeypatch.setattr(browser_tool, "_get_session_info", lambda task_id: sessions[task_id])
+    monkeypatch.setattr(
+        browser_tool,
+        "_find_agent_browser",
+        lambda **_kwargs: "npx agent-browser",
+    )
+    browser_tool._cached_agent_browser = None
+    browser_tool._agent_browser_resolved = False
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            click_future = pool.submit(
+                browser_tool._run_browser_command,
+                "pytest-action-a",
+                "click",
+                ["#owned-click"],
+            )
+            fill_future = pool.submit(
+                browser_tool._run_browser_command,
+                "pytest-action-b",
+                "fill",
+                ["#owned-input", "task-b"],
+            )
+            click_result = click_future.result(timeout=30)
+            fill_result = fill_future.result(timeout=30)
+
+        assert click_result["success"] is True, click_result
+        assert fill_result["success"] is True, fill_result
+        assert first.evaluate_runtime("document.title").get("result") == "clicked"
+        assert second.evaluate_runtime("document.querySelector('#owned-input').value").get("result") == "task-b"
+    finally:
+        for task_id in sessions:
+            try:
+                browser_tool._run_browser_command(task_id, "close", [], timeout=10)
+            except Exception:
+                pass
 
 
 def test_main_frame_alert_detection_and_dismiss(chrome_cdp, supervisor_registry):

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -32,6 +32,7 @@ import asyncio
 import base64
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -278,10 +279,12 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
         for task_id in all_task_ids:
             result = json.loads(browser_tool.browser_navigate(page_url, task_id=task_id))
             assert result["success"] is True, result
+        snapshots = {}
         for task_id in all_task_ids:
             snapshot = json.loads(browser_tool.browser_snapshot(task_id=task_id))
             assert snapshot["success"] is True, snapshot
             assert "Click" in snapshot["snapshot"]
+            snapshots[task_id] = snapshot["snapshot"]
 
         if retire_page:
             tab_refs = {}
@@ -298,18 +301,25 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
         first = supervisor_registry.get(task_ids[0])
         second = supervisor_registry.get(task_ids[1])
         assert first is not None and second is not None
+        click_selector, fill_selector = "#owned-click", "#owned-input"
+        if not retire_page:
+            click_ref = re.search(r"button[^\n]*\[ref=(e\d+)\]", snapshots[task_ids[0]])
+            fill_ref = re.search(r"textbox[^\n]*\[ref=(e\d+)\]", snapshots[task_ids[1]])
+            assert click_ref is not None, snapshots[task_ids[0]]
+            assert fill_ref is not None, snapshots[task_ids[1]]
+            click_selector, fill_selector = f"@{click_ref[1]}", f"@{fill_ref[1]}"
         with ThreadPoolExecutor(max_workers=2) as pool:
             click_future = pool.submit(
                 browser_tool_session._run_browser_command,
                 task_ids[0],
                 "click",
-                ["#owned-click"],
+                [click_selector],
             )
             fill_future = pool.submit(
                 browser_tool_session._run_browser_command,
                 task_ids[1],
                 "fill",
-                ["#owned-input", "task-b"],
+                [fill_selector, "task-b"],
             )
             click_result = click_future.result(timeout=30)
             fill_result = fill_future.result(timeout=30)

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -278,27 +278,36 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
         for task_id in all_task_ids:
             result = json.loads(browser_tool.browser_navigate(page_url, task_id=task_id))
             assert result["success"] is True, result
-        first = supervisor_registry.get(task_ids[0])
-        second = supervisor_registry.get(task_ids[1])
-        assert first is not None and second is not None
         for task_id in all_task_ids:
             snapshot = json.loads(browser_tool.browser_snapshot(task_id=task_id))
             assert snapshot["success"] is True, snapshot
             assert "Click" in snapshot["snapshot"]
 
         if retire_page:
+            tab_refs = {}
+            for task_id in all_task_ids:
+                supervisor = supervisor_registry.get(task_id)
+                assert supervisor is not None
+                binding = supervisor.page_target_tab_ref()
+                assert binding["ok"] is True, binding
+                tab_refs[task_id] = int(binding["tab_ref"][1:])
+            retired_task = min(tab_refs, key=tab_refs.__getitem__)
+            task_ids = tuple(task_id for task_id in all_task_ids if task_id != retired_task)
             browser_tool_lifecycle._cleanup_single_browser_session(retired_task)
 
+        first = supervisor_registry.get(task_ids[0])
+        second = supervisor_registry.get(task_ids[1])
+        assert first is not None and second is not None
         with ThreadPoolExecutor(max_workers=2) as pool:
             click_future = pool.submit(
                 browser_tool_session._run_browser_command,
-                "pytest-action-a",
+                task_ids[0],
                 "click",
                 ["#owned-click"],
             )
             fill_future = pool.submit(
                 browser_tool_session._run_browser_command,
-                "pytest-action-b",
+                task_ids[1],
                 "fill",
                 ["#owned-input", "task-b"],
             )

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -174,44 +174,20 @@ def _interactive_page_url() -> str:
     return "data:text/html;base64," + base64.b64encode(html.encode()).decode()
 
 
-def _fire_on_page(cdp_url: str, expression: str) -> None:
-    """Navigate the first page target to a data URL and fire `expression`."""
-    import asyncio
-    import websockets as _ws_mod
+def _fire_on_page(supervisor, expression: str) -> None:
+    """Navigate and fire an expression on the page actually owned by the supervisor."""
+    from tools.browser_supervisor import _schedule
 
-    async def run():
-        async with _ws_mod.connect(cdp_url, max_size=50 * 1024 * 1024) as ws:
-            next_id = [1]
-
-            async def call(method, params=None, session_id=None):
-                cid = next_id[0]
-                next_id[0] += 1
-                p = {"id": cid, "method": method}
-                if params:
-                    p["params"] = params
-                if session_id:
-                    p["sessionId"] = session_id
-                await ws.send(json.dumps(p))
-                async for raw in ws:
-                    m = json.loads(raw)
-                    if m.get("id") == cid:
-                        return m
-
-            targets = (await call("Target.getTargets"))["result"]["targetInfos"]
-            page = next(t for t in targets if t.get("type") == "page")
-            attach = await call(
-                "Target.attachToTarget", {"targetId": page["targetId"], "flatten": True}
-            )
-            sid = attach["result"]["sessionId"]
-            await call("Page.navigate", {"url": _test_page_url()}, session_id=sid)
-            await asyncio.sleep(1.5)  # let the page load
-            await call(
-                "Runtime.evaluate",
-                {"expression": expression, "returnByValue": True},
-                session_id=sid,
-            )
-
-    asyncio.run(run())
+    result = _schedule(
+        supervisor._cdp("Page.navigate", {"url": _test_page_url()}, session_id=supervisor._page_session_id),
+        supervisor._loop,
+        timeout=10,
+    )
+    assert "error" not in result, result
+    assert not result.get("result", {}).get("errorText"), result
+    time.sleep(1.5)
+    result = supervisor.evaluate_runtime(expression)
+    assert result["ok"] is True, result
 
 
 @pytest.fixture
@@ -239,7 +215,7 @@ def test_supervisor_start_and_snapshot(chrome_cdp, supervisor_registry):
     supervisor = supervisor_registry.get_or_start(task_id="pytest-1", cdp_url=cdp_url)
 
     # Navigate so the frame tree populates.
-    _fire_on_page(cdp_url, "/* no dialog */ void 0")
+    _fire_on_page(supervisor, "/* no dialog */ void 0")
 
     # Give a moment for frame events to propagate
     time.sleep(1.0)
@@ -285,23 +261,25 @@ def test_two_supervisors_navigate_distinct_owned_pages(chrome_cdp, supervisor_re
     not shutil.which("agent-browser") and not shutil.which("npx"),
     reason="agent-browser integration requires agent-browser or npx",
 )
-def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, supervisor_registry, monkeypatch):
+def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, supervisor_registry, monkeypatch, tmp_path):
     """Concurrent click/fill operations stay on their task-owned CDP pages."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("browser:\n  allow_private_urls: true\n", encoding="utf-8")
     from tools import browser_tool, browser_tool_lifecycle, browser_tool_session
 
     cdp_url, _port = chrome_cdp
     monkeypatch.setenv("BROWSER_CDP_URL", cdp_url)
     task_ids = ("pytest-action-a", "pytest-action-b")
     page_url = _interactive_page_url()
-    for task_id in task_ids:
-        result = json.loads(browser_tool.browser_navigate(page_url, task_id=task_id))
-        assert result["success"] is True, result
-    first = supervisor_registry.get(task_ids[0])
-    second = supervisor_registry.get(task_ids[1])
-    assert first is not None and second is not None
-    assert first.page_target_id() != second.page_target_id()
-
     try:
+        for task_id in task_ids:
+            result = json.loads(browser_tool.browser_navigate(page_url, task_id=task_id))
+            assert result["success"] is True, result
+        first = supervisor_registry.get(task_ids[0])
+        second = supervisor_registry.get(task_ids[1])
+        assert first is not None and second is not None
+        assert first.page_target_id() != second.page_target_id()
+
         with ThreadPoolExecutor(max_workers=2) as pool:
             click_future = pool.submit(
                 browser_tool_session._run_browser_command,
@@ -334,7 +312,7 @@ def test_main_frame_alert_detection_and_dismiss(chrome_cdp, supervisor_registry)
     cdp_url, _port = chrome_cdp
     supervisor = supervisor_registry.get_or_start(task_id="pytest-2", cdp_url=cdp_url)
 
-    _fire_on_page(cdp_url, "setTimeout(() => alert('PYTEST-MAIN-ALERT'), 50)")
+    _fire_on_page(supervisor, "setTimeout(() => alert('PYTEST-MAIN-ALERT'), 50)")
     dialogs = _wait_for_dialog(supervisor)
     assert dialogs, "no dialog detected"
     d = dialogs[0]
@@ -354,7 +332,7 @@ def test_iframe_contentwindow_alert(chrome_cdp, supervisor_registry):
     supervisor = supervisor_registry.get_or_start(task_id="pytest-3", cdp_url=cdp_url)
 
     _fire_on_page(
-        cdp_url,
+        supervisor,
         "setTimeout(() => document.querySelector('#inner').contentWindow.alert('PYTEST-IFRAME'), 50)",
     )
     dialogs = _wait_for_dialog(supervisor)
@@ -372,7 +350,7 @@ def test_prompt_dialog_with_response_text(chrome_cdp, supervisor_registry):
 
     # Fire a prompt and stash the answer on window
     _fire_on_page(
-        cdp_url,
+        supervisor,
         "setTimeout(() => { window.__promptResult = prompt('give me a token', 'default-x'); }, 50)",
     )
     dialogs = _wait_for_dialog(supervisor)
@@ -392,7 +370,7 @@ def test_browser_dialog_tool_end_to_end(chrome_cdp, supervisor_registry):
     cdp_url, _port = chrome_cdp
     supervisor = supervisor_registry.get_or_start(task_id="pytest-tool", cdp_url=cdp_url)
 
-    _fire_on_page(cdp_url, "setTimeout(() => alert('PYTEST-TOOL-END2END'), 50)")
+    _fire_on_page(supervisor, "setTimeout(() => alert('PYTEST-TOOL-END2END'), 50)")
     assert _wait_for_dialog(supervisor), "no dialog detected via wait_for_dialog"
 
     r = json.loads(browser_dialog(action="dismiss", task_id="pytest-tool"))
@@ -437,7 +415,7 @@ def test_evaluate_runtime_unserializable_value(chrome_cdp, supervisor_registry):
     cdp_url, _port = chrome_cdp
     supervisor = supervisor_registry.get_or_start(task_id="pytest-eval-5", cdp_url=cdp_url)
 
-    _fire_on_page(cdp_url, "void 0")
+    _fire_on_page(supervisor, "void 0")
     time.sleep(0.5)
 
     out = supervisor.evaluate_runtime("Infinity")

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -261,7 +261,8 @@ def test_two_supervisors_navigate_distinct_owned_pages(chrome_cdp, supervisor_re
     not shutil.which("agent-browser") and not shutil.which("npx"),
     reason="agent-browser integration requires agent-browser or npx",
 )
-def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, supervisor_registry, monkeypatch, tmp_path):
+@pytest.mark.parametrize("retire_page", [False, True], ids=["stable-pages", "closed-page"])
+def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, supervisor_registry, monkeypatch, tmp_path, retire_page):
     """Concurrent click/fill operations stay on their task-owned CDP pages."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / "config.yaml").write_text("browser:\n  allow_private_urls: true\n", encoding="utf-8")
@@ -270,18 +271,23 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
     cdp_url, _port = chrome_cdp
     monkeypatch.setenv("BROWSER_CDP_URL", cdp_url)
     task_ids = ("pytest-action-a", "pytest-action-b")
+    retired_task = "pytest-action-retired"
+    all_task_ids = (retired_task, *task_ids) if retire_page else task_ids
     page_url = _interactive_page_url()
     try:
-        for task_id in task_ids:
+        for task_id in all_task_ids:
             result = json.loads(browser_tool.browser_navigate(page_url, task_id=task_id))
             assert result["success"] is True, result
         first = supervisor_registry.get(task_ids[0])
         second = supervisor_registry.get(task_ids[1])
         assert first is not None and second is not None
-        for task_id in task_ids:
+        for task_id in all_task_ids:
             snapshot = json.loads(browser_tool.browser_snapshot(task_id=task_id))
             assert snapshot["success"] is True, snapshot
             assert "Click" in snapshot["snapshot"]
+
+        if retire_page:
+            browser_tool_lifecycle._cleanup_single_browser_session(retired_task)
 
         with ThreadPoolExecutor(max_workers=2) as pool:
             click_future = pool.submit(
@@ -306,7 +312,7 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
         assert first.evaluate_runtime("document.querySelector('#owned-input').value").get("result") == ""
         assert second.evaluate_runtime("document.title").get("result") == "interactive"
     finally:
-        for task_id in task_ids:
+        for task_id in all_task_ids:
             browser_tool_lifecycle._cleanup_single_browser_session(task_id)
 
 

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -257,6 +257,23 @@ def test_two_supervisors_navigate_distinct_owned_pages(chrome_cdp, supervisor_re
 
     assert titles == ("owned-page-a", "owned-page-b")
 
+    # A transport reconnect must retain the owned page and its loaded document.
+    from tools.browser_supervisor import _schedule
+
+    target_id, session_id = first.page_target_id(), first._page_session_id
+    assert first._ws is not None
+    _schedule(first._ws.close(), first._loop, timeout=5)
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        if first.snapshot().active and first._page_session_id != session_id:
+            break
+        time.sleep(0.05)
+    assert first.snapshot().active
+    assert first._page_session_id != session_id
+    assert first.page_target_id() == target_id
+    assert first.evaluate_runtime("document.title").get("result") == "owned-page-a"
+    assert second.evaluate_runtime("document.title").get("result") == "owned-page-b"
+
 
 @pytest.mark.skipif(
     not shutil.which("agent-browser") and not shutil.which("npx"),

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -287,14 +287,20 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
             snapshots[task_id] = snapshot["snapshot"]
 
         if retire_page:
-            tab_refs = {}
+            from tools.browser_supervisor import _schedule
+
+            probe_supervisor = supervisor_registry.get(all_task_ids[0])
+            assert probe_supervisor is not None
+            targets = _schedule(
+                probe_supervisor._cdp("Target.getTargets"), probe_supervisor._loop, timeout=5,
+            )["result"]["targetInfos"]
+            target_order = {target["targetId"]: index for index, target in enumerate(targets)}
+            task_positions = {}
             for task_id in all_task_ids:
                 supervisor = supervisor_registry.get(task_id)
                 assert supervisor is not None
-                binding = supervisor.page_target_tab_ref()
-                assert binding["ok"] is True, binding
-                tab_refs[task_id] = int(binding["tab_ref"][1:])
-            retired_task = min(tab_refs, key=tab_refs.__getitem__)
+                task_positions[task_id] = target_order[supervisor.page_target_id()]
+            retired_task = min(task_positions, key=task_positions.__getitem__)
             task_ids = tuple(task_id for task_id in all_task_ids if task_id != retired_task)
             browser_tool_lifecycle._cleanup_single_browser_session(retired_task)
 

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -278,7 +278,10 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
         first = supervisor_registry.get(task_ids[0])
         second = supervisor_registry.get(task_ids[1])
         assert first is not None and second is not None
-        assert first.page_target_id() != second.page_target_id()
+        for task_id in task_ids:
+            snapshot = json.loads(browser_tool.browser_snapshot(task_id=task_id))
+            assert snapshot["success"] is True, snapshot
+            assert "Click" in snapshot["snapshot"]
 
         with ThreadPoolExecutor(max_workers=2) as pool:
             click_future = pool.submit(

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -358,6 +358,54 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
             browser_tool_lifecycle._cleanup_single_browser_session(task_id)
 
 
+
+@pytest.mark.skipif(
+    not shutil.which("agent-browser") and not shutil.which("npx"),
+    reason="agent-browser integration requires agent-browser or npx",
+)
+def test_new_foreign_page_cannot_steal_follow_up_action(chrome_cdp, supervisor_registry, monkeypatch, tmp_path):
+    """A new tab between browser commands cannot become this task's action target."""
+    from tools import browser_tool, browser_tool_lifecycle, browser_tool_session
+    from tools.browser_supervisor import _schedule
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("browser:\n  allow_private_urls: true\n", encoding="utf-8")
+    cdp_url, _port = chrome_cdp
+    monkeypatch.setenv("BROWSER_CDP_URL", cdp_url)
+    task_id = "pytest-new-foreign-page"
+    try:
+        navigated = json.loads(browser_tool.browser_navigate(_interactive_page_url(), task_id=task_id))
+        assert navigated["success"] is True, navigated
+        snapshot = json.loads(browser_tool.browser_snapshot(task_id=task_id))
+        assert snapshot["success"] is True, snapshot
+        supervisor = supervisor_registry.get(task_id)
+        assert supervisor is not None
+        created = _schedule(
+            supervisor._cdp("Target.createTarget", {"url": _interactive_page_url()}),
+            supervisor._loop, timeout=5,
+        )
+        foreign_target = created["result"]["targetId"]
+        assert foreign_target != supervisor.page_target_id()
+        inventory = browser_tool_session._run_browser_command(task_id, "tab", ["list"])
+        assert inventory["success"] is True, inventory
+        assert len(inventory["data"]["tabs"]) == 1, inventory
+        clicked = browser_tool_session._run_browser_command(task_id, "click", ["#owned-click"])
+        assert clicked["success"] is True, clicked
+        assert supervisor.evaluate_runtime("document.title").get("result") == "clicked"
+        attached = _schedule(
+            supervisor._cdp("Target.attachToTarget", {"targetId": foreign_target, "flatten": True}),
+            supervisor._loop, timeout=5,
+        )
+        foreign_title = _schedule(
+            supervisor._cdp("Runtime.evaluate", {"expression": "document.title", "returnByValue": True},
+                            session_id=attached["result"]["sessionId"]),
+            supervisor._loop, timeout=5,
+        )
+        assert foreign_title["result"]["result"]["value"] == "interactive"
+    finally:
+        browser_tool_lifecycle._cleanup_single_browser_session(task_id)
+
+
 def test_main_frame_alert_detection_and_dismiss(chrome_cdp, supervisor_registry):
     """alert() in the main frame surfaces and can be dismissed via the sync API."""
     cdp_url, _port = chrome_cdp

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -92,6 +92,7 @@ def chrome_cdp(request):
             "--headless=new",
             "--disable-gpu",
             "--site-per-process",  # force OOPIFs for cross-origin iframes
+            "about:blank",  # avoid browser-owned new-tab content and background renderers
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -296,6 +297,9 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
         for task_id in all_task_ids:
             result = json.loads(browser_tool.browser_navigate(page_url, task_id=task_id))
             assert result["success"] is True, result
+            assert result["title"] == "interactive", result
+            assert "Click" in result["snapshot"], result
+            assert browser_tool._last_active_session_key[task_id] == task_id
         snapshots = {}
         for task_id in all_task_ids:
             snapshot = json.loads(browser_tool.browser_snapshot(task_id=task_id))

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -281,41 +281,36 @@ def test_two_supervisors_navigate_distinct_owned_pages(chrome_cdp, supervisor_re
     assert titles == ("owned-page-a", "owned-page-b")
 
 
-@pytest.mark.skipif(not shutil.which("npx"), reason="agent-browser integration requires npx")
+@pytest.mark.skipif(
+    not shutil.which("agent-browser") and not shutil.which("npx"),
+    reason="agent-browser integration requires agent-browser or npx",
+)
 def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, supervisor_registry, monkeypatch):
     """Concurrent click/fill operations stay on their task-owned CDP pages."""
-    from tools import browser_tool
+    from tools import browser_tool, browser_tool_lifecycle, browser_tool_session
 
     cdp_url, _port = chrome_cdp
-    first = supervisor_registry.get_or_start(task_id="pytest-action-a", cdp_url=cdp_url)
-    second = supervisor_registry.get_or_start(task_id="pytest-action-b", cdp_url=cdp_url)
+    monkeypatch.setenv("BROWSER_CDP_URL", cdp_url)
+    task_ids = ("pytest-action-a", "pytest-action-b")
     page_url = _interactive_page_url()
-    assert first.navigate_page(page_url)["ok"] is True
-    assert second.navigate_page(page_url)["ok"] is True
-
-    sessions = {
-        "pytest-action-a": {"session_name": "pytest_action_a", "cdp_url": cdp_url},
-        "pytest-action-b": {"session_name": "pytest_action_b", "cdp_url": cdp_url},
-    }
-    monkeypatch.setattr(browser_tool, "_get_session_info", lambda task_id: sessions[task_id])
-    monkeypatch.setattr(
-        browser_tool,
-        "_find_agent_browser",
-        lambda **_kwargs: "npx agent-browser",
-    )
-    browser_tool._cached_agent_browser = None
-    browser_tool._agent_browser_resolved = False
+    for task_id in task_ids:
+        result = json.loads(browser_tool.browser_navigate(page_url, task_id=task_id))
+        assert result["success"] is True, result
+    first = supervisor_registry.get(task_ids[0])
+    second = supervisor_registry.get(task_ids[1])
+    assert first is not None and second is not None
+    assert first.page_target_id() != second.page_target_id()
 
     try:
         with ThreadPoolExecutor(max_workers=2) as pool:
             click_future = pool.submit(
-                browser_tool._run_browser_command,
+                browser_tool_session._run_browser_command,
                 "pytest-action-a",
                 "click",
                 ["#owned-click"],
             )
             fill_future = pool.submit(
-                browser_tool._run_browser_command,
+                browser_tool_session._run_browser_command,
                 "pytest-action-b",
                 "fill",
                 ["#owned-input", "task-b"],
@@ -327,12 +322,11 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
         assert fill_result["success"] is True, fill_result
         assert first.evaluate_runtime("document.title").get("result") == "clicked"
         assert second.evaluate_runtime("document.querySelector('#owned-input').value").get("result") == "task-b"
+        assert first.evaluate_runtime("document.querySelector('#owned-input').value").get("result") == ""
+        assert second.evaluate_runtime("document.title").get("result") == "interactive"
     finally:
-        for task_id in sessions:
-            try:
-                browser_tool._run_browser_command(task_id, "close", [], timeout=10)
-            except Exception:
-                pass
+        for task_id in task_ids:
+            browser_tool_lifecycle._cleanup_single_browser_session(task_id)
 
 
 def test_main_frame_alert_detection_and_dismiss(chrome_cdp, supervisor_registry):

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -358,7 +358,6 @@ def test_two_supervisors_bind_concurrent_follow_up_actions(chrome_cdp, superviso
             browser_tool_lifecycle._cleanup_single_browser_session(task_id)
 
 
-
 @pytest.mark.skipif(
     not shutil.which("agent-browser") and not shutil.which("npx"),
     reason="agent-browser integration requires agent-browser or npx",
@@ -402,8 +401,23 @@ def test_new_foreign_page_cannot_steal_follow_up_action(chrome_cdp, supervisor_r
             supervisor._loop, timeout=5,
         )
         assert foreign_title["result"]["result"]["value"] == "interactive"
+        endpoint = supervisor.page_command_endpoint()
+
+        async def reject_foreign_attachment():
+            from websockets.asyncio.client import connect
+
+            async with connect(endpoint, proxy=None) as connection:
+                await connection.send(json.dumps({"id": 1, "method": "Target.attachToTarget",
+                                                  "params": {"targetId": foreign_target, "flatten": True}}))
+                response = json.loads(await asyncio.wait_for(connection.recv(), 5))
+                assert "error" in response, response
+                assert "sessionId" not in response.get("result", {}), response
+
+        asyncio.run(reject_foreign_attachment())
     finally:
         browser_tool_lifecycle._cleanup_single_browser_session(task_id)
+    assert supervisor._thread is not None
+    assert not supervisor._thread.is_alive(), "session cleanup left the supervisor running"
 
 
 def test_main_frame_alert_detection_and_dismiss(chrome_cdp, supervisor_registry):

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -247,6 +247,119 @@ def test_navigate_page_uses_owned_session_and_activates_target(monkeypatch):
     )
 
 
+def test_page_target_tab_ref_matches_agent_browser_target_order(monkeypatch):
+    """The tab ref must identify the owned target, not merely activate it."""
+    sup = _make_supervisor()
+    sup._active = True
+    sup._page_target_id = "TAB-OWNED"
+    methods: List[str] = []
+
+    async def fake_cdp(
+        method: str,
+        params: Optional[dict] = None,
+        session_id: Optional[str] = None,
+        timeout: float = 10.0,
+    ) -> dict:
+        methods.append(method)
+        if method == "Target.getTargets":
+            return {
+                "result": {
+                    "targetInfos": [
+                        {"targetId": "DEVTOOLS", "type": "page", "url": "devtools://devtools"},
+                        {"targetId": "TAB-OTHER", "type": "page", "url": "https://other.example"},
+                        {"targetId": "TAB-OWNED", "type": "page", "url": "about:blank"},
+                    ]
+                }
+            }
+        return {"result": {}}
+
+    class _Loop:
+        def is_running(self) -> bool:
+            return True
+
+    class _Fut:
+        def __init__(self, value):
+            self._value = value
+
+        def result(self, timeout=None):
+            return self._value
+
+    def schedule(coro, loop):
+        loop_local = asyncio.new_event_loop()
+        try:
+            return _Fut(loop_local.run_until_complete(coro))
+        finally:
+            loop_local.close()
+
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", schedule)
+    sup._loop = _Loop()  # type: ignore[assignment]
+    sup._cdp = fake_cdp  # type: ignore[method-assign]
+
+    result = sup.page_target_tab_ref()
+
+    assert result == {"ok": True, "target_id": "TAB-OWNED", "tab_ref": "t2"}
+    assert methods == ["Target.getTargets"]
+
+
+def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(monkeypatch, tmp_path):
+    """Click/type-style operations must select the owned tab in the same daemon call."""
+    import json
+    from unittest.mock import MagicMock, mock_open
+
+    import tools.browser_tool as browser_tool
+
+    session = {
+        "session_name": "cdp-task",
+        "cdp_url": "wss://browser.example/cdp",
+    }
+    captured: List[List[str]] = []
+    process = MagicMock()
+    process.wait.return_value = 0
+    process.returncode = 0
+    stdout = json.dumps([
+        {"command": ["tab", "t2"], "success": True, "result": []},
+        {"command": ["click", "@e1"], "success": True, "result": {"clicked": "@e1"}},
+    ])
+
+    def capture_popen(command, **kwargs):
+        captured.append(command)
+        return process
+
+    monkeypatch.setattr(browser_tool, "_get_session_info", lambda _task_id: session)
+    monkeypatch.setattr(browser_tool, "_find_agent_browser", lambda: "/usr/bin/agent-browser")
+    monkeypatch.setattr(browser_tool, "_ensure_cdp_supervisor", lambda _task_id: None)
+    monkeypatch.setattr(browser_tool, "_bind_session_page_target", lambda _task_id, _session: None)
+    monkeypatch.setattr(browser_tool, "_session_page_tab_ref", lambda _task_id, _session: "t2")
+    monkeypatch.setattr(browser_tool, "_get_browser_engine", lambda: "auto")
+    monkeypatch.setattr(browser_tool, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(browser_tool, "_build_browser_env", lambda: {})
+    monkeypatch.setattr(browser_tool, "_write_owner_pid", lambda *_args: None)
+    monkeypatch.setattr(browser_tool, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(browser_tool, "_safe_command_timeout", lambda: 10)
+    monkeypatch.setattr(browser_tool.subprocess, "Popen", capture_popen)
+    monkeypatch.setattr(browser_tool.os, "open", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr(browser_tool.os, "close", lambda *_args: None)
+    monkeypatch.setattr(browser_tool.os, "unlink", lambda *_args: None)
+    monkeypatch.setattr(browser_tool.os, "makedirs", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(browser_tool, "_read_command_output_files", lambda *_args: (stdout, ""))
+    monkeypatch.setattr(browser_tool, "_unlink_command_output_files", lambda *_args: None)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+    monkeypatch.setattr("builtins.open", mock_open(read_data=stdout))
+
+    result = browser_tool._run_browser_command("task", "click", ["@e1"])
+
+    assert result == {"success": True, "data": {"clicked": "@e1"}}
+    assert captured == [[
+        "/usr/bin/agent-browser",
+        "--cdp",
+        "wss://browser.example/cdp",
+        "--json",
+        "batch",
+        "tab t2",
+        "click @e1",
+    ]]
+
+
 def test_browser_navigate_cdp_uses_supervisor_page(monkeypatch):
     """browser_navigate on a CDP session must not fall through to unbound CLI."""
     import json

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -4,20 +4,25 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
 
 import pytest
 
 
 def _make_supervisor() -> Any:
+    import threading
     from tools.browser_supervisor import CDPSupervisor
 
     sup = object.__new__(CDPSupervisor)
     sup.task_id = "session-A"
     sup.cdp_url = "ws://example.test/cdp"
+    sup._state_lock = threading.Lock()
+    sup._active = False
     sup._page_session_id = None
     sup._page_target_id = None
     sup._owns_page_target = False
     sup._child_sessions = {}
+    sup._loop = None
     return sup
 
 
@@ -182,3 +187,178 @@ async def test_reconnect_reuses_owned_page_target():
     assert methods.count("Target.getTargets") == 1
     assert sup._page_target_id == "OWNED-TAB"
     assert sup._page_session_id == "SID-REUSE"
+
+
+def test_navigate_page_uses_owned_session_and_activates_target(monkeypatch):
+    """Public navigation must hit the dedicated page session (#69727 review)."""
+    sup = _make_supervisor()
+    sup._active = True
+    sup._page_session_id = "SID-NAV"
+    sup._page_target_id = "TAB-NAV"
+    sup._owns_page_target = True
+    methods: List[tuple] = []
+
+    async def fake_cdp(
+        method: str,
+        params: Optional[dict] = None,
+        session_id: Optional[str] = None,
+        timeout: float = 10.0,
+    ) -> dict:
+        methods.append((method, params, session_id))
+        if method == "Page.navigate":
+            return {"result": {"frameId": "frame-1", "loaderId": "load-1"}}
+        return {"result": {}}
+
+    class _Loop:
+        def is_running(self) -> bool:
+            return True
+
+    class _Fut:
+        def __init__(self, value):
+            self._value = value
+
+        def result(self, timeout=None):
+            return self._value
+
+    def schedule(coro, loop):
+        # Run the coroutine on a private loop to completion.
+        loop_local = asyncio.new_event_loop()
+        try:
+            return _Fut(loop_local.run_until_complete(coro))
+        finally:
+            loop_local.close()
+
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe", schedule
+    )
+    sup._loop = _Loop()  # type: ignore[assignment]
+    sup._cdp = fake_cdp  # type: ignore[method-assign]
+
+    result = sup.navigate_page("https://example.com/search")
+
+    assert result["ok"] is True
+    assert result["target_id"] == "TAB-NAV"
+    assert ("Target.activateTarget", {"targetId": "TAB-NAV"}, None) in methods
+    assert any(
+        m[0] == "Page.navigate"
+        and m[1] == {"url": "https://example.com/search"}
+        and m[2] == "SID-NAV"
+        for m in methods
+    )
+
+
+def test_browser_navigate_cdp_uses_supervisor_page(monkeypatch):
+    """browser_navigate on a CDP session must not fall through to unbound CLI."""
+    import json
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bsup
+
+    session = {
+        "session_name": "cdp_test",
+        "cdp_url": "ws://127.0.0.1:9222/devtools/browser/x",
+        "page_target_id": "TASK-TAB",
+        "_first_nav": True,
+    }
+
+    class _Sup:
+        def page_target_id(self):
+            return "TASK-TAB"
+
+        def navigate_page(self, url, timeout=30.0):
+            return {
+                "ok": True,
+                "target_id": "TASK-TAB",
+                "frame_id": "f1",
+                "loader_id": "l1",
+            }
+
+    class _Reg:
+        def get(self, task_id):
+            return _Sup()
+
+    monkeypatch.setattr(bt, "_get_session_info", lambda key: session)
+    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda task_id: None)
+    monkeypatch.setattr(bt, "_bind_session_page_target", lambda tid, info: None)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(bt, "_is_local_backend", lambda: False)
+    monkeypatch.setattr(bt, "_allow_private_urls", lambda: True)
+    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
+    monkeypatch.setattr(bt, "check_website_access", lambda url: None)
+    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: None)
+    monkeypatch.setattr(bt, "_maybe_start_recording", lambda key: None)
+    monkeypatch.setattr(bt, "_sensitive_query_param_name", lambda url: None)
+    monkeypatch.setattr(bt, "_normalize_url_for_request", lambda url: url)
+    monkeypatch.setattr(bsup, "SUPERVISOR_REGISTRY", _Reg())
+
+    def _fail_cli(*a, **k):
+        raise AssertionError("must not call agent-browser CLI for CDP navigate")
+
+    monkeypatch.setattr(bt, "_run_browser_command", _fail_cli)
+
+    out = json.loads(bt.browser_navigate("https://www.baidu.com", task_id="sess-A"))
+    assert out["success"] is True
+    assert out["page_target_id"] == "TASK-TAB"
+    assert out["via"] == "cdp_supervisor"
+
+
+def test_two_task_navigate_paths_keep_distinct_targets(monkeypatch):
+    """Two task_ids must route navigate to different page targets."""
+    import json
+    import tools.browser_tool as bt
+    import tools.browser_supervisor as bsup
+
+    sessions = {
+        "sess-A": {
+            "session_name": "cdp_a",
+            "cdp_url": "ws://127.0.0.1:9222/devtools/browser/x",
+            "_first_nav": True,
+        },
+        "sess-B": {
+            "session_name": "cdp_b",
+            "cdp_url": "ws://127.0.0.1:9222/devtools/browser/x",
+            "_first_nav": True,
+        },
+    }
+    seen: Dict[str, str] = {}
+
+    class _Sup:
+        def __init__(self, tid: str, tab: str):
+            self.tid = tid
+            self.tab = tab
+
+        def page_target_id(self):
+            return self.tab
+
+        def navigate_page(self, url, timeout=30.0):
+            seen[self.tid] = self.tab
+            return {"ok": True, "target_id": self.tab, "frame_id": "f"}
+
+    class _Reg:
+        def get(self, task_id):
+            tab = "TAB-A" if task_id == "sess-A" else "TAB-B"
+            return _Sup(task_id, tab)
+
+    monkeypatch.setattr(bt, "_get_session_info", lambda key: sessions[key])
+    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda task_id: None)
+    monkeypatch.setattr(bt, "_bind_session_page_target", lambda tid, info: None)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(bt, "_is_local_backend", lambda: False)
+    monkeypatch.setattr(bt, "_allow_private_urls", lambda: True)
+    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
+    monkeypatch.setattr(bt, "check_website_access", lambda url: None)
+    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: None)
+    monkeypatch.setattr(bt, "_maybe_start_recording", lambda key: None)
+    monkeypatch.setattr(bt, "_sensitive_query_param_name", lambda url: None)
+    monkeypatch.setattr(bt, "_normalize_url_for_request", lambda url: url)
+    monkeypatch.setattr(bsup, "SUPERVISOR_REGISTRY", _Reg())
+    monkeypatch.setattr(
+        bt,
+        "_run_browser_command",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no CLI")),
+    )
+
+    a = json.loads(bt.browser_navigate("https://www.baidu.com", task_id="sess-A"))
+    b = json.loads(bt.browser_navigate("https://www.sina.com.cn", task_id="sess-B"))
+    assert a["page_target_id"] == "TAB-A"
+    assert b["page_target_id"] == "TAB-B"
+    assert seen == {"sess-A": "TAB-A", "sess-B": "TAB-B"}

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -1,0 +1,184 @@
+"""Unit tests: CDP supervisor attaches a dedicated page per task_id (#69727)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+
+def _make_supervisor() -> Any:
+    from tools.browser_supervisor import CDPSupervisor
+
+    sup = object.__new__(CDPSupervisor)
+    sup.task_id = "session-A"
+    sup.cdp_url = "ws://example.test/cdp"
+    sup._page_session_id = None
+    sup._page_target_id = None
+    sup._owns_page_target = False
+    sup._child_sessions = {}
+    return sup
+
+
+@pytest.mark.asyncio
+async def test_attach_creates_dedicated_page_even_when_pages_exist():
+    """Existing page targets must not be adopted by a second Hermes session."""
+    sup = _make_supervisor()
+    calls: List[Dict[str, Any]] = []
+
+    async def fake_cdp(
+        method: str,
+        params: Optional[dict] = None,
+        session_id: Optional[str] = None,
+        timeout: float = 10.0,
+    ) -> dict:
+        calls.append({"method": method, "params": params, "session_id": session_id})
+        if method == "Target.createTarget":
+            return {"result": {"targetId": "NEW-TAB-A"}}
+        if method == "Target.attachToTarget":
+            return {"result": {"sessionId": "SID-A"}}
+        if method in {
+            "Page.enable",
+            "Runtime.enable",
+            "Target.setAutoAttach",
+            "Page.addScriptToEvaluateOnNewDocument",
+            "Fetch.enable",
+        }:
+            return {"result": {}}
+        if method == "Target.getTargets":
+            # Would previously steal EXISTING-SHARED — must not happen.
+            return {
+                "result": {
+                    "targetInfos": [
+                        {"targetId": "EXISTING-SHARED", "type": "page", "url": "https://baidu.com"},
+                        {"targetId": "OTHER", "type": "page", "url": "https://sina.com"},
+                    ]
+                }
+            }
+        return {"result": {}}
+
+    # Bypass dialog bridge install (Fetch/addScript) complexity for this unit.
+    async def _noop_bridge(_session_id: str) -> None:
+        return None
+
+    sup._cdp = fake_cdp  # type: ignore[method-assign]
+    sup._install_dialog_bridge = _noop_bridge  # type: ignore[method-assign]
+
+    await sup._attach_initial_page()
+
+    create_calls = [c for c in calls if c["method"] == "Target.createTarget"]
+    assert len(create_calls) == 1
+    assert create_calls[0]["params"] == {"url": "about:blank"}
+
+    attach_calls = [c for c in calls if c["method"] == "Target.attachToTarget"]
+    assert len(attach_calls) == 1
+    assert attach_calls[0]["params"] == {"targetId": "NEW-TAB-A", "flatten": True}
+
+    # Must not have preferred the existing shared page.
+    assert all(
+        c["params"].get("targetId") != "EXISTING-SHARED"
+        for c in attach_calls
+        if c.get("params")
+    )
+    assert sup._page_target_id == "NEW-TAB-A"
+    assert sup._owns_page_target is True
+    assert sup._page_session_id == "SID-A"
+
+
+@pytest.mark.asyncio
+async def test_two_supervisors_get_distinct_page_targets():
+    """Simulates two Hermes sessions against one shared CDP browser."""
+    created_ids = ["TAB-1", "TAB-2"]
+    create_index = {"i": 0}
+
+    async def make_attach(sup_name: str):
+        sup = _make_supervisor()
+        sup.task_id = sup_name
+        attached: List[str] = []
+
+        async def fake_cdp(
+            method: str,
+            params: Optional[dict] = None,
+            session_id: Optional[str] = None,
+            timeout: float = 10.0,
+        ) -> dict:
+            if method == "Target.createTarget":
+                tid = created_ids[create_index["i"]]
+                create_index["i"] += 1
+                return {"result": {"targetId": tid}}
+            if method == "Target.attachToTarget":
+                attached.append(params["targetId"])
+                return {"result": {"sessionId": f"SID-{params['targetId']}"}}
+            if method == "Target.getTargets":
+                return {
+                    "result": {
+                        "targetInfos": [
+                            {"targetId": "SHARED", "type": "page", "url": "about:blank"},
+                        ]
+                    }
+                }
+            return {"result": {}}
+
+        async def _noop_bridge(_session_id: str) -> None:
+            return None
+
+        sup._cdp = fake_cdp  # type: ignore[method-assign]
+        sup._install_dialog_bridge = _noop_bridge  # type: ignore[method-assign]
+        await sup._attach_initial_page()
+        return sup, attached
+
+    a, attached_a = await make_attach("session-A")
+    b, attached_b = await make_attach("session-B")
+
+    assert a._page_target_id == "TAB-1"
+    assert b._page_target_id == "TAB-2"
+    assert a._page_target_id != b._page_target_id
+    assert attached_a == ["TAB-1"]
+    assert attached_b == ["TAB-2"]
+    assert "SHARED" not in attached_a + attached_b
+
+
+@pytest.mark.asyncio
+async def test_reconnect_reuses_owned_page_target():
+    """After reconnect, re-attach the same dedicated tab when it still exists."""
+    sup = _make_supervisor()
+    sup._page_target_id = "OWNED-TAB"
+    sup._owns_page_target = True
+    methods: List[str] = []
+
+    async def fake_cdp(
+        method: str,
+        params: Optional[dict] = None,
+        session_id: Optional[str] = None,
+        timeout: float = 10.0,
+    ) -> dict:
+        methods.append(method)
+        if method == "Target.getTargets":
+            return {
+                "result": {
+                    "targetInfos": [
+                        {"targetId": "OWNED-TAB", "type": "page", "url": "about:blank"},
+                        {"targetId": "OTHER", "type": "page", "url": "https://example.com"},
+                    ]
+                }
+            }
+        if method == "Target.createTarget":
+            raise AssertionError("must not create a new tab when owned page still exists")
+        if method == "Target.attachToTarget":
+            assert params["targetId"] == "OWNED-TAB"
+            return {"result": {"sessionId": "SID-REUSE"}}
+        return {"result": {}}
+
+    async def _noop_bridge(_session_id: str) -> None:
+        return None
+
+    sup._cdp = fake_cdp  # type: ignore[method-assign]
+    sup._install_dialog_bridge = _noop_bridge  # type: ignore[method-assign]
+
+    await sup._attach_initial_page()
+
+    assert "Target.createTarget" not in methods
+    assert methods.count("Target.getTargets") == 1
+    assert sup._page_target_id == "OWNED-TAB"
+    assert sup._page_session_id == "SID-REUSE"

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -268,131 +268,47 @@ def test_navigate_page_uses_owned_session_and_activates_target(monkeypatch):
     )
 
 
-@pytest.mark.parametrize("owned_page", ["active", "listed", "missing"])
-def test_cdp_page_selection_uses_daemon_identity(monkeypatch, owned_page):
-    """Keep valid refs; otherwise select the actual daemon ID among identical URLs."""
-    import tools.browser_tool_session as session
-
-    prefix = ["agent-browser", "--cdp", "ws://browser.test/cdp"]
-    responses: list[dict[str, Any] | list[dict[str, Any]]] = [
-        {"success": True, "data": {"result": owned_page == "active"}}]
-    if owned_page != "active":
-        responses.append({"success": True, "data": {"tabs": [
-            {"tabId": "t4", "url": "https://same.test"},
-            {"tabId": "t9", "url": "https://same.test"},
-        ]}})
-        for matched in (False, owned_page == "listed"):
-            responses.append([
-                {"success": True, "result": {}},
-                {"success": True, "result": {"result": matched}},
-            ])
-    captured = []
-
-    def collect(task_id, info, argv, command, engine, timeout):
-        captured.append(argv)
-        return responses.pop(0)
-
-    monkeypatch.setattr(session, "_spawn_and_collect", collect)
-    if owned_page == "missing":
-        with pytest.raises(RuntimeError, match="supervisor-owned CDP page is unavailable"):
-            session._select_cdp_page("task", {}, prefix, "marker", "auto", 10)
-    else:
-        session._select_cdp_page("task", {}, prefix, "marker", "auto", 10)
-    assert not responses
-    assert captured[0] == prefix + ["--json", "eval", 'globalThis["marker"] === true']
-    if owned_page == "active":
-        assert len(captured) == 1  # Switching even to the same tab would invalidate refs.
-    else:
-        assert captured[1] == prefix + ["--json", "tab", "list"]
-        assert [argv[-2] for argv in captured[2:]] == ["tab t4", "tab t9"]
-        assert all(argv[3:6] == ["--json", "batch", "--bail"] for argv in captured[2:])
-
-
-@pytest.mark.parametrize(
-    "command, arguments, payload, encoded",
-    [
-        ("click", ["@e1"], {"clicked": "@e1"}, "click @e1"),
-        ("snapshot", ["-c"], {"snapshot": "- button Click", "refs": {"e1": {"role": "button"}}}, "snapshot -c"),
-    ],
-)
-@pytest.mark.parametrize("binding_succeeds", [True, False])
-def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(
-    monkeypatch, tmp_path, command, arguments, payload, encoded, binding_succeeds,
+@pytest.mark.parametrize("command,args,payload", [
+    ("click", ["@e1"], {"clicked": "@e1"}),
+    ("snapshot", ["-c"], {"snapshot": "- button Click", "refs": {"e1": {"role": "button"}}}),
+])
+@pytest.mark.parametrize("previous,close_succeeds", [(None, True), ("owned", True), ("old", True), ("old", False)])
+def test_cdp_command_uses_owned_endpoint_and_replaces_stale_daemon(
+    monkeypatch, command, args, payload, previous, close_succeeds,
 ):
-    """The owned-page guard must stop a failed binding before the actual action."""
-    import json
-    import shlex
-    from unittest.mock import MagicMock, mock_open
+    """Keep valid refs on the same endpoint; never reuse a daemon bound to a retired target."""
+    from tools import browser_supervisor, browser_tool_session
 
-    import tools.browser_supervisor as supervisor_module
-
-    import tools.browser_tool as browser_tool
-    import tools.browser_tool_session as _session
-    import tools.browser_tool_cdp as _cdp
-    import tools.browser_tool_cloud as _cloud
-
-    session = {
-        "session_name": "cdp-task",
-        "cdp_url": "wss://browser.example/cdp",
-    }
-    captured: List[List[str]] = []
-    process = MagicMock()
-    process.wait.return_value = 0
-    process.returncode = 0
-    batch_result = [{"command": ["eval", "binding-guard"], "success": binding_succeeds,
-                     "result": {"result": True}, "error": None if binding_succeeds else "page changed"}]
-    if binding_succeeds:
-        batch_result.append({"command": [command, *arguments], "success": True, "result": payload})
-    stdout = json.dumps(batch_result)
     supervisor = MagicMock()
-    supervisor.page_target_id.return_value = "owned-target"
-    supervisor.evaluate_runtime.return_value = {"ok": True, "result": True}
-    monkeypatch.setattr(supervisor_module.SUPERVISOR_REGISTRY, "get", lambda _task_id: supervisor)
-    monkeypatch.setattr(_session.uuid, "uuid4", lambda: MagicMock(hex="bindingtest"))
+    supervisor.page_target_id.return_value = "target"
+    supervisor.page_command_endpoint.return_value = "ws://127.0.0.1/owned"
+    monkeypatch.setattr(browser_supervisor.SUPERVISOR_REGISTRY, "get", lambda task_id: supervisor)
+    session = {"session_name": "task", "cdp_url": "wss://browser.test/remote"}
+    if previous is not None:
+        session["_page_command_endpoint"] = f"ws://127.0.0.1/{previous}"
+    calls = []
 
-    def capture_popen(cmd_parts, browser_env, task_socket_dir, command):
-        captured.append(cmd_parts)
-        return process
+    def collect(task_id, info, argv, operation, engine, timeout):
+        calls.append((argv, operation))
+        if operation == "close":
+            return {"success": close_succeeds, "error": "close failed"}
+        return {"success": True, "data": payload}
 
-    monkeypatch.setattr(_session, "_get_session_info", lambda _task_id: session)
-    monkeypatch.setattr(_session, "_agent_browser_argv", lambda cmd: [cmd])
-    monkeypatch.setattr(_session, "_browser_command_preflight", lambda: {"browser_cmd": "/usr/bin/agent-browser"})
-    monkeypatch.setattr(_cdp, "_ensure_cdp_supervisor", lambda _task_id: None)
-    monkeypatch.setattr(_session, "_bind_session_page_target", lambda _task_id, _info: None)
-    monkeypatch.setattr(_session, "_select_cdp_page", lambda *_args: None)
-    monkeypatch.setattr(_session, "_agent_browser_command_env", lambda _dir: {})
-    monkeypatch.setattr(_session, "_prepare_session_socket_dir", lambda _name: str(tmp_path))
-    monkeypatch.setattr(_session, "_popen_agent_browser", capture_popen)
-    monkeypatch.setattr(_session, "_read_command_output_files", lambda *_args: (stdout, ""))
-    monkeypatch.setattr(_session, "_unlink_command_output_files", lambda *_args: None)
-    monkeypatch.setattr(_session, "_apply_chromium_sandbox_args", lambda _env: None)
-    monkeypatch.setattr(_session, "_handle_browser_command_timeout", lambda *_args: None)
-    import tools.browser_tool_cloud as _cloud
-    monkeypatch.setattr(_cloud, "_get_browser_engine", lambda: "auto")
-    monkeypatch.setattr(browser_tool, "_safe_command_timeout", lambda: 10)
-    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
-    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
-    monkeypatch.setattr("builtins.open", mock_open(read_data=stdout))
-
-    result = _session._run_browser_command("task", command, arguments)
-
-    if binding_succeeds:
-        assert result == {"success": True, "data": payload}
-        assert supervisor.evaluate_runtime.call_count == 1
+    monkeypatch.setattr(browser_tool_session, "_spawn_and_collect", collect)
+    result = browser_tool_session._run_cdp_page_command(
+        "task", session, ["agent-browser", "--cdp", session["cdp_url"]], command, args, "auto", 10,
+    )
+    if previous == "old" and not close_succeeds:
+        assert result == {"success": False, "error": "close failed"}
+        assert session["_page_command_endpoint"] == "ws://127.0.0.1/old"
+        assert [operation for _, operation in calls] == ["close"]
     else:
-        assert result == {"success": False, "error": "page changed"}
-        assert supervisor.evaluate_runtime.call_count == 2
-        assert supervisor.evaluate_runtime.call_args.args[0] == 'delete globalThis["__hermes_page_bindingtest"]'
-    assert len(captured) == 1
-    assert captured[0][:-2] == [
-        "/usr/bin/agent-browser", "--cdp", "wss://browser.example/cdp", "--json", "batch", "--bail",
-    ]
-    guard = shlex.split(captured[0][-2])
-    assert guard[0] == "eval"
-    assert 'globalThis["__hermes_page_bindingtest"]' in guard[1]
-    assert "delete " in guard[1]
-    assert "throw new Error" in guard[1]
-    assert captured[0][-1] == encoded
+        assert result == {"success": True, "data": payload}
+        assert session["_page_command_endpoint"] == "ws://127.0.0.1/owned"
+        assert [operation for _, operation in calls] == (["close", command] if previous == "old" else [command])
+        assert calls[-1][0][-len(args)-1:] == [command, *args]
+    assert all(argv[:4] == ["agent-browser", "--cdp", "ws://127.0.0.1/owned", "--json"] for argv, _ in calls)
+    supervisor.page_command_endpoint.assert_called_once_with(timeout=10)
 
 
 def test_browser_navigate_cdp_uses_supervisor_page(monkeypatch):

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -270,6 +270,7 @@ def test_navigate_page_uses_owned_session_and_activates_target(monkeypatch):
 
 @pytest.mark.parametrize("command,args,payload", [
     ("click", ["@e1"], {"clicked": "@e1"}),
+    ("open", ["https://example.test"], {"url": "https://example.test", "title": "Owned"}),
     ("snapshot", ["-c"], {"snapshot": "- button Click", "refs": {"e1": {"role": "button"}}}),
 ])
 @pytest.mark.parametrize("previous,close_succeeds", [(None, True), ("owned", True), ("old", True), ("old", False)])
@@ -311,124 +312,50 @@ def test_cdp_command_uses_owned_endpoint_and_replaces_stale_daemon(
     supervisor.page_command_endpoint.assert_called_once_with(timeout=10)
 
 
-def test_browser_navigate_cdp_uses_supervisor_page(monkeypatch):
-    """browser_navigate on a CDP session must not fall through to unbound CLI."""
+@pytest.mark.parametrize("final_url,blocked", [
+    ("https://example.test/owned", False),
+    ("http://169.254.169.254/latest/meta-data/", True),
+])
+def test_browser_navigate_cdp_preserves_response_and_redirect_guard(monkeypatch, final_url, blocked):
+    """CDP navigation must retain the common response and redirect safety contract."""
     import json
-    import tools.browser_tool as bt
-    import tools.browser_tool_session as _session
-    import tools.browser_tool_cdp as _cdp
-    import tools.browser_tool_cloud as _cloud
-    import tools.browser_supervisor as bsup
+    from tools import browser_supervisor, browser_tool, browser_tool_cdp, browser_tool_cloud, browser_tool_session
 
-    session = {
-        "session_name": "cdp_test",
-        "cdp_url": "ws://127.0.0.1:9222/devtools/browser/x",
-        "page_target_id": "TASK-TAB",
-        "_first_nav": True,
-    }
+    session = {"session_name": "cdp_test", "cdp_url": "ws://127.0.0.1:9222/browser",
+               "page_target_id": "OWNED", "_first_nav": False}
+    supervisor = MagicMock()
+    supervisor.page_target_id.return_value = "OWNED"
+    supervisor.navigate_page.return_value = {"ok": True, "target_id": "OWNED"}
+    monkeypatch.setattr(browser_supervisor.SUPERVISOR_REGISTRY, "get", lambda key: supervisor)
+    monkeypatch.setattr(browser_tool_session, "_get_session_info", lambda key: session)
+    monkeypatch.setattr(browser_tool_cdp, "_ensure_cdp_supervisor", lambda key: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool_cloud, "_get_cloud_provider", lambda: None)
+    monkeypatch.setattr(browser_tool_cloud, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda url: None)
+    monkeypatch.setattr(browser_tool, "_last_active_session_key", {})
+    calls = []
 
-    class _Sup:
-        def page_target_id(self):
-            return "TASK-TAB"
+    def command(task_id, operation, args, **kwargs):
+        calls.append((task_id, operation, args))
+        if operation == "open":
+            return {"success": True, "data": {"url": final_url, "title": "Owned"}}
+        assert operation == "snapshot"
+        return {"success": True, "data": {"snapshot": "- button Click", "refs": {"e1": {"role": "button"}}}}
 
-        def navigate_page(self, url, timeout=30.0):
-            return {
-                "ok": True,
-                "target_id": "TASK-TAB",
-                "frame_id": "f1",
-                "loader_id": "l1",
-            }
+    monkeypatch.setattr(browser_tool_session, "_run_browser_command", command)
+    result = json.loads(browser_tool.browser_navigate("https://example.test", task_id="task"))
 
-    class _Reg:
-        def get(self, task_id):
-            return _Sup()
-
-    monkeypatch.setattr(_session, "_get_session_info", lambda key: session)
-    monkeypatch.setattr(_cdp, "_ensure_cdp_supervisor", lambda task_id: None)
-    monkeypatch.setattr(_session, "_bind_session_page_target", lambda tid, info: None)
-    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
-    monkeypatch.setattr(_cloud, "_is_local_backend", lambda: False)
-    monkeypatch.setattr(_cloud, "_allow_private_urls", lambda: True)
-    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
-    monkeypatch.setattr(bt, "check_website_access", lambda url: None)
-    monkeypatch.setattr(_cloud, "_get_cloud_provider", lambda: None)
-    monkeypatch.setattr(bt, "_maybe_start_recording", lambda key: None)
-    monkeypatch.setattr(bt, "_sensitive_query_param_name", lambda url: None)
-    monkeypatch.setattr(bt, "_normalize_url_for_request", lambda url: url)
-    monkeypatch.setattr(bsup, "SUPERVISOR_REGISTRY", _Reg())
-
-    def _fail_cli(*a, **k):
-        raise AssertionError("must not call agent-browser CLI for CDP navigate")
-
-    monkeypatch.setattr(_session, "_run_browser_command", _fail_cli)
-
-    out = json.loads(bt.browser_navigate("https://www.baidu.com", task_id="sess-A"))
-    assert out["success"] is True
-    assert out["page_target_id"] == "TASK-TAB"
-    assert out["via"] == "cdp_supervisor"
-
-
-def test_two_task_navigate_paths_keep_distinct_targets(monkeypatch):
-    """Two task_ids must route navigate to different page targets."""
-    import json
-    import tools.browser_tool as bt
-    import tools.browser_tool_session as _session
-    import tools.browser_tool_cdp as _cdp
-    import tools.browser_tool_cloud as _cloud
-    import tools.browser_supervisor as bsup
-
-    sessions = {
-        "sess-A": {
-            "session_name": "cdp_a",
-            "cdp_url": "ws://127.0.0.1:9222/devtools/browser/x",
-            "_first_nav": True,
-        },
-        "sess-B": {
-            "session_name": "cdp_b",
-            "cdp_url": "ws://127.0.0.1:9222/devtools/browser/x",
-            "_first_nav": True,
-        },
-    }
-    seen: Dict[str, str] = {}
-
-    class _Sup:
-        def __init__(self, tid: str, tab: str):
-            self.tid = tid
-            self.tab = tab
-
-        def page_target_id(self):
-            return self.tab
-
-        def navigate_page(self, url, timeout=30.0):
-            seen[self.tid] = self.tab
-            return {"ok": True, "target_id": self.tab, "frame_id": "f"}
-
-    class _Reg:
-        def get(self, task_id):
-            tab = "TAB-A" if task_id == "sess-A" else "TAB-B"
-            return _Sup(task_id, tab)
-
-    monkeypatch.setattr(_session, "_get_session_info", lambda key: sessions[key])
-    monkeypatch.setattr(_cdp, "_ensure_cdp_supervisor", lambda task_id: None)
-    monkeypatch.setattr(_session, "_bind_session_page_target", lambda tid, info: None)
-    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
-    monkeypatch.setattr(_cloud, "_is_local_backend", lambda: False)
-    monkeypatch.setattr(_cloud, "_allow_private_urls", lambda: True)
-    monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
-    monkeypatch.setattr(bt, "check_website_access", lambda url: None)
-    monkeypatch.setattr(_cloud, "_get_cloud_provider", lambda: None)
-    monkeypatch.setattr(bt, "_maybe_start_recording", lambda key: None)
-    monkeypatch.setattr(bt, "_sensitive_query_param_name", lambda url: None)
-    monkeypatch.setattr(bt, "_normalize_url_for_request", lambda url: url)
-    monkeypatch.setattr(bsup, "SUPERVISOR_REGISTRY", _Reg())
-    monkeypatch.setattr(
-        _session,
-        "_run_browser_command",
-        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no CLI")),
-    )
-
-    a = json.loads(bt.browser_navigate("https://www.baidu.com", task_id="sess-A"))
-    b = json.loads(bt.browser_navigate("https://www.sina.com.cn", task_id="sess-B"))
-    assert a["page_target_id"] == "TAB-A"
-    assert b["page_target_id"] == "TAB-B"
-    assert seen == {"sess-A": "TAB-A", "sess-B": "TAB-B"}
+    if blocked:
+        assert result["success"] is False, result
+        assert "cloud metadata endpoint" in result["error"]
+        assert calls == [("task", "open", ["https://example.test"]), ("task", "open", ["about:blank"])]
+        assert browser_tool._last_active_session_key == {}
+    else:
+        assert result["success"] is True, result
+        assert result["url"] == final_url
+        assert result["title"] == "Owned"
+        assert result["snapshot"] == "- button Click"
+        assert result["element_count"] == 1
+        assert browser_tool._last_active_session_key == {"task": "task"}
+        assert calls == [("task", "open", ["https://example.test"]), ("task", "snapshot", ["-c"])]

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -274,7 +274,8 @@ def test_cdp_page_selection_uses_daemon_identity(monkeypatch, owned_page):
     import tools.browser_tool_session as session
 
     prefix = ["agent-browser", "--cdp", "ws://browser.test/cdp"]
-    responses = [{"success": True, "data": {"result": owned_page == "active"}}]
+    responses: list[dict[str, Any] | list[dict[str, Any]]] = [
+        {"success": True, "data": {"result": owned_page == "active"}}]
     if owned_page != "active":
         responses.append({"success": True, "data": {"tabs": [
             {"tabId": "t4", "url": "https://same.test"},
@@ -318,7 +319,7 @@ def test_cdp_page_selection_uses_daemon_identity(monkeypatch, owned_page):
 def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(
     monkeypatch, tmp_path, command, arguments, payload, encoded, binding_succeeds,
 ):
-    """Click/type-style operations must select the owned tab in the same daemon call."""
+    """The owned-page guard must stop a failed binding before the actual action."""
     import json
     import shlex
     from unittest.mock import MagicMock, mock_open

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -92,6 +92,25 @@ async def test_attach_creates_dedicated_page_even_when_pages_exist():
 
 
 @pytest.mark.asyncio
+async def test_missing_created_target_id_never_adopts_a_shared_page():
+    """An invalid create response must fail instead of restoring the original shared-tab bug."""
+    sup = _make_supervisor()
+    methods = []
+
+    async def cdp(method, params=None, session_id=None, timeout=10.0):
+        methods.append(method)
+        if method == "Target.createTarget":
+            return {"result": {}}
+        return {"result": {"targetInfos": [{"targetId": "SHARED", "type": "page"}]}}
+
+    sup._cdp = cdp
+    with pytest.raises(RuntimeError, match="Target.createTarget returned no targetId"):
+        await sup._resolve_dedicated_page_target()
+    assert methods == ["Target.createTarget"]
+    assert sup._page_target_id is None
+
+
+@pytest.mark.asyncio
 async def test_two_supervisors_get_distinct_page_targets():
     """Simulates two Hermes sessions against one shared CDP browser."""
     created_ids = ["TAB-1", "TAB-2"]
@@ -249,58 +268,43 @@ def test_navigate_page_uses_owned_session_and_activates_target(monkeypatch):
     )
 
 
-def test_page_target_tab_ref_matches_agent_browser_target_order(monkeypatch):
-    """The tab ref must identify the owned target, not merely activate it."""
-    sup = _make_supervisor()
-    sup._active = True
-    sup._page_target_id = "TAB-OWNED"
-    methods: List[str] = []
+@pytest.mark.parametrize("owned_page", ["active", "listed", "missing"])
+def test_cdp_page_selection_uses_daemon_identity(monkeypatch, owned_page):
+    """Keep valid refs; otherwise select the actual daemon ID among identical URLs."""
+    import tools.browser_tool_session as session
 
-    async def fake_cdp(
-        method: str,
-        params: Optional[dict] = None,
-        session_id: Optional[str] = None,
-        timeout: float = 10.0,
-    ) -> dict:
-        methods.append(method)
-        if method == "Target.getTargets":
-            return {
-                "result": {
-                    "targetInfos": [
-                        {"targetId": "DEVTOOLS", "type": "page", "url": "devtools://devtools"},
-                        {"targetId": "TAB-OTHER", "type": "page", "url": "https://other.example"},
-                        {"targetId": "TAB-OWNED", "type": "page", "url": "about:blank"},
-                    ]
-                }
-            }
-        return {"result": {}}
+    prefix = ["agent-browser", "--cdp", "ws://browser.test/cdp"]
+    responses = [{"success": True, "data": {"result": owned_page == "active"}}]
+    if owned_page != "active":
+        responses.append({"success": True, "data": {"tabs": [
+            {"tabId": "t4", "url": "https://same.test"},
+            {"tabId": "t9", "url": "https://same.test"},
+        ]}})
+        for matched in (False, owned_page == "listed"):
+            responses.append([
+                {"success": True, "result": {}},
+                {"success": True, "result": {"result": matched}},
+            ])
+    captured = []
 
-    class _Loop:
-        def is_running(self) -> bool:
-            return True
+    def collect(task_id, info, argv, command, engine, timeout):
+        captured.append(argv)
+        return responses.pop(0)
 
-    class _Fut:
-        def __init__(self, value):
-            self._value = value
-
-        def result(self, timeout=None):
-            return self._value
-
-    def schedule(coro, loop):
-        loop_local = asyncio.new_event_loop()
-        try:
-            return _Fut(loop_local.run_until_complete(coro))
-        finally:
-            loop_local.close()
-
-    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", schedule)
-    sup._loop = _Loop()
-    sup._cdp = fake_cdp
-
-    result = sup.page_target_tab_ref()
-
-    assert result == {"ok": True, "target_id": "TAB-OWNED", "tab_ref": "t2"}
-    assert methods == ["Target.getTargets"]
+    monkeypatch.setattr(session, "_spawn_and_collect", collect)
+    if owned_page == "missing":
+        with pytest.raises(RuntimeError, match="supervisor-owned CDP page is unavailable"):
+            session._select_cdp_page("task", {}, prefix, "marker", "auto", 10)
+    else:
+        session._select_cdp_page("task", {}, prefix, "marker", "auto", 10)
+    assert not responses
+    assert captured[0] == prefix + ["--json", "eval", 'globalThis["marker"] === true']
+    if owned_page == "active":
+        assert len(captured) == 1  # Switching even to the same tab would invalidate refs.
+    else:
+        assert captured[1] == prefix + ["--json", "tab", "list"]
+        assert [argv[-2] for argv in captured[2:]] == ["tab t4", "tab t9"]
+        assert all(argv[3:6] == ["--json", "batch", "--bail"] for argv in captured[2:])
 
 
 @pytest.mark.parametrize(
@@ -310,12 +314,16 @@ def test_page_target_tab_ref_matches_agent_browser_target_order(monkeypatch):
         ("snapshot", ["-c"], {"snapshot": "- button Click", "refs": {"e1": {"role": "button"}}}, "snapshot -c"),
     ],
 )
+@pytest.mark.parametrize("binding_succeeds", [True, False])
 def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(
-    monkeypatch, tmp_path, command, arguments, payload, encoded,
+    monkeypatch, tmp_path, command, arguments, payload, encoded, binding_succeeds,
 ):
     """Click/type-style operations must select the owned tab in the same daemon call."""
     import json
+    import shlex
     from unittest.mock import MagicMock, mock_open
+
+    import tools.browser_supervisor as supervisor_module
 
     import tools.browser_tool as browser_tool
     import tools.browser_tool_session as _session
@@ -330,10 +338,16 @@ def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(
     process = MagicMock()
     process.wait.return_value = 0
     process.returncode = 0
-    stdout = json.dumps([
-        {"command": ["tab", "t2"], "success": True, "result": []},
-        {"command": [command, *arguments], "success": True, "result": payload},
-    ])
+    batch_result = [{"command": ["eval", "binding-guard"], "success": binding_succeeds,
+                     "result": {"result": True}, "error": None if binding_succeeds else "page changed"}]
+    if binding_succeeds:
+        batch_result.append({"command": [command, *arguments], "success": True, "result": payload})
+    stdout = json.dumps(batch_result)
+    supervisor = MagicMock()
+    supervisor.page_target_id.return_value = "owned-target"
+    supervisor.evaluate_runtime.return_value = {"ok": True, "result": True}
+    monkeypatch.setattr(supervisor_module.SUPERVISOR_REGISTRY, "get", lambda _task_id: supervisor)
+    monkeypatch.setattr(_session.uuid, "uuid4", lambda: MagicMock(hex="bindingtest"))
 
     def capture_popen(cmd_parts, browser_env, task_socket_dir, command):
         captured.append(cmd_parts)
@@ -344,7 +358,7 @@ def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(
     monkeypatch.setattr(_session, "_browser_command_preflight", lambda: {"browser_cmd": "/usr/bin/agent-browser"})
     monkeypatch.setattr(_cdp, "_ensure_cdp_supervisor", lambda _task_id: None)
     monkeypatch.setattr(_session, "_bind_session_page_target", lambda _task_id, _info: None)
-    monkeypatch.setattr(_session, "_session_page_tab_ref", lambda _task_id, _info: "t2")
+    monkeypatch.setattr(_session, "_select_cdp_page", lambda *_args: None)
     monkeypatch.setattr(_session, "_agent_browser_command_env", lambda _dir: {})
     monkeypatch.setattr(_session, "_prepare_session_socket_dir", lambda _name: str(tmp_path))
     monkeypatch.setattr(_session, "_popen_agent_browser", capture_popen)
@@ -361,16 +375,23 @@ def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(
 
     result = _session._run_browser_command("task", command, arguments)
 
-    assert result == {"success": True, "data": payload}
-    assert captured == [[
-        "/usr/bin/agent-browser",
-        "--cdp",
-        "wss://browser.example/cdp",
-        "--json",
-        "batch",
-        "tab t2",
-        encoded,
-    ]]
+    if binding_succeeds:
+        assert result == {"success": True, "data": payload}
+        assert supervisor.evaluate_runtime.call_count == 1
+    else:
+        assert result == {"success": False, "error": "page changed"}
+        assert supervisor.evaluate_runtime.call_count == 2
+        assert supervisor.evaluate_runtime.call_args.args[0] == 'delete globalThis["__hermes_page_bindingtest"]'
+    assert len(captured) == 1
+    assert captured[0][:-2] == [
+        "/usr/bin/agent-browser", "--cdp", "wss://browser.example/cdp", "--json", "batch", "--bail",
+    ]
+    guard = shlex.split(captured[0][-2])
+    assert guard[0] == "eval"
+    assert 'globalThis["__hermes_page_bindingtest"]' in guard[1]
+    assert "delete " in guard[1]
+    assert "throw new Error" in guard[1]
+    assert captured[0][-1] == encoded
 
 
 def test_browser_navigate_cdp_uses_supervisor_page(monkeypatch):

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -303,7 +303,16 @@ def test_page_target_tab_ref_matches_agent_browser_target_order(monkeypatch):
     assert methods == ["Target.getTargets"]
 
 
-def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "command, arguments, payload, encoded",
+    [
+        ("click", ["@e1"], {"clicked": "@e1"}, "click @e1"),
+        ("snapshot", ["-c"], {"snapshot": "- button Click", "refs": {"e1": {"role": "button"}}}, "snapshot -c"),
+    ],
+)
+def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(
+    monkeypatch, tmp_path, command, arguments, payload, encoded,
+):
     """Click/type-style operations must select the owned tab in the same daemon call."""
     import json
     from unittest.mock import MagicMock, mock_open
@@ -323,7 +332,7 @@ def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(monkeypat
     process.returncode = 0
     stdout = json.dumps([
         {"command": ["tab", "t2"], "success": True, "result": []},
-        {"command": ["click", "@e1"], "success": True, "result": {"clicked": "@e1"}},
+        {"command": [command, *arguments], "success": True, "result": payload},
     ])
 
     def capture_popen(cmd_parts, browser_env, task_socket_dir, command):
@@ -350,9 +359,9 @@ def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(monkeypat
     monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
     monkeypatch.setattr("builtins.open", mock_open(read_data=stdout))
 
-    result = _session._run_browser_command("task", "click", ["@e1"])
+    result = _session._run_browser_command("task", command, arguments)
 
-    assert result == {"success": True, "data": {"clicked": "@e1"}}
+    assert result == {"success": True, "data": payload}
     assert captured == [[
         "/usr/bin/agent-browser",
         "--cdp",
@@ -360,7 +369,7 @@ def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(monkeypat
         "--json",
         "batch",
         "tab t2",
-        "click @e1",
+        encoded,
     ]]
 
 

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -21,7 +21,6 @@ def _make_supervisor() -> Any:
     sup._page_session_id = None
     sup._page_target_id = None
     sup._owns_page_target = False
-    sup._child_sessions = {}
     sup._loop = None
     return sup
 

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -307,6 +307,9 @@ def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(monkeypat
     from unittest.mock import MagicMock, mock_open
 
     import tools.browser_tool as browser_tool
+    import tools.browser_tool_session as _session
+    import tools.browser_tool_cdp as _cdp
+    import tools.browser_tool_cloud as _cloud
 
     session = {
         "session_name": "cdp-task",
@@ -321,32 +324,31 @@ def test_cdp_follow_up_command_binds_target_inside_agent_browser_batch(monkeypat
         {"command": ["click", "@e1"], "success": True, "result": {"clicked": "@e1"}},
     ])
 
-    def capture_popen(command, **kwargs):
-        captured.append(command)
+    def capture_popen(cmd_parts, browser_env, task_socket_dir, command):
+        captured.append(cmd_parts)
         return process
 
-    monkeypatch.setattr(browser_tool, "_get_session_info", lambda _task_id: session)
-    monkeypatch.setattr(browser_tool, "_find_agent_browser", lambda: "/usr/bin/agent-browser")
-    monkeypatch.setattr(browser_tool, "_ensure_cdp_supervisor", lambda _task_id: None)
-    monkeypatch.setattr(browser_tool, "_bind_session_page_target", lambda _task_id, _session: None)
-    monkeypatch.setattr(browser_tool, "_session_page_tab_ref", lambda _task_id, _session: "t2")
-    monkeypatch.setattr(browser_tool, "_get_browser_engine", lambda: "auto")
-    monkeypatch.setattr(browser_tool, "_socket_safe_tmpdir", lambda: str(tmp_path))
-    monkeypatch.setattr(browser_tool, "_build_browser_env", lambda: {})
-    monkeypatch.setattr(browser_tool, "_write_owner_pid", lambda *_args: None)
-    monkeypatch.setattr(browser_tool, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(_session, "_get_session_info", lambda _task_id: session)
+    monkeypatch.setattr(_session, "_agent_browser_argv", lambda cmd: [cmd])
+    monkeypatch.setattr(_session, "_browser_command_preflight", lambda: {"browser_cmd": "/usr/bin/agent-browser"})
+    monkeypatch.setattr(_cdp, "_ensure_cdp_supervisor", lambda _task_id: None)
+    monkeypatch.setattr(_session, "_bind_session_page_target", lambda _task_id, _info: None)
+    monkeypatch.setattr(_session, "_session_page_tab_ref", lambda _task_id, _info: "t2")
+    monkeypatch.setattr(_session, "_agent_browser_command_env", lambda _dir: {})
+    monkeypatch.setattr(_session, "_prepare_session_socket_dir", lambda _name: str(tmp_path))
+    monkeypatch.setattr(_session, "_popen_agent_browser", capture_popen)
+    monkeypatch.setattr(_session, "_read_command_output_files", lambda *_args: (stdout, ""))
+    monkeypatch.setattr(_session, "_unlink_command_output_files", lambda *_args: None)
+    monkeypatch.setattr(_session, "_apply_chromium_sandbox_args", lambda _env: None)
+    monkeypatch.setattr(_session, "_handle_browser_command_timeout", lambda *_args: None)
+    import tools.browser_tool_cloud as _cloud
+    monkeypatch.setattr(_cloud, "_get_browser_engine", lambda: "auto")
     monkeypatch.setattr(browser_tool, "_safe_command_timeout", lambda: 10)
-    monkeypatch.setattr(browser_tool.subprocess, "Popen", capture_popen)
-    monkeypatch.setattr(browser_tool.os, "open", lambda *_args, **_kwargs: 1)
-    monkeypatch.setattr(browser_tool.os, "close", lambda *_args: None)
-    monkeypatch.setattr(browser_tool.os, "unlink", lambda *_args: None)
-    monkeypatch.setattr(browser_tool.os, "makedirs", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(browser_tool, "_read_command_output_files", lambda *_args: (stdout, ""))
-    monkeypatch.setattr(browser_tool, "_unlink_command_output_files", lambda *_args: None)
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
     monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
     monkeypatch.setattr("builtins.open", mock_open(read_data=stdout))
 
-    result = browser_tool._run_browser_command("task", "click", ["@e1"])
+    result = _session._run_browser_command("task", "click", ["@e1"])
 
     assert result == {"success": True, "data": {"clicked": "@e1"}}
     assert captured == [[
@@ -364,6 +366,9 @@ def test_browser_navigate_cdp_uses_supervisor_page(monkeypatch):
     """browser_navigate on a CDP session must not fall through to unbound CLI."""
     import json
     import tools.browser_tool as bt
+    import tools.browser_tool_session as _session
+    import tools.browser_tool_cdp as _cdp
+    import tools.browser_tool_cloud as _cloud
     import tools.browser_supervisor as bsup
 
     session = {
@@ -389,15 +394,15 @@ def test_browser_navigate_cdp_uses_supervisor_page(monkeypatch):
         def get(self, task_id):
             return _Sup()
 
-    monkeypatch.setattr(bt, "_get_session_info", lambda key: session)
-    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda task_id: None)
-    monkeypatch.setattr(bt, "_bind_session_page_target", lambda tid, info: None)
+    monkeypatch.setattr(_session, "_get_session_info", lambda key: session)
+    monkeypatch.setattr(_cdp, "_ensure_cdp_supervisor", lambda task_id: None)
+    monkeypatch.setattr(_session, "_bind_session_page_target", lambda tid, info: None)
     monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
-    monkeypatch.setattr(bt, "_is_local_backend", lambda: False)
-    monkeypatch.setattr(bt, "_allow_private_urls", lambda: True)
+    monkeypatch.setattr(_cloud, "_is_local_backend", lambda: False)
+    monkeypatch.setattr(_cloud, "_allow_private_urls", lambda: True)
     monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
     monkeypatch.setattr(bt, "check_website_access", lambda url: None)
-    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: None)
+    monkeypatch.setattr(_cloud, "_get_cloud_provider", lambda: None)
     monkeypatch.setattr(bt, "_maybe_start_recording", lambda key: None)
     monkeypatch.setattr(bt, "_sensitive_query_param_name", lambda url: None)
     monkeypatch.setattr(bt, "_normalize_url_for_request", lambda url: url)
@@ -406,7 +411,7 @@ def test_browser_navigate_cdp_uses_supervisor_page(monkeypatch):
     def _fail_cli(*a, **k):
         raise AssertionError("must not call agent-browser CLI for CDP navigate")
 
-    monkeypatch.setattr(bt, "_run_browser_command", _fail_cli)
+    monkeypatch.setattr(_session, "_run_browser_command", _fail_cli)
 
     out = json.loads(bt.browser_navigate("https://www.baidu.com", task_id="sess-A"))
     assert out["success"] is True
@@ -418,6 +423,9 @@ def test_two_task_navigate_paths_keep_distinct_targets(monkeypatch):
     """Two task_ids must route navigate to different page targets."""
     import json
     import tools.browser_tool as bt
+    import tools.browser_tool_session as _session
+    import tools.browser_tool_cdp as _cdp
+    import tools.browser_tool_cloud as _cloud
     import tools.browser_supervisor as bsup
 
     sessions = {
@@ -451,21 +459,21 @@ def test_two_task_navigate_paths_keep_distinct_targets(monkeypatch):
             tab = "TAB-A" if task_id == "sess-A" else "TAB-B"
             return _Sup(task_id, tab)
 
-    monkeypatch.setattr(bt, "_get_session_info", lambda key: sessions[key])
-    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda task_id: None)
-    monkeypatch.setattr(bt, "_bind_session_page_target", lambda tid, info: None)
+    monkeypatch.setattr(_session, "_get_session_info", lambda key: sessions[key])
+    monkeypatch.setattr(_cdp, "_ensure_cdp_supervisor", lambda task_id: None)
+    monkeypatch.setattr(_session, "_bind_session_page_target", lambda tid, info: None)
     monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
-    monkeypatch.setattr(bt, "_is_local_backend", lambda: False)
-    monkeypatch.setattr(bt, "_allow_private_urls", lambda: True)
+    monkeypatch.setattr(_cloud, "_is_local_backend", lambda: False)
+    monkeypatch.setattr(_cloud, "_allow_private_urls", lambda: True)
     monkeypatch.setattr(bt, "_is_always_blocked_url", lambda url: False)
     monkeypatch.setattr(bt, "check_website_access", lambda url: None)
-    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: None)
+    monkeypatch.setattr(_cloud, "_get_cloud_provider", lambda: None)
     monkeypatch.setattr(bt, "_maybe_start_recording", lambda key: None)
     monkeypatch.setattr(bt, "_sensitive_query_param_name", lambda url: None)
     monkeypatch.setattr(bt, "_normalize_url_for_request", lambda url: url)
     monkeypatch.setattr(bsup, "SUPERVISOR_REGISTRY", _Reg())
     monkeypatch.setattr(
-        bt,
+        _session,
         "_run_browser_command",
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("no CLI")),
     )

--- a/tests/tools/test_browser_supervisor_page_isolation.py
+++ b/tests/tools/test_browser_supervisor_page_isolation.py
@@ -67,8 +67,8 @@ async def test_attach_creates_dedicated_page_even_when_pages_exist():
     async def _noop_bridge(_session_id: str) -> None:
         return None
 
-    sup._cdp = fake_cdp  # type: ignore[method-assign]
-    sup._install_dialog_bridge = _noop_bridge  # type: ignore[method-assign]
+    sup._cdp = fake_cdp
+    sup._install_dialog_bridge = _noop_bridge
 
     await sup._attach_initial_page()
 
@@ -113,6 +113,7 @@ async def test_two_supervisors_get_distinct_page_targets():
                 create_index["i"] += 1
                 return {"result": {"targetId": tid}}
             if method == "Target.attachToTarget":
+                assert params is not None
                 attached.append(params["targetId"])
                 return {"result": {"sessionId": f"SID-{params['targetId']}"}}
             if method == "Target.getTargets":
@@ -128,8 +129,8 @@ async def test_two_supervisors_get_distinct_page_targets():
         async def _noop_bridge(_session_id: str) -> None:
             return None
 
-        sup._cdp = fake_cdp  # type: ignore[method-assign]
-        sup._install_dialog_bridge = _noop_bridge  # type: ignore[method-assign]
+        sup._cdp = fake_cdp
+        sup._install_dialog_bridge = _noop_bridge
         await sup._attach_initial_page()
         return sup, attached
 
@@ -171,6 +172,7 @@ async def test_reconnect_reuses_owned_page_target():
         if method == "Target.createTarget":
             raise AssertionError("must not create a new tab when owned page still exists")
         if method == "Target.attachToTarget":
+            assert params is not None
             assert params["targetId"] == "OWNED-TAB"
             return {"result": {"sessionId": "SID-REUSE"}}
         return {"result": {}}
@@ -178,8 +180,8 @@ async def test_reconnect_reuses_owned_page_target():
     async def _noop_bridge(_session_id: str) -> None:
         return None
 
-    sup._cdp = fake_cdp  # type: ignore[method-assign]
-    sup._install_dialog_bridge = _noop_bridge  # type: ignore[method-assign]
+    sup._cdp = fake_cdp
+    sup._install_dialog_bridge = _noop_bridge
 
     await sup._attach_initial_page()
 
@@ -231,8 +233,8 @@ def test_navigate_page_uses_owned_session_and_activates_target(monkeypatch):
     monkeypatch.setattr(
         "agent.async_utils.safe_schedule_threadsafe", schedule
     )
-    sup._loop = _Loop()  # type: ignore[assignment]
-    sup._cdp = fake_cdp  # type: ignore[method-assign]
+    sup._loop = _Loop()
+    sup._cdp = fake_cdp
 
     result = sup.navigate_page("https://example.com/search")
 
@@ -292,8 +294,8 @@ def test_page_target_tab_ref_matches_agent_browser_target_order(monkeypatch):
             loop_local.close()
 
     monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", schedule)
-    sup._loop = _Loop()  # type: ignore[assignment]
-    sup._cdp = fake_cdp  # type: ignore[method-assign]
+    sup._loop = _Loop()
+    sup._cdp = fake_cdp
 
     result = sup.page_target_tab_ref()
 

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -516,6 +516,107 @@ class CDPSupervisor:
             return {"ok": False, "error": f"{type(e).__name__}: {e}"}
         return {"ok": True, "dialog": snapshot_copy.to_dict()}
 
+    def page_target_id(self) -> Optional[str]:
+        """Return the dedicated page target for this task, if attached."""
+        return self._page_target_id
+
+    def activate_owned_page(self, timeout: float = 5.0) -> Dict[str, Any]:
+        """Bring this supervisor's dedicated page to the front (shared CDP).
+
+        Required before agent-browser CLI commands against a multi-session
+        headed browser so navigate/click hit our tab, not another session's.
+        """
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return {"ok": False, "error": "supervisor loop is not running"}
+        with self._state_lock:
+            if not self._active:
+                return {"ok": False, "error": "supervisor is not active"}
+            target_id = self._page_target_id
+        if not target_id:
+            return {"ok": False, "error": "supervisor has no dedicated page target"}
+
+        async def _do_activate() -> None:
+            await self._cdp(
+                "Target.activateTarget",
+                {"targetId": target_id},
+                timeout=timeout,
+            )
+
+        try:
+            from agent.async_utils import safe_schedule_threadsafe
+
+            fut = safe_schedule_threadsafe(_do_activate(), loop)
+            if fut is None:
+                return {"ok": False, "error": "Browser supervisor loop unavailable"}
+            fut.result(timeout=timeout + 1)
+        except Exception as exc:
+            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        return {"ok": True, "target_id": target_id}
+
+    def navigate_page(self, url: str, timeout: float = 30.0) -> Dict[str, Any]:
+        """Navigate this supervisor's dedicated page via live CDP Page.navigate.
+
+        Bypasses agent-browser so multi-session CDP sessions do not race on
+        whichever tab agent-browser considers active.
+        """
+        if not isinstance(url, str) or not url.strip():
+            return {"ok": False, "error": "url must be a non-empty string"}
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return {"ok": False, "error": "supervisor loop is not running"}
+        with self._state_lock:
+            if not self._active:
+                return {"ok": False, "error": "supervisor is not active"}
+            session_id = self._page_session_id
+            target_id = self._page_target_id
+        if not session_id:
+            return {"ok": False, "error": "supervisor has no attached page session"}
+
+        async def _do_nav() -> Dict[str, Any]:
+            if target_id:
+                try:
+                    await self._cdp(
+                        "Target.activateTarget",
+                        {"targetId": target_id},
+                        timeout=min(timeout, 5.0),
+                    )
+                except Exception:
+                    pass
+            return await self._cdp(
+                "Page.navigate",
+                {"url": url.strip()},
+                session_id=session_id,
+                timeout=timeout,
+            )
+
+        try:
+            from agent.async_utils import safe_schedule_threadsafe
+
+            fut = safe_schedule_threadsafe(_do_nav(), loop)
+            if fut is None:
+                return {"ok": False, "error": "Browser supervisor loop unavailable"}
+            response = fut.result(timeout=timeout + 1)
+        except Exception as exc:
+            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+        result = response.get("result") if isinstance(response, dict) else None
+        error_text = None
+        if isinstance(result, dict):
+            error_text = result.get("errorText")
+        if error_text:
+            return {
+                "ok": False,
+                "error": str(error_text),
+                "target_id": target_id,
+            }
+        return {
+            "ok": True,
+            "target_id": target_id,
+            "frame_id": (result or {}).get("frameId") if isinstance(result, dict) else None,
+            "loader_id": (result or {}).get("loaderId") if isinstance(result, dict) else None,
+        }
+
     def evaluate_runtime(
         self,
         expression: str,

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -341,6 +341,12 @@ class CDPSupervisor:
         self._pending_calls: Dict[int, asyncio.Future] = {}
         self._ws: Optional[ClientConnection] = None
         self._page_session_id: Optional[str] = None
+        # Dedicated page target for this Hermes task_id. Multiple sessions can
+        # share one headed browser via the same CDP endpoint; each supervisor
+        # must own its own tab so they do not race on the first open page
+        # (#69727).
+        self._page_target_id: Optional[str] = None
+        self._owns_page_target: bool = False
         self._child_sessions: Dict[str, Dict[str, Any]] = {}  # session_id -> info
 
         # Dialog auto-dismiss watchdog handles (per dialog id).
@@ -400,7 +406,13 @@ class CDPSupervisor:
             # Close the WebSocket from inside the loop — this makes ``async for
             # raw in self._ws`` return cleanly, ``_run`` hits its ``finally``,
             # pending tasks get cancelled in order, THEN the thread exits.
-            async def _close_ws():
+            async def _shutdown_ws():
+                # Drop our dedicated tab before closing the socket so shared
+                # headed browsers do not accumulate blank pages per session.
+                try:
+                    await self._close_owned_page_target()
+                except Exception:
+                    pass
                 ws = self._ws
                 self._ws = None
                 if ws is not None:
@@ -411,7 +423,7 @@ class CDPSupervisor:
 
             try:
                 from agent.async_utils import safe_schedule_threadsafe
-                fut = safe_schedule_threadsafe(_close_ws(), loop)
+                fut = safe_schedule_threadsafe(_shutdown_ws(), loop)
                 if fut is not None:
                     try:
                         fut.result(timeout=2.0)
@@ -738,16 +750,83 @@ class CDPSupervisor:
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, 10.0)
 
-    async def _attach_initial_page(self) -> None:
-        """Find a page target, attach flattened session, enable domains, install dialog bridge."""
+    async def _resolve_dedicated_page_target(self) -> str:
+        """Return a page target exclusive to this supervisor/task_id.
+
+        Prefer re-attaching to a page we already created (reconnect path).
+        Otherwise always ``Target.createTarget`` a fresh blank page — never
+        adopt the first existing page, which is shared across all Hermes
+        sessions connected to the same headed browser (#69727).
+        """
+        if self._page_target_id:
+            try:
+                resp = await self._cdp("Target.getTargets")
+                targets = (resp.get("result") or {}).get("targetInfos") or []
+                if any(
+                    isinstance(t, dict) and t.get("targetId") == self._page_target_id
+                    for t in targets
+                ):
+                    return self._page_target_id
+            except Exception as exc:
+                logger.debug(
+                    "CDP supervisor %s: getTargets while reusing page failed: %s",
+                    self.task_id,
+                    _redact_cdp_error_text(exc),
+                )
+            # Prior page is gone (user closed tab, browser restarted, …).
+            self._page_target_id = None
+            self._owns_page_target = False
+
+        created = await self._cdp("Target.createTarget", {"url": "about:blank"})
+        target_id = (created.get("result") or {}).get("targetId")
+        if target_id:
+            self._page_target_id = str(target_id)
+            self._owns_page_target = True
+            return self._page_target_id
+
+        # Rare backend: createTarget rejected or returned nothing. Fall back to
+        # an existing page only as last resort so attach can still succeed.
         resp = await self._cdp("Target.getTargets")
-        targets = resp.get("result", {}).get("targetInfos", [])
-        page_target = next((t for t in targets if t.get("type") == "page"), None)
-        if page_target is None:
-            created = await self._cdp("Target.createTarget", {"url": "about:blank"})
-            target_id = created["result"]["targetId"]
-        else:
-            target_id = page_target["targetId"]
+        targets = (resp.get("result") or {}).get("targetInfos") or []
+        page_target = next(
+            (t for t in targets if isinstance(t, dict) and t.get("type") == "page"),
+            None,
+        )
+        if page_target is None or not page_target.get("targetId"):
+            raise RuntimeError(
+                "CDP Target.createTarget returned no targetId and no page target exists"
+            )
+        self._page_target_id = str(page_target["targetId"])
+        self._owns_page_target = False
+        logger.warning(
+            "CDP supervisor %s: createTarget unavailable; reusing shared page %s "
+            "(multi-session tab isolation degraded)",
+            self.task_id,
+            self._page_target_id[:16],
+        )
+        return self._page_target_id
+
+    async def _close_owned_page_target(self) -> None:
+        """Close the blank page we created for this task_id, if any."""
+        if not self._owns_page_target or not self._page_target_id:
+            return
+        target_id = self._page_target_id
+        try:
+            await self._cdp("Target.closeTarget", {"targetId": target_id})
+        except Exception as exc:
+            logger.debug(
+                "CDP supervisor %s: closeTarget %s failed: %s",
+                self.task_id,
+                target_id[:16],
+                _redact_cdp_error_text(exc),
+            )
+        finally:
+            self._page_target_id = None
+            self._owns_page_target = False
+
+    async def _attach_initial_page(self) -> None:
+        """Attach a dedicated page target, enable domains, install dialog bridge."""
+        target_id = await self._resolve_dedicated_page_target()
 
         attach = await self._cdp(
             "Target.attachToTarget",

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -520,6 +520,61 @@ class CDPSupervisor:
         """Return the dedicated page target for this task, if attached."""
         return self._page_target_id
 
+    def page_target_tab_ref(self, timeout: float = 5.0) -> Dict[str, Any]:
+        """Return agent-browser's stable tab ref for this owned page.
+
+        ``agent-browser --cdp`` connects to the browser endpoint and keeps its
+        own page list.  It has no CLI flag for a raw CDP target id, so the
+        Hermes path binds the command by switching that daemon to the matching
+        stable tab id inside one ``batch`` request.  The stable id is derived
+        from the same filtered ``Target.getTargets`` order agent-browser uses
+        when it creates its page list.
+        """
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return {"ok": False, "error": "supervisor loop is not running"}
+        with self._state_lock:
+            if not self._active:
+                return {"ok": False, "error": "supervisor is not active"}
+            target_id = self._page_target_id
+        if not target_id:
+            return {"ok": False, "error": "supervisor has no dedicated page target"}
+
+        async def _resolve() -> Dict[str, Any]:
+            response = await self._cdp("Target.getTargets", timeout=timeout)
+            infos = (response.get("result") or {}).get("targetInfos") or []
+            pages = [
+                info
+                for info in infos
+                if isinstance(info, dict)
+                and info.get("type") in {"page", "webview"}
+                and not str(info.get("url") or "").startswith(
+                    ("chrome://", "chrome-extension://", "devtools://")
+                )
+            ]
+            for index, info in enumerate(pages, start=1):
+                if info.get("targetId") == target_id:
+                    return {
+                        "ok": True,
+                        "target_id": target_id,
+                        "tab_ref": f"t{index}",
+                    }
+            return {
+                "ok": False,
+                "error": "dedicated page target is not present in Target.getTargets",
+                "target_id": target_id,
+            }
+
+        try:
+            from agent.async_utils import safe_schedule_threadsafe
+
+            fut = safe_schedule_threadsafe(_resolve(), loop)
+            if fut is None:
+                return {"ok": False, "error": "Browser supervisor loop unavailable"}
+            return fut.result(timeout=timeout + 1)
+        except Exception as exc:
+            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
     def activate_owned_page(self, timeout: float = 5.0) -> Dict[str, Any]:
         """Bring this supervisor's dedicated page to the front (shared CDP).
 

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -89,7 +89,7 @@ class SupervisorSnapshot:
 
 class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
     """One supervisor per (task_id, cdp_url) pair. ``start()`` spawns a daemon thread
-    running its own asyncio loop, connects, attaches to the first page target, enables
+    running its own asyncio loop, connects, attaches to its dedicated page target, enables
     domains and auto-attach. ``snapshot()`` / ``respond_to_dialog()`` / ``evaluate_runtime()``
     are sync, thread-safe bridges onto that loop; all CDP I/O lives on the loop."""
 
@@ -499,27 +499,7 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
             self._owns_page_target = True
             return self._page_target_id
 
-        # Rare backend: createTarget rejected or returned nothing. Fall back to
-        # an existing page only as last resort so attach can still succeed.
-        resp = await self._cdp("Target.getTargets")
-        targets = (resp.get("result") or {}).get("targetInfos") or []
-        page_target = next(
-            (t for t in targets if isinstance(t, dict) and t.get("type") == "page"),
-            None,
-        )
-        if page_target is None or not page_target.get("targetId"):
-            raise RuntimeError(
-                "CDP Target.createTarget returned no targetId and no page target exists"
-            )
-        self._page_target_id = str(page_target["targetId"])
-        self._owns_page_target = False
-        logger.warning(
-            "CDP supervisor %s: createTarget unavailable; reusing shared page %s "
-            "(multi-session tab isolation degraded)",
-            self.task_id,
-            self._page_target_id[:16],
-        )
-        return self._page_target_id
+        raise RuntimeError("CDP Target.createTarget returned no targetId; cannot create an isolated page")
 
     async def _close_owned_page_target(self) -> None:
         """Close the blank page we created for this task_id, if any."""

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -401,11 +401,12 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         return True
 
     async def _close_ws(self) -> None:
-        """Drop our dedicated tab, then detach and close the WebSocket, swallowing close errors."""
-        # Drop our dedicated tab before closing the socket so shared headed
-        # browsers do not accumulate blank pages per session (#69727).
-        with contextlib.suppress(Exception):
-            await self._close_owned_page_target()
+        """Close the transport; only an explicit stop releases the owned page."""
+        # A transport reconnect must reattach the same document. Explicit stop
+        # closes it while the reader can still receive Target.closeTarget's reply.
+        if self._stop_requested:
+            with contextlib.suppress(Exception):
+                await self._close_owned_page_target()
         ws, self._ws = self._ws, None
         if ws is not None:
             with contextlib.suppress(Exception):

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -215,6 +215,61 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         """Return the dedicated page target for this task, if attached."""
         return self._page_target_id
 
+    def page_target_tab_ref(self, timeout: float = 5.0) -> Dict[str, Any]:
+        """Return agent-browser's stable tab ref for this owned page.
+
+        ``agent-browser --cdp`` connects to the browser endpoint and keeps its
+        own page list.  It has no CLI flag for a raw CDP target id, so the
+        Hermes path binds the command by switching that daemon to the matching
+        stable tab id inside one ``batch`` request.  The stable id is derived
+        from the same filtered ``Target.getTargets`` order agent-browser uses
+        when it creates its page list.
+        """
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return {"ok": False, "error": "supervisor loop is not running"}
+        with self._state_lock:
+            if not self._active:
+                return {"ok": False, "error": "supervisor is not active"}
+            target_id = self._page_target_id
+        if not target_id:
+            return {"ok": False, "error": "supervisor has no dedicated page target"}
+
+        async def _resolve() -> Dict[str, Any]:
+            response = await self._cdp("Target.getTargets", timeout=timeout)
+            infos = (response.get("result") or {}).get("targetInfos") or []
+            pages = [
+                info
+                for info in infos
+                if isinstance(info, dict)
+                and info.get("type") in {"page", "webview"}
+                and not str(info.get("url") or "").startswith(
+                    ("chrome://", "chrome-extension://", "devtools://")
+                )
+            ]
+            for index, info in enumerate(pages, start=1):
+                if info.get("targetId") == target_id:
+                    return {
+                        "ok": True,
+                        "target_id": target_id,
+                        "tab_ref": f"t{index}",
+                    }
+            return {
+                "ok": False,
+                "error": "dedicated page target is not present in Target.getTargets",
+                "target_id": target_id,
+            }
+
+        try:
+            from agent.async_utils import safe_schedule_threadsafe
+
+            fut = safe_schedule_threadsafe(_resolve(), loop)
+            if fut is None:
+                return {"ok": False, "error": "Browser supervisor loop unavailable"}
+            return fut.result(timeout=timeout + 1)
+        except Exception as exc:
+            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
     def activate_owned_page(self, timeout: float = 5.0) -> Dict[str, Any]:
         """Bring this supervisor's dedicated page to the front (shared CDP).
 

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -215,61 +215,6 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         """Return the dedicated page target for this task, if attached."""
         return self._page_target_id
 
-    def page_target_tab_ref(self, timeout: float = 5.0) -> Dict[str, Any]:
-        """Return agent-browser's stable tab ref for this owned page.
-
-        ``agent-browser --cdp`` connects to the browser endpoint and keeps its
-        own page list.  It has no CLI flag for a raw CDP target id, so the
-        Hermes path binds the command by switching that daemon to the matching
-        stable tab id inside one ``batch`` request.  The stable id is derived
-        from the same filtered ``Target.getTargets`` order agent-browser uses
-        when it creates its page list.
-        """
-        loop = self._loop
-        if loop is None or not loop.is_running():
-            return {"ok": False, "error": "supervisor loop is not running"}
-        with self._state_lock:
-            if not self._active:
-                return {"ok": False, "error": "supervisor is not active"}
-            target_id = self._page_target_id
-        if not target_id:
-            return {"ok": False, "error": "supervisor has no dedicated page target"}
-
-        async def _resolve() -> Dict[str, Any]:
-            response = await self._cdp("Target.getTargets", timeout=timeout)
-            infos = (response.get("result") or {}).get("targetInfos") or []
-            pages = [
-                info
-                for info in infos
-                if isinstance(info, dict)
-                and info.get("type") in {"page", "webview"}
-                and not str(info.get("url") or "").startswith(
-                    ("chrome://", "chrome-extension://", "devtools://")
-                )
-            ]
-            for index, info in enumerate(pages, start=1):
-                if info.get("targetId") == target_id:
-                    return {
-                        "ok": True,
-                        "target_id": target_id,
-                        "tab_ref": f"t{index}",
-                    }
-            return {
-                "ok": False,
-                "error": "dedicated page target is not present in Target.getTargets",
-                "target_id": target_id,
-            }
-
-        try:
-            from agent.async_utils import safe_schedule_threadsafe
-
-            fut = safe_schedule_threadsafe(_resolve(), loop)
-            if fut is None:
-                return {"ok": False, "error": "Browser supervisor loop unavailable"}
-            return fut.result(timeout=timeout + 1)
-        except Exception as exc:
-            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
-
     def activate_owned_page(self, timeout: float = 5.0) -> Dict[str, Any]:
         """Bring this supervisor's dedicated page to the front (shared CDP).
 

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -127,7 +127,6 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         self._page_target_id: Optional[str] = None
         self._owns_page_target: bool = False
         self._page_proxy: Optional[OwnedPageProxy] = None
-        self._child_sessions: Dict[str, Dict[str, Any]] = {}  # session_id -> info
 
         # Dialog auto-dismiss watchdog handles (per dialog id) + id generator.
         self._dialog_watchdogs: Dict[str, asyncio.TimerHandle] = {}
@@ -237,40 +236,6 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
             return await self._page_proxy.start()
 
         return _schedule(endpoint(), loop, timeout=timeout)
-
-    def activate_owned_page(self, timeout: float = 5.0) -> Dict[str, Any]:
-        """Bring this supervisor's dedicated page to the front (shared CDP).
-
-        Required before agent-browser CLI commands against a multi-session
-        headed browser so navigate/click hit our tab, not another session's.
-        """
-        loop = self._loop
-        if loop is None or not loop.is_running():
-            return {"ok": False, "error": "supervisor loop is not running"}
-        with self._state_lock:
-            if not self._active:
-                return {"ok": False, "error": "supervisor is not active"}
-            target_id = self._page_target_id
-        if not target_id:
-            return {"ok": False, "error": "supervisor has no dedicated page target"}
-
-        async def _do_activate() -> None:
-            await self._cdp(
-                "Target.activateTarget",
-                {"targetId": target_id},
-                timeout=timeout,
-            )
-
-        try:
-            from agent.async_utils import safe_schedule_threadsafe
-
-            fut = safe_schedule_threadsafe(_do_activate(), loop)
-            if fut is None:
-                return {"ok": False, "error": "Browser supervisor loop unavailable"}
-            fut.result(timeout=timeout + 1)
-        except Exception as exc:
-            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
-        return {"ok": True, "target_id": target_id}
 
     def navigate_page(self, url: str, timeout: float = 30.0) -> Dict[str, Any]:
         """Navigate this supervisor's dedicated page via live CDP Page.navigate.

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -119,6 +119,14 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         self._pending_calls: Dict[int, asyncio.Future] = {}
         self._ws: Optional[ClientConnection] = None
         self._page_session_id: Optional[str] = None
+        # Dedicated page target for this Hermes task_id. Multiple sessions can
+        # share one headed browser via the same CDP endpoint; each supervisor
+        # must own its own tab so they do not race on the first open page
+        # (#69727).
+        self._page_target_id: Optional[str] = None
+        self._owns_page_target: bool = False
+        self._child_sessions: Dict[str, Dict[str, Any]] = {}  # session_id -> info
+
         # Dialog auto-dismiss watchdog handles (per dialog id) + id generator.
         self._dialog_watchdogs: Dict[str, asyncio.TimerHandle] = {}
         self._dialog_seq = 0
@@ -150,6 +158,7 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         if loop is not None and loop.is_running():
             # Close the WebSocket from inside the loop so ``async for raw in self._ws``
             # returns cleanly, ``_run`` hits its ``finally``, THEN the thread exits.
+            # _close_ws also drops our dedicated page target first (#69727).
             with contextlib.suppress(Exception):  # loop already shutting down / close timed out
                 _schedule(self._close_ws(), loop, timeout=2.0)
         if self._thread is not None:
@@ -291,7 +300,11 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         return True
 
     async def _close_ws(self) -> None:
-        """Detach and close the current WebSocket, swallowing close errors."""
+        """Drop our dedicated tab, then detach and close the WebSocket, swallowing close errors."""
+        # Drop our dedicated tab before closing the socket so shared headed
+        # browsers do not accumulate blank pages per session (#69727).
+        with contextlib.suppress(Exception):
+            await self._close_owned_page_target()
         ws, self._ws = self._ws, None
         if ws is not None:
             with contextlib.suppress(Exception):
@@ -351,13 +364,84 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, 10.0)
 
+    async def _resolve_dedicated_page_target(self) -> str:
+        """Return a page target exclusive to this supervisor/task_id.
+
+        Prefer re-attaching to a page we already created (reconnect path).
+        Otherwise always ``Target.createTarget`` a fresh blank page — never
+        adopt the first existing page, which is shared across all Hermes
+        sessions connected to the same headed browser (#69727).
+        """
+        if self._page_target_id:
+            try:
+                resp = await self._cdp("Target.getTargets")
+                targets = (resp.get("result") or {}).get("targetInfos") or []
+                if any(
+                    isinstance(t, dict) and t.get("targetId") == self._page_target_id
+                    for t in targets
+                ):
+                    return self._page_target_id
+            except Exception as exc:
+                logger.debug(
+                    "CDP supervisor %s: getTargets while reusing page failed: %s",
+                    self.task_id,
+                    _redact_cdp_error_text(exc),
+                )
+            # Prior page is gone (user closed tab, browser restarted, …).
+            self._page_target_id = None
+            self._owns_page_target = False
+
+        created = await self._cdp("Target.createTarget", {"url": "about:blank"})
+        target_id = (created.get("result") or {}).get("targetId")
+        if target_id:
+            self._page_target_id = str(target_id)
+            self._owns_page_target = True
+            return self._page_target_id
+
+        # Rare backend: createTarget rejected or returned nothing. Fall back to
+        # an existing page only as last resort so attach can still succeed.
+        resp = await self._cdp("Target.getTargets")
+        targets = (resp.get("result") or {}).get("targetInfos") or []
+        page_target = next(
+            (t for t in targets if isinstance(t, dict) and t.get("type") == "page"),
+            None,
+        )
+        if page_target is None or not page_target.get("targetId"):
+            raise RuntimeError(
+                "CDP Target.createTarget returned no targetId and no page target exists"
+            )
+        self._page_target_id = str(page_target["targetId"])
+        self._owns_page_target = False
+        logger.warning(
+            "CDP supervisor %s: createTarget unavailable; reusing shared page %s "
+            "(multi-session tab isolation degraded)",
+            self.task_id,
+            self._page_target_id[:16],
+        )
+        return self._page_target_id
+
+    async def _close_owned_page_target(self) -> None:
+        """Close the blank page we created for this task_id, if any."""
+        if not self._owns_page_target or not self._page_target_id:
+            return
+        target_id = self._page_target_id
+        try:
+            await self._cdp("Target.closeTarget", {"targetId": target_id})
+        except Exception as exc:
+            logger.debug(
+                "CDP supervisor %s: closeTarget %s failed: %s",
+                self.task_id,
+                target_id[:16],
+                _redact_cdp_error_text(exc),
+            )
+        finally:
+            self._page_target_id = None
+            self._owns_page_target = False
+
     async def _attach_initial_page(self) -> None:
-        """Find (or create) a page target, attach flattened, enable domains, install dialog bridge."""
-        targets = (await self._cdp("Target.getTargets")).get("result", {}).get("targetInfos", [])
-        page_target = next((t for t in targets if t.get("type") == "page"), None)
-        if page_target is None:
-            page_target = (await self._cdp("Target.createTarget", {"url": "about:blank"}))["result"]
-        attach = await self._cdp("Target.attachToTarget", {"targetId": page_target["targetId"], "flatten": True})
+        """Attach a dedicated page target, enable domains, install dialog bridge."""
+        target_id = await self._resolve_dedicated_page_target()
+        attach = await self._cdp("Target.attachToTarget", {"targetId": target_id, "flatten": True})
         self._page_session_id = sid = attach["result"]["sessionId"]
         await self._enable_page_domains(sid, timeout=10.0)
         await self._install_dialog_bridge(sid)

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -575,8 +575,8 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         assert self._ws is not None
         try:
             async for raw in self._ws:
-                if self._stop_requested:
-                    break
+                # Shutdown still needs command replies to close the owned page.
+                # The transport close ends this reader after cleanup completes.
                 try:
                     msg = json.loads(raw)
                 except Exception:
@@ -590,7 +590,7 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
                         fut.set_exception(RuntimeError(f"CDP error on id={msg['id']}: {msg['error']}"))
                     else:
                         fut.set_result(msg)
-                elif handler := self._EVENT_HANDLERS.get(msg.get("method")):
+                elif not self._stop_requested and (handler := self._EVENT_HANDLERS.get(msg.get("method"))):
                     result = handler(self, msg.get("params", {}), msg.get("sessionId"))
                     if result is not None:
                         await result

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -211,6 +211,107 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
             return _err(e)
         return {"ok": True, "dialog": dialog.to_dict()}
 
+    def page_target_id(self) -> Optional[str]:
+        """Return the dedicated page target for this task, if attached."""
+        return self._page_target_id
+
+    def activate_owned_page(self, timeout: float = 5.0) -> Dict[str, Any]:
+        """Bring this supervisor's dedicated page to the front (shared CDP).
+
+        Required before agent-browser CLI commands against a multi-session
+        headed browser so navigate/click hit our tab, not another session's.
+        """
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return {"ok": False, "error": "supervisor loop is not running"}
+        with self._state_lock:
+            if not self._active:
+                return {"ok": False, "error": "supervisor is not active"}
+            target_id = self._page_target_id
+        if not target_id:
+            return {"ok": False, "error": "supervisor has no dedicated page target"}
+
+        async def _do_activate() -> None:
+            await self._cdp(
+                "Target.activateTarget",
+                {"targetId": target_id},
+                timeout=timeout,
+            )
+
+        try:
+            from agent.async_utils import safe_schedule_threadsafe
+
+            fut = safe_schedule_threadsafe(_do_activate(), loop)
+            if fut is None:
+                return {"ok": False, "error": "Browser supervisor loop unavailable"}
+            fut.result(timeout=timeout + 1)
+        except Exception as exc:
+            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        return {"ok": True, "target_id": target_id}
+
+    def navigate_page(self, url: str, timeout: float = 30.0) -> Dict[str, Any]:
+        """Navigate this supervisor's dedicated page via live CDP Page.navigate.
+
+        Bypasses agent-browser so multi-session CDP sessions do not race on
+        whichever tab agent-browser considers active.
+        """
+        if not isinstance(url, str) or not url.strip():
+            return {"ok": False, "error": "url must be a non-empty string"}
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return {"ok": False, "error": "supervisor loop is not running"}
+        with self._state_lock:
+            if not self._active:
+                return {"ok": False, "error": "supervisor is not active"}
+            session_id = self._page_session_id
+            target_id = self._page_target_id
+        if not session_id:
+            return {"ok": False, "error": "supervisor has no attached page session"}
+
+        async def _do_nav() -> Dict[str, Any]:
+            if target_id:
+                try:
+                    await self._cdp(
+                        "Target.activateTarget",
+                        {"targetId": target_id},
+                        timeout=min(timeout, 5.0),
+                    )
+                except Exception:
+                    pass
+            return await self._cdp(
+                "Page.navigate",
+                {"url": url.strip()},
+                session_id=session_id,
+                timeout=timeout,
+            )
+
+        try:
+            from agent.async_utils import safe_schedule_threadsafe
+
+            fut = safe_schedule_threadsafe(_do_nav(), loop)
+            if fut is None:
+                return {"ok": False, "error": "Browser supervisor loop unavailable"}
+            response = fut.result(timeout=timeout + 1)
+        except Exception as exc:
+            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+        result = response.get("result") if isinstance(response, dict) else None
+        error_text = None
+        if isinstance(result, dict):
+            error_text = result.get("errorText")
+        if error_text:
+            return {
+                "ok": False,
+                "error": str(error_text),
+                "target_id": target_id,
+            }
+        return {
+            "ok": True,
+            "target_id": target_id,
+            "frame_id": (result or {}).get("frameId") if isinstance(result, dict) else None,
+            "loader_id": (result or {}).get("loaderId") if isinstance(result, dict) else None,
+        }
+
     def evaluate_runtime(self, expression: str, *, return_by_value: bool = True,
                          await_promise: bool = True, timeout: float = 10.0) -> Dict[str, Any]:
         """Evaluate ``expression`` in the page's Runtime context over the live WS.

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -29,6 +29,7 @@ from tools.browser_supervisor_frames import FrameInfo, FrameTrackingMixin
 # ``websockets`` costs ~22 ms at import and is only needed once a supervisor connects.
 if TYPE_CHECKING:
     from websockets.asyncio.client import ClientConnection
+    from tools.browser_supervisor_proxy import OwnedPageProxy
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +126,7 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         # (#69727).
         self._page_target_id: Optional[str] = None
         self._owns_page_target: bool = False
+        self._page_proxy: Optional[OwnedPageProxy] = None
         self._child_sessions: Dict[str, Dict[str, Any]] = {}  # session_id -> info
 
         # Dialog auto-dismiss watchdog handles (per dialog id) + id generator.
@@ -214,6 +216,27 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
     def page_target_id(self) -> Optional[str]:
         """Return the dedicated page target for this task, if attached."""
         return self._page_target_id
+
+    def page_command_endpoint(self, timeout: float = 10.0) -> str:
+        """Expose only the owned page to the task's agent-browser daemon."""
+        from tools.browser_supervisor_proxy import OwnedPageProxy
+
+        loop = self._loop
+        if loop is None or not loop.is_running() or not self.snapshot().active:
+            raise RuntimeError("CDP supervisor is not active")
+
+        async def endpoint() -> str:
+            target_id = self._page_target_id
+            if not target_id:
+                raise RuntimeError("No supervisor-owned CDP page is available")
+            if self._page_proxy is not None and self._page_proxy.target_id != target_id:
+                await self._page_proxy.close()
+                self._page_proxy = None
+            if self._page_proxy is None:
+                self._page_proxy = OwnedPageProxy(self.cdp_url, target_id)
+            return await self._page_proxy.start()
+
+        return _schedule(endpoint(), loop, timeout=timeout)
 
     def activate_owned_page(self, timeout: float = 5.0) -> Dict[str, Any]:
         """Bring this supervisor's dedicated page to the front (shared CDP).
@@ -405,6 +428,9 @@ class CDPSupervisor(DialogSupervisionMixin, FrameTrackingMixin):
         # A transport reconnect must reattach the same document. Explicit stop
         # closes it while the reader can still receive Target.closeTarget's reply.
         if self._stop_requested:
+            if self._page_proxy is not None:
+                await self._page_proxy.close()
+                self._page_proxy = None
             with contextlib.suppress(Exception):
                 await self._close_owned_page_target()
         ws, self._ws = self._ws, None

--- a/tools/browser_supervisor_proxy.py
+++ b/tools/browser_supervisor_proxy.py
@@ -1,0 +1,134 @@
+"""A task-owned CDP view for clients that otherwise auto-select foreign tabs."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from typing import Any
+
+from websockets.asyncio.client import connect
+from websockets.asyncio.server import Server, ServerConnection, serve
+from websockets.exceptions import ConnectionClosed
+
+
+class OwnedPageProxy:
+    """Keep agent-browser discovery and attachment on one immutable page target.
+
+    Runs on the supervisor loop. Each client retains its own upstream connection,
+    flattened CDP sessions, request IDs and page events, including child frames.
+    This is a routing boundary for the browser driver, not a general CDP sandbox.
+    """
+
+    def __init__(self, cdp_url: str, target_id: str) -> None:
+        self.cdp_url = cdp_url
+        self.target_id = target_id
+        self._path = "/" + secrets.token_urlsafe(32)
+        self._server: Server | None = None
+        self.url = ""
+        self._lifecycle_lock = asyncio.Lock()
+
+    async def start(self) -> str:
+        async with self._lifecycle_lock:
+            if self._server is None:
+                self._server = await serve(
+                    self._handle, "127.0.0.1", 0, origins=[None],
+                    max_size=50 * 1024 * 1024, close_timeout=1,
+                )
+                port = self._server.sockets[0].getsockname()[1]
+                self.url = f"ws://127.0.0.1:{port}{self._path}"
+            return self.url
+
+    async def close(self) -> None:
+        async with self._lifecycle_lock:
+            server, self._server = self._server, None
+            if server is not None:
+                server.close()
+                await server.wait_closed()
+
+    async def _handle(self, client: ServerConnection) -> None:
+        if client.request is None or client.request.path != self._path:
+            await client.close(code=1008, reason="Unknown page endpoint")
+            return
+        requests: dict[int, str] = {}
+        sessions: set[str] = set()
+        try:
+            async with connect(self.cdp_url, max_size=50 * 1024 * 1024,
+                               open_timeout=5, close_timeout=1) as browser:
+                async def to_browser() -> None:
+                    async for raw in client:
+                        message = json.loads(raw)
+                        method = message.get("method", "")
+                        params = message.get("params") or {}
+                        target_id = params.get("targetId", self.target_id)
+                        session_id = message.get("sessionId")
+                        forbidden = (
+                            target_id != self.target_id
+                            or (session_id is not None and session_id not in sessions)
+                            or method in {"Target.createTarget", "Target.createBrowserContext",
+                                          "Target.disposeBrowserContext", "Target.attachToBrowserTarget", "Browser.close"}
+                            or (method == "Target.setAutoAttach" and session_id is None)
+                        )
+                        if forbidden:
+                            await client.send(json.dumps({"id": message["id"], "error": {
+                                "code": -32000, "message": "Command is outside the task-owned page",
+                            }}))
+                            continue
+                        if method == "Target.getTargetInfo":
+                            message["params"] = {**params, "targetId": self.target_id}
+                        requests[message["id"]] = method
+                        await browser.send(json.dumps(message))
+
+                async def to_client() -> None:
+                    async for raw in browser:
+                        message = json.loads(raw)
+                        if "id" in message:
+                            method = requests.pop(message["id"], "")
+                            result = message.get("result") or {}
+                            if method == "Target.getTargets":
+                                result["targetInfos"] = [target for target in result.get("targetInfos", [])
+                                                         if target.get("targetId") == self.target_id]
+                            if method == "Target.attachToTarget" and result.get("sessionId"):
+                                sessions.add(result["sessionId"])
+                        elif not self._owned_event(message, sessions):
+                            continue
+                        await client.send(json.dumps(message))
+
+                tasks = [asyncio.create_task(to_browser()), asyncio.create_task(to_client())]
+                try:
+                    completed, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                    for task in completed:
+                        task.result()
+                finally:
+                    for task in tasks:
+                        task.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+        except ConnectionClosed:
+            pass
+        except Exception as exc:
+            # Upstream WebSocket exceptions may contain endpoint credentials.
+            await client.close(code=1011, reason=f"Page connection failed: {type(exc).__name__}")
+
+    def _owned_event(self, message: dict[str, Any], sessions: set[str]) -> bool:
+        method = message.get("method", "")
+        params = message.get("params") or {}
+        parent_session = message.get("sessionId")
+        if parent_session is not None and parent_session not in sessions:
+            return False
+        if method == "Target.attachedToTarget":
+            target = params.get("targetInfo") or {}
+            owned = target.get("targetId") == self.target_id
+            child = parent_session in sessions and target.get("type") not in {"page", "webview"}
+            if not (owned or child):
+                return False
+            sessions.add(params["sessionId"])
+        elif method == "Target.detachedFromTarget":
+            session_id = params.get("sessionId")
+            if session_id not in sessions:
+                return False
+            sessions.discard(session_id)
+        elif method.startswith("Target."):
+            target_id = (params.get("targetInfo") or {}).get("targetId", params.get("targetId"))
+            if target_id is not None and target_id != self.target_id:
+                return False
+        return True

--- a/tools/browser_supervisor_proxy.py
+++ b/tools/browser_supervisor_proxy.py
@@ -35,7 +35,7 @@ class OwnedPageProxy:
                     self._handle, "127.0.0.1", 0, origins=[None],
                     max_size=50 * 1024 * 1024, close_timeout=1,
                 )
-                port = self._server.sockets[0].getsockname()[1]
+                port = next(iter(self._server.sockets)).getsockname()[1]
                 self.url = f"ws://127.0.0.1:{port}{self._path}"
             return self.url
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2278,8 +2278,94 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
     # Skip for local sidecars — they have no CDP URL.
     if not force_local:
         _ensure_cdp_supervisor(task_id)
+        _bind_session_page_target(task_id, session_info)
 
     return session_info
+
+
+def _bind_session_page_target(task_id: str, session_info: Dict[str, Any]) -> None:
+    """Copy the supervisor's dedicated page target onto session_info.
+
+    Multi-session CDP isolation requires the public browser path (navigate /
+    click / …) to know which page this task_id owns (#69727).
+    """
+    if not session_info.get("cdp_url") and not _get_cdp_override_raw():
+        return
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        supervisor = SUPERVISOR_REGISTRY.get(task_id)
+        if supervisor is None:
+            return
+        target_id = supervisor.page_target_id()
+        if target_id:
+            session_info["page_target_id"] = target_id
+    except Exception as exc:
+        logger.debug(
+            "Could not bind page_target_id for task=%s: %s", task_id, exc
+        )
+
+
+def _activate_session_page_target(task_id: str, session_info: Dict[str, Any]) -> None:
+    """Focus this task's dedicated CDP page before agent-browser CLI work."""
+    if not session_info.get("cdp_url") and not session_info.get("page_target_id"):
+        return
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        supervisor = SUPERVISOR_REGISTRY.get(task_id)
+        if supervisor is None:
+            return
+        result = supervisor.activate_owned_page()
+        if not result.get("ok"):
+            logger.debug(
+                "activate_owned_page failed for task=%s: %s",
+                task_id,
+                result.get("error"),
+            )
+    except Exception as exc:
+        logger.debug("activate_owned_page error for task=%s: %s", task_id, exc)
+
+
+def _navigate_via_supervisor_page(
+    task_id: str, url: str, session_info: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Navigate using the supervisor's dedicated page when on CDP.
+
+    Returns a result dict on success/handled-failure, or ``None`` to fall
+    through to the agent-browser CLI path (local sessions, no supervisor).
+    """
+    if not session_info.get("cdp_url"):
+        return None
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        _ensure_cdp_supervisor(task_id)
+        _bind_session_page_target(task_id, session_info)
+        supervisor = SUPERVISOR_REGISTRY.get(task_id)
+        if supervisor is None or not supervisor.page_target_id():
+            return None
+        nav = supervisor.navigate_page(url)
+        if not nav.get("ok"):
+            return {
+                "success": False,
+                "error": nav.get("error") or "supervisor Page.navigate failed",
+                "page_target_id": session_info.get("page_target_id"),
+            }
+        return {
+            "success": True,
+            "url": url,
+            "page_target_id": nav.get("target_id") or session_info.get("page_target_id"),
+            "frame_id": nav.get("frame_id"),
+            "via": "cdp_supervisor",
+        }
+    except Exception as exc:
+        logger.debug(
+            "supervisor navigate failed for task=%s, falling back to CLI: %s",
+            task_id,
+            exc,
+        )
+        return None
 
 
 
@@ -2516,7 +2602,11 @@ def _run_browser_command(
     # Local mode: --session <name> launches a local headless Chromium.
     # The rest of the command (--json, command, args) is identical.
     if session_info.get("cdp_url"):
-        # Cloud mode — connect to remote Browserbase browser via CDP
+        # Cloud / user CDP — connect via CDP. Focus this task's dedicated page
+        # first so multi-session headed browsers do not race on one tab (#69727).
+        _ensure_cdp_supervisor(task_id)
+        _bind_session_page_target(task_id, session_info)
+        _activate_session_page_target(task_id, session_info)
         # IMPORTANT: Do NOT use --session with --cdp. In agent-browser >=0.13,
         # --session creates a local browser instance and silently ignores --cdp.
         backend_args = ["--cdp", session_info["cdp_url"]]
@@ -3057,6 +3147,16 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     if is_first_nav:
         session_info["_first_nav"] = False
         _maybe_start_recording(nav_session_key)
+
+    # CDP multi-session: navigate on the supervisor-owned page, not whichever
+    # tab agent-browser considers active (#69727).
+    supervisor_result = _navigate_via_supervisor_page(
+        nav_session_key, url, session_info
+    )
+    if supervisor_result is not None:
+        if is_first_nav and session_info.get("features"):
+            supervisor_result["stealth"] = session_info.get("features")
+        return json.dumps(supervisor_result)
 
     result = _run_browser_command(
         nav_session_key,

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -55,6 +55,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import subprocess
 import shutil
 import sys
@@ -1568,6 +1569,34 @@ _cleanup_running = False
 # (subagents run concurrently via ThreadPoolExecutor)
 _cleanup_lock = threading.Lock()
 
+# agent-browser's CDP mode has no command-line target/session selector.  For a
+# shared endpoint we therefore use its own stable tab ids inside a single
+# ``batch`` request (``tab tN`` followed by the real operation).  The fallback
+# lock below protects older/proxy backends where that tab lookup is unavailable
+# by keeping Target.activateTarget and the CLI command in one critical section.
+_CDP_PAGE_BOUND_COMMANDS = frozenset({
+    "back",
+    "click",
+    "console",
+    "errors",
+    "eval",
+    "fill",
+    "open",
+    "press",
+    "record",
+    "screenshot",
+    "scroll",
+    "snapshot",
+})
+_cdp_binding_locks: Dict[str, threading.Lock] = {}
+_cdp_binding_locks_guard = threading.Lock()
+
+
+def _cdp_binding_lock(cdp_url: str) -> threading.Lock:
+    """Return the process-wide lock for one shared CDP endpoint."""
+    with _cdp_binding_locks_guard:
+        return _cdp_binding_locks.setdefault(cdp_url, threading.Lock())
+
 
 def _session_expiry_timestamp(session_info: Dict[str, Any]) -> Optional[float]:
     """Return a provider-authoritative session expiry as epoch seconds.
@@ -2327,6 +2356,29 @@ def _activate_session_page_target(task_id: str, session_info: Dict[str, Any]) ->
         logger.debug("activate_owned_page error for task=%s: %s", task_id, exc)
 
 
+def _session_page_tab_ref(task_id: str, session_info: Dict[str, Any]) -> Optional[str]:
+    """Return the agent-browser tab ref bound to this Hermes task's page."""
+    if not session_info.get("cdp_url"):
+        return None
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        supervisor = SUPERVISOR_REGISTRY.get(task_id)
+        if supervisor is None:
+            return None
+        result = supervisor.page_target_tab_ref()
+        if result.get("ok") and result.get("tab_ref"):
+            return str(result["tab_ref"])
+        logger.debug(
+            "Could not resolve agent-browser tab ref for task=%s: %s",
+            task_id,
+            result.get("error"),
+        )
+    except Exception as exc:
+        logger.debug("page-target tab binding error for task=%s: %s", task_id, exc)
+    return None
+
+
 def _navigate_via_supervisor_page(
     task_id: str, url: str, session_info: Dict[str, Any]
 ) -> Optional[Dict[str, Any]]:
@@ -2601,12 +2653,26 @@ def _run_browser_command(
     # Cloud mode: --cdp <websocket_url> connects to Browserbase.
     # Local mode: --session <name> launches a local headless Chromium.
     # The rest of the command (--json, command, args) is identical.
+    cdp_tab_ref = None
+    cdp_binding_lock = None
+    uses_cdp_tab_batch = False
     if session_info.get("cdp_url"):
-        # Cloud / user CDP — connect via CDP. Focus this task's dedicated page
-        # first so multi-session headed browsers do not race on one tab (#69727).
+        # Cloud / user CDP — connect via CDP.  agent-browser exposes no raw
+        # target/session flag, so bind page operations through its stable tab
+        # state in one batch request.  Older/proxy backends that cannot expose
+        # Target.getTargets use the serialized activation fallback below.
         _ensure_cdp_supervisor(task_id)
         _bind_session_page_target(task_id, session_info)
-        _activate_session_page_target(task_id, session_info)
+        if command in _CDP_PAGE_BOUND_COMMANDS:
+            cdp_tab_ref = _session_page_tab_ref(task_id, session_info)
+            uses_cdp_tab_batch = cdp_tab_ref is not None
+            if not uses_cdp_tab_batch:
+                cdp_binding_lock = _cdp_binding_lock(str(session_info["cdp_url"]))
+                cdp_binding_lock.acquire()
+        if not uses_cdp_tab_batch:
+            # Keep activation and the CLI request linearized when a target
+            # index cannot be queried from the remote CDP proxy.
+            _activate_session_page_target(task_id, session_info)
         # IMPORTANT: Do NOT use --session with --cdp. In agent-browser >=0.13,
         # --session creates a local browser instance and silently ignores --cdp.
         backend_args = ["--cdp", session_info["cdp_url"]]
@@ -2633,10 +2699,20 @@ def _run_browser_command(
     else:
         cmd_prefix = [browser_cmd]
 
-    cmd_parts = cmd_prefix + backend_args + [
-        "--json",
-        command
-    ] + args
+    if uses_cdp_tab_batch:
+        # ``batch`` executes both commands in the same agent-browser daemon,
+        # making the selected target/session part of the operation rather than
+        # a racy browser-global focus side effect.
+        batch_commands = [
+            shlex.join(["tab", str(cdp_tab_ref)]),
+            shlex.join([command, *(str(arg) for arg in args)]),
+        ]
+        cmd_parts = cmd_prefix + backend_args + ["--json", "batch", *batch_commands]
+    else:
+        cmd_parts = cmd_prefix + backend_args + [
+            "--json",
+            command
+        ] + args
 
     try:
         # Give each task its own socket directory to prevent concurrency conflicts.
@@ -2778,6 +2854,17 @@ def _run_browser_command(
             elif stdout_text:
                 try:
                     parsed = json.loads(stdout_text)
+                    if uses_cdp_tab_batch:
+                        if not isinstance(parsed, list) or not parsed:
+                            raise ValueError("agent-browser batch returned no command result")
+                        final = parsed[-1]
+                        result = {
+                            "success": bool(final.get("success")),
+                            "data": final.get("result") or {},
+                        }
+                        if final.get("error"):
+                            result["error"] = final["error"]
+                        parsed = result
                     # Warn if snapshot came back empty (common sign of daemon/CDP issues)
                     if command == "snapshot" and parsed.get("success"):
                         snap_data = parsed.get("data", {})
@@ -2831,6 +2918,9 @@ def _run_browser_command(
     except Exception as e:
         logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
         result = {"success": False, "error": str(e)}
+
+    if cdp_binding_lock is not None:
+        cdp_binding_lock.release()
 
     # --- Lightpanda automatic Chrome fallback ---
     # If engine is lightpanda and the result looks broken, retry with Chrome.

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -700,47 +700,6 @@ def _attach_auto_snapshot(response: Dict[str, Any], nav_session_key: str) -> Non
         logger.debug("Auto-snapshot after navigate failed: %s", e)
 
 
-def _navigate_via_supervisor_page(
-    task_id: str, url: str, session_info: Dict[str, Any]
-) -> Optional[Dict[str, Any]]:
-    """Navigate using the supervisor's dedicated page when on CDP.
-
-    Returns a result dict on success/handled-failure, or ``None`` to fall
-    through to the agent-browser CLI path (local sessions, no supervisor).
-    """
-    if not session_info.get("cdp_url"):
-        return None
-    try:
-        from tools.browser_supervisor import SUPERVISOR_REGISTRY
-
-        _cdp._ensure_cdp_supervisor(task_id)
-        _session._bind_session_page_target(task_id, session_info)
-        supervisor = SUPERVISOR_REGISTRY.get(task_id)
-        if supervisor is None or not supervisor.page_target_id():
-            return None
-        nav = supervisor.navigate_page(url)
-        if not nav.get("ok"):
-            return {
-                "success": False,
-                "error": nav.get("error") or "supervisor Page.navigate failed",
-                "page_target_id": session_info.get("page_target_id"),
-            }
-        return {
-            "success": True,
-            "url": url,
-            "page_target_id": nav.get("target_id") or session_info.get("page_target_id"),
-            "frame_id": nav.get("frame_id"),
-            "via": "cdp_supervisor",
-        }
-    except Exception as exc:
-        logger.debug(
-            "supervisor navigate failed for task=%s, falling back to CLI: %s",
-            task_id,
-            exc,
-        )
-        return None
-
-
 def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     """Navigate to ``url``; JSON with title, compact snapshot and, on first nav, stealth features.
     Hybrid routing decides BEFORE the safety checks whether this URL goes to a local sidecar
@@ -770,16 +729,6 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     if is_first_nav:
         session_info["_first_nav"] = False
         _maybe_start_recording(nav_session_key)
-
-    # CDP multi-session: navigate on the supervisor-owned page, not whichever
-    # tab agent-browser considers active (#69727).
-    supervisor_result = _navigate_via_supervisor_page(
-        nav_session_key, url, session_info
-    )
-    if supervisor_result is not None:
-        if is_first_nav and session_info.get("features"):
-            supervisor_result["stealth"] = session_info.get("features")
-        return json.dumps(supervisor_result)
 
     result = _session._run_browser_command(nav_session_key, "open", [url],
                                   timeout=_get_open_command_timeout(first_open=is_first_nav))

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -700,6 +700,47 @@ def _attach_auto_snapshot(response: Dict[str, Any], nav_session_key: str) -> Non
         logger.debug("Auto-snapshot after navigate failed: %s", e)
 
 
+def _navigate_via_supervisor_page(
+    task_id: str, url: str, session_info: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Navigate using the supervisor's dedicated page when on CDP.
+
+    Returns a result dict on success/handled-failure, or ``None`` to fall
+    through to the agent-browser CLI path (local sessions, no supervisor).
+    """
+    if not session_info.get("cdp_url"):
+        return None
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        _cdp._ensure_cdp_supervisor(task_id)
+        _session._bind_session_page_target(task_id, session_info)
+        supervisor = SUPERVISOR_REGISTRY.get(task_id)
+        if supervisor is None or not supervisor.page_target_id():
+            return None
+        nav = supervisor.navigate_page(url)
+        if not nav.get("ok"):
+            return {
+                "success": False,
+                "error": nav.get("error") or "supervisor Page.navigate failed",
+                "page_target_id": session_info.get("page_target_id"),
+            }
+        return {
+            "success": True,
+            "url": url,
+            "page_target_id": nav.get("target_id") or session_info.get("page_target_id"),
+            "frame_id": nav.get("frame_id"),
+            "via": "cdp_supervisor",
+        }
+    except Exception as exc:
+        logger.debug(
+            "supervisor navigate failed for task=%s, falling back to CLI: %s",
+            task_id,
+            exc,
+        )
+        return None
+
+
 def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     """Navigate to ``url``; JSON with title, compact snapshot and, on first nav, stealth features.
     Hybrid routing decides BEFORE the safety checks whether this URL goes to a local sidecar
@@ -729,6 +770,16 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     if is_first_nav:
         session_info["_first_nav"] = False
         _maybe_start_recording(nav_session_key)
+
+    # CDP multi-session: navigate on the supervisor-owned page, not whichever
+    # tab agent-browser considers active (#69727).
+    supervisor_result = _navigate_via_supervisor_page(
+        nav_session_key, url, session_info
+    )
+    if supervisor_result is not None:
+        if is_first_nav and session_info.get("features"):
+            supervisor_result["stealth"] = session_info.get("features")
+        return json.dumps(supervisor_result)
 
     result = _session._run_browser_command(nav_session_key, "open", [url],
                                   timeout=_get_open_command_timeout(first_open=is_first_nav))

--- a/tools/browser_tool_session.py
+++ b/tools/browser_tool_session.py
@@ -722,11 +722,14 @@ def _run_browser_command(
 
     try:
         result = _spawn_and_collect(task_id, session_info, cmd_parts, command, engine, timeout)
-        if uses_cdp_tab_batch and isinstance(result, dict) and result.get("success"):
-            # _spawn_and_collect returns parsed JSON; for batch mode the real
-            # result is the last element of the list.  Unwrap it here so the
-            # caller sees the same shape as a non-batch command.
-            pass  # _spawn_and_collect already handles JSON parsing
+        if uses_cdp_tab_batch and isinstance(result, list) and result:
+            final = result[-1]
+            result = {
+                "success": bool(final.get("success")),
+                "data": final.get("result") or {},
+            }
+            if final.get("error"):
+                result["error"] = final["error"]
     except Exception as e:
         _bt.logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
         result = {"success": False, "error": str(e)}

--- a/tools/browser_tool_session.py
+++ b/tools/browser_tool_session.py
@@ -310,8 +310,55 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
     # Lightpanda sessions (Browser Use mode hides the tools that consume supervisor state).
     if not force_local and not (session_info.get("features") or {}).get("lightpanda"):
         _cdp._ensure_cdp_supervisor(task_id)
+        _bind_session_page_target(task_id, session_info)
 
     return session_info
+
+
+def _bind_session_page_target(task_id: str, session_info: Dict[str, Any]) -> None:
+    """Copy the supervisor's dedicated page target onto session_info.
+
+    Multi-session CDP isolation requires the public browser path (navigate /
+    click / …) to know which page this task_id owns (#69727).
+    """
+    if not session_info.get("cdp_url") and not _cdp._get_cdp_override_raw():
+        return
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        supervisor = SUPERVISOR_REGISTRY.get(task_id)
+        if supervisor is None:
+            return
+        target_id = supervisor.page_target_id()
+        if target_id:
+            session_info["page_target_id"] = target_id
+    except Exception as exc:
+        _bt.logger.debug(
+            "Could not bind page_target_id for task=%s: %s", task_id, exc
+        )
+
+
+def _activate_session_page_target(task_id: str, session_info: Dict[str, Any]) -> None:
+    """Focus this task's dedicated CDP page before agent-browser CLI work."""
+    if not session_info.get("cdp_url") and not session_info.get("page_target_id"):
+        return
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        supervisor = SUPERVISOR_REGISTRY.get(task_id)
+        if supervisor is None:
+            return
+        result = supervisor.activate_owned_page()
+        if not result.get("ok"):
+            _bt.logger.debug(
+                "activate_owned_page for task=%s: %s",
+                task_id,
+                result.get("error") or "unknown",
+            )
+    except Exception as exc:
+        _bt.logger.debug(
+            "Could not activate page_target_id for task=%s: %s", task_id, exc
+        )
 
 
 def _discard_timed_out_browser_session(task_id: str, session_info: Dict[str, Any], task_socket_dir: str) -> None:
@@ -577,6 +624,9 @@ def _run_browser_command(
     # Cleanup stops the supervisor before closing the backend; keep it stopped.
     if command != "close" and session_info.get("cdp_url"):
         _cdp._ensure_cdp_supervisor(task_id)
+        # Focus this task's dedicated page so agent-browser CLI hits our tab,
+        # not another session's (#69727).
+        _activate_session_page_target(task_id, session_info)
 
     # Cloud/CDP: ``--cdp <ws_url>`` (NEVER with --session: agent-browser >=0.13
     # would create a local browser and silently ignore --cdp). Local: ``--session <name>``.

--- a/tools/browser_tool_session.py
+++ b/tools/browser_tool_session.py
@@ -565,7 +565,7 @@ def _interpret_browser_command_output(command: str, stdout: str, stderr: str, re
         return {"success": False, "error": f"Non-JSON output from agent-browser for '{command}': {raw}"}
 
     # Empty snapshot content is a common sign of daemon/CDP issues.
-    if command == "snapshot" and parsed.get("success"):
+    if command == "snapshot" and isinstance(parsed, dict) and parsed.get("success"):
         snap_data = parsed.get("data", {})
         if not snap_data.get("snapshot") and not snap_data.get("refs"):
             _bt.logger.warning("snapshot returned empty content. Possible stale daemon or CDP connection issue. "

--- a/tools/browser_tool_session.py
+++ b/tools/browser_tool_session.py
@@ -7,7 +7,6 @@ Split out of ``tools/browser_tool.py``. Facade-owned state is read through ``_bt
 import json
 import logging
 import os
-import shlex
 import shutil
 import subprocess
 import threading
@@ -340,118 +339,39 @@ def _bind_session_page_target(task_id: str, session_info: Dict[str, Any]) -> Non
         )
 
 
-# Each task has a private agent-browser daemon. Serialize its selection and
-# command so concurrent calls cannot change that daemon's active page.
-_CDP_PAGE_BOUND_COMMANDS = frozenset({
-    "back",
-    "click",
-    "console",
-    "errors",
-    "eval",
-    "fill",
-    "open",
-    "press",
-    "record",
-    "screenshot",
-    "scroll",
-    "snapshot",
-})
+# A daemon caches snapshot refs and its CDP endpoint across commands.
 _cdp_binding_locks: Dict[str, threading.Lock] = {}
 _cdp_binding_locks_guard = threading.Lock()
 
 
 def _cdp_binding_lock(session_name: str) -> threading.Lock:
-    """Return the command lock for one task's private agent-browser daemon."""
+    """Serialize commands and endpoint replacement for a task's private daemon."""
     with _cdp_binding_locks_guard:
         return _cdp_binding_locks.setdefault(session_name, threading.Lock())
-
-
-def _select_cdp_page(
-    task_id: str, session_info: Dict[str, Any], prefix: List[str],
-    marker: str, engine: str, timeout: int,
-) -> None:
-    """Find the marked page using the daemon's real IDs, preserving an existing binding."""
-    probe_args = ["eval", f"globalThis[{json.dumps(marker)}] === true"]
-    probe = _spawn_and_collect(
-        task_id, session_info, prefix + ["--json", *probe_args], "binding-probe", engine, timeout,
-    )
-    if not probe.get("success"):
-        raise RuntimeError(probe.get("error") or "Could not inspect the active CDP page")
-    if (probe.get("data") or {}).get("result") is True:
-        return
-
-    listed = _spawn_and_collect(
-        task_id, session_info, prefix + ["--json", "tab", "list"], "binding-tabs", engine, timeout,
-    )
-    if not listed.get("success"):
-        raise RuntimeError(listed.get("error") or "Could not list CDP pages")
-    tabs = (listed.get("data") or {}).get("tabs")
-    if not isinstance(tabs, list):
-        raise RuntimeError("agent-browser returned no CDP tab inventory")
-    for tab in tabs:
-        if not isinstance(tab, dict) or not isinstance(tab.get("tabId"), str):
-            continue
-        commands = [shlex.join(["tab", tab["tabId"]]), shlex.join(probe_args)]
-        result = _spawn_and_collect(
-            task_id, session_info, prefix + ["--json", "batch", "--bail", *commands],
-            "binding-probe", engine, timeout,
-        )
-        if (isinstance(result, list) and len(result) == 2
-                and all(isinstance(item, dict) and item.get("success") for item in result)
-                and (result[-1].get("result") or {}).get("result") is True):
-            return
-    raise RuntimeError("The supervisor-owned CDP page is unavailable in agent-browser")
 
 
 def _run_cdp_page_command(
     task_id: str, session_info: Dict[str, Any], prefix: List[str],
     command: str, args: List[str], engine: str, timeout: int,
 ) -> Dict[str, Any]:
-    """Select by live page identity and abort before the action if that identity changes."""
+    """Connect the driver to an immutable view of the supervisor-owned target."""
     from tools.browser_supervisor import SUPERVISOR_REGISTRY
 
     supervisor = SUPERVISOR_REGISTRY.get(task_id)
     if supervisor is None or not supervisor.page_target_id():
         return {"success": False, "error": "No supervisor-owned CDP page is available"}
-    marker = f"__hermes_page_{uuid.uuid4().hex}"
-    key = json.dumps(marker)
-    marked = supervisor.evaluate_runtime(
-        f"Object.defineProperty(globalThis, {key}, {{value: true, configurable: true}}); true",
-        timeout=min(timeout, 10),
-    )
-    if not marked.get("ok") or marked.get("result") is not True:
-        return {"success": False, "error": marked.get("error") or "Could not identify the owned CDP page"}
-    needs_cleanup = True
-    try:
-        _select_cdp_page(task_id, session_info, prefix, marker, engine, timeout)
-        guard = (
-            f"(() => {{ const owned = globalThis[{key}] === true; delete globalThis[{key}]; "
-            'if (!owned) throw new Error("CDP page ownership changed"); return true; })()'
-        )
-        commands = [shlex.join(["eval", guard]), shlex.join([command, *(str(arg) for arg in args)])]
-        result = _spawn_and_collect(
-            task_id, session_info, prefix + ["--json", "batch", "--bail", *commands],
-            command, engine, timeout,
-        )
-        if not isinstance(result, list):
-            if not result.get("success"):
-                return result
-            return {"success": False, "error": "agent-browser returned no bound command batch"}
-        if result and isinstance(result[0], dict) and result[0].get("success"):
-            needs_cleanup = False  # The guard removed the marker before the action.
-        if (len(result) != 2
-                or not all(isinstance(item, dict) and item.get("success") for item in result)):
-            error = next(
-                (item.get("error") for item in result if isinstance(item, dict) and item.get("error")),
-                "The bound CDP command did not complete",
-            )
-            return {"success": False, "error": error}
-        return {"success": True, "data": result[-1].get("result") or {}}
-    finally:
-        if needs_cleanup:
-            removed = supervisor.evaluate_runtime(f"delete globalThis[{key}]", timeout=min(timeout, 5))
-            if not removed.get("ok"):
-                _bt.logger.debug("Could not clear CDP page marker for task=%s", task_id)
+    endpoint = supervisor.page_command_endpoint(timeout=min(timeout, 10))
+    prefix = [*prefix[:-1], endpoint]
+    previous_endpoint = session_info.get("_page_command_endpoint")
+    if previous_endpoint is not None and previous_endpoint != endpoint:
+        # agent-browser ignores a changed --cdp URL while its daemon is running.
+        closed = _spawn_and_collect(task_id, session_info, prefix + ["--json", "close"],
+                                    "close", engine, timeout)
+        if not closed.get("success"):
+            return closed
+    session_info["_page_command_endpoint"] = endpoint
+    return _spawn_and_collect(task_id, session_info, prefix + ["--json", command, *args],
+                              command, engine, timeout)
 
 
 def _discard_timed_out_browser_session(task_id: str, session_info: Dict[str, Any], task_socket_dir: str) -> None:
@@ -735,7 +655,7 @@ def _run_browser_command(
 
     prefix = _agent_browser_argv(browser_cmd) + backend_args
     try:
-        if session_info.get("cdp_url") and command in _CDP_PAGE_BOUND_COMMANDS:
+        if session_info.get("cdp_url") and command != "close":
             with _cdp_binding_lock(str(session_info["session_name"])):
                 result = _run_cdp_page_command(
                     task_id, session_info, prefix, command, args, engine, timeout,

--- a/tools/browser_tool_session.py
+++ b/tools/browser_tool_session.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shutil
 import subprocess
+import threading
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -361,6 +362,58 @@ def _activate_session_page_target(task_id: str, session_info: Dict[str, Any]) ->
         )
 
 
+# agent-browser's CDP mode has no command-line target/session selector.  For a
+# shared endpoint we therefore use its own stable tab ids inside a single
+# ``batch`` request (``tab tN`` followed by the real operation).  The fallback
+# lock below protects older/proxy backends where that tab lookup is unavailable
+# by keeping Target.activateTarget and the CLI command in one critical section.
+_CDP_PAGE_BOUND_COMMANDS = frozenset({
+    "back",
+    "click",
+    "console",
+    "errors",
+    "eval",
+    "fill",
+    "open",
+    "press",
+    "record",
+    "screenshot",
+    "scroll",
+    "snapshot",
+})
+_cdp_binding_locks: Dict[str, threading.Lock] = {}
+_cdp_binding_locks_guard = threading.Lock()
+
+
+def _cdp_binding_lock(cdp_url: str) -> threading.Lock:
+    """Return the process-wide lock for one shared CDP endpoint."""
+    with _cdp_binding_locks_guard:
+        return _cdp_binding_locks.setdefault(cdp_url, threading.Lock())
+
+
+def _session_page_tab_ref(task_id: str, session_info: Dict[str, Any]) -> Optional[str]:
+    """Return the agent-browser tab ref bound to this Hermes task's page."""
+    if not session_info.get("cdp_url"):
+        return None
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+        supervisor = SUPERVISOR_REGISTRY.get(task_id)
+        if supervisor is None:
+            return None
+        result = supervisor.page_target_tab_ref()
+        if result.get("ok") and result.get("tab_ref"):
+            return str(result["tab_ref"])
+        _bt.logger.debug(
+            "Could not resolve agent-browser tab ref for task=%s: %s",
+            task_id,
+            result.get("error"),
+        )
+    except Exception as exc:
+        _bt.logger.debug("page-target tab binding error for task=%s: %s", task_id, exc)
+    return None
+
+
 def _discard_timed_out_browser_session(task_id: str, session_info: Dict[str, Any], task_socket_dir: str) -> None:
     """Drop a stuck client generation without losing cloud cleanup state."""
     with _bt._cleanup_lock:
@@ -622,11 +675,22 @@ def _run_browser_command(
         _bt.logger.warning("Failed to create browser session for task=%s: %s", task_id, e)
         return {"success": False, "error": f"Failed to create browser session: {str(e)}"}
     # Cleanup stops the supervisor before closing the backend; keep it stopped.
+    cdp_tab_ref = None
+    cdp_binding_lock = None
+    uses_cdp_tab_batch = False
     if command != "close" and session_info.get("cdp_url"):
         _cdp._ensure_cdp_supervisor(task_id)
-        # Focus this task's dedicated page so agent-browser CLI hits our tab,
-        # not another session's (#69727).
-        _activate_session_page_target(task_id, session_info)
+        _bind_session_page_target(task_id, session_info)
+        if command in _CDP_PAGE_BOUND_COMMANDS:
+            cdp_tab_ref = _session_page_tab_ref(task_id, session_info)
+            uses_cdp_tab_batch = cdp_tab_ref is not None
+            if not uses_cdp_tab_batch:
+                cdp_binding_lock = _cdp_binding_lock(str(session_info["cdp_url"]))
+                cdp_binding_lock.acquire()
+        if not uses_cdp_tab_batch:
+            # Keep activation and the CLI request linearized when a target
+            # index cannot be queried from the remote CDP proxy.
+            _activate_session_page_target(task_id, session_info)
 
     # Cloud/CDP: ``--cdp <ws_url>`` (NEVER with --session: agent-browser >=0.13
     # would create a local browser and silently ignore --cdp). Local: ``--session <name>``.
@@ -642,13 +706,33 @@ def _run_browser_command(
         if engine != "auto" and not _bt._is_camofox_mode():
             backend_args += ["--engine", engine]
 
-    cmd_parts = _agent_browser_argv(browser_cmd) + backend_args + ["--json", command] + args
+    import shlex
+    cmd_prefix = _agent_browser_argv(browser_cmd)
+    if uses_cdp_tab_batch:
+        # ``batch`` executes both commands in the same agent-browser daemon,
+        # making the selected target/session part of the operation rather than
+        # a racy browser-global focus side effect.
+        batch_commands = [
+            shlex.join(["tab", str(cdp_tab_ref)]),
+            shlex.join([command, *(str(arg) for arg in args)]),
+        ]
+        cmd_parts = cmd_prefix + backend_args + ["--json", "batch", *batch_commands]
+    else:
+        cmd_parts = cmd_prefix + backend_args + ["--json", command] + args
 
     try:
         result = _spawn_and_collect(task_id, session_info, cmd_parts, command, engine, timeout)
+        if uses_cdp_tab_batch and isinstance(result, dict) and result.get("success"):
+            # _spawn_and_collect returns parsed JSON; for batch mode the real
+            # result is the last element of the list.  Unwrap it here so the
+            # caller sees the same shape as a non-batch command.
+            pass  # _spawn_and_collect already handles JSON parsing
     except Exception as e:
         _bt.logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
         result = {"success": False, "error": str(e)}
+    finally:
+        if cdp_binding_lock is not None:
+            cdp_binding_lock.release()
 
     # Lightpanda automatic Chrome fallback — runs for ALL exit paths (timeout,
     # empty, non-JSON, nonzero rc, parsed).

--- a/tools/browser_tool_session.py
+++ b/tools/browser_tool_session.py
@@ -7,6 +7,7 @@ Split out of ``tools/browser_tool.py``. Facade-owned state is read through ``_bt
 import json
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import threading
@@ -339,34 +340,8 @@ def _bind_session_page_target(task_id: str, session_info: Dict[str, Any]) -> Non
         )
 
 
-def _activate_session_page_target(task_id: str, session_info: Dict[str, Any]) -> None:
-    """Focus this task's dedicated CDP page before agent-browser CLI work."""
-    if not session_info.get("cdp_url") and not session_info.get("page_target_id"):
-        return
-    try:
-        from tools.browser_supervisor import SUPERVISOR_REGISTRY
-
-        supervisor = SUPERVISOR_REGISTRY.get(task_id)
-        if supervisor is None:
-            return
-        result = supervisor.activate_owned_page()
-        if not result.get("ok"):
-            _bt.logger.debug(
-                "activate_owned_page for task=%s: %s",
-                task_id,
-                result.get("error") or "unknown",
-            )
-    except Exception as exc:
-        _bt.logger.debug(
-            "Could not activate page_target_id for task=%s: %s", task_id, exc
-        )
-
-
-# agent-browser's CDP mode has no command-line target/session selector.  For a
-# shared endpoint we therefore use its own stable tab ids inside a single
-# ``batch`` request (``tab tN`` followed by the real operation).  The fallback
-# lock below protects older/proxy backends where that tab lookup is unavailable
-# by keeping Target.activateTarget and the CLI command in one critical section.
+# Each task has a private agent-browser daemon. Serialize its selection and
+# command so concurrent calls cannot change that daemon's active page.
 _CDP_PAGE_BOUND_COMMANDS = frozenset({
     "back",
     "click",
@@ -385,33 +360,98 @@ _cdp_binding_locks: Dict[str, threading.Lock] = {}
 _cdp_binding_locks_guard = threading.Lock()
 
 
-def _cdp_binding_lock(cdp_url: str) -> threading.Lock:
-    """Return the process-wide lock for one shared CDP endpoint."""
+def _cdp_binding_lock(session_name: str) -> threading.Lock:
+    """Return the command lock for one task's private agent-browser daemon."""
     with _cdp_binding_locks_guard:
-        return _cdp_binding_locks.setdefault(cdp_url, threading.Lock())
+        return _cdp_binding_locks.setdefault(session_name, threading.Lock())
 
 
-def _session_page_tab_ref(task_id: str, session_info: Dict[str, Any]) -> Optional[str]:
-    """Return the agent-browser tab ref bound to this Hermes task's page."""
-    if not session_info.get("cdp_url"):
-        return None
-    try:
-        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+def _select_cdp_page(
+    task_id: str, session_info: Dict[str, Any], prefix: List[str],
+    marker: str, engine: str, timeout: int,
+) -> None:
+    """Find the marked page using the daemon's real IDs, preserving an existing binding."""
+    probe_args = ["eval", f"globalThis[{json.dumps(marker)}] === true"]
+    probe = _spawn_and_collect(
+        task_id, session_info, prefix + ["--json", *probe_args], "binding-probe", engine, timeout,
+    )
+    if not probe.get("success"):
+        raise RuntimeError(probe.get("error") or "Could not inspect the active CDP page")
+    if (probe.get("data") or {}).get("result") is True:
+        return
 
-        supervisor = SUPERVISOR_REGISTRY.get(task_id)
-        if supervisor is None:
-            return None
-        result = supervisor.page_target_tab_ref()
-        if result.get("ok") and result.get("tab_ref"):
-            return str(result["tab_ref"])
-        _bt.logger.debug(
-            "Could not resolve agent-browser tab ref for task=%s: %s",
-            task_id,
-            result.get("error"),
+    listed = _spawn_and_collect(
+        task_id, session_info, prefix + ["--json", "tab", "list"], "binding-tabs", engine, timeout,
+    )
+    if not listed.get("success"):
+        raise RuntimeError(listed.get("error") or "Could not list CDP pages")
+    tabs = (listed.get("data") or {}).get("tabs")
+    if not isinstance(tabs, list):
+        raise RuntimeError("agent-browser returned no CDP tab inventory")
+    for tab in tabs:
+        if not isinstance(tab, dict) or not isinstance(tab.get("tabId"), str):
+            continue
+        commands = [shlex.join(["tab", tab["tabId"]]), shlex.join(probe_args)]
+        result = _spawn_and_collect(
+            task_id, session_info, prefix + ["--json", "batch", "--bail", *commands],
+            "binding-probe", engine, timeout,
         )
-    except Exception as exc:
-        _bt.logger.debug("page-target tab binding error for task=%s: %s", task_id, exc)
-    return None
+        if (isinstance(result, list) and len(result) == 2
+                and all(isinstance(item, dict) and item.get("success") for item in result)
+                and (result[-1].get("result") or {}).get("result") is True):
+            return
+    raise RuntimeError("The supervisor-owned CDP page is unavailable in agent-browser")
+
+
+def _run_cdp_page_command(
+    task_id: str, session_info: Dict[str, Any], prefix: List[str],
+    command: str, args: List[str], engine: str, timeout: int,
+) -> Dict[str, Any]:
+    """Select by live page identity and abort before the action if that identity changes."""
+    from tools.browser_supervisor import SUPERVISOR_REGISTRY
+
+    supervisor = SUPERVISOR_REGISTRY.get(task_id)
+    if supervisor is None or not supervisor.page_target_id():
+        return {"success": False, "error": "No supervisor-owned CDP page is available"}
+    marker = f"__hermes_page_{uuid.uuid4().hex}"
+    key = json.dumps(marker)
+    marked = supervisor.evaluate_runtime(
+        f"Object.defineProperty(globalThis, {key}, {{value: true, configurable: true}}); true",
+        timeout=min(timeout, 10),
+    )
+    if not marked.get("ok") or marked.get("result") is not True:
+        return {"success": False, "error": marked.get("error") or "Could not identify the owned CDP page"}
+    needs_cleanup = True
+    try:
+        _select_cdp_page(task_id, session_info, prefix, marker, engine, timeout)
+        guard = (
+            f"(() => {{ const owned = globalThis[{key}] === true; delete globalThis[{key}]; "
+            'if (!owned) throw new Error("CDP page ownership changed"); return true; })()'
+        )
+        commands = [shlex.join(["eval", guard]), shlex.join([command, *(str(arg) for arg in args)])]
+        result = _spawn_and_collect(
+            task_id, session_info, prefix + ["--json", "batch", "--bail", *commands],
+            command, engine, timeout,
+        )
+        if not isinstance(result, list):
+            if not result.get("success"):
+                return result
+            return {"success": False, "error": "agent-browser returned no bound command batch"}
+        if result and isinstance(result[0], dict) and result[0].get("success"):
+            needs_cleanup = False  # The guard removed the marker before the action.
+        if (len(result) != 2
+                or not all(isinstance(item, dict) and item.get("success") for item in result)):
+            error = next(
+                (item.get("error") for item in result if isinstance(item, dict) and item.get("error")),
+                "The bound CDP command did not complete",
+            )
+            return {"success": False, "error": error}
+        return {"success": True, "data": result[-1].get("result") or {}}
+    finally:
+        if needs_cleanup:
+            removed = supervisor.evaluate_runtime(f"delete globalThis[{key}]", timeout=min(timeout, 5))
+            if not removed.get("ok"):
+                _bt.logger.debug("Could not clear CDP page marker for task=%s", task_id)
 
 
 def _discard_timed_out_browser_session(task_id: str, session_info: Dict[str, Any], task_socket_dir: str) -> None:
@@ -675,22 +715,9 @@ def _run_browser_command(
         _bt.logger.warning("Failed to create browser session for task=%s: %s", task_id, e)
         return {"success": False, "error": f"Failed to create browser session: {str(e)}"}
     # Cleanup stops the supervisor before closing the backend; keep it stopped.
-    cdp_tab_ref = None
-    cdp_binding_lock = None
-    uses_cdp_tab_batch = False
     if command != "close" and session_info.get("cdp_url"):
         _cdp._ensure_cdp_supervisor(task_id)
         _bind_session_page_target(task_id, session_info)
-        if command in _CDP_PAGE_BOUND_COMMANDS:
-            cdp_tab_ref = _session_page_tab_ref(task_id, session_info)
-            uses_cdp_tab_batch = cdp_tab_ref is not None
-            if not uses_cdp_tab_batch:
-                cdp_binding_lock = _cdp_binding_lock(str(session_info["cdp_url"]))
-                cdp_binding_lock.acquire()
-        if not uses_cdp_tab_batch:
-            # Keep activation and the CLI request linearized when a target
-            # index cannot be queried from the remote CDP proxy.
-            _activate_session_page_target(task_id, session_info)
 
     # Cloud/CDP: ``--cdp <ws_url>`` (NEVER with --session: agent-browser >=0.13
     # would create a local browser and silently ignore --cdp). Local: ``--session <name>``.
@@ -706,36 +733,20 @@ def _run_browser_command(
         if engine != "auto" and not _bt._is_camofox_mode():
             backend_args += ["--engine", engine]
 
-    import shlex
-    cmd_prefix = _agent_browser_argv(browser_cmd)
-    if uses_cdp_tab_batch:
-        # ``batch`` executes both commands in the same agent-browser daemon,
-        # making the selected target/session part of the operation rather than
-        # a racy browser-global focus side effect.
-        batch_commands = [
-            shlex.join(["tab", str(cdp_tab_ref)]),
-            shlex.join([command, *(str(arg) for arg in args)]),
-        ]
-        cmd_parts = cmd_prefix + backend_args + ["--json", "batch", *batch_commands]
-    else:
-        cmd_parts = cmd_prefix + backend_args + ["--json", command] + args
-
+    prefix = _agent_browser_argv(browser_cmd) + backend_args
     try:
-        result = _spawn_and_collect(task_id, session_info, cmd_parts, command, engine, timeout)
-        if uses_cdp_tab_batch and isinstance(result, list) and result:
-            final = result[-1]
-            result = {
-                "success": bool(final.get("success")),
-                "data": final.get("result") or {},
-            }
-            if final.get("error"):
-                result["error"] = final["error"]
+        if session_info.get("cdp_url") and command in _CDP_PAGE_BOUND_COMMANDS:
+            with _cdp_binding_lock(str(session_info["session_name"])):
+                result = _run_cdp_page_command(
+                    task_id, session_info, prefix, command, args, engine, timeout,
+                )
+        else:
+            result = _spawn_and_collect(
+                task_id, session_info, prefix + ["--json", command] + args, command, engine, timeout,
+            )
     except Exception as e:
         _bt.logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
         result = {"success": False, "error": str(e)}
-    finally:
-        if cdp_binding_lock is not None:
-            cdp_binding_lock.release()
 
     # Lightpanda automatic Chrome fallback — runs for ALL exit paths (timeout,
     # empty, non-JSON, nonzero rc, parsed).

--- a/website/docs/developer-guide/browser-supervisor.md
+++ b/website/docs/developer-guide/browser-supervisor.md
@@ -69,7 +69,8 @@ frozen snapshot without awaiting.
 ### Task-owned pages
 
 Each CDP task creates a dedicated page and reuses that target after a transport
-reconnect. Navigation uses its attached page session directly. The task's
+reconnect. Navigation and follow-up actions share the normal browser command
+path, preserving redirect checks, response metadata and snapshots. The task's
 agent-browser daemon connects through a loopback WebSocket view that exposes
 only this page in target inventories and discovery events. New tabs from other
 tasks cannot change the daemon's active page between commands. Attached child

--- a/website/docs/developer-guide/browser-supervisor.md
+++ b/website/docs/developer-guide/browser-supervisor.md
@@ -66,6 +66,22 @@ Subscribes on attach:
 Thread-safe state access via a snapshot lock; tool handlers (sync) read the
 frozen snapshot without awaiting.
 
+### Task-owned pages
+
+Each CDP task creates a dedicated page and reuses that target after a transport
+reconnect. Navigation uses its attached page session directly. The task's
+agent-browser daemon connects through a loopback WebSocket view that exposes
+only this page in target inventories and discovery events. New tabs from other
+tasks cannot change the daemon's active page between commands. Attached child
+frames retain their own CDP sessions.
+
+The view runs on the supervisor loop, uses an unpredictable endpoint path, and
+rejects browser-origin WebSocket connections. Session teardown closes its
+listener and the owned page. If the page is replaced, the driver daemon restarts
+against the new endpoint because it caches its original CDP connection. The
+view constrains driver routing; it does not replace the general `browser_cdp`
+tool or isolate browser-wide state such as cookies.
+
 ### Lifecycle
 
 - **Start:** `SupervisorRegistry.get_or_start(task_id, cdp_url)` — called by
@@ -189,10 +205,10 @@ expiry, while the supervisor's long-lived connection keeps a valid session.
 
 ## Testing
 
-Unit tests (`tests/tools/test_browser_supervisor.py`) use an asyncio mock CDP
-server that speaks enough of the protocol to exercise all state transitions:
-attach, enable, navigate, dialog fire, dialog dismiss, frame attach/detach,
-child target attach, session teardown. Real-backend E2E (Browserbase + local
-Chromium-family browser) is manual — exercise via `/browser connect` to a
-live Chromium-family browser and run the dialog/frame test cases described
-above.
+`tests/tools/test_browser_supervisor_page_isolation.py` checks ownership and
+driver endpoint replacement. `tests/tools/test_browser_supervisor.py` exercises
+real local Chrome, dialogs, reconnects, concurrent click/fill operations,
+snapshot references, and newly opened foreign tabs. Run the real-browser suite
+with `HERMES_E2E_BROWSER=1 scripts/run_tests.sh -m integration tests/tools/test_browser_supervisor.py`.
+Chrome and agent-browser must be installed. Browserbase and the documented
+cross-origin iframe smoke test require separate backend validation.


### PR DESCRIPTION
## What does this PR do?

Two Hermes tasks sharing a CDP browser could drive the same tab. Each task now owns a dedicated page and connects its agent-browser daemon through a CDP view exposing only that page. Opening another tab cannot redirect subsequent click, fill or snapshot commands.

## Related Issue

Fixes #69727

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Create a page per task, retain it across transport reconnects, and close it during session teardown.
- Filter driver target discovery and reject foreign-page attachment through a task-owned loopback CDP endpoint. Preserve the endpoint while the page is unchanged; replace the driver connection when ownership changes.
- Keep receiving CDP command replies during shutdown so the owned page and supervisor thread can close.
- Use the common navigation path so CDP tasks retain redirect safety checks, title, snapshot and active-session tracking.
- Exercise concurrent click/fill, snapshot references, closed tabs, newly opened foreign tabs, foreign attachment rejection and thread cleanup against real Chrome.

The view constrains driver routing. Browser-wide state such as cookies remains shared; the general browser_cdp tool is unchanged.

## How to Test

With Chrome and agent-browser installed:

```bash
HERMES_E2E_BROWSER=1 scripts/run_tests.sh -m "integration or not integration" tests/tools/test_browser_supervisor_page_isolation.py tests/tools/test_browser_supervisor.py tests/tools/test_browser_supervisor_healthcheck.py
```

The real-browser tests create separate tasks, run concurrent follow-up actions and verify both pages independently. A foreign tab opened after the first snapshot must stay outside the driver inventory and remain unchanged by the owned task.

Local checker: 31 passed, zero failed, one existing manual-OOPIF skip. With identical test bytes, the stable parallel test fails on the current base because one task writes into the other task's page; HEAD passes all ten browser cases with the existing skip.

Platform: local macOS with Chrome for Testing and agent-browser 0.26.0. Browserbase and the existing manual cross-origin iframe smoke test require separate backend validation.

## Checklist

- [x] Code follows the project style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing
- [x] No new core tools or env vars introduced
- [x] Prompt caching and role alternation preserved
