### PR TITLE
fix(process): post-spawn PTY failure must not orphan the process or double-spawn

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1369,3 +1369,62 @@ class TestReaderLoopOrphanedPipe:
             except (ProcessLookupError, PermissionError):
                 pass
 
+
+
+class TestPtyPostSpawnFailure:
+    def test_post_spawn_failure_kills_pty_and_does_not_double_spawn(self, registry):
+        """A failure AFTER the PTY process exists (reader/registry/checkpoint)
+        must terminate that process and propagate — not fall through to the
+        pipe path, which would leave the PTY process running untracked and
+        spawn the same command a second time under the same session id."""
+        mock_pty_proc = MagicMock()
+        mock_pty_proc.pid = 5556
+
+        mock_pty_module = MagicMock()
+        mock_pty_module.PtyProcess.spawn = MagicMock(return_value=mock_pty_proc)
+
+        fake_thread = MagicMock()
+        fake_thread.daemon = False
+
+        with patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+             patch("tools.process_registry._IS_WINDOWS", False), \
+             patch.dict("sys.modules", {"ptyprocess": mock_pty_module}), \
+             patch("threading.Thread", return_value=fake_thread), \
+             patch.object(registry, "_write_checkpoint",
+                          side_effect=OSError("disk full")), \
+             patch("subprocess.Popen") as mock_popen:
+            with pytest.raises(OSError, match="disk full"):
+                registry.spawn_local("echo hello", cwd="/tmp", use_pty=True)
+
+        mock_pty_proc.terminate.assert_called_once_with(force=True)
+        assert not mock_popen.called, \
+            "pipe fallback must not double-spawn after the PTY process exists"
+        assert registry._running == {}, \
+            "half-registered session must not stay in _running"
+
+    def test_pre_spawn_failure_still_falls_back_to_pipe(self, registry):
+        """A failure BEFORE the PTY process exists keeps the documented
+        fallback: the command runs once, via the pipe path."""
+        mock_pty_module = MagicMock()
+        mock_pty_module.PtyProcess.spawn = MagicMock(
+            side_effect=OSError("openpty failed")
+        )
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 4321
+        fake_proc.stdout = iter([])
+        fake_proc.poll.return_value = None
+
+        fake_thread = MagicMock()
+        fake_thread.daemon = False
+
+        with patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+             patch("tools.process_registry._IS_WINDOWS", False), \
+             patch.dict("sys.modules", {"ptyprocess": mock_pty_module}), \
+             patch("threading.Thread", return_value=fake_thread), \
+             patch.object(registry, "_write_checkpoint"), \
+             patch("subprocess.Popen", return_value=fake_proc) as mock_popen:
+            session = registry.spawn_local("echo hello", cwd="/tmp", use_pty=True)
+
+        assert mock_popen.called, "pipe fallback should run for pre-spawn failures"
+        assert session.pid == 4321

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -725,6 +725,7 @@ class ProcessRegistry:
 
         if use_pty:
             # Try PTY mode for interactive CLI tools
+            _pty_live = False
             try:
                 if _IS_WINDOWS:
                     from winpty import PtyProcess as _PtyProcessCls
@@ -739,6 +740,11 @@ class ProcessRegistry:
                     env=pty_env,
                     dimensions=(30, 120),
                 )
+                # The OS process exists from here on: a later failure in this
+                # block must NOT fall through to the pipe path — that would
+                # leave pty_proc running untracked AND spawn the same command
+                # a second time under the same session id.
+                _pty_live = True
                 session.pid = pty_proc.pid
                 session.host_start_time = self._safe_host_start_time(session.pid)
                 # Store the pty handle on the session for read/write
@@ -764,6 +770,17 @@ class ProcessRegistry:
             except ImportError:
                 logger.warning("ptyprocess not installed, falling back to pipe mode")
             except Exception as e:
+                if _pty_live:
+                    # Post-spawn failure (reader/registry/checkpoint): kill the
+                    # live PTY process and drop the half-registered session,
+                    # then propagate — never double-spawn via the pipe path.
+                    try:
+                        pty_proc.terminate(force=True)
+                    except Exception:
+                        pass
+                    with self._lock:
+                        self._running.pop(session.id, None)
+                    raise
                 logger.warning("PTY spawn failed (%s), falling back to pipe mode", e)
 
         # Standard Popen path (non-PTY or PTY fallback)


### PR DESCRIPTION
## Summary
`spawn_local`'s PTY branch catches every `Exception` and falls back to the pipe path. That's correct **before** the process exists (`ptyprocess` missing, `openpty` failure) — but a failure **after** `PtyProcess.spawn()` returned (reader-thread creation, registry insert, `_write_checkpoint`) fell into the same handler. Consequences: the live PTY process kept running untracked (unkillable through the registry), and the pipe path then spawned the same command a **second time** under the same session id — for a non-idempotent command that's a real double-execution.

The fix tracks whether the OS process exists (`_pty_live`); on a post-spawn failure it terminates the PTY process, removes the half-registered session, and propagates the error instead of falling through. Pre-spawn failures keep the documented pipe fallback.

## Validation
- New test: a post-spawn `_write_checkpoint` failure terminates the PTY process, never invokes `subprocess.Popen`, leaves `_running` empty, and propagates. **Red before the fix** (the old code fell through and double-spawned), green after.
- New test: a pre-spawn failure (`PtyProcess.spawn` raising) still falls back to the pipe path exactly once.
- Full `tests/tools/test_process_registry.py`: 49 passed.

## Notes
`terminate(force=True)` matches ptyprocess's API; the call is wrapped so a dead-on-arrival process can't mask the original error.
