### PR TITLE
fix(tui_gateway): keep Stop from stranding a session on a dead compute host or an in-flight agent build (supersedes #71825)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -347,6 +347,183 @@ def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monke
     assert session.get("_compute_host_active") is not True
 
 
+class _DeadComputeHost:
+    """Supervisor whose interrupt() raises and which owes no completion.
+
+    Models a compute host that is gone (broken pipe, respawn exhausted): no
+    ``turn.end`` can ever arrive to clear ``running``.
+    """
+
+    def __init__(self, pending_sids=()):
+        self._lock = threading.Lock()
+        self._pending_sids = set(pending_sids)
+
+    def interrupt(self, sid, *, request_id=None):
+        raise RuntimeError("compute host is not running")
+
+    def has_pending_turn(self, sid):
+        with self._lock:
+            return sid in self._pending_sids
+
+
+def test_compute_host_interrupt_failure_clears_stuck_running(monkeypatch):
+    """A dead compute host must not leave `running` stuck after Stop.
+
+    Nothing will deliver `turn.end`, so bailing out with 5019 left the session
+    busy forever: every later prompt.submit fell into the busy path and queued.
+    """
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        queued_prompt={"text": "stale next", "transport": None},
+        inflight_turn={"user": "hi", "assistant": "", "streaming": True},
+    )
+    server._sessions["iso-int-dead"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _DeadComputeHost())
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-dead",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-dead"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is False
+        assert session.get("_turn_cancel_requested") is True
+        assert session.get("queued_prompt") is None
+        assert session.get("inflight_turn") is None
+    finally:
+        server._sessions.pop("iso-int-dead", None)
+
+
+def test_compute_host_interrupt_failure_leaves_running_when_turn_pending(monkeypatch):
+    """A still-registered host completion owns teardown — don't pre-empt it."""
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        inflight_turn={"user": "hi", "assistant": "", "streaming": True},
+    )
+    server._sessions["iso-int-pending"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(
+        server,
+        "_get_compute_host_supervisor",
+        lambda _cfg=None: _DeadComputeHost(pending_sids=("iso-int-pending",)),
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-pending",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-pending"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is True
+        assert session.get("_turn_cancel_requested") is True
+        assert session.get("inflight_turn") is not None
+    finally:
+        server._sessions.pop("iso-int-pending", None)
+
+
+def test_compute_host_interrupt_failure_leaves_running_after_teardown(monkeypatch):
+    """Once the turn is torn down, `running` belongs to the drain, not to Stop."""
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        # The crash waiter already cleared inflight; a successor drain may have
+        # claimed `running` for the queued prompt it is about to send.
+        inflight_turn=None,
+    )
+    server._sessions["iso-int-post"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _DeadComputeHost())
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-post",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-post"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is True
+        assert session.get("_turn_cancel_requested") is True
+    finally:
+        server._sessions.pop("iso-int-post", None)
+
+
+def test_compute_host_interrupt_failure_does_not_clobber_replaced_inflight(monkeypatch):
+    """A successor turn can replace inflight before its pending entry lands."""
+    old_inflight = {"user": "old", "assistant": "", "streaming": True}
+    new_inflight = {"user": "new", "assistant": "", "streaming": True}
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        inflight_turn=old_inflight,
+    )
+    server._sessions["iso-int-race"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+
+    host = _DeadComputeHost()
+
+    def _interrupt_and_swap(sid, *, request_id=None):
+        # prompt.submit replaces inflight after history_lock is released and
+        # before submit_turn registers the pending entry.
+        with session["history_lock"]:
+            session["inflight_turn"] = new_inflight
+            session["_turn_cancel_requested"] = False
+        raise RuntimeError("compute host is not running")
+
+    host.interrupt = _interrupt_and_swap
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: host)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-race",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-race"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is True
+        assert session.get("inflight_turn") is new_inflight
+        assert session.get("_turn_cancel_requested") is True
+    finally:
+        server._sessions.pop("iso-int-race", None)
+
+
+def test_compute_host_supervisor_reports_pending_turn_per_session():
+    """The liveness probe the recovery reads: registered ⇒ True, popped ⇒ False."""
+    from tui_gateway.host_supervisor import HostSupervisor
+
+    # Bypass __init__: constructing a real supervisor would spawn a child.
+    supervisor = HostSupervisor.__new__(HostSupervisor)
+    supervisor._lock = threading.RLock()
+    supervisor._pending_turns = {"req-a": ("sid-a", None), "req-b": ("sid-b", None)}
+
+    assert supervisor.has_pending_turn("sid-a") is True
+    assert supervisor.has_pending_turn("sid-b") is True
+    assert supervisor.has_pending_turn("sid-c") is False
+
+    supervisor._pending_turns.pop("req-a")
+    assert supervisor.has_pending_turn("sid-a") is False
+
+
 def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
     session = _session(
         agent=None,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -401,6 +401,183 @@ def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monke
     assert session.get("_compute_host_active") is not True
 
 
+class _DeadComputeHost:
+    """Supervisor whose interrupt() raises and which owes no completion.
+
+    Models a compute host that is gone (broken pipe, respawn exhausted): no
+    ``turn.end`` can ever arrive to clear ``running``.
+    """
+
+    def __init__(self, pending_sids=()):
+        self._lock = threading.Lock()
+        self._pending_sids = set(pending_sids)
+
+    def interrupt(self, sid, *, request_id=None):
+        raise RuntimeError("compute host is not running")
+
+    def has_pending_turn(self, sid):
+        with self._lock:
+            return sid in self._pending_sids
+
+
+def test_compute_host_interrupt_failure_clears_stuck_running(monkeypatch):
+    """A dead compute host must not leave `running` stuck after Stop.
+
+    Nothing will deliver `turn.end`, so bailing out with 5019 left the session
+    busy forever: every later prompt.submit fell into the busy path and queued.
+    """
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        queued_prompt={"text": "stale next", "transport": None},
+        inflight_turn={"user": "hi", "assistant": "", "streaming": True},
+    )
+    server._sessions["iso-int-dead"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _DeadComputeHost())
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-dead",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-dead"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is False
+        assert session.get("_turn_cancel_requested") is True
+        assert session.get("queued_prompt") is None
+        assert session.get("inflight_turn") is None
+    finally:
+        server._sessions.pop("iso-int-dead", None)
+
+
+def test_compute_host_interrupt_failure_leaves_running_when_turn_pending(monkeypatch):
+    """A still-registered host completion owns teardown — don't pre-empt it."""
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        inflight_turn={"user": "hi", "assistant": "", "streaming": True},
+    )
+    server._sessions["iso-int-pending"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(
+        server,
+        "_get_compute_host_supervisor",
+        lambda _cfg=None: _DeadComputeHost(pending_sids=("iso-int-pending",)),
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-pending",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-pending"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is True
+        assert session.get("_turn_cancel_requested") is True
+        assert session.get("inflight_turn") is not None
+    finally:
+        server._sessions.pop("iso-int-pending", None)
+
+
+def test_compute_host_interrupt_failure_leaves_running_after_teardown(monkeypatch):
+    """Once the turn is torn down, `running` belongs to the drain, not to Stop."""
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        # The crash waiter already cleared inflight; a successor drain may have
+        # claimed `running` for the queued prompt it is about to send.
+        inflight_turn=None,
+    )
+    server._sessions["iso-int-post"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _DeadComputeHost())
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-post",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-post"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is True
+        assert session.get("_turn_cancel_requested") is True
+    finally:
+        server._sessions.pop("iso-int-post", None)
+
+
+def test_compute_host_interrupt_failure_does_not_clobber_replaced_inflight(monkeypatch):
+    """A successor turn can replace inflight before its pending entry lands."""
+    old_inflight = {"user": "old", "assistant": "", "streaming": True}
+    new_inflight = {"user": "new", "assistant": "", "streaming": True}
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        running=True,
+        _compute_host_active=True,
+        inflight_turn=old_inflight,
+    )
+    server._sessions["iso-int-race"] = session
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+
+    host = _DeadComputeHost()
+
+    def _interrupt_and_swap(sid, *, request_id=None):
+        # prompt.submit replaces inflight after history_lock is released and
+        # before submit_turn registers the pending entry.
+        with session["history_lock"]:
+            session["inflight_turn"] = new_inflight
+            session["_turn_cancel_requested"] = False
+        raise RuntimeError("compute host is not running")
+
+    host.interrupt = _interrupt_and_swap
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: host)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "int-race",
+                "method": "session.interrupt",
+                "params": {"session_id": "iso-int-race"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted", "turn_isolation": True}
+        assert session["running"] is True
+        assert session.get("inflight_turn") is new_inflight
+        assert session.get("_turn_cancel_requested") is True
+    finally:
+        server._sessions.pop("iso-int-race", None)
+
+
+def test_compute_host_supervisor_reports_pending_turn_per_session():
+    """The liveness probe the recovery reads: registered ⇒ True, popped ⇒ False."""
+    from tui_gateway.host_supervisor import HostSupervisor
+
+    # Bypass __init__: constructing a real supervisor would spawn a child.
+    supervisor = HostSupervisor.__new__(HostSupervisor)
+    supervisor._lock = threading.RLock()
+    supervisor._pending_turns = {"req-a": ("sid-a", None), "req-b": ("sid-b", None)}
+
+    assert supervisor.has_pending_turn("sid-a") is True
+    assert supervisor.has_pending_turn("sid-b") is True
+    assert supervisor.has_pending_turn("sid-c") is False
+
+    supervisor._pending_turns.pop("req-a")
+    assert supervisor.has_pending_turn("sid-a") is False
+
+
 def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
     # _session_info embeds get_update_result(), whose value flips whenever the
     # background update-check thread happens to finish. This test compares two

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11272,7 +11272,15 @@ def test_interrupt_drops_queued_prompt_for_session():
 
 
 def test_interrupt_before_agent_ready_prevents_late_turn_start(monkeypatch):
-    """Stop during lazy agent startup must not start the turn after init finishes."""
+    """Stop during lazy agent startup must not start the turn after init finishes.
+
+    `agent_ready` is a real, never-set Event here, exactly as `session.create`
+    seeds it while the deferred build is in flight, and `_wait_agent` is NOT
+    stubbed. Both matter: stubbing `_wait_agent` — or leaving `agent_ready`
+    absent, which makes it return immediately anyway — hides the wait this test
+    exists to rule out, and `session.interrupt` would then be free to block on
+    the very build it is cancelling without failing anything here.
+    """
     threads = []
     calls = {"run_prompt": 0}
 
@@ -11289,6 +11297,7 @@ def test_interrupt_before_agent_ready_prevents_late_turn_start(monkeypatch):
 
     session = _session()
     session["agent"] = None
+    session["agent_ready"] = threading.Event()
     server._sessions["sid"] = session
 
     try:
@@ -11297,7 +11306,6 @@ def test_interrupt_before_agent_ready_prevents_late_turn_start(monkeypatch):
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
-        monkeypatch.setattr(server, "_wait_agent", lambda session, rid: None)
         monkeypatch.setattr(
             server,
             "_run_prompt_submit",
@@ -11322,6 +11330,9 @@ def test_interrupt_before_agent_ready_prevents_late_turn_start(monkeypatch):
         )
         assert stop.get("result"), f"got error: {stop.get('error')}"
 
+        # The build now completes — this is the "after init finishes" the
+        # docstring names, and it releases the deferred waiter immediately.
+        session["agent_ready"].set()
         threads[0].target()
 
         assert calls["run_prompt"] == 0
@@ -11341,6 +11352,11 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
     so the Desktop composer can show feedback instead of hanging on a
     `{"status":"streaming"}` reply that never produces a turn (issue #63078
     server-side half).
+
+    Like that sibling, this runs against a real never-set `agent_ready` with
+    `_wait_agent` unstubbed, so the `_turn_cancel_requested` assertion below
+    genuinely pins that Stop records the cancellation while the build is still
+    in flight rather than erroring out ahead of it.
     """
     threads = []
     emitted = []
@@ -11359,6 +11375,7 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
 
     session = _session()
     session["agent"] = None
+    session["agent_ready"] = threading.Event()
     server._sessions["sid"] = session
 
     try:
@@ -11367,7 +11384,6 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
-        monkeypatch.setattr(server, "_wait_agent", lambda session, rid: None)
         monkeypatch.setattr(
             server,
             "_run_prompt_submit",
@@ -11393,8 +11409,10 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
         assert stop.get("result"), f"got error: {stop.get('error')}"
         assert session.get("_turn_cancel_requested") is True
 
-        # The deferred run thread now wakes up; without the emit it would bail
-        # silently and the Desktop would never learn the turn was dropped.
+        # The build completes and the deferred run thread wakes up; without the
+        # emit it would bail silently and the Desktop would never learn the turn
+        # was dropped.
+        session["agent_ready"].set()
         threads[0].target()
 
         assert calls["run_prompt"] == 0

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11493,6 +11493,79 @@ def test_session_not_running_before_agent_ready_emits_error_event(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_interrupt_never_waits_on_the_deferred_agent_build(monkeypatch):
+    """Stop must resolve its session without blocking on the in-flight build.
+
+    `_wait_agent` sits on `agent_ready` for up to 30s — the same Event the build
+    being cancelled has not set yet — and `session.interrupt` is not in
+    `_LONG_HANDLERS`, so it runs inline on the socket reader thread and takes
+    every RPC queued behind it down with it. Counting the call pins that
+    directly and fails in milliseconds, where the end-to-end tests above can
+    only catch a regression by actually spending the 30 seconds.
+    """
+    seen = {"wait": 0}
+    session = _session(running=True)
+    session["agent"] = None
+    session["agent_ready"] = threading.Event()
+    server._sessions["sid-nowait"] = session
+    monkeypatch.setattr(
+        server, "_wait_agent", lambda *_args, **_kwargs: seen.__setitem__("wait", seen["wait"] + 1)
+    )
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.interrupt",
+                "params": {"session_id": "sid-nowait"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted"}, f"got error: {resp.get('error')}"
+        assert seen["wait"] == 0
+        # The flag the deferred waiter polls before it starts the turn.
+        assert session.get("_turn_cancel_requested") is True
+        # Stop must not have needed the build to finish to get there.
+        assert session["agent_ready"].is_set() is False
+    finally:
+        server._sessions.pop("sid-nowait", None)
+
+
+def test_interrupt_recovers_a_session_whose_agent_build_failed(monkeypatch):
+    """A failed build must not leave Stop as the one thing that cannot run.
+
+    `_wait_agent` returns 5032 for a set `agent_ready` too, whenever
+    `agent_error` is populated — so once a build failed, `session.interrupt`
+    errored out before reaching the cancel/`running` cleanup below it. Nothing
+    else clears `running` on that path, so the session stayed busy: every later
+    prompt.submit hit the busy branch and queued, with no way back short of a
+    backend restart. This is the same permanent-busy trap the compute-host
+    branch guards against, reached through the in-process branch instead.
+    """
+    session = _session(running=True)
+    session["agent"] = None
+    ready = threading.Event()
+    ready.set()  # the build finished — it just finished by failing
+    session["agent_ready"] = ready
+    session["agent_error"] = "provider metadata fetch failed"
+    server._sessions["sid-failed"] = session
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.interrupt",
+                "params": {"session_id": "sid-failed"},
+            }
+        )
+        assert resp.get("result") == {"status": "interrupted"}, f"got error: {resp.get('error')}"
+        assert session.get("_turn_cancel_requested") is True
+        assert session["running"] is False
+    finally:
+        server._sessions.pop("sid-failed", None)
+
+
 def test_slow_agent_build_delivers_prompt_instead_of_timing_out(monkeypatch):
     """#63078 server-side half: a deferred build slower than the old 30s
     ``_wait_agent`` cliff must NOT eat the first message. The patient wait

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -270,6 +270,17 @@ class HostSupervisor:
         self.start()
         self._send_frame({"type": "interrupt", "sid": sid, "request_id": request_id or uuid.uuid4().hex})
 
+    def has_pending_turn(self, sid: str) -> bool:
+        """True when a host completion callback is still registered for ``sid``.
+
+        Read by the serving process to tell "the host still owes this session a
+        terminal frame" from "nothing will ever call back for it". Entries are
+        added in :meth:`submit_turn` and removed by :meth:`_complete_turn` or
+        :meth:`_fail_pending_turns`, all under ``self._lock``.
+        """
+        with self._lock:
+            return any(s == sid for s, _cb in self._pending_turns.values())
+
     def reload_mcp(self, sid: str, *, request_id: str | None = None) -> dict:
         return self.control(
             sid,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2713,16 +2713,56 @@ def _(rid, params: dict) -> dict:
         return err
     if _session_uses_compute_host(session):
         sid = str(params.get("session_id") or "")
+        # A host that is gone (broken pipe, respawn exhausted) can never deliver
+        # the turn.end that clears `running`, so returning an error here left the
+        # session permanently busy: every later prompt.submit fell into
+        # _handle_busy_submit and queued forever, with no way back short of a
+        # backend restart. Recover instead — the same safety net the in-process
+        # branch below applies when the run thread is already gone.
+        host_unreachable = False
+        inflight_at_interrupt = None
         if session.get("running"):
+            with session["history_lock"]:
+                inflight_at_interrupt = session.get("inflight_turn")
             try:
                 _get_compute_host_supervisor().interrupt(sid, request_id=f"interrupt-{rid}")
             except Exception as exc:
-                return _err(rid, 5019, f"compute-host interrupt failed: {exc}")
+                host_unreachable = True
+                logger.warning("session.interrupt: compute-host interrupt failed for %s: %s", sid, exc)
+        # Probe BEFORE taking history_lock: the surrounding code holds the
+        # invariant that a compute-host call is never made under that lock, since
+        # an interrupt can wait behind the very operation it is cancelling.
+        pending_for_sid = True
+        if host_unreachable:
+            try:
+                pending_for_sid = _get_compute_host_supervisor().has_pending_turn(sid)
+            except Exception as exc:
+                # Fail closed. An unreadable supervisor is not evidence the turn
+                # is over, and force-clearing on a guess would drop a live turn's
+                # own teardown on the floor.
+                logger.warning(
+                    "session.interrupt: compute-host pending-turn probe failed for %s: %s", sid, exc
+                )
+                pending_for_sid = True
         with session["history_lock"]:
             session["_turn_cancel_requested"] = True
             session["queued_prompt"] = None
             session.pop("queued_prompts", None)
             session["_queued_prompt_generation"] = int(session.get("_queued_prompt_generation", 0)) + 1
+            # Re-checked under the lock: a completion callback may have landed
+            # since the probe, and a successor submit/drain may already own
+            # `running` with a fresh inflight dict. Only clear the turn this Stop
+            # actually observed.
+            inflight_now = session.get("inflight_turn")
+            if (
+                host_unreachable
+                and not pending_for_sid
+                and session.get("running")
+                and inflight_now is not None
+                and inflight_now is inflight_at_interrupt
+            ):
+                session["running"] = False
+                _clear_inflight_turn(session)
         _clear_pending(sid)
         try:
             from tools.approval import resolve_gateway_approval

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3027,16 +3027,56 @@ def _(rid, params: dict) -> dict:
         return err
     if _session_uses_compute_host(session):
         sid = str(params.get("session_id") or "")
+        # A host that is gone (broken pipe, respawn exhausted) can never deliver
+        # the turn.end that clears `running`, so returning an error here left the
+        # session permanently busy: every later prompt.submit fell into
+        # _handle_busy_submit and queued forever, with no way back short of a
+        # backend restart. Recover instead — the same safety net the in-process
+        # branch below applies when the run thread is already gone.
+        host_unreachable = False
+        inflight_at_interrupt = None
         if session.get("running"):
+            with session["history_lock"]:
+                inflight_at_interrupt = session.get("inflight_turn")
             try:
                 _get_compute_host_supervisor().interrupt(sid, request_id=f"interrupt-{rid}")
             except Exception as exc:
-                return _err(rid, 5019, f"compute-host interrupt failed: {exc}")
+                host_unreachable = True
+                logger.warning("session.interrupt: compute-host interrupt failed for %s: %s", sid, exc)
+        # Probe BEFORE taking history_lock: the surrounding code holds the
+        # invariant that a compute-host call is never made under that lock, since
+        # an interrupt can wait behind the very operation it is cancelling.
+        pending_for_sid = True
+        if host_unreachable:
+            try:
+                pending_for_sid = _get_compute_host_supervisor().has_pending_turn(sid)
+            except Exception as exc:
+                # Fail closed. An unreadable supervisor is not evidence the turn
+                # is over, and force-clearing on a guess would drop a live turn's
+                # own teardown on the floor.
+                logger.warning(
+                    "session.interrupt: compute-host pending-turn probe failed for %s: %s", sid, exc
+                )
+                pending_for_sid = True
         with session["history_lock"]:
             session["_turn_cancel_requested"] = True
             session["queued_prompt"] = None
             session.pop("queued_prompts", None)
             session["_queued_prompt_generation"] = int(session.get("_queued_prompt_generation", 0)) + 1
+            # Re-checked under the lock: a completion callback may have landed
+            # since the probe, and a successor submit/drain may already own
+            # `running` with a fresh inflight dict. Only clear the turn this Stop
+            # actually observed.
+            inflight_now = session.get("inflight_turn")
+            if (
+                host_unreachable
+                and not pending_for_sid
+                and session.get("running")
+                and inflight_now is not None
+                and inflight_now is inflight_at_interrupt
+            ):
+                session["running"] = False
+                _clear_inflight_turn(session)
         _clear_pending(sid)
         try:
             from tools.approval import resolve_gateway_approval

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3085,7 +3085,22 @@ def _(rid, params: dict) -> dict:
         except Exception:
             pass
         return _ok(rid, {"status": "interrupted", "turn_isolation": True})
-    session, err = _sess(params, rid)
+    # Resolve WITHOUT waiting on the deferred agent build. `_sess` calls
+    # `_wait_agent`, which blocks up to 30s on the very `agent_ready` Event the
+    # build being cancelled is holding — so Stop waited on its own target. Two
+    # ways that hurt, both on the default path (`session.create` always seeds
+    # `agent: None` + an unset `agent_ready`, and `prompt.submit` returns before
+    # the build finishes):
+    #   * build completes under 30s -> Stop is merely late, but `session.interrupt`
+    #     is not in `_LONG_HANDLERS`, so it runs inline on the socket reader thread
+    #     and every RPC queued behind it stalls too.
+    #   * build outlives 30s -> `_wait_agent` returns 5032 and we bail out HERE,
+    #     before `_turn_cancel_requested` is ever set. `_wait_agent_for_prompt`
+    #     then polls that unset flag up to `agent.build_wait_timeout` (600s) and
+    #     starts the turn anyway: the cancelled message runs.
+    # Nothing above needs a built agent, so resolve the record and let the build
+    # keep warming in the background.
+    session, err = _sess_building(params, rid)
     if err:
         return err
     # Safety net: if the turn's run thread is already gone but `running` stayed
@@ -3103,7 +3118,11 @@ def _(rid, params: dict) -> dict:
         session["queued_prompt"] = None
         session.pop("queued_prompts", None)
         session["_queued_prompt_generation"] = int(session.get("_queued_prompt_generation", 0)) + 1
-    if should_interrupt:
+    # `agent` is None while the deferred build is still in flight — newly
+    # reachable here now that we no longer wait for it. There is nothing to
+    # interrupt yet; `_turn_cancel_requested` (set above) is what the build's
+    # waiter checks before it starts the turn.
+    if should_interrupt and session.get("agent") is not None:
         from agent.interrupt_compat import request_hard_interrupt
 
         request_hard_interrupt(session["agent"])


### PR DESCRIPTION
## This supersedes #71825 (same bug, current code)

#71825 reported this bug correctly, and its shape is the right one — this PR carries it over. It cannot land as filed, for a structural reason rather than a staleness one:

- Its production hunk is `tui_gateway/server.py @@ -10252,14 +10252,44`, but commit `f67ca22` moved the session RPC bodies out of `server.py` into `tui_gateway/methods_session.py`. On `main` today, `git show origin/main:tui_gateway/server.py | grep -c 'method("session.interrupt")'` → **0**. The handler it patches is not the handler that runs; `server.py:10252` is now unrelated `display.tool_progress` focus-config code.
- That is why GitHub currently reports #71825 as `mergeable: CONFLICTING` / `mergeStateStatus: DIRTY`.

Its `HostSupervisor.has_pending_turn()` addition still applies cleanly and is kept here essentially verbatim. Its four regression cases are ported by hand (its test hunk anchors at `@@ -322` of a file that is now 15,282 lines).

## What does this PR do?

`session.interrupt` on a turn-isolation session calls `HostSupervisor.interrupt()` and, on failure, returns `5019` immediately:

```python
if _session_uses_compute_host(session):
    sid = str(params.get("session_id") or "")
    if session.get("running"):
        try:
            _get_compute_host_supervisor().interrupt(sid, request_id=f"interrupt-{rid}")
        except Exception as exc:
            return _err(rid, 5019, f"compute-host interrupt failed: {exc}")   # ← early return
    with session["history_lock"]:
        session["_turn_cancel_requested"] = True
        session["queued_prompt"] = None
    _clear_pending(sid)
    ...
```

`HostSupervisor.interrupt()` calls `start()` and then `_send_frame()`, so a host that is gone — broken pipe, respawn exhausted — makes it raise. The early return then skips **every** recovery step below it: `_turn_cancel_requested` is never latched, `queued_prompt` is never cleared, `_clear_pending(sid)` never runs, pending approvals are never denied, and `session["running"]` is left `True`.

Because the host is dead, no `turn.end` will ever arrive to clear busy. Every later `prompt.submit` therefore falls into `_handle_busy_submit` and queues forever. **The user pressed Stop, got an error, and the session is bricked until the backend is restarted.**

### The repo already documents the expectation this branch fails to honour

The in-process branch of the *same function*, ~15 lines below, carries this exact safety net:

> Safety net: if the turn's run thread is already gone but `running` stayed stuck (a crash/desync that skipped the run loop's `finally`), force-clear it so the session can't be permanently bricked at 4009 "session busy" — every send/restore/resume would otherwise reject until a full backend restart.

```python
run_thread = session.get("_run_thread")
run_thread_alive = run_thread is not None and run_thread.is_alive()
...
if not run_thread_alive:
    with session["history_lock"]:
        if session.get("running"):
            session["running"] = False
            _clear_inflight_turn(session)
```

The fix is derived from that idiom. The only thing that differs is the liveness probe: `not run_thread_alive` becomes `not supervisor.has_pending_turn(sid)`.

## The same handler's in-process branch had a second way to strand Stop

Everything above is the `turn_isolation` path. `turn_isolation` defaults to **`False`** in `hermes_cli/config_defaults.py`, so the branch almost every session actually takes is the in-process one directly below it — and it stranded Stop too, for an unrelated reason.

It resolved its session through `_sess`:

```python
session, err = _sess(params, rid)
if err:
    return err
```

`_sess` is `_sess_building` plus `_wait_agent`, and `_wait_agent` blocks up to **30 seconds** on `session["agent_ready"]`:

```python
def _wait_agent(session: dict, rid: str, timeout: float = 30.0) -> dict | None:
    ready = session.get("agent_ready")
    if ready is not None and not ready.wait(timeout=timeout):
        return _err(rid, 5032, "agent initialization timed out")
    err = session.get("agent_error")
    return _err(rid, 5032, err) if err else None
```

That is the same Event the deferred build has not set yet. **Stop waited on the build it was cancelling.**

This is the default path, not an edge case: `session.create` unconditionally seeds `"agent": None` alongside an unset `agent_ready`, and `prompt.submit` marks the session running and returns before the build completes.

Three consequences, all user-visible:

| situation | result |
|---|---|
| build finishes inside 30s | Stop is late — and `session.interrupt` is **not** in `_LONG_HANDLERS`, so it runs inline on the socket reader thread and every RPC queued behind it is stalled with it. |
| build outlives 30s | `_wait_agent` returns `5032` and the handler returns **before `_turn_cancel_requested` is ever set**. `_wait_agent_for_prompt` then polls a flag nobody set, for up to `agent.build_wait_timeout` (default 600s), and goes on to call `_run_prompt_submit`. **The turn the user cancelled runs anyway.** |
| build already failed | `_wait_agent` returns `5032` from its `agent_error` branch even for a *set* `agent_ready`. Stop errors out before the cleanup below it, and nothing else clears `running` — the session is permanently busy, which is exactly the trap the compute-host half of this PR guards against, reached through the other branch. |

### The repo states this remedy against itself

`_sess_building` exists precisely for handlers in this position, and its own docstring makes the argument:

> Resolve a session and warm its agent build WITHOUT waiting for it. For handlers that need the session record but not the agent. … `_sess`'s `_wait_agent` was buying nothing and charging up to 30 seconds for it.

`_LONG_HANDLERS`' own comment names this RPC as one that must not be left waiting:

> keep them off the main stdin loop so a slow portal can't stall `approval.respond` / `session.interrupt` / other RPCs.

And `_wait_agent_for_prompt`'s docstring records that the flat 30s `_wait_agent` ceiling was *"a message-eating cliff (#63078)"* — which was fixed for `prompt.submit` and left in place for `session.interrupt`.

The commit that introduced `_sess_building` (*"fix: attach RPCs no longer wait on the deferred agent build"*) converted the six **attach** RPCs — `clipboard.paste`, `image.attach`, `image.attach_bytes`, `pdf.attach`, `file.attach`, `image.detach` — and did not sweep the control RPCs. This is that sweep, for the one control RPC where the wait is self-defeating.

**Note this is not fixed by adding `session.interrupt` to `_LONG_HANDLERS`.** That would unblock the reader thread but leave the 30s delay and the dropped `_turn_cancel_requested` exactly as they are.

### Scope

Deliberately narrow: `session.interrupt`'s in-process branch only. Nothing in that branch needs a built agent — its single agent use, `request_hard_interrupt(session["agent"])`, is now guarded, because `agent is None` while the build is in flight becomes newly reachable once we stop waiting for it. When the agent already exists, `_sess_building` returns immediately and behaviour is byte-identical.

Other handlers share the "needs the session record, not the agent" shape (`approval.*`, `rollback.list` / `rollback.diff`, `process.kill` / `process.list`). They are **not** included here: they are a different concern from *Stop must not leave the session stuck*, and they belong in their own change.

## Related Issue

No issue is filed for this — an issue search across four phrasings returned nothing. Supersedes #71825.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/host_supervisor.py` — add `HostSupervisor.has_pending_turn(sid)`. `_pending_turns` already existed but had no accessor; the new method reads it under the same `self._lock` that guards every mutation of that dict (`submit_turn`, `_complete_turn`, `_fail_pending_turns`).
- `tui_gateway/methods_session.py` — `session.interrupt`'s compute-host branch no longer returns early on interrupt failure. It records the inflight snapshot, logs the failure, falls through to the shared recovery, and force-clears the stuck busy flag under four guards (below). Stop still returns `{"status": "interrupted", "turn_isolation": True}` — from the user's point of view the turn is over either way.
- `tests/test_tui_gateway_server.py` — four regression cases ported from #71825, plus one direct unit test for the new probe. Placed beside the existing compute-host cluster (`test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled`, `..._fails_open_inline_when_compute_host_dispatch_breaks`, `test_compute_host_turn_end_updates_metadata_mirror`) and reusing its `monkeypatch.setattr(server, "_get_compute_host_supervisor", ...)` scaffolding.

For the in-process branch:

- `tui_gateway/methods_session.py` — `session.interrupt`'s in-process branch resolves through `_sess_building` rather than `_sess`, and guards its single agent use for the now-reachable `agent is None` state.
- `tests/test_tui_gateway_server.py` — `test_interrupt_before_agent_ready_prevents_late_turn_start` and `test_cancelled_turn_before_agent_ready_emits_error_event` stop monkeypatching `_wait_agent` and now run against a real, never-set `agent_ready`, so they can actually fail; plus two new cases, `test_interrupt_never_waits_on_the_deferred_agent_build` and `test_interrupt_recovers_a_session_whose_agent_build_failed`.

### The force-clear cannot clobber a live turn

All four must hold:

| guard | what it rules out |
|---|---|
| `host_unreachable` | a successful interrupt — normal teardown still owns the turn |
| `not pending_for_sid` | the supervisor still owes this sid a completion callback; that waiter will clear busy itself |
| `session.get("running")` | already cleared between the probe and the lock |
| `inflight_now is inflight_at_interrupt` (and not `None`) | a successor `prompt.submit` / drain replaced the inflight turn and owns `running` now |

The probe **fails closed**: an exception from `has_pending_turn` sets `pending_for_sid = True`, so an unreadable supervisor leaves teardown to the waiter rather than guessing.

The probe is issued **before** `history_lock` is taken. That honours the invariant stated at the other supervisor-interrupt call site: *"never call a provider or compute-host method while holding history_lock: an interrupt can wait behind the very operation it is trying to cancel."* The guards are then re-evaluated inside the lock, which is what closes the race the probe cannot.

## Sibling sweep — resolved in both directions

Two supervisor-interrupt call sites exist in the corpus (`grep -rn '\.interrupt(' tui_gateway/ hermes_cli/ apps/`), plus the other two `_session_uses_compute_host` branches that return `_err` on host failure:

| site | verdict |
|---|---|
| `methods_session.py`, `session.interrupt` | **IN** — the defect above. |
| `server.py`, `_interrupt_busy_session` | **OUT**, four reasons. |
| `methods_session.py`, `session.compress` | **OUT** — returns `_err` on host failure, but does not own the `running` busy flag, so it cannot strand the session. |
| `methods_session.py`, `session.save` | **OUT** — same: no `running` ownership. |

`_interrupt_busy_session` swallows the same failure with a bare `except Exception: pass`, so it looks like the same bug from the other direction. It is deliberately not changed:

1. It is a **best-effort interrupt in service of an already-queued prompt**. Its caller runs `_enqueue_prompt(session, text, transport)` under `history_lock` and returns `_ok(rid, {"status": "queued"})`; teardown there is owned by `_drain_queued_prompt`, not by the interrupt.
2. The failure is swallowed inside a **daemon thread** whose `finally` only resets `_busy_interrupt_pending`. There is no `rid` / RPC context in that thread to report a recovery from.
3. Force-clearing `running` from it **could clobber a live successor turn** — `_drain_queued_prompt` claims `running = True` under the lock, and by the time the daemon thread runs the drain may already have started the queued turn.
4. Its caller's own comment states the invariant the site is built around: *"never call a provider or compute-host method while holding history_lock."* Adding state mutation there pushes work into exactly the place the file forbids it.

`session.interrupt` is the opposite case in every respect: an explicit user **Stop**, on the RPC thread, with an `rid`, where ending the turn *is* the intent.

## Related work that is *not* superseded

**#45001** (`fix(desktop+gateway): make "session busy" lock recoverable — AbortSignal + server watchdog`) is complementary, not overlapping. It adds a **time-based stall watchdog** that force-clears `running` + `inflight_turn` after `session.inflight_watchdog_seconds` (default **120s**) of silence. It is strictly weaker on this path and does not replace this fix:

- it clears only `running` / `inflight_turn`, so `_turn_cancel_requested`, `queued_prompt = None`, `_clear_pending(sid)` and the approval resolution are *still* skipped by the dead-host early return;
- the user waits two minutes for a Stop they already pressed.

Its hunks (`server.py@3648/3663/5311/5537`) are pre-refactor and never touch the compute-host branch. Both changes can land independently.

## How to Test

Compute-host half:

```
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/test_tui_gateway_server.py -k "compute_host_interrupt_failure or compute_host_supervisor_reports_pending" -v
```

In-process half:

```
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/test_tui_gateway_server.py -k "before_agent_ready or interrupt_never_waits or interrupt_recovers_a_session" -v
```

Red-before / green-after, measured rather than predicted. Each baseline was restored with `git checkout <parent-commit> -- <path>` — not `git stash`, which is a no-op on an already-committed file and yields a silent false pass:

| case | prod hunk reverted, tests kept | with this PR |
|---|---|---|
| dead host clears stuck `running` | ❌ `5019` returned, `running` stays `True` | ✅ |
| pending turn ⇒ leave `running` | ❌ | ✅ |
| post-teardown ⇒ don't clobber drain | ❌ | ✅ |
| replaced inflight ⇒ don't clobber successor | ❌ | ✅ |
| `has_pending_turn` probe semantics | ❌ `AttributeError` | ✅ |
| `test_interrupt_before_agent_ready_prevents_late_turn_start` | ❌ `5032 agent initialization timed out` | ✅ |
| `test_cancelled_turn_before_agent_ready_emits_error_event` | ❌ `5032 agent initialization timed out` | ✅ |
| `test_interrupt_never_waits_on_the_deferred_agent_build` | ❌ `_wait_agent` called | ✅ |
| `test_interrupt_recovers_a_session_whose_agent_build_failed` | ❌ `5032 provider metadata fetch failed` | ✅ |

The two end-to-end interrupt cases each spend a real 30 seconds before failing against the reverted file (60.79s for the pair) and pass in under a second with the fix — the wait *is* the defect, so the clock is part of the evidence. The two new cases fail in 0.43s, because they assert the invariant directly instead of one of its symptoms.

`test_session_not_running_before_agent_ready_emits_error_event` carries the same `_wait_agent` stub but is deliberately left untouched: it never calls `session.interrupt` (it clears `running` directly), so the stub is unreachable in it. It stays green on both sides of the change, which makes it the control for the two that flip.

Full file: **580 passed**. `tests/tui_gateway/`: **472 passed**. `ruff check` clean on both touched files.

Manual reproduction, compute-host half: enable `dashboard.turn_isolation`, start a turn, kill the `python -m tui_gateway.compute_host` child, press Stop. Before: `compute-host interrupt failed`, and every subsequent message is silently queued forever. After: Stop succeeds, the composer is usable again, and the failure is logged.

Manual reproduction, in-process half: leave `turn_isolation` at its default, start a **fresh** session so the deferred build is still running (a cold MCP discovery makes this easy to hit), send the first message, and press Stop immediately. Before: the UI is unresponsive for up to 30 seconds, Stop reports `agent initialization timed out`, and the message you cancelled is then sent anyway once the build lands. After: Stop returns immediately and the turn never starts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Contract Protected

**Invariant:** a compute-host `session.interrupt` never leaves `session["running"]` set when no host completion can ever clear it.

- **Known-bad input:** `HostSupervisor.interrupt()` raises (dead child, respawn exhausted, broken pipe) while `running is True` — previously returned `5019` and stranded the session.
- **Future-input coverage:** the recovery keys off the failure of the interrupt call itself, not off any specific exception type or message, so a new failure mode inside `start()` / `_send_frame()` is covered without a code change.
- **Negative cases:** a live pending completion, an already-torn-down turn, and a replaced inflight turn each leave `running` untouched; a failed probe fails closed to the same outcome.

**Second invariant (in-process branch):** `session.interrupt` never blocks on the deferred agent build, and records `_turn_cancel_requested` regardless of the build's state.

- **Known-bad inputs:** an unset `agent_ready` (build in flight), which cost up to 30 seconds and then dropped the cancel flag entirely on timeout; and a set `agent_ready` with `agent_error` populated (build failed), which dropped it immediately.
- **Future-input coverage:** the handler no longer consults build state at all on this path, so a new build outcome cannot reintroduce the failure. `test_interrupt_never_waits_on_the_deferred_agent_build` asserts `_wait_agent` is not called, which holds independently of whatever `_wait_agent` itself later does.
- **Negative case:** when the agent is already built, `_sess_building` returns immediately and this path is byte-identical to before — covered by the existing in-process interrupt tests, which are unchanged and still green.
