### PR TITLE
fix(tests): de-flake timing-sensitive ui-tui tests

### DIFF
--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.test.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.test.ts
@@ -95,9 +95,12 @@ describe.skipIf(onWindows)('execFileNoThrow with daemon-style children', () => {
 
     // The shell exits in a few ms. resolveOnExit lets us return on exit
     // (code 0) instead of waiting for the orphaned sleeper to release
-    // stdio. Should be well under 200ms even on slow CI.
+    // stdio. Normally well under 200ms; observed 550ms under load.
+    // Bound of 2000ms (= the call's own timeout) still catches the
+    // regression this guards: a broken resolveOnExit hangs to timeout,
+    // elapsed == 2000, and 2000 < 2000 is false.
     expect(result.code).toBe(0)
-    expect(elapsed).toBeLessThan(500)
+    expect(elapsed).toBeLessThan(2000)
   })
 
   it("still surfaces the right code when resolveOnExit'd child exits non-zero", async () => {

--- a/ui-tui/src/__tests__/cursorDriftRegression.test.ts
+++ b/ui-tui/src/__tests__/cursorDriftRegression.test.ts
@@ -68,7 +68,12 @@ describe('cursor-drift regression — composer cursorLayout matches Ink renderin
         ).toEqual(expected)
       }
     }
-  }, 30_000)
+  // Brute-force walk: ~3500 wrap-ansi calls (7 widths x every char prefix).
+  // Measured 6.6s idle / 32.4s under load — the default 30s vitest timeout
+  // flakes on busy machines. 120s keeps it a correctness test, not a
+  // performance one; a logic regression still fails fast at the first
+  // mismatched prefix.
+  }, 120_000)
 
   it('keeps cursor on the same row when text exactly fills the terminal width', () => {
     // wrap-ansi does NOT push exact-fill text onto a phantom next line.


### PR DESCRIPTION
## Summary

Two ui-tui tests flake under machine load (both reproduced locally: pass on an idle machine, fail intermittently under load).

### 1. `cursorDriftRegression.test.ts` — vitest 30s timeout

The brute-force walk (~3,500 wrap-ansi calls: 7 terminal widths × every char prefix of a 500-char message) measured **6.6s idle / 32.4s under load**, tripping the explicit `30_000` timeout. Raised to `120_000` with a comment. It's a correctness test — a logic regression still fails at the first mismatched prefix; the timeout only guards against pathological slowness.

### 2. `execFileNoThrow.test.ts` — 500ms settle bound

The `resolveOnExit` settle-time assertion measured **550ms under load**. Raised `toBeLessThan(500)` → `toBeLessThan(2000)`. The bound now equals the call's own `timeout: 2000`, so the regression this guards (a broken `resolveOnExit` hanging to timeout) still trips it: elapsed == 2000, `2000 < 2000` is false.

## Verification

- Both tests pass in isolation and in the full workspace run
- `npm run check --workspace ui-tui` (build:ink + typecheck + vitest + eslint): **135 files / 1456 passed, 0 failed**
