### PR TITLE
feat(kanban): open task deep links across boards

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -504,6 +504,23 @@
   // Root page
   // -------------------------------------------------------------------------
 
+  function taskIdFromLocation() {
+    try {
+      return (new URLSearchParams(window.location.search).get("task") || "").trim();
+    } catch (_e) {
+      return "";
+    }
+  }
+
+  function replaceTaskInLocation(taskId) {
+    try {
+      const url = new URL(window.location.href);
+      if (taskId) url.searchParams.set("task", taskId);
+      else url.searchParams.delete("task");
+      window.history.replaceState(window.history.state, "", url.pathname + url.search + url.hash);
+    } catch (_e) { /* non-fatal: drawer navigation still works */ }
+  }
+
   function KanbanPage() {
     const { t } = useI18n();
     const [board, setBoard] = useState(() => readSelectedBoard() || null);
@@ -531,7 +548,18 @@
     const [laneByProfile, setLaneByProfile] = useState(true);
     const [configApplied, setConfigApplied] = useState(false);
 
+    const [deepLinkTaskId] = useState(taskIdFromLocation);
+    const [deepLinkNotice, setDeepLinkNotice] = useState(null);
     const [selectedTaskId, setSelectedTaskId] = useState(null);
+    const openTask = useCallback(function (taskId) {
+      setSelectedTaskId(taskId);
+      setDeepLinkNotice(null);
+      replaceTaskInLocation(taskId);
+    }, []);
+    const closeTask = useCallback(function () {
+      setSelectedTaskId(null);
+      replaceTaskInLocation(null);
+    }, []);
     const [selectedIds, setSelectedIds] = useState(() => new Set());
     const [lastSelectedId, setLastSelectedId] = useState(null);
     const [failedIds, setFailedIds] = useState(() => new Set());
@@ -606,6 +634,35 @@
     }, [board]);
 
     useEffect(function () { loadBoardList(); }, [loadBoardList]);
+
+    // Resolve /kanban?task=<id> without requiring callers to know the board.
+    // The auth gate preserves the full path+query in its `next` parameter, so
+    // this runs unchanged after an OAuth/password round trip.
+    useEffect(function () {
+      if (!deepLinkTaskId) return;
+      SDK.fetchJSON(`${API}/tasks/locate/${encodeURIComponent(deepLinkTaskId)}`)
+        .then(function (result) {
+          const targetBoard = result && result.board;
+          const targetTask = result && result.task && result.task.id;
+          if (!targetBoard || !targetTask) throw new Error("invalid task lookup response");
+          if (targetBoard !== board) {
+            setBoardData(null);
+            cursorRef.current = 0;
+            setLoading(true);
+            setBoard(targetBoard);
+            writeSelectedBoard(targetBoard);
+            setSearch("");
+            setTenantFilter("");
+            setAssigneeFilter("");
+            setIncludeArchived(false);
+          }
+          openTask(targetTask);
+        })
+        .catch(function () {
+          setDeepLinkNotice(`Card ${deepLinkTaskId} was not found or is archived.`);
+          replaceTaskInLocation(null);
+        });
+    }, []);  // deep-link input is immutable for this page load
 
     const scheduleReload = useCallback(function () {
       if (reloadTimerRef.current) return;
@@ -1069,7 +1126,7 @@
         h(OrchestrationPanel, null),
         h(AttentionStrip, {
           boardData,
-          onOpen: setSelectedTaskId,
+          onOpen: openTask,
         }),
         h(BoardToolbar, {
           board: boardData,
@@ -1093,6 +1150,10 @@
          onSelectAllVisible: selectAllVisible,
          onDelete: deleteSelected,
        }) : null,
+        deepLinkNotice ? h("div", {
+          className: "text-xs text-muted-foreground border border-border bg-muted/40 px-3 py-2",
+          role: "status",
+        }, deepLinkNotice) : null,
         error ? h("div", { className: "text-xs text-destructive px-2" }, error) : null,
         h(BoardColumns, {
           board: filteredBoard,
@@ -1109,15 +1170,15 @@
           onMove: moveTask,
           onMoveSelected: moveSelected,
           onDelete: deleteTask,
-          onOpen: setSelectedTaskId,
+          onOpen: openTask,
           onCreate: createTask,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
         }),
         selectedTaskId ? h(TaskDrawer, {
           taskId: selectedTaskId,
           boardSlug: board,
-          onClose: function () { setSelectedTaskId(null); },
-          onOpenTask: setSelectedTaskId,
+          onClose: closeTask,
+          onOpenTask: openTask,
           onRefresh: loadBoard,
           renderMarkdown: renderMd,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -511,6 +511,39 @@ def get_board(
 
 
 # ---------------------------------------------------------------------------
+# GET /tasks/locate/:id — resolve a deep link across active boards
+# ---------------------------------------------------------------------------
+
+@router.get("/tasks/locate/{task_id}")
+def locate_task(task_id: str):
+    """Return the active board containing ``task_id``.
+
+    Dashboard links intentionally carry only the globally-random task id so
+    chat integrations do not need to know which board currently owns a card.
+    Archived boards and archived cards are excluded: those links fall back to
+    the normal board with a small not-found notice instead of opening stale
+    work.
+    """
+    for meta in kanban_db.list_boards(include_archived=False):
+        slug = meta["slug"]
+        conn = _conn(board=slug)
+        try:
+            task = kanban_db.get_task(conn, task_id)
+            if task is not None and task.status != "archived":
+                return {
+                    "board": slug,
+                    "task": {
+                        "id": task.id,
+                        "title": task.title,
+                        "status": task.status,
+                    },
+                }
+        finally:
+            conn.close()
+    raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+
+
+# ---------------------------------------------------------------------------
 # GET /tasks/:id
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -483,6 +483,14 @@ class TestAuthCallbackNext:
         assert r.status_code == 302
         assert r.headers["location"] == "/sessions"
 
+    def test_callback_preserves_kanban_task_deep_link(self, gated_app):
+        deep_link = "/kanban?task=t_03dc00df"
+
+        r = self._drive_oauth_via_login(gated_app, next_path=deep_link)
+
+        assert r.status_code == 302
+        assert r.headers["location"] == deep_link
+
 
     def test_attacker_callback_next_param_is_ignored(self, gated_app):
         """Hardening: even if an attacker crafts a callback URL with a

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -115,6 +115,56 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_locate_task_finds_active_card_across_boards(client):
+    kb.create_board("ops")
+    created = client.post(
+        "/api/plugins/kanban/tasks?board=ops",
+        json={"title": "Deep-linked card"},
+    ).json()["task"]
+
+    response = client.get(
+        f"/api/plugins/kanban/tasks/locate/{created['id']}"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "board": "ops",
+        "task": {
+            "id": created["id"],
+            "title": "Deep-linked card",
+            "status": "ready",
+        },
+    }
+
+
+def test_locate_task_treats_unknown_and_archived_cards_as_not_found(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Archived card"},
+    ).json()["task"]
+    archived = client.patch(
+        f"/api/plugins/kanban/tasks/{created['id']}",
+        json={"status": "archived"},
+    )
+    assert archived.status_code == 200
+
+    for task_id in (created["id"], "t_does_not_exist"):
+        response = client.get(f"/api/plugins/kanban/tasks/locate/{task_id}")
+        assert response.status_code == 404
+
+
+def test_dashboard_bundle_supports_task_deep_links():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = (
+        repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text()
+
+    assert 'new URLSearchParams(window.location.search).get("task")' in bundle
+    assert "`${API}/tasks/locate/${encodeURIComponent(deepLinkTaskId)}`" in bundle
+    assert "was not found or is archived" in bundle
+    assert "replaceTaskInLocation(taskId)" in bundle
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")


### PR DESCRIPTION
## Summary
- support `/kanban?task=<task_id>` by resolving the card across active boards
- select the owning board and open the existing task drawer
- keep internal card opens reflected in the URL; closing removes the query
- gracefully fall back with a status notice for unknown or archived cards
- cover the existing auth `next` round trip for a Kanban task URL

## Verification
- `PYTHONPATH="$PWD" .../venv/bin/python -m pytest tests/plugins/test_kanban_dashboard_plugin.py tests/hermes_cli/test_dashboard_auth_401_reauth.py -q -o addopts=` (48 passed)
- `node --check plugins/kanban/dashboard/dist/index.js`
- `ruff check` on changed Python files
- real-board TestClient probe resolved `t_03dc00df` to its owning board and returned 404 for an unknown id