### PR TITLE
fix(wake): stabilize exclusive and duplex audio handoffs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12025,18 +12025,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 return
 
             recorder = self._voice_recorder
-            release_for_wake = (
-                getattr(self, "_wake_suspended", False)
-                and not self._voice_continuous
-            )
+            release_for_wake = getattr(self, "_wake_suspended", False)
             try:
                 wav_path = recorder.stop()
             finally:
-                # A wake-triggered turn hands the capture device back to the
-                # wake listener after one utterance. AudioRecorder.stop()
-                # deliberately keeps its stream alive for regular/continuous
-                # voice mode, but the wake listener cannot reopen an exclusive
-                # device while that persistent stream still owns it. Release it
+                # A wake-triggered capture hands the device to another owner:
+                # the wake listener after a single-turn command, or a
+                # full-duplex/follow-up recorder in continuous conversation.
+                # AudioRecorder.stop() deliberately keeps its stream alive for
+                # ordinary voice mode, but no wake hand-off can reopen an
+                # exclusive device while that stream still owns it. Release it
                 # before transcription, including when stop() itself fails.
                 if release_for_wake:
                     try:

--- a/cli.py
+++ b/cli.py
@@ -11870,10 +11870,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # continuous recording falls back to the documented defaults
         # instead of crashing on ``.get()``.
         voice_cfg: dict = {}
+        wake_cfg: dict = {}
         try:
             from hermes_cli.config import load_config
-            _cfg = load_config().get("voice")
+            _full_cfg = load_config()
+            _cfg = _full_cfg.get("voice")
             voice_cfg = _cfg if isinstance(_cfg, dict) else {}
+            _wake_cfg = _full_cfg.get("wake_word")
+            wake_cfg = _wake_cfg if isinstance(_wake_cfg, dict) else {}
         except Exception:
             pass
 
@@ -11932,7 +11936,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if self._voice_beeps_enabled():
             try:
                 from tools.voice_mode import play_beep
-                play_beep(frequency=880, count=1)
+                if (
+                    getattr(self, "_wake_suspended", False)
+                    and wake_cfg.get("duplex_output_device") is not None
+                ):
+                    # A newly reopened HFP sink can discard the first short
+                    # buffer while SCO starts. Warm it with silence so the
+                    # actual wake cue remains audible.
+                    play_beep(frequency=880, count=1, pre_roll=0.25)
+                else:
+                    play_beep(frequency=880, count=1)
             except Exception:
                 pass
 

--- a/cli.py
+++ b/cli.py
@@ -12024,7 +12024,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if self._voice_recorder is None:
                 return
 
-            wav_path = self._voice_recorder.stop()
+            recorder = self._voice_recorder
+            release_for_wake = (
+                getattr(self, "_wake_suspended", False)
+                and not self._voice_continuous
+            )
+            try:
+                wav_path = recorder.stop()
+            finally:
+                # A wake-triggered turn hands the capture device back to the
+                # wake listener after one utterance. AudioRecorder.stop()
+                # deliberately keeps its stream alive for regular/continuous
+                # voice mode, but the wake listener cannot reopen an exclusive
+                # device while that persistent stream still owns it. Release it
+                # before transcription, including when stop() itself fails.
+                if release_for_wake:
+                    try:
+                        recorder.shutdown()
+                    except Exception:
+                        pass
+                    if self._voice_recorder is recorder:
+                        self._voice_recorder = None
 
             # Audio cue: double beep after stream stopped (no CoreAudio conflict)
             if self._voice_beeps_enabled():

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1481,6 +1481,7 @@ DEFAULT_CONFIG = {
 
     "voice": {
         "record_key": "ctrl+b",
+        "output_device": None,         # PortAudio output index/name for beeps; null uses platform default
         "max_recording_seconds": 120,
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
@@ -1504,6 +1505,7 @@ DEFAULT_CONFIG = {
         "enabled": False,
         "surface": "auto",            # eligible surface: "auto" (first claimant) | "cli" | "tui" | "gui"
         "input_device": None,          # PortAudio input device index/name; null uses the process default
+        "duplex_output_device": None,  # optional output kept silently open for HFP-style full-duplex capture
         "provider": "openwakeword",   # "openwakeword" (free, local) | "sherpa" (free, ANY phrase, no training) | "porcupine" (premium; needs PORCUPINE_ACCESS_KEY)
         "phrase": "hey hermes",       # for "sherpa" this IS the detected phrase (any text works); for other engines it's a cosmetic label — detection is keyed by the model/keyword below
         "sensitivity": 0.6,           # 0.0-1.0 detection threshold, consistent across engines (higher = stricter, fewer false triggers)

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -180,6 +180,39 @@ class TestVoiceBeepConfigReal:
         recorder.start.assert_called_once()
         mock_beep.assert_not_called()
 
+    @patch("cli._cprint")
+    @patch("cli.threading.Thread")
+    @patch("tools.voice_mode.play_beep")
+    @patch("tools.voice_mode.create_audio_recorder")
+    @patch(
+        "tools.voice_mode.check_voice_requirements",
+        return_value={
+            "available": True,
+            "audio_available": True,
+            "stt_available": True,
+            "details": "OK",
+            "missing_packages": [],
+        },
+    )
+    @patch(
+        "hermes_cli.config.load_config",
+        return_value={
+            "voice": {"beep_enabled": True},
+            "wake_word": {"duplex_output_device": "jabra_bluetooth"},
+        },
+    )
+    def test_wake_recording_warms_duplex_output_before_first_beep(
+        self, _cfg, _req, mock_create, mock_beep, mock_thread, _cp
+    ):
+        recorder = MagicMock(supports_silence_autostop=True)
+        mock_create.return_value = recorder
+        mock_thread.return_value = MagicMock(start=MagicMock())
+
+        cli = _make_voice_cli(_wake_suspended=True)
+        cli._voice_start_recording()
+
+        mock_beep.assert_called_once_with(frequency=880, count=1, pre_roll=0.25)
+
 
 class TestMaxRecordingSecondsConfigReal:
     """voice.max_recording_seconds must reach the recorder from config.

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -322,6 +322,66 @@ class TestVoiceStopAndTranscribeReal:
         assert cli._pending_input.empty()
 
     @patch("cli._cprint")
+    @patch("tools.voice_mode.play_beep")
+    def test_wake_turn_without_speech_releases_capture_device(self, _beep, _cp):
+        recorder = MagicMock()
+        recorder.stop.return_value = None
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _wake_suspended=True,
+        )
+
+        cli._voice_stop_and_transcribe()
+
+        recorder.shutdown.assert_called_once_with()
+        assert cli._voice_recorder is None
+        assert cli._pending_input.empty()
+
+    def test_wake_turn_releases_capture_device_before_transcription(self):
+        events = []
+        recorder = MagicMock()
+        recorder.stop.return_value = "/tmp/test.wav"
+        recorder.shutdown.side_effect = lambda: events.append("shutdown")
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _wake_suspended=True,
+        )
+
+        def transcribe(*_args, **_kwargs):
+            events.append("transcribe")
+            return {"success": True, "transcript": "hello world"}
+
+        with patch("cli._cprint"), \
+             patch("cli.os.path.isfile", return_value=False), \
+             patch("hermes_cli.config.load_config", return_value={"stt": {}}), \
+             patch("tools.voice_mode.play_beep"), \
+             patch("tools.voice_mode.transcribe_recording",
+                   side_effect=transcribe) as mock_transcribe:
+            cli._voice_stop_and_transcribe()
+
+        assert events == ["shutdown", "transcribe"]
+        assert cli._voice_recorder is None
+        mock_transcribe.assert_called_once_with("/tmp/test.wav", model=None)
+
+    @patch("cli._cprint")
+    def test_wake_turn_releases_capture_device_when_stop_fails(self, _cp):
+        recorder = MagicMock()
+        recorder.stop.side_effect = RuntimeError("wav write failed")
+        cli = _make_voice_cli(
+            _voice_recording=True,
+            _voice_recorder=recorder,
+            _wake_suspended=True,
+        )
+
+        cli._voice_stop_and_transcribe()
+
+        recorder.shutdown.assert_called_once_with()
+        assert cli._voice_recorder is None
+        assert cli._voice_processing is False
+
+    @patch("cli._cprint")
     @patch("cli.os.unlink")
     @patch("cli.os.path.isfile", return_value=True)
     @patch("hermes_cli.config.load_config", return_value={"stt": {}})
@@ -341,6 +401,8 @@ class TestVoiceStopAndTranscribeReal:
         from cli import _VoiceInputMessage
         assert isinstance(queued, _VoiceInputMessage)
         assert str(queued) == "hello world"
+        recorder.shutdown.assert_not_called()
+        assert cli._voice_recorder is recorder
 
 
     def test_non_local_stt_keeps_generic_transcribing_status(self):

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -338,7 +338,8 @@ class TestVoiceStopAndTranscribeReal:
         assert cli._voice_recorder is None
         assert cli._pending_input.empty()
 
-    def test_wake_turn_releases_capture_device_before_transcription(self):
+    @pytest.mark.parametrize("continuous", [False, True])
+    def test_wake_turn_releases_capture_device_before_transcription(self, continuous):
         events = []
         recorder = MagicMock()
         recorder.stop.return_value = "/tmp/test.wav"
@@ -346,6 +347,7 @@ class TestVoiceStopAndTranscribeReal:
         cli = _make_voice_cli(
             _voice_recording=True,
             _voice_recorder=recorder,
+            _voice_continuous=continuous,
             _wake_suspended=True,
         )
 

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -708,6 +708,35 @@ class TestPlayBeep:
         assert audio_arg.dtype == np.int16
         assert len(audio_arg) > 0
 
+    def test_beep_can_prepend_silent_device_warmup(self, mock_sd):
+        np = pytest.importorskip("numpy")
+        from tools import voice_mode as vm
+
+        mock_stream = MagicMock(active=False)
+        mock_sd.get_stream.return_value = mock_stream
+
+        vm.play_beep(frequency=880, duration=0.1, count=1, pre_roll=0.25)
+
+        audio = mock_sd.play.call_args[0][0]
+        warmup_samples = int(vm.SAMPLE_RATE * 0.25)
+        assert len(audio) == warmup_samples + int(vm.SAMPLE_RATE * 0.1)
+        assert np.all(audio[:warmup_samples] == 0)
+        assert np.any(audio[warmup_samples:] != 0)
+
+    def test_beep_uses_configured_output_device(self, mock_sd):
+        pytest.importorskip("numpy")
+        from tools.voice_mode import play_beep
+
+        mock_stream = MagicMock(active=False)
+        mock_sd.get_stream.return_value = mock_stream
+        with patch(
+            "tools.voice_mode.configured_output_device",
+            return_value="Jabra Speak2 55 UC",
+        ):
+            play_beep()
+
+        assert mock_sd.play.call_args.kwargs["device"] == "Jabra Speak2 55 UC"
+
 # ============================================================================
 # Silence detection
 # ============================================================================

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -23,11 +23,22 @@ import tools.wake_word as ww
 
 
 def test_config_defaults_and_clamping():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert ww._DEFAULTS["duplex_output_device"] is None
+    assert DEFAULT_CONFIG["wake_word"]["duplex_output_device"] is None
     assert ww._provider({}) == "openwakeword"
     assert ww._provider({"provider": "Porcupine"}) == "porcupine"
     assert ww._input_device({}) is None
     assert ww._input_device({"input_device": 7}) == 7
     assert ww._input_device({"input_device": " Microphone Array "}) == "Microphone Array"
+    assert ww._duplex_output_device({}) is None
+    assert ww._duplex_output_device({"duplex_output_device": 8}) == 8
+    assert (
+        ww._duplex_output_device({"duplex_output_device": " Jabra Bluetooth "})
+        == "Jabra Bluetooth"
+    )
+    assert ww._duplex_output_device({"duplex_output_device": ""}) is None
     assert ww._input_device({"input_device": ""}) is None
     assert ww._input_device({"input_device": False}) is None
     assert ww._sensitivity({"sensitivity": 5}) == 1.0
@@ -472,6 +483,79 @@ def test_detector_opens_configured_input_device_and_reports_backend(monkeypatch)
         det.stop()
 
 
+def test_detector_keeps_optional_duplex_output_open_and_silent(monkeypatch):
+    opened = []
+    input_streams = []
+    output_streams = []
+
+    class _OutputStream(_FakeStream):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            output_streams.append(self)
+
+    class _OutputBuffer:
+        def __init__(self):
+            self.value = None
+
+        def fill(self, value):
+            self.value = value
+
+    class _CallbackInputStream(_FakeStream):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            input_streams.append(self)
+
+        def read(self, _n):
+            raise AssertionError("duplex wake capture must not use blocking read()")
+
+    def _input_stream(**kwargs):
+        opened.append(("input", kwargs))
+        return _CallbackInputStream(**kwargs)
+
+    def _output_stream(**kwargs):
+        opened.append(("output", kwargs))
+        return _OutputStream(**kwargs)
+
+    fake_sd = types.SimpleNamespace(
+        InputStream=_input_stream,
+        OutputStream=_output_stream,
+        query_devices=lambda selector, kind: {
+            "name": str(selector),
+            "hostapi": 0,
+            "max_input_channels": 1,
+            "default_samplerate": 16000.0,
+        },
+        query_hostapis=lambda index: {"name": "ALSA"},
+    )
+    monkeypatch.setattr(ww, "_import_audio", lambda: (fake_sd, None))
+
+    det = ww.WakeWordDetector(
+        _FakeEngine(fire=False),
+        lambda: None,
+        input_device="Bluetooth Mic",
+        duplex_output_device="Bluetooth Speaker",
+    )
+    det.start()
+    try:
+        assert [kind for kind, _kwargs in opened] == ["output", "input"]
+        output_kwargs = opened[0][1]
+        assert output_kwargs["device"] == "Bluetooth Speaker"
+        assert output_kwargs["samplerate"] == ww.SAMPLE_RATE
+        assert output_kwargs["channels"] == 1
+        assert output_kwargs["dtype"] == "int16"
+        buffer = _OutputBuffer()
+        output_kwargs["callback"](buffer, 4, None, None)
+        assert buffer.value == 0
+        input_kwargs = opened[1][1]
+        assert callable(input_kwargs["callback"])
+        input_kwargs["callback"](_Frame([500] * 4), 4, None, None)
+    finally:
+        det.stop()
+
+    assert input_streams[0].closed is True
+    assert output_streams[0].closed is True
+
+
 def test_windows_silent_hint_names_selected_device(monkeypatch):
     monkeypatch.setattr(ww.sys, "platform", "win32")
     hint = ww.silent_audio_hint(
@@ -523,6 +607,7 @@ def test_detector_flags_silent_stream_and_recovers(monkeypatch):
 
 def test_detection_callback_can_pause_and_close_stream(monkeypatch, tmp_path):
     streams = []
+    callback_saw_closed_stream = []
 
     def _stream(**kw):
         stream = _FakeStream(**kw)
@@ -537,6 +622,7 @@ def test_detection_callback_can_pause_and_close_stream(monkeypatch, tmp_path):
     paused = threading.Event()
 
     def _on_wake():
+        callback_saw_closed_stream.append(streams[0].closed)
         if ww.pause_listening(owner=owner):
             paused.set()
 
@@ -544,6 +630,7 @@ def test_detection_callback_can_pause_and_close_stream(monkeypatch, tmp_path):
     assert paused.wait(2)
     assert ww.is_listening() is False
     assert streams[0].closed is True
+    assert callback_saw_closed_stream == [True]
     assert ww.stop_listening(owner=owner) is True
 
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -101,6 +101,27 @@ def _audio_available() -> bool:
         return False
 
 
+def configured_output_device() -> int | str | None:
+    """Return the explicit PortAudio output selector for voice audio cues."""
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        voice = config.get("voice") if isinstance(config, dict) else None
+        voice = voice if isinstance(voice, dict) else {}
+        value = voice.get("output_device")
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+    except Exception:
+        pass
+    return None
+
+
 def _default_input_samplerate(sd) -> int:
     """Return the preferred capture rate for the default input device.
 
@@ -474,13 +495,19 @@ def _is_nan(value: float) -> bool:
         return False
 
 
-def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> None:
+def play_beep(
+    frequency: int = 880,
+    duration: float = 0.12,
+    count: int = 1,
+    pre_roll: float = 0.0,
+) -> None:
     """Play a short beep tone using numpy + sounddevice.
 
     Args:
         frequency: Tone frequency in Hz (default 880 = A5).
         duration: Duration of each beep in seconds.
         count: Number of beeps to play (with short gap between).
+        pre_roll: Optional leading silence used to warm a cold output transport.
     """
     # Synthesize the tone with numpy only (no sounddevice import yet, so the
     # macOS TCC prompt is not triggered on the synthesis step).
@@ -492,9 +519,15 @@ def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> N
         gap = 0.06  # seconds between beeps
         samples_per_beep = int(SAMPLE_RATE * duration)
         samples_per_gap = int(SAMPLE_RATE * gap)
+        try:
+            pre_roll_seconds = max(0.0, float(pre_roll))
+        except (TypeError, ValueError):
+            pre_roll_seconds = 0.0
 
         beep_volume = _get_beep_volume()
         parts = []
+        if pre_roll_seconds:
+            parts.append(np.zeros(int(SAMPLE_RATE * pre_roll_seconds), dtype=np.int16))
         for i in range(count):
             t = np.linspace(0, duration, samples_per_beep, endpoint=False)
             # Apply fade in/out to avoid click artifacts
@@ -517,7 +550,11 @@ def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> N
             sd, _ = _import_audio()
         except (ImportError, OSError):
             return
-        sd.play(audio, samplerate=SAMPLE_RATE)
+        sd.play(
+            audio,
+            samplerate=SAMPLE_RATE,
+            device=configured_output_device(),
+        )
         # sd.wait() calls Event.wait() without timeout — hangs forever if the
         # audio device stalls.  Poll with a 2s ceiling and force-stop.
         deadline = time.monotonic() + 2.0

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import logging
 import os
+import queue
 import sys
 import threading
 import time
@@ -81,6 +82,7 @@ _DEFAULTS: Dict[str, Any] = {
     "sensitivity": 0.6,
     "confirmation_frames": _DEFAULT_CONFIRMATION_FRAMES,
     "start_new_session": True,
+    "duplex_output_device": None,
 }
 
 # Bundled "hey hermes" model (tools/wakewords/) — the default, so the wake word
@@ -206,6 +208,17 @@ def _provider(cfg: Dict[str, Any]) -> str:
 def _input_device(cfg: Dict[str, Any]) -> int | str | None:
     """Configured PortAudio input selector, preserving indices and names."""
     raw = _get(cfg, "input_device")
+    if raw is None or isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw
+    value = str(raw).strip()
+    return value or None
+
+
+def _duplex_output_device(cfg: Dict[str, Any]) -> int | str | None:
+    """Optional output selector kept open to support full-duplex input devices."""
+    raw = _get(cfg, "duplex_output_device")
     if raw is None or isinstance(raw, bool):
         return None
     if isinstance(raw, int):
@@ -875,12 +888,14 @@ class WakeWordDetector:
     def __init__(self, engine: _Engine, on_wake: Callable[[], None],
                  cooldown: float = _FIRE_COOLDOWN_SECONDS,
                  on_failure: Optional[Callable[["WakeWordDetector"], None]] = None,
-                 input_device: int | str | None = None):
+                 input_device: int | str | None = None,
+                 duplex_output_device: int | str | None = None):
         self.engine = engine
         self.on_wake = on_wake
         self.cooldown = cooldown
         self.on_failure = on_failure
         self.input_device = input_device
+        self.duplex_output_device = duplex_output_device
         self.input_device_details: Dict[str, Any] = {"selector": input_device}
         self._thread: Optional[threading.Thread] = None
         self._stop = threading.Event()
@@ -969,17 +984,60 @@ class WakeWordDetector:
             self.input_device_details.get("default_samplerate") or "unknown",
             SAMPLE_RATE,
         )
+        output_stream = None
+        audio_queue = None
+        capture_callback = None
         try:
+            if self.duplex_output_device is not None:
+                def _write_silence(outdata, _frames, _time_info, _status):
+                    outdata.fill(0)
+
+                audio_queue = queue.Queue(maxsize=8)
+
+                def _capture_audio(indata, _frames, _time_info, status):
+                    if status:
+                        logger.debug("wake word: duplex capture status: %s", status)
+                    frame = indata.copy()
+                    try:
+                        audio_queue.put_nowait(frame)
+                    except queue.Full:
+                        try:
+                            audio_queue.get_nowait()
+                        except queue.Empty:
+                            pass
+                        try:
+                            audio_queue.put_nowait(frame)
+                        except queue.Full:
+                            pass
+
+                capture_callback = _capture_audio
+
+                output_stream = sd.OutputStream(
+                    device=self.duplex_output_device,
+                    samplerate=SAMPLE_RATE,
+                    channels=1,
+                    dtype="int16",
+                    blocksize=frame_length,
+                    callback=_write_silence,
+                )
+                output_stream.start()
             stream = sd.InputStream(
                 device=self.input_device,
                 samplerate=SAMPLE_RATE,
                 channels=1,
                 dtype="int16",
                 blocksize=frame_length,
+                callback=capture_callback,
             )
             stream.start()
         except Exception as e:
             logger.error("wake word: failed to open microphone: %s", e)
+            if output_stream is not None:
+                try:
+                    output_stream.stop()
+                    output_stream.close()
+                except Exception:
+                    pass
             startup_errors.append(e)
             ready.set()
             return
@@ -995,13 +1053,22 @@ class WakeWordDetector:
         logger.info("wake word: listening (frame=%d, rate=%d)", frame_length, SAMPLE_RATE)
         ready.set()
         failed = False
+        dispatch_wake = False
         # ~seconds of consecutive near-zero frames before we flag the stream
         # as silent.
         silent_alert_frames = max(1, int(_SILENCE_ALERT_SECONDS * SAMPLE_RATE / max(1, frame_length)))
         try:
             while not self._stop.is_set():
                 try:
-                    data, _overflow = stream.read(frame_length)
+                    if audio_queue is None:
+                        data, _overflow = stream.read(frame_length)
+                    else:
+                        try:
+                            data = audio_queue.get(timeout=0.2)
+                        except queue.Empty:
+                            if not getattr(stream, "active", True):
+                                raise RuntimeError("duplex input stream became inactive")
+                            continue
                 except Exception as e:
                     logger.warning("wake word: stream read error: %s", e)
                     failed = not self._stop.is_set()
@@ -1037,11 +1104,10 @@ class WakeWordDetector:
                         logger.info("wake word: phrase detected — firing callback")
                         if not self._callback_inflight.is_set():
                             self._callback_inflight.set()
-                            threading.Thread(
-                                target=self._dispatch_wake,
-                                daemon=True,
-                                name="wake-word-callback",
-                            ).start()
+                            dispatch_wake = True
+                            # Release both halves of a duplex device before the
+                            # callback opens the command recorder and first cue.
+                            break
                     else:
                         logger.debug("wake word: detection within cooldown — ignored")
         finally:
@@ -1050,9 +1116,21 @@ class WakeWordDetector:
                 stream.close()
             except Exception:
                 pass
+            if output_stream is not None:
+                try:
+                    output_stream.stop()
+                    output_stream.close()
+                except Exception:
+                    pass
             logger.info("wake word: stream closed")
             if failed and self.on_failure is not None:
                 self.on_failure(self)
+        if dispatch_wake:
+            threading.Thread(
+                target=self._dispatch_wake,
+                daemon=True,
+                name="wake-word-callback",
+            ).start()
 
 
 # ---------------------------------------------------------------------------
@@ -1163,6 +1241,7 @@ def start_listening(
                 on_wake,
                 on_failure=_detector_failed,
                 input_device=_input_device(cfg),
+                duplex_output_device=_duplex_output_device(cfg),
             )
             _detector = detector
             _detector_owner = owner


### PR DESCRIPTION
## What does this PR do?

Stabilizes the wake-to-voice audio handoff on exclusive input devices and opt-in full-duplex HFP transports.

## Changes

- Release the CLI `AudioRecorder` after every wake-suspended capture, before transcription or follow-up capture reacquires the device.
- Add optional `wake_word.duplex_output_device` support: keep a silent 16 kHz output stream open while wake capture uses a bounded callback queue.
- Close both wake streams before dispatching the wake callback, preventing the command recorder and first cue from racing stream teardown.
- Add `voice.output_device` for explicit cue routing and a 250 ms silent preroll for the first cue after an HFP wake.
- Preserve ordinary non-wake recorder reuse and the existing input-only wake path.

Deployment-specific selectors, launchers, STT-provider changes, and local wake engines are intentionally excluded.

## Verification

- Six focused regressions: `6 passed`.
- Full affected slice on the PR branch: `96 passed`.
- Same patch applied cleanly to current upstream `main`: `116 passed`; ruff and `git diff --check` clean.
- Raspberry Pi 5 + Jabra Speak2 55 over Bluetooth HFP/mSBC: first wake phrase detected on the first attempt, first cue audible, command/TTS/follow-up completed, wake resumed after the 60-second cap, and no BlueALSA overruns or device-busy errors were observed.

## Related context

Complementary to #74152 and #74996.

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Security fix

## Checklist

- [x] Scope is limited to the audio lifecycle fix and its regressions.
- [x] Current `main` compatibility was verified.
- [x] Real-device end-to-end validation completed on Raspberry Pi OS 13/aarch64.
- [x] No deployment credentials or device-specific values are included.
