### PR TITLE
fix(desktop): dedupe auto-spoken replies by content fingerprint

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
-import { chatMessageText, collectUnspokenTurnSpeech } from '@/lib/chat-messages'
+import { chatMessageText, collectUnspokenTurnSpeech, latestSpokenReply } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
 import { $voiceConversationStartRequest, takeVoiceConversationStart } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
@@ -61,7 +61,14 @@ export function useComposerVoice({
   // A tile's composer speaks ITS transcript, not the primary chat's.
   const { $messages } = useComposerScope()
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
+  // Id-based "spoken" marker for the voice-conversation path: its live speech
+  // session binds to a specific message id for the turn, and the turn's bubbles
+  // keep their ids while streaming (see collectUnspokenTurnSpeech).
   const lastSpokenIdRef = useRef<string | null>(null)
+  // Content-fingerprint "spoken" marker for the auto-speak path. Message ids
+  // are rewritten by the post-turn hydrate (assistant-stream-* → persisted),
+  // so an id check would re-read the same reply; the fingerprint survives.
+  const lastSpokenFingerprintRef = useRef<string | null>(null)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
 
   const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
@@ -74,23 +81,8 @@ export function useComposerVoice({
   /** Auto-speak selector: the latest unspoken reply only — a backlog collapses to the newest. */
   const pendingResponse = () => {
     const messages = $messages.get()
-    const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
 
-    if (!last || last.id === lastSpokenIdRef.current) {
-      return null
-    }
-
-    const text = chatMessageText(last).trim()
-
-    if (!text) {
-      return null
-    }
-
-    return {
-      id: last.id,
-      pending: Boolean(last.pending),
-      text
-    }
+    return latestSpokenReply(messages, lastSpokenFingerprintRef.current)
   }
 
   /**
@@ -106,6 +98,7 @@ export function useComposerVoice({
 
     if (last) {
       lastSpokenIdRef.current = last.id
+      lastSpokenFingerprintRef.current = chatMessageText(last).trim()
     }
   }
 

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -8,6 +8,7 @@ import {
   appendReasoningPart,
   chatMessageText,
   collectUnspokenTurnSpeech,
+  latestSpokenReply,
   mergeFinalAssistantText,
   preserveLocalAssistantErrors,
   reasoningPart,
@@ -1132,5 +1133,59 @@ describe('collectUnspokenTurnSpeech', () => {
     expect(collectUnspokenTurnSpeech([], null)).toBeNull()
     expect(collectUnspokenTurnSpeech([assistant('a1', 'Done.')], 'a1')).toBeNull()
     expect(collectUnspokenTurnSpeech([user('u1', 'hello'), assistant('a1', '')], null)).toBeNull()
+  })
+})
+
+describe('latestSpokenReply', () => {
+  const assistant = (id: string, text: string, extra: Partial<ChatMessage> = {}): ChatMessage => ({
+    id,
+    role: 'assistant',
+    parts: text ? [{ type: 'text', text }] : [],
+    ...extra
+  })
+
+  it('returns the latest assistant reply with its fingerprint as identity', () => {
+    const reply = latestSpokenReply([assistant('stream-1', 'Hello there.')], null)
+
+    expect(reply).not.toBeNull()
+    expect(reply?.id).toBe('Hello there.')
+    expect(reply?.text).toBe('Hello there.')
+    expect(reply?.pending).toBe(false)
+  })
+
+  it('skips a reply whose fingerprint was already spoken — even when its id changed', () => {
+    // Streaming bubble id…
+    const streaming = [assistant('assistant-stream-123-1', 'The answer is 42.')]
+    expect(latestSpokenReply(streaming, null)?.id).toBe('The answer is 42.')
+
+    // …hydrated rebuild with the SAME content but a persisted id: the
+    // fingerprint matches, so auto-speak must not read it aloud again.
+    const hydrated = [assistant('1720000000000-0-assistant', 'The answer is 42.')]
+    expect(latestSpokenReply(hydrated, 'The answer is 42.')).toBeNull()
+  })
+
+  it('still reads a NEW reply after an old one was spoken', () => {
+    const messages = [assistant('a1', 'First reply.'), assistant('a2', 'Second reply.')]
+    const first = latestSpokenReply(messages, null)
+
+    expect(first?.id).toBe('Second reply.')
+
+    // Consumed the latest; the same list is now fully spoken.
+    expect(latestSpokenReply(messages, 'Second reply.')).toBeNull()
+  })
+
+  it('ignores hidden and empty assistant bubbles', () => {
+    const messages = [
+      assistant('a1', 'hidden note', { hidden: true }),
+      assistant('a2', ''),
+      assistant('a3', 'Real reply.')
+    ]
+
+    expect(latestSpokenReply(messages, null)?.id).toBe('Real reply.')
+    expect(latestSpokenReply([assistant('a1', 'hidden', { hidden: true })], null)).toBeNull()
+  })
+
+  it('reports pending while the reply is still streaming', () => {
+    expect(latestSpokenReply([assistant('a1', 'Partial…', { pending: true })], null)?.pending).toBe(true)
   })
 })

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -171,6 +171,54 @@ export function chatMessageText(message: ChatMessage): string {
     .join('')
 }
 
+/**
+ * Content fingerprint of an assistant reply for spoken-reply dedupe.
+ *
+ * Message ids are NOT stable across a hydration boundary: during streaming the
+ * bubble carries a runtime id (`assistant-stream-<ts>-<seq>`), and the post-turn
+ * hydrateFromStoredSession rebuild replaces it with a persisted id
+ * (`<timestamp>-<index>-<role>`). An id-based "already spoken" check then
+ * misses the same reply and reads it aloud a second time. The trimmed text
+ * survives the id rewrite, so fingerprint on it instead.
+ */
+export function speechFingerprint(message: ChatMessage): string {
+  return chatMessageText(message).trim()
+}
+
+/**
+ * Resolve the latest assistant reply for auto-speak, skipping a reply whose
+ * content fingerprint was already spoken. Returns a stable identity usable as
+ * an ambient-cue key (the fingerprint itself, not the volatile message id).
+ */
+export function latestSpokenReply(
+  messages: ChatMessage[],
+  lastSpokenFingerprint: string | null
+): { id: string; pending: boolean; text: string } | null {
+  const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
+
+  if (!last) {
+    return null
+  }
+
+  const text = chatMessageText(last).trim()
+
+  if (!text) {
+    return null
+  }
+
+  const fingerprint = text
+
+  if (fingerprint === lastSpokenFingerprint) {
+    return null
+  }
+
+  return {
+    id: fingerprint,
+    pending: Boolean(last.pending),
+    text
+  }
+}
+
 export interface UnspokenTurnSpeech {
   /** First unspoken assistant bubble — stable for the turn, the live speech session binds to it. */
   id: string


### PR DESCRIPTION
## Problem

Auto-speak (voice.auto_tts) sometimes reads the same reply aloud twice.

Root cause: spoken-reply dedupe tracked the last spoken message by its id, but message ids are NOT stable across the post-turn hydrate:

1. During streaming, the bubble carries a runtime id (`assistant-stream-<ts>-<seq>`)
2. On `message.complete`, `completeAssistantMessage` settles that bubble and auto-speak reads it (first playback)
3. The same handler then calls `hydrateFromStoredSession` → `toChatMessages` rebuilds the list with persisted ids (`<timestamp>-<index>-<role>`)
4. `` emits again → `pendingReply` sees a 'new' id ≠ `lastSpokenIdRef` → plays the same text a second time

Both existing dedupe layers fail: `lastSpokenIdRef` (id rewritten by hydrate) and `ownsAmbientCue` (1s window, the two triggers are a network round-trip apart).

## Fix

- `lib/chat-messages.ts`: add `speechFingerprint()` (trimmed text) and `latestSpokenReply()` — an auto-speak selector that dedupes on content, which survives the hydrate id rewrite, and returns the fingerprint as the ambient-cue key.
- `use-composer-voice.ts`: auto-speak path (`pendingResponse` / `consumePendingResponse`) uses the fingerprint ref. The voice-conversation path keeps id semantics — its live speech session binds to a message id for the turn and depends on it staying stable while streaming.

## Verification

- `vitest run src/lib/chat-messages.test.ts` → 57/57 (5 new tests incl. the streaming→hydrated id-rewrite case)
- `vitest run src/app/chat/composer/hooks/use-voice-conversation*.test.tsx` → 11/11 (voice-conversation path unaffected)
- `tsc --noEmit`: no new errors (11 pre-existing errors in user-edit-composer.tsx, unrelated @assistant-ui version drift)