### PR TITLE
fix(cli): scan past invalid closer candidates, require closing fences to have no info string

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2861,9 +2861,101 @@ def _rich_text_from_ansi(text: str) -> _RichText:
     return _RichText.from_ansi(text or "")
 
 
+_FENCE_OPEN_LINE_RE = re.compile(r"^([ \t]{0,3})(`{3,}|~{3,})[ \t]*([^\n`~]*)$")
+# A closing fence may have ONLY whitespace after its marker -- an info
+# string there (e.g. "```python") is not a valid closer per CommonMark,
+# and would otherwise be mistaken for one if content inside a fence
+# happens to look like a fresh opener (review of #75462's second point).
+_FENCE_CLOSE_LINE_RE = re.compile(r"^([ \t]{0,3})(`{3,}|~{3,})[ \t]*$")
+
+# Matches a single line that IS a fence marker (opening, with an optional
+# info string) -- used by the streaming line-by-line strip-mode formatter,
+# which processes one line at a time and can't run the whole-response
+# scan below. Streaming's own closing-line check is separate (see
+# _emit_stream_text): only a line matching _FENCE_CLOSE_LINE_RE's stricter
+# (marker + whitespace-only) shape may close an already-open fence.
+_STREAM_FENCE_LINE_RE = _FENCE_OPEN_LINE_RE
+
+
+def _extract_fenced_blocks(text: str) -> tuple[str, list[str]]:
+    """Replace each validly-closed fenced code block in *text* with a
+    placeholder, returning the modified text and the extracted block
+    contents (in placeholder order).
+
+    Manual line-based scan rather than a single regex pass: a regex
+    callback that rejects an invalid candidate closer (wrong character
+    type, or shorter than the opener) has already consumed that match's
+    span by the time the callback runs, so re.sub resumes scanning AFTER
+    it and can never reach a later, valid closer for the SAME opener
+    (review of #75462's first point) -- e.g. an opening ```` followed by
+    a stray, unrelated ``` line (itself not meant as this block's
+    closer) and then the genuine ```` closer further down. This scan
+    instead keeps looking from the line after each rejected candidate
+    until a valid closer is found or the text ends (falling through to
+    the documented unterminated-fence behavior for that block only).
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    blocks: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        m = _FENCE_OPEN_LINE_RE.match(lines[i])
+        if not m:
+            out.append(lines[i])
+            i += 1
+            continue
+        indent, opener = m.group(1), m.group(2)
+        # Scan forward from the line after the opener for a VALID closer:
+        # same indent, same character type, length >= opener's, and
+        # nothing but whitespace after the marker. Skips any invalid
+        # candidate (too short, wrong type, or carrying an info string)
+        # rather than stopping at the first line that merely looks
+        # fence-marker-shaped.
+        close_at = None
+        j = i + 1
+        while j < n:
+            cm = _FENCE_CLOSE_LINE_RE.match(lines[j])
+            if (
+                cm
+                and cm.group(1) == indent
+                and cm.group(2)[0] == opener[0]
+                and len(cm.group(2)) >= len(opener)
+            ):
+                close_at = j
+                break
+            j += 1
+        if close_at is None:
+            # No valid closer anywhere in the rest of the text: same
+            # documented fallback as before (issue #73217/#75188) --
+            # leave this line as ordinary text and keep scanning; the
+            # unterminated block's content is processed as prose.
+            out.append(lines[i])
+            i += 1
+            continue
+        blocks.append("\n".join(lines[i + 1:close_at]))
+        out.append(f"\x00FENCE{len(blocks) - 1}\x00")
+        i = close_at + 1
+    return "\n".join(out), blocks
+
+
 def _strip_markdown_syntax(text: str) -> str:
     """Best-effort markdown marker removal for plain-text display."""
     plain = _rich_text_from_ansi(text or "").plain
+
+    # Extract fenced code blocks BEFORE any prose-markdown stripping below.
+    # Code content must survive byte-for-byte: the emphasis-stripping regexes
+    # further down (`__x__` -> `x`, `*x*` -> `x`) don't know Python from
+    # prose, so a real docstring/dunder like `__name__` or `__main__` was
+    # being silently corrupted into `name`/`main` when it appeared inside a
+    # fenced block in `strip` mode -- code that ran fine got displayed (and,
+    # if copied, executed) with different semantics (issue #73212). Pull
+    # each fenced block out into a placeholder, run the existing prose
+    # stripping on what's left, then splice the untouched code back in. The
+    # opening fence's language tag (e.g. "python") is dropped entirely in
+    # this plain-text mode rather than left as a stray visible line.
+    plain, code_blocks = _extract_fenced_blocks(plain)
+
     # Avoid stripping cron-style expressions like "* * * * *" as if they were
     # Markdown horizontal rules. CommonMark treats three or more "*" as an HR,
     # but in Hermes output it's common to display cron schedules verbatim.
@@ -2888,6 +2980,20 @@ def _strip_markdown_syntax(text: str) -> str:
     plain = re.sub(r"(?<!\w)_([^_]+)_(?!\w)", r"\1", plain)
     plain = re.sub(r"~~([^~]+)~~", r"\1", plain)
     plain = re.sub(r"\n{3,}", "\n\n", plain)
+
+    # Splice the untouched code blocks back in, byte-for-byte -- no
+    # rstrip("\n") here. An earlier version trimmed trailing newlines off
+    # each captured block before splicing it back, which silently dropped
+    # trailing blank lines that were genuinely part of the fenced content
+    # (review of #73217: "trailing blank lines inside a captured block are
+    # not preserved byte-for-byte"). The block's own captured text
+    # (match.group(4) in _extract_fence above) already excludes the
+    # closing-fence line itself (the regex's trailing ^\1\2 anchor stops
+    # capture there), so there's nothing left to trim -- whatever newlines
+    # are in the captured group are genuinely part of the code content.
+    for i, code in enumerate(code_blocks):
+        plain = plain.replace(f"\x00FENCE{i}\x00", code)
+
     return plain.strip("\n")
 
 
@@ -4343,6 +4449,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # populated only while `_in_stream_table` is True.
         self._stream_table_buf: list[str] = []
         self._in_stream_table = False
+        # True while a streamed fenced code block (```/~~~) is open --
+        # i.e. we've seen the opening fence line but not yet the matching
+        # closing fence line. strip mode must skip prose-markdown
+        # stripping for every line in between, or a real code dunder like
+        # __name__ streamed line-by-line gets corrupted the same way the
+        # whole-response path was before it became fence-aware (issue
+        # #73212's fix didn't cover streaming at all -- review of #73217).
+        self._in_stream_code_fence = False
+        # The fence character ('`' or '~') that opened the current block,
+        # so a same-type closing fence is recognized and a different-type
+        # run of the other character mid-block is not mistaken for a
+        # closer.
+        self._stream_code_fence_char = ""
+        # The opener's marker LENGTH (e.g. 4 for "````"), so a closer must
+        # be at least this long to be recognized -- a shorter closer for a
+        # longer opener is invalid per CommonMark (review of #75188).
+        self._stream_code_fence_len = 0
         self._pending_edit_snapshots = {}
         self._last_input_mode_recovery = 0.0
         self._input_mode_recovery_notice_shown = False
@@ -6697,6 +6820,65 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         while "\n" in self._stream_buf:
             line, self._stream_buf = self._stream_buf.split("\n", 1)
 
+            # Fence detection must run BEFORE table-row buffering. A
+            # fenced code line can coincidentally look like a table row
+            # (e.g. a fence opener/closer, or content inside the fence
+            # like "| __name__ |"), and must never be swallowed into
+            # table buffering -- which invokes markdown stripping on
+            # flush -- while a code fence is open or transitioning
+            # (review of #75188).
+            _fence_transition = False
+            if self.final_response_markdown == "strip":
+                if not self._in_stream_code_fence:
+                    _fence_m = _FENCE_OPEN_LINE_RE.match(line)
+                    if _fence_m:
+                        # Opening fence: mark in-fence and remember which
+                        # character (backtick/tilde) and LENGTH close it.
+                        # This line itself (fence markers + language tag)
+                        # is left unstripped rather than reconstructed
+                        # with the language tag dropped, the way the
+                        # whole-response path does -- streaming can't
+                        # safely rewrite a line already flushed to the
+                        # terminal, so the fence markers stay visible
+                        # here (a minor, intentional difference from the
+                        # whole-response splice behavior).
+                        self._in_stream_code_fence = True
+                        self._stream_code_fence_char = _fence_m.group(2)[0]
+                        self._stream_code_fence_len = len(_fence_m.group(2))
+                        _fence_transition = True
+                else:
+                    # Already inside a fence: only a line with NOTHING but
+                    # whitespace after the marker can close it. A line
+                    # like "```python" here (matching the OPEN regex's
+                    # permissive info-string suffix) is genuine fence
+                    # CONTENT -- e.g. the assistant's own reply showing an
+                    # example fence inside a fence -- not a closer, and
+                    # must not be mistaken for one.
+                    _close_m = _FENCE_CLOSE_LINE_RE.match(line)
+                    if (
+                        _close_m
+                        and _close_m.group(2)[0] == self._stream_code_fence_char
+                        and len(_close_m.group(2)) >= self._stream_code_fence_len
+                    ):
+                        # Closing fence: same character type AND at least
+                        # as long as the opener (a shorter closer, e.g.
+                        # ``` closing ````, is invalid per CommonMark and
+                        # doesn't end the block).
+                        self._in_stream_code_fence = False
+                        self._stream_code_fence_char = ""
+                        self._stream_code_fence_len = 0
+                        _fence_transition = True
+
+            if self._in_stream_code_fence or _fence_transition:
+                # Inside an active fence, or this line IS a fence marker
+                # itself: never buffer as a table row (flush any table
+                # already in progress first -- the fence takes
+                # precedence), and never strip.
+                if self._in_stream_table:
+                    _flush_table_buf()
+                _emit_one(line)
+                continue
+
             # Hold table-shaped lines in a side-buffer so we can re-pad
             # the whole block once it ends.  Streaming line-by-line, we
             # cannot re-align mid-table without reflowing already-printed
@@ -6812,6 +6994,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._deferred_content = ""
         self._stream_table_buf = []
         self._in_stream_table = False
+        self._in_stream_code_fence = False
+        self._stream_code_fence_char = ""
+        self._stream_code_fence_len = 0
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -1,3 +1,4 @@
+import re
 from io import StringIO
 
 from rich.console import Console
@@ -102,3 +103,368 @@ def test_strip_mode_still_strips_boundary_underscore_emphasis():
 
     output = _render_to_text(renderable)
     assert "say hi and bold now" in output
+
+
+# -- Fenced code blocks must survive strip mode literally (issue #73212) ----
+
+def test_strip_mode_preserves_dunder_underscores_inside_fenced_code():
+    """The reporter's exact repro: __name__ must not become name."""
+    renderable = _render_final_assistant_content(
+        "```python\nprint(type(executor).__name__)\n```",
+        mode="strip",
+    )
+    output = _render_to_text(renderable)
+    assert "__name__" in output
+    # The language tag must not appear as a stray visible line.
+    lines = [l.strip() for l in output.splitlines() if l.strip()]
+    assert lines[0] != "python"
+
+
+def test_strip_mode_preserves_dunder_main_guard_inside_fenced_code():
+    renderable = _render_final_assistant_content(
+        '```python\nif __name__ == "__main__":\n    main()\n```',
+        mode="strip",
+    )
+    output = _render_to_text(renderable)
+    assert '__name__ == "__main__"' in output
+
+
+def test_strip_mode_drops_language_tag_line(monkeypatch):
+    """The opening fence's language tag must not be rendered as a plain
+    visible line of output (it was previously left behind verbatim once
+    the backtick fence markers were stripped)."""
+    from cli import _strip_markdown_syntax
+    rendered = _strip_markdown_syntax("```python\nx = 1\n```")
+    lines = [l for l in rendered.splitlines() if l.strip()]
+    assert "python" not in lines
+
+
+def test_strip_mode_preserves_asterisk_emphasis_markers_inside_fenced_code():
+    """Code that happens to contain single/double asterisks (e.g. **kwargs,
+    a docstring with *args) must not have them stripped as Markdown
+    emphasis -- only prose outside code fences gets that treatment."""
+    from cli import _strip_markdown_syntax
+    rendered = _strip_markdown_syntax(
+        "```python\ndef f(*args, **kwargs):\n    pass\n```"
+    )
+    assert "def f(*args, **kwargs):" in rendered
+
+
+def test_strip_mode_preserves_backtick_fence_markers_would_have_removed():
+    """Sanity: without fence-awareness, the bare '(```+|~~~+)' removal
+    regex would strip ALL backtick fences anywhere, including a fence
+    that legitimately appears inside another fenced block's content
+    (e.g. an assistant explaining Markdown syntax). The extracted block's
+    raw text must round-trip untouched."""
+    from cli import _strip_markdown_syntax
+    source = "```text\nUse ``` to start a code fence.\n```"
+    rendered = _strip_markdown_syntax(source)
+    assert "```" in rendered
+
+
+def test_strip_mode_prose_dunder_stripping_still_works_outside_code():
+    """Regression: this fix must not disable emphasis stripping for
+    prose outside code fences -- only protect literal code content."""
+    renderable = _render_final_assistant_content(
+        "say __bold__ now",
+        mode="strip",
+    )
+    output = _render_to_text(renderable)
+    assert "say bold now" in output
+
+
+def test_strip_mode_multiple_fenced_blocks_each_preserved_independently():
+    from cli import _strip_markdown_syntax
+    source = (
+        "First:\n```python\n__version__ = \"1.0\"\n```\n"
+        "Second:\n```python\n__author__ = \"x\"\n```"
+    )
+    rendered = _strip_markdown_syntax(source)
+    assert "__version__" in rendered
+    assert "__author__" in rendered
+
+
+# -- Follow-up fixes per review of #73217 ------------------------------------
+
+def test_strip_mode_preserves_trailing_blank_lines_inside_fenced_block():
+    """Regression: the splice-back loop used to code.rstrip("\\n") each
+    captured block before re-inserting it, silently dropping trailing
+    blank lines that were genuinely part of the fenced content (e.g. a
+    file ending in a blank line, or deliberate spacing before a closing
+    bracket). The block sits mid-response (followed by more prose) so
+    this isolates the splice-back behavior from the unrelated outer
+    plain.strip("\\n") cleanup applied to the whole response boundary."""
+    from cli import _strip_markdown_syntax
+    source = "```python\nx = 1\n\n\n```\nDone."
+    rendered = _strip_markdown_syntax(source)
+    assert "x = 1\n\n\n" in rendered, (
+        f"trailing blank lines inside the fenced block were trimmed: {rendered!r}"
+    )
+
+
+def test_strip_mode_longer_closing_fence_still_recognized():
+    """Regression: a closing fence with MORE backticks than the opener
+    (valid per CommonMark -- the closer only needs to be at least as long
+    as the opener, not exactly equal) must still be recognized as the
+    block's end, protecting the content inside."""
+    from cli import _strip_markdown_syntax
+    source = "```python\nprint(__name__)\n````"
+    rendered = _strip_markdown_syntax(source)
+    assert "__name__" in rendered
+
+
+def test_strip_mode_scans_past_invalid_closer_to_a_later_valid_one():
+    """Regression (review of #75462): a single-pass regex that rejects an
+    invalid candidate closer (wrong type, or shorter than the opener) by
+    returning the whole match unchanged has already CONSUMED that match's
+    span -- so scanning resumes after it and never reaches a later,
+    valid closer for the SAME opener. Here, a stray ``` line (too short
+    for the ```` opener, and not meant as this block's closer at all)
+    appears before the genuine ```` closer further down. The manual scan
+    must skip the invalid candidate and find the later valid one,
+    correctly extracting and protecting the whole block -- not fall
+    through to the unterminated-fence fallback just because the FIRST
+    candidate it found was invalid."""
+    from cli import _strip_markdown_syntax
+    source = "````python\nprint(__name__)\n```\nmore code with __other__ dunder\n````"
+    rendered = _strip_markdown_syntax(source)
+    assert "__name__" in rendered, (
+        f"must scan past the invalid ``` to find the later valid ```` "
+        f"closer, extracting and protecting the whole block: {rendered!r}"
+    )
+    assert "__other__" in rendered, rendered
+    assert "````" not in rendered, (
+        "the fence markers themselves should not leak into the rendered "
+        f"output once the block is correctly extracted: {rendered!r}"
+    )
+
+
+def test_strip_mode_shorter_closer_with_no_later_valid_one_is_unterminated():
+    """Companion to the scan-past-invalid-candidate test above: when
+    there is NO later valid closer anywhere (only a too-short ``` and
+    nothing else), the block genuinely has no valid closer and falls
+    through to the documented unterminated-fence fallback -- __name__ IS
+    affected here (becomes name), because ordinary prose-emphasis
+    stripping runs on it. This is the known, accepted limitation for the
+    undecidable case, distinct from the scan-past-invalid-candidate case
+    where a valid closer DOES exist further down."""
+    from cli import _strip_markdown_syntax
+    source = "````python\nprint(__name__)\n```"
+    rendered = _strip_markdown_syntax(source)
+    assert "__name__" not in rendered, (
+        f"with no valid closer anywhere, the block must not be extracted: {rendered!r}"
+    )
+
+
+def test_strip_mode_unterminated_fence_documented_fallback_behavior():
+    """Regression (review of #73217, cross-referencing #73315): an
+    unterminated fence (opening marker with no matching close anywhere in
+    the text -- e.g. a response cut off mid-code-block) cannot be
+    protected as a literal block, since there's no way to know where it
+    was meant to end. This documents the current, intentional fallback:
+    _extract_fenced_blocks() simply finds no valid closer (the scan
+    reaches the end of the text), so the
+    content is never extracted/protected at all -- the bare fence-marker
+    removal and ordinary prose-emphasis stripping run on it like any
+    other text. A dunder like __name__ IS still affected in this specific
+    corner case (it structurally matches the double-underscore emphasis
+    pattern), unlike a properly-closed block. This is a known, accepted
+    limitation -- not a crash, not silent data loss of the rest of the
+    response, just the pre-#73212 behavior for the one case that can't be
+    disambiguated without a closing fence. Must not raise."""
+    from cli import _strip_markdown_syntax
+    source = "```python\nprint(__name__)"  # no closing fence anywhere
+    rendered = _strip_markdown_syntax(source)  # must not raise
+    assert "```" not in rendered
+    assert "name" in rendered  # __name__ -> name, the known limitation
+
+
+class TestStreamingStripModeFenceState:
+    """Regression tests for issue #73217/#75188's review: strip mode's
+    per-line STREAMING formatter (HermesCLI._emit_stream_text) is a
+    completely separate code path from _strip_markdown_syntax()'s
+    whole-response handling -- it processes one line at a time as chunks
+    arrive and has no visibility into the full response, so the
+    fence-awareness fix didn't cover it at all. A fenced __name__
+    streamed line-by-line remained corrupted even after #73212's fix
+    landed.
+
+    Drives the REAL _emit_stream_text()/_reset_stream_state() methods
+    (not a hand-rolled duplicate of the fence-detection conditional), so
+    production-only ordering -- e.g. table-row buffering happening before
+    fence detection -- is actually covered.
+    """
+
+    def _make_cli(self):
+        """Minimal HermesCLI instance with just enough state for
+        _emit_stream_text() to run without a full construction."""
+        import cli as cli_mod
+        obj = object.__new__(cli_mod.HermesCLI)
+        obj.final_response_markdown = "strip"
+        obj._stream_buf = ""
+        obj._stream_started = True
+        obj._stream_box_opened = True
+        obj._stream_table_buf = []
+        obj._in_stream_table = False
+        obj._in_stream_code_fence = False
+        obj._stream_code_fence_char = ""
+        obj._stream_code_fence_len = 0
+        obj._reasoning_preview_buf = ""
+        obj._reasoning_box_opened = False
+        obj._reasoning_buf = ""
+        obj._deferred_content = ""
+        obj.show_reasoning = False
+        obj.show_timestamps = False
+        return obj
+
+    def _feed_and_capture(self, monkeypatch, obj, chunks):
+        """Feed `chunks` through the real _emit_stream_text(), capturing
+        every printed line via a patched cli._cprint. Strips the padding/
+        ANSI wrapper _emit_one() adds so assertions can check line content
+        directly."""
+        import cli as cli_mod
+
+        printed = []
+        monkeypatch.setattr(cli_mod, "_cprint", lambda text: printed.append(text))
+
+        for chunk in chunks:
+            obj._emit_stream_text(chunk)
+
+        lines = []
+        for text in printed:
+            # _emit_one() wraps each line as f"{_STREAM_PAD}{...}{_RST}" or
+            # f"{_STREAM_PAD}{_tc}{...}{_RST}" -- strip the pad prefix and
+            # any trailing ANSI reset/color codes to get the raw line.
+            stripped = text
+            if stripped.startswith(cli_mod._STREAM_PAD):
+                stripped = stripped[len(cli_mod._STREAM_PAD):]
+            stripped = re.sub(r"\x1b\[[0-9;]*m", "", stripped)
+            lines.append(stripped)
+        return lines
+
+    def test_dunder_survives_when_fence_and_code_arrive_in_separate_chunks(
+        self, monkeypatch
+    ):
+        """The exact scenario the review flagged: streamed content is
+        split at each newline and each line stripped independently, with
+        no memory of a fence opened on a PREVIOUS chunk."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(
+            monkeypatch, obj,
+            ["```python\n", "print(type(x).__name__)\n", "```\n"],
+        )
+        assert any("__name__" in l for l in emitted), emitted
+        assert not any(l.strip() == "__main__" for l in emitted)
+
+    def test_fence_state_persists_across_multiple_stream_chunks(self, monkeypatch):
+        """A single line of code split mid-token across two separate
+        streamed deltas (the buffer only flushes complete lines, so this
+        exercises accumulation) must still be protected once the line is
+        complete, and fence state must still be correctly open."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(monkeypatch, obj, ["```python\n"])
+        assert obj._in_stream_code_fence is True
+        assert obj._stream_code_fence_char == "`"
+        assert obj._stream_code_fence_len == 3
+
+        emitted += self._feed_and_capture(
+            monkeypatch, obj, ['if __name__ == "__main__":\n']
+        )
+        assert obj._in_stream_code_fence is True
+        assert any('__name__ == "__main__"' in l for l in emitted), emitted
+
+        self._feed_and_capture(monkeypatch, obj, ["```\n"])
+        assert obj._in_stream_code_fence is False
+
+    def test_prose_outside_stream_fence_still_stripped(self, monkeypatch):
+        """Sanity: this fix must not disable stripping for ordinary
+        streamed prose lines outside any fence."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(monkeypatch, obj, ["say __bold__ now\n"])
+        assert emitted == ["say bold now"]
+
+    def test_stream_fence_state_resets_between_responses(self, monkeypatch):
+        """A fence left open (e.g. a bug elsewhere, or an unterminated
+        block) must not leak into the NEXT response's streaming state.
+        Drives the REAL _reset_stream_state() method (per review of
+        #75188), not a hand-simulated copy of its reset assignments."""
+        obj = self._make_cli()
+        self._feed_and_capture(monkeypatch, obj, ["```python\n"])
+        assert obj._in_stream_code_fence is True
+
+        obj._reset_stream_state()
+
+        assert obj._in_stream_code_fence is False
+        assert obj._stream_code_fence_char == ""
+        assert obj._stream_code_fence_len == 0
+
+    def test_shorter_closer_does_not_close_longer_opener_while_streaming(
+        self, monkeypatch
+    ):
+        """Regression (review of #75188): the streaming fence state only
+        tracked the marker CHARACTER, not its length, so a 3-backtick
+        closer incorrectly ended a 4-backtick-opened block. A genuine
+        3-backtick line appearing mid-block (e.g. the assistant explaining
+        Markdown fence syntax inside a real code block) must not be
+        mistaken for the closer, and __name__ after it must stay
+        protected."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(
+            monkeypatch, obj,
+            [
+                "````python\n",
+                "# use ``` to start a fence\n",
+                "print(__name__)\n",
+                "````\n",
+            ],
+        )
+        assert obj._in_stream_code_fence is False  # correctly closed by ````
+        assert any("__name__" in l for l in emitted), emitted
+        assert not any(l.strip() == "__main__" for l in emitted)
+
+    def test_fenced_pipe_line_not_swallowed_by_table_buffering(self, monkeypatch):
+        """Regression (review of #75188): table-row buffering used to run
+        BEFORE fence-state detection, so a fenced line shaped like a
+        table row (e.g. a Markdown table example inside a code fence)
+        got swallowed into table buffering instead of being recognized
+        as fenced content -- and table-buffer flushing invokes markdown
+        stripping, which would corrupt a dunder the same way as before."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(
+            monkeypatch, obj,
+            [
+                "```text\n",
+                "| __name__ | value |\n",
+                "|---|---|\n",
+                "```\n",
+            ],
+        )
+        assert obj._in_stream_table is False, (
+            "the pipe-shaped fenced line must not have been buffered as a table row"
+        )
+        assert any("__name__" in l for l in emitted), emitted
+        assert not any(l.strip() == "__main__" for l in emitted)
+
+    def test_info_suffixed_line_inside_fence_does_not_close_it(self, monkeypatch):
+        """Regression (review of #75462): a line matching the fence
+        MARKER pattern but carrying an info string after it (e.g.
+        "```python" appearing while ALREADY inside an open fence -- the
+        assistant's own reply showing an example fence-within-a-fence)
+        is not a valid closer per CommonMark, which requires nothing but
+        whitespace after a closing marker. The streaming detector used
+        the same permissive open-line regex for both opening and closing
+        checks, so this line incorrectly closed the block early,
+        de-protecting everything meant to still be inside it."""
+        obj = self._make_cli()
+        emitted = self._feed_and_capture(
+            monkeypatch, obj,
+            [
+                "```markdown\n",
+                "```python is how you'd start a Python fence\n",
+                "print(__name__)\n",
+                "```\n",
+            ],
+        )
+        assert obj._in_stream_code_fence is False  # correctly closed by the real ```
+        assert any("__name__" in l for l in emitted), emitted
+        assert not any(l.strip() == "__main__" for l in emitted)


### PR DESCRIPTION
## Context

Supersedes #75462 per @teknium1's review -- two real regex/algorithm issues.

## Fixes

1. **Invalid closer consumed the match, blocking a later valid one.** A single-pass regex+callback rejecting an invalid candidate closer had already consumed that match's span, so scanning could never reach a later valid closer for the same opener. Replaced with a manual line-based scan (`_extract_fenced_blocks()`) that skips invalid candidates and keeps looking.
2. **Closing recognition allowed an info string.** The streaming detector used the same permissive regex for opening and closing checks, so a line like `"""python` appearing inside an already-open fence incorrectly closed it early. Split into separate open/close regexes matching CommonMark's actual rule (closer = marker + whitespace only).

## Tests

Fixed a previous test that was encoding the OLD bug's behavior instead of testing for its absence (its own source had a later valid closer). Added a companion unterminated-case test, plus the requested scan-past-invalid-candidate and info-suffixed pseudo-closer regressions. Verified both fixes independently by reverting each and confirming the corresponding test fails with the exact reported symptom.

26/26 pass in the full test file; 47/47 across two more dependent test files (no regression).