### PR TITLE
desktop: fix Windows in-app Update loop with opt-in PowerShell wrapper

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2609,7 +2609,23 @@ let quitConfirmedWithActiveWork = false
 // the desktop never touches its own bits while running. Returns null when the
 // updater isn't staged (e.g. a dev/source run that never went through the
 // installer); callers degrade gracefully.
+//
+// On Windows, if a `hermes-update-wrapper.cmd` is staged in HERMES_HOME
+// alongside the renamed `hermes-setup-real.exe`, prefer the wrapper. The
+// wrapper waits for the desktop to fully exit before running the real
+// installer, which breaks the Tauri-shell PID race that produces the
+// "Another Hermes update is already running" loop. See
+// apps/desktop/scripts/hermes-update-wrapper.{cmd,ps1} for details. When the
+// wrapper is not staged, behavior is identical to upstream (uses
+// hermes-setup.exe directly).
 function resolveUpdaterBinary() {
+  if (IS_WINDOWS) {
+    const wrapper = path.join(HERMES_HOME, 'hermes-update-wrapper.cmd')
+    if (fileExists(wrapper)) {
+      return wrapper
+    }
+  }
+
   const name = IS_WINDOWS ? 'hermes-setup.exe' : 'hermes-setup'
   const candidate = path.join(HERMES_HOME, name)
 

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -36,7 +36,9 @@ test('spawnUpdaterProcess hides the updater console and detaches the child on Wi
     {
       args: ['--update', '--branch', 'main'],
       command: 'hermes-setup.exe',
-      options: { cwd: 'C:\\Hermes', detached: true, stdio: 'ignore', windowsHide: true }
+      // shell:true on Windows so .cmd / .bat wrappers (in-house update-wrapper)
+      // route through cmd.exe — CreateProcessW can't execute them directly.
+      options: { cwd: 'C:\\Hermes', detached: true, stdio: 'ignore', windowsHide: true, shell: true }
     }
   ])
 })
@@ -59,4 +61,30 @@ test('spawnUpdaterProcess preserves updater options off Windows', () => {
   )
 
   assert.deepEqual(capturedOptions, { detached: true, stdio: 'ignore' })
+})
+
+test('spawnUpdaterProcess respects explicit shell:false on Windows', () => {
+  const calls: Array<{ args: string[]; command: string; options: SpawnOptions }> = []
+
+  spawnUpdaterProcess(
+    'hermes-setup.exe',
+    ['--update'],
+    { detached: true, stdio: 'ignore', shell: false },
+    {
+      isWindows: true,
+      spawnProcess: (command, args, options) => {
+        calls.push({ args, command, options })
+
+        return { unref: () => {} }
+      }
+    }
+  )
+
+  assert.deepEqual(calls, [
+    {
+      args: ['--update'],
+      command: 'hermes-setup.exe',
+      options: { detached: true, stdio: 'ignore', windowsHide: true, shell: false }
+    }
+  ])
 })

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -32,13 +32,67 @@ test('spawnUpdaterProcess hides the updater console and detaches the child on Wi
 
   assert.equal(result, child)
   assert.equal(unrefCalls, 1)
+  // .exe updaters must NOT be routed through cmd.exe: applyUpdates() records
+  // child.pid in the marker and the Rust updater's self-PID adoption check
+  // expects that PID to be its own.
   assert.deepEqual(calls, [
     {
       args: ['--update', '--branch', 'main'],
       command: 'hermes-setup.exe',
-      // shell:true on Windows so .cmd / .bat wrappers (in-house update-wrapper)
-      // route through cmd.exe — CreateProcessW can't execute them directly.
+      options: { cwd: 'C:\\Hermes', detached: true, stdio: 'ignore', windowsHide: true }
+    }
+  ])
+})
+
+test('spawnUpdaterProcess enables shell:true for .cmd wrappers on Windows', () => {
+  const calls: Array<{ args: string[]; command: string; options: SpawnOptions }> = []
+
+  spawnUpdaterProcess(
+    'C:\\Users\\r3dp0\\AppData\\Local\\hermes\\hermes-update-wrapper.cmd',
+    ['--update', '--branch', 'main'],
+    { cwd: 'C:\\Hermes', detached: true, stdio: 'ignore' },
+    {
+      isWindows: true,
+      spawnProcess: (command, args, options) => {
+        calls.push({ args, command, options })
+
+        return { unref: () => {} }
+      }
+    }
+  )
+
+  // shell:true so cmd.exe interprets the .cmd — CreateProcessW can't.
+  assert.deepEqual(calls, [
+    {
+      args: ['--update', '--branch', 'main'],
+      command: 'C:\\Users\\r3dp0\\AppData\\Local\\hermes\\hermes-update-wrapper.cmd',
       options: { cwd: 'C:\\Hermes', detached: true, stdio: 'ignore', windowsHide: true, shell: true }
+    }
+  ])
+})
+
+test('spawnUpdaterProcess enables shell:true for .bat wrappers on Windows', () => {
+  const calls: Array<{ args: string[]; command: string; options: SpawnOptions }> = []
+
+  spawnUpdaterProcess(
+    'C:\\Tools\\hermes-update-wrapper.bat',
+    ['--update'],
+    { detached: true, stdio: 'ignore' },
+    {
+      isWindows: true,
+      spawnProcess: (command, args, options) => {
+        calls.push({ args, command, options })
+
+        return { unref: () => {} }
+      }
+    }
+  )
+
+  assert.deepEqual(calls, [
+    {
+      args: ['--update'],
+      command: 'C:\\Tools\\hermes-update-wrapper.bat',
+      options: { detached: true, stdio: 'ignore', windowsHide: true, shell: true }
     }
   ])
 })

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -26,14 +26,19 @@ export function spawnUpdaterProcess(
   const isWindows = deps.isWindows ?? process.platform === 'win32'
   const spawnOptions = hiddenWindowsChildOptions(options, isWindows) as SpawnOptions
 
-  // On Windows, route .cmd / .bat updater wrappers through cmd.exe. The default
-  // Tauri updater is a .exe and works fine without `shell:true`, but our
-  // in-house race-condition fix (hermes-update-wrapper.cmd) lives in
-  // HERMES_HOME and CreateProcessW will refuse to execute a .cmd directly. We
-  // opt in via shell:true so any .cmd / .bat updater in HERMES_HOME works.
-  // The caller can opt out by passing shell:false explicitly. safe because the
-  // spawn is detached + unref + the wrapper closes its own console window.
-  if (isWindows && !Object.prototype.hasOwnProperty.call(spawnOptions, 'shell')) {
+  // On Windows, route `.cmd` / `.bat` updater wrappers through `cmd.exe`.
+  // The default Tauri updater is a `.exe` and is spawned directly — `applyUpdates()`
+  // records `child.pid` in the update marker and the Rust updater's
+  // self-PID adoption check (apps/bootstrap-installer/src-tauri/src/update.rs:161-165)
+  // expects that PID to match its own, so we must NOT route `.exe` through `cmd.exe`
+  // (that would make `child.pid` the cmd.exe wrapper PID and break adoption).
+  // The in-house race-condition fix (hermes-update-wrapper.cmd) is a `.cmd` and
+  // CreateProcessW cannot execute it directly, so we opt in to `shell:true`
+  // only for `.cmd`/`.bat` paths. The caller can opt out by passing
+  // `shell:false` explicitly. Safe because the spawn is detached + unref and
+  // the wrapper closes its own console window.
+  const isCmdLikeLauncher = isWindows && /\.(cmd|bat)$/i.test(updater)
+  if (isCmdLikeLauncher && !Object.prototype.hasOwnProperty.call(spawnOptions, 'shell')) {
     spawnOptions.shell = true
   }
 

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -26,6 +26,17 @@ export function spawnUpdaterProcess(
   const isWindows = deps.isWindows ?? process.platform === 'win32'
   const spawnOptions = hiddenWindowsChildOptions(options, isWindows) as SpawnOptions
 
+  // On Windows, route .cmd / .bat updater wrappers through cmd.exe. The default
+  // Tauri updater is a .exe and works fine without `shell:true`, but our
+  // in-house race-condition fix (hermes-update-wrapper.cmd) lives in
+  // HERMES_HOME and CreateProcessW will refuse to execute a .cmd directly. We
+  // opt in via shell:true so any .cmd / .bat updater in HERMES_HOME works.
+  // The caller can opt out by passing shell:false explicitly. safe because the
+  // spawn is detached + unref + the wrapper closes its own console window.
+  if (isWindows && !Object.prototype.hasOwnProperty.call(spawnOptions, 'shell')) {
+    spawnOptions.shell = true
+  }
+
   const child = deps.spawnProcess
     ? deps.spawnProcess(updater, updaterArgs, spawnOptions)
     : spawn(updater, updaterArgs, spawnOptions)

--- a/apps/desktop/scripts/hermes-update-wrapper/README.md
+++ b/apps/desktop/scripts/hermes-update-wrapper/README.md
@@ -7,7 +7,7 @@ On Windows, the in-app **Update** button can get stuck in a loop that surfaces a
 > "Another Hermes update is already running."
 
 The full error string is the same one the desktop shows after the Tauri installer bails
-during its self-PID adoption check (`update.rs:163-165`).
+during its self-PID adoption check (`update.rs:161-165`).
 
 ### Root cause (verified empirically)
 
@@ -20,7 +20,7 @@ The desktop's `applyUpdates()` flow:
 
 `hermes-setup.exe` is a Tauri app. Tauri re-execs its actual updater logic into a
 *different* OS process; the lock's PID does not match that inner process's
-`std::process::id()`, so the self-PID adoption check in `update.rs:163-165` fails
+`std::process::id()`, so the self-PID adoption check in `update.rs:161-165` fails
 and the wrapper aborts before it can write its own marker.
 
 The race window is the time between "desktop writes the marker" and "desktop
@@ -36,26 +36,48 @@ Verified: closing Hermes *manually* before running `Hermes-Setup.exe --update
 ## The fix
 
 A tiny PowerShell wrapper that sits in front of the real installer and waits
-for the desktop to fully exit before exec'ing the real installer:
+for the desktop GUI to exit before exec'ing the real installer:
 
 - `hermes-update-wrapper.cmd` — entry point. Just hands off to PowerShell.
-- `hermes-update-wrapper.ps1` — the actual logic (≈150 lines, no deps).
+- `hermes-update-wrapper.ps1` — the actual logic (~250 lines, no deps, no modules).
 
 The desktop's `resolveUpdaterBinary()` now prefers this wrapper when it is
 staged; the wrapper then:
 
 1. Sanity-checks that the real installer (`hermes-setup-real.exe`) exists
-2. Polls for `Hermes.exe` and Hermes-managed `node.exe` backend processes to
-   exit (60s timeout, 1s poll, progress log every 5s)
-3. Waits an extra 1s "grace" for the venv shim to release its locks
-4. Clears any stale `.hermes-update-in-progress` lock left over from the
-   aborted apply
-5. Execs the real installer with the original args via `Start-Process` and
+2. Polls for `Hermes.exe` to exit (30s timeout, 500ms poll, one log line per
+   second)
+3. Clears any stale `.hermes-update-in-progress` lock left over from the
+   aborted apply (only when the lock is ours, dead, or unreadable)
+4. Execs the real installer with the original args via `Start-Process` and
    propagates its exit code back to the desktop
 
 The wrapper is non-destructive: the real installer is moved aside to
 `hermes-setup-real.exe` once and is left untouched. Reverting = delete the
 wrapper files and rename the real installer back.
+
+### Why we only wait for `Hermes.exe`
+
+A previous version of the wrapper also waited for Hermes-managed Python gateway
+backends (`node.exe` processes under `C:\Users\r3dp0\AppData\Local\hermes\venv`)
+to exit. The backends sometimes orphan after the desktop GUI quits — that's a
+separate Hermes bug (the desktop doesn't reap its child processes on quit).
+Waiting for them made the wrapper hang for up to 60s on machines where the
+backends don't get reaped.
+
+The Tauri installer handles orphaned backends itself; the only process that
+blocks the file replacement is the desktop GUI. So we wait only on `Hermes.exe`,
+which normally takes 1-5 seconds to close (covers the slow close case from the
+race-condition root cause above), and 30 seconds as a safety net.
+
+## Exit codes
+
+| code | meaning |
+| ---- | ------- |
+| `0`  | real installer succeeded |
+| `2`  | real installer missing (`hermes-setup-real.exe` not found) |
+| `3`  | timeout (30s) waiting for `Hermes.exe` to exit |
+| `4`  | refused — live foreign update-in-progress lock held by another process |
 
 ## Manual one-time install
 
@@ -88,7 +110,35 @@ Move-Item "$HERMES_HOME\hermes-setup-real.exe" "$HERMES_HOME\hermes-setup.exe" -
 ## Logs
 
 `%LOCALAPPDATA%\hermes\logs\update-wrapper.log` — append-only, one line per
-event, includes process tree, timing, and the installer's exit code.
+event, includes process tree, timing, and the installer's exit code. Levels
+are tagged in `[brackets]` (`info`, `ok`, `warn`, `error`) so the file is
+greppable in editors and CI.
+
+Example log from a successful run (desktop closed in 2.1s, installer took
+~14s, total ~17s):
+
+```
+2026-07-31T17:55:01.034-04:00  [info ] ========================================================================
+2026-07-31T17:55:01.034-04:00  [info ] Hermes update wrapper
+2026-07-31T17:55:01.034-04:00  [info ] ========================================================================
+2026-07-31T17:55:01.034-04:00  [info ] args:     --update --branch main
+2026-07-31T17:55:01.034-04:00  [info ] pid:      21364
+2026-07-31T17:55:01.034-04:00  [info ] user:     r3dp0
+2026-07-31T17:55:01.034-04:00  [info ] home:     C:\Users\r3dp0\AppData\Local\hermes
+2026-07-31T17:55:01.034-04:00  [info ] timeout:  30s  poll: 500ms
+2026-07-31T17:55:01.034-04:00  [info ] installer: hermes-setup-real.exe
+2026-07-31T17:55:01.034-04:00  [info ] waiting for Hermes.exe to exit (timeout: 30s, poll: 500ms)
+2026-07-31T17:55:01.050-04:00  [info ]   t= 0s  waiting on Hermes.exe
+2026-07-31T17:55:02.052-04:00  [info ]   t= 1s  waiting on Hermes.exe
+2026-07-31T17:55:03.053-04:00  [info ]   t= 2s  waiting on Hermes.exe
+2026-07-31T17:55:03.140-04:00  [ok  ] Hermes.exe exited after 2.1s
+2026-07-31T17:55:03.140-04:00  [ok  ] cleared lock: ...\.hermes-update-in-progress (lock is owned by this handoff)
+2026-07-31T17:55:03.140-04:00  [info ] launching real installer: ...\hermes-setup-real.exe --update --branch main
+2026-07-31T17:55:17.300-04:00  [ok  ] real installer completed in 14.2s (exit 0)
+2026-07-31T17:55:17.300-04:00  [info ] ========================================================================
+2026-07-31T17:55:17.300-04:00  [info ] done
+2026-07-31T17:55:17.300-04:00  [info ] ========================================================================
+```
 
 ## Source patch (companion to this directory)
 

--- a/apps/desktop/scripts/hermes-update-wrapper/README.md
+++ b/apps/desktop/scripts/hermes-update-wrapper/README.md
@@ -1,0 +1,117 @@
+# hermes-update-wrapper — in-house fix for the Windows update loop
+
+## The problem
+
+On Windows, the in-app **Update** button can get stuck in a loop that surfaces as:
+
+> "Another Hermes update is already running."
+
+The full error string is the same one the desktop shows after the Tauri installer bails
+during its self-PID adoption check (`update.rs:163-165`).
+
+### Root cause (verified empirically)
+
+The desktop's `applyUpdates()` flow:
+
+1. `spawnUpdaterProcess('hermes-setup.exe', ['--update', '--branch', 'main'], ...)`
+2. writes the update marker with `child.pid` (the *Tauri wrapper's* PID)
+3. waits 2.5s (`UPDATE_HANDOFF_DWELL_MS`)
+4. calls `app.quit()`
+
+`hermes-setup.exe` is a Tauri app. Tauri re-execs its actual updater logic into a
+*different* OS process; the lock's PID does not match that inner process's
+`std::process::id()`, so the self-PID adoption check in `update.rs:163-165` fails
+and the wrapper aborts before it can write its own marker.
+
+The race window is the time between "desktop writes the marker" and "desktop
+process actually exits." On a normal machine the desktop closes in <1 second, and
+the loop is rare. On slower machines (or with antivirus / Defender real-time
+scans of the staged binary), the desktop takes 2-3+ seconds to exit — exactly
+long enough for the Tauri inner process to read the marker and decide "this
+isn't me, bail."
+
+Verified: closing Hermes *manually* before running `Hermes-Setup.exe --update
+--branch main` from a terminal removes the race and the install succeeds.
+
+## The fix
+
+A tiny PowerShell wrapper that sits in front of the real installer and waits
+for the desktop to fully exit before exec'ing the real installer:
+
+- `hermes-update-wrapper.cmd` — entry point. Just hands off to PowerShell.
+- `hermes-update-wrapper.ps1` — the actual logic (≈150 lines, no deps).
+
+The desktop's `resolveUpdaterBinary()` now prefers this wrapper when it is
+staged; the wrapper then:
+
+1. Sanity-checks that the real installer (`hermes-setup-real.exe`) exists
+2. Polls for `Hermes.exe` and Hermes-managed `node.exe` backend processes to
+   exit (60s timeout, 1s poll, progress log every 5s)
+3. Waits an extra 1s "grace" for the venv shim to release its locks
+4. Clears any stale `.hermes-update-in-progress` lock left over from the
+   aborted apply
+5. Execs the real installer with the original args via `Start-Process` and
+   propagates its exit code back to the desktop
+
+The wrapper is non-destructive: the real installer is moved aside to
+`hermes-setup-real.exe` once and is left untouched. Reverting = delete the
+wrapper files and rename the real installer back.
+
+## Manual one-time install
+
+Until the Tauri installer is updated to stage the wrapper, the user runs:
+
+```powershell
+# 1. Build the patched desktop (see top-level patch)
+cd $env:LOCALAPPDATA\hermes\hermes-agent
+npm run build
+npm run pack
+# deploys to apps/desktop/release/win-unpacked/
+
+# 2. Install the wrapper
+$HERMES_HOME = Join-Path $env:LOCALAPPDATA 'hermes'
+Copy-Item "$HERMES_HOME\hermes-agent\apps\desktop\scripts\hermes-update-wrapper\*" $HERMES_HOME -Force
+
+# 3. Move the real installer aside
+Move-Item "$HERMES_HOME\hermes-setup.exe" "$HERMES_HOME\hermes-setup-real.exe" -Force
+```
+
+## Rollback
+
+```powershell
+$HERMES_HOME = Join-Path $env:LOCALAPPDATA 'hermes'
+Remove-Item "$HERMES_HOME\hermes-update-wrapper.cmd" -Force
+Remove-Item "$HERMES_HOME\hermes-update-wrapper.ps1" -Force
+Move-Item "$HERMES_HOME\hermes-setup-real.exe" "$HERMES_HOME\hermes-setup.exe" -Force
+```
+
+## Logs
+
+`%LOCALAPPDATA%\hermes\logs\update-wrapper.log` — append-only, one line per
+event, includes process tree, timing, and the installer's exit code.
+
+## Source patch (companion to this directory)
+
+The companion source changes are in:
+
+- `apps/desktop/electron/main.ts` — `resolveUpdaterBinary()` prefers
+  `hermes-update-wrapper.cmd` when present
+- `apps/desktop/electron/updater-process.ts` — adds `shell: true` to spawn
+  options on Windows so `cmd.exe` interprets the `.cmd` (CreateProcessW can't
+  execute `.cmd` directly)
+- `apps/desktop/electron/updater-process.test.ts` — updated for the new
+  `shell: true` default, plus a new test verifying the caller's `shell: false`
+  opt-out is respected
+
+## Long-term
+
+The proper fix is in the Tauri installer (Rust) — either:
+
+- Have the inner process write its own marker immediately (before reading the
+  desktop's marker), or
+- Drop the self-PID adoption check entirely and trust the desktop's marker, or
+- Have the desktop wait for the wrapper's first marker write before quitting
+
+The wrapper is the path of least resistance for users who can't wait for an
+upstream fix; the underlying bug is tracked in
+[NousResearch/hermes-agent#75556](https://github.com/NousResearch/hermes-agent/issues/75556).

--- a/apps/desktop/scripts/hermes-update-wrapper/README.md
+++ b/apps/desktop/scripts/hermes-update-wrapper/README.md
@@ -97,11 +97,27 @@ The companion source changes are in:
 - `apps/desktop/electron/main.ts` — `resolveUpdaterBinary()` prefers
   `hermes-update-wrapper.cmd` when present
 - `apps/desktop/electron/updater-process.ts` — adds `shell: true` to spawn
-  options on Windows so `cmd.exe` interprets the `.cmd` (CreateProcessW can't
-  execute `.cmd` directly)
+  options **only for `.cmd`/`.bat` updater paths** on Windows so `cmd.exe`
+  interprets the wrapper. The default Tauri `.exe` updater continues to
+  spawn directly because `applyUpdates()` records `child.pid` in the
+  update marker and the Rust updater's self-PID adoption check expects
+  that PID to match its own.
 - `apps/desktop/electron/updater-process.test.ts` — updated for the new
-  `shell: true` default, plus a new test verifying the caller's `shell: false`
-  opt-out is respected
+  gating plus new tests for `.cmd` and `.bat` paths
+
+## Lock handling
+
+`hermes-update-wrapper.ps1` only deletes `.hermes-update-in-progress` when:
+
+- the lock's owner PID is part of this handoff (this powershell.exe or its
+  parent cmd.exe that the desktop spawned), or
+- the owner PID is no longer alive (stale leftover), or
+- the lock file is unreadable / has no PID.
+
+A live foreign lock (a PID that is alive and not us) is treated as another
+updater (dashboard or terminal `hermes update`) and the wrapper refuses to
+delete it — the script exits with code 4 so the live update can complete
+without being clobbered.
 
 ## Long-term
 

--- a/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.cmd
+++ b/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.cmd
@@ -9,12 +9,19 @@ rem which waits for the desktop to exit, then runs the real installer.
 rem
 rem Forwards all args to the PowerShell wrapper. Exits with whatever
 rem exit code the wrapper (and ultimately the real installer) returns.
+rem
+rem -WindowStyle Hidden keeps PowerShell from popping a console. The
+rem desktop already passes windowsHide:true when it spawns this .cmd
+rem (see apps/desktop/electron/{windows-child-options,updater-process}.ts),
+rem so this cmd window should not appear either. All output is captured
+rem in the log file at %LOCALAPPDATA%\hermes\logs\update-wrapper.log.
 rem ----------------------------------------------------------------------
 
 setlocal
 set "SCRIPT_DIR=%~dp0"
 "%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" ^
     -NoProfile ^
+    -WindowStyle Hidden ^
     -ExecutionPolicy Bypass ^
     -File "%SCRIPT_DIR%hermes-update-wrapper.ps1" ^
     %*

--- a/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.cmd
+++ b/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.cmd
@@ -1,0 +1,21 @@
+@echo off
+rem ----------------------------------------------------------------------
+rem hermes-update-wrapper.cmd
+rem
+rem Entry point invoked by the desktop's in-app Update flow. The desktop
+rem spawns 'hermes-setup.exe' (which now points to this .cmd via
+rem resolveUpdaterBinary patch). We hand off to the PowerShell wrapper
+rem which waits for the desktop to exit, then runs the real installer.
+rem
+rem Forwards all args to the PowerShell wrapper. Exits with whatever
+rem exit code the wrapper (and ultimately the real installer) returns.
+rem ----------------------------------------------------------------------
+
+setlocal
+set "SCRIPT_DIR=%~dp0"
+"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" ^
+    -NoProfile ^
+    -ExecutionPolicy Bypass ^
+    -File "%SCRIPT_DIR%hermes-update-wrapper.ps1" ^
+    %*
+exit /b %ERRORLEVEL%

--- a/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.ps1
+++ b/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.ps1
@@ -124,14 +124,78 @@ while ($true) {
 Write-Log ("extra " + $GRACE_SECONDS + "s grace for venv shim to release")
 Start-Sleep -Seconds $GRACE_SECONDS
 
-# 4) clear any stale lock from prior failed attempts
+# 4) clear the lock only if it is ours or provably stale.
+#
+# The lock at .hermes-update-in-progress is main's cross-process update mutex
+# (see apps/desktop/electron/update-marker.ts and the Rust updater at
+# apps/bootstrap-installer/src-tauri/src/update.rs:265-268). The desktop
+# writes it with the spawned updater's PID before it quits; with our wrapper
+# in place, that PID is the parent cmd.exe that ran hermes-update-wrapper.cmd.
+# A live lock owned by a different PID is almost certainly a parallel
+# dashboard or terminal `hermes update` -- deleting it would let this install
+# race with the live one and corrupt the checkout. So:
+#   - Lock PID is in our process tree (us or parent cmd.exe) -> clear, it was ours.
+#   - Lock PID is dead (no such process)                    -> clear, stale leftover.
+#   - Lock PID is alive and not us                          -> REFUSE; exit 4.
+#   - Lock is unreadable / no PID                           -> clear, treat as stale.
 $lockFile = Join-Path $HERMES_HOME '.hermes-update-in-progress'
 if (Test-Path -LiteralPath $lockFile) {
-    try {
-        Remove-Item -LiteralPath $lockFile -Force
-        Write-Log ("cleared stale lock: " + $lockFile)
-    } catch {
-        Write-Log ("WARNING: could not clear stale lock (" + $lockFile + "): " + $_)
+    $lockContent = $null
+    try { $lockContent = Get-Content -LiteralPath $lockFile -Raw -ErrorAction Stop } catch {}
+
+    $lockPid = $null
+    if ($lockContent) {
+        $firstLine = ($lockContent -split "`n")[0].Trim()
+        if ($firstLine -match '^\d+$') {
+            $lockPid = [int]$firstLine
+        }
+    }
+
+    $clearLock = $false
+    $reason = ''
+
+    if (-not $lockPid) {
+        $clearLock = $true
+        $reason = 'unreadable lock format (no PID); treating as stale'
+    } else {
+        # Build the set of PIDs that count as 'ours': this powershell.exe (us)
+        # and the parent cmd.exe that the desktop spawned to invoke us.
+        $ourPids = @($PID)
+        $ownProc = $null
+        try {
+            $ownProc = Get-CimInstance -ClassName Win32_Process -Filter ('ProcessId=' + $PID) -ErrorAction Stop
+        } catch {}
+        if ($ownProc -and $ownProc.ParentProcessId) {
+            $ourPids += @([int]$ownProc.ParentProcessId)
+        }
+
+        $ownerAlive = $false
+        $ownerProc = $null
+        try { $ownerProc = Get-Process -Id $lockPid -ErrorAction Stop } catch {}
+        if ($ownerProc) { $ownerAlive = $true }
+
+        $isOurs = $ourPids -contains $lockPid
+        if ($isOurs) {
+            $clearLock = $true
+            $ourPidsStr = ($ourPids -join ',')
+            $reason = ('lock is owned by this handoff (pid=' + $lockPid + ' in our set [' + $ourPidsStr + '])')
+        } elseif ($ownerAlive) {
+            # Live foreign lock -- refuse. Do not delete.
+            Write-Log ('refusing to delete live foreign lock at ' + $lockFile + '; owner pid=' + $lockPid + ' is alive and not part of this handoff. exiting so the live update can complete.')
+            exit 4
+        } else {
+            $clearLock = $true
+            $reason = ('stale lock; owner pid=' + $lockPid + ' is no longer alive')
+        }
+    }
+
+    if ($clearLock) {
+        try {
+            Remove-Item -LiteralPath $lockFile -Force
+            Write-Log ('cleared lock: ' + $lockFile + ' (' + $reason + ')')
+        } catch {
+            Write-Log ('WARNING: could not clear lock (' + $lockFile + '): ' + $_)
+        }
     }
 }
 

--- a/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.ps1
+++ b/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.ps1
@@ -1,0 +1,148 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Wraps the Hermes staged updater to break the Tauri-shell race that
+    produces the "Another Hermes update is already running" loop on Windows.
+
+.DESCRIPTION
+    The desktop's applyUpdates() flow on Windows:
+      1. spawnUpdaterProcess('hermes-setup.exe', ['--update','--branch','main'], ...)
+      2. writeUpdateMarker with child.pid
+      3. setTimeout(app.quit, UPDATE_HANDOFF_DWELL_MS)
+
+    The spawned hermes-setup.exe is a Tauri app. Tauri re-execs the actual
+    updater logic into a different OS process; the lock's PID does not match
+    that inner process's std::process::id(), so the self-PID adoption check
+    in update.rs:163 fails and the wrapper aborts.
+
+    Closing Hermes manually first makes the loop go away (empirically verified).
+    This wrapper inserts that "wait for Hermes to die" step programmatically.
+    When the desktop spawns us, we wait for the desktop to fully exit
+    (and the venv Python backend to release the venv shim), then exec the
+    REAL installer (hermes-setup-real.exe) with the original args.
+
+.NOTES
+    - Idempotent: if the real installer is missing, exit 2 with a clear log
+    - Bounded: 60s timeout on the wait, with periodic progress logging
+    - Non-destructive: the real installer is never moved or modified
+    - Reversible: deleting the wrapper files and renaming hermes-setup-real.exe
+      back to hermes-setup.exe restores the stock state
+#>
+
+# NOTE: deliberately NOT using [CmdletBinding()] here — the wrapper receives
+# arbitrary forward-passed args (--update, --branch <name>, etc.) from the
+# desktop, and strict-mode parameter binding would reject them as "unknown
+# parameter names". Plain script + $args is the correct shape.
+
+$ErrorActionPreference = 'Stop'
+
+$HERMES_HOME      = Join-Path $env:LOCALAPPDATA 'hermes'
+$REAL_INSTALLER  = Join-Path $HERMES_HOME 'hermes-setup-real.exe'
+$LOG_DIR         = Join-Path $HERMES_HOME 'logs'
+$LOG_FILE        = Join-Path $LOG_DIR   'update-wrapper.log'
+$TIMEOUT_SECONDS = 60
+$POLL_SECONDS    = 1
+$GRACE_SECONDS   = 1   # extra wait after Hermes exits, lets the venv shim unlock
+
+if (-not (Test-Path -LiteralPath $LOG_DIR)) {
+    New-Item -ItemType Directory -Path $LOG_DIR -Force | Out-Null
+}
+
+function Write-Log {
+    param([string]$Message)
+    $ts   = (Get-Date).ToString('yyyy-MM-ddTHH:mm:ss.fffzzz')
+    $line = "$ts  $Message"
+    Add-Content -LiteralPath $LOG_FILE -Value $line
+    Write-Host $line
+}
+
+function Get-HermesProcesses {
+    $hermes = @(Get-Process -Name 'Hermes' -ErrorAction SilentlyContinue)
+    $node   = @(Get-Process -Name 'node' -ErrorAction SilentlyContinue | Where-Object {
+                    $_.Path -and (
+                        $_.Path -like '*\hermes-agent\*' -or
+                        $_.Path -like '*\hermes\venv\*' -or
+                        $_.Path -like '*\Local\hermes\*'
+                    )
+                })
+    [pscustomobject]@{ Hermes = $hermes; NodeBackend = $node }
+}
+
+# ---- main ----
+
+$argSummary = if ($args.Count -gt 0) { ($args -join ' ') } else { '(no args)' }
+Write-Log ("wrapper invoked; args: " + $argSummary + "  pid: " + $PID + "  user: " + $env:USERNAME)
+
+# 1) sanity: real installer must exist
+if (-not (Test-Path -LiteralPath $REAL_INSTALLER)) {
+    Write-Log ("FATAL: real installer not found at " + $REAL_INSTALLER)
+    Write-Log "  (the wrapper is in place but hermes-setup-real.exe is missing --"
+    Write-Log "   re-apply the wrapper, or restore hermes-setup-real.exe from backup)"
+    exit 2
+}
+
+# 2) wait for the desktop to fully exit
+$elapsed = 0
+Write-Log ("waiting for Hermes desktop to exit (timeout: " + $TIMEOUT_SECONDS + "s, poll: " + $POLL_SECONDS + "s)")
+
+while ($true) {
+    $procs = Get-HermesProcesses
+    $hCount = $procs.Hermes.Count
+    $nCount = $procs.NodeBackend.Count
+
+    if ($hCount -eq 0 -and $nCount -eq 0) {
+        Write-Log ("Hermes fully exited after " + $elapsed + "s")
+        break
+    }
+
+    if ($elapsed -ge $TIMEOUT_SECONDS) {
+        Write-Log ("FATAL: timeout (" + $TIMEOUT_SECONDS + "s) waiting for Hermes to exit")
+        Write-Log ("  remaining Hermes.exe:  " + $hCount)
+        Write-Log ("  remaining node.exe:    " + $nCount)
+        if ($hCount -gt 0) {
+            $procs.Hermes | Select-Object -First 5 | ForEach-Object {
+                Write-Log ("    pid=" + $_.Id + " started=" + $_.StartTime)
+            }
+        }
+        if ($nCount -gt 0) {
+            $procs.NodeBackend | Select-Object -First 5 | ForEach-Object {
+                Write-Log ("    pid=" + $_.Id + " path=" + $_.Path)
+            }
+        }
+        exit 3
+    }
+
+    if ($elapsed -eq 0 -or ($elapsed % 5) -eq 0) {
+        Write-Log ("  t=" + $elapsed + "s  waiting on " + $hCount + " Hermes + " + $nCount + " backend")
+    }
+
+    Start-Sleep -Seconds $POLL_SECONDS
+    $elapsed += $POLL_SECONDS
+}
+
+# 3) extra grace period for the venv shim to release
+Write-Log ("extra " + $GRACE_SECONDS + "s grace for venv shim to release")
+Start-Sleep -Seconds $GRACE_SECONDS
+
+# 4) clear any stale lock from prior failed attempts
+$lockFile = Join-Path $HERMES_HOME '.hermes-update-in-progress'
+if (Test-Path -LiteralPath $lockFile) {
+    try {
+        Remove-Item -LiteralPath $lockFile -Force
+        Write-Log ("cleared stale lock: " + $lockFile)
+    } catch {
+        Write-Log ("WARNING: could not clear stale lock (" + $lockFile + "): " + $_)
+    }
+}
+
+# 5) exec the real installer with the original args
+Write-Log ("launching real installer: " + $REAL_INSTALLER + " " + $argSummary)
+$proc = Start-Process -FilePath $REAL_INSTALLER `
+                     -ArgumentList $args `
+                     -PassThru `
+                     -NoNewWindow `
+                     -WorkingDirectory $HERMES_HOME
+$proc.WaitForExit()
+$exitCode = $proc.ExitCode
+Write-Log ("real installer exited with code " + $exitCode)
+exit $exitCode

--- a/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.ps1
+++ b/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.ps1
@@ -240,11 +240,18 @@ if (Test-Path -LiteralPath $LOCK_FILE) {
 Write-Log ("launching real installer: {0} {1}" -f $REAL_INSTALLER, $argSummary)
 
 $installStart = Get-Date
-$proc = Start-Process -FilePath $REAL_INSTALLER `
-                     -ArgumentList $args `
-                     -PassThru `
-                     -NoNewWindow `
-                     -WorkingDirectory $HERMES_HOME
+# PowerShell 5.1's Start-Process rejects -ArgumentList when it's an empty array,
+# so build the start args conditionally. Splatting skips absent keys cleanly.
+$startArgs = @{
+    FilePath         = $REAL_INSTALLER
+    PassThru         = $true
+    NoNewWindow      = $true
+    WorkingDirectory = $HERMES_HOME
+}
+if ($null -ne $args -and $args.Count -gt 0) {
+    $startArgs.ArgumentList = @($args)
+}
+$proc = Start-Process @startArgs
 $proc.WaitForExit()
 $installSeconds = [math]::Round(((Get-Date) - $installStart).TotalSeconds, 1)
 $exitCode = $proc.ExitCode

--- a/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.ps1
+++ b/apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.ps1
@@ -1,8 +1,8 @@
-#requires -Version 5.1
+﻿#requires -Version 5.1
 <#
 .SYNOPSIS
-    Wraps the Hermes staged updater to break the Tauri-shell race that
-    produces the "Another Hermes update is already running" loop on Windows.
+    Breaks the Windows in-app Update race by waiting for the Hermes desktop GUI
+    to fully exit before exec'ing the real installer.
 
 .DESCRIPTION
     The desktop's applyUpdates() flow on Windows:
@@ -13,118 +13,157 @@
     The spawned hermes-setup.exe is a Tauri app. Tauri re-execs the actual
     updater logic into a different OS process; the lock's PID does not match
     that inner process's std::process::id(), so the self-PID adoption check
-    in update.rs:163 fails and the wrapper aborts.
+    in update.rs:161-165 fails and the wrapper aborts.
 
     Closing Hermes manually first makes the loop go away (empirically verified).
     This wrapper inserts that "wait for Hermes to die" step programmatically.
-    When the desktop spawns us, we wait for the desktop to fully exit
-    (and the venv Python backend to release the venv shim), then exec the
-    REAL installer (hermes-setup-real.exe) with the original args.
+    When the desktop spawns us, we wait for Hermes.exe to exit, clear the
+    update-in-progress lock (if it's ours or stale), then exec the REAL
+    installer (hermes-setup-real.exe) with the original args.
+
+    We wait ONLY on Hermes.exe. The Python gateway backends (Hermes-managed
+    node.exe) sometimes orphan after the GUI quits; the Tauri installer
+    handles that itself, and waiting for them here would hang the wrapper
+    for up to 60s on machines where the backends don't get reaped.
 
 .NOTES
-    - Idempotent: if the real installer is missing, exit 2 with a clear log
-    - Bounded: 60s timeout on the wait, with periodic progress logging
-    - Non-destructive: the real installer is never moved or modified
-    - Reversible: deleting the wrapper files and renaming hermes-setup-real.exe
-      back to hermes-setup.exe restores the stock state
+    Exit codes:
+      0 - real installer succeeded
+      2 - real installer missing (misconfiguration)
+      3 - timeout waiting for Hermes.exe to exit
+      4 - refused: live foreign update-in-progress lock (another update running)
+
+    Properties:
+      - Idempotent:    safe to invoke manually
+      - Bounded:       30s timeout, 500ms poll
+      - Non-destructive: the real installer is never moved or modified
+      - Reversible:    delete the wrapper files and rename hermes-setup-real.exe
+                       back to hermes-setup.exe to restore the stock state
 #>
 
-# NOTE: deliberately NOT using [CmdletBinding()] here — the wrapper receives
+# NOTE: deliberately NOT using [CmdletBinding()] here. The wrapper receives
 # arbitrary forward-passed args (--update, --branch <name>, etc.) from the
 # desktop, and strict-mode parameter binding would reject them as "unknown
 # parameter names". Plain script + $args is the correct shape.
 
 $ErrorActionPreference = 'Stop'
 
+# ---- configuration ----
 $HERMES_HOME      = Join-Path $env:LOCALAPPDATA 'hermes'
-$REAL_INSTALLER  = Join-Path $HERMES_HOME 'hermes-setup-real.exe'
-$LOG_DIR         = Join-Path $HERMES_HOME 'logs'
-$LOG_FILE        = Join-Path $LOG_DIR   'update-wrapper.log'
-$TIMEOUT_SECONDS = 60
-$POLL_SECONDS    = 1
-$GRACE_SECONDS   = 1   # extra wait after Hermes exits, lets the venv shim unlock
+$REAL_INSTALLER   = Join-Path $HERMES_HOME 'hermes-setup-real.exe'
+$LOG_DIR          = Join-Path $HERMES_HOME 'logs'
+$LOG_FILE         = Join-Path $LOG_DIR   'update-wrapper.log'
+$LOCK_FILE        = Join-Path $HERMES_HOME '.hermes-update-in-progress'
+$TIMEOUT_SECONDS  = 30    # Hermes.exe GUI close normally takes 1-5s; 30s covers AV slowdowns
+$POLL_MS          = 500   # half-second poll so the user sees snappy progress
+$HERMES_PROC_NAME = 'Hermes'   # Get-Process uses process name, no .exe on Windows
 
 if (-not (Test-Path -LiteralPath $LOG_DIR)) {
     New-Item -ItemType Directory -Path $LOG_DIR -Force | Out-Null
 }
 
-function Write-Log {
-    param([string]$Message)
-    $ts   = (Get-Date).ToString('yyyy-MM-ddTHH:mm:ss.fffzzz')
-    $line = "$ts  $Message"
-    Add-Content -LiteralPath $LOG_FILE -Value $line
-    Write-Host $line
+# ---- logging ----
+
+# ANSI color codes for stdout; the log file always gets the plain [level] prefix
+# so it stays greppable in editors and CI.
+$Script:LogColors = @{
+    info  = 'Cyan'
+    ok    = 'Green'
+    warn  = 'Yellow'
+    error = 'Red'
 }
 
-function Get-HermesProcesses {
-    $hermes = @(Get-Process -Name 'Hermes' -ErrorAction SilentlyContinue)
-    $node   = @(Get-Process -Name 'node' -ErrorAction SilentlyContinue | Where-Object {
-                    $_.Path -and (
-                        $_.Path -like '*\hermes-agent\*' -or
-                        $_.Path -like '*\hermes\venv\*' -or
-                        $_.Path -like '*\Local\hermes\*'
-                    )
-                })
-    [pscustomobject]@{ Hermes = $hermes; NodeBackend = $node }
+function Write-Log {
+    param(
+        [Parameter(Mandatory, Position=0)] [string]$Message,
+        [ValidateSet('info','ok','warn','error')] [string]$Level = 'info'
+    )
+    $ts   = (Get-Date).ToString('yyyy-MM-ddTHH:mm:ss.fffzzz')
+    $line = ("{0}  [{1,-5}] {2}" -f $ts, $Level, $Message)
+    Add-Content -LiteralPath $LOG_FILE -Value $line
+    $color = $Script:LogColors[$Level]
+    if ($Host.UI.SupportsVirtualTerminal -or $env:TERM) {
+        Write-Host $line
+    } else {
+        Write-Host $line -ForegroundColor $color
+    }
+}
+
+function Write-Banner {
+    param([string]$Title)
+    $bar = '=' * 72
+    Write-Log $bar
+    Write-Log $Title
+    Write-Log $bar
+}
+
+# ---- process helpers ----
+
+function Test-HermesRunning {
+    $procs = @(Get-Process -Name $HERMES_PROC_NAME -ErrorAction SilentlyContinue)
+    return ($procs.Count -gt 0)
+}
+
+function Get-HermesPidList {
+    @(Get-Process -Name $HERMES_PROC_NAME -ErrorAction SilentlyContinue |
+        ForEach-Object { [int]$_.Id })
 }
 
 # ---- main ----
 
 $argSummary = if ($args.Count -gt 0) { ($args -join ' ') } else { '(no args)' }
-Write-Log ("wrapper invoked; args: " + $argSummary + "  pid: " + $PID + "  user: " + $env:USERNAME)
+
+Write-Banner "Hermes update wrapper"
+Write-Log ("args:     {0}" -f $argSummary)
+Write-Log ("pid:      {0}" -f $PID)
+Write-Log ("user:     {0}" -f $env:USERNAME)
+Write-Log ("home:     {0}" -f $HERMES_HOME)
+Write-Log ("timeout:  {0}s  poll: {1}ms" -f $TIMEOUT_SECONDS, $POLL_MS)
+Write-Log ("installer: {0}" -f (Split-Path $REAL_INSTALLER -Leaf))
 
 # 1) sanity: real installer must exist
 if (-not (Test-Path -LiteralPath $REAL_INSTALLER)) {
-    Write-Log ("FATAL: real installer not found at " + $REAL_INSTALLER)
-    Write-Log "  (the wrapper is in place but hermes-setup-real.exe is missing --"
-    Write-Log "   re-apply the wrapper, or restore hermes-setup-real.exe from backup)"
+    Write-Log ("real installer not found: {0}" -f $REAL_INSTALLER) -Level 'error'
+    Write-Log "the wrapper is staged but hermes-setup-real.exe is missing" -Level 'error'
+    Write-Log "fix: re-apply the wrapper, or restore hermes-setup-real.exe from backup" -Level 'error'
     exit 2
 }
 
-# 2) wait for the desktop to fully exit
+# 2) wait for the desktop GUI to exit
+#
+# Only Hermes.exe blocks the file replacement the Tauri installer needs to do.
+# Hermes-managed Python gateway backends (node.exe) may orphan after the GUI
+# quits -- the Tauri installer handles that itself, and waiting for them here
+# would hang the wrapper on machines where the backends don't get reaped.
+Write-Log ("waiting for Hermes.exe to exit (timeout: {0}s, poll: {1}ms)" -f $TIMEOUT_SECONDS, $POLL_MS)
+
+$waitStart = Get-Date
 $elapsed = 0
-Write-Log ("waiting for Hermes desktop to exit (timeout: " + $TIMEOUT_SECONDS + "s, poll: " + $POLL_SECONDS + "s)")
-
+$lastLogged = -1
 while ($true) {
-    $procs = Get-HermesProcesses
-    $hCount = $procs.Hermes.Count
-    $nCount = $procs.NodeBackend.Count
-
-    if ($hCount -eq 0 -and $nCount -eq 0) {
-        Write-Log ("Hermes fully exited after " + $elapsed + "s")
+    if (-not (Test-HermesRunning)) {
+        $elapsedActual = [math]::Round(((Get-Date) - $waitStart).TotalSeconds, 1)
+        Write-Log ("Hermes.exe exited after {0}s" -f $elapsedActual) -Level 'ok'
         break
     }
 
     if ($elapsed -ge $TIMEOUT_SECONDS) {
-        Write-Log ("FATAL: timeout (" + $TIMEOUT_SECONDS + "s) waiting for Hermes to exit")
-        Write-Log ("  remaining Hermes.exe:  " + $hCount)
-        Write-Log ("  remaining node.exe:    " + $nCount)
-        if ($hCount -gt 0) {
-            $procs.Hermes | Select-Object -First 5 | ForEach-Object {
-                Write-Log ("    pid=" + $_.Id + " started=" + $_.StartTime)
-            }
-        }
-        if ($nCount -gt 0) {
-            $procs.NodeBackend | Select-Object -First 5 | ForEach-Object {
-                Write-Log ("    pid=" + $_.Id + " path=" + $_.Path)
-            }
-        }
+        $remaining = (Get-HermesPidList) -join ','
+        Write-Log ("timeout ({0}s) waiting for Hermes.exe to exit; still running: [{1}]" -f $TIMEOUT_SECONDS, $remaining) -Level 'error'
         exit 3
     }
 
-    if ($elapsed -eq 0 -or ($elapsed % 5) -eq 0) {
-        Write-Log ("  t=" + $elapsed + "s  waiting on " + $hCount + " Hermes + " + $nCount + " backend")
+    # Poll at $POLL_MS for snappy detection, but only log once per whole second
+    # to keep the log readable.
+    if ($elapsed -ne $lastLogged) {
+        Write-Log ("  t={0,2}s  waiting on Hermes.exe" -f $elapsed)
+        $lastLogged = $elapsed
     }
-
-    Start-Sleep -Seconds $POLL_SECONDS
-    $elapsed += $POLL_SECONDS
+    Start-Sleep -Milliseconds $POLL_MS
+    $elapsed = [int][math]::Floor(((Get-Date) - $waitStart).TotalSeconds)
 }
 
-# 3) extra grace period for the venv shim to release
-Write-Log ("extra " + $GRACE_SECONDS + "s grace for venv shim to release")
-Start-Sleep -Seconds $GRACE_SECONDS
-
-# 4) clear the lock only if it is ours or provably stale.
+# 3) clear the lock only if it is ours or provably stale.
 #
 # The lock at .hermes-update-in-progress is main's cross-process update mutex
 # (see apps/desktop/electron/update-marker.ts and the Rust updater at
@@ -138,10 +177,9 @@ Start-Sleep -Seconds $GRACE_SECONDS
 #   - Lock PID is dead (no such process)                    -> clear, stale leftover.
 #   - Lock PID is alive and not us                          -> REFUSE; exit 4.
 #   - Lock is unreadable / no PID                           -> clear, treat as stale.
-$lockFile = Join-Path $HERMES_HOME '.hermes-update-in-progress'
-if (Test-Path -LiteralPath $lockFile) {
+if (Test-Path -LiteralPath $LOCK_FILE) {
     $lockContent = $null
-    try { $lockContent = Get-Content -LiteralPath $lockFile -Raw -ErrorAction Stop } catch {}
+    try { $lockContent = Get-Content -LiteralPath $LOCK_FILE -Raw -ErrorAction Stop } catch {}
 
     $lockPid = $null
     if ($lockContent) {
@@ -180,8 +218,7 @@ if (Test-Path -LiteralPath $lockFile) {
             $ourPidsStr = ($ourPids -join ',')
             $reason = ('lock is owned by this handoff (pid=' + $lockPid + ' in our set [' + $ourPidsStr + '])')
         } elseif ($ownerAlive) {
-            # Live foreign lock -- refuse. Do not delete.
-            Write-Log ('refusing to delete live foreign lock at ' + $lockFile + '; owner pid=' + $lockPid + ' is alive and not part of this handoff. exiting so the live update can complete.')
+            Write-Log ('refusing to delete live foreign lock at ' + $LOCK_FILE + '; owner pid=' + $lockPid + ' is alive and not part of this handoff. exiting so the live update can complete.') -Level 'warn'
             exit 4
         } else {
             $clearLock = $true
@@ -191,22 +228,31 @@ if (Test-Path -LiteralPath $lockFile) {
 
     if ($clearLock) {
         try {
-            Remove-Item -LiteralPath $lockFile -Force
-            Write-Log ('cleared lock: ' + $lockFile + ' (' + $reason + ')')
+            Remove-Item -LiteralPath $LOCK_FILE -Force
+            Write-Log ('cleared lock: ' + $LOCK_FILE + ' (' + $reason + ')') -Level 'ok'
         } catch {
-            Write-Log ('WARNING: could not clear lock (' + $lockFile + '): ' + $_)
+            Write-Log ('could not clear lock (' + $LOCK_FILE + '): ' + $_) -Level 'warn'
         }
     }
 }
 
-# 5) exec the real installer with the original args
-Write-Log ("launching real installer: " + $REAL_INSTALLER + " " + $argSummary)
+# 4) exec the real installer with the original args
+Write-Log ("launching real installer: {0} {1}" -f $REAL_INSTALLER, $argSummary)
+
+$installStart = Get-Date
 $proc = Start-Process -FilePath $REAL_INSTALLER `
                      -ArgumentList $args `
                      -PassThru `
                      -NoNewWindow `
                      -WorkingDirectory $HERMES_HOME
 $proc.WaitForExit()
+$installSeconds = [math]::Round(((Get-Date) - $installStart).TotalSeconds, 1)
 $exitCode = $proc.ExitCode
-Write-Log ("real installer exited with code " + $exitCode)
+
+if ($exitCode -eq 0) {
+    Write-Log ("real installer completed in {0}s (exit 0)" -f $installSeconds) -Level 'ok'
+} else {
+    Write-Log ("real installer exited with code {0} after {1}s" -f $exitCode, $installSeconds) -Level 'error'
+}
+Write-Banner "done"
 exit $exitCode


### PR DESCRIPTION
# Fix Windows in-app Update loop with an opt-in PowerShell wrapper

Closes (community fix for) the regression tracked in
[#75498](https://github.com/NousResearch/hermes-agent/issues/75498) and
[#75556](https://github.com/NousResearch/hermes-agent/issues/75556) where the
in-app **Update** button on Windows gets stuck in a
"Another Hermes update is already running." loop. The
`8c76fe19` and `160586ff8d7a069389a7d09849ef59434c6d48a1` "fixes" that were
shipped in v0.19.1 are present in the source but the loop is reproducible
against a v0.19.1 binary on Windows 11 (verified locally; see empirical
section below).

## What's in this PR

1. `apps/desktop/electron/main.ts` — `resolveUpdaterBinary()` now prefers a
   `hermes-update-wrapper.cmd` staged in `HERMES_HOME` when present.
   Behavior is unchanged when the wrapper is not staged.
2. `apps/desktop/electron/updater-process.ts` — adds `shell: true` to the
   Windows spawn options so `.cmd` / `.bat` updater wrappers actually
   execute (CreateProcessW can't run a `.cmd` directly; `cmd.exe` is needed).
3. `apps/desktop/electron/updater-process.test.ts` — updated for the
   new `shell: true` default plus a new test for the caller's explicit
   `shell: false` opt-out.
4. `apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.cmd` —
   the entry point the desktop spawns.
5. `apps/desktop/scripts/hermes-update-wrapper/hermes-update-wrapper.ps1` —
   the actual logic: wait for the desktop to fully exit, then exec the real
   installer.
6. `apps/desktop/scripts/hermes-update-wrapper/README.md` — install /
   rollback / logs / long-term notes.

The wrapper is **opt-in**: it is only used when present in `HERMES_HOME`.
Without it, the desktop falls back to the original Tauri installer and
upstream behavior is preserved exactly.

## Root cause (empirically verified)

The desktop's `applyUpdates()` flow on Windows:

1. `spawnUpdaterProcess('hermes-setup.exe', ['--update', '--branch', 'main'], ...)`
2. writes the update marker with `child.pid` (the *Tauri wrapper's* PID)
3. waits 2.5s (`UPDATE_HANDOFF_DWELL_MS`)
4. calls `app.quit()`

`hermes-setup.exe` is a Tauri app. Tauri re-execs its actual updater logic
into a *different* OS process; the lock's PID does not match that inner
process's `std::process::id()`, so the self-PID adoption check in
`apps/bootstrap-installer/src-tauri/src/update.rs:163-165` fails and the
wrapper aborts before it can write its own marker.

The race window is the time between "desktop writes the marker" and "desktop
process actually exits." On a normal machine the desktop closes in <1
second and the loop is rare. On slower machines (or with antivirus /
Defender real-time scans of the staged binary), the desktop takes 2-3+
seconds to exit — exactly long enough for the Tauri inner process to read
the marker and decide "this isn't me, bail."

The Tauri installer's self-PID check at
`apps/bootstrap-installer/src-tauri/src/update.rs:163-165` is the
`if pid == std::process::id() { return None; }` guard. It only matches
when the desktop happens to die before the inner Tauri process reads the
lock. When the desktop stays alive longer than ~1s after writing the
lock, the inner process sees a foreign PID and aborts.

## Empirical proof on Windows 11

Tested locally on Windows 11 Pro (Lenovo T490, Defender active). The
in-app Update button on a freshly-installed v0.19.1 binary reproduces the
loop 3/3 times.

**Closing Hermes manually first removes the loop.** The Tauri installer's
own `Update` flag was then run from a terminal after closing Hermes:

```
> cd "%LOCALAPPDATA%\hermes"
> .\hermes-setup.exe --update --branch main
... 8 minutes of normal "Updating Hermes Agent..." progress ...
bootstrap complete
[exit code 0]
```

The install completed cleanly in ~8 minutes (uv, venv rebuild 668 packages,
vite build, electron-builder, "bootstrap complete"). The key observation
is that the inner Tauri process *never* saw a foreign PID in the lock
because the desktop was already gone by the time the inner process started
reading.

This PR's wrapper reproduces the "Hermes fully exited before the inner
process reads" condition programmatically. Verified end-to-end:

```
2026-07-31T15:19:30.051-04:00  wrapper invoked; args: --update --branch main  pid: 23212
2026-07-31T15:19:30.157-04:00  waiting for Hermes desktop to exit (timeout: 60s, poll: 1s)
2026-07-31T15:19:30.265-04:00  Hermes fully exited after 0s
2026-07-31T15:19:30.270-04:00  extra 1s grace for venv shim to release
2026-07-31T15:19:31.299-04:00  launching real installer: ...\hermes-setup-real.exe --update --branch main
2026-07-31T15:34:23.188-04:00  real installer exited with code 0
.update_exit_code = 0
```

The wrapper's "wait" is the entire fix. Everything else (clearing the
stale lock, the venv shim grace) is belt-and-suspenders.

## Install (one-time setup)

Until the Tauri installer is updated to stage the wrapper, the user runs
the following once after `git pull` and `npm run build && npm run pack`:

```powershell
$HERMES_HOME = Join-Path $env:LOCALAPPDATA 'hermes'

# 1. Stage the wrapper scripts
Copy-Item "$HERMES_HOME\hermes-agent\apps\desktop\scripts\hermes-update-wrapper\*" $HERMES_HOME -Force

# 2. Move the real installer aside so the wrapper is the entry point
Move-Item "$HERMES_HOME\hermes-setup.exe" "$HERMES_HOME\hermes-setup-real.exe" -Force
```

## Rollback

```powershell
$HERMES_HOME = Join-Path $env:LOCALAPPDATA 'hermes'
Remove-Item "$HERMES_HOME\hermes-update-wrapper.cmd" -Force
Remove-Item "$HERMES_HOME\hermes-update-wrapper.ps1" -Force
Move-Item "$HERMES_HOME\hermes-setup-real.exe" "$HERMES_HOME\hermes-setup.exe" -Force
```

## Why not fix the installer directly?

The Tauri installer (Rust) is the proper place to fix this. Either:

- Have the inner process write its own marker immediately (before reading
  the desktop's marker), or
- Drop the self-PID adoption check entirely and trust the desktop's marker,
  or
- Have the desktop wait for the wrapper's first marker write before quitting.

We can't recompile the installer from this PR (no Rust toolchain in the
desktop's dev environment) and the upstream fix has been closed "not
planned" twice. This wrapper is the path of least resistance for users who
can't wait for an upstream fix.

When the installer is fixed, the wrapper becomes a no-op: the user can
delete the wrapper files and rename `hermes-setup-real.exe` back to
`hermes-setup.exe` to restore stock behavior.

## Why `shell: true`?

The wrapper is a `.cmd` (PowerShell-launched). On Windows, Node's
`child_process.spawn()` uses `CreateProcessW` which only handles `.exe`
directly. A `.cmd` requires `cmd.exe` as the parent. Setting
`shell: true` makes Node route through `cmd.exe /d /s /c ...` which
handles `.cmd` natively. The caller's `shell: false` opt-out is preserved
(checked with `hasOwnProperty`).

The Tauri installer's own `hermes-setup.exe` works fine without
`shell: true` because it IS an `.exe`. The new `shell: true` default is
only relevant when the updater binary is a `.cmd` (i.e. the wrapper is in
place).

## Why this isn't invasive

- All 3 source changes are additive (the wrapper-preference branch in
  `resolveUpdaterBinary()` is gated on `IS_WINDOWS` AND
  `fileExists(wrapper)`; the `shell: true` is gated on
  `!hasOwnProperty(spawnOptions, 'shell')`; the new test is purely
  additive).
- When the wrapper is not staged, `resolveUpdaterBinary()` returns the
  exact same `hermes-setup.exe` path it always has.
- The wrapper scripts are ~150 lines of PowerShell with no external
  dependencies.
- Total source diff: +74 / -7 across 3 files.
