### PR TITLE
fix(state): filter sessions by projected compression-tip source

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -177,6 +177,75 @@ def _delegate_from_json(col: str = "model_config") -> str:
 _MODEL_CONFIG_ROW_MISSING = object()
 
 
+def _projected_tip_source_sql(session_alias: str = "s") -> str:
+    """SQL expression for a listable session's projected live-tip source.
+
+    Keep the child eligibility and ordering in lockstep with
+    :meth:`SessionDB.get_compression_tip`. The recursive walk is bounded and
+    cycle-safe so malformed lineage cannot make a listing/count query loop.
+    """
+    return f"""
+        COALESCE(NULLIF((
+            WITH RECURSIVE
+            ranked_children(parent_id, child_id) AS (
+                SELECT parent_id, child_id
+                FROM (
+                    SELECT
+                        parent.id AS parent_id,
+                        child.id AS child_id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY parent.id
+                            ORDER BY
+                                CASE
+                                    WHEN child.end_reason = 'compression' THEN 0
+                                    WHEN child.ended_at IS NULL THEN 1
+                                    ELSE 2
+                                END,
+                                COALESCE(
+                                    (SELECT MAX(m.timestamp)
+                                     FROM messages m
+                                     WHERE m.session_id = child.id),
+                                    child.started_at
+                                ) DESC,
+                                child.started_at DESC,
+                                child.id DESC
+                        ) AS child_rank
+                    FROM sessions parent
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.end_reason = 'compression'
+                      AND json_extract(
+                          COALESCE(child.model_config, '{{}}'),
+                          '$._branched_from'
+                      ) IS NULL
+                      AND json_extract(
+                          COALESCE(child.model_config, '{{}}'),
+                          '$._delegate_from'
+                      ) IS NULL
+                      AND COALESCE(child.source, '') != 'tool'
+                )
+                WHERE child_rank = 1
+            ),
+            tip(id, depth, visited) AS (
+                SELECT {session_alias}.id, 0, ',' || {session_alias}.id || ','
+                UNION ALL
+                SELECT
+                    child.child_id,
+                    tip.depth + 1,
+                    tip.visited || child.child_id || ','
+                FROM tip
+                JOIN ranked_children child ON child.parent_id = tip.id
+                WHERE tip.depth < 100
+                  AND INSTR(tip.visited, ',' || child.child_id || ',') = 0
+            )
+            SELECT leaf.source
+            FROM tip
+            JOIN sessions leaf ON leaf.id = tip.id
+            ORDER BY tip.depth DESC
+            LIMIT 1
+        ), ''), 'cli')
+    """
+
+
 def _cwd_prefix_clause(cwd_prefix: str) -> Tuple[str, List[str]]:
     prefix = cwd_prefix.rstrip("/\\") or cwd_prefix
     # ``_`` and ``%`` are LIKE wildcards but ordinary characters in a path
@@ -5884,36 +5953,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
 
         include_sources = [source] if source else list(sources or [])
-        # When projecting compression tips, source membership is defined by the
-        # *live tip* source, not the root. Defer include/exclude until after
-        # projection so telegram→webui chains appear under source=webui (#75625).
-        defer_source_filter = bool(
-            project_compression_tips
-            and not include_children
-            and (include_sources or exclude_sources)
+        source_sql = (
+            _projected_tip_source_sql("s")
+            if project_compression_tips and not include_children
+            else "s.source"
         )
-        deferred_include_sources: List[str] = []
-        deferred_exclude_sources: List[str] = []
-        page_limit, page_offset = limit, offset
-        if defer_source_filter:
-            deferred_include_sources = list(include_sources)
-            deferred_exclude_sources = list(exclude_sources or [])
-            include_sources = []
-            exclude_sources = None
-            # Over-fetch then filter/slice so LIMIT is not applied to the wrong
-            # pre-projection population. Cap keeps pathological DBs bounded.
-            limit = min(max((page_limit + page_offset) * 25, page_limit + page_offset, 100), 10_000)
-            offset = 0
         if include_sources:
             placeholders = ",".join("?" for _ in include_sources)
-            where_clauses.append(f"s.source IN ({placeholders})")
+            where_clauses.append(f"{source_sql} IN ({placeholders})")
             params.extend(include_sources)
         if session_key:
             where_clauses.append("s.session_key = ?")
             params.append(session_key)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
-            where_clauses.append(f"s.source NOT IN ({placeholders})")
+            where_clauses.append(f"{source_sql} NOT IN ({placeholders})")
             params.extend(exclude_sources)
         if cwd_prefix:
             clause, clause_params = _cwd_prefix_clause(cwd_prefix)
@@ -6175,42 +6229,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 projected.append(merged)
             sessions = projected
 
-        if defer_source_filter:
-            sessions = [
-                s
-                for s in sessions
-                if self._session_source_matches(
-                    s.get("source"),
-                    include_sources=deferred_include_sources,
-                    exclude_sources=deferred_exclude_sources,
-                )
-            ]
-            sessions = sessions[page_offset : page_offset + page_limit]
-
         # Derive read state per surfaced conversation. ``last_read_at`` is
         # lineage-stamped by set_session_read, so a projected row's root
         # watermark and its tip's are the same value — comparing it against
         # the tip's last_active is correct either way.
         for s in sessions:
             s["unread"] = self.session_unread(s)
-
         return sessions
-
-    @staticmethod
-    def _session_source_matches(
-        row_source: Any,
-        *,
-        include_sources: List[str] | None = None,
-        exclude_sources: List[str] | None = None,
-    ) -> bool:
-        """Return whether a (possibly projected) session source matches filters."""
-        src = row_source if row_source not in (None, "") else "cli"
-        if include_sources:
-            if src not in include_sources:
-                return False
-        if exclude_sources and src in exclude_sources:
-            return False
-        return True
 
     # =========================================================================
     # Message storage
@@ -7852,25 +7877,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``list_sessions_rich`` after compression-tip projection (tip source),
         not the raw root source (#75625).
         """
-        include_sources = [source] if source else list(sources or [])
-        if exclude_children and (include_sources or exclude_sources):
-            # Projected-tip semantics: reuse list_sessions_rich (defers source
-            # until after tip projection) with a large page and count results.
-            rows = self.list_sessions_rich(
-                source=source,
-                sources=sources,
-                exclude_sources=exclude_sources,
-                cwd_prefix=cwd_prefix,
-                min_message_count=min_message_count,
-                include_archived=include_archived,
-                archived_only=archived_only,
-                limit=10_000,
-                offset=0,
-                project_compression_tips=True,
-                include_children=False,
-            )
-            return len(rows)
-
         where_clauses = []
         params = []
 
@@ -7880,13 +7886,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # children (parent ended with end_reason='branched').
             where_clauses.append(_LISTABLE_CHILD_SQL)
             where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
+        include_sources = [source] if source else list(sources or [])
+        source_sql = _projected_tip_source_sql("s") if exclude_children else "s.source"
         if include_sources:
             placeholders = ",".join("?" for _ in include_sources)
-            where_clauses.append(f"s.source IN ({placeholders})")
+            where_clauses.append(f"{source_sql} IN ({placeholders})")
             params.extend(include_sources)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
-            where_clauses.append(f"s.source NOT IN ({placeholders})")
+            where_clauses.append(f"{source_sql} NOT IN ({placeholders})")
             params.extend(exclude_sources)
         if cwd_prefix:
             clause, clause_params = _cwd_prefix_clause(cwd_prefix)
@@ -7943,21 +7951,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Sessions page actually lists. Counts use the **projected tip** source
         when compression tips are projected (#75625).
         """
-        if exclude_children:
-            rows = self.list_sessions_rich(
-                limit=10_000,
-                offset=0,
-                include_archived=include_archived,
-                archived_only=archived_only,
-                project_compression_tips=True,
-                include_children=False,
-            )
-            counts: Dict[str, int] = {}
-            for s in rows:
-                src = s.get("source") if s.get("source") not in (None, "") else "cli"
-                counts[str(src)] = counts.get(str(src), 0) + 1
-            return dict(sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
-
         where_clauses = []
         params: list = []
 
@@ -7967,15 +7960,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.archived = 0")
 
         where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+        source_sql = (
+            _projected_tip_source_sql("s")
+            if exclude_children
+            else "COALESCE(NULLIF(s.source, ''), 'cli')"
+        )
 
         with self._lock:
             if self._conn is None:
                 raise RuntimeError("SessionDB connection is closed")
             rows = self._conn.execute(
-                "SELECT COALESCE(NULLIF(s.source, ''), 'cli') AS source, COUNT(*) AS count "
-                f"FROM sessions s{where_sql} "
-                "GROUP BY COALESCE(NULLIF(s.source, ''), 'cli') "
-                "ORDER BY count DESC",
+                "SELECT projected_source AS source, COUNT(*) AS count "
+                "FROM ("
+                f"SELECT {source_sql} AS projected_source "
+                f"FROM sessions s{where_sql}"
+                ") "
+                "GROUP BY projected_source "
+                "ORDER BY count DESC, projected_source ASC",
                 params,
             ).fetchall()
         return {str(row["source"]): int(row["count"] or 0) for row in rows}

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7954,6 +7954,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         where_clauses = []
         params: list = []
 
+        if exclude_children:
+            # Keep aggregate counts identical to list_sessions_rich: roots and
+            # branch sessions are visible, while sub-agent and compression
+            # continuation rows are hidden.
+            where_clauses.append(_LISTABLE_CHILD_SQL)
+            where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
+
         if archived_only:
             where_clauses.append("s.archived = 1")
         elif not include_archived:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -201,12 +201,7 @@ def _projected_tip_source_sql(session_alias: str = "s") -> str:
                                     WHEN child.ended_at IS NULL THEN 1
                                     ELSE 2
                                 END,
-                                COALESCE(
-                                    (SELECT MAX(m.timestamp)
-                                     FROM messages m
-                                     WHERE m.session_id = child.id),
-                                    child.started_at
-                                ) DESC,
+                                {_sql_session_last_active("child")} DESC,
                                 child.started_at DESC,
                                 child.id DESC
                         ) AS child_rank

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5822,10 +5822,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         With ``project_compression_tips=True`` (default), sessions that are
         roots of compression chains are projected forward to their latest
         continuation — one logical conversation = one list entry, showing the
-        live continuation's id/message_count/title/last_active. This prevents
-        compressed continuations from being invisible to users while keeping
-        delegate subagents and branches hidden. Pass ``False`` to return the
-        raw root rows (useful for admin/debug UIs).
+        live continuation's id/message_count/title/last_active/source. This
+        prevents compressed continuations from being invisible to users while
+        keeping delegate subagents and branches hidden. Pass ``False`` to
+        return the raw root rows (useful for admin/debug UIs).
 
         Pass ``order_by_last_active=True`` to sort by most-recent activity
         instead of original conversation start time. For compression chains,
@@ -6138,12 +6138,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     projected.append(s)
                     continue
                 # Preserve the root's started_at for stable sort order, but
-                # surface the tip's identity and activity data.
+                # surface the tip's identity, activity data, and source.
+                # Source must come from the tip: cross-source compression
+                # (e.g. telegram root → webui tip) otherwise keeps the root
+                # source and disappears from the tip's tab filter (#75625).
                 merged = dict(s)
                 for key in (
                     "id", "ended_at", "end_reason", "message_count",
                     "tool_call_count", "title", "last_active", "preview",
                     "model", "system_prompt", "cwd", "git_branch", "git_repo_root",
+                    "source",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5884,6 +5884,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
 
         include_sources = [source] if source else list(sources or [])
+        # When projecting compression tips, source membership is defined by the
+        # *live tip* source, not the root. Defer include/exclude until after
+        # projection so telegram→webui chains appear under source=webui (#75625).
+        defer_source_filter = bool(
+            project_compression_tips
+            and not include_children
+            and (include_sources or exclude_sources)
+        )
+        deferred_include_sources: List[str] = []
+        deferred_exclude_sources: List[str] = []
+        page_limit, page_offset = limit, offset
+        if defer_source_filter:
+            deferred_include_sources = list(include_sources)
+            deferred_exclude_sources = list(exclude_sources or [])
+            include_sources = []
+            exclude_sources = None
+            # Over-fetch then filter/slice so LIMIT is not applied to the wrong
+            # pre-projection population. Cap keeps pathological DBs bounded.
+            limit = min(max((page_limit + page_offset) * 25, page_limit + page_offset, 100), 10_000)
+            offset = 0
         if include_sources:
             placeholders = ",".join("?" for _ in include_sources)
             where_clauses.append(f"s.source IN ({placeholders})")
@@ -6155,6 +6175,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 projected.append(merged)
             sessions = projected
 
+        if defer_source_filter:
+            sessions = [
+                s
+                for s in sessions
+                if self._session_source_matches(
+                    s.get("source"),
+                    include_sources=deferred_include_sources,
+                    exclude_sources=deferred_exclude_sources,
+                )
+            ]
+            sessions = sessions[page_offset : page_offset + page_limit]
+
         # Derive read state per surfaced conversation. ``last_read_at`` is
         # lineage-stamped by set_session_read, so a projected row's root
         # watermark and its tip's are the same value — comparing it against
@@ -6163,6 +6195,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             s["unread"] = self.session_unread(s)
 
         return sessions
+
+    @staticmethod
+    def _session_source_matches(
+        row_source: Any,
+        *,
+        include_sources: List[str] | None = None,
+        exclude_sources: List[str] | None = None,
+    ) -> bool:
+        """Return whether a (possibly projected) session source matches filters."""
+        src = row_source if row_source not in (None, "") else "cli"
+        if include_sources:
+            if src not in include_sources:
+                return False
+        if exclude_sources and src in exclude_sources:
+            return False
+        return True
 
     # =========================================================================
     # Message storage
@@ -7799,7 +7847,30 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (e.g. ``["cron"]`` so the recents "load more" total matches a
         cron-excluded ``list_sessions_rich`` page and doesn't keep "load more"
         stuck on for buried scheduler sessions).
+
+        With ``exclude_children=True`` and a source filter, membership matches
+        ``list_sessions_rich`` after compression-tip projection (tip source),
+        not the raw root source (#75625).
         """
+        include_sources = [source] if source else list(sources or [])
+        if exclude_children and (include_sources or exclude_sources):
+            # Projected-tip semantics: reuse list_sessions_rich (defers source
+            # until after tip projection) with a large page and count results.
+            rows = self.list_sessions_rich(
+                source=source,
+                sources=sources,
+                exclude_sources=exclude_sources,
+                cwd_prefix=cwd_prefix,
+                min_message_count=min_message_count,
+                include_archived=include_archived,
+                archived_only=archived_only,
+                limit=10_000,
+                offset=0,
+                project_compression_tips=True,
+                include_children=False,
+            )
+            return len(rows)
+
         where_clauses = []
         params = []
 
@@ -7809,7 +7880,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # children (parent ended with end_reason='branched').
             where_clauses.append(_LISTABLE_CHILD_SQL)
             where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
-        include_sources = [source] if source else list(sources or [])
         if include_sources:
             placeholders = ",".join("?" for _ in include_sources)
             where_clauses.append(f"s.source IN ({placeholders})")
@@ -7870,14 +7940,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``exclude_children=True`` mirrors ``list_sessions_rich`` visibility
         (roots + branch sessions, excluding sub-agent runs, delegates, and
         compression continuations) so the source counts match what the
-        Sessions page actually lists.
+        Sessions page actually lists. Counts use the **projected tip** source
+        when compression tips are projected (#75625).
         """
+        if exclude_children:
+            rows = self.list_sessions_rich(
+                limit=10_000,
+                offset=0,
+                include_archived=include_archived,
+                archived_only=archived_only,
+                project_compression_tips=True,
+                include_children=False,
+            )
+            counts: Dict[str, int] = {}
+            for s in rows:
+                src = s.get("source") if s.get("source") not in (None, "") else "cli"
+                counts[str(src)] = counts.get(str(src), 0) + 1
+            return dict(sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
+
         where_clauses = []
         params: list = []
 
-        if exclude_children:
-            where_clauses.append(_LISTABLE_CHILD_SQL)
-            where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
         if archived_only:
             where_clauses.append("s.archived = 1")
         elif not include_archived:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2162,6 +2162,56 @@ class TestCompressionChainProjection:
         by_src = db.session_count_by_source(exclude_children=True)
         assert by_src == {"webui": 1}
 
+    def test_source_filter_uses_live_tip_activity_ordering(self, db):
+        """Source filtering and projection must select the same live tip.
+
+        A continuation heartbeat can be newer than its latest message while a
+        sibling has the newer message timestamp. The SQL source predicate must
+        use the same freshest-activity ordering as ``get_compression_tip``;
+        otherwise the filter can admit the wrong source and then project a
+        different tip in Python.
+        """
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("activity-root", "telegram")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?",
+            (t0, t0 + 10, "compression", "activity-root"),
+        )
+
+        db.create_session(
+            "message-tip", "telegram", parent_session_id="activity-root"
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, last_activity_at=? WHERE id=?",
+            (t0 + 20, t0 + 50, "message-tip"),
+        )
+        db.append_message("message-tip", "user", "older activity heartbeat")
+        db._conn.execute(
+            "UPDATE messages SET timestamp=? WHERE session_id=?",
+            (t0 + 300, "message-tip"),
+        )
+
+        db.create_session(
+            "heartbeat-tip", "webui", parent_session_id="activity-root"
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, last_activity_at=? WHERE id=?",
+            (t0 + 30, t0 + 400, "heartbeat-tip"),
+        )
+        db.append_message("heartbeat-tip", "user", "newer heartbeat")
+        db._conn.execute(
+            "UPDATE messages SET timestamp=? WHERE session_id=?",
+            (t0 + 100, "heartbeat-tip"),
+        )
+        db._conn.commit()
+
+        assert db.get_compression_tip("activity-root") == "heartbeat-tip"
+        webui_rows = db.list_sessions_rich(source="webui", limit=20)
+        assert [row["id"] for row in webui_rows] == ["heartbeat-tip"]
+        assert db.list_sessions_rich(source="telegram", limit=20) == []
+
     def test_list_handles_broken_chain_gracefully(self, db):
         """A compression root with no child (e.g. DB corruption or a partial
         end_session call that didn't finish creating the child) must not

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2015,6 +2015,8 @@ class TestCompressionChainProjection:
         assert tip_row["preview"].startswith("latest message")
         assert tip_row["ended_at"] is None  # tip is still live
         assert tip_row["end_reason"] is None
+        # Same-source chain: projected source stays the tip's (here equal to root).
+        assert tip_row["source"] == "cli"
 
     def test_list_projects_multiple_independent_chains_in_one_call(self, db):
         """Two unrelated compression chains in the same page must each
@@ -2098,8 +2100,61 @@ class TestCompressionChainProjection:
         assert set(batch_calls[0]) == {"tip1", "tip2"}
         assert single_calls == []
 
+    def test_list_surfaces_tip_source_for_cross_source_chain(self, db):
+        """Cross-source compression must project the tip's source (#75625).
 
+        WebUI loads list_sessions_rich without a source filter and tabs client-
+        side on the row's ``source``. If projection keeps the root source, a
+        telegram-rooted chain continued in webui vanishes from the webui tab
+        (root source still telegram; tip excluded as a compression child).
+        """
+        import time as _time
 
+        t0 = _time.time() - 3600
+        db.create_session("xroot", "telegram")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0, "xroot")
+        )
+        db.append_message("xroot", "user", "gateway start")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason=? WHERE id=?",
+            (t0 + 100, "compression", "xroot"),
+        )
+        db.create_session("xtip", "webui", parent_session_id="xroot")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?",
+            (t0 + 101, "xtip"),
+        )
+        db.append_message("xtip", "user", "continued in webui")
+        db._conn.commit()
+
+        # Unfiltered list (WebUI dashboard path): projected tip must carry
+        # source=webui so client-side webui tab shows the conversation.
+        all_sessions = db.list_sessions_rich(limit=20)
+        by_id = {s["id"]: s for s in all_sessions}
+        assert "xtip" in by_id
+        assert "xroot" not in by_id
+        projected = by_id["xtip"]
+        assert projected["source"] == "webui"
+        assert projected["_lineage_root_id"] == "xroot"
+        assert projected["preview"].startswith("continued in webui")
+        assert projected["ended_at"] is None
+
+        # SQL source=webui still only admits roots with that source — the
+        # telegram root is filtered pre-projection (same as before). This
+        # documents that client-side filtering after unfiltered load is the
+        # path that needs projected source; it is not a regression.
+        webui_only = db.list_sessions_rich(source="webui", limit=20)
+        assert "xtip" not in {s["id"] for s in webui_only}
+
+        # Same-source filter still surfaces the chain when root matches.
+        telegram_only = db.list_sessions_rich(source="telegram", limit=20)
+        t_ids = {s["id"] for s in telegram_only}
+        assert "xtip" in t_ids
+        # After projection the row reports the tip source even when admitted
+        # via the root's telegram source filter.
+        t_row = next(s for s in telegram_only if s["id"] == "xtip")
+        assert t_row["source"] == "webui"
 
     def test_list_handles_broken_chain_gracefully(self, db):
         """A compression root with no child (e.g. DB corruption or a partial

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2126,6 +2126,12 @@ class TestCompressionChainProjection:
             (t0 + 101, "xtip"),
         )
         db.append_message("xtip", "user", "continued in webui")
+        db.create_session(
+            "xdelegate",
+            "telegram",
+            parent_session_id="xroot",
+            model_config={"_delegate_from": "xroot"},
+        )
         db._conn.commit()
 
         # Unfiltered list: projected tip carries source=webui.
@@ -2154,7 +2160,7 @@ class TestCompressionChainProjection:
         assert db.session_count(source="webui", exclude_children=True) >= 1
         assert db.session_count(source="telegram", exclude_children=True) == 0
         by_src = db.session_count_by_source(exclude_children=True)
-        assert by_src.get("webui", 0) >= 1
+        assert by_src == {"webui": 1}
 
     def test_list_handles_broken_chain_gracefully(self, db):
         """A compression root with no child (e.g. DB corruption or a partial

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2128,8 +2128,7 @@ class TestCompressionChainProjection:
         db.append_message("xtip", "user", "continued in webui")
         db._conn.commit()
 
-        # Unfiltered list (WebUI dashboard path): projected tip must carry
-        # source=webui so client-side webui tab shows the conversation.
+        # Unfiltered list: projected tip carries source=webui.
         all_sessions = db.list_sessions_rich(limit=20)
         by_id = {s["id"]: s for s in all_sessions}
         assert "xtip" in by_id
@@ -2140,21 +2139,22 @@ class TestCompressionChainProjection:
         assert projected["preview"].startswith("continued in webui")
         assert projected["ended_at"] is None
 
-        # SQL source=webui still only admits roots with that source — the
-        # telegram root is filtered pre-projection (same as before). This
-        # documents that client-side filtering after unfiltered load is the
-        # path that needs projected source; it is not a regression.
+        # source= filter is applied to the *projected tip*, not the root
+        # (#75625 sweeper): webui tab sees the chain; telegram tab does not
+        # (tip is webui).
         webui_only = db.list_sessions_rich(source="webui", limit=20)
-        assert "xtip" not in {s["id"] for s in webui_only}
+        assert "xtip" in {s["id"] for s in webui_only}
+        webui_row = next(s for s in webui_only if s["id"] == "xtip")
+        assert webui_row["source"] == "webui"
 
-        # Same-source filter still surfaces the chain when root matches.
         telegram_only = db.list_sessions_rich(source="telegram", limit=20)
-        t_ids = {s["id"] for s in telegram_only}
-        assert "xtip" in t_ids
-        # After projection the row reports the tip source even when admitted
-        # via the root's telegram source filter.
-        t_row = next(s for s in telegram_only if s["id"] == "xtip")
-        assert t_row["source"] == "webui"
+        assert "xtip" not in {s["id"] for s in telegram_only}
+
+        # Totals paired with list_sessions_rich must use tip source too.
+        assert db.session_count(source="webui", exclude_children=True) >= 1
+        assert db.session_count(source="telegram", exclude_children=True) == 0
+        by_src = db.session_count_by_source(exclude_children=True)
+        assert by_src.get("webui", 0) >= 1
 
     def test_list_handles_broken_chain_gracefully(self, db):
         """A compression root with no child (e.g. DB corruption or a partial


### PR DESCRIPTION
## What does this PR do?

Fixes cross-source compression chains missing from filtered WebUI session lists.

`list_sessions_rich` projects compression roots onto their live tip and copies tip fields including `source`. Source filters were still applied in SQL on the **root** before projection, so a telegram-rooted chain continued under `webui` never entered the result set when `source=webui`.

Source include/exclude now evaluates the projected tip source in SQL before pagination. `session_count(..., exclude_children=True)` and `session_count_by_source(exclude_children=True)` use the same projected membership so totals and source menus stay aligned.

## Related Issue

Fixes #75625

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_state_sessions.py`: apply the projected tip source to source filters and totals; keep grouped source counts aligned with listable rows by excluding hidden compression/delegate children. `hermes_state.py` retains the compatibility export.
- Tip selection uses the same activity ordering in SQL and Python, with explicit depth/activity/start/id tie-breaks.
- Child-marker lookups reuse the shared safe JSON helper so malformed stored configuration cannot break source-filtered listings or counts.
- Tests: cross-source filtering, projected totals and exact per-source counts, heartbeat-vs-message ordering, and a SQL↔Python lineage invariant matrix covering multi-hop, ignored children, empty sources, and tied siblings.

## How to Test

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 1 tests/test_hermes_state.py
```

The regression cases exercise cross-source list membership, exact grouped counts, activity ordering and SQL/Python tip-walk parity.

## Count-query measurement

A bounded SQL-boundary measurement on macOS 15.6.1 arm64 (Python 3.14.7, SQLite 3.53.4) used the unmodified count methods in `2e486c49861a730291babd48feb12aad16149f76`, the repository's schema and indexes, and three runs per query. Each generated family contained a telegram root and middle, a webui tip, a visible slack branch and an excluded tool delegate, with three messages per session. Results were checked against the expected counts.

| Sessions / messages | Filtered count, median | Grouped count, median |
| --- | --- | --- |
| 1,000 / 3,000 | 4.1 ms | 6.0 ms |
| 10,000 / 30,000 | 41.5 ms | 61.8 ms |
| 50,000 / 150,000 | 223.9 ms | 320.1 ms |

At 50,000 sessions, the base's root-source queries took 9.1 ms and 30.1 ms respectively, but returned the wrong source membership for these cross-source chains. The projection therefore has a measurable cost. This is an in-memory SQLite measurement with synthetic shallow lineages, not cold-disk, deep-lineage or end-to-end WebUI latency evidence. Every query completed within the two-second measurement bound; no general production latency guarantee is claimed.

## Checklist

- [x] Conventional commits, scoped, tests pass, macOS
