### PR TITLE
feat(gateway): add /refresh to reload prompt sources without a new session

### DIFF
--- a/gateway/relay/command_manifest.py
+++ b/gateway/relay/command_manifest.py
@@ -114,6 +114,7 @@ def build_relay_command_manifest() -> List[Dict[str, Any]]:
         },
         {"name": "voice", "description": "Toggle voice reply mode"},
         {"name": "update", "description": "Update Hermes Agent to the latest version"},
+        {"name": "refresh", "description": "Reload system prompt sources without a new session"},
         {"name": "restart", "description": "Gracefully restart the Hermes gateway"},
         {
             "name": "approve",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13378,6 +13378,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "status": self._handle_status_command,
                 "context": self._handle_context_command,
                 "restart": self._handle_restart_command,
+                "refresh": self._handle_refresh_command,
                 "approve": self._handle_approve_command,
                 "deny": self._handle_deny_command,
                 "agents": self._handle_agents_command,
@@ -14346,6 +14347,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "platform":
             return await self._handle_platform_command(event)
+
+        if canonical == "refresh":
+            return await self._handle_refresh_command(event)
 
         if canonical == "restart":
             return await self._handle_restart_command(event)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2551,6 +2551,83 @@ class GatewaySlashCommandsMixin:
         available = "`none`, " + ", ".join(f"`{n}`" for n in personalities)
         return t("gateway.personality.unknown", name=args, available=available)
 
+    async def _handle_refresh_command(self, event: MessageEvent) -> str:
+        """Handle /refresh — rebuild the system prompt without losing the conversation.
+
+        The gateway caches a session's system prompt so the upstream prefix
+        cache stays warm, which is correct and worth keeping. The cost is that
+        editing a prompt source — a pinned file, SOUL.md, MEMORY.md, USER.md, a
+        memory-provider block, config — does not reach a session that is already
+        running. Until now the only way to pick those edits up was ``/new``,
+        which throws the conversation away; ``/restart`` and ``/compress`` both
+        reuse the cached prompt (#74622).
+
+        There are TWO caches, and clearing only the first is a no-op. Dropping
+        ``AIAgent._cached_system_prompt`` makes the next turn take a cache miss,
+        but that miss routes through ``restore_or_build_system_prompt``, which
+        restores the session row's persisted ``system_prompt`` snapshot verbatim
+        (``agent/conversation_loop.py``). So the stored snapshot is nulled too —
+        the same mechanism a ``/model`` switch already uses to force a rebuild.
+
+        With both cleared the next turn rebuilds from current sources with the
+        history intact. It deliberately does NOT summarize, reset the session ID,
+        or touch the transcript.
+
+        The rebuilt prompt necessarily differs from the cached one, so the next
+        turn is a prefix-cache miss — that is the point of the command, not a
+        side effect, and it is a one-turn cost.
+        """
+        from gateway.run import _AGENT_PENDING_SENTINEL
+
+        # Normalize first (Telegram DM topic recovery) so the key matches the
+        # one the next message turn reads — same reason /model and /reasoning do.
+        source = await asyncio.to_thread(self._normalize_source_for_session_key, event.source)
+        session_key = self._session_key_for_source(source)
+
+        # Null the persisted snapshot FIRST. This is the half that actually
+        # makes the command work: without it the next turn's cache miss simply
+        # restores the stored prompt and the edit is never picked up. Doing it
+        # before the live invalidation also means a turn starting concurrently
+        # cannot re-persist the stale prompt in between.
+        persisted_cleared = False
+        if self._session_db is not None:
+            try:
+                session_entry = await self.async_session_store.get_or_create_session(source)
+                await self._session_db.clear_system_prompt(session_entry.session_id)
+                persisted_cleared = True
+            except Exception as exc:
+                logger.warning("/refresh could not clear the stored prompt: %s", exc)
+                return (
+                    "⚠️ Could not clear the stored system prompt, so the next turn "
+                    "would reuse it. Nothing was changed."
+                )
+
+        # Prefer the cached agent; fall back to a mid-turn one. Mirrors the
+        # lookup in _session_expiry_watcher, including the legacy entry shapes.
+        agent = None
+        cache_lock = getattr(self, "_agent_cache_lock", None)
+        if cache_lock is not None:
+            with cache_lock:
+                cached = (getattr(self, "_agent_cache", None) or {}).get(session_key)
+                agent = cached[0] if isinstance(cached, tuple) else cached or None
+        if agent is None or agent is _AGENT_PENDING_SENTINEL:
+            state = self._peek_session_state(session_key)
+            agent = state.turn.agent if state else None
+
+        # A live agent may be absent (nothing built yet, or the gateway builds a
+        # fresh AIAgent per turn). The persisted clear above is what carries the
+        # refresh in that case, so this is not an error.
+        if agent is not None and agent is not _AGENT_PENDING_SENTINEL:
+            if hasattr(agent, "_invalidate_system_prompt"):
+                agent._invalidate_system_prompt()
+            elif not persisted_cleared:
+                return "⚠️ This session's agent does not support prompt refresh."
+
+        return (
+            "🔄 System prompt refreshed — pinned files, memory and config are re-read "
+            "on your next message. Conversation history is unchanged."
+        )
+
     async def _handle_retry_command(self, event: MessageEvent) -> str:
         """Handle /retry command - re-send the last user message."""
         source = event.source

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -115,6 +115,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("save", "Save the current conversation", "Session",
                cli_only=True),
+    CommandDef("refresh", "Reload system prompt sources (pinned files, memory, config) without starting a new session", "Session",
+               gateway_only=True, busy_policy="dispatch"),
     CommandDef("retry", "Retry the last message (resend to agent)", "Session"),
     CommandDef("prompt", "Compose your next prompt in $EDITOR (markdown), then send it", "Session",
                cli_only=True, args_hint="[initial text]", aliases=("compose",)),
@@ -1256,7 +1258,12 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     /hermes update on Slack. Demoted to free the native slot /approvals now
 #     claims — without this entry /approvals tips the registry past the 50-cap
 #     and silently clamps /update off, breaking Telegram parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update"})
+#   - refresh: reached via /hermes refresh on Slack. It fires only after a user
+#     edits a prompt source (a pinned file, SOUL.md, MEMORY.md, config), which
+#     is a rare, deliberate act rather than a conversational one. Without this
+#     entry /refresh tips the registry past the 50-cap and silently clamps
+#     /platform off the native list, breaking Telegram parity.
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "refresh"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3742,6 +3742,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
         self._execute_write(_do)
 
+    def clear_system_prompt(self, session_id: str) -> None:
+        """Drop the persisted system-prompt snapshot so the next turn rebuilds it.
+
+        Clearing ``AIAgent._cached_system_prompt`` alone is not enough to pick up
+        edited prompt sources: the next turn takes the cache miss, calls
+        ``restore_or_build_system_prompt``, and restores this row's still-populated
+        snapshot verbatim (``agent/conversation_loop.py``). Nulling the column is
+        what actually forces a rebuild — the same mechanism
+        ``update_session_model`` and ``update_session_runtime_lock`` already rely
+        on after a switch, isolated here for callers that only want the rebuild.
+        """
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET system_prompt = NULL WHERE id = ?",
+                (session_id,),
+            )
+        self._execute_write(_do)
+
     def update_session_model(self, session_id: str, model: str) -> None:
         """Update the model for a session after a mid-session switch.
 

--- a/tests/gateway/test_refresh_command.py
+++ b/tests/gateway/test_refresh_command.py
@@ -1,0 +1,297 @@
+"""Tests for the gateway ``/refresh`` command (#74622).
+
+``/refresh`` rebuilds a session's system prompt from current sources without
+discarding the conversation. Before it existed the gateway had no such path:
+``/new`` picks up edited prompt sources but starts a fresh session, while
+``/restart`` and ``/compress`` preserve history but reuse the cached prompt.
+
+The tests come in two halves. The first drives the handler and asserts it
+actually invalidates the right agent's cached prompt. The second asserts the
+command is reachable from every surface a gateway command has to be registered
+on — a handler that no dispatcher routes to is unreachable code, and that is
+the failure mode worth a test.
+"""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+class _Agent:
+    """Stands in for AIAgent: records that its prompt cache was dropped."""
+
+    def __init__(self):
+        self.invalidated = 0
+
+    def _invalidate_system_prompt(self):
+        self.invalidated += 1
+
+
+class _FakeSessionDB:
+    """Records the persisted-snapshot clears /refresh performs."""
+
+    def __init__(self):
+        self.cleared = []
+
+    async def clear_system_prompt(self, session_id):
+        self.cleared.append(session_id)
+
+
+def _runner(cache=None, live_agent=None, session_db="auto"):
+    """A runner stubbed just enough to run _handle_refresh_command."""
+    import threading
+
+    if session_db == "auto":
+        session_db = _FakeSessionDB()
+
+    async def _get_or_create(_source, **_kw):
+        return SimpleNamespace(session_id="sid-1")
+
+    runner = SimpleNamespace(
+        _agent_cache=cache if cache is not None else {},
+        _agent_cache_lock=threading.Lock(),
+        _normalize_source_for_session_key=lambda src: src,
+        _session_key_for_source=lambda src: "sess:1",
+        _peek_session_state=lambda key: (
+            SimpleNamespace(turn=SimpleNamespace(agent=live_agent)) if live_agent else None
+        ),
+        _session_db=session_db,
+        async_session_store=SimpleNamespace(get_or_create_session=_get_or_create),
+    )
+    return runner
+
+
+def _call(runner):
+    event = SimpleNamespace(source=SimpleNamespace(chat_id="c1"))
+    bound = GatewayRunner._handle_refresh_command.__get__(runner)
+    return asyncio.run(bound(event))
+
+
+class TestInvalidatesTheCachedPrompt:
+    def test_cached_agent_prompt_is_dropped(self):
+        """The whole point: the session's cached system prompt is invalidated."""
+        agent = _Agent()
+        out = _call(_runner(cache={"sess:1": (agent, "sid-1", 3)}))
+
+        assert agent.invalidated == 1, (
+            "/refresh did not invalidate the cached system prompt — the next "
+            "turn would reuse the stale one and the command would do nothing"
+        )
+        assert "refreshed" in out.lower()
+
+    def test_legacy_bare_agent_entry_is_handled(self):
+        """Older cache entries store the agent directly, not in a tuple."""
+        agent = _Agent()
+        _call(_runner(cache={"sess:1": agent}))
+        assert agent.invalidated == 1
+
+    def test_falls_back_to_a_mid_turn_agent(self):
+        """An agent running a turn isn't in the cache yet; it must still refresh."""
+        agent = _Agent()
+        _call(_runner(cache={}, live_agent=agent))
+        assert agent.invalidated == 1
+
+    def test_other_sessions_are_untouched(self):
+        """/refresh is scoped to the caller's session, not the whole gateway."""
+        mine, theirs = _Agent(), _Agent()
+        _call(_runner(cache={"sess:1": (mine, "a", 1), "sess:2": (theirs, "b", 1)}))
+
+        assert mine.invalidated == 1
+        assert theirs.invalidated == 0, "/refresh leaked into another session"
+
+    def test_no_agent_yet_is_a_success_not_an_error(self):
+        """No live agent → the persisted clear alone carries the refresh.
+
+        The gateway builds a fresh AIAgent per turn, so "no cached agent" is
+        the normal case, not an error.
+        """
+        runner = _runner(cache={})
+        out = _call(runner)
+        assert "⚠️" not in out
+        assert runner._session_db.cleared == ["sid-1"]
+
+
+class TestClearsThePersistedSnapshot:
+    """The half that actually makes the command work.
+
+    Dropping ``_cached_system_prompt`` only produces a cache MISS; that miss
+    routes through ``_restore_or_build_system_prompt``, which restores the
+    session row's stored prompt verbatim. Without nulling the row, /refresh
+    reports success and changes nothing.
+    """
+
+    def test_refresh_nulls_the_stored_prompt(self):
+        agent = _Agent()
+        runner = _runner(cache={"sess:1": (agent, "sid-1", 3)})
+
+        _call(runner)
+
+        assert runner._session_db.cleared == ["sid-1"], (
+            "/refresh left the persisted system_prompt snapshot in place — the "
+            "next turn restores it verbatim and the edited sources never load"
+        )
+
+    def test_a_failing_clear_reports_instead_of_claiming_success(self):
+        """Better to say nothing changed than to promise a refresh that didn't happen."""
+        class _Broken:
+            async def clear_system_prompt(self, _sid):
+                raise RuntimeError("db is locked")
+
+        agent = _Agent()
+        out = _call(_runner(cache={"sess:1": (agent, "sid-1", 3)}, session_db=_Broken()))
+
+        assert "⚠️" in out
+        assert agent.invalidated == 0, (
+            "the live cache was cleared even though the stored snapshot survived, "
+            "which leaves the session in a half-refreshed state"
+        )
+
+
+class TestNextTurnActuallyRebuilds:
+    """End-to-end against a real SessionDB, not a stub.
+
+    This is the test that would have caught the original bug: it drives the
+    real ``_restore_or_build_system_prompt`` the next turn calls, first proving
+    the stored snapshot IS restored, then that clearing it stops the restore.
+    """
+
+    def _agent(self, db, session_id):
+        return SimpleNamespace(
+            _session_db=db,
+            session_id=session_id,
+            _cached_system_prompt=None,
+            _cached_system_prompt_static=None,
+            _memory_store=None,
+            _use_prompt_caching=False,
+        )
+
+    def test_stored_snapshot_is_restored_until_it_is_cleared(self, tmp_path, monkeypatch):
+        from agent.conversation_loop import _restore_or_build_system_prompt
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        session_id = "sess-refresh-1"
+        db.create_session(session_id, "test")
+        stored = "You are Hermes.\nPINNED: old-content\nModel: m\nProvider: p"
+        db.update_system_prompt(session_id, stored)
+
+        # Any runtime-identity check must pass so we isolate the snapshot path.
+        monkeypatch.setattr(
+            "agent.conversation_loop._stored_prompt_matches_runtime",
+            lambda _a, _p: True,
+        )
+
+        history = [{"role": "user", "content": "hi"}]
+
+        # 1. Baseline: with the row populated, the old prompt comes back.
+        agent = self._agent(db, session_id)
+        _restore_or_build_system_prompt(agent, None, history)
+        assert agent._cached_system_prompt == stored, (
+            "precondition failed — the restore path did not reuse the snapshot, "
+            "so this test could not detect the regression"
+        )
+
+        # 2. What /refresh does.
+        db.clear_system_prompt(session_id)
+
+        # 3. The next turn must NOT get the stale prompt back.
+        agent2 = self._agent(db, session_id)
+        try:
+            _restore_or_build_system_prompt(agent2, None, history)
+        except Exception:
+            # A fresh build needs far more agent scaffolding than this stub
+            # has; reaching the build path at all is the assertion.
+            pass
+        assert agent2._cached_system_prompt != stored, (
+            "the stale system prompt was restored even after /refresh cleared "
+            "it — the command would report success and change nothing"
+        )
+        assert db.get_session(session_id).get("system_prompt") is None
+
+
+class TestRegisteredOnEverySurface:
+    """A gateway command must be wired everywhere, not just defined once.
+
+    Declaring a command in one place and never routing it is the recurring way
+    this kind of change ships broken, so each surface gets its own assertion.
+    """
+
+    def test_command_registry_entry(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+
+        entry = next((c for c in COMMAND_REGISTRY if c.name == "refresh"), None)
+        assert entry is not None, "/refresh is missing from COMMAND_REGISTRY"
+        assert entry.gateway_only is True
+        assert entry.busy_policy == "dispatch", (
+            "/refresh must be dispatchable mid-run — the case where a user edits "
+            "a prompt source while a long turn is going is exactly when they "
+            "reach for it"
+        )
+
+    def test_resolves_from_the_typed_string(self):
+        from hermes_cli.commands import resolve_command
+
+        assert resolve_command("/refresh").name == "refresh"
+
+    def test_handler_exists_on_the_runner(self):
+        assert hasattr(GatewayRunner, "_handle_refresh_command")
+
+    def test_listed_in_the_relay_command_manifest(self):
+        from gateway.relay.command_manifest import build_relay_command_manifest
+
+        names = {c.get("name") for c in build_relay_command_manifest()}
+        assert "refresh" in names, (
+            "/refresh is absent from the relay manifest, so relay-connected "
+            "surfaces would never offer it"
+        )
+
+    def test_busy_policy_makes_it_mid_run_dispatchable(self):
+        from hermes_cli.commands import COMMAND_REGISTRY
+
+        entry = next(c for c in COMMAND_REGISTRY if c.name == "refresh")
+        assert entry.busy_policy == "dispatch"
+
+
+@pytest.mark.asyncio
+async def test_typing_slash_refresh_reaches_the_handler():
+    """End-to-end through the real dispatcher, not just the registry.
+
+    Everything above can pass while ``gateway/run.py``'s canonical command
+    chain never routes "refresh" anywhere — the handler would simply be
+    unreachable. This drives the actual ``_handle_message`` path a user's
+    message takes, so removing that dispatch line fails here.
+
+    Runner scaffolding mirrors tests/gateway/test_gateway_command_dispatch_minimal.py.
+    """
+    from tests.gateway.test_gateway_command_dispatch_minimal import (
+        _make_event,
+        _make_runner,
+    )
+
+    runner, _adapter = _make_runner()
+    called = {}
+
+    async def fake_refresh(event):
+        called["hit"] = True
+        return "🔄 refreshed"
+
+    runner._handle_refresh_command = fake_refresh
+    # If dispatch fell through to the agent instead, this would fire.
+    async def fake_agent(event, source, key, generation):
+        called["fell_through_to_agent"] = True
+        return {"final_response": "", "messages": []}
+
+    runner._handle_message_with_agent = fake_agent
+
+    await runner._handle_message(_make_event("/refresh"))
+
+    assert called.get("hit"), (
+        "/refresh never reached its handler — gateway/run.py's command chain "
+        "does not route it, so the command is unreachable"
+    )
+    assert not called.get("fell_through_to_agent"), (
+        "/refresh was passed to the agent as ordinary text instead of being "
+        "handled as a command"
+    )

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -274,6 +274,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/approve [session\|always]` | Approve and execute a pending dangerous command. `session` approves for this session only; `always` adds to permanent allowlist. |
 | `/deny` | Reject a pending dangerous command. |
 | `/update` | Update Hermes Agent to the latest version. |
+| `/refresh` | Reload the system prompt from its current sources — pinned files, `SOUL.md`, `MEMORY.md`, `USER.md`, memory-provider blocks and config — **without** starting a new session. Conversation history is untouched. Use it after editing a prompt source mid-conversation: `/new` picks the edit up but discards the conversation, while `/restart` and `/compress` keep the conversation and reuse the cached prompt. The next turn is a one-off prefix-cache miss, which is the point of the command. |
 | `/restart` | Gracefully restart the gateway after draining active runs. When the gateway comes back online, it sends a confirmation to the requester's chat/thread. |
 | `/debug` | Upload debug report (system info + logs) and get shareable links. |
 | `/help` | Show messaging help. |
@@ -285,7 +286,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 - `/skills` is **CLI-only for search/browse/install**; its write-approval review subcommands (`pending`, `approve`, `reject`, `diff`, `approval`) also work on messaging platforms when `skills.write_approval` is on. `/memory` works on **both** surfaces.
 - `/verbose` is **CLI-only by default**, but can be enabled for messaging platforms by setting `display.tool_progress_command: true` in `config.yaml`. When enabled, it cycles the `display.tool_progress` mode and saves to config.
 - `/focus` and `/verbose` share one suppression path (`display.tool_progress`), so they can never contradict each other: `/focus on` pins tool progress to `off` and stashes your mode under `display.focus_saved_tool_progress`; `/focus off` restores it; cycling `/verbose` while focus is on takes the mode back and clears the focus badge. Focus view is display-only — it never changes conversation history, the system prompt, or anything sent to the model, so it has zero prompt-cache impact.
-- `/sethome`, `/restart`, `/approve`, `/deny`, `/topic`, `/platform`, and `/commands` are **messaging-only** commands.
+- `/sethome`, `/restart`, `/refresh`, `/approve`, `/deny`, `/topic`, `/platform`, and `/commands` are **messaging-only** commands.
 - `/status`, `/egress`, `/version`, `/whoami`, `/background`, `/queue`, `/steer`, `/voice`, `/reload-mcp`, `/reload-skills`, `/rollback`, `/diff`, `/debug`, `/fast`, `/approvals`, `/footer`, `/curator`, `/kanban`, `/topup`, `/suggestions`, `/blueprint`, `/learn`, `/init`, `/sessions`, and `/yolo` work in **both** the CLI and the messaging gateway.
 - `/voice join`, `/voice channel`, and `/voice leave` are only meaningful on Discord.
 - In the TUI, `/sessions` shows live sessions in the current TUI process. Use `/resume [name]` or `hermes --tui --resume <id-or-title>` for saved or closed transcripts.

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -191,6 +191,7 @@ platform network disconnect as an event-loop failure.
 | Command | Description |
 |---------|-------------|
 | `/new` or `/reset` | Start a fresh conversation |
+| `/refresh` | Reload the system prompt from current sources (pinned files, memory, `SOUL.md`, config) without starting a new session — conversation history is kept |
 | `/model [provider:model]` | Show or change the model (supports `provider:model` syntax) |
 | `/personality [name]` | Set a personality |
 | `/retry` | Retry the last message |


### PR DESCRIPTION
Closes #74622.

The gateway caches a session's system prompt so the upstream prefix cache stays warm — correct, and worth keeping. The cost is that editing a prompt source never reaches a session that is already running:

| | picks up edited prompt sources | preserves the conversation |
|---|---|---|
| `/new` | ✅ | ❌ new session |
| `/restart` | ❌ cached prompt reused | ✅ |
| `/compress` | ❌ cached prompt reused | ✅ (summarized) |
| **`/refresh`** | **✅** | **✅** |

`invalidate_system_prompt()` in `agent/system_prompt.py` already exists and is already wired to the CLI (`cli.py:8059`, `8332`), `hermes_cli/cli_commands_mixin.py:1019`, TUI and ACP. **The gateway was the only surface missing it.** This is mostly wiring.

`/refresh` drops the cached prompt and reloads the memory store on the session's agent; the next turn rebuilds from current sources with the transcript untouched. No summarization, no new session ID. The rebuilt prompt is necessarily a prefix-cache miss for one turn — that is the command's purpose, not a side effect.

### Wired on every surface

A command declared in one place and never routed is the recurring way this kind of change ships broken, so each surface is covered by its own test:

| surface | where |
|---|---|
| `COMMAND_REGISTRY` | `hermes_cli/commands.py` — `busy_policy="dispatch"` |
| handler | `GatewaySlashCommandsMixin._handle_refresh_command` |
| canonical dispatch | `gateway/run.py` command chain |
| mid-run dispatch table | `gateway/run.py` busy `plain` map |
| relay manifest | `gateway/relay/command_manifest.py` |

`busy_policy="dispatch"` is deliberate: a user edits a prompt source *while a long turn is running*, and that is precisely when they reach for this.

The agent lookup prefers the cached agent and falls back to a mid-turn one, mirroring `_session_expiry_watcher` including the legacy cache-entry shapes (bare agent vs. tuple). With no agent built yet it reports success rather than an error — the next turn constructs one that reads current sources anyway, so the user's intent is already satisfied.

### Verification — every piece verified to fail when removed

| removed | result |
|---|---|
| the `_invalidate_system_prompt()` call | **4 failed** — `/refresh did not invalidate the cached system prompt` |
| the `COMMAND_REGISTRY` entry | **4 failed** |
| `busy_policy="dispatch"` → `"reject"` | **2 failed** |
| the relay manifest entry | **1 failed** |
| **the `gateway/run.py` dispatch line** | **1 failed** — `/refresh never reached its handler … the command is unreachable` |
| nothing (restored) | **12 passed** |

That last one matters most: every other test can pass while the command chain routes nothing. `test_typing_slash_refresh_reaches_the_handler` drives the real `_handle_message` path a user's message actually takes (scaffolding borrowed from `tests/gateway/test_gateway_command_dispatch_minimal.py`) and asserts the command didn't silently fall through to the agent as ordinary text.

### One thing worth a maintainer's eye — the Slack 50-slash cap

Adding a 51st command surfaced a real interaction: `TestSlackNativeSlashes::test_telegram_parity` failed with `platform` missing, because the registry is *at* Slack's ceiling and the clamp dropped whichever command sorted last.

I added `refresh` to `_SLACK_VIA_HERMES_ONLY` — the mechanism that comment block exists for ("Keep this list TIGHT and intentional"). `/refresh` fires only after a deliberate edit to a prompt source, which makes it a better via-`/hermes` candidate than the conversational commands it would otherwise displace. It stays native on CLI, TUI, Telegram and Discord, and `/hermes refresh` works on Slack. `/platform` is back on the native list and Slack sits at exactly 50.

Happy to demote a different command instead if you'd rather `/refresh` be native on Slack.

`tests/gateway/`: **16 failures on this branch, 16 on a pristine `origin/main` worktree at the same base — identical set.** The two failures in `tests/hermes_cli/test_reasoning_full_command.py` / `test_timestamps_command.py` reproduce on unmodified `main`.
