### PR TITLE
fix(codex): normalize projected tool names

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.message_sanitization import deterministic_call_id
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.codex_tool_names import normalize_codex_tool_name
 
 logger = logging.getLogger(__name__)
 
@@ -570,7 +571,7 @@ def _chat_messages_to_responses_input(
                         items.append({
                             "type": "function_call",
                             "call_id": _clamp_responses_call_id(call_id),
-                            "name": fn_name,
+                            "name": normalize_codex_tool_name(fn_name),
                             "arguments": arguments,
                         })
                 continue
@@ -657,7 +658,7 @@ def _preflight_codex_input_items(
                 {
                     "type": "function_call",
                     "call_id": call_id.strip(),
-                    "name": name.strip(),
+                    "name": normalize_codex_tool_name(name),
                     "arguments": arguments,
                 }
             )

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -22,6 +22,7 @@ import time
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
+from agent.codex_tool_names import normalize_codex_tool_name
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 
 logger = logging.getLogger(__name__)
@@ -323,10 +324,10 @@ def _codex_item_to_tool_name(item: dict) -> str:
         server = item.get("server") or "mcp"
         tool = item.get("tool") or "unknown"
         if server == _INTERNAL_MCP_SERVER:
-            return tool
-        return f"mcp.{server}.{tool}"
+            return normalize_codex_tool_name(tool)
+        return normalize_codex_tool_name(f"mcp__{server}__{tool}")
     if item_type == "dynamicToolCall":
-        return item.get("tool") or "dynamic"
+        return normalize_codex_tool_name(item.get("tool"), default="dynamic")
     if item_type == "webSearch":
         return "web_search"
     return item_type or "unknown"

--- a/agent/codex_tool_names.py
+++ b/agent/codex_tool_names.py
@@ -1,0 +1,14 @@
+"""Codex-compatible names for projected and replayed function calls."""
+
+from __future__ import annotations
+
+import re
+
+
+_INVALID_CODEX_TOOL_NAME = re.compile(r"[^A-Za-z0-9_-]")
+
+
+def normalize_codex_tool_name(name: object, *, default: str = "unknown") -> str:
+    """Replace characters rejected by the Responses function-name schema."""
+    normalized = _INVALID_CODEX_TOOL_NAME.sub("_", str(name or "")).strip("_")
+    return normalized or default

--- a/agent/transports/codex_event_projector.py
+++ b/agent/transports/codex_event_projector.py
@@ -11,7 +11,7 @@ Codex emits items with a discriminator field `type`:
   - reasoning           → stashed in the assistant's "reasoning" field
   - commandExecution    → assistant tool_call(name="exec") + tool result
   - fileChange          → assistant tool_call(name="apply_patch") + tool result
-  - mcpToolCall         → assistant tool_call(name=f"mcp.{server}.{tool}") + tool result
+  - mcpToolCall         → assistant tool_call(name="mcp__server__tool") + tool result
   - dynamicToolCall     → assistant tool_call(name=tool) + tool result
   - plan/hookPrompt/collabAgentToolCall → recorded as opaque assistant notes
 
@@ -32,6 +32,8 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from typing import Any, Optional
+
+from agent.codex_tool_names import normalize_codex_tool_name
 
 
 def _deterministic_call_id(item_type: str, item_id: str) -> str:
@@ -217,9 +219,10 @@ class CodexEventProjector:
     def _project_mcp_tool_call(self, item: dict, item_id: str) -> ProjectionResult:
         server = item.get("server") or "mcp"
         tool = item.get("tool") or "unknown"
+        tool_name = normalize_codex_tool_name(f"mcp__{server}__{tool}")
         # Mirror the native MCP tool-name convention (mcp__server__tool) so the
         # deterministic call_id input stays consistent with registration names.
-        call_id = _deterministic_call_id(f"mcp__{server}__{tool}", item_id)
+        call_id = _deterministic_call_id(tool_name, item_id)
         args = item.get("arguments") or {}
         if not isinstance(args, dict):
             args = {"arguments": args}
@@ -231,7 +234,7 @@ class CodexEventProjector:
                     "id": call_id,
                     "type": "function",
                     "function": {
-                        "name": f"mcp.{server}.{tool}",
+                        "name": tool_name,
                         "arguments": _format_tool_args(args),
                     },
                 }
@@ -261,7 +264,8 @@ class CodexEventProjector:
         self, item: dict, item_id: str
     ) -> ProjectionResult:
         tool = item.get("tool") or "unknown"
-        call_id = _deterministic_call_id(f"dyn_{tool}", item_id)
+        tool_name = normalize_codex_tool_name(tool)
+        call_id = _deterministic_call_id(f"dyn_{tool_name}", item_id)
         args = item.get("arguments") or {}
         if not isinstance(args, dict):
             args = {"arguments": args}
@@ -273,7 +277,7 @@ class CodexEventProjector:
                     "id": call_id,
                     "type": "function",
                     "function": {
-                        "name": tool,
+                        "name": tool_name,
                         "arguments": _format_tool_args(args),
                     },
                 }

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -146,6 +146,44 @@ def test_chat_messages_to_responses_input_keeps_short_call_id():
     assert output["call_id"] == "call_abc123"
 
 
+def test_chat_messages_to_responses_input_normalizes_legacy_tool_name():
+    items = _chat_messages_to_responses_input(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_legacy",
+                        "function": {
+                            "name": "mcp.notion.fetch",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+
+    call = next(item for item in items if item.get("type") == "function_call")
+    assert call["name"] == "mcp_notion_fetch"
+
+
+def test_preflight_codex_input_items_normalizes_function_name():
+    items = _preflight_codex_input_items(
+        [
+            {
+                "type": "function_call",
+                "call_id": "call_legacy",
+                "name": "mcp.notion/fetch",
+                "arguments": "{}",
+            }
+        ]
+    )
+
+    assert items[0]["name"] == "mcp_notion_fetch"
+
+
 
 
 
@@ -302,7 +340,6 @@ def _xai_reasoning_only_response(reasoning_text):
             )
         ],
     )
-
 
 
 

--- a/tests/agent/test_codex_runtime_live_events.py
+++ b/tests/agent/test_codex_runtime_live_events.py
@@ -68,7 +68,7 @@ def test_stable_ids_match_history_projector():
     bridge({"method": "item/started", "params": {"item": mcp}})
     call_id, name, args = calls["tool_start"][0]
     assert call_id == _deterministic_call_id("mcp__filesystem__read", "m1")
-    assert name == "mcp.filesystem.read"
+    assert name == "mcp__filesystem__read"
     assert args == {"path": "a.py"}
 
     calls["tool_start"].clear()
@@ -102,7 +102,6 @@ def test_failed_command_result_and_error_flag_are_preserved():
     assert is_error is True
     assert calls["tool_progress"][0][1]["is_error"] is True
     assert calls["tool_complete"][0][3] == "[exit 2]\nboom"
-
 
 
 

--- a/tests/agent/transports/test_codex_event_projector.py
+++ b/tests/agent/transports/test_codex_event_projector.py
@@ -186,8 +186,44 @@ class TestMcpToolCallProjection:
         msgs = CodexEventProjector().project(
             {"method": "item/completed", "params": {"item": item}}
         ).messages
-        assert msgs[0]["tool_calls"][0]["function"]["name"] == "mcp.obsidian.search_notes"
+        assert (
+            msgs[0]["tool_calls"][0]["function"]["name"]
+            == "mcp__obsidian__search_notes"
+        )
         assert "found" in msgs[1]["content"]
+
+    def test_mcp_tool_name_replaces_responses_incompatible_characters(self) -> None:
+        item = {
+            "type": "mcpToolCall",
+            "id": "m3",
+            "server": "codex.apps",
+            "tool": "notion/fetch",
+            "arguments": {},
+            "result": None,
+        }
+        messages = CodexEventProjector().project(
+            {"method": "item/completed", "params": {"item": item}}
+        ).messages
+
+        assert (
+            messages[0]["tool_calls"][0]["function"]["name"]
+            == "mcp__codex_apps__notion_fetch"
+        )
+
+    def test_dynamic_tool_name_replaces_responses_incompatible_characters(self) -> None:
+        item = {
+            "type": "dynamicToolCall",
+            "id": "d2",
+            "tool": "notion.fetch",
+            "arguments": {},
+            "contentItems": [],
+            "success": True,
+        }
+        messages = CodexEventProjector().project(
+            {"method": "item/completed", "params": {"item": item}}
+        ).messages
+
+        assert messages[0]["tool_calls"][0]["function"]["name"] == "notion_fetch"
 
     def test_mcp_error_surfaced(self) -> None:
         item = {

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -730,7 +730,7 @@ class TestCodexToolProgressBridge:
             _codex_item_to_tool_name,
         )
         mcp = {"type": "mcpToolCall", "server": "fs", "tool": "read", "arguments": {"p": 1}}
-        assert _codex_item_to_tool_name(mcp) == "mcp.fs.read"
+        assert _codex_item_to_tool_name(mcp) == "mcp__fs__read"
         assert _codex_item_to_args(mcp) == {"p": 1}
 
         dyn = {"type": "dynamicToolCall", "tool": "web_search", "arguments": {"q": "x"}}


### PR DESCRIPTION
## What it does

Normalizes Codex app-server projected MCP and dynamic tool names, plus legacy replayed function names, to Responses-compatible identifiers. This prevents background memory and skill review from failing after projected tool use.

## Decisions

Projection now follows Hermes's existing `mcp__server__tool` convention, while a small shared normalizer also protects dynamic calls and previously persisted dotted names at replay/preflight boundaries. The fix is intentionally separate from the open thread-resume and native-compaction work in #41905 and #73715. The focused Codex projector, adapter, event bridge, runtime, and integration suite passes (81 tests).
