### PR TITLE
chore(contributors): map spfcraze contributor email

### DIFF
--- a/contributors/emails/spfcraze@users.noreply.github.com
+++ b/contributors/emails/spfcraze@users.noreply.github.com
@@ -1,0 +1,1 @@
+spfcraze


### PR DESCRIPTION
## What does this PR do?

Adds `contributors/emails/spfcraze@users.noreply.github.com` so the `contributor-check` CI job stops failing with "Unmapped contributor email(s)" on PRs authored under this email (currently every one of them).

One file, one line — matching the existing per-email mapping format (`<github-username>\n`).

## Related Issue

No GitHub issue — the CI failure is visible on recent spfcraze PR branches.

## Changes Made

- `contributors/emails/spfcraze@users.noreply.github.com`: new mapping file containing `spfcraze`.

## How to Test

- `scripts/release.py`'s contributor attribution check resolves `spfcraze@users.noreply.github.com` → `spfcraze` instead of emitting "Unmapped contributor email(s)".

## Logs

Failing check this unblocks (from a recent PR branch CI run):

```
Unmapped contributor email(s): New contributor email(s) are not in AUTHOR_MAP.
detail: spfcraze@users.noreply.github.com
how_to_fix: Add mappings to scripts/release.py AUTHOR_MAP or contributors/emails/
```
