### PR TITLE
fix(skills): scope background-review read marks per review fork

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -874,3 +874,65 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+class TestBackgroundReviewReadMarksSurviveToolThreads:
+    """Read marks must be visible across per-tool worker threads (#75618).
+
+    Tool dispatch snapshots the parent turn via ``copy_context()`` *before*
+    hopping to a worker (``propagate_context_to_thread``). A ContextVar set
+    inside one worker's private context is invisible to a later skill_manage
+    worker — the curator could never satisfy the read-before-write guard.
+    """
+
+    def test_mark_on_worker_thread_visible_to_other_worker(self, tmp_path):
+        import contextvars
+        import threading
+
+        from tools.skill_manager_tool import (
+            _background_review_has_read,
+            _reset_background_review_read_marks,
+            mark_background_review_skill_read,
+        )
+        from tools.skill_provenance import (
+            BACKGROUND_REVIEW,
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        target = tmp_path / "skill" / "SKILL.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("x", encoding="utf-8")
+        _reset_background_review_read_marks()
+
+        # Parent turn is background_review (set before tool dispatch).
+        parent_token = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            errors: list[str] = []
+            # Snapshot on the parent — same as propagate_context_to_thread.
+            view_ctx = contextvars.copy_context()
+            manage_ctx = contextvars.copy_context()
+
+            def _skill_view_worker():
+                view_ctx.run(mark_background_review_skill_read, target)
+
+            def _skill_manage_worker():
+                def _run():
+                    if not _background_review_has_read(target):
+                        errors.append("read mark missing on manage worker")
+
+                manage_ctx.run(_run)
+
+            t1 = threading.Thread(target=_skill_view_worker)
+            t1.start()
+            t1.join(timeout=5)
+            assert t1.is_alive() is False
+            t2 = threading.Thread(target=_skill_manage_worker)
+            t2.start()
+            t2.join(timeout=5)
+            assert t2.is_alive() is False
+            assert not errors, errors
+            assert _background_review_has_read(target)
+        finally:
+            reset_current_write_origin(parent_token)
+            _reset_background_review_read_marks()

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -936,3 +936,38 @@ class TestBackgroundReviewReadMarksSurviveToolThreads:
         finally:
             reset_current_write_origin(parent_token)
             _reset_background_review_read_marks()
+
+    def test_read_marks_isolated_between_review_forks(self, tmp_path):
+        """A mark from review A must not authorize a write in review B (#75661)."""
+        import contextvars
+
+        from tools.skill_manager_tool import (
+            _background_review_has_read,
+            _reset_background_review_read_marks,
+            mark_background_review_skill_read,
+        )
+        from tools.skill_provenance import (
+            BACKGROUND_REVIEW,
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        target = tmp_path / "skill" / "SKILL.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("x", encoding="utf-8")
+
+        parent_token = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            _reset_background_review_read_marks()
+            review_a = contextvars.copy_context()
+            _reset_background_review_read_marks()
+            review_b = contextvars.copy_context()
+
+            review_a.run(mark_background_review_skill_read, target)
+            assert review_a.run(_background_review_has_read, target) is True
+            assert review_b.run(_background_review_has_read, target) is False
+            # Parent holds review B's store after the second reset.
+            assert _background_review_has_read(target) is False
+        finally:
+            reset_current_write_origin(parent_token)
+            _reset_background_review_read_marks()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -55,16 +55,38 @@ logger = logging.getLogger(__name__)
 
 # Read-before-write marks for the autonomous background-review fork.
 #
-# These MUST NOT be ContextVars. Tool dispatch runs each call inside
-# ``contextvars.copy_context().run(...)`` on a worker thread
-# (``tools.thread_context.propagate_context_to_thread``), so a
-# ContextVar ``.set()`` performed in ``skill_view`` is invisible to a later
-# ``skill_manage`` call on a different worker — the curator can never satisfy
-# the read-before-write guard (#75618). A process-visible set shared under a
-# lock is correct: marks are reset at the start of each review fork, and only
-# one background review runs at a time.
-_background_review_read_paths: set[str] = set()
-_background_review_read_paths_lock = threading.Lock()
+# Tool dispatch runs each call inside ``contextvars.copy_context().run(...)``
+# on a worker (``tools.thread_context.propagate_context_to_thread``). A
+# ContextVar that stores an *immutable* frozenset and is re-``.set()`` on each
+# mark only updates that worker's private copy — a later skill_manage worker
+# never sees the mark (#75618).
+#
+# Instead the ContextVar holds a **mutable** lock-protected store object.
+# ``_reset_background_review_read_marks`` installs a fresh store at review
+# start (parent context). Workers copy the ContextVar and therefore share the
+# same object reference within one review, while a second review that resets
+# gets a different object — so forks stay isolated (#75661 / sweeper).
+
+
+class _BackgroundReviewReadMarks:
+    """Mutable read-mark set shared by copied tool contexts within one review."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._paths: set[str] = set()
+
+    def add(self, path: str) -> None:
+        with self._lock:
+            self._paths.add(path)
+
+    def contains(self, path: str) -> bool:
+        with self._lock:
+            return path in self._paths
+
+
+_background_review_read_paths: "_ctxvars.ContextVar[Optional[_BackgroundReviewReadMarks]]" = (
+    _ctxvars.ContextVar("background_review_read_paths", default=None)
+)
 
 
 def mark_background_review_skill_read(path: Path) -> None:
@@ -87,8 +109,13 @@ def mark_background_review_skill_read(path: Path) -> None:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    with _background_review_read_paths_lock:
-        _background_review_read_paths.add(resolved)
+    marks = _background_review_read_paths.get()
+    if marks is None:
+        # Review should call _reset first; fall back so a single in-thread
+        # call still works in tests that mark without an explicit reset.
+        marks = _BackgroundReviewReadMarks()
+        _background_review_read_paths.set(marks)
+    marks.add(resolved)
 
 
 def _background_review_has_read(path: Path) -> bool:
@@ -96,14 +123,17 @@ def _background_review_has_read(path: Path) -> bool:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    with _background_review_read_paths_lock:
-        return resolved in _background_review_read_paths
+    marks = _background_review_read_paths.get()
+    return marks is not None and marks.contains(resolved)
 
 
 def _reset_background_review_read_marks() -> None:
-    """Clear read-before-write marks (start of review fork / test helper)."""
-    with _background_review_read_paths_lock:
-        _background_review_read_paths.clear()
+    """Install a fresh read-mark store for the current review context.
+
+    Called at review-fork start (``agent/background_review.py``) and between
+    tests. Subsequent ``copy_context()`` tool workers share this object.
+    """
+    _background_review_read_paths.set(_BackgroundReviewReadMarks())
 
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -36,6 +36,7 @@ import json
 import logging
 import re
 import shutil
+import threading
 import contextvars as _ctxvars
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -52,9 +53,18 @@ from agent.skill_utils import (
 
 logger = logging.getLogger(__name__)
 
-_background_review_read_paths: "_ctxvars.ContextVar[frozenset[str]]" = _ctxvars.ContextVar(
-    "background_review_read_paths", default=frozenset()
-)
+# Read-before-write marks for the autonomous background-review fork.
+#
+# These MUST NOT be ContextVars. Tool dispatch runs each call inside
+# ``contextvars.copy_context().run(...)`` on a worker thread
+# (``tools.thread_context.propagate_context_to_thread``), so a
+# ContextVar ``.set()`` performed in ``skill_view`` is invisible to a later
+# ``skill_manage`` call on a different worker — the curator can never satisfy
+# the read-before-write guard (#75618). A process-visible set shared under a
+# lock is correct: marks are reset at the start of each review fork, and only
+# one background review runs at a time.
+_background_review_read_paths: set[str] = set()
+_background_review_read_paths_lock = threading.Lock()
 
 
 def mark_background_review_skill_read(path: Path) -> None:
@@ -77,9 +87,8 @@ def mark_background_review_skill_read(path: Path) -> None:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    current = set(_background_review_read_paths.get())
-    current.add(resolved)
-    _background_review_read_paths.set(frozenset(current))
+    with _background_review_read_paths_lock:
+        _background_review_read_paths.add(resolved)
 
 
 def _background_review_has_read(path: Path) -> bool:
@@ -87,12 +96,14 @@ def _background_review_has_read(path: Path) -> bool:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    return resolved in _background_review_read_paths.get()
+    with _background_review_read_paths_lock:
+        return resolved in _background_review_read_paths
 
 
 def _reset_background_review_read_marks() -> None:
-    """Test helper: clear read-before-write marks for the current context."""
-    _background_review_read_paths.set(frozenset())
+    """Clear read-before-write marks (start of review fork / test helper)."""
+    with _background_review_read_paths_lock:
+        _background_review_read_paths.clear()
 
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.


### PR DESCRIPTION
## What does this PR do?

Fixes background-review skill curation always refusing patches after `skill_view`, without leaking read marks across concurrent review forks.

Tool dispatch runs each call in a private `copy_context()`. Storing marks as an immutable ContextVar frozenset that is re-`.set()` per mark only updates that worker's copy — a later `skill_manage` never sees the mark.

This holds a **mutable, lock-protected store object** in a ContextVar. `_reset_background_review_read_marks` installs a fresh store at review start (parent context). Workers share that object via `copy_context()`, so marks accumulate within one review. A second review that resets gets a different object, so forks stay isolated.

## Related Issue

Fixes #75618

## Related open work

#73975 targets the same failure with a similar review-scoped mutable store. This PR keeps worker-thread coverage and adds an explicit two-fork isolation regression.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/skill_manager_tool.py`: `_BackgroundReviewReadMarks` + ContextVar; reset installs a new store.
- Tests: cross-worker visibility + isolation between two review contexts.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_skill_manager_tool.py
```

Final local head `42cf9f45327edabe4f338cf08f4dec68ec2e632a`: 47/47 changed-file tests passed. The branch is rebased onto current `main` (`f5be9236e`). `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/75618` passes all blocking gates.

## Checklist

- [x] Conventional commits, scoped change, tests pass, macOS