### PR TITLE
fix(doctor): recognize builtin memory provider

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2613,11 +2613,11 @@ def run_doctor(args):
                 _raw_cfg = managed_scope.apply_managed_overlay(_raw_cfg)
             except Exception:
                 pass
-            _active_memory_provider = str((_raw_cfg.get("memory") or {}).get("provider") or "").strip().lower()
+            _active_memory_provider = (_raw_cfg.get("memory") or {}).get("provider", "")
     except Exception:
         pass
 
-    if _active_memory_provider in ("", "default", "builtin", "none"):
+    if not _active_memory_provider or _active_memory_provider == "builtin":
         check_ok("Built-in memory active", "(no external provider configured — this is fine)")
     elif _active_memory_provider == "honcho":
         try:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2613,11 +2613,11 @@ def run_doctor(args):
                 _raw_cfg = managed_scope.apply_managed_overlay(_raw_cfg)
             except Exception:
                 pass
-            _active_memory_provider = (_raw_cfg.get("memory") or {}).get("provider", "")
+            _active_memory_provider = str((_raw_cfg.get("memory") or {}).get("provider") or "").strip().lower()
     except Exception:
         pass
 
-    if _active_memory_provider in ("", "builtin"):
+    if _active_memory_provider in ("", "default", "builtin", "none"):
         check_ok("Built-in memory active", "(no external provider configured — this is fine)")
     elif _active_memory_provider == "honcho":
         try:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2618,7 +2618,7 @@ def run_doctor(args):
         pass
 
     _normalized_memory_provider = str(_active_memory_provider or "").strip().lower()
-    if not _active_memory_provider or _normalized_memory_provider in {"default", "builtin", "built-in", "none"}:
+    if not _normalized_memory_provider or _normalized_memory_provider in {"default", "builtin", "built-in", "none"}:
         check_ok("Built-in memory active", "(no external provider configured — this is fine)")
     elif _active_memory_provider == "honcho":
         try:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2617,7 +2617,7 @@ def run_doctor(args):
     except Exception:
         pass
 
-    if not _active_memory_provider:
+    if _active_memory_provider in ("", "builtin"):
         check_ok("Built-in memory active", "(no external provider configured — this is fine)")
     elif _active_memory_provider == "honcho":
         try:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2617,7 +2617,8 @@ def run_doctor(args):
     except Exception:
         pass
 
-    if not _active_memory_provider or _active_memory_provider == "builtin":
+    _normalized_memory_provider = str(_active_memory_provider or "").strip().lower()
+    if not _active_memory_provider or _normalized_memory_provider in {"default", "builtin", "built-in", "none"}:
         check_ok("Built-in memory active", "(no external provider configured — this is fine)")
     elif _active_memory_provider == "honcho":
         try:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -272,7 +272,7 @@ class TestDoctorMemoryProviderSection:
         assert "Mem0" not in out
 
     def test_builtin_provider_aliases_show_builtin_ok(self, monkeypatch, tmp_path):
-        for provider in ("default", "builtin", "built-in", "none", " BuiltIn "):
+        for provider in ("default", "builtin", "built-in", "none", " BuiltIn ", "   "):
             out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider=provider)
 
             assert "Built-in memory active" in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -224,18 +224,18 @@ def test_doctor_reports_vercel_backend_diagnostics(monkeypatch, tmp_path):
 class TestDoctorMemoryProviderSection:
     """The ◆ Memory Provider section should respect memory.provider config."""
 
-    def _make_hermes_home(self, tmp_path, provider=""):
+    def _make_hermes_home(self, tmp_path, provider="", include_provider=False):
         """Create a minimal HERMES_HOME with config.yaml."""
         home = tmp_path / ".hermes"
         home.mkdir(parents=True, exist_ok=True)
         import yaml
-        config = {"memory": {"provider": provider}} if provider else {"memory": {}}
+        config = {"memory": {"provider": provider}} if include_provider or provider else {"memory": {}}
         (home / "config.yaml").write_text(yaml.dump(config))
         return home
 
-    def _run_doctor_and_capture(self, monkeypatch, tmp_path, provider=""):
+    def _run_doctor_and_capture(self, monkeypatch, tmp_path, provider="", include_provider=False):
         """Run doctor and capture stdout."""
-        home = self._make_hermes_home(tmp_path, provider)
+        home = self._make_hermes_home(tmp_path, provider, include_provider)
         monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
         monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
@@ -271,11 +271,20 @@ class TestDoctorMemoryProviderSection:
         assert "Honcho API key" not in out
         assert "Mem0" not in out
 
-    def test_builtin_provider_shows_builtin_ok(self, monkeypatch, tmp_path):
-        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="builtin")
+    def test_builtin_provider_aliases_show_builtin_ok(self, monkeypatch, tmp_path):
+        for provider in ("default", "builtin", "none", " BuiltIn "):
+            out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider=provider)
+
+            assert "Built-in memory active" in out
+            assert "plugin not found" not in out
+
+    def test_null_provider_shows_builtin_ok(self, monkeypatch, tmp_path):
+        out = self._run_doctor_and_capture(
+            monkeypatch, tmp_path, provider=None, include_provider=True
+        )
 
         assert "Built-in memory active" in out
-        assert "builtin plugin not found" not in out
+        assert "check failed" not in out
 
 
     def test_mem0_provider_not_installed_shows_fail(self, monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -271,6 +271,12 @@ class TestDoctorMemoryProviderSection:
         assert "Honcho API key" not in out
         assert "Mem0" not in out
 
+    def test_builtin_provider_shows_builtin_ok(self, monkeypatch, tmp_path):
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="builtin")
+
+        assert "Built-in memory active" in out
+        assert "builtin plugin not found" not in out
+
 
     def test_mem0_provider_not_installed_shows_fail(self, monkeypatch, tmp_path):
         # Make mem0 import fail

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -271,11 +271,12 @@ class TestDoctorMemoryProviderSection:
         assert "Honcho API key" not in out
         assert "Mem0" not in out
 
-    def test_builtin_provider_shows_builtin_ok(self, monkeypatch, tmp_path):
-        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="builtin")
+    def test_builtin_provider_aliases_show_builtin_ok(self, monkeypatch, tmp_path):
+        for provider in ("default", "builtin", "built-in", "none", " BuiltIn "):
+            out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider=provider)
 
-        assert "Built-in memory active" in out
-        assert "builtin plugin not found" not in out
+            assert "Built-in memory active" in out
+            assert "plugin not found" not in out
 
 
     def test_mem0_provider_not_installed_shows_fail(self, monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -224,18 +224,18 @@ def test_doctor_reports_vercel_backend_diagnostics(monkeypatch, tmp_path):
 class TestDoctorMemoryProviderSection:
     """The ◆ Memory Provider section should respect memory.provider config."""
 
-    def _make_hermes_home(self, tmp_path, provider="", include_provider=False):
+    def _make_hermes_home(self, tmp_path, provider=""):
         """Create a minimal HERMES_HOME with config.yaml."""
         home = tmp_path / ".hermes"
         home.mkdir(parents=True, exist_ok=True)
         import yaml
-        config = {"memory": {"provider": provider}} if include_provider or provider else {"memory": {}}
+        config = {"memory": {"provider": provider}} if provider else {"memory": {}}
         (home / "config.yaml").write_text(yaml.dump(config))
         return home
 
-    def _run_doctor_and_capture(self, monkeypatch, tmp_path, provider="", include_provider=False):
+    def _run_doctor_and_capture(self, monkeypatch, tmp_path, provider=""):
         """Run doctor and capture stdout."""
-        home = self._make_hermes_home(tmp_path, provider, include_provider)
+        home = self._make_hermes_home(tmp_path, provider)
         monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
         monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
@@ -271,20 +271,11 @@ class TestDoctorMemoryProviderSection:
         assert "Honcho API key" not in out
         assert "Mem0" not in out
 
-    def test_builtin_provider_aliases_show_builtin_ok(self, monkeypatch, tmp_path):
-        for provider in ("default", "builtin", "none", " BuiltIn "):
-            out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider=provider)
-
-            assert "Built-in memory active" in out
-            assert "plugin not found" not in out
-
-    def test_null_provider_shows_builtin_ok(self, monkeypatch, tmp_path):
-        out = self._run_doctor_and_capture(
-            monkeypatch, tmp_path, provider=None, include_provider=True
-        )
+    def test_builtin_provider_shows_builtin_ok(self, monkeypatch, tmp_path):
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="builtin")
 
         assert "Built-in memory active" in out
-        assert "check failed" not in out
+        assert "builtin plugin not found" not in out
 
 
     def test_mem0_provider_not_installed_shows_fail(self, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fixes #75647. `hermes doctor` now recognizes built-in memory configuration values (`default`, `builtin`, `built-in`, `none`, and blank/whitespace) instead of attempting to load them as external plugins and reporting a false warning. External provider names remain unmodified for their existing diagnostic paths.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q -k "TestDoctorMemoryProviderSection"` — 3 passed
- `.venv/bin/ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py` — passed
- `git diff --check` — passed
- Fresh Claude review of final `main...HEAD` — no findings

Note: the complete doctor test file has one pre-existing Vercel test failure on unmodified `main` in this environment; the focused memory-provider suite is green.