### PR TITLE
fix(tui): debounce quiet empty-paste clipboard probes (#75150)

### DIFF
--- a/ui-tui/src/__tests__/quietClipboardProbe.test.ts
+++ b/ui-tui/src/__tests__/quietClipboardProbe.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clipboardImageFingerprint,
+  createQuietClipboardProbeState,
+  noteQuietClipboardAttach,
+  noteQuietClipboardProbe,
+  QUIET_CLIPBOARD_ATTACH_DEDUPE_MS,
+  QUIET_CLIPBOARD_PROBE_COOLDOWN_MS,
+  shouldAttachQuietClipboardImage,
+  shouldQuietClipboardProbe
+} from '../lib/quietClipboardProbe.js'
+
+describe('quietClipboardProbe', () => {
+  it('allows the first quiet probe and cools down subsequent ones', () => {
+    const state = createQuietClipboardProbeState()
+    const t0 = 1_000_000
+
+    expect(shouldQuietClipboardProbe(state, t0)).toBe(true)
+    noteQuietClipboardProbe(state, t0)
+    expect(shouldQuietClipboardProbe(state, t0 + QUIET_CLIPBOARD_PROBE_COOLDOWN_MS - 1)).toBe(false)
+    expect(shouldQuietClipboardProbe(state, t0 + QUIET_CLIPBOARD_PROBE_COOLDOWN_MS)).toBe(true)
+  })
+
+  it('dedupes the same clipboard image fingerprint within the attach window', () => {
+    const state = createQuietClipboardProbeState()
+    const t0 = 2_000_000
+    const key = clipboardImageFingerprint({ width: 1594, height: 1382, token_estimate: 1000 })
+
+    expect(shouldAttachQuietClipboardImage(state, key, t0)).toBe(true)
+    noteQuietClipboardAttach(state, key, t0)
+    expect(shouldAttachQuietClipboardImage(state, key, t0 + 1_000)).toBe(false)
+    expect(shouldAttachQuietClipboardImage(state, key, t0 + QUIET_CLIPBOARD_ATTACH_DEDUPE_MS)).toBe(true)
+  })
+
+  it('allows a different fingerprint immediately after a quiet attach', () => {
+    const state = createQuietClipboardProbeState()
+    const t0 = 3_000_000
+    const first = clipboardImageFingerprint({ width: 100, height: 100, token_estimate: 85 })
+    const second = clipboardImageFingerprint({ width: 200, height: 200, token_estimate: 85 })
+
+    noteQuietClipboardAttach(state, first, t0)
+    expect(shouldAttachQuietClipboardImage(state, second, t0 + 10)).toBe(true)
+  })
+
+  it('builds a stable fingerprint from width/height/token estimate', () => {
+    expect(clipboardImageFingerprint({ width: 10, height: 20, token_estimate: 30 })).toBe('10x20:30')
+    expect(clipboardImageFingerprint({})).toBe('0x0:0')
+  })
+})

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -16,6 +16,14 @@ import { useQueue } from '../hooks/useQueue.js'
 import { isUsableClipboardText, readClipboardText } from '../lib/clipboard.js'
 import { resolveEditor } from '../lib/editor.js'
 import { readOsc52Clipboard } from '../lib/osc52.js'
+import {
+  clipboardImageFingerprint,
+  createQuietClipboardProbeState,
+  noteQuietClipboardAttach,
+  noteQuietClipboardProbe,
+  shouldAttachQuietClipboardImage,
+  shouldQuietClipboardProbe
+} from '../lib/quietClipboardProbe.js'
 import { isRemoteShellSession } from '../lib/terminalSetup.js'
 import { pasteTokenLabel, stripTrailingPasteNewlines } from '../lib/text.js'
 
@@ -198,6 +206,11 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
     [setComposerTokens]
   )
 
+  // Empty-bracketed-paste storms (#75150): mouse/focus fragments can look like
+  // empty pastes and re-probe the pasteboard. Quiet probes share this gate;
+  // explicit `/paste` and hotkey paste (quiet=false) always go through.
+  const quietClipboardProbeRef = useRef(createQuietClipboardProbeState())
+
   /**
    * Pull an image off the system clipboard into the composer as a token.
    *
@@ -213,11 +226,30 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
         return null
       }
 
+      const now = Date.now()
+      const probeState = quietClipboardProbeRef.current
+
+      if (quiet && !shouldQuietClipboardProbe(probeState, now)) {
+        return null
+      }
+
+      if (quiet) {
+        noteQuietClipboardProbe(probeState, now)
+      }
+
       const r = await gw
         .request<ClipboardPasteResponse & { path?: string }>('clipboard.paste', { session_id: sid })
         .catch(() => null)
 
       if (r?.attached) {
+        const fingerprint = clipboardImageFingerprint(r)
+
+        if (quiet && !shouldAttachQuietClipboardImage(probeState, fingerprint, now)) {
+          return null
+        }
+
+        noteQuietClipboardAttach(probeState, fingerprint, now)
+
         return attachImageToken(r, value, cursor)
       }
 

--- a/ui-tui/src/lib/quietClipboardProbe.ts
+++ b/ui-tui/src/lib/quietClipboardProbe.ts
@@ -1,0 +1,91 @@
+/**
+ * Guard the TUI's empty-bracketed-paste → clipboard.paste probe.
+ *
+ * Terminals (notably Ghostty with mouse_tracking=all) can emit empty
+ * bracketed-paste markers from torn mouse/focus fragments. Each one used to
+ * hit the system pasteboard and re-attach the same clipboard image (#75150).
+ *
+ * Explicit `/paste` and hotkey paste bypass this gate (quiet=false).
+ */
+
+/** Minimum gap between quiet pasteboard probes. */
+export const QUIET_CLIPBOARD_PROBE_COOLDOWN_MS = 2_000
+
+/**
+ * Skip re-attaching an image that matches the last quiet attach within this
+ * window. Explicit paste still attaches.
+ */
+export const QUIET_CLIPBOARD_ATTACH_DEDUPE_MS = 30_000
+
+export type QuietClipboardProbeState = {
+  lastAttachedAt: number | null
+  lastAttachedKey: string | null
+  lastProbeAt: number | null
+}
+
+export type ClipboardImageMeta = {
+  height?: number
+  path?: string
+  token_estimate?: number
+  width?: number
+}
+
+export function createQuietClipboardProbeState(): QuietClipboardProbeState {
+  return {
+    lastAttachedAt: null,
+    lastAttachedKey: null,
+    lastProbeAt: null
+  }
+}
+
+/** Stable-ish fingerprint for "same clipboard image" dedupe. */
+export function clipboardImageFingerprint(meta: ClipboardImageMeta): string {
+  const width = meta.width ?? 0
+  const height = meta.height ?? 0
+  const tokens = meta.token_estimate ?? 0
+
+  return `${width}x${height}:${tokens}`
+}
+
+export function shouldQuietClipboardProbe(
+  state: QuietClipboardProbeState,
+  now: number,
+  cooldownMs: number = QUIET_CLIPBOARD_PROBE_COOLDOWN_MS
+): boolean {
+  if (state.lastProbeAt == null) {
+    return true
+  }
+
+  return now - state.lastProbeAt >= cooldownMs
+}
+
+export function shouldAttachQuietClipboardImage(
+  state: QuietClipboardProbeState,
+  fingerprint: string,
+  now: number,
+  dedupeMs: number = QUIET_CLIPBOARD_ATTACH_DEDUPE_MS
+): boolean {
+  if (state.lastAttachedKey == null || state.lastAttachedAt == null) {
+    return true
+  }
+
+  if (state.lastAttachedKey !== fingerprint) {
+    return true
+  }
+
+  return now - state.lastAttachedAt >= dedupeMs
+}
+
+export function noteQuietClipboardProbe(state: QuietClipboardProbeState, now: number): void {
+  state.lastProbeAt = now
+}
+
+export function noteQuietClipboardAttach(
+  state: QuietClipboardProbeState,
+  fingerprint: string,
+  now: number
+): void {
+  state.lastAttachedAt = now
+  state.lastAttachedKey = fingerprint
+  state.lastProbeAt = now
+}


### PR DESCRIPTION
## Summary
- Gate the TUI empty-bracketed-paste → `clipboard.paste` path with a 2s quiet-probe cooldown so torn mouse/focus fragments stop storming the macOS pasteboard.
- Dedupe quiet re-attaches of the same clipboard image fingerprint (`WxH:token_estimate`) for 30s so the same screenshot is not attached over and over.
- Leave explicit `/paste` and hotkey paste (`quiet=false`) unrestricted.

Fixes #75150.

Related: #23984, #24078 (opt-out remains complementary).

## Test plan
- [x] `cd ui-tui && npm test -- src/__tests__/quietClipboardProbe.test.ts` (4 passed)
- [ ] Manual: `hermes --tui` in Ghostty with `display.mouse_tracking: all`, clipboard holding a screenshot; move mouse and confirm no privacy-prompt / re-attach storm
- [ ] Manual: empty image paste still attaches once; `/paste` still attaches on demand