### PR TITLE
fix(memory/hindsight): probe the local embedded daemon's real port for append-dedup

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1168,14 +1168,29 @@ class HindsightMemoryProvider(MemoryProvider):
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
 
-        For local_embedded the daemon is on a per-profile dynamic port,
-        so we prefer the running client's URL when available; otherwise
-        fall back to the configured api_url.
+        For local_embedded the daemon is on a per-profile dynamic port, so
+        we prefer the running client's URL when available; otherwise fall
+        back to the configured api_url. Never fall back to the static
+        default (localhost:8888) while the client is still starting — that
+        dead port would fail every probe and lock the process into legacy
+        per-process document_id. The daemon's dynamic port is deterministic
+        per profile, so it can be resolved from the daemon manager or the
+        profile env file without blocking on daemon startup.
         """
-        if self._mode == "local_embedded" and self._client is not None:
-            url = getattr(self._client, "url", None)
-            if url:
-                return str(url)
+        if self._mode == "local_embedded":
+            if self._client is not None:
+                mgr = getattr(self._client, "_manager", None)
+                get_url = getattr(mgr, "get_url", None)
+                profile = getattr(self._client, "profile", None)
+                if get_url is not None and profile:
+                    try:
+                        return str(get_url(profile))
+                    except Exception:
+                        pass
+            env = _load_simple_env(_embedded_profile_env_path(self._config or {}))
+            port = env.get("HINDSIGHT_API_PORT")
+            if port:
+                return f"http://127.0.0.1:{port}"
         return self._api_url or ""
 
     def _resolve_retain_target(self, fallback_document_id: str) -> tuple[str, str | None]:


### PR DESCRIPTION
## Problem

In local_embedded mode the Hindsight daemon binds a **per-profile dynamic port** (e.g. hermes → 9177), but `_probe_url()` fell back to the static default `localhost:8888` whenever the embedded client hadn't been created yet (first retain of a session races daemon startup in the background thread). The `/version` capability probe therefore hit a dead port, returned None, and the process was locked into legacy per-process `document_id` — silently disabling `update_mode='append'` session dedup for the entire session, even though the daemon was up and serving.

## Fix

`_probe_url()` for local_embedded now resolves the real daemon URL without blocking:
1. Via the daemon manager's `get_url(profile)` when the client exists (non-blocking, deterministic per profile).
2. Falling back to `HINDSIGHT_API_PORT` from the profile env file (`~/.hindsight/profiles/<profile>.env`) when the client hasn't been created yet.

Verified live: probe now hits `http://127.0.0.1:9177` → `api_version 0.8.6` → `_check_api_supports_update_mode_append` returns True, and the daemon log shows append-mode retains.

## Tests

`scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py` — 116 passed.