### PR TITLE
fix(kanban): parentless dependency blocks must converge, not silently respawn-loop

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5580,7 +5580,34 @@ def block_task(
         # wait in ``todo`` and let ``recompute_ready`` gate on parents. Routing
         # here (rather than ``blocked``) is what keeps a cron from ever seeing
         # a dependency-wait as something to "unblock".
+        #
+        # That self-resolution only exists while an OPEN parent link gates the
+        # card. WITHOUT one there is nothing for ``recompute_ready`` to gate
+        # on: the card is re-promoted immediately and the worker loops
+        # block → todo → ready → respawn with nobody ever notified. Count
+        # exactly those parentless dependency re-blocks through the same
+        # ``block_recurrences`` chain as every other kind (the counter
+        # survives promotion and resets on completion), and at
+        # ``BLOCK_RECURRENCE_LIMIT`` fall through to the loop breaker below,
+        # which routes to ``triage`` for a human decision. A parent-gated
+        # wait never increments, so a task may wait on any number of
+        # sequential parents without ever escalating.
         if kind == "dependency":
+            _dep_has_open_parent = conn.execute(
+                "SELECT 1 FROM task_links l JOIN tasks p ON p.id = l.parent_id "
+                "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') "
+                "LIMIT 1",
+                (task_id,),
+            ).fetchone() is not None
+            if _dep_has_open_parent:
+                _dep_recurrences = 0
+            elif prev_kind == "dependency":
+                _dep_recurrences = prev_recurrences + 1
+            else:
+                _dep_recurrences = 1
+        if kind == "dependency" and (
+            _dep_has_open_parent or _dep_recurrences < BLOCK_RECURRENCE_LIMIT
+        ):
             cur = conn.execute(
                 """
                 UPDATE tasks
@@ -5588,12 +5615,13 @@ def block_task(
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,
-                       block_kind    = ?
+                       block_kind    = ?,
+                       block_recurrences = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, task_id) if expected_run_id is None
-                else (kind, task_id, int(expected_run_id)),
+                (kind, _dep_recurrences, task_id) if expected_run_id is None
+                else (kind, _dep_recurrences, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
                 return False

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1408,3 +1408,79 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         conn.close()
 
 
+
+
+# ---------------------------------------------------------------------------
+# Parentless dependency blocks must converge, not silently respawn-loop
+# ---------------------------------------------------------------------------
+
+class TestParentlessDependencyLoopBreaker:
+    def _mk_running(self, conn, tid):
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at) "
+            "VALUES (?, 'x', 'running', 1)",
+            (tid,),
+        )
+        conn.commit()
+
+    def test_parentless_dependency_converges_to_triage(self, kanban_home):
+        """With no open parent there is nothing for recompute_ready to gate
+        on: the todo shortcut re-promotes immediately and the worker loops
+        block -> todo -> ready -> respawn with nobody notified. The second
+        parentless dependency block must trip the existing loop breaker."""
+        conn = kb.connect()
+        try:
+            self._mk_running(conn, "t_loop")
+            assert kb.block_task(conn, "t_loop", reason="external thing",
+                                 kind="dependency") is True
+            row = conn.execute(
+                "SELECT status, block_recurrences FROM tasks WHERE id='t_loop'"
+            ).fetchone()
+            assert (row["status"], row["block_recurrences"]) == ("todo", 1)
+
+            conn.execute("UPDATE tasks SET status='running' WHERE id='t_loop'")
+            conn.commit()
+            assert kb.block_task(conn, "t_loop", reason="external thing",
+                                 kind="dependency") is True
+            row = conn.execute(
+                "SELECT status FROM tasks WHERE id='t_loop'"
+            ).fetchone()
+            assert row["status"] == "triage"
+            event = conn.execute(
+                "SELECT kind FROM task_events WHERE task_id='t_loop' "
+                "ORDER BY id DESC LIMIT 1"
+            ).fetchone()[0]
+            assert event == "block_loop_detected"
+        finally:
+            conn.close()
+
+    def test_parent_gated_dependency_never_escalates(self, kanban_home):
+        """A wait gated by a real open parent is self-resolving; any number of
+        sequential waits must keep the recurrence counter at zero."""
+        conn = kb.connect()
+        try:
+            self._mk_running(conn, "t_parent")
+            self._mk_running(conn, "t_wait")
+            conn.execute(
+                "INSERT INTO task_links (parent_id, child_id) "
+                "VALUES ('t_parent', 't_wait')"
+            )
+            conn.commit()
+            for _ in range(4):
+                assert kb.block_task(conn, "t_wait", reason="waiting",
+                                     kind="dependency") is True
+                conn.execute(
+                    "UPDATE tasks SET status='running' WHERE id='t_wait'"
+                )
+                conn.commit()
+            row = conn.execute(
+                "SELECT block_recurrences FROM tasks WHERE id='t_wait'"
+            ).fetchone()
+            assert row["block_recurrences"] == 0
+            loops = conn.execute(
+                "SELECT COUNT(*) FROM task_events WHERE task_id='t_wait' "
+                "AND kind='block_loop_detected'"
+            ).fetchone()[0]
+            assert loops == 0
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary
`kind="dependency"` blocks route to `todo` so `recompute_ready` can gate on parents — by design they "never enter the human blocked bucket". But when the card has **no open parent link**, there is nothing to gate on: `recompute_ready` re-promotes it immediately, the dispatcher respawns the worker, the worker hits the same external blocker and dependency-blocks again — an infinite `block → todo → ready → respawn` loop that burns workers with **nobody ever notified**, because the todo route deliberately bypasses every human surface.

The fix distinguishes the two cases inside the existing transaction:
- **Parent-gated wait** (an open parent link exists): self-resolving as today, and now explicitly keeps `block_recurrences` at 0 — a task may wait on any number of sequential parents without ever escalating.
- **Parentless dependency block**: counts through the existing `block_recurrences` chain (the counter survives promotion and resets on completion), and at `BLOCK_RECURRENCE_LIMIT` falls through to the **existing loop breaker**, which routes to `triage` with the `block_loop_detected` event — the same convergence every other block kind already has.

## Validation
- New test: a parentless dependency block goes `todo` (recurrences 1) → second block trips to `triage` + `block_loop_detected`. **Red before the fix** — the card stayed in the silent loop forever.
- New test: four sequential parent-gated waits keep the counter at 0 with zero loop events.
- `tests/hermes_cli/test_kanban_core_functionality.py` + `tests/tools/test_kanban_tools.py`: 53 passed.

## Notes
No new machinery: the open-parent probe is one indexed query, and escalation reuses the recurrence counter and triage loop breaker that already exist for the other kinds. The dependency-wait shortcut's semantics for linked parents are unchanged.
