### PR TITLE
fix(auth): keep explicit OpenRouter on credential pool

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1805,13 +1805,8 @@ def resolve_runtime_provider(
         )
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()
-        env_openai_base_url = _getenv("OPENAI_BASE_URL", "").strip()
         env_openrouter_base_url = _getenv("OPENROUTER_BASE_URL", "").strip()
-        has_custom_endpoint = bool(
-            explicit_base_url
-            or env_openrouter_base_url
-            or (not explicit_openrouter_request and env_openai_base_url)
-        )
+        has_custom_endpoint = bool(explicit_base_url or env_openrouter_base_url)
         if (
             not explicit_openrouter_request
             and cfg_base_url

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -301,21 +301,50 @@ def _get_model_config() -> Dict[str, Any]:
     return {}
 
 
-def _provider_supports_explicit_api_mode(provider: Optional[str], configured_provider: Optional[str] = None) -> bool:
-    """Check whether a persisted api_mode should be honored for a given provider.
+def _canonical_builtin_provider_name(provider: Optional[str]) -> str:
+    from providers import get_provider_profile
+    from hermes_cli.models import normalize_provider
 
-    Prevents stale api_mode from a previous provider leaking into a
-    different one after a model/provider switch.  Only applies the
-    persisted mode when the config's provider matches the runtime
-    provider (or when no configured provider is recorded).
-    """
+    normalized = normalize_provider(provider)
+    profile = get_provider_profile(normalized)
+    return getattr(profile, "name", None) or normalized
+
+
+def _configured_provider_matches_runtime(provider: Optional[str], configured_provider: Optional[str]) -> bool:
     normalized_provider = (provider or "").strip().lower()
     normalized_configured = (configured_provider or "").strip().lower()
     if not normalized_configured:
-        return True
+        return False
+    # Named custom providers own alias-like names before built-in canonicalization.
+    try:
+        configured_custom = _get_named_custom_provider(normalized_configured)
+    except Exception:
+        configured_custom = None
+    if configured_custom is not None:
+        return normalized_provider == "custom"
     if normalized_provider == "custom":
-        return normalized_configured == "custom" or normalized_configured.startswith("custom:")
-    return normalized_configured == normalized_provider
+        return normalized_configured == "custom"
+    return _canonical_builtin_provider_name(normalized_configured) == _canonical_builtin_provider_name(normalized_provider)
+
+
+def _configured_base_url(model_cfg: Dict[str, Any], provider: str, *, validator=None) -> str:
+    configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+    if not _configured_provider_matches_runtime(provider, configured_provider):
+        return ""
+    base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+    return base_url if not validator or validator(base_url) else ""
+
+
+def _configured_anthropic_base_url(model_cfg: Dict[str, Any]) -> str:
+    return _configured_base_url(model_cfg, "anthropic", validator=_anthropic_base_url_override_ok)
+
+
+def _provider_supports_explicit_api_mode(provider: Optional[str], configured_provider: Optional[str] = None) -> bool:
+    """Honor persisted mode only when config and runtime share provider ownership."""
+    normalized_configured = (configured_provider or "").strip().lower()
+    if not normalized_configured:
+        return True
+    return _configured_provider_matches_runtime(provider, configured_provider)
 
 
 def _copilot_runtime_api_mode(
@@ -329,12 +358,8 @@ def _copilot_runtime_api_mode(
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
-    # Use the model being resolved for this runtime, not the persisted global
-    # default. MoA slots, fallback models, and mid-session model switches all
-    # resolve credentials for a target model that can differ from config.yaml's
-    # model.default. If we derive Copilot api_mode from the stale default, a
-    # Claude/Gemini MoA slot can inherit codex_responses from a GPT-5 default and
-    # fail with "model ... does not support Responses API".
+    # Target model wins over the persisted default so MoA/fallback/model switches
+    # cannot carry a GPT/Codex mode into Claude/Gemini slots.
     model_name = str(target_model or model_cfg.get("default") or "").strip()
     if not model_name:
         return "chat_completions"
@@ -345,6 +370,31 @@ def _copilot_runtime_api_mode(
         return copilot_model_api_mode(model_name, api_key=api_key)
     except Exception:
         return "chat_completions"
+
+
+def _resolve_static_api_mode(
+    provider: str,
+    model_cfg: Dict[str, Any],
+    base_url: str,
+    *,
+    api_key: str = "",
+    target_model: Optional[str] = None,
+) -> str:
+    if provider == "xai":
+        return "codex_responses"
+    if provider == "copilot":
+        return _copilot_runtime_api_mode(model_cfg, api_key, target_model=target_model)
+    if provider in {"opencode-zen", "opencode-go"}:
+        # One provider serves both modes; the target model, not persisted mode,
+        # is authoritative during model switches (ref #16878).
+        from hermes_cli.models import opencode_model_api_mode
+
+        return opencode_model_api_mode(provider, target_model or model_cfg.get("default", ""))
+    configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+    configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+    if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+        return configured_mode
+    return _detect_api_mode_for_url(base_url) or "chat_completions"
 
 
 _VALID_API_MODES = {
@@ -415,6 +465,7 @@ def _resolve_runtime_from_pool_entry(
     model_cfg: Optional[Dict[str, Any]] = None,
     pool: Optional[CredentialPool] = None,
     target_model: Optional[str] = None,
+    selected_base_url: Optional[str] = None,
 ) -> Dict[str, Any]:
     model_cfg = model_cfg or _get_model_config()
     # When the caller is resolving for a specific target model (e.g. a /model
@@ -424,7 +475,12 @@ def _resolve_runtime_from_pool_entry(
     # opencode-zen /v1 to be stripped for chat_completions requests when
     # config.default was still a Claude model.
     effective_model = (target_model or model_cfg.get("default") or "")
-    base_url = (getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or "").rstrip("/")
+    base_url = (
+        selected_base_url
+        or getattr(entry, "runtime_base_url", None)
+        or getattr(entry, "base_url", None)
+        or ""
+    ).rstrip("/")
     api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
     api_mode = "chat_completions"
     if provider == "openai-codex":
@@ -446,29 +502,16 @@ def _resolve_runtime_from_pool_entry(
         base_url = base_url or (pconfig.inference_base_url if pconfig else "")
     elif provider == "anthropic":
         api_mode = "anthropic_messages"
-        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-        cfg_base_url = ""
-        if cfg_provider == "anthropic":
-            cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
-            if not _anthropic_base_url_override_ok(cfg_base_url):
-                cfg_base_url = ""
+        cfg_base_url = _configured_anthropic_base_url(model_cfg)
         base_url = cfg_base_url or base_url or "https://api.anthropic.com"
     elif provider == "openrouter":
         base_url = base_url or OPENROUTER_BASE_URL
-    elif provider == "xai":
-        api_mode = "codex_responses"
+        api_mode = _resolve_static_api_mode(provider, model_cfg, base_url)
     elif provider == "nous":
         from hermes_cli.providers import nous_api_mode
 
         api_mode = nous_api_mode(effective_model)
         base_url = _nous_inference_base_url_override() or base_url
-    elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(
-            model_cfg,
-            getattr(entry, "runtime_api_key", ""),
-            target_model=effective_model,
-        )
-        base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
@@ -496,35 +539,24 @@ def _resolve_runtime_from_pool_entry(
         if api_mode == "anthropic_messages":
             base_url = re.sub(r"/v1/?$", "", base_url)
     else:
-        configured_provider = str(model_cfg.get("provider") or "").strip().lower()
         # Honour model.base_url from config.yaml when the configured provider
         # matches this provider — same pattern as the Anthropic branch above.
         # Only override when the pool entry has no explicit base_url (i.e. it
         # fell back to the hardcoded default).  Env var overrides win (#6039).
         pconfig = PROVIDER_REGISTRY.get(provider)
+        if pconfig and not base_url:
+            base_url = pconfig.inference_base_url
         pool_url_is_default = pconfig and base_url.rstrip("/") == pconfig.inference_base_url.rstrip("/")
-        if configured_provider == provider and pool_url_is_default:
-            cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
-            if cfg_base_url:
-                base_url = cfg_base_url
-        configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-        if provider in {"opencode-zen", "opencode-go"}:
-            # Re-derive api_mode from the effective model rather than the
-            # persisted api_mode: the opencode providers serve both
-            # anthropic_messages and chat_completions models, so the previous
-            # session's mode must not leak across /model switches.
-            # Refs #16878.
-            from hermes_cli.models import opencode_model_api_mode
-            api_mode = opencode_model_api_mode(provider, effective_model)
-        elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
-            api_mode = configured_mode
-        else:
-            # Auto-detect Anthropic-compatible endpoints (/anthropic suffix,
-            # Kimi /coding, api.openai.com → codex_responses, api.x.ai →
-            # codex_responses).
-            detected = _detect_api_mode_for_url(base_url)
-            if detected:
-                api_mode = detected
+        cfg_base_url = _configured_base_url(model_cfg, provider)
+        if cfg_base_url and pool_url_is_default:
+            base_url = cfg_base_url
+        api_mode = _resolve_static_api_mode(
+            provider,
+            model_cfg,
+            base_url,
+            api_key=api_key,
+            target_model=effective_model,
+        )
 
     # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
     # Anthropic SDK prepends its own /v1/messages to the base_url.  Normalize
@@ -1026,10 +1058,9 @@ def _resolve_named_custom_runtime(
             pass
     if requested_norm == "custom" and explicit_base_url:
         base_url = explicit_base_url.strip().rstrip("/")
-        # Check credential pool first — mirrors the named-custom-provider path
-        # so bare `provider: custom` with a configured custom_providers entry
-        # also gets its api_key from the pool instead of env var fallbacks.
-        pool_result = _try_resolve_from_custom_pool(base_url, "custom", None)
+        # Without an explicit caller key, prefer a matching credential pool to
+        # environment fallbacks, mirroring the named-custom-provider path.
+        pool_result = None if explicit_api_key else _try_resolve_from_custom_pool(base_url, "custom", None)
         if pool_result:
             pool_result["source"] = "direct-alias"
             return pool_result
@@ -1062,15 +1093,24 @@ def _resolve_named_custom_runtime(
     if not custom_provider:
         return None
 
-    base_url = (
-        (explicit_base_url or "").strip()
-        or custom_provider.get("base_url", "")
-    ).rstrip("/")
+    configured_base_url = str(custom_provider.get("base_url") or "").strip().rstrip("/")
+    explicit_base_url_clean = str(explicit_base_url or "").strip().rstrip("/")
+    base_url = explicit_base_url_clean or configured_base_url
     if not base_url:
         return None
 
-    # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
+    # Without an explicit caller key, use a pool only for this endpoint. Name
+    # matching is authoritative only while an explicit URL still matches the
+    # named provider; otherwise lookup falls back to exact URL matching.
+    pool_provider_name = custom_provider.get("name") if base_url == configured_base_url else None
+    pool_result = None
+    if not explicit_api_key:
+        pool_result = _try_resolve_from_custom_pool(
+            base_url,
+            "custom",
+            custom_provider.get("api_mode"),
+            provider_name=pool_provider_name,
+        )
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -1137,6 +1177,7 @@ class _OpenRouterEndpoint(NamedTuple):
     base_url: str
     source: str
     requested_provider: str
+    provider: str
 
 
 def _resolve_openrouter_endpoint(
@@ -1146,10 +1187,13 @@ def _resolve_openrouter_endpoint(
     model_cfg: Optional[Dict[str, Any]] = None,
 ) -> _OpenRouterEndpoint:
     model_cfg = _get_model_config() if model_cfg is None else model_cfg
-    cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
-    cfg_provider = model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
+    raw_cfg_base_url = model_cfg.get("base_url")
+    raw_cfg_provider = model_cfg.get("provider")
+    cfg_base_url = raw_cfg_base_url if isinstance(raw_cfg_base_url, str) else ""
+    cfg_provider = raw_cfg_provider if isinstance(raw_cfg_provider, str) else ""
     requested_norm = (requested_provider or "").strip().lower()
     cfg_provider = cfg_provider.strip().lower()
+    configured_openrouter = _configured_provider_matches_runtime("openrouter", cfg_provider)
 
     if requested_norm and requested_norm != "custom":
         try:
@@ -1162,7 +1206,9 @@ def _resolve_openrouter_endpoint(
 
     use_config_base_url = False
     if cfg_base_url.strip() and not explicit_base_url:
-        if requested_norm == "auto":
+        if configured_openrouter:
+            use_config_base_url = True
+        elif requested_norm == "auto":
             use_config_base_url = not cfg_provider or cfg_provider == "auto"
         elif requested_norm == "custom" and _config_base_url_trustworthy_for_bare_custom(
             cfg_base_url, cfg_provider
@@ -1171,13 +1217,24 @@ def _resolve_openrouter_endpoint(
 
     candidates = (
         ("explicit", (explicit_base_url or "").strip()),
-        ("custom_env", _getenv("CUSTOM_BASE_URL", "").strip()),
+        (
+            "custom_env",
+            _getenv("CUSTOM_BASE_URL", "").strip() if requested_norm in {"auto", "custom"} else "",
+        ),
         ("config", cfg_base_url.strip() if use_config_base_url else ""),
         ("openrouter_env", _getenv("OPENROUTER_BASE_URL", "").strip()),
         ("default", OPENROUTER_BASE_URL),
     )
     source, base_url = next((source, value) for source, value in candidates if value)
-    return _OpenRouterEndpoint(base_url.rstrip("/"), source, requested_norm)
+    requested_openrouter = _configured_provider_matches_runtime("openrouter", requested_norm)
+    openrouter_owned = requested_norm != "custom" and (
+        base_url_host_matches(base_url, "openrouter.ai")
+        or source in {"openrouter_env", "default"}
+        or (source == "config" and configured_openrouter)
+        or (source == "explicit" and requested_openrouter)
+    )
+    provider = "openrouter" if openrouter_owned else "custom"
+    return _OpenRouterEndpoint(base_url.rstrip("/"), source, requested_norm, provider)
 
 
 def _resolve_openrouter_runtime(
@@ -1200,13 +1257,12 @@ def _resolve_openrouter_runtime(
     )
     base_url = endpoint.base_url
 
-    # Choose API key based on whether the resolved base_url targets OpenRouter.
-    # When hitting OpenRouter, prefer OPENROUTER_API_KEY (issue #289).
-    # When hitting a custom endpoint (e.g. Z.ai, local LLM), prefer
-    # OPENAI_API_KEY so the OpenRouter key doesn't leak to an unrelated
-    # provider (issues #420, #560).
+    # Choose API keys from the resolved endpoint's trust boundary. OpenRouter
+    # accepts its own key (issue #289); custom endpoints accept an explicit
+    # caller override first, then config or host-matched vendor keys so
+    # unrelated credentials cannot leak (issues #420, #560, #28660).
     _is_openrouter_url = base_url_host_matches(base_url, "openrouter.ai")
-    _is_openrouter_context = _is_openrouter_url or endpoint.source == "openrouter_env"
+    _is_openrouter_context = endpoint.provider == "openrouter"
     if _is_openrouter_context:
         api_key_candidates = [
             explicit_api_key,
@@ -1247,19 +1303,19 @@ def _resolve_openrouter_runtime(
 
     source = "explicit" if (explicit_api_key or explicit_base_url) else "env/config"
 
-    # When "custom" was explicitly requested, preserve that as the provider
-    # name instead of silently relabeling to "openrouter" (#2562).
-    # Also provide a placeholder API key for local servers that don't require
-    # authentication — the OpenAI SDK requires a non-empty api_key string.
-    effective_provider = "custom" if endpoint.requested_provider == "custom" else "openrouter"
+    # Preserve custom endpoint identity instead of silently relabeling it to
+    # OpenRouter (#2562); endpoint ownership is independent of credentials.
+    effective_provider = endpoint.provider
+    effective_api_mode = (
+        _resolve_plain_custom_api_mode(model_cfg, base_url)
+        if effective_provider == "custom"
+        else _resolve_static_api_mode("openrouter", model_cfg, base_url)
+    )
 
     # For custom endpoints, check if a credential pool exists
-    if effective_provider == "custom" and base_url:
-        # Pass requested_provider so pool lookup prefers name match over base_url,
-        # fixing credential mix-ups when multiple custom providers share a base_url.
+    if effective_provider == "custom" and base_url and not explicit_api_key:
         pool_result = _try_resolve_from_custom_pool(
-            base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
-            provider_name=requested_provider if endpoint.requested_provider != "custom" else None,
+            base_url, effective_provider, effective_api_mode,
         )
         if pool_result:
             return pool_result
@@ -1269,11 +1325,7 @@ def _resolve_openrouter_runtime(
 
     return {
         "provider": effective_provider,
-        "api_mode": _resolve_plain_custom_api_mode(model_cfg, base_url)
-        if effective_provider == "custom"
-        else _parse_api_mode(model_cfg.get("api_mode"))
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": effective_api_mode,
         "base_url": base_url,
         "api_key": api_key,
         "source": source,
@@ -1464,12 +1516,7 @@ def _resolve_explicit_runtime(
         return None
 
     if provider == "anthropic":
-        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-        cfg_base_url = ""
-        if cfg_provider == "anthropic":
-            cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
-            if not _anthropic_base_url_override_ok(cfg_base_url):
-                cfg_base_url = ""
+        cfg_base_url = _configured_anthropic_base_url(model_cfg)
         base_url = explicit_base_url or cfg_base_url or "https://api.anthropic.com"
         api_key = explicit_api_key
         if not api_key:
@@ -1560,13 +1607,16 @@ def _resolve_explicit_runtime(
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
+        configured_base_url = _configured_base_url(model_cfg, provider)
         env_url = ""
         if pconfig.base_url_env_var:
             env_url = _getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:
-            if provider in {"kimi-coding", "kimi-coding-cn"}:
+            if configured_base_url:
+                base_url = configured_base_url
+            elif provider in {"kimi-coding", "kimi-coding-cn"}:
                 creds = resolve_api_key_provider_credentials(provider)
                 base_url = creds.get("base_url", "").rstrip("/")
             else:
@@ -1579,25 +1629,13 @@ def _resolve_explicit_runtime(
             if not base_url:
                 base_url = creds.get("base_url", "").rstrip("/")
 
-        api_mode = "chat_completions"
-        if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(
-                model_cfg,
-                api_key,
-                target_model=target_model,
-            )
-        elif provider == "xai":
-            api_mode = "codex_responses"
-        else:
-            configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode:
-                api_mode = configured_mode
-            else:
-                # Auto-detect from URL (Anthropic /anthropic suffix,
-                # api.openai.com → Responses, Kimi /coding, etc.).
-                detected = _detect_api_mode_for_url(base_url)
-                if detected:
-                    api_mode = detected
+        api_mode = _resolve_static_api_mode(
+            provider,
+            model_cfg,
+            base_url,
+            api_key=api_key,
+            target_model=target_model,
+        )
 
         return {
             "provider": provider,
@@ -1660,7 +1698,7 @@ def resolve_runtime_provider(
                 provider_config_key = resolved_provider_hint
                 _block = _provs_cfg.get(provider_config_key)
         if isinstance(_block, dict) and not is_provider_enabled(_block):
-            raise ValueError(
+            raise AuthError(
                 f"provider {requested_provider!r} is disabled in config "
                 f"(providers.{provider_config_key}.enabled: false)"
             )
@@ -1806,6 +1844,7 @@ def resolve_runtime_provider(
     if explicit_runtime:
         return explicit_runtime
 
+    selected_pool_base_url = None
     should_use_pool = provider != "openrouter"
     if provider == "openrouter":
         explicit_openrouter_request = requested_provider not in {"auto", "custom"}
@@ -1814,10 +1853,12 @@ def resolve_runtime_provider(
             explicit_base_url=explicit_base_url,
             model_cfg=model_cfg,
         )
+        selected_pool_base_url = endpoint.base_url
         should_use_pool = (
             (requested_provider == "auto" or explicit_openrouter_request)
             and not explicit_api_key
-            and endpoint.source == "default"
+            and endpoint.provider == "openrouter"
+            and endpoint.source in {"config", "default"}
         )
 
     try:
@@ -1866,17 +1907,19 @@ def resolve_runtime_provider(
                 if not pool_api_key or not _agent_key_is_usable(nous_state, min_ttl):
                     logger.debug("Nous pool entry agent_key still unavailable, falling through to runtime resolution")
                     pool_api_key = ""
+        pool_base_url = selected_pool_base_url or (
+            getattr(entry, "runtime_base_url", None)
+            or getattr(entry, "base_url", None)
+            or ""
+        )
+        pool_match_base_url = OPENROUTER_BASE_URL if provider == "openrouter" else pool_base_url
         if (
             entry is not None
             and pool_api_key
             and credential_pool_matches_provider(
                 pool,
                 provider,
-                base_url=(
-                    getattr(entry, "runtime_base_url", None)
-                    or getattr(entry, "base_url", None)
-                    or ""
-                ),
+                base_url=pool_match_base_url,
             )
         ):
             return _resolve_runtime_from_pool_entry(
@@ -1886,6 +1929,7 @@ def resolve_runtime_provider(
                 model_cfg=model_cfg,
                 pool=pool,
                 target_model=target_model,
+                selected_base_url=selected_pool_base_url,
             )
 
     if provider == "nous":
@@ -1997,15 +2041,9 @@ def resolve_runtime_provider(
 
     # Anthropic (native Messages API)
     if provider == "anthropic":
-        # Allow base URL override from config.yaml model.base_url, but only
-        # when the configured provider is anthropic — otherwise a non-Anthropic
-        # base_url (e.g. Codex endpoint) would leak into Anthropic requests.
-        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-        cfg_base_url = ""
-        if cfg_provider == "anthropic":
-            cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
-            if not _anthropic_base_url_override_ok(cfg_base_url):
-                cfg_base_url = ""
+        # Allow model.base_url only when the configured provider belongs to the
+        # Anthropic family; otherwise a stale endpoint could receive its key.
+        cfg_base_url = _configured_anthropic_base_url(model_cfg)
         base_url = cfg_base_url or "https://api.anthropic.com"
 
         # For Microsoft Foundry endpoints, use ANTHROPIC_API_KEY directly —
@@ -2163,45 +2201,15 @@ def resolve_runtime_provider(
         # matches this provider — mirrors the Anthropic path above.  Without
         # this, users who set model.base_url to e.g. api.minimaxi.com/anthropic
         # (China endpoint) still get the hardcoded api.minimax.io default (#6039).
-        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-        cfg_base_url = ""
-        if cfg_provider == provider:
-            cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+        cfg_base_url = _configured_base_url(model_cfg, provider)
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
-        api_mode = "chat_completions"
-        if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(
-                model_cfg,
-                creds.get("api_key", ""),
-                target_model=target_model,
-            )
-        elif provider == "xai":
-            api_mode = "codex_responses"
-        else:
-            configured_provider = str(model_cfg.get("provider") or "").strip().lower()
-            # Only honor persisted api_mode when it belongs to the same provider family.
-            configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if provider in {"opencode-zen", "opencode-go"}:
-                # opencode-zen/go must always re-derive api_mode from the
-                # target model (not the stale persisted api_mode), because
-                # the same provider serves both anthropic_messages
-                # (e.g. minimax-m2.7) and chat_completions (e.g.
-                # deepseek-v4-flash) and switching models via /model would
-                # otherwise carry the previous mode forward, stripping /v1
-                # from base_url for chat_completions models and 404'ing.
-                # Refs #16878.
-                from hermes_cli.models import opencode_model_api_mode
-                _effective = target_model or model_cfg.get("default", "")
-                api_mode = opencode_model_api_mode(provider, _effective)
-            elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
-                api_mode = configured_mode
-            else:
-                # Auto-detect Anthropic-compatible endpoints by URL convention
-                # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)
-                # plus api.openai.com → codex_responses and api.x.ai → codex_responses.
-                detected = _detect_api_mode_for_url(base_url)
-                if detected:
-                    api_mode = detected
+        api_mode = _resolve_static_api_mode(
+            provider,
+            model_cfg,
+            base_url,
+            api_key=creds.get("api_key", ""),
+            target_model=target_model,
+        )
         # Normalize the /v1 suffix for OpenCode by API mode (see comment above).
         if provider in {"opencode-zen", "opencode-go"}:
             from hermes_cli.models import normalize_opencode_base_url

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 from urllib.parse import urlparse
-from typing import Any, Dict, Optional
+from typing import Any, Dict, NamedTuple, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -1133,6 +1133,53 @@ def _resolve_named_custom_runtime(
     return result
 
 
+class _OpenRouterEndpoint(NamedTuple):
+    base_url: str
+    source: str
+    requested_provider: str
+
+
+def _resolve_openrouter_endpoint(
+    *,
+    requested_provider: str,
+    explicit_base_url: Optional[str] = None,
+    model_cfg: Optional[Dict[str, Any]] = None,
+) -> _OpenRouterEndpoint:
+    model_cfg = _get_model_config() if model_cfg is None else model_cfg
+    cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
+    cfg_provider = model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
+    requested_norm = (requested_provider or "").strip().lower()
+    cfg_provider = cfg_provider.strip().lower()
+
+    if requested_norm and requested_norm != "custom":
+        try:
+            from hermes_cli.auth import resolve_provider as _resolve_provider
+
+            if _resolve_provider(requested_norm) == "custom":
+                requested_norm = "custom"
+        except Exception:
+            pass
+
+    use_config_base_url = False
+    if cfg_base_url.strip() and not explicit_base_url:
+        if requested_norm == "auto":
+            use_config_base_url = not cfg_provider or cfg_provider == "auto"
+        elif requested_norm == "custom" and _config_base_url_trustworthy_for_bare_custom(
+            cfg_base_url, cfg_provider
+        ):
+            use_config_base_url = True
+
+    candidates = (
+        ("explicit", (explicit_base_url or "").strip()),
+        ("custom_env", _getenv("CUSTOM_BASE_URL", "").strip()),
+        ("config", cfg_base_url.strip() if use_config_base_url else ""),
+        ("openrouter_env", _getenv("OPENROUTER_BASE_URL", "").strip()),
+        ("default", OPENROUTER_BASE_URL),
+    )
+    source, base_url = next((source, value) for source, value in candidates if value)
+    return _OpenRouterEndpoint(base_url.rstrip("/"), source, requested_norm)
+
+
 def _resolve_openrouter_runtime(
     *,
     requested_provider: str,
@@ -1140,52 +1187,18 @@ def _resolve_openrouter_runtime(
     explicit_base_url: Optional[str] = None,
 ) -> Dict[str, Any]:
     model_cfg = _get_model_config()
-    cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
-    cfg_provider = model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
     cfg_api_key = ""
     for k in ("api_key", "api"):
         v = model_cfg.get(k)
         if isinstance(v, str) and v.strip():
             cfg_api_key = v.strip()
             break
-    requested_norm = (requested_provider or "").strip().lower()
-    cfg_provider = cfg_provider.strip().lower()
-    # GitHub #27132: provider aliases follow the same base_url trust + routing
-    # rules as their canonical custom/OpenRouter provider. Normalising here
-    # keeps every check below alias-aware without duplicating the alias map.
-    if requested_norm and requested_norm not in {"auto", "custom"}:
-        try:
-            from hermes_cli.auth import resolve_provider as _resolve_provider
-
-            resolved_requested = _resolve_provider(requested_norm)
-            if resolved_requested in {"custom", "openrouter"}:
-                requested_norm = resolved_requested
-        except Exception:
-            pass
-
-    env_openrouter_base_url = _getenv("OPENROUTER_BASE_URL", "").strip()
-    env_custom_base_url = _getenv("CUSTOM_BASE_URL", "").strip()
-
-    # Use config base_url when available and the provider context matches.
-    # OPENAI_BASE_URL env var is no longer consulted — config.yaml is
-    # the single source of truth for endpoint URLs.
-    use_config_base_url = False
-    if cfg_base_url.strip() and not explicit_base_url:
-        if requested_norm == "auto":
-            if not cfg_provider or cfg_provider == "auto":
-                use_config_base_url = True
-        elif requested_norm == "custom" and _config_base_url_trustworthy_for_bare_custom(
-            cfg_base_url, cfg_provider
-        ):
-            use_config_base_url = True
-
-    base_url = (
-        (explicit_base_url or "").strip()
-        or env_custom_base_url
-        or (cfg_base_url.strip() if use_config_base_url else "")
-        or env_openrouter_base_url
-        or OPENROUTER_BASE_URL
-    ).rstrip("/")
+    endpoint = _resolve_openrouter_endpoint(
+        requested_provider=requested_provider,
+        explicit_base_url=explicit_base_url,
+        model_cfg=model_cfg,
+    )
+    base_url = endpoint.base_url
 
     # Choose API key based on whether the resolved base_url targets OpenRouter.
     # When hitting OpenRouter, prefer OPENROUTER_API_KEY (issue #289).
@@ -1193,14 +1206,7 @@ def _resolve_openrouter_runtime(
     # OPENAI_API_KEY so the OpenRouter key doesn't leak to an unrelated
     # provider (issues #420, #560).
     _is_openrouter_url = base_url_host_matches(base_url, "openrouter.ai")
-    # Also treat explicitly-configured OpenRouter mirrors/proxies as OpenRouter
-    # for key selection — if the user set OPENROUTER_BASE_URL or requested
-    # provider=openrouter explicitly, OPENROUTER_API_KEY should still be used.
-    _is_openrouter_context = _is_openrouter_url or (
-        requested_norm == "openrouter"
-        and (env_openrouter_base_url or base_url == env_openrouter_base_url)
-        and base_url == (env_openrouter_base_url or "").rstrip("/")
-    )
+    _is_openrouter_context = _is_openrouter_url or endpoint.source == "openrouter_env"
     if _is_openrouter_context:
         api_key_candidates = [
             explicit_api_key,
@@ -1224,7 +1230,7 @@ def _resolve_openrouter_runtime(
         # Mirrors the OLLAMA_API_KEY host-gate added in GHSA-76xc-57q6-vm5m.
         api_key_candidates = [
             explicit_api_key,
-            (cfg_api_key if use_config_base_url else ""),
+            (cfg_api_key if endpoint.source == "config" else ""),
             (_getenv("OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
             (_getenv("OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),
             (_getenv("OPENROUTER_API_KEY") if _is_openrouter_url                   else ""),
@@ -1245,7 +1251,7 @@ def _resolve_openrouter_runtime(
     # name instead of silently relabeling to "openrouter" (#2562).
     # Also provide a placeholder API key for local servers that don't require
     # authentication — the OpenAI SDK requires a non-empty api_key string.
-    effective_provider = "custom" if requested_norm == "custom" else "openrouter"
+    effective_provider = "custom" if endpoint.requested_provider == "custom" else "openrouter"
 
     # For custom endpoints, check if a credential pool exists
     if effective_provider == "custom" and base_url:
@@ -1253,7 +1259,7 @@ def _resolve_openrouter_runtime(
         # fixing credential mix-ups when multiple custom providers share a base_url.
         pool_result = _try_resolve_from_custom_pool(
             base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
-            provider_name=requested_provider if requested_norm != "custom" else None,
+            provider_name=requested_provider if endpoint.requested_provider != "custom" else None,
         )
         if pool_result:
             return pool_result
@@ -1637,23 +1643,26 @@ def resolve_runtime_provider(
     from hermes_cli.config import is_provider_enabled, load_config
     _full_cfg = load_config()
     _provs_cfg = _full_cfg.get("providers") if isinstance(_full_cfg, dict) else None
+    resolved_provider_hint = None
     if isinstance(_provs_cfg, dict):
-        _provider_config_key = requested_provider
-        _block = _provs_cfg.get(_provider_config_key)
+        provider_config_key = requested_provider
+        _block = _provs_cfg.get(provider_config_key)
         if (
             not isinstance(_block, dict)
             and requested_provider != "auto"
             and _get_named_custom_provider(requested_provider) is None
         ):
             try:
-                _provider_config_key = auth_mod.resolve_provider(requested_provider)
+                resolved_provider_hint = auth_mod.resolve_provider(requested_provider)
             except AuthError:
-                _provider_config_key = requested_provider
-            _block = _provs_cfg.get(_provider_config_key)
+                pass
+            else:
+                provider_config_key = resolved_provider_hint
+                _block = _provs_cfg.get(provider_config_key)
         if isinstance(_block, dict) and not is_provider_enabled(_block):
             raise ValueError(
                 f"provider {requested_provider!r} is disabled in config "
-                f"(providers.{_provider_config_key}.enabled: false)"
+                f"(providers.{provider_config_key}.enabled: false)"
             )
 
     if requested_provider == "moa":
@@ -1780,7 +1789,7 @@ def resolve_runtime_provider(
                 runtime["requested_provider"] = requested_provider
                 return runtime
 
-    provider = resolve_provider(
+    provider = resolved_provider_hint or resolve_provider(
         requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
@@ -1799,25 +1808,16 @@ def resolve_runtime_provider(
 
     should_use_pool = provider != "openrouter"
     if provider == "openrouter":
-        explicit_openrouter_request = (
-            requested_provider != "auto"
-            and auth_mod.resolve_provider(requested_provider) == "openrouter"
+        explicit_openrouter_request = requested_provider not in {"auto", "custom"}
+        endpoint = _resolve_openrouter_endpoint(
+            requested_provider=requested_provider,
+            explicit_base_url=explicit_base_url,
+            model_cfg=model_cfg,
         )
-        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-        cfg_base_url = str(model_cfg.get("base_url") or "").strip()
-        env_openrouter_base_url = _getenv("OPENROUTER_BASE_URL", "").strip()
-        has_custom_endpoint = bool(explicit_base_url or env_openrouter_base_url)
-        if (
-            not explicit_openrouter_request
-            and cfg_base_url
-            and cfg_provider in {"auto", "custom"}
-        ):
-            has_custom_endpoint = True
-        has_runtime_override = bool(explicit_api_key or explicit_base_url)
         should_use_pool = (
-            (explicit_openrouter_request or requested_provider == "auto")
-            and not has_custom_endpoint
-            and not has_runtime_override
+            (requested_provider == "auto" or explicit_openrouter_request)
+            and not explicit_api_key
+            and endpoint.source == "default"
         )
 
     try:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1150,17 +1150,16 @@ def _resolve_openrouter_runtime(
             break
     requested_norm = (requested_provider or "").strip().lower()
     cfg_provider = cfg_provider.strip().lower()
-    # GitHub #27132: provider aliases that resolve to "custom" (ollama,
-    # vllm, llamacpp, …) follow the same base_url trust + routing rules
-    # as a bare `provider: custom`. Normalising here keeps every check
-    # below — `requested_norm == "custom"`, the trust check, the pool
-    # gate up the stack — alias-aware without duplicating the alias map.
+    # GitHub #27132: provider aliases follow the same base_url trust + routing
+    # rules as their canonical custom/OpenRouter provider. Normalising here
+    # keeps every check below alias-aware without duplicating the alias map.
     if requested_norm and requested_norm != "custom":
         try:
             from hermes_cli.auth import resolve_provider as _resolve_provider
 
-            if _resolve_provider(requested_norm) == "custom":
-                requested_norm = "custom"
+            resolved_requested = _resolve_provider(requested_norm)
+            if resolved_requested in {"custom", "openrouter"}:
+                requested_norm = resolved_requested
         except Exception:
             pass
 
@@ -1639,11 +1638,22 @@ def resolve_runtime_provider(
     _full_cfg = load_config()
     _provs_cfg = _full_cfg.get("providers") if isinstance(_full_cfg, dict) else None
     if isinstance(_provs_cfg, dict):
-        _block = _provs_cfg.get(requested_provider)
+        _provider_config_key = requested_provider
+        _block = _provs_cfg.get(_provider_config_key)
+        if (
+            not isinstance(_block, dict)
+            and requested_provider != "auto"
+            and _get_named_custom_provider(requested_provider) is None
+        ):
+            try:
+                _provider_config_key = auth_mod.resolve_provider(requested_provider)
+            except AuthError:
+                _provider_config_key = requested_provider
+            _block = _provs_cfg.get(_provider_config_key)
         if isinstance(_block, dict) and not is_provider_enabled(_block):
             raise ValueError(
                 f"provider {requested_provider!r} is disabled in config "
-                f"(providers.{requested_provider}.enabled: false)"
+                f"(providers.{_provider_config_key}.enabled: false)"
             )
 
     if requested_provider == "moa":
@@ -1789,20 +1799,28 @@ def resolve_runtime_provider(
 
     should_use_pool = provider != "openrouter"
     if provider == "openrouter":
+        explicit_openrouter_request = (
+            requested_provider != "auto"
+            and auth_mod.resolve_provider(requested_provider) == "openrouter"
+        )
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()
         env_openai_base_url = _getenv("OPENAI_BASE_URL", "").strip()
         env_openrouter_base_url = _getenv("OPENROUTER_BASE_URL", "").strip()
         has_custom_endpoint = bool(
             explicit_base_url
-            or env_openai_base_url
             or env_openrouter_base_url
+            or (not explicit_openrouter_request and env_openai_base_url)
         )
-        if cfg_base_url and cfg_provider in {"auto", "custom"}:
+        if (
+            not explicit_openrouter_request
+            and cfg_base_url
+            and cfg_provider in {"auto", "custom"}
+        ):
             has_custom_endpoint = True
         has_runtime_override = bool(explicit_api_key or explicit_base_url)
         should_use_pool = (
-            requested_provider in {"openrouter", "auto"}
+            (explicit_openrouter_request or requested_provider == "auto")
             and not has_custom_endpoint
             and not has_runtime_override
         )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1153,7 +1153,7 @@ def _resolve_openrouter_runtime(
     # GitHub #27132: provider aliases follow the same base_url trust + routing
     # rules as their canonical custom/OpenRouter provider. Normalising here
     # keeps every check below alias-aware without duplicating the alias map.
-    if requested_norm and requested_norm != "custom":
+    if requested_norm and requested_norm not in {"auto", "custom"}:
         try:
             from hermes_cli.auth import resolve_provider as _resolve_provider
 

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -54,4 +54,30 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         # Should have been called at least twice (primary + fallback)
         assert call_count["n"] >= 2
 
+    def test_disabled_primary_uses_configured_fallback(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "model:\n"
+            "  provider: or\n"
+            "providers:\n"
+            "  openrouter:\n"
+            "    enabled: false\n"
+            "fallback_model:\n"
+            "  provider: custom\n"
+            "  model: fallback-model\n"
+            "  base_url: https://fallback.example/v1\n"
+            "  api_key: fallback-key\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        from gateway.run import _resolve_runtime_agent_kwargs
+
+        result = _resolve_runtime_agent_kwargs()
+
+        assert result["provider"] == "custom"
+        assert result["api_key"] == "fallback-key"
+        assert result["base_url"] == "https://fallback.example/v1"
+        assert result["model"] == "fallback-model"
+
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -365,7 +365,88 @@ def test_resolve_runtime_provider_openrouter_ignores_codex_config_base_url(monke
     assert resolved["base_url"] == rp.OPENROUTER_BASE_URL
 
 
-def _write_openrouter_pool(hermes_home, api_keys=("pool-key",)):
+@pytest.mark.parametrize(
+    ("configured_provider", "stale_api_mode"),
+    [
+        pytest.param("anthropic", "anthropic_messages", id="anthropic"),
+        pytest.param("openai-codex", "codex_responses", id="codex"),
+    ],
+)
+def test_explicit_openrouter_ignores_stale_provider_api_mode(
+    monkeypatch,
+    configured_provider,
+    stale_api_mode,
+):
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": configured_provider,
+            "api_mode": stale_api_mode,
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="or",
+        explicit_api_key="explicit-key",
+    )
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_mode"] == "chat_completions"
+
+
+def test_explicit_openrouter_honors_persisted_alias_api_mode(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "or",
+            "api_mode": "anthropic_messages",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="or",
+        explicit_api_key="explicit-key",
+    )
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_mode"] == "anthropic_messages"
+
+
+@pytest.mark.parametrize(
+    ("requested", "configured_provider", "stale_api_mode"),
+    [
+        pytest.param("gemini", "anthropic", "anthropic_messages", id="gemini-from-anthropic"),
+        pytest.param("zai", "openai-codex", "codex_responses", id="zai-from-codex"),
+    ],
+)
+def test_explicit_registry_provider_ignores_stale_api_mode(
+    monkeypatch,
+    requested,
+    configured_provider,
+    stale_api_mode,
+):
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": configured_provider,
+            "api_mode": stale_api_mode,
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested=requested,
+        explicit_api_key="explicit-key",
+    )
+
+    assert resolved["provider"] == requested
+    assert resolved["api_mode"] == "chat_completions"
+
+
+def _write_openrouter_pool(hermes_home, api_keys=("pool-key",), *, base_url=None):
+    base_url = base_url or rp.OPENROUTER_BASE_URL
     (hermes_home / "auth.json").write_text(
         json.dumps(
             {
@@ -379,7 +460,7 @@ def _write_openrouter_pool(hermes_home, api_keys=("pool-key",)):
                             "priority": index,
                             "source": "manual",
                             "access_token": api_key,
-                            "base_url": rp.OPENROUTER_BASE_URL,
+                            "base_url": base_url,
                         }
                         for index, api_key in enumerate(api_keys)
                     ]
@@ -390,8 +471,304 @@ def _write_openrouter_pool(hermes_home, api_keys=("pool-key",)):
     )
 
 
+def _write_custom_pool(
+    hermes_home,
+    *,
+    name="pooled-custom",
+    base_url="https://custom.example/v1",
+    api_key="custom-pool-key",
+):
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    f"custom:{name}": [
+                        {
+                            "id": api_key,
+                            "label": api_key,
+                            "auth_type": "api_key",
+                            "priority": 0,
+                            "source": "manual",
+                            "access_token": api_key,
+                            "base_url": base_url,
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_api_key_pool(
+    hermes_home,
+    *,
+    provider,
+    base_url,
+    api_key="pool-key",
+):
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    provider: [
+                        {
+                            "id": api_key,
+                            "label": api_key,
+                            "auth_type": "api_key",
+                            "priority": 0,
+                            "source": "manual",
+                            "access_token": api_key,
+                            "base_url": base_url,
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("credential_source", ["explicit", "environment", "pool"])
+def test_alias_config_base_url_applies_across_registry_routes(
+    tmp_path,
+    monkeypatch,
+    credential_source,
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    configured_base_url = "https://zai-proxy.example/v1"
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: glm\n"
+        f"  base_url: {configured_base_url}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("GLM_BASE_URL", raising=False)
+    monkeypatch.delenv("GLM_API_KEY", raising=False)
+    monkeypatch.delenv("ZAI_API_KEY", raising=False)
+    monkeypatch.delenv("Z_AI_API_KEY", raising=False)
+    explicit_api_key = None
+    if credential_source == "explicit":
+        explicit_api_key = "explicit-key"
+    elif credential_source == "environment":
+        monkeypatch.setenv("GLM_API_KEY", "environment-key")
+    else:
+        _write_api_key_pool(
+            hermes_home,
+            provider="zai",
+            base_url=rp.PROVIDER_REGISTRY["zai"].inference_base_url,
+        )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="zai",
+        explicit_api_key=explicit_api_key,
+    )
+
+    assert resolved["provider"] == "zai"
+    assert resolved["base_url"] == configured_base_url
+
+
+def test_custom_provider_shadow_prevents_builtin_alias_config_capture(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: glm\n"
+        "  base_url: https://custom-glm.example/v1\n"
+        "  api_mode: anthropic_messages\n"
+        "custom_providers:\n"
+        "  - name: glm\n"
+        "    base_url: https://custom-glm.example/v1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = rp.resolve_runtime_provider(
+        requested="zai",
+        explicit_api_key="explicit-key",
+    )
+
+    assert resolved["provider"] == "zai"
+    assert resolved["base_url"] == rp.PROVIDER_REGISTRY["zai"].inference_base_url
+    assert resolved["api_mode"] == "chat_completions"
+
+
+def test_provider_canonicalization_does_not_resolve_auto_from_credentials(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "ambient-key")
+
+    assert rp._canonical_builtin_provider_name("auto") == "auto"
+
+
+@pytest.mark.parametrize("credential_source", ["explicit", "environment", "pool"])
+def test_anthropic_alias_owns_config_base_url_across_routes(
+    tmp_path,
+    monkeypatch,
+    credential_source,
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    configured_base_url = "https://proxy.example/anthropic"
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: claude\n"
+        f"  base_url: {configured_base_url}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    explicit_api_key = None
+    if credential_source == "explicit":
+        explicit_api_key = "explicit-key"
+    elif credential_source == "environment":
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "environment-key")
+    else:
+        _write_api_key_pool(
+            hermes_home,
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+        )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="anthropic",
+        explicit_api_key=explicit_api_key,
+    )
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["base_url"] == configured_base_url
+
+
+@pytest.mark.parametrize("credential_source", ["explicit", "environment", "pool"])
+def test_openrouter_alias_config_endpoint_is_independent_of_credential_source(
+    tmp_path,
+    monkeypatch,
+    credential_source,
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    configured_base_url = "https://openrouter-proxy.example/v1"
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: or\n"
+        f"  base_url: {configured_base_url}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    explicit_api_key = None
+    expected_api_key = f"{credential_source}-key"
+    if credential_source == "explicit":
+        explicit_api_key = expected_api_key
+    elif credential_source == "environment":
+        monkeypatch.setenv("OPENROUTER_API_KEY", expected_api_key)
+    else:
+        _write_openrouter_pool(hermes_home, api_keys=(expected_api_key,))
+
+    resolved = rp.resolve_runtime_provider(
+        requested="or",
+        explicit_api_key=explicit_api_key,
+    )
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["base_url"] == configured_base_url
+    assert resolved["api_key"] == expected_api_key
+
+
 @pytest.mark.parametrize(
-    ("requested", "config_text", "openai_base_url"),
+    ("explicit_api_key", "expected_api_key"),
+    [(None, "no-key-required"), ("explicit-key", "explicit-key")],
+)
+def test_auto_explicit_custom_endpoint_does_not_inherit_openrouter_key(
+    tmp_path,
+    monkeypatch,
+    explicit_api_key,
+    expected_api_key,
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "ambient-openrouter-key")
+    custom_base_url = "https://custom.example/v1"
+
+    resolved = rp.resolve_runtime_provider(
+        requested="auto",
+        explicit_api_key=explicit_api_key,
+        explicit_base_url=custom_base_url,
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == custom_base_url
+    assert resolved["api_key"] == expected_api_key
+
+
+def test_openrouter_pool_credentials_do_not_override_selected_route(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openrouter\n",
+        encoding="utf-8",
+    )
+    _write_openrouter_pool(
+        hermes_home,
+        base_url="https://stale.example/v1",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "pool-key"
+    assert resolved["base_url"] == rp.OPENROUTER_BASE_URL
+
+
+def test_copilot_pool_without_base_url_uses_registry_default(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: copilot\n",
+        encoding="utf-8",
+    )
+    _write_api_key_pool(
+        hermes_home,
+        provider="copilot",
+        base_url="",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = rp.resolve_runtime_provider(requested="copilot")
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["base_url"] == rp.PROVIDER_REGISTRY["copilot"].inference_base_url
+
+
+def test_openrouter_pool_preserves_persisted_alias_api_mode(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: or\n"
+        "  api_mode: anthropic_messages\n",
+        encoding="utf-8",
+    )
+    _write_openrouter_pool(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = rp.resolve_runtime_provider(requested="or")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "pool-key"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["source"] == "manual"
+
+
+@pytest.mark.parametrize(
+    ("requested", "config_text", "openai_base_url", "custom_base_url"),
     [
         pytest.param(
             "openrouter",
@@ -400,18 +777,21 @@ def _write_openrouter_pool(hermes_home, api_keys=("pool-key",)):
             "  base_url: https://litellm.example/v1\n"
             "  api_key: custom-key\n",
             None,
+            None,
             id="model-config",
         ),
         pytest.param(
             "openrouter",
             "{}\n",
             "https://custom.example/v1",
+            None,
             id="environment",
         ),
         pytest.param(
             "auto",
             "{}\n",
             "https://stale-openai.example/v1",
+            None,
             id="auto-ignores-stale-openai-environment",
         ),
         pytest.param(
@@ -421,7 +801,15 @@ def _write_openrouter_pool(hermes_home, api_keys=("pool-key",)):
             "  base_url: https://litellm.example/v1\n"
             "  api_key: custom-key\n",
             None,
+            None,
             id="provider-alias",
+        ),
+        pytest.param(
+            "openrouter",
+            "{}\n",
+            None,
+            "https://unrelated-custom.example/v1",
+            id="explicit-ignores-custom-base-environment",
         ),
     ],
 )
@@ -431,6 +819,7 @@ def test_openrouter_pool_ignores_unrelated_custom_endpoint(
     requested,
     config_text,
     openai_base_url,
+    custom_base_url,
 ):
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
@@ -441,6 +830,10 @@ def test_openrouter_pool_ignores_unrelated_custom_endpoint(
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     else:
         monkeypatch.setenv("OPENAI_BASE_URL", openai_base_url)
+    if custom_base_url is None:
+        monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    else:
+        monkeypatch.setenv("CUSTOM_BASE_URL", custom_base_url)
     monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
@@ -508,25 +901,38 @@ def test_explicit_openrouter_alias_honors_disabled_provider(tmp_path, monkeypatc
     _write_openrouter_pool(hermes_home)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-    with pytest.raises(ValueError, match=r"providers\.openrouter\.enabled: false"):
+    with pytest.raises(rp.AuthError, match=r"providers\.openrouter\.enabled: false"):
         rp.resolve_runtime_provider(requested="or")
 
 
 @pytest.mark.parametrize(
-    ("requested", "base_url_env", "expected_api_key"),
+    ("requested", "base_url_env", "base_url_value", "expected_provider", "expected_api_key"),
     [
-        pytest.param("openrouter", "OPENROUTER_BASE_URL", "fallback-key", id="openrouter-explicit"),
-        pytest.param("or", "OPENROUTER_BASE_URL", "fallback-key", id="openrouter-alias"),
-        pytest.param("auto", "OPENROUTER_BASE_URL", "fallback-key", id="openrouter-auto"),
-        pytest.param("openrouter", "CUSTOM_BASE_URL", "", id="custom-explicit"),
-        pytest.param("auto", "CUSTOM_BASE_URL", "", id="custom-auto"),
+        pytest.param(
+            "openrouter", "OPENROUTER_BASE_URL", "https://openrouter-proxy.example/v1",
+            "openrouter", "fallback-key", id="openrouter-explicit",
+        ),
+        pytest.param(
+            "or", "OPENROUTER_BASE_URL", "https://openrouter-proxy.example/v1",
+            "openrouter", "fallback-key", id="openrouter-alias",
+        ),
+        pytest.param(
+            "auto", "OPENROUTER_BASE_URL", "https://openrouter-proxy.example/v1",
+            "openrouter", "fallback-key", id="openrouter-auto",
+        ),
+        pytest.param(
+            "auto", "CUSTOM_BASE_URL", "  https://openrouter-proxy.example/v1  ",
+            "custom", "no-key-required", id="custom-auto-padded",
+        ),
     ],
 )
-def test_openrouter_base_url_override_skips_populated_pool(
+def test_endpoint_base_url_override_skips_populated_openrouter_pool(
     tmp_path,
     monkeypatch,
     requested,
     base_url_env,
+    base_url_value,
+    expected_provider,
     expected_api_key,
 ):
     hermes_home = tmp_path / "hermes"
@@ -535,10 +941,13 @@ def test_openrouter_base_url_override_skips_populated_pool(
     _write_openrouter_pool(hermes_home)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
-    monkeypatch.setenv(base_url_env, "https://openrouter-proxy.example/v1")
+    monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv(base_url_env, base_url_value)
 
     resolved = rp.resolve_runtime_provider(requested=requested)
 
+    assert resolved["provider"] == expected_provider
     assert resolved["api_key"] == expected_api_key
     assert resolved["base_url"] == "https://openrouter-proxy.example/v1"
     assert resolved.get("credential_pool") is None
@@ -557,12 +966,126 @@ def test_auto_custom_config_skips_populated_openrouter_pool(tmp_path, monkeypatc
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv("CUSTOM_BASE_URL", "   ")
     monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
 
     resolved = rp.resolve_runtime_provider(requested="auto")
 
-    assert resolved["api_key"] == ""
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "no-key-required"
     assert resolved["base_url"] == "https://custom.example/v1"
+    assert resolved.get("credential_pool") is None
+
+
+def test_auto_custom_pool_uses_plain_custom_api_mode_policy(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: auto\n"
+        "  base_url: https://custom.example/v1\n"
+        "  api_mode: codex_responses\n"
+        "custom_providers:\n"
+        "  - name: pooled-custom\n"
+        "    base_url: https://custom.example/v1\n",
+        encoding="utf-8",
+    )
+    _write_custom_pool(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = rp.resolve_runtime_provider(requested="auto")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "custom-pool-key"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["source"] == "pool:custom:pooled-custom"
+
+
+def test_explicit_key_bypasses_auto_custom_pool(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: auto\n"
+        "  base_url: https://custom.example/v1\n"
+        "custom_providers:\n"
+        "  - name: pooled-custom\n"
+        "    base_url: https://custom.example/v1\n",
+        encoding="utf-8",
+    )
+    _write_custom_pool(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = rp.resolve_runtime_provider(
+        requested="auto",
+        explicit_api_key="explicit-key",
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "explicit-key"
+    assert resolved["source"] == "explicit"
+    assert resolved.get("credential_pool") is None
+
+
+def test_explicit_key_bypasses_direct_alias_custom_pool(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "custom_providers:\n"
+        "  - name: pooled-custom\n"
+        "    base_url: https://custom.example/v1\n",
+        encoding="utf-8",
+    )
+    _write_custom_pool(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom",
+        explicit_api_key="explicit-key",
+        explicit_base_url="https://custom.example/v1",
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "explicit-key"
+    assert resolved["source"] == "direct-alias"
+    assert resolved.get("credential_pool") is None
+
+
+@pytest.mark.parametrize(
+    ("explicit_api_key", "explicit_base_url", "expected_api_key"),
+    [
+        pytest.param("explicit-key", None, "explicit-key", id="explicit-key"),
+        pytest.param(None, "https://override.example/v1", "no-key-required", id="explicit-url"),
+    ],
+)
+def test_named_custom_pool_respects_explicit_overrides(
+    tmp_path,
+    monkeypatch,
+    explicit_api_key,
+    explicit_base_url,
+    expected_api_key,
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "custom_providers:\n"
+        "  - name: pooled-custom\n"
+        "    base_url: https://custom.example/v1\n",
+        encoding="utf-8",
+    )
+    _write_custom_pool(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = rp.resolve_runtime_provider(
+        requested="pooled-custom",
+        explicit_api_key=explicit_api_key,
+        explicit_base_url=explicit_base_url,
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == expected_api_key
+    assert resolved["base_url"] == (explicit_base_url or "https://custom.example/v1")
+    assert resolved["source"] == "custom_provider:pooled-custom"
     assert resolved.get("credential_pool") is None
 
 
@@ -583,7 +1106,8 @@ def test_resolve_runtime_provider_auto_uses_custom_config_base_url(monkeypatch):
 
     resolved = rp.resolve_runtime_provider(requested="auto")
 
-    assert resolved["provider"] == "openrouter"
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "no-key-required"
     assert resolved["base_url"] == "https://custom.example/v1"
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from hermes_cli import config as config_mod
 from hermes_cli import runtime_provider as rp
 
 
@@ -366,7 +365,7 @@ def test_resolve_runtime_provider_openrouter_ignores_codex_config_base_url(monke
     assert resolved["base_url"] == rp.OPENROUTER_BASE_URL
 
 
-def _write_openrouter_pool(hermes_home):
+def _write_openrouter_pool(hermes_home, api_keys=("pool-key",)):
     (hermes_home / "auth.json").write_text(
         json.dumps(
             {
@@ -374,14 +373,15 @@ def _write_openrouter_pool(hermes_home):
                 "credential_pool": {
                     "openrouter": [
                         {
-                            "id": "daily-key",
-                            "label": "daily-key",
+                            "id": f"daily-key-{index}",
+                            "label": f"daily-key-{index}",
                             "auth_type": "api_key",
-                            "priority": 0,
+                            "priority": index,
                             "source": "manual",
-                            "access_token": "pool-key",
+                            "access_token": api_key,
                             "base_url": rp.OPENROUTER_BASE_URL,
                         }
+                        for index, api_key in enumerate(api_keys)
                     ]
                 },
             }
@@ -453,19 +453,93 @@ def test_openrouter_pool_ignores_unrelated_custom_endpoint(
     assert resolved["credential_pool"].provider == "openrouter"
 
 
-@pytest.mark.parametrize("requested", ["openrouter", "or"])
-def test_openrouter_base_url_override_skips_populated_pool(tmp_path, monkeypatch, requested):
+def test_explicit_openrouter_daily_limit_402_rotates_resolved_pool(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: custom\n"
+        "  base_url: https://litellm.example/v1\n"
+        "  api_key: custom-key\n",
+        encoding="utf-8",
+    )
+    _write_openrouter_pool(hermes_home, ("first-pool-key", "second-pool-key"))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    runtime = rp.resolve_runtime_provider(requested="openrouter")
+    pool = runtime["credential_pool"]
+    agent = SimpleNamespace(
+        _credential_pool=pool,
+        _credential_pool_entry_id=pool.current().id,
+        provider="openrouter",
+        api_key=runtime["api_key"],
+    )
+
+    def swap_credential(entry):
+        agent.api_key = entry.runtime_api_key
+        agent._credential_pool_entry_id = entry.id
+
+    agent._swap_credential = swap_credential
+
+    from agent.agent_runtime_helpers import recover_with_credential_pool
+
+    recovered, _ = recover_with_credential_pool(
+        agent,
+        status_code=402,
+        has_retried_429=False,
+        error_context={"message": "adjust the key's daily limit"},
+    )
+
+    assert recovered is True
+    assert agent.api_key == "second-pool-key"
+
+
+def test_explicit_openrouter_alias_honors_disabled_provider(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "providers:\n"
+        "  openrouter:\n"
+        "    enabled: false\n",
+        encoding="utf-8",
+    )
+    _write_openrouter_pool(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(ValueError, match=r"providers\.openrouter\.enabled: false"):
+        rp.resolve_runtime_provider(requested="or")
+
+
+@pytest.mark.parametrize(
+    ("requested", "base_url_env", "expected_api_key"),
+    [
+        pytest.param("openrouter", "OPENROUTER_BASE_URL", "fallback-key", id="openrouter-explicit"),
+        pytest.param("or", "OPENROUTER_BASE_URL", "fallback-key", id="openrouter-alias"),
+        pytest.param("auto", "OPENROUTER_BASE_URL", "fallback-key", id="openrouter-auto"),
+        pytest.param("openrouter", "CUSTOM_BASE_URL", "", id="custom-explicit"),
+        pytest.param("auto", "CUSTOM_BASE_URL", "", id="custom-auto"),
+    ],
+)
+def test_openrouter_base_url_override_skips_populated_pool(
+    tmp_path,
+    monkeypatch,
+    requested,
+    base_url_env,
+    expected_api_key,
+):
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir()
     (hermes_home / "config.yaml").write_text("{}\n", encoding="utf-8")
     _write_openrouter_pool(hermes_home)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
-    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://openrouter-proxy.example/v1")
+    monkeypatch.setenv(base_url_env, "https://openrouter-proxy.example/v1")
 
     resolved = rp.resolve_runtime_provider(requested=requested)
 
-    assert resolved["api_key"] == "fallback-key"
+    assert resolved["api_key"] == expected_api_key
     assert resolved["base_url"] == "https://openrouter-proxy.example/v1"
     assert resolved.get("credential_pool") is None
 
@@ -481,7 +555,6 @@ def test_auto_custom_config_skips_populated_openrouter_pool(tmp_path, monkeypatc
     )
     _write_openrouter_pool(hermes_home)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-    getattr(config_mod, "_LOAD_CONFIG_CACHE").clear()
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
     monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
@@ -491,22 +564,6 @@ def test_auto_custom_config_skips_populated_openrouter_pool(tmp_path, monkeypatc
     assert resolved["api_key"] == ""
     assert resolved["base_url"] == "https://custom.example/v1"
     assert resolved.get("credential_pool") is None
-
-
-def test_explicit_openrouter_alias_honors_disabled_provider(tmp_path, monkeypatch):
-    hermes_home = tmp_path / "hermes"
-    hermes_home.mkdir()
-    (hermes_home / "config.yaml").write_text(
-        "providers:\n"
-        "  openrouter:\n"
-        "    enabled: false\n",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-    monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
-
-    with pytest.raises(ValueError, match=r"providers\.openrouter\.enabled: false"):
-        rp.resolve_runtime_provider(requested="or")
 
 
 def test_resolve_runtime_provider_auto_uses_custom_config_base_url(monkeypatch):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -408,6 +408,12 @@ def _write_openrouter_pool(hermes_home):
             id="environment",
         ),
         pytest.param(
+            "auto",
+            "{}\n",
+            "https://stale-openai.example/v1",
+            id="auto-ignores-stale-openai-environment",
+        ),
+        pytest.param(
             "or",
             "model:\n"
             "  provider: custom\n"
@@ -418,7 +424,7 @@ def _write_openrouter_pool(hermes_home):
         ),
     ],
 )
-def test_explicit_openrouter_uses_pool_despite_unrelated_custom_endpoint(
+def test_openrouter_pool_ignores_unrelated_custom_endpoint(
     tmp_path,
     monkeypatch,
     requested,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -365,6 +365,120 @@ def test_resolve_runtime_provider_openrouter_ignores_codex_config_base_url(monke
     assert resolved["base_url"] == rp.OPENROUTER_BASE_URL
 
 
+def _write_openrouter_pool(hermes_home):
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    "openrouter": [
+                        {
+                            "id": "daily-key",
+                            "label": "daily-key",
+                            "auth_type": "api_key",
+                            "priority": 0,
+                            "source": "manual",
+                            "access_token": "pool-key",
+                            "base_url": rp.OPENROUTER_BASE_URL,
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("requested", "config_text", "openai_base_url"),
+    [
+        pytest.param(
+            "openrouter",
+            "model:\n"
+            "  provider: custom\n"
+            "  base_url: https://litellm.example/v1\n"
+            "  api_key: custom-key\n",
+            None,
+            id="model-config",
+        ),
+        pytest.param(
+            "openrouter",
+            "{}\n",
+            "https://custom.example/v1",
+            id="environment",
+        ),
+        pytest.param(
+            "or",
+            "model:\n"
+            "  provider: custom\n"
+            "  base_url: https://litellm.example/v1\n"
+            "  api_key: custom-key\n",
+            None,
+            id="provider-alias",
+        ),
+    ],
+)
+def test_explicit_openrouter_uses_pool_despite_unrelated_custom_endpoint(
+    tmp_path,
+    monkeypatch,
+    requested,
+    config_text,
+    openai_base_url,
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(config_text, encoding="utf-8")
+    _write_openrouter_pool(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    if openai_base_url is None:
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    else:
+        monkeypatch.setenv("OPENAI_BASE_URL", openai_base_url)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
+
+    resolved = rp.resolve_runtime_provider(requested=requested)
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["api_key"] == "pool-key"
+    assert resolved["base_url"] == rp.OPENROUTER_BASE_URL
+    assert resolved["credential_pool"].provider == "openrouter"
+
+
+@pytest.mark.parametrize("requested", ["openrouter", "or"])
+def test_openrouter_base_url_override_skips_populated_pool(tmp_path, monkeypatch, requested):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    _write_openrouter_pool(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://openrouter-proxy.example/v1")
+
+    resolved = rp.resolve_runtime_provider(requested=requested)
+
+    assert resolved["api_key"] == "fallback-key"
+    assert resolved["base_url"] == "https://openrouter-proxy.example/v1"
+    assert resolved.get("credential_pool") is None
+
+
+def test_explicit_openrouter_alias_honors_disabled_provider(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "providers:\n"
+        "  openrouter:\n"
+        "    enabled: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
+
+    with pytest.raises(ValueError, match=r"providers\.openrouter\.enabled: false"):
+        rp.resolve_runtime_provider(requested="or")
+
+
 def test_resolve_runtime_provider_auto_uses_custom_config_base_url(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
     monkeypatch.setattr(

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from hermes_cli import config as config_mod
 from hermes_cli import runtime_provider as rp
 
 
@@ -466,6 +467,29 @@ def test_openrouter_base_url_override_skips_populated_pool(tmp_path, monkeypatch
 
     assert resolved["api_key"] == "fallback-key"
     assert resolved["base_url"] == "https://openrouter-proxy.example/v1"
+    assert resolved.get("credential_pool") is None
+
+
+def test_auto_custom_config_skips_populated_openrouter_pool(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: auto\n"
+        "  base_url: https://custom.example/v1\n",
+        encoding="utf-8",
+    )
+    _write_openrouter_pool(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    getattr(config_mod, "_LOAD_CONFIG_CACHE").clear()
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "fallback-key")
+
+    resolved = rp.resolve_runtime_provider(requested="auto")
+
+    assert resolved["api_key"] == ""
+    assert resolved["base_url"] == "https://custom.example/v1"
     assert resolved.get("credential_pool") is None
 
 


### PR DESCRIPTION
## Bug Description

Explicitly switching to OpenRouter can bypass its credential pool when the current global model configuration points at an unrelated custom endpoint. The runtime then has no `credential_pool`, uses `OPENROUTER_API_KEY` directly, and cannot rotate when that key hits OpenRouter's daily limit.

A stale `OPENAI_BASE_URL` can cause the same pool bypass.

## Root Cause

Pool eligibility mixed the selected OpenRouter provider with endpoint state belonging to other provider routes. An unrelated custom `model.base_url` or `OPENAI_BASE_URL` suppressed `load_pool("openrouter")` before explicit provider precedence took effect.

## Fix

- Let an explicit OpenRouter selection—including the `or` alias—use its credential pool despite unrelated custom endpoint state.
- Preserve pool bypasses for an explicit API key, an explicit base URL, `OPENROUTER_BASE_URL`, `CUSTOM_BASE_URL`, and automatic/custom endpoint routing.
- Resolve endpoint precedence once and share that decision between pool eligibility, fallback routing, and API-key trust.
- Treat `OPENROUTER_BASE_URL` as the OpenRouter proxy boundary for fallback key selection.
- Resolve canonical provider identity once at the top-level disabled-provider gate and reuse it, while preserving exact named-custom provider shadowing.
- Add a real-path regression proving an OpenRouter daily-limit HTTP 402 rotates from the selected pool key to the next key.

Related but distinct: #42845 covers an explicitly supplied canonical OpenRouter URL, while #42982 covers `auto` with a canonical configured URL. Neither covers unrelated custom-endpoint state suppressing an explicit OpenRouter selection.

## How to Verify

1. Configure a custom model provider with its own `model.base_url`.
2. Add at least two OpenRouter credential-pool entries and set `OPENROUTER_API_KEY` to a different fallback credential.
3. Resolve or switch explicitly to OpenRouter; the runtime should contain the first pool credential and `credential_pool`.
4. Feed that runtime an HTTP 402 daily-limit failure; recovery should exhaust the first pool entry and swap to the second.

## Test Plan

- [x] Base regression is RED: `KeyError: credential_pool` before the fix
- [x] `scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_switch_model_pool_reload_52727.py tests/run_agent/test_31273_402_not_retried.py tests/run_agent/test_63425_credential_pool_auto_detect.py` — 72 passed
- [x] `python -m ruff check hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py`
- [x] `git diff --check`

## Risk Assessment

Low — the change is confined to shared runtime-provider resolution. Explicit runtime overrides and automatic/custom endpoint routing retain their existing behavior; filesystem-backed tests cover canonical, alias, automatic, override, disabled-provider, and 402-rotation paths.
