### PR TITLE
fix(kanban): close the documented idempotency_key create race

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2435,9 +2435,36 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # is cheap thanks to ``IF NOT EXISTS`` and stays correct on fresh DBs
     # (where the columns already exist from SCHEMA_SQL).
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_tenant ON tasks(tenant)")
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
-    )
+    # Upgrade ``idx_tasks_idempotency`` to a partial UNIQUE index so the
+    # check-then-insert in ``create_task`` stops being the documented race
+    # ("two concurrent creators with the same key might both insert").
+    # Archived rows are excluded on purpose: creating a fresh task under a
+    # key whose previous task was archived is legal today and stays legal.
+    # Legacy boards that already contain duplicate live keys (a lost race
+    # from before this index) cannot satisfy UNIQUE — for those we keep the
+    # plain index and the old best-effort behaviour rather than failing
+    # initialization.
+    _idem_idx = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' "
+        "AND name='idx_tasks_idempotency'"
+    ).fetchone()
+    if _idem_idx and "UNIQUE" not in (_idem_idx[0] or ""):
+        conn.execute("DROP INDEX idx_tasks_idempotency")
+    try:
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_idempotency "
+            "ON tasks(idempotency_key) "
+            "WHERE idempotency_key IS NOT NULL AND status != 'archived'"
+        )
+    except sqlite3.IntegrityError:
+        _log.warning(
+            "kanban: duplicate live idempotency keys exist (pre-unique race); "
+            "keeping the non-unique index for this board"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency "
+            "ON tasks(idempotency_key)"
+        )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
@@ -3216,7 +3243,21 @@ def create_task(
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
-        except sqlite3.IntegrityError:
+        except sqlite3.IntegrityError as exc:
+            if "idempotency_key" in str(exc):
+                # Another creator won the race on the same idempotency_key
+                # between our pre-check and this INSERT; the partial UNIQUE
+                # index did its job. Return the winner — the exact contract
+                # the pre-check promises.
+                row = conn.execute(
+                    "SELECT id FROM tasks WHERE idempotency_key = ? "
+                    "AND status != 'archived' "
+                    "ORDER BY created_at DESC LIMIT 1",
+                    (idempotency_key,),
+                ).fetchone()
+                if row:
+                    return row["id"]
+                raise
             if attempt == 1:
                 raise
             # Retry with a fresh id.

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1408,3 +1408,104 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         conn.close()
 
 
+
+
+# ---------------------------------------------------------------------------
+# Idempotency-key uniqueness (create race)
+# ---------------------------------------------------------------------------
+
+class TestIdempotencyKeyRace:
+    def test_index_is_partial_unique(self, kanban_home):
+        conn = kb.connect()
+        try:
+            sql = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name='idx_tasks_idempotency'"
+            ).fetchone()[0]
+            assert "UNIQUE" in sql
+            assert "status != 'archived'" in sql
+        finally:
+            conn.close()
+
+    def test_lost_race_returns_the_winner(self, kanban_home):
+        """When the pre-check misses (another creator inserted between the
+        SELECT and our INSERT), the unique index rejects the duplicate and
+        create_task returns the winner instead of raising."""
+        conn = kb.connect()
+        try:
+            winner = kb.create_task(conn, title="A", assignee="x",
+                                    idempotency_key="K-race")
+
+            class RaceConn:
+                """First idempotency pre-check sees nothing (simulated race)."""
+                def __init__(self, real):
+                    self._real = real
+                    self._first = True
+
+                def __getattr__(self, name):
+                    return getattr(self._real, name)
+
+                def execute(self, sql, *args):
+                    if ("SELECT id FROM tasks WHERE idempotency_key" in sql
+                            and self._first):
+                        self._first = False
+                        class _Empty:
+                            def fetchone(self):
+                                return None
+                        return _Empty()
+                    return self._real.execute(sql, *args)
+
+            got = kb.create_task(RaceConn(conn), title="A", assignee="x",
+                                 idempotency_key="K-race")
+            assert got == winner
+        finally:
+            conn.close()
+
+    def test_archived_key_can_be_reused(self, kanban_home):
+        conn = kb.connect()
+        try:
+            first = kb.create_task(conn, title="B", assignee="x",
+                                   idempotency_key="K-arch")
+            conn.execute("UPDATE tasks SET status='archived' WHERE id=?",
+                         (first,))
+            conn.commit()
+            second = kb.create_task(conn, title="B2", assignee="x",
+                                    idempotency_key="K-arch")
+            assert second != first
+        finally:
+            conn.close()
+
+    def test_legacy_duplicates_keep_plain_index(self, kanban_home):
+        """A board that already contains duplicate live keys (a lost race from
+        before the unique index) must still initialize — with the plain index
+        and the old best-effort behaviour, not a crash."""
+        conn = kb.connect()
+        try:
+            conn.execute("DROP INDEX idx_tasks_idempotency")
+            conn.execute(
+                "CREATE INDEX idx_tasks_idempotency ON tasks(idempotency_key)"
+            )
+            conn.execute(
+                "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+                "VALUES ('t_dup_a', 'a', 'ready', 1, 'DUP')"
+            )
+            conn.execute(
+                "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+                "VALUES ('t_dup_b', 'b', 'ready', 2, 'DUP')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        kb._INITIALIZED_PATHS.clear()
+        conn = kb.connect()
+        try:
+            sql = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name='idx_tasks_idempotency'"
+            ).fetchone()[0]
+            assert "UNIQUE" not in sql
+            count = conn.execute(
+                "SELECT COUNT(*) FROM tasks WHERE idempotency_key='DUP'"
+            ).fetchone()[0]
+            assert count == 2
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary
`create_task`'s idempotency check is a `SELECT` followed by an `INSERT`, with an explicit *"Race is acceptable: two concurrent creators with the same key might both insert"* comment. For the producers an idempotency key exists for — automation that retries — that race is precisely the duplicate-card bug the key is supposed to prevent.

This PR makes the key actually idempotent:
- `idx_tasks_idempotency` becomes a **partial UNIQUE** index over live rows (`idempotency_key IS NOT NULL AND status != 'archived'`), so the race is resolved by SQLite, not by the caller's earlier read.
- The `INSERT`'s `IntegrityError` handler now distinguishes a key conflict from the existing id-collision retry: on a lost race it re-reads and returns the **winner** — the exact contract the pre-check promises.
- Archiving a task frees its key, exactly as today (the partial predicate excludes archived rows).

## Migration safety
A board that already contains duplicate live keys (a lost race from before this index) cannot satisfy UNIQUE. Initialization detects that, keeps the plain index for that board, logs once, and preserves the old best-effort behaviour — no existing board can fail to open because of this change.

## Validation
- New tests: index shape; a simulated lost race (pre-check misses, INSERT conflicts) returns the winner — **red before the fix** (duplicate row), green after; archived keys stay reusable; a legacy board with pre-existing duplicates still initializes with the plain-index fallback and intact rows.
- `tests/hermes_cli/test_kanban_core_functionality.py` + `tests/tools/test_kanban_tools.py`: 51 passed.

## Notes
The fast-path pre-check stays (no write lock during the common lookup); only its failure mode changes from "duplicate card" to "return the winner".
