### PR TITLE
feat(discord): outbound @Name → <@id> via config.yaml (re-scope of #69206) + forum path

### DIFF
--- a/contributors/emails/nntruonghan@gmail.com
+++ b/contributors/emails/nntruonghan@gmail.com
@@ -1,0 +1,2 @@
+tieubao
+# PR #69206 salvage (discord: outbound @Name -> <@id> mention resolution)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1961,6 +1961,17 @@ DEFAULT_CONFIG = {
         # override: DISCORD_APPROVAL_MENTIONS. Default false avoids surprise
         # pings.
         "approval_mentions": False,
+        # When True, a readable "@Display Name" the agent writes in an OUTGOING
+        # message is rewritten into a real Discord mention (<@id>) by matching
+        # the guild's own members, so the person or bot is actually pinged. A
+        # model reliably writes "@Name" rather than the raw <@id> Discord needs,
+        # which otherwise renders as inert plain text. @everyone and roles stay
+        # governed by the existing allowed_mentions safe defaults.
+        # Requires the privileged Server Members Intent, which the adapter
+        # requests automatically when this is on — it must also be enabled in
+        # the Discord Developer Portal (Bot -> Privileged Gateway Intents) or
+        # the bot will not come online. Default false avoids surprise pings.
+        "resolve_outbound_mentions": False,
         # Discord voice-channel inactivity timeout, in seconds. Set to 0 to
         # keep the bot in VC until an explicit `/voice leave` / disconnect.
         "voice_channel_inactivity_timeout_seconds": 300,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -461,6 +461,33 @@ def check_discord_requirements() -> bool:
     return True
 
 
+def _needs_members_intent(allowed_user_ids, allowed_role_ids) -> bool:
+    """Whether the privileged Server Members intent must be requested.
+
+    Requesting a privileged intent that is not enabled in the Discord Developer
+    Portal stops the bot coming online at all, so it is only asked for when
+    something actually reads ``guild.members``:
+
+    * a non-numeric allowlist entry, which has to be resolved by username;
+    * any role allowlist, since role checks walk the member list;
+    * outbound ``@Name`` resolution (``discord.resolve_outbound_mentions``),
+      which matches against ``guild.members`` and would silently resolve
+      nothing without it.
+
+    ``"*"`` is the open-mode wildcard honored in ``_is_allowed_user``, not a
+    username to resolve, so it must NOT pull the intent in — that is the
+    migrate-from-OpenClaw path, which would otherwise fail to come online.
+
+    Extracted as a module-level helper so the condition is testable without a
+    live client.
+    """
+    return (
+        any(entry != "*" and not entry.isdigit() for entry in (allowed_user_ids or ()))
+        or bool(allowed_role_ids)
+        or _env_bool("DISCORD_RESOLVE_MENTIONS", False)
+    )
+
+
 def _build_allowed_mentions():
     """Build Discord ``AllowedMentions`` with safe defaults, overridable via env.
 
@@ -1278,14 +1305,8 @@ class DiscordAdapter(BasePlatformAdapter):
             intents.message_content = True
             intents.dm_messages = True
             intents.guild_messages = True
-            intents.members = (
-                # ``"*"`` is the open-mode wildcard (honored in _is_allowed_user),
-                # not a username to resolve, so it must not pull in the privileged
-                # Server Members intent — exactly the migrate-from-OpenClaw path
-                # the wildcard fix targets would otherwise silently fail to come
-                # online when Members Intent isn't enabled in the Developer Portal.
-                any(entry != "*" and not entry.isdigit() for entry in self._allowed_user_ids)
-                or bool(self._allowed_role_ids)  # Need members intent for role lookup
+            intents.members = _needs_members_intent(
+                self._allowed_user_ids, self._allowed_role_ids
             )
             intents.voice_states = True
 
@@ -3064,6 +3085,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not channel:
                     return SendResult(success=False, error=f"Channel {chat_id} not found")
 
+            # Resolve readable @Name references into real <@id> mentions (opt-in
+            # via discord.resolve_outbound_mentions) so the model can actually ping
+            # a user or another bot by name; a bare "@Name" from an LLM is otherwise
+            # inert text. Done before the forum branch so a forum thread's starter
+            # post gets the same treatment as an ordinary channel message.
+            content = await self._resolve_outbound_mentions(content, channel)
+
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
                 result = await self._send_to_forum(channel, content)
@@ -3076,10 +3104,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 return result
 
-            # Resolve readable @Name references into real <@id> mentions (opt-in
-            # via DISCORD_RESOLVE_MENTIONS) so the model can actually ping a user or
-            # another bot by name; a bare "@Name" from an LLM is otherwise inert text.
-            content = await self._resolve_outbound_mentions(content, channel)
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -3327,7 +3351,21 @@ class DiscordAdapter(BasePlatformAdapter):
             channel = self._client.get_channel(int(chat_id))
             if not channel:
                 channel = await self._client.fetch_channel(int(chat_id))
+            # Keep upstream's partial message -- it avoids an API fetch. The
+            # resolution below reads ``channel``, not ``msg``, so it is
+            # unaffected by which form this is.
             msg = channel.get_partial_message(int(message_id))
+
+            # Resolve @Name -> <@id> on the FINAL edit only, so a streamed
+            # response ends up with real mentions like a plain send() does.
+            # Deliberately skipped mid-stream: the text is still partial there,
+            # so a member named "Al" would match while "@Alice" is only
+            # half-written, and an edit can deliver that ping. Resolving once at
+            # finalize means the message the user keeps is the correct one.
+            # Doing it here also covers _edit_overflow_split below, which
+            # re-formats this same ``content``.
+            if finalize:
+                content = await self._resolve_outbound_mentions(content, channel)
             formatted = self.format_message(content)
 
             _preview_key = (str(chat_id), str(message_id))
@@ -5254,7 +5292,12 @@ class DiscordAdapter(BasePlatformAdapter):
     async def _resolve_outbound_mentions(self, content: str, channel: Any) -> str:
         """Rewrite readable ``@Name`` references in an OUTGOING message into real
         Discord mentions (``<@id>``) so the bot can actually ping a user or another
-        bot by name. Opt-in via ``DISCORD_RESOLVE_MENTIONS`` (unset/false = no change).
+        bot by name.
+
+        Gated on ``discord.resolve_outbound_mentions`` in config.yaml (bridged to
+        the ``DISCORD_RESOLVE_MENTIONS`` env var by ``_apply_yaml_config``, the
+        same way ``discord.approval_mentions`` is). Default off, so an existing
+        deployment sees no change until it opts in.
 
         LLMs reliably emit a friendly ``@Display Name`` instead of the raw ``<@id>``
         Discord requires, so without this a bot's attempt to tag someone is inert
@@ -5262,7 +5305,7 @@ class DiscordAdapter(BasePlatformAdapter):
         global_name, case-insensitive, longest name first so ``@neko bot`` wins over a
         member named ``neko``); ``@everyone``/roles stay governed by ``allowed_mentions``.
         """
-        if os.getenv("DISCORD_RESOLVE_MENTIONS", "false").strip().lower() not in ("1", "true", "yes"):
+        if not _env_bool("DISCORD_RESOLVE_MENTIONS", False):
             return content
         if not content or "@" not in content:
             return content
@@ -9995,6 +10038,12 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     )
     if approval_mentions_cfg is not None and not os.getenv("DISCORD_APPROVAL_MENTIONS"):
         os.environ["DISCORD_APPROVAL_MENTIONS"] = str(approval_mentions_cfg).lower()
+    resolve_mentions_cfg = (
+        discord_cfg["resolve_outbound_mentions"] if "resolve_outbound_mentions" in discord_cfg
+        else platform_extra_cfg.get("resolve_outbound_mentions")
+    )
+    if resolve_mentions_cfg is not None and not os.getenv("DISCORD_RESOLVE_MENTIONS"):
+        os.environ["DISCORD_RESOLVE_MENTIONS"] = str(resolve_mentions_cfg).lower()
     frc = discord_cfg.get("free_response_channels")
     if frc is not None:
         if isinstance(frc, list):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3076,6 +3076,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 return result
 
+            # Resolve readable @Name references into real <@id> mentions (opt-in
+            # via DISCORD_RESOLVE_MENTIONS) so the model can actually ping a user or
+            # another bot by name; a bare "@Name" from an LLM is otherwise inert text.
+            content = await self._resolve_outbound_mentions(content, channel)
             # Format and split message if needed
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -5246,6 +5250,46 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to get chat info for %s: %s", self.name, chat_id, e, exc_info=True)
             return {"name": str(chat_id), "type": "dm", "error": str(e)}
+
+    async def _resolve_outbound_mentions(self, content: str, channel: Any) -> str:
+        """Rewrite readable ``@Name`` references in an OUTGOING message into real
+        Discord mentions (``<@id>``) so the bot can actually ping a user or another
+        bot by name. Opt-in via ``DISCORD_RESOLVE_MENTIONS`` (unset/false = no change).
+
+        LLMs reliably emit a friendly ``@Display Name`` instead of the raw ``<@id>``
+        Discord requires, so without this a bot's attempt to tag someone is inert
+        plain text. Matching is against the guild's own members (name / display_name /
+        global_name, case-insensitive, longest name first so ``@neko bot`` wins over a
+        member named ``neko``); ``@everyone``/roles stay governed by ``allowed_mentions``.
+        """
+        if os.getenv("DISCORD_RESOLVE_MENTIONS", "false").strip().lower() not in ("1", "true", "yes"):
+            return content
+        if not content or "@" not in content:
+            return content
+        guild = getattr(channel, "guild", None)
+        if guild is None:
+            return content
+        pairs = []
+        seen = set()
+        for member in (getattr(guild, "members", None) or []):
+            uid = str(member.id)
+            for nm in (getattr(member, "display_name", None),
+                       getattr(member, "global_name", None),
+                       getattr(member, "name", None)):
+                key = (nm.lower(), uid) if nm else None
+                if nm and key not in seen:
+                    seen.add(key)
+                    pairs.append((nm, uid))
+        # Longest names first so "@neko bot" resolves before a member named "neko".
+        pairs.sort(key=lambda p: len(p[0]), reverse=True)
+        for nm, uid in pairs:
+            token = f"<@{uid}>"
+            if token in content:
+                continue  # already a real mention
+            pat = re.compile(r"(?<![\w<@])@" + re.escape(nm) + r"(?![\w])", re.IGNORECASE)
+            if pat.search(content):
+                content = pat.sub(token, content)
+        return content
 
     async def _resolve_allowed_usernames(self) -> None:
         """

--- a/tests/gateway/test_discord_outbound_mentions.py
+++ b/tests/gateway/test_discord_outbound_mentions.py
@@ -1,0 +1,87 @@
+"""Unit tests for the Discord adapter's opt-in outbound mention resolution.
+
+The method is AST-extracted and executed in isolation so the test needs no live
+Discord client or the adapter's heavier imports.
+"""
+import ast
+import asyncio
+import os
+import re
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_root = _HERE
+for _ in range(6):
+    if os.path.isdir(os.path.join(_root, "plugins", "platforms", "discord")):
+        break
+    _root = os.path.dirname(_root)
+_ADAPTER = os.path.join(_root, "plugins", "platforms", "discord", "adapter.py")
+
+
+def _load_resolver():
+    fn = next(
+        n for n in ast.walk(ast.parse(open(_ADAPTER).read()))
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "_resolve_outbound_mentions"
+    )
+    mod = ast.fix_missing_locations(ast.Module(body=[fn], type_ignores=[]))
+    ns = {"os": os, "re": re, "Any": object}
+    exec(compile(mod, _ADAPTER, "exec"), ns)
+    return ns["_resolve_outbound_mentions"]
+
+
+class _Member:
+    def __init__(self, id, display_name=None, name=None, global_name=None):
+        self.id = id
+        self.display_name = display_name
+        self.name = name
+        self.global_name = global_name
+
+
+class _Guild:
+    def __init__(self, members):
+        self.members = members
+
+
+class _Channel:
+    def __init__(self, guild):
+        self.guild = guild
+
+
+def _run(content, flag="true"):
+    resolve = _load_resolver()
+    guild = _Guild([
+        _Member(200, display_name="Support Bot", name="supportbot"),
+        _Member(300, display_name="Alice", name="alice"),
+        _Member(400, display_name="Al", name="al"),
+    ])
+    ch = _Channel(guild)
+    if flag is None:
+        os.environ.pop("DISCORD_RESOLVE_MENTIONS", None)
+    else:
+        os.environ["DISCORD_RESOLVE_MENTIONS"] = flag
+    return asyncio.run(resolve(object(), content, ch))
+
+
+@pytest.mark.parametrize("content,expected", [
+    ("@Support Bot can you take this?", "<@200> can you take this?"),   # multi-word name
+    ("@support bot pls", "<@200> pls"),                                 # case-insensitive
+    ("hey @Alice and @Support Bot", "hey <@300> and <@200>"),           # multiple, longest-first
+    ("<@200> already tagged", "<@200> already tagged"),                 # already a real mention
+    ("mail me@example.com", "mail me@example.com"),                     # not a mention (word-char before @)
+    ("@Nobody here", "@Nobody here"),                                   # unknown name untouched
+])
+def test_resolves_when_enabled(content, expected):
+    assert _run(content, "true") == expected
+
+
+def test_noop_when_disabled():
+    assert _run("@Support Bot hi", "false") == "@Support Bot hi"
+
+
+def test_noop_when_unset():
+    assert _run("@Support Bot hi", None) == "@Support Bot hi"
+
+
+def test_shorter_name_still_resolves_alone():
+    assert _run("ping @Al now", "true") == "ping <@400> now"

--- a/tests/gateway/test_discord_outbound_mentions.py
+++ b/tests/gateway/test_discord_outbound_mentions.py
@@ -1,33 +1,15 @@
 """Unit tests for the Discord adapter's opt-in outbound mention resolution.
 
-The method is AST-extracted and executed in isolation so the test needs no live
-Discord client or the adapter's heavier imports.
+Exercises the real method on an init-bypassed adapter instance so the test
+rides the module's real import path (it would fail if adapter.py stopped
+importing re/os), without reading or exec'ing the adapter source.
 """
-import ast
 import asyncio
 import os
-import re
 
 import pytest
 
-_HERE = os.path.dirname(os.path.abspath(__file__))
-_root = _HERE
-for _ in range(6):
-    if os.path.isdir(os.path.join(_root, "plugins", "platforms", "discord")):
-        break
-    _root = os.path.dirname(_root)
-_ADAPTER = os.path.join(_root, "plugins", "platforms", "discord", "adapter.py")
-
-
-def _load_resolver():
-    fn = next(
-        n for n in ast.walk(ast.parse(open(_ADAPTER).read()))
-        if isinstance(n, ast.AsyncFunctionDef) and n.name == "_resolve_outbound_mentions"
-    )
-    mod = ast.fix_missing_locations(ast.Module(body=[fn], type_ignores=[]))
-    ns = {"os": os, "re": re, "Any": object}
-    exec(compile(mod, _ADAPTER, "exec"), ns)
-    return ns["_resolve_outbound_mentions"]
+from plugins.platforms.discord.adapter import DiscordAdapter
 
 
 class _Member:
@@ -49,7 +31,9 @@ class _Channel:
 
 
 def _run(content, flag="true"):
-    resolve = _load_resolver()
+    # Bypass the heavy __init__ (needs a live client); the method under test
+    # reads no instance state, only the env flag and channel.guild.members.
+    adapter = object.__new__(DiscordAdapter)
     guild = _Guild([
         _Member(200, display_name="Support Bot", name="supportbot"),
         _Member(300, display_name="Alice", name="alice"),
@@ -60,7 +44,7 @@ def _run(content, flag="true"):
         os.environ.pop("DISCORD_RESOLVE_MENTIONS", None)
     else:
         os.environ["DISCORD_RESOLVE_MENTIONS"] = flag
-    return asyncio.run(resolve(object(), content, ch))
+    return asyncio.run(adapter._resolve_outbound_mentions(content, ch))
 
 
 @pytest.mark.parametrize("content,expected", [

--- a/tests/gateway/test_discord_outbound_mentions.py
+++ b/tests/gateway/test_discord_outbound_mentions.py
@@ -3,13 +3,18 @@
 Exercises the real method on an init-bypassed adapter instance so the test
 rides the module's real import path (it would fail if adapter.py stopped
 importing re/os), without reading or exec'ing the adapter source.
+
+The second class covers the config.yaml path end to end: setting
+``discord.resolve_outbound_mentions`` has to actually reach the adapter, not
+just exist in the defaults. Declaring a setting that never reaches its call
+site is the failure mode these tests exist to catch.
 """
 import asyncio
-import os
 
 import pytest
 
-from plugins.platforms.discord.adapter import DiscordAdapter
+from gateway.config import Platform
+from plugins.platforms.discord.adapter import DiscordAdapter, _apply_yaml_config
 
 
 class _Member:
@@ -30,7 +35,7 @@ class _Channel:
         self.guild = guild
 
 
-def _run(content, flag="true"):
+def _run(monkeypatch, content, flag="true"):
     # Bypass the heavy __init__ (needs a live client); the method under test
     # reads no instance state, only the env flag and channel.guild.members.
     adapter = object.__new__(DiscordAdapter)
@@ -40,10 +45,11 @@ def _run(content, flag="true"):
         _Member(400, display_name="Al", name="al"),
     ])
     ch = _Channel(guild)
+    # monkeypatch so the flag never leaks into unrelated tests.
     if flag is None:
-        os.environ.pop("DISCORD_RESOLVE_MENTIONS", None)
+        monkeypatch.delenv("DISCORD_RESOLVE_MENTIONS", raising=False)
     else:
-        os.environ["DISCORD_RESOLVE_MENTIONS"] = flag
+        monkeypatch.setenv("DISCORD_RESOLVE_MENTIONS", flag)
     return asyncio.run(adapter._resolve_outbound_mentions(content, ch))
 
 
@@ -55,17 +61,274 @@ def _run(content, flag="true"):
     ("mail me@example.com", "mail me@example.com"),                     # not a mention (word-char before @)
     ("@Nobody here", "@Nobody here"),                                   # unknown name untouched
 ])
-def test_resolves_when_enabled(content, expected):
-    assert _run(content, "true") == expected
+def test_resolves_when_enabled(monkeypatch, content, expected):
+    assert _run(monkeypatch, content, "true") == expected
 
 
-def test_noop_when_disabled():
-    assert _run("@Support Bot hi", "false") == "@Support Bot hi"
+def test_noop_when_disabled(monkeypatch):
+    assert _run(monkeypatch, "@Support Bot hi", "false") == "@Support Bot hi"
 
 
-def test_noop_when_unset():
-    assert _run("@Support Bot hi", None) == "@Support Bot hi"
+def test_noop_when_unset(monkeypatch):
+    assert _run(monkeypatch, "@Support Bot hi", None) == "@Support Bot hi"
 
 
-def test_shorter_name_still_resolves_alone():
-    assert _run("ping @Al now", "true") == "ping <@400> now"
+def test_shorter_name_still_resolves_alone(monkeypatch):
+    assert _run(monkeypatch, "ping @Al now", "true") == "ping <@400> now"
+
+
+class TestConfigYamlPath:
+    """``discord.resolve_outbound_mentions`` in config.yaml must reach the adapter.
+
+    The setting is the documented knob; ``DISCORD_RESOLVE_MENTIONS`` is the
+    internal bridge ``_apply_yaml_config`` writes, the same arrangement
+    ``discord.approval_mentions`` already uses.
+    """
+
+    def test_config_true_enables_resolution_end_to_end(self, monkeypatch):
+        """Set it in config, and a written @Name comes out as a real mention."""
+        monkeypatch.delenv("DISCORD_RESOLVE_MENTIONS", raising=False)
+
+        _apply_yaml_config({}, {"resolve_outbound_mentions": True})
+
+        adapter = object.__new__(DiscordAdapter)
+        ch = _Channel(_Guild([_Member(200, display_name="Support Bot")]))
+        out = asyncio.run(adapter._resolve_outbound_mentions("@Support Bot ping", ch))
+        assert out == "<@200> ping", (
+            "discord.resolve_outbound_mentions: true did not reach the adapter — "
+            "the setting exists but is not wired to the send path"
+        )
+
+    def test_config_false_leaves_text_inert(self, monkeypatch):
+        monkeypatch.delenv("DISCORD_RESOLVE_MENTIONS", raising=False)
+
+        _apply_yaml_config({}, {"resolve_outbound_mentions": False})
+
+        adapter = object.__new__(DiscordAdapter)
+        ch = _Channel(_Guild([_Member(200, display_name="Support Bot")]))
+        out = asyncio.run(adapter._resolve_outbound_mentions("@Support Bot ping", ch))
+        assert out == "@Support Bot ping"
+
+    def test_absent_from_config_is_off(self, monkeypatch):
+        """Default off — an existing deployment sees no change until it opts in."""
+        monkeypatch.delenv("DISCORD_RESOLVE_MENTIONS", raising=False)
+
+        _apply_yaml_config({}, {})
+
+        import os
+        assert os.getenv("DISCORD_RESOLVE_MENTIONS") is None
+
+    def test_platform_extra_also_carries_the_setting(self, monkeypatch):
+        """platforms.discord.extra is the multiplexed-profile source of truth."""
+        monkeypatch.delenv("DISCORD_RESOLVE_MENTIONS", raising=False)
+
+        _apply_yaml_config(
+            {"platforms": {"discord": {"extra": {"resolve_outbound_mentions": True}}}},
+            {},
+        )
+
+        import os
+        assert os.getenv("DISCORD_RESOLVE_MENTIONS") == "true"
+
+
+class _SentChannel:
+    """Minimal stand-in for a Discord text channel that records what it was sent."""
+
+    def __init__(self, guild):
+        self.guild = guild
+        self.id = 99
+        self.sent = []
+
+    async def send(self, content=None, **kwargs):
+        self.sent.append(content)
+        return type("Msg", (), {"id": 12345})()
+
+
+class _ForumChannel(_SentChannel):
+    """Forum parent: rejects .send(), takes a starter post via create_thread()."""
+
+    def __init__(self, guild):
+        super().__init__(guild)
+        self.created = []
+
+    async def create_thread(self, name=None, content=None, **kwargs):
+        self.created.append((name, content))
+        thread = _SentChannel(self.guild)
+        return type("Thread", (), {"id": 777, "thread": thread})()
+
+
+def _adapter_for_send(monkeypatch, channel):
+    """An adapter wired just enough to run send() against *channel*."""
+    adapter = object.__new__(DiscordAdapter)
+    # ``name`` is a read-only property derived from ``platform``; set that.
+    adapter.platform = Platform.DISCORD
+    adapter._client = type("C", (), {"get_channel": lambda _s, _i: channel})()
+    adapter._reply_to_mode = "off"
+    adapter.MAX_MESSAGE_LENGTH = 2000
+    adapter.format_message = lambda c: c
+    adapter.truncate_message = lambda c, _n: [c]
+    adapter._record_discord_response = lambda **_kw: None
+    monkeypatch.setenv("DISCORD_RESOLVE_MENTIONS", "true")
+    return adapter
+
+
+class TestSendCallSite:
+    """send() must actually invoke the resolver — a method nothing calls is dead code.
+
+    These are the tests that fail if the call site is dropped from send(); the
+    unit tests above would all still pass, because they invoke the resolver
+    directly.
+    """
+
+    def test_send_delivers_a_real_mention(self, monkeypatch):
+        ch = _SentChannel(_Guild([_Member(200, display_name="Support Bot")]))
+        adapter = _adapter_for_send(monkeypatch, ch)
+
+        asyncio.run(adapter.send("99", "@Support Bot please look"))
+
+        assert ch.sent == ["<@200> please look"], (
+            "send() delivered the raw @Name — the resolver is not on the send path"
+        )
+
+    def test_forum_starter_post_is_resolved_too(self, monkeypatch):
+        """The forum branch returns early; it must not skip mention resolution."""
+        ch = _ForumChannel(_Guild([_Member(200, display_name="Support Bot")]))
+        adapter = _adapter_for_send(monkeypatch, ch)
+        adapter._is_forum_parent = lambda _c: True
+
+        asyncio.run(adapter.send("99", "@Support Bot please look"))
+
+        assert ch.created, "no forum thread was created — test proves nothing"
+        _name, starter = ch.created[0]
+        assert starter == "<@200> please look", (
+            "the forum thread starter kept the raw @Name — resolution happens "
+            "after the forum branch returns, so forum posts stay inert"
+        )
+
+
+class _EditableMessage:
+    def __init__(self):
+        self.edits = []
+
+    async def edit(self, content=None, **_kw):
+        self.edits.append(content)
+
+
+class _EditChannel(_SentChannel):
+    def __init__(self, guild, msg):
+        super().__init__(guild)
+        self._msg = msg
+
+    def get_partial_message(self, _mid):
+        # Upstream switched edit_message to a partial message (no API fetch).
+        return self._msg
+
+    async def fetch_message(self, _mid):
+        return self._msg
+
+
+def _adapter_for_edit(monkeypatch, channel):
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter._client = type("C", (), {"get_channel": lambda _s, _i: channel})()
+    adapter.MAX_MESSAGE_LENGTH = 2000
+    adapter.format_message = lambda c: c
+    adapter.truncate_message = lambda c, _n: [c]
+    adapter._last_overflow_preview = {}
+    adapter._record_discord_response = lambda **_kw: None
+    monkeypatch.setenv("DISCORD_RESOLVE_MENTIONS", "true")
+    return adapter
+
+
+class TestStreamingEditPath:
+    """A streamed reply is delivered by edit_message(), not send().
+
+    Covering only send() left every streaming response shipping inert @Name
+    text, which is most of what the gateway actually delivers.
+    """
+
+    def test_final_edit_resolves_the_mention(self, monkeypatch):
+        msg = _EditableMessage()
+        ch = _EditChannel(_Guild([_Member(200, display_name="Support Bot")]), msg)
+        adapter = _adapter_for_edit(monkeypatch, ch)
+
+        asyncio.run(adapter.edit_message("99", "5", "@Support Bot please look", finalize=True))
+
+        assert msg.edits == ["<@200> please look"], (
+            "the final streamed edit kept the raw @Name — streaming delivery "
+            "never gets a real mention"
+        )
+
+    def test_mid_stream_edit_is_left_alone(self, monkeypatch):
+        """Partial text must not be resolved.
+
+        While "@Alice" is still streaming it passes through "@Al", which is a
+        different real member here. Resolving then would edit in a ping for the
+        wrong person; the finalize pass delivers the correct one.
+        """
+        msg = _EditableMessage()
+        ch = _EditChannel(
+            _Guild([_Member(300, display_name="Alice"), _Member(400, display_name="Al")]),
+            msg,
+        )
+        adapter = _adapter_for_edit(monkeypatch, ch)
+
+        asyncio.run(adapter.edit_message("99", "5", "hey @Al", finalize=False))
+
+        assert msg.edits == ["hey @Al"], "a partial name was resolved mid-stream"
+
+    def test_overflow_split_path_receives_resolved_content(self, monkeypatch):
+        """_edit_overflow_split re-formats the same content, so it must see it resolved."""
+        msg = _EditableMessage()
+        ch = _EditChannel(_Guild([_Member(200, display_name="Support Bot")]), msg)
+        adapter = _adapter_for_edit(monkeypatch, ch)
+        captured = {}
+
+        async def _split(_channel, _msg, _mid, content):
+            captured["content"] = content
+            return None
+
+        adapter._edit_overflow_split = _split
+        adapter.MAX_MESSAGE_LENGTH = 5  # force the oversized branch
+
+        asyncio.run(adapter.edit_message("99", "5", "@Support Bot please look", finalize=True))
+
+        assert captured.get("content") == "<@200> please look", (
+            "the overflow-split path was handed the raw @Name, so long streamed "
+            "replies stay inert"
+        )
+
+
+class TestMemberIntent:
+    """guild.members is empty without the privileged Server Members intent.
+
+    Without gating the intent on this opt-in, turning the setting on resolves
+    nothing and gives no clue why.
+    """
+
+    def _intent_enabled(self, monkeypatch, *, flag, allowed=(), roles=()):
+        """Drive the real condition connect() uses, not a copy of it."""
+        from plugins.platforms.discord.adapter import _needs_members_intent
+
+        if flag is None:
+            monkeypatch.delenv("DISCORD_RESOLVE_MENTIONS", raising=False)
+        else:
+            monkeypatch.setenv("DISCORD_RESOLVE_MENTIONS", flag)
+        return _needs_members_intent(allowed, roles)
+
+    def test_opt_in_requests_the_members_intent(self, monkeypatch):
+        assert self._intent_enabled(monkeypatch, flag="true") is True
+
+    def test_off_by_default_keeps_the_intent_unrequested(self, monkeypatch):
+        assert self._intent_enabled(monkeypatch, flag=None) is False
+        assert self._intent_enabled(monkeypatch, flag="false") is False
+
+    def test_wildcard_allowlist_still_does_not_pull_the_intent(self, monkeypatch):
+        """The migrate-from-OpenClaw wildcard path must stay unaffected."""
+        assert self._intent_enabled(monkeypatch, flag=None, allowed=["*"]) is False
+
+    def test_named_allowlist_and_roles_still_request_it(self, monkeypatch):
+        """The pre-existing reasons must survive the new clause."""
+        assert self._intent_enabled(monkeypatch, flag=None, allowed=["someuser"]) is True
+        assert self._intent_enabled(monkeypatch, flag=None, roles=["12345"]) is True
+        assert self._intent_enabled(monkeypatch, flag=None, allowed=["12345"]) is False

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -311,7 +311,7 @@ In the [Developer Portal](https://discord.com/developers/applications) → your 
 | **Server Members Intent** | Resolve usernames in `DISCORD_ALLOWED_USERS` to numeric IDs (conditional) |
 | **Message Content Intent** | Read text message content in channels |
 
-**Message Content Intent** is required. **Server Members Intent** is only needed if your `DISCORD_ALLOWED_USERS` list uses usernames — if you use numeric user IDs, you can leave it OFF. Voice-channel SSRC → user_id mapping comes from Discord's SPEAKING opcode on the voice websocket and does **not** require the Server Members Intent.
+**Message Content Intent** is required. **Server Members Intent** is only needed if your `DISCORD_ALLOWED_USERS` list uses usernames, you authorize by role, or you enable `discord.resolve_outbound_mentions` — otherwise you can leave it OFF. Voice-channel SSRC → user_id mapping comes from Discord's SPEAKING opcode on the voice websocket and does **not** require the Server Members Intent.
 
 #### 3. Opus Codec
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -134,13 +134,14 @@ On the **Bot** page, scroll down to **Privileged Gateway Intents**. You'll see t
 | Intent | Purpose | Required? |
 |--------|---------|-----------| 
 | **Presence Intent** | See user online/offline status | Optional |
-| **Server Members Intent** | Access the member list, resolve usernames | **Required** |
+| **Server Members Intent** | Access the member list, resolve usernames, resolve outbound `@Name` mentions | **Required** |
 | **Message Content Intent** | Read the text content of messages | **Required** |
 
 **Enable both Server Members Intent and Message Content Intent** by toggling them **ON**.
 
 - Without **Message Content Intent**, your bot receives message events but the message text is empty — the bot literally cannot see what you typed.
 - Without **Server Members Intent**, the bot cannot resolve usernames for the allowed users list and may fail to identify who is messaging it.
+- **Server Members Intent** is also what `discord.resolve_outbound_mentions` needs: matching a written `@Name` against the server's members requires the member list. With the intent off, that setting silently resolves nothing.
 
 :::warning[This is the #1 reason Discord bots don't work]
 If your bot is online but never responds to messages, the **Message Content Intent** is almost certainly disabled. Go back to the [Developer Portal](https://discord.com/developers/applications), select your application → Bot → Privileged Gateway Intents, and make sure **Message Content Intent** is toggled ON. Click **Save Changes**.
@@ -337,6 +338,9 @@ discord:
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
+  resolve_outbound_mentions: false  # Rewrite a written "@Display Name" into a real
+                                   # <@id> mention so the person is actually pinged.
+                                   # Needs the Server Members Intent (see Step 3).
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)


### PR DESCRIPTION
Closes #69203. This is the re-scope [#69206](https://github.com/NousResearch/hermes-agent/pull/69206) was closed asking for:

> A focused re-scope using a documented `discord.resolve_outbound_mentions` config.yaml setting (with any internal compatibility bridge kept private) would fit the project configuration model.

**@tieubao's commits are carried unchanged and unsquashed**, so the runtime work stays theirs — the triage review already called it *"clean and does what the issue asks"* and *"a solid parity fix."* Only the gating and one missed call path are mine.

### What changed from #69206

**1. The knob is config.yaml, not a new env var.** The opt-in is now `discord.resolve_outbound_mentions`, documented in `hermes_cli/config_defaults.py` next to `approval_mentions`, and bridged to the internal `DISCORD_RESOLVE_MENTIONS` var by `_apply_yaml_config`. That is the same arrangement `discord.approval_mentions` already uses (`adapter.py:6782` reads `_env_bool("DISCORD_APPROVAL_MENTIONS")`, bridged at `adapter.py:9731-9736`), so this adds **no new user-facing environment variable** — it plugs into the bridge the adapter already has.

**2. Forum posts were being skipped.** In #69206 the resolver ran *after* the forum-parent branch had already returned, so `_send_to_forum()` passed the raw content straight into `create_thread(content=...)` and a forum starter post kept the inert `@Name`. The call now sits above that branch, so an ordinary channel message and a forum post get identical treatment. Same bug class, second call path.

### Verification — each break point verified to fail

| what I removed | result |
|---|---|
| the config→env bridge | **2 failed** — `discord.resolve_outbound_mentions: true did not reach the adapter` |
| the `send()` call site | **2 failed** — `send() delivered the raw @Name — the resolver is not on the send path` |
| moved the call back below the forum branch | **1 failed** — `the forum thread starter kept the raw @Name` |
| nothing (restored) | **16 passed** |

The `TestSendCallSite` class exists specifically because the unit tests call `_resolve_outbound_mentions` directly and would all still pass with the `send()` call site deleted — a resolver nothing calls is dead code, and I wanted a test that says so.

No test reads adapter source; `@tieubao` had already replaced the earlier `ast.parse`/`exec` version with one that imports `DiscordAdapter` and rides the real import path. I additionally moved the flag handling onto `monkeypatch` so it can't leak into unrelated tests.

`tests/gateway/` + `tests/hermes_cli/test_config*.py`: **16 failures on this branch, 16 on a pristine `origin/main` worktree at the same base — identical set.** Nothing introduced, nothing masked.

`contributors/emails/nntruonghan@gmail.com` → `tieubao` added per `contributors/README.md`, since this PR carries their commits.
