### PR TITLE
docs: document Poolside access via custom endpoint and OpenRouter

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1165,17 +1165,19 @@ ClawRouter requires a USDC-funded wallet on Base or Solana for payment. All requ
 
 ---
 
-### Poolside
+### Poolside — Coding Models
 
-Hermes can access Poolside models through its built-in OpenRouter provider or through an OpenAI-compatible custom endpoint:
+[Poolside](https://poolside.ai) provides coding models through Poolside Platform, organization deployments, and OpenRouter.
 
 | Access method | Hermes setup | Base URL | Credential |
 |---------------|--------------|----------|------------|
-| **[Poolside Platform](https://docs.poolside.ai/api/overview)** | Custom endpoint | `https://inference.poolside.ai/v1` | Poolside Platform API key |
+| **[Poolside Platform](https://platform.poolside.ai/)** | Custom endpoint | `https://inference.poolside.ai/v1` | Poolside Platform API key |
 | **Your organization's Poolside deployment** | Custom endpoint | `https://<api-domain>/openai/v1` | API key or token supplied by your Poolside administrator |
 | **[OpenRouter](https://openrouter.ai/poolside)** | OpenRouter provider | `https://openrouter.ai/api/v1` | OpenRouter API key |
 
-Run `hermes model`, then choose **Custom endpoint** and copy the matching URL above, or choose **OpenRouter** and select a Poolside model.
+Configure Hermes with `hermes model` → Custom endpoint → the matching URL above → API key → model ID.
+
+For OpenRouter: `hermes model` → OpenRouter → API key → Enter custom model name → an ID from [Poolside models on OpenRouter](https://openrouter.ai/poolside).
 
 ---
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -53,6 +53,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **MiniMax OAuth** | `hermes model` → "MiniMax (OAuth)" (provider: `minimax-oauth`; browser PKCE login) |
 | **StepFun** | `STEPFUN_API_KEY` in `~/.hermes/.env` (provider: `stepfun`) |
 | **LM Studio** | `hermes model` → "LM Studio" (provider: `lmstudio`, optional `LM_API_KEY`) |
+| **Poolside** | `hermes model` → "Custom endpoint" or "OpenRouter" |
 | **Custom Endpoint** | `hermes model` → choose "Custom endpoint" (saved in `config.yaml`) |
 
 For the official API-key path, see the dedicated [Google Gemini guide](/guides/google-gemini).
@@ -1161,6 +1162,20 @@ Routing profiles:
 :::note
 ClawRouter requires a USDC-funded wallet on Base or Solana for payment. All requests route through BlockRun's backend API. Run `npx @blockrun/clawrouter doctor` to check wallet status.
 :::
+
+---
+
+### Poolside
+
+Hermes can access Poolside models through its built-in OpenRouter provider or through an OpenAI-compatible custom endpoint:
+
+| Access method | Hermes setup | Base URL | Credential |
+|---------------|--------------|----------|------------|
+| **[Poolside Platform](https://docs.poolside.ai/api/overview)** | Custom endpoint | `https://inference.poolside.ai/v1` | Poolside Platform API key |
+| **Your organization's Poolside deployment** | Custom endpoint | `https://<api-domain>/openai/v1` | API key or token supplied by your Poolside administrator |
+| **[OpenRouter](https://openrouter.ai/poolside)** | OpenRouter provider | `https://openrouter.ai/api/v1` | OpenRouter API key |
+
+Run `hermes model`, then choose **Custom endpoint** and copy the matching URL above, or choose **OpenRouter** and select a Poolside model.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Documents how to use Poolside models through Hermes’s existing Custom endpoint and OpenRouter flows.

The guide distinguishes Poolside Platform from organization deployments because they use different base URL patterns. This is documentation-only and does not add a Poolside provider plugin or change Hermes behavior.

## Related Issue

N/A — documentation-only clarification.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added Poolside to the inference-provider summary table.
- Documented Poolside Platform at `https://inference.poolside.ai/v1`.
- Documented organization deployments at `https://<api-domain>/openai/v1`.
- Documented OpenRouter as an alternative access path.
- Avoided model-specific names, limits, pricing, and context-window details that may become outdated.

## How to Test

1. Run `git diff --check`.
2. Run `cd website && ./node_modules/.bin/docusaurus build --locale en`.
3. Confirm the Poolside links and table render correctly on the AI Providers page.

The Poolside Platform and organization deployment `/models` and `/chat/completions` endpoints were also manually verified with HTTP 200 responses.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this documentation update
- [x] Python tests: N/A — documentation-only change
- [x] New tests: N/A — no executable behavior changed
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example`: N/A — no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A — no architecture or workflow changes
- [x] Cross-platform impact: N/A — no executable behavior changed
- [x] Tool descriptions/schemas: N/A — no tool behavior changed

## Screenshots / Logs

N/A — no UI changes.