### PR TITLE
fix(desktop): use repo root for main branch sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -175,6 +175,7 @@ function RepoFlatSection({
           onNewSession={group.isKanban ? undefined : onNewSession}
           onRemove={group.isMain || group.isKanban ? undefined : () => setRemoveTarget(group)}
           renderRows={renderRows}
+          repoPath={repo.path}
         />
       ))}
     </>

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarWorkspaceGroup } from './workspace-group'
+
+const { switchBranchInRepo } = vi.hoisted(() => ({ switchBranchInRepo: vi.fn() }))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        newSessionIn: (label: string) => `New session in ${label}`,
+        noSessions: 'No sessions'
+      },
+      statusStack: { coding: { switchFailed: (branch: string) => `Failed to switch ${branch}` } }
+    }
+  })
+}))
+vi.mock('@/store/layout', () => ({ setWorkspaceNodeOpen: vi.fn() }))
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+vi.mock('@/store/profile', () => ({ newSessionInProfile: vi.fn() }))
+vi.mock('@/store/projects', () => ({ switchBranchInRepo }))
+vi.mock('../chrome', () => ({ SidebarRowStack: ({ children }: { children: React.ReactNode }) => <div>{children}</div> }))
+vi.mock('../load-more-row', () => ({ SidebarLoadMoreRow: () => null }))
+vi.mock('./model', () => ({ SIDEBAR_GROUP_PAGE: 20, useWorkspaceNodeOpen: () => [true, vi.fn()] }))
+vi.mock('./workspace-header', () => ({
+  WorkspaceAddButton: ({ label, onClick }: { label: string; onClick: () => void }) => (
+    <button onClick={onClick} type="button">
+      {label}
+    </button>
+  ),
+  WorkspaceContextMenu: ({ children }: { children: React.ReactNode }) => children,
+  WorkspaceHeader: ({ action }: { action: React.ReactNode }) => <div>{action}</div>,
+  WorkspaceMenu: () => null,
+  WorkspaceShowMoreButton: () => null
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('SidebarWorkspaceGroup main-checkout session creation', () => {
+  it('switches and starts the session in the authoritative repo root', async () => {
+    const onNewSession = vi.fn()
+
+    render(
+      <SidebarWorkspaceGroup
+        group={{ id: 'main', isMain: true, label: 'main', path: '/project/container', sessions: [] }}
+        onNewSession={onNewSession}
+        renderRows={() => null}
+        repoPath="/actual/repo"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'New session in main' }))
+
+    await waitFor(() => expect(switchBranchInRepo).toHaveBeenCalledWith('/actual/repo', 'main'))
+    expect(onNewSession).toHaveBeenCalledWith('/actual/repo')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -13,7 +13,7 @@ import { SidebarRowStack } from '../chrome'
 import { SidebarLoadMoreRow } from '../load-more-row'
 
 import { SIDEBAR_GROUP_PAGE, useWorkspaceNodeOpen } from './model'
-import type { SidebarSessionGroup } from './workspace-groups'
+import { mainBranchSwitchPath, type SidebarSessionGroup } from './workspace-groups'
 import {
   WorkspaceAddButton,
   WorkspaceContextMenu,
@@ -26,12 +26,14 @@ interface SidebarWorkspaceGroupProps {
   group: SidebarSessionGroup
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
   onNewSession?: (path: null | string) => void
+  /** Authoritative Git root for main-checkout branch mutations. */
+  repoPath?: null | string
   // When set (linked worktree rows), shows a remove affordance that runs a real
   // `git worktree remove`.
   onRemove?: () => void
 }
 
-export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemove }: SidebarWorkspaceGroupProps) {
+export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemove, repoPath }: SidebarWorkspaceGroupProps) {
   const { t } = useI18n()
   const s = t.sidebar
   const isProfileGroup = group.mode === 'profile'
@@ -95,9 +97,11 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
     // Main-checkout lanes are branch-labeled views over the same repo root path.
     // Clicking "+" on `main` should open on `main`, not whatever branch the root
     // currently sits on (`test0`, etc.), so explicitly switch first.
-    if (group.isMain && group.path && group.label) {
+    const switchPath = mainBranchSwitchPath(group, repoPath)
+
+    if (switchPath && group.label) {
       try {
-        await switchBranchInRepo(group.path, group.label)
+        await switchBranchInRepo(switchPath, group.label)
       } catch (err) {
         notifyError(err, t.statusStack.coding.switchFailed(group.label))
 
@@ -105,7 +109,7 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
       }
     }
 
-    onNewSession(group.path)
+    onNewSession(switchPath ?? group.path)
   }
 
   return (

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -8,6 +8,7 @@ import {
   excludeProjectSessions,
   kanbanWorktreeDir,
   liveSessionProjectId,
+  mainBranchSwitchPath,
   mergeRepoWorktreeGroups,
   NO_PROJECT_ID,
   overlayLiveLanes,
@@ -49,6 +50,19 @@ const lane = (over: Partial<SidebarSessionGroup> & Pick<SidebarSessionGroup, 'id
   path: null,
   sessions: [],
   ...over
+})
+
+describe('mainBranchSwitchPath', () => {
+  it('uses the repo root instead of a stale main-lane path', () => {
+    const group = lane({ id: 'main', isMain: true, label: 'main', path: '/project/container' })
+
+    expect(mainBranchSwitchPath(group, '/actual/repo')).toBe('/actual/repo')
+  })
+
+  it('rejects branch switching without an authoritative repo root', () => {
+    expect(mainBranchSwitchPath(lane({ id: 'main', isMain: true, label: 'main', path: '/project/container' }))).toBeNull()
+    expect(mainBranchSwitchPath(lane({ id: 'feature', label: 'feature' }), '/actual/repo')).toBeNull()
+  })
 })
 
 describe('baseName', () => {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -68,6 +68,11 @@ export interface SidebarProjectTree {
   previewSessions?: SessionInfo[]
 }
 
+/** Repository-level mutations require the repo node's authoritative root.
+ * Lane paths are session-derived and may point at a project container. */
+export const mainBranchSwitchPath = (group: SidebarSessionGroup, repoPath?: null | string): null | string =>
+  group.isMain ? repoPath?.trim() || null : null
+
 /** Path split into segments, ignoring trailing slashes and mixed separators. */
 const segments = (path: string): string[] =>
   path


### PR DESCRIPTION
## Summary

- route main-checkout branch switches through the repository node's authoritative `repo.path` instead of the session-derived lane path
- start the new session in that same repository root after the switch
- add pure resolver and interaction-level regression coverage

## Reproduction

1. Create a Desktop project whose organizational/session folder is not itself a Git repository.
2. Add a real Git repository beneath the project and open its `main` lane.
3. Click `+` to create a new session in `main`.

Before this change, `SidebarWorkspaceGroup` passed `group.path` to `git switch`. For projects where that lane path resolves to the project container rather than the repo root, Desktop runs `git switch main` with a non-repository cwd and reports:

```text
fatal: not a git repository (or any of the parent directories): .git
```

## Root cause

`RepoFlatSection` already owns the backend-authoritative repository node and its `repo.path`, but that path was not passed to `SidebarWorkspaceGroup`. The component instead treated the session-derived `group.path` as authoritative for a repository mutation.

## Fix

Pass `repo.path` into each workspace group. Main-checkout session creation now uses that authoritative root for both `switchBranchInRepo(...)` and `onNewSession(...)`. Non-main lanes, linked worktrees, kanban groups, and profile groups retain their existing routing.

## Verification

- `npx vitest run --project ui src/app/chat/sidebar/projects/workspace-group.test.tsx src/app/chat/sidebar/projects/workspace-groups.test.ts` — 58 passed
- `npm run typecheck` — passed
- targeted ESLint for all changed Desktop files — passed
- `git diff --check` — passed
- reviewed twice with `xai-oauth:grok-4.5`; final verdict: ready, no blockers

The full UI suite was also attempted; it exceeded the five-minute local timeout and showed unrelated existing failures in billing, skills, and date-format tests. The affected project-sidebar suites remained green.