### PR TITLE
fix(agent): clamp tail-cut boundary and summary-scan indices to prevent IndexError

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4075,6 +4075,12 @@ This compaction should PRIORITISE preserving all information related to the focu
         end: int,
     ) -> list[tuple[int, str]]:
         """Find handoff summaries inside a compression window."""
+        n = len(messages)
+        # Defensive: clamp bounds so a caller passing an out-of-range end
+        # (e.g. tail-cut returning len(messages)+1 when head_end >= n)
+        # cannot trigger IndexError.  (#75588)
+        start = max(0, min(start, n))
+        end = max(start, min(end, n))
         summaries: list[tuple[int, str]] = []
         for idx in range(start, end):
             content = messages[idx].get("content")
@@ -4844,7 +4850,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # exists to prevent.  Re-align FORWARD (never backward, which would give
         # the floor's message back) so a raised cut skips to the end of the
         # group and the whole call/result pair is summarised together.
-        return self._align_boundary_forward(messages, max(cut_idx, head_end + 1))
+        return min(n, self._align_boundary_forward(messages, max(cut_idx, head_end + 1)))
 
     # ------------------------------------------------------------------
     # ContextEngine: manual /compress preflight

--- a/tests/agent/test_compressor_tail_cut_oob_fix.py
+++ b/tests/agent/test_compressor_tail_cut_oob_fix.py
@@ -1,0 +1,115 @@
+"""Regression test for #75588 — short tool-only suffix can make context
+compressor scan past messages, causing IndexError in _find_context_summaries()."""
+
+import pytest
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor
+
+
+@pytest.fixture()
+def compressor():
+    """Create a ContextCompressor with mocked dependencies."""
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        c = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+        return c
+
+
+class TestTailCutBoundaryClamp:
+    """Verify that _find_tail_cut_by_tokens never returns > len(messages).
+
+    When a short conversation ends in a tool-call/result group and the
+    protected head alignment reaches the end of the list, the tail-cut
+    function used to return len(messages) + 1, which then caused
+    _find_context_summaries() to index past the array boundary.  (#75588)
+    """
+
+    def _make_tool_group(self, call_id, n_results=1):
+        msgs = [{"role": "assistant", "tool_calls": [{"id": call_id, "type": "function", "function": {"name": "x", "arguments": "{}"}}]}]
+        for i in range(n_results):
+            msgs.append({"role": "tool", "content": f"result {i}", "tool_call_id": call_id})
+        return msgs
+
+    def test_tail_cut_never_exceeds_len_messages(self, compressor):
+        """Simulate the exact bounds from the issue: head_end reaches n,
+        so max(cut_idx, head_end+1) would produce n+1."""
+        # Build a short transcript ending in a tool group
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            *self._make_tool_group("tc1", n_results=2),
+        ]
+        n = len(messages)
+        # Force head_end to cover everything up to n (the protected head
+        # swallowing the entire message list)
+        head_end = n
+        result = compressor._find_tail_cut_by_tokens(messages, head_end)
+        assert result <= n, (
+            f"_find_tail_cut_by_tokens returned {result} for len(messages)={n}; "
+            "it must never exceed len(messages)"
+        )
+
+    def test_tail_cut_with_head_at_last_message(self, compressor):
+        """head_end = n-1 (last message is the only unprotected one)."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "tool", "content": "result", "tool_call_id": "tc1"},
+        ]
+        n = len(messages)
+        result = compressor._find_tail_cut_by_tokens(messages, n - 1)
+        assert result <= n
+
+    def test_tail_cut_with_empty_tail(self, compressor):
+        """head_end = n (no messages available for the tail at all)."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "u"},
+        ]
+        n = len(messages)
+        result = compressor._find_tail_cut_by_tokens(messages, n)
+        assert result <= n
+
+
+class TestFindContextSummariesDefensiveClamp:
+    """Verify that _find_context_summaries clamps its start/end bounds
+    defensively, so it never raises IndexError even with bad caller input."""
+
+    def test_out_of_range_end_does_not_crash(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+        ]
+        # end > len(messages) should not crash
+        result = ContextCompressor._find_context_summaries(messages, 0, 999)
+        assert result == []
+
+    def test_negative_start_does_not_crash(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+        ]
+        result = ContextCompressor._find_context_summaries(messages, -10, 1)
+        assert result == []
+
+    def test_start_beyond_end_is_empty(self):
+        messages = [{"role": "user", "content": "hello"}]
+        result = ContextCompressor._find_context_summaries(messages, 50, 100)
+        assert result == []
+
+    def test_find_latest_context_summary_with_bad_bounds(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        idx, body = ContextCompressor._find_latest_context_summary(messages, 0, 999)
+        assert idx is None
+        assert body == ""


### PR DESCRIPTION
## 背景

修复 #75588: 当短对话以 tool-call/result 组结尾且受保护的 head 对齐到消息列表末尾时，_find_tail_cut_by_tokens() 会返回 len(messages)+1，导致 _find_context_summaries() 在索引 messages[idx] 时触发 IndexError，直接中断 gateway 活跃轮次。

## 根因分析

当 head_end >= len(messages) 时，_find_tail_cut_by_tokens() 末尾的 return 语句使用 max(cut_idx, head_end + 1) 会将索引推到 len(messages)+1。这个越界值随后传入 _find_context_summaries()，后者在 range(start, end) 中迭代并直接索引 messages[idx]，未做任何范围钳制，最终抛出 IndexError。

## 修复方式

两层防御：
1. **源头修复**：_find_tail_cut_by_tokens() 的返回值用 min(n, ...) 钳制，确保永远不超过 len(messages)
2. **防御层**：_find_context_summaries() 对 start/end 参数做 [0, len(messages)] 范围钳制，即使未来调用方传入越界值也不会崩溃

## 验证

- [x] 新增 7 个回归测试，覆盖精确的越界场景
- [x] 全部 214 个现有 test_context_compressor.py 测试通过
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更

Closes #75588