### PR TITLE
feat(model-catalog): merge optional supplemental provider catalogs

### DIFF
--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -306,19 +306,74 @@ def _fetch_provider_override(provider: str) -> dict[str, Any] | None:
     return _fetch_manifest(override_url.strip(), DEFAULT_FETCH_TIMEOUT)
 
 
-def _get_provider_block(provider: str) -> dict[str, Any] | None:
-    """Return the provider's manifest block, respecting per-provider overrides."""
-    override = _fetch_provider_override(provider)
-    if override is not None:
-        block = override.get("providers", {}).get(provider)
-        if isinstance(block, dict):
-            return block
-
-    catalog = get_catalog()
-    if not catalog:
+def _fetch_provider_supplement(provider: str) -> dict[str, Any] | None:
+    """Fetch an optional provider list that is appended to the regular catalog."""
+    cfg = _load_catalog_config()
+    if not cfg["enabled"]:
         return None
-    block = catalog.get("providers", {}).get(provider)
-    return block if isinstance(block, dict) else None
+    provider_cfg = cfg["providers"].get(provider)
+    if not isinstance(provider_cfg, dict):
+        return None
+    supplemental_url = provider_cfg.get("supplemental_url")
+    if not isinstance(supplemental_url, str) or not supplemental_url.strip():
+        return None
+    return _fetch_manifest(supplemental_url.strip(), DEFAULT_FETCH_TIMEOUT)
+
+
+def _merge_provider_blocks(
+    regular: dict[str, Any] | None,
+    supplemental: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Append unique supplemental models while preserving regular order/metadata."""
+    if not isinstance(regular, dict):
+        return supplemental if isinstance(supplemental, dict) else None
+    if not isinstance(supplemental, dict):
+        return regular
+
+    merged = dict(regular)
+    regular_models = regular.get("models", [])
+    supplemental_models = supplemental.get("models", [])
+    models = list(regular_models) if isinstance(regular_models, list) else []
+    seen = {
+        str(model.get("id") or "").strip()
+        for model in models
+        if isinstance(model, dict)
+    }
+    if isinstance(supplemental_models, list):
+        for model in supplemental_models:
+            if not isinstance(model, dict):
+                continue
+            model_id = str(model.get("id") or "").strip()
+            if model_id and model_id not in seen:
+                models.append(model)
+                seen.add(model_id)
+    merged["models"] = models
+    return merged
+
+
+def _get_provider_block(provider: str) -> dict[str, Any] | None:
+    """Return the provider block with optional override and supplemental union."""
+    override = _fetch_provider_override(provider)
+    block = None
+    if override is not None:
+        candidate = override.get("providers", {}).get(provider)
+        if isinstance(candidate, dict):
+            block = candidate
+
+    if block is None:
+        catalog = get_catalog()
+        if catalog:
+            candidate = catalog.get("providers", {}).get(provider)
+            if isinstance(candidate, dict):
+                block = candidate
+
+    supplemental_manifest = _fetch_provider_supplement(provider)
+    supplemental_block = None
+    if supplemental_manifest is not None:
+        candidate = supplemental_manifest.get("providers", {}).get(provider)
+        if isinstance(candidate, dict):
+            supplemental_block = candidate
+    return _merge_provider_blocks(block, supplemental_block)
 
 
 def get_curated_openrouter_models() -> list[tuple[str, str]] | None:

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -405,6 +405,52 @@ class TestProviderOverride:
         assert result == [("override/model", "custom")]
 
 
+class TestProviderSupplement:
+    def test_supplement_is_appended_to_regular_catalog_without_duplicates(
+        self, isolated_home
+    ):
+        from hermes_cli import model_catalog
+
+        supplemental_payload = {
+            "version": 1,
+            "providers": {
+                "openrouter": {
+                    "models": [
+                        {"id": "openai/gpt-5.4", "description": "duplicate"},
+                        {"id": "xiaomi/mimo-v2.5", "description": "Roy custom"},
+                    ]
+                }
+            },
+        }
+
+        def fake_fetch(url, timeout):
+            if "supplemental" in url:
+                return supplemental_payload
+            return _valid_manifest()
+
+        with patch.object(
+            model_catalog,
+            "_load_catalog_config",
+            return_value={
+                "enabled": True,
+                "url": "http://master",
+                "ttl_hours": 24.0,
+                "providers": {
+                    "openrouter": {"supplemental_url": "http://supplemental"}
+                },
+            },
+        ):
+            with patch.object(model_catalog, "_fetch_manifest", side_effect=fake_fetch):
+                result = model_catalog.get_curated_openrouter_models()
+
+        assert result == [
+            ("anthropic/claude-opus-4.7", "recommended"),
+            ("openai/gpt-5.4", ""),
+            ("openrouter/elephant-alpha", "free"),
+            ("xiaomi/mimo-v2.5", "Roy custom"),
+        ]
+
+
 class TestIntegrationWithModelsModule:
     """Exercise the fallback paths via the real callers in hermes_cli.models."""
 


### PR DESCRIPTION
## Summary
- Adds optional `model_catalog.providers.<provider>.supplemental_url` support so operators can keep Hermes' normal auto-refreshed curated catalog and append a separately maintained local/remote model list.
- Merges by model ID, preserving regular catalog order/metadata and appending only unique supplemental entries.
- Covers the merge path with a unit test that asserts duplicate IDs stay on the regular entry while new IDs appear in the picker source list.

## Why
Users want cheap/custom OpenRouter models in the interactive picker without freezing or replacing Hermes' curated catalog. The existing `providers.<provider>.url` override is replacement-only; this adds a true union path.

## Config example
```yaml
model_catalog:
  providers:
    openrouter:
      supplemental_url: file:///path/to/openrouter-supplemental-models.json
```

## Test plan
- [x] `uv run --with pytest pytest tests/hermes_cli/test_model_catalog.py -q` (34 passed)
- [ ] Configure a local supplemental OpenRouter manifest with one duplicate ID and one new ID
- [ ] Confirm `get_curated_openrouter_models()` preserves regular order/metadata and appends only the unique model
- [ ] Confirm `hermes model` / OpenRouter picker still shows the normal curated list plus the supplemental models that are live and tool-capable
- [ ] Confirm refresh still updates the normal curated catalog without wiping the supplemental list