### PR TITLE
feat(tools): widen command TTS output_format allowlist to 25 extensions

### DIFF
--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -203,6 +203,35 @@ class TestConfigGetters:
         assert _get_command_tts_output_format({}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
 
 
+    def test_output_format_rejects_unknown(self):
+        assert _get_command_tts_output_format({"format": "midi"}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
+        assert _get_command_tts_output_format({}, "/tmp/clip.midi") == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
+
+
+    def test_output_format_default_is_recognized(self):
+        assert DEFAULT_COMMAND_TTS_OUTPUT_FORMAT in COMMAND_TTS_OUTPUT_FORMATS
+
+
+    @pytest.mark.parametrize("fmt", sorted(COMMAND_TTS_OUTPUT_FORMATS))
+    def test_output_format_accepts_every_supported_format(self, fmt):
+        # Every recognized extension must survive both entry points: an explicit
+        # config value and inference from the output path suffix. A format that
+        # is allowed but silently coerced back to mp3 would mismatch the path
+        # the post-run existence check expects.
+        assert _get_command_tts_output_format({"format": fmt}) == fmt
+        assert _get_command_tts_output_format({"output_format": fmt}) == fmt
+        assert _get_command_tts_output_format({}, f"/tmp/clip.{fmt}") == fmt
+
+
+    def test_output_format_suffix_overrides_config(self):
+        assert _get_command_tts_output_format({"format": "mp3"}, "/tmp/clip.m4a") == "m4a"
+
+
+    def test_output_format_normalizes_case_and_dot(self):
+        assert _get_command_tts_output_format({"format": ".M4A"}) == "m4a"
+        assert _get_command_tts_output_format({}, "/tmp/clip.OPUS") == "opus"
+
+
     def test_voice_compatible_boolean(self):
         assert _is_command_tts_voice_compatible({"voice_compatible": True}) is True
         assert _is_command_tts_voice_compatible({"voice_compatible": False}) is False

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -623,9 +623,40 @@ BUILTIN_TTS_PROVIDERS = frozenset({
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
-COMMAND_TTS_OUTPUT_FORMATS = frozenset(
-    {"mp3", "wav", "ogg", "flac", "m4a", "aac", "amr", "opus"}
-)
+# Recognized ``output_format`` values for command-type providers. This set only
+# decides how Hermes *names* the output file (and what ``{format}`` expands to);
+# the provider's own command produces the bytes.
+#
+# Entries are audio extensions a stock ffmpeg build can write. A few need an
+# explicit encoder rather than the default one ffmpeg picks for the extension
+# (``.3gp`` defaults to AMR, so it wants ``-c:a aac``), but none require ffmpeg
+# to be rebuilt. Formats that do need an external encoder library are left out
+# -- Speex (libspeex), AMR-WB (libvo-amrwbenc) and GSM (libgsm) are unusable on
+# a stock build, so allowing the name would just move the failure downstream.
+#
+# ``amr`` is the one exception: it also needs an external library
+# (libopencore-amrnb) but predates this list, so it stays for compatibility
+# with configs that already declare it.
+#
+# An unrecognized value falls back to DEFAULT_COMMAND_TTS_OUTPUT_FORMAT.
+COMMAND_TTS_OUTPUT_FORMATS = frozenset({
+    # MPEG audio
+    "mp3", "mp2",
+    # Ogg family
+    "ogg", "oga", "opus",
+    # MP4 / 3GPP family
+    "m4a", "m4b", "mp4", "aac", "3gp",
+    # Matroska family
+    "mka", "webm",
+    # Uncompressed / PCM containers
+    "wav", "w64", "aiff", "aif", "au", "caf", "pcm",
+    # Lossless compressed
+    "flac", "wv", "tta",
+    # Speech / telephony (external encoder, kept for compatibility)
+    "amr",
+    # Other lossy
+    "ac3", "wma",
+})
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000
 
 # Platforms whose native voice-bubble delivery requires Ogg/Opus audio.
@@ -849,7 +880,11 @@ def _get_command_tts_output_format(
     config: Dict[str, Any],
     output_path: Optional[str] = None,
 ) -> str:
-    """Return the validated output format (mp3/wav/ogg/flac)."""
+    """Return the output format, or the default when it is unrecognized.
+
+    A suffix on ``output_path`` wins over the provider's configured value;
+    both are matched against COMMAND_TTS_OUTPUT_FORMATS.
+    """
     if output_path:
         suffix = Path(output_path).suffix.lower().strip().lstrip(".")
         if suffix in COMMAND_TTS_OUTPUT_FORMATS:

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -285,7 +285,22 @@ tts:
       output_format: wav
 ```
 
-**Supported `output_format` values:** `mp3` (default), `wav`, `ogg`, `flac`, `m4a`, `aac`, `amr`, `opus`. Your command must actually produce that format (e.g. via `ffmpeg`); Hermes only validates the declared value and names the output file accordingly. An unknown value falls back to `mp3`. The chosen format is also exposed to the command as the `{format}` placeholder.
+**Supported `output_format` values** (`mp3` is the default):
+
+| Family | Extensions |
+|--------|------------|
+| MPEG audio | `mp3`, `mp2` |
+| Ogg | `ogg`, `oga`, `opus` |
+| MP4 / 3GPP | `m4a`, `m4b`, `mp4`, `aac`, `3gp` |
+| Matroska | `mka`, `webm` |
+| Uncompressed / PCM | `wav`, `w64`, `aiff`, `aif`, `au`, `caf`, `pcm` |
+| Lossless compressed | `flac`, `wv`, `tta` |
+| Speech / telephony | `amr` |
+| Other lossy | `ac3`, `wma` |
+
+Your command must actually produce that format (e.g. via `ffmpeg`); Hermes only decides how the output file is *named* and what `{format}` expands to — it never encodes on your behalf. Every extension above can be written by a stock `ffmpeg`, though a few need an explicit encoder instead of the default one ffmpeg picks for the extension — `.3gp` defaults to AMR, so pass `-c:a aac`. Formats requiring an external encoder library are deliberately not recognized: Speex, AMR-WB (`.awb`) and GSM are unusable on a stock build. `amr` is the exception — it needs libopencore-amrnb but is kept for compatibility with existing configs.
+
+An unrecognized value falls back to `mp3`. Matching is case-insensitive and a leading dot is ignored, so `.M4A` and `m4a` are equivalent. A recognized suffix on an explicit `output_path` takes precedence over the configured value.
 
 **Subprocess environment:** command providers (TTS and STT) run with Hermes secrets scrubbed from the child environment — gateway bot tokens, LLM provider API keys, and internal relay credentials are removed; `PATH`, `HOME`, locale, and other normal variables are kept. If your command template needs its own API key from the environment (e.g. a `curl` one-liner), list the variable names under `env_passthrough` in the provider config:
 
@@ -332,7 +347,7 @@ Your command template can reference these placeholders. Hermes substitutes them 
 | `{input_path}`   | Path to the temp UTF-8 text file Hermes wrote        |
 | `{text_path}`    | Alias for `{input_path}`                             |
 | `{output_path}`  | Path the command must write audio to                 |
-| `{format}`       | `mp3` / `wav` / `ogg` / `flac`                       |
+| `{format}`       | The resolved `output_format` (see table above)       |
 | `{voice}`        | `tts.providers.<name>.voice`, empty when unset       |
 | `{model}`        | `tts.providers.<name>.model`                         |
 | `{speed}`        | Resolved speed multiplier (provider or global)       |
@@ -344,7 +359,7 @@ Use `{{` and `}}` for literal braces.
 | Key                | Default | Meaning                                                                                                    |
 |--------------------|---------|------------------------------------------------------------------------------------------------------------|
 | `timeout`          | `120`   | Idle seconds; stdout or stderr output resets the deadline. The process tree is killed after inactivity (Unix `killpg`, Windows `taskkill /T`). |
-| `output_format`    | `mp3`   | One of `mp3` / `wav` / `ogg` / `flac`. Auto-inferred from the output extension if Hermes picks a path.      |
+| `output_format`    | `mp3`   | Any extension from the supported formats table above. Auto-inferred from the output extension if Hermes picks a path. |
 | `voice_compatible` | `false` | When `true`, Hermes converts MP3/WAV output to Opus/OGG via ffmpeg so Telegram renders a voice bubble.      |
 | `max_text_length`  | `5000`  | Input is truncated to this length before rendering the command.                                             |
 | `voice` / `model`  | empty   | Passed to the command as placeholder values only.                                                           |


### PR DESCRIPTION
## What

Command-type TTS providers name their output file after `output_format` and expand it into the `{format}` placeholder — the provider's own command produces the bytes. The allowlist therefore governs *naming* only, yet it recognized just 8 extensions. Any other value was silently coerced back to `mp3`, so the file the command wrote no longer matched the path the post-run existence check looks for, and generation failed with a confusing error.

This widens the set from 8 to 25 and restores the regression coverage a later test prune removed.

## Format selection

Entries are limited to extensions a **stock ffmpeg** can write, verified empirically against ffmpeg 8.1.2:

| Family | Extensions |
|---|---|
| MPEG audio | `mp3`, `mp2` |
| Ogg | `ogg`, `oga`, `opus` |
| MP4 / 3GPP | `m4a`, `m4b`, `mp4`, `aac`, `3gp` |
| Matroska | `mka`, `webm` |
| Uncompressed / PCM | `wav`, `w64`, `aiff`, `aif`, `au`, `caf`, `pcm` |
| Lossless compressed | `flac`, `wv`, `tta` |
| Speech / telephony | `amr` |
| Other lossy | `ac3`, `wma` |

24 of the 25 are produced by stock ffmpeg with its default encoder for the extension; `.3gp` needs `-c:a aac`, because ffmpeg defaults that extension to AMR.

**Deliberately excluded:** formats requiring an external encoder library — Speex (`libspeex`), AMR-WB `.awb` (`libvo-amrwbenc`), and GSM (`libgsm`). None are present in a stock build, so recognizing the name would only move the failure downstream into the user's ffmpeg invocation.

**`amr` is the one exception.** It also needs an external library (`libopencore-amrnb`), but it predates this list, so dropping it would break configs that already declare it.

No built-in provider behavior changes, and no new required config.

## Tests

This allowlist's coverage was removed by 39975613b (`test: prune wave 2`), which also left `COMMAND_TTS_OUTPUT_FORMATS` as an unused import in the test module. Restored, and rewritten so it cannot rot the same way again:

- `test_output_format_accepts_every_supported_format` is parametrized over the entire frozenset and exercises both entry points — an explicit `format` / `output_format` config value, and inference from the output path suffix. Adding or removing an entry changes the test matrix automatically.
- Adds behavior that was never covered: suffix precedence over the configured value, and case / leading-dot normalization.
- `test_output_format_rejects_unknown` now also covers the path-suffix branch.

`tests/tools/test_tts_command_providers.py` goes 36 → 65 tests. 102 pass across it plus `tests/agent/test_tts_registry.py` and `tests/tools/test_tts_mistral.py`; `ruff check` is clean.

## Docs

Three spots still advertised the pre-#73514 `mp3`/`wav`/`ogg`/`flac` set and are corrected: the supported-values prose (now a grouped table), the `{format}` placeholder row, and the `output_format` optional-keys row. Also fixes the `_get_command_tts_output_format` docstring, which still read `(mp3/wav/ogg/flac)`.

## Not in scope

- **`agent/tts_provider.py` has a second, independent allowlist.** `VALID_OUTPUT_FORMATS = {mp3, wav, ogg, opus, flac}`, used by `resolve_output_format()` for plugin-registered `TTSProvider` backends. That is a different subsystem from command providers, so it is left untouched to keep this change reviewable. Happy to align the two in a follow-up if you'd prefer.
- **The zh-Hans translation is not updated.** `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/tts.md` still documents the original four formats in the `{format}` row (line 271) and the `output_format` row (line 283). It never received the #73514 `m4a`/`aac`/`amr`/`opus` change either, so it is already a release behind and appears to be maintained out-of-band; updating just those two rows would leave it internally inconsistent with the surrounding untranslated text. Flagging rather than half-fixing — glad to include it if translations are expected in the same PR.
