### PR TITLE
test(telegram): prefer the real PTB library over process-wide mocks

### DIFF
--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -94,6 +94,23 @@ def _ensure_telegram_mock() -> None:
     if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
         return  # Real library is installed — nothing to mock
 
+    # Prefer the REAL library whenever it is importable. The mock below is
+    # process-wide and permanent, and it poisons every later-collected test
+    # that needs genuine PTB classes (tests/test_telegram_polling_progress_ptb
+    # subclasses the real BaseRequest) whenever a gateway file collects
+    # first. PTB is a production dependency, so in a normal venv this branch
+    # always wins; the mock survives only for genuinely PTB-less environments.
+    try:
+        import telegram  # noqa: F401
+        import telegram.constants  # noqa: F401
+        import telegram.error  # noqa: F401
+        import telegram.ext  # noqa: F401
+        import telegram.request  # noqa: F401
+        if hasattr(sys.modules.get("telegram"), "__file__"):
+            return
+    except ImportError:
+        pass
+
     mod = MagicMock()
     mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
     # One shared PTB-faithful enum namespace per constant, attached to BOTH

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -24,6 +24,18 @@ def _ensure_telegram_mock():
     if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
         return
 
+    # Prefer the REAL library whenever it is importable — same rationale as
+    # the gateway conftest: the fakes below are process-wide and permanent.
+    try:
+        import telegram  # noqa: F401
+        import telegram.constants  # noqa: F401
+        import telegram.error  # noqa: F401
+        import telegram.ext  # noqa: F401
+        import telegram.request  # noqa: F401
+        return
+    except ImportError:
+        pass
+
     mod = MagicMock()
     mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
     mod.constants.ParseMode.MARKDOWN = "Markdown"

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -312,9 +312,12 @@ async def test_legacy_send_error_redacts_bot_token_without_traceback(monkeypatch
     assert result.success is False
     assert result.error is not None
     assert token not in result.error
-    assert "bot123456789:***/sendMessage" in result.error
+    # Real PTB TelegramError capitalize()s its message (the mock did not) —
+    # assert the token redaction case-insensitively; the property under
+    # test is the redaction, not the URL casing.
+    assert "bot123456789:***/sendmessage" in result.error.lower()
     assert token not in caplog.text
-    assert "bot123456789:***/sendMessage" in caplog.text
+    assert "bot123456789:***/sendmessage" in caplog.text.lower()
     adapter._bot.do_api_request.assert_not_called()
 
 
@@ -454,9 +457,9 @@ async def test_legacy_edit_error_logs_redacted_bot_token_without_traceback(monke
     assert result.success is False
     assert result.error is not None
     assert token not in result.error
-    assert "bot123456789:***/editMessageText" in result.error
+    assert "bot123456789:***/editmessagetext" in result.error.lower()
     assert token not in caplog.text
-    assert "bot123456789:***/editMessageText" in caplog.text
+    assert "bot123456789:***/editmessagetext" in caplog.text.lower()
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`tests/gateway/conftest.py` (and the file-local copy in `test_telegram_approval_buttons.py`) install a **permanent, process-wide MagicMock** for the `telegram` module family whenever the real library hasn't been imported yet. Collection order decides the outcome: when any gateway file collects first, every later-collected test that needs genuine PTB classes is poisoned. Concretely, `tests/test_telegram_polling_progress_ptb.py` subclasses the real `BaseRequest` and fails 6/6 with `object MagicMock can't be used in 'await' expression`:

```
pytest tests/gateway/test_telegram_approval_buttons.py tests/test_telegram_polling_progress_ptb.py
# 6 failed, 10 passed  (either order — collection imports both modules first)
```

Both `_ensure_telegram_mock` variants now try to import the real library first and install fakes only when PTB is genuinely absent. Since `python-telegram-bot` is a production dependency, a normal dev/CI venv now always tests against real PTB semantics; the mock remains as a fallback for PTB-less environments.

## Flip side (included)
Real `TelegramError` `capitalize()`s its message where the mock did not. The bot-token-redaction assertions in `test_telegram_rich_messages.py` now compare case-insensitively — the property under test is the token redaction (`bot123456789:***`), not the URL casing.

## Validation
- Two-file reproduction above: 6 failed → 16 passed (both orders).
- Full telegram test set (56 files, one run): **524 passed, 0 failed**.

## Notes
Found by bisecting a 6-test order-coupling; the mock's own guard ("skips when the real library is already imported") shows real-PTB runs were always intended to be valid — this just makes them the default instead of an accident of import order.
