### PR TITLE
fix(delegation): age out 'dropped' records like 'delivered'

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -729,3 +729,42 @@ def test_gateway_cli_origin_event_left_unrouted():
     runner._enrich_async_delegation_routing(evt)
     assert "platform" not in evt
 
+
+
+def test_prune_ages_out_dropped_records_like_delivered(tmp_path, monkeypatch):
+    """'dropped' is terminal (an unroutable row converges there and is never
+    replayed), so the age-based purge must treat it like 'delivered'. It used
+    to skip dropped rows, which then lingered until the size cap overflowed."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    old = time.time() - ad._DURABLE_RETENTION_SECONDS - 60
+
+    for delegation_id, state in (
+        ("deleg_delivered", "delivered"),
+        ("deleg_dropped", "dropped"),
+        ("deleg_pending", "pending"),
+    ):
+        ad._persist_dispatch({
+            "delegation_id": delegation_id,
+            "session_key": "owner",
+            "origin_ui_session_id": "",
+            "parent_session_id": None,
+            "dispatched_at": 1.0,
+        })
+        ad._persist_completion(
+            {"delegation_id": delegation_id, "status": "completed",
+             "completed_at": 2.0},
+            {"status": "completed", "summary": delegation_id},
+        )
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute(
+                "UPDATE async_delegations SET delivery_state=?, updated_at=? "
+                "WHERE delegation_id=?",
+                (state, old, delegation_id),
+            )
+
+    ad._prune_durable_records()
+
+    assert ad.get_durable_delegation("deleg_delivered") is None
+    assert ad.get_durable_delegation("deleg_dropped") is None
+    # An undelivered pending row is never age-purged, no matter how old.
+    assert ad.get_durable_delegation("deleg_pending") is not None

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -236,8 +236,14 @@ def _prune_durable_records() -> None:
     now = time.time()
     cutoff = now - _DURABLE_RETENTION_SECONDS
     with _DB_LOCK, _transaction() as conn:
+        # 'dropped' is a terminal give-up state (an unroutable row converges
+        # here and is never replayed — see the delivery-attempt cap above), so
+        # it is retention-eligible exactly like 'delivered'. Leaving it out of
+        # the age-based purge let dropped rows linger until the size cap
+        # overflowed, instead of aging out with the rest of the history.
         conn.execute(
-            "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?",
+            "DELETE FROM async_delegations "
+            "WHERE delivery_state IN ('delivered', 'dropped') AND updated_at < ?",
             (cutoff,),
         )
         terminal_count = conn.execute(


### PR DESCRIPTION
## Summary
`_prune_durable_records()`'s age-based purge deleted only `delivery_state='delivered'` rows. `'dropped'` is equally terminal — an unroutable completion converges there after the delivery-attempt cap and is never replayed — but dropped rows were skipped by the TTL delete and lingered until the *size cap* overflowed. On a quiet store that never reaches the cap, they lingered indefinitely.

This includes `'dropped'` in the age-based delete. Undelivered `pending` rows remain exempt from age-based pruning, exactly as before — losing an unacknowledged result is the failure the durable ledger exists to prevent.

## Validation
- New test: an over-age dropped row is pruned alongside an over-age delivered one, while an over-age *pending* row survives. Red before the fix, green after.
- Full `tests/tools/test_async_delegation.py`: 20 passed.

## Notes
The size-cap branch already treats all terminal rows uniformly (preferring delivered for deletion) and is unchanged.
