### PR TITLE
fix(buzz): localize authenticated inbound media

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -97,7 +97,7 @@ _MEDIA_URL_PATTERN = (
     r"[0-9a-f]{64}(?:\.[a-z0-9]{1,10})?(?:\?[^\s<>\[\]()]*)?"
 )
 _MARKDOWN_MEDIA_RE = re.compile(
-    rf"!\[[^\]]*\]\(\s*(?P<url>{_MEDIA_URL_PATTERN})"
+    rf"!\[(?P<alt>[^\]]*)\]\(\s*(?P<url>{_MEDIA_URL_PATTERN})"
     r"(?:\s+[\"'][^\"']*[\"'])?\s*\)",
     re.IGNORECASE,
 )
@@ -138,10 +138,10 @@ def _is_relay_media_url(url: str, relay_url: str) -> bool:
 
 def _find_relay_media_refs(
     text: str, relay_url: str
-) -> Tuple[List[str], List[Tuple[int, int]]]:
-    """Find same-relay media URLs and the content spans that contain them."""
+) -> Tuple[List[str], List[Tuple[int, int, str]]]:
+    """Find same-relay media URLs and their safe text replacements."""
     urls: List[str] = []
-    spans: List[Tuple[int, int]] = []
+    replacements: List[Tuple[int, int, str]] = []
     markdown_spans: List[Tuple[int, int]] = []
 
     for match in _MARKDOWN_MEDIA_RE.finditer(text):
@@ -149,7 +149,7 @@ def _find_relay_media_refs(
         if not _is_relay_media_url(url, relay_url):
             continue
         markdown_spans.append(match.span())
-        spans.append(match.span())
+        replacements.append((*match.span(), match.group("alt").strip()))
         if url not in urls:
             urls.append(url)
 
@@ -162,18 +162,17 @@ def _find_relay_media_refs(
         url = match.group(0)
         if not _is_relay_media_url(url, relay_url):
             continue
-        spans.append(match.span())
+        replacements.append((*match.span(), ""))
         if url not in urls:
             urls.append(url)
 
-    return urls, spans
+    return urls, replacements
 
 
-def _remove_media_spans(text: str, spans: List[Tuple[int, int]]) -> str:
-    chars = list(text)
-    for start, end in sorted(spans, reverse=True):
-        del chars[start:end]
-    cleaned = "".join(chars)
+def _replace_media_refs(text: str, replacements: List[Tuple[int, int, str]]) -> str:
+    cleaned = text
+    for start, end, replacement in sorted(replacements, reverse=True):
+        cleaned = f"{cleaned[:start]}{replacement}{cleaned[end:]}"
     cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
     return cleaned.strip()
@@ -1285,11 +1284,11 @@ class BuzzAdapter(BasePlatformAdapter):
         Each object is independent: one failed download is logged and skipped
         without discarding the caption or any other successfully cached files.
         """
-        urls, spans = _find_relay_media_refs(text, self.relay_url)
+        urls, replacements = _find_relay_media_refs(text, self.relay_url)
         if not urls:
             return text, [], [], MessageType.TEXT
 
-        cleaned_text = _remove_media_spans(text, spans)
+        cleaned_text = _replace_media_refs(text, replacements)
         media_urls: List[str] = []
         media_types: List[str] = []
         media_kinds: List[str] = []

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -39,9 +39,11 @@ environment and is never logged.
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import re
 import shutil
+import tempfile
 import time
 from collections import OrderedDict
 from datetime import datetime
@@ -86,6 +88,95 @@ _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
 _DEFAULT_CREDENTIALS_DIR = Path("~/.config/buzz").expanduser()
+
+# Buzz-hosted Blossom media is private to the community. Inbound messages
+# carry media as markdown or bare relay URLs, so the adapter must authenticate
+# and localise those references before the gateway hands them to vision.
+_MEDIA_URL_PATTERN = (
+    r"https?://[^\s<>\[\]()]+/media/"
+    r"[0-9a-f]{64}(?:\.[a-z0-9]{1,10})?(?:\?[^\s<>\[\]()]*)?"
+)
+_MARKDOWN_MEDIA_RE = re.compile(
+    rf"!\[[^\]]*\]\(\s*(?P<url>{_MEDIA_URL_PATTERN})"
+    r"(?:\s+[\"'][^\"']*[\"'])?\s*\)",
+    re.IGNORECASE,
+)
+_BARE_MEDIA_RE = re.compile(_MEDIA_URL_PATTERN, re.IGNORECASE)
+_MEDIA_PATH_RE = re.compile(
+    r"^/media/(?P<sha>[0-9a-f]{64})(?P<ext>\.[a-z0-9]{1,10})?/?$",
+    re.IGNORECASE,
+)
+
+
+def _effective_port(parsed) -> Optional[int]:
+    try:
+        if parsed.port is not None:
+            return parsed.port
+    except ValueError:
+        return None
+    if parsed.scheme in ("https", "wss"):
+        return 443
+    if parsed.scheme in ("http", "ws"):
+        return 80
+    return None
+
+
+def _is_relay_media_url(url: str, relay_url: str) -> bool:
+    """Return whether *url* is a Buzz media object on the configured relay."""
+    candidate = urlsplit(url)
+    relay = urlsplit(relay_url)
+    if candidate.scheme not in ("http", "https"):
+        return False
+    if not candidate.hostname or not relay.hostname:
+        return False
+    if candidate.hostname.lower() != relay.hostname.lower():
+        return False
+    if _effective_port(candidate) != _effective_port(relay):
+        return False
+    return bool(_MEDIA_PATH_RE.fullmatch(candidate.path))
+
+
+def _find_relay_media_refs(
+    text: str, relay_url: str
+) -> Tuple[List[str], List[Tuple[int, int]]]:
+    """Find same-relay media URLs and the content spans that contain them."""
+    urls: List[str] = []
+    spans: List[Tuple[int, int]] = []
+    markdown_spans: List[Tuple[int, int]] = []
+
+    for match in _MARKDOWN_MEDIA_RE.finditer(text):
+        url = match.group("url")
+        if not _is_relay_media_url(url, relay_url):
+            continue
+        markdown_spans.append(match.span())
+        spans.append(match.span())
+        if url not in urls:
+            urls.append(url)
+
+    for match in _BARE_MEDIA_RE.finditer(text):
+        if any(
+            start <= match.start() and match.end() <= end
+            for start, end in markdown_spans
+        ):
+            continue
+        url = match.group(0)
+        if not _is_relay_media_url(url, relay_url):
+            continue
+        spans.append(match.span())
+        if url not in urls:
+            urls.append(url)
+
+    return urls, spans
+
+
+def _remove_media_spans(text: str, spans: List[Tuple[int, int]]) -> str:
+    chars = list(text)
+    for start, end in sorted(spans, reverse=True):
+        del chars[start:end]
+    cleaned = "".join(chars)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
 
 
 def _load_nostr_auth():
@@ -1186,6 +1277,101 @@ class BuzzAdapter(BasePlatformAdapter):
             state["seen"][event_id] = None
             self._trim_seen(state)
 
+    async def _localize_inbound_media(
+        self, text: str, message_id: str
+    ) -> Tuple[str, List[str], List[str], MessageType]:
+        """Authenticate and cache same-relay media references in *text*.
+
+        Each object is independent: one failed download is logged and skipped
+        without discarding the caption or any other successfully cached files.
+        """
+        urls, spans = _find_relay_media_refs(text, self.relay_url)
+        if not urls:
+            return text, [], [], MessageType.TEXT
+
+        cleaned_text = _remove_media_spans(text, spans)
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        media_kinds: List[str] = []
+
+        from gateway.platforms.base import (
+            cache_media_bytes,
+            validate_inbound_media_size,
+        )
+
+        for url in urls:
+            path_match = _MEDIA_PATH_RE.fullmatch(urlsplit(url).path)
+            if path_match is None:
+                continue
+            ext = (path_match.group("ext") or ".bin").lower()
+            label = f"{path_match.group('sha')[:12]}{ext}"
+            try:
+                with tempfile.TemporaryDirectory(prefix="hermes-buzz-media-") as temp_dir:
+                    download_path = Path(temp_dir) / f"buzz_{label}"
+                    code, _out, _err = await self._run_cli(
+                        ["media", "get", "-o", str(download_path), url]
+                    )
+                    if code != 0 or not download_path.is_file():
+                        logger.warning(
+                            "Buzz: failed to localize inbound media %s (exit %d)",
+                            label,
+                            code,
+                        )
+                        continue
+                    validate_inbound_media_size(
+                        download_path.stat().st_size,
+                        media_type="Buzz media",
+                    )
+                    mime_type = (
+                        mimetypes.guess_type(download_path.name)[0]
+                        or "application/octet-stream"
+                    )
+                    cached = cache_media_bytes(
+                        download_path.read_bytes(),
+                        filename=download_path.name,
+                        mime_type=mime_type,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Buzz: failed to localize inbound media %s (%s)",
+                    label,
+                    type(exc).__name__,
+                )
+                continue
+
+            if cached is None:
+                logger.warning("Buzz: rejected invalid inbound media %s", label)
+                continue
+            media_urls.append(cached.path)
+            media_types.append(cached.media_type)
+            media_kinds.append(cached.kind)
+
+        if media_urls:
+            logger.info(
+                "Buzz: localized %d inbound media attachment(s) for message %s",
+                len(media_urls),
+                message_id[:12],
+            )
+
+        if "image" in media_kinds:
+            message_type = MessageType.PHOTO
+        elif "audio" in media_kinds:
+            message_type = MessageType.AUDIO
+        elif "video" in media_kinds:
+            message_type = MessageType.VIDEO
+        elif media_kinds:
+            message_type = MessageType.DOCUMENT
+        else:
+            message_type = MessageType.TEXT
+
+        if not cleaned_text:
+            cleaned_text = (
+                "(attachment)"
+                if media_urls
+                else "(Buzz media attachment unavailable)"
+            )
+        return cleaned_text, media_urls, media_types, message_type
+
     async def _dispatch_message(
         self,
         text: str,
@@ -1200,6 +1386,10 @@ class BuzzAdapter(BasePlatformAdapter):
         if not self._message_handler:
             return
 
+        text, media_urls, media_types, message_type = await self._localize_inbound_media(
+            text, message_id
+        )
+
         source = self.build_source(
             chat_id=chat_id,
             chat_name=self._channel_names.get(chat_id, chat_id),
@@ -1210,10 +1400,12 @@ class BuzzAdapter(BasePlatformAdapter):
 
         event = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT,
+            message_type=message_type,
             source=source,
             message_id=message_id,
             timestamp=datetime.fromtimestamp(created_at) if created_at else datetime.now(),
+            media_urls=media_urls,
+            media_types=media_types,
         )
 
         await self.handle_message(event)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1,12 +1,14 @@
 """Tests for the Buzz platform adapter plugin."""
 
 import asyncio
+import base64
 import json
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+from gateway.platforms.base import MessageType
 
 # Load plugins/platforms/buzz/adapter.py under a unique module name
 # (plugin_adapter_buzz) so it cannot collide with other plugin adapters
@@ -422,6 +424,296 @@ class TestBuzzAdapterSend:
         assert args[args.index("--file") + 1] == str(img)
 
 
+# ── Inbound media localisation ─────────────────────────────────────────────────
+
+
+class TestInboundMediaLocalisation:
+
+    @staticmethod
+    def _capture_dispatch(adapter, *, failed_urls=None):
+        captured = []
+        cli_calls = []
+        failed_urls = set(failed_urls or [])
+
+        async def capture(event):
+            captured.append(event)
+
+        async def cli(args, *, input_text=None):
+            cli_calls.append(list(args))
+            assert args[:2] == ["media", "get"]
+            url = args[-1]
+            if url in failed_urls:
+                return 2, "", '{"error":"relay_error","message":"denied"}'
+            output_path = args[args.index("-o") + 1]
+            if url.endswith(".jpg"):
+                payload = b"\xff\xd8\xff\xe0JFIF test image"
+            elif url.endswith(".pdf"):
+                payload = b"%PDF-1.4\n% test document\n"
+            else:
+                payload = base64.b64decode(
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+                    "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+                )
+            with open(output_path, "wb") as handle:
+                handle.write(payload)
+            return 0, "", ""
+
+        adapter.handle_message = capture
+        adapter._message_handler = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+        adapter._run_cli = cli
+        return captured, cli_calls
+
+    @pytest.mark.asyncio
+    async def test_markdown_relay_image_is_localised_before_dispatch(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, cli_calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'a' * 64}.png"
+
+        await adapter._dispatch_message(
+            text=f"Please inspect this screenshot\n\n![]({media_url})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="media-event",
+            created_at=1000,
+        )
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert event.text == "Please inspect this screenshot"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+        assert event.media_urls[0].startswith(str(tmp_path / "hermes" / "cache"))
+        assert media_url not in event.text
+        assert cli_calls[0][-1] == media_url
+
+    @pytest.mark.asyncio
+    async def test_bare_relay_image_url_is_localised(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, _calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'b' * 64}.png"
+
+        await adapter._dispatch_message(
+            text=f"What is in this? {media_url}",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="bare-media-event",
+            created_at=1001,
+        )
+
+        event = captured[0]
+        assert event.text == "What is in this?"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_image_only_message_gets_attachment_placeholder(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, _calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'5' * 64}.png"
+
+        await adapter._dispatch_message(
+            text=f"![]({media_url})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="image-only-event",
+            created_at=1002,
+        )
+
+        event = captured[0]
+        assert event.text == "(attachment)"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_multiple_images_are_localised_in_content_order(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, calls = self._capture_dispatch(adapter)
+        first = f"https://test.relay/media/{'c' * 64}.png"
+        second = f"https://test.relay/media/{'d' * 64}.jpg"
+
+        await adapter._dispatch_message(
+            text=f"Compare these\n![]({first})\n{second}",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="multi-media-event",
+            created_at=1002,
+        )
+
+        event = captured[0]
+        assert event.text == "Compare these"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/png", "image/jpeg"]
+        assert len(event.media_urls) == 2
+        assert [call[-1] for call in calls] == [first, second]
+
+    @pytest.mark.asyncio
+    async def test_non_image_attachment_is_cached_as_document(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, _calls = self._capture_dispatch(adapter)
+        media_url = f"https://test.relay/media/{'e' * 64}.pdf"
+
+        await adapter._dispatch_message(
+            text=f"Read this report\n{media_url}",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="document-media-event",
+            created_at=1003,
+        )
+
+        event = captured[0]
+        assert event.text == "Read this report"
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_types == ["application/pdf"]
+        assert len(event.media_urls) == 1
+        assert "/cache/documents/" in event.media_urls[0]
+
+    @pytest.mark.asyncio
+    async def test_download_failure_keeps_caption_and_dispatches_text(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        media_url = f"https://test.relay/media/{'f' * 64}.png"
+        captured, _calls = self._capture_dispatch(adapter, failed_urls=[media_url])
+
+        await adapter._dispatch_message(
+            text=f"The error is visible here\n![]({media_url})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="failed-media-event",
+            created_at=1004,
+        )
+
+        event = captured[0]
+        assert event.text == "The error is visible here"
+        assert event.message_type == MessageType.TEXT
+        assert event.media_urls == []
+        assert event.media_types == []
+
+    @pytest.mark.asyncio
+    async def test_one_failed_download_does_not_drop_other_media(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        failed = f"https://test.relay/media/{'2' * 64}.png"
+        succeeded = f"https://test.relay/media/{'3' * 64}.jpg"
+        captured, calls = self._capture_dispatch(adapter, failed_urls=[failed])
+
+        await adapter._dispatch_message(
+            text=f"Compare what loaded\n![]({failed})\n![]({succeeded})",
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="partial-media-event",
+            created_at=1005,
+        )
+
+        event = captured[0]
+        assert event.text == "Compare what loaded"
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/jpeg"]
+        assert len(event.media_urls) == 1
+        assert [call[-1] for call in calls] == [failed, succeeded]
+
+    @pytest.mark.asyncio
+    async def test_real_event_handler_localises_media_before_gateway_dispatch(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {
+            "chat_type": "dm",
+            "last_ts": 0,
+            "seen": {},
+        }
+        captured = []
+        media_url = f"https://test.relay/media/{'4' * 64}.png"
+
+        async def capture(event):
+            captured.append(event)
+
+        async def cli(args, *, input_text=None):
+            if args[:2] == ["users", "get"]:
+                return 0, json.dumps([{"display_name": "Joel"}]), ""
+            assert args[:2] == ["media", "get"]
+            output_path = args[args.index("-o") + 1]
+            payload = base64.b64decode(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+                "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+            )
+            with open(output_path, "wb") as handle:
+                handle.write(payload)
+            return 0, "", ""
+
+        adapter.handle_message = capture
+        adapter._message_handler = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+        adapter._run_cli = cli
+
+        await adapter._handle_event(
+            DM_CHANNEL,
+            adapter._channel_state[DM_CHANNEL],
+            _tagged_event(
+                "handler-media-event",
+                DM_CHANNEL,
+                content=f"Can you read this? ![]({media_url})",
+                p=SELF_PUBKEY,
+            ),
+        )
+
+        assert len(captured) == 1
+        assert captured[0].text == "Can you read this?"
+        assert captured[0].message_type == MessageType.PHOTO
+        assert len(captured[0].media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_external_media_url_is_left_untouched(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        adapter = _make_adapter()
+        captured, calls = self._capture_dispatch(adapter)
+        media_url = f"https://cdn.example/media/{'1' * 64}.png"
+        text = f"External reference: ![]({media_url})"
+
+        await adapter._dispatch_message(
+            text=text,
+            chat_id=CHANNEL,
+            chat_type="dm",
+            user_id=OTHER_PUBKEY,
+            user_name="Joel",
+            message_id="external-media-event",
+            created_at=1006,
+        )
+
+        event = captured[0]
+        assert event.text == text
+        assert event.message_type == MessageType.TEXT
+        assert event.media_urls == []
+        assert calls == []
+
+
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 
 
@@ -536,5 +828,3 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
-
-

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -465,7 +465,7 @@ class TestInboundMediaLocalisation:
         return captured, cli_calls
 
     @pytest.mark.asyncio
-    async def test_markdown_relay_image_is_localised_before_dispatch(
+    async def test_markdown_relay_image_preserves_alt_text_before_dispatch(
         self, monkeypatch, tmp_path
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
@@ -474,7 +474,7 @@ class TestInboundMediaLocalisation:
         media_url = f"https://test.relay/media/{'a' * 64}.png"
 
         await adapter._dispatch_message(
-            text=f"Please inspect this screenshot\n\n![]({media_url})",
+            text=f"Please inspect this screenshot\n\n![Login error dialog]({media_url})",
             chat_id=CHANNEL,
             chat_type="dm",
             user_id=OTHER_PUBKEY,
@@ -485,7 +485,7 @@ class TestInboundMediaLocalisation:
 
         assert len(captured) == 1
         event = captured[0]
-        assert event.text == "Please inspect this screenshot"
+        assert event.text == "Please inspect this screenshot\n\nLogin error dialog"
         assert event.message_type == MessageType.PHOTO
         assert event.media_types == ["image/png"]
         assert len(event.media_urls) == 1
@@ -589,7 +589,7 @@ class TestInboundMediaLocalisation:
         assert "/cache/documents/" in event.media_urls[0]
 
     @pytest.mark.asyncio
-    async def test_download_failure_keeps_caption_and_dispatches_text(
+    async def test_download_failure_preserves_caption_and_alt_text(
         self, monkeypatch, tmp_path
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
@@ -598,7 +598,7 @@ class TestInboundMediaLocalisation:
         captured, _calls = self._capture_dispatch(adapter, failed_urls=[media_url])
 
         await adapter._dispatch_message(
-            text=f"The error is visible here\n![]({media_url})",
+            text=f"The error is visible here\n![Checkout error dialog]({media_url})",
             chat_id=CHANNEL,
             chat_type="dm",
             user_id=OTHER_PUBKEY,
@@ -608,7 +608,7 @@ class TestInboundMediaLocalisation:
         )
 
         event = captured[0]
-        assert event.text == "The error is visible here"
+        assert event.text == "The error is visible here\nCheckout error dialog"
         assert event.message_type == MessageType.TEXT
         assert event.media_urls == []
         assert event.media_types == []


### PR DESCRIPTION
## Cause

Buzz inbound events currently dispatch only text. Hosted Blossom media URLs require Buzz authentication, so downstream vision sees the remote URL and gets HTTP 401.

## Fix

- detect markdown image and bare media URLs on the configured relay host
- download each object with the adapter's existing authenticated `buzz media get` path
- validate and copy downloads into Hermes' profile-aware media caches
- populate `MessageEvent.media_urls`, `media_types`, and the appropriate message type
- preserve captions while removing private relay URLs from agent-facing text
- isolate failures per attachment and leave external hosts untouched

Current live Buzz events expose media only through `content`. No structured attachment field is present to consume.

## Proof

- `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py -q` - 32 passed
- adjacent cache, image-routing, and platform-base regressions - 147 passed
- `ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py` - passed
- real hosted-relay proof with the configured Buzz CLI - private PNG authenticated, cached under an isolated Hermes profile, classified as `photo`, and its remote URL removed without printing credentials or the media URL

## Dogfood note

The native gateway must restart on this code before the final DM proof where Rocky describes a newly attached screenshot. Do not start Desktop ACP with the same Buzz identity during that test.
