### PR TITLE
fix(kanban): supervise workers and recover provider access

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2236,6 +2236,10 @@ def run_conversation(
                     if isinstance(getattr(agent, "client", None), Mock):
                         _use_streaming = False
 
+                # Snapshot the concrete provider used by this request. A later
+                # fallback may mutate agent.provider before another attempt.
+                _request_provider = agent.provider
+
                 def _perform_api_call(next_api_kwargs):
                     if agent.api_mode == "codex_responses":
                         next_api_kwargs = agent._get_transport().preflight_kwargs(
@@ -5474,6 +5478,21 @@ def run_conversation(
                     assistant_message.content = "\n".join(parts)
                 else:
                     assistant_message.content = str(raw)
+
+            # Core authority: only this real, non-None provider response path,
+            # after transport normalization and content normalization, may
+            # publish durable recovery proof. Optional plugin hooks below are
+            # observational and cannot synthesize this call.
+            from agent.provider_recovery import (
+                publish_successful_live_provider_request,
+            )
+
+            publish_successful_live_provider_request(
+                provider=_request_provider,
+                request_id=api_request_id,
+                session_id=agent.session_id or "",
+                provider_observed_at=int(api_start_time + api_duration),
+            )
 
             try:
                 from hermes_cli.lifecycle import (

--- a/agent/provider_recovery.py
+++ b/agent/provider_recovery.py
@@ -1,0 +1,163 @@
+"""Core success-only publication of durable provider recovery proof.
+
+This module deliberately accepts no request/response payload, credential, usage,
+or retry metadata.  A publication is authorized only by the three trusted scope
+values explicitly injected into a supervised Kanban worker's environment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import sqlite3
+from pathlib import Path
+from typing import Mapping, Optional
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+
+logger = logging.getLogger(__name__)
+
+KANBAN_DB_ENV = "HERMES_KANBAN_DB"
+WORKER_PROFILE_ENV = "HERMES_PROFILE"
+CREDENTIAL_GENERATION_ENV = "HERMES_PROVIDER_CREDENTIAL_GENERATION"
+
+_PUBLISHER_ID = "hermes-agent-core"
+_PUBLISHER_VERSION = "r2a"
+_POSITIVE_INTEGER_RE = re.compile(r"[1-9][0-9]*\Z")
+_DB_BUSY_TIMEOUT_MS = 250
+
+
+def _trusted_scope_from_env(
+    environ: Mapping[str, str],
+) -> Optional[tuple[Path, str, int]]:
+    """Return strict supervised scope or ``None`` without touching the DB."""
+    raw_db_path = environ.get(KANBAN_DB_ENV)
+    raw_profile = environ.get(WORKER_PROFILE_ENV)
+    raw_generation = environ.get(CREDENTIAL_GENERATION_ENV)
+    if not raw_db_path or not raw_profile or not raw_generation:
+        return None
+
+    db_path = Path(raw_db_path)
+    try:
+        if not db_path.is_absolute() or not db_path.is_file():
+            return None
+    except OSError:
+        return None
+
+    try:
+        normalized_profile = normalize_profile_name(raw_profile)
+        validate_profile_name(normalized_profile)
+    except (TypeError, ValueError):
+        return None
+    if normalized_profile != raw_profile:
+        return None
+
+    if _POSITIVE_INTEGER_RE.fullmatch(raw_generation) is None:
+        return None
+    generation = int(raw_generation)
+    if generation <= 0:
+        return None
+
+    return db_path, normalized_profile, generation
+
+
+def _stable_proof_id(*, request_id: str, session_id: str) -> Optional[str]:
+    """Derive an opaque id from non-secret request/session identifiers only."""
+    if not isinstance(request_id, str) or not request_id:
+        return None
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    request_bytes = request_id.encode("utf-8")
+    session_bytes = session_id.encode("utf-8")
+    material = (
+        len(session_bytes).to_bytes(8, "big")
+        + session_bytes
+        + len(request_bytes).to_bytes(8, "big")
+        + request_bytes
+    )
+    digest = hashlib.sha256(material).hexdigest()
+    return f"provider-request:{digest}"
+
+
+def _open_recovery_db(db_path: Path) -> sqlite3.Connection:
+    """Open an existing trusted DB read/write with a short lock timeout."""
+    uri = f"{db_path.as_uri()}?mode=rw"
+    conn = sqlite3.connect(
+        uri,
+        uri=True,
+        isolation_level=None,
+        timeout=_DB_BUSY_TIMEOUT_MS / 1000,
+    )
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(f"PRAGMA busy_timeout = {_DB_BUSY_TIMEOUT_MS}")
+    return conn
+
+
+def publish_successful_live_provider_request(
+    *,
+    provider: str,
+    request_id: str,
+    session_id: str,
+    provider_observed_at: int,
+) -> bool:
+    """Durably publish one normalized live-provider success proof.
+
+    Invalid or absent supervised scope fails closed.  Once a model request has
+    succeeded, database failures fail open: they emit one fixed, bounded,
+    non-secret diagnostic and never alter the successful model result.
+    """
+    trusted_scope = _trusted_scope_from_env(os.environ)
+    if trusted_scope is None:
+        return False
+    db_path, profile, generation = trusted_scope
+
+    proof_id = _stable_proof_id(request_id=request_id, session_id=session_id)
+    if proof_id is None:
+        return False
+    if (
+        not isinstance(provider_observed_at, int)
+        or isinstance(provider_observed_at, bool)
+        or provider_observed_at <= 0
+    ):
+        return False
+
+    try:
+        scope = kb.ProviderRecoveryScope(
+            profile=profile,
+            provider=provider,
+            credential_generation=generation,
+        )
+        proof = kb.ProviderRecoveryProof(
+            stable_proof_id=proof_id,
+            scope=scope,
+            kind=kb.ProviderRecoveryProofKind.LIVE_REQUEST_SUCCEEDED,
+            provider_observed_at=provider_observed_at,
+            publisher_id=_PUBLISHER_ID,
+            publisher_version=_PUBLISHER_VERSION,
+        )
+    except (TypeError, ValueError):
+        return False
+
+    conn: Optional[sqlite3.Connection] = None
+    try:
+        conn = _open_recovery_db(db_path)
+        kb.publish_provider_recovery_event(conn, proof)
+    except Exception as exc:
+        error_type = type(exc).__name__[:64]
+        logger.warning(
+            "Provider recovery proof publication failed (%s)",
+            error_type,
+        )
+        return False
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    return True

--- a/agent/provider_recovery.py
+++ b/agent/provider_recovery.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 KANBAN_DB_ENV = "HERMES_KANBAN_DB"
 WORKER_PROFILE_ENV = "HERMES_PROFILE"
+BOUND_PROVIDER_ENV = "HERMES_PROVIDER"
 CREDENTIAL_GENERATION_ENV = "HERMES_PROVIDER_CREDENTIAL_GENERATION"
 
 _PUBLISHER_ID = "hermes-agent-core"
@@ -33,12 +34,13 @@ _DB_BUSY_TIMEOUT_MS = 250
 
 def _trusted_scope_from_env(
     environ: Mapping[str, str],
-) -> Optional[tuple[Path, str, int]]:
+) -> Optional[tuple[Path, str, str, int]]:
     """Return strict supervised scope or ``None`` without touching the DB."""
     raw_db_path = environ.get(KANBAN_DB_ENV)
     raw_profile = environ.get(WORKER_PROFILE_ENV)
+    raw_provider = environ.get(BOUND_PROVIDER_ENV)
     raw_generation = environ.get(CREDENTIAL_GENERATION_ENV)
-    if not raw_db_path or not raw_profile or not raw_generation:
+    if not raw_db_path or not raw_profile or not raw_provider or not raw_generation:
         return None
 
     db_path = Path(raw_db_path)
@@ -62,7 +64,16 @@ def _trusted_scope_from_env(
     if generation <= 0:
         return None
 
-    return db_path, normalized_profile, generation
+    try:
+        bound_scope = kb.ProviderRecoveryScope(
+            profile=normalized_profile,
+            provider=raw_provider,
+            credential_generation=generation,
+        )
+    except (TypeError, ValueError):
+        return None
+
+    return db_path, normalized_profile, bound_scope.provider, generation
 
 
 def _stable_proof_id(*, request_id: str, session_id: str) -> Optional[str]:
@@ -114,7 +125,7 @@ def publish_successful_live_provider_request(
     trusted_scope = _trusted_scope_from_env(os.environ)
     if trusted_scope is None:
         return False
-    db_path, profile, generation = trusted_scope
+    db_path, profile, bound_provider, generation = trusted_scope
 
     proof_id = _stable_proof_id(request_id=request_id, session_id=session_id)
     if proof_id is None:
@@ -132,6 +143,8 @@ def publish_successful_live_provider_request(
             provider=provider,
             credential_generation=generation,
         )
+        if scope.provider != bound_provider:
+            return False
         proof = kb.ProviderRecoveryProof(
             stable_proof_id=proof_id,
             scope=scope,

--- a/cli.py
+++ b/cli.py
@@ -4533,6 +4533,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.conversation_history: List[Dict[str, Any]] = []
         self.session_start = datetime.now()
         self._resumed = False
+        self._resume_session_validated = False
         # Per-prompt elapsed timer — started at the beginning of each chat turn,
         # frozen when the agent thread completes, displayed in the status bar.
         self._prompt_start_time: Optional[float] = None  # time.time() when turn started
@@ -17746,6 +17747,27 @@ def main(
     if query or image:
         if not cli._claim_active_session("cli", stderr=bool(quiet)):
             sys.exit(1)
+        from hermes_cli.worker_lifecycle import (
+            emit_start_identity_event,
+            worker_start_contract_configured,
+        )
+
+        _supervised_start = worker_start_contract_configured()
+        if _supervised_start:
+            # This is the child side of the dispatcher handshake.  Validate
+            # and preload the exact resume target before any credential,
+            # provider, model, image-analysis, or agent initialization work.
+            cli.tool_progress_mode = "off"
+            if not quiet or not cli._resumed:
+                print("Invalid supervised worker start contract.", file=sys.stderr)
+                sys.exit(1)
+            cli._preload_resumed_session(exact=True)
+            if not getattr(cli, "_resume_session_validated", False):
+                print("Supervised worker resume session was not found.", file=sys.stderr)
+                sys.exit(1)
+            if not emit_start_identity_event(session_id=cli.session_id):
+                print("Supervised worker identity emission failed.", file=sys.stderr)
+                sys.exit(1)
         try:
             query, single_query_images = _collect_query_images(query, image)
             # Kanban workers spawn with ``hermes chat -q "work kanban task <id>"``;

--- a/cli.py
+++ b/cli.py
@@ -17937,6 +17937,12 @@ def main(
                                     _exit_code = _RL_CODE
                                 except Exception:
                                     _exit_code = 1
+                        try:
+                            from hermes_cli.worker_lifecycle import emit_terminal_event
+
+                            emit_terminal_event(result, session_id=cli.session_id)
+                        except Exception as _lifecycle_exc:
+                            logger.debug("worker lifecycle event emission failed: %s", _lifecycle_exc)
                         sys.exit(_exit_code)
 
                 # Exit with error code if credentials or agent init fails

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -163,9 +163,35 @@ class CLIAgentSetupMixin:
                     and _provider != "auto"
                     and _state_db is not None
                 ):
-                    _generation = _state_db.get_or_create_provider_credential_generation(
+                    _bound_scope = getattr(
+                        self,
+                        "_provider_credential_generation_binding",
+                        None,
+                    )
+                    if (
+                        credentials_changed
+                        and isinstance(_bound_scope, tuple)
+                        and len(_bound_scope) == 3
+                        and _bound_scope[:2] == (_profile, _provider)
+                    ):
+                        _generation = (
+                            _state_db.rotate_provider_credential_generation(
+                                _profile,
+                                _provider,
+                                expected_generation=_bound_scope[2],
+                            )
+                        )
+                    else:
+                        _generation = (
+                            _state_db.get_or_create_provider_credential_generation(
+                                _profile,
+                                _provider,
+                            )
+                        )
+                    self._provider_credential_generation_binding = (
                         _profile,
                         _provider,
+                        _generation,
                     )
                     os.environ["HERMES_PROVIDER"] = _provider
                     os.environ["HERMES_PROVIDER_CREDENTIAL_GENERATION"] = str(

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -14,6 +14,7 @@ loaded) so this module never imports ``cli`` at import time -> no import cycle.
 
 from __future__ import annotations
 
+import os
 import sys
 
 from rich.markup import escape as _escape
@@ -96,6 +97,9 @@ class CLIAgentSetupMixin:
         # invokes it before every request. Skip the string-only validation
         # and placeholder substitution for callables.
         _is_callable_provider = callable(api_key) and not isinstance(api_key, str)
+        _credential_loaded = _is_callable_provider or (
+            isinstance(api_key, str) and bool(api_key)
+        )
         if not _is_callable_provider and (not isinstance(api_key, str) or not api_key):
             # Custom / local endpoints (llama.cpp, ollama, vLLM, etc.) often
             # don't require authentication.  When a base_url IS configured but
@@ -134,6 +138,44 @@ class CLIAgentSetupMixin:
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
+
+        # Bind provider recovery only after this exact worker loaded a usable
+        # credential. The generation is opaque profile metadata and is never
+        # derived from, or logged with, credential data.
+        os.environ.pop("HERMES_PROVIDER", None)
+        os.environ.pop("HERMES_PROVIDER_CREDENTIAL_GENERATION", None)
+        _worker_scope = (
+            os.environ.get("HERMES_KANBAN_TASK", "").strip(),
+            os.environ.get("HERMES_KANBAN_RUN_ID", "").strip(),
+            os.environ.get("HERMES_WORKER_SESSION_ID", "").strip(),
+            os.environ.get("HERMES_PROFILE", "").strip(),
+        )
+        if _credential_loaded and all(_worker_scope):
+            try:
+                from hermes_cli.profiles import normalize_profile_name
+
+                _profile = normalize_profile_name(_worker_scope[3])
+                _provider = str(resolved_provider or "").strip().lower()
+                _state_db = getattr(self, "_session_db", None)
+                if (
+                    _profile == _worker_scope[3]
+                    and _provider
+                    and _provider != "auto"
+                    and _state_db is not None
+                ):
+                    _generation = _state_db.get_or_create_provider_credential_generation(
+                        _profile,
+                        _provider,
+                    )
+                    os.environ["HERMES_PROVIDER"] = _provider
+                    os.environ["HERMES_PROVIDER_CREDENTIAL_GENERATION"] = str(
+                        _generation
+                    )
+            except Exception as _scope_exc:
+                logger.debug(
+                    "Provider recovery scope binding failed (%s)",
+                    type(_scope_exc).__name__,
+                )
 
         # When a custom_provider entry carries an explicit `model` field,
         # use it as the effective model name.  Without this, running
@@ -461,7 +503,7 @@ class CLIAgentSetupMixin:
             ChatConsole().print(f"[bold red]Failed to initialize agent: {e}[/]")
             return False
 
-    def _preload_resumed_session(self) -> bool:
+    def _preload_resumed_session(self, *, exact: bool = False) -> bool:
         """Load a resumed session's history from the DB early (before first chat).
 
         Called from run() so the conversation history is available for display
@@ -473,6 +515,7 @@ class CLIAgentSetupMixin:
         already populated and skips the DB round-trip.
         """
         from cli import _accent_hex
+        self._resume_session_validated = False
         if not self._resumed or not self._session_db:
             return False
 
@@ -487,21 +530,26 @@ class CLIAgentSetupMixin:
             )
             return False
 
-        # If the requested session is the (empty) head of a compression chain,
-        # walk to the descendant that actually holds the messages. See #15000.
-        try:
-            resolved_id = self._session_db.resolve_resume_session_id(self.session_id)
-        except Exception:
-            resolved_id = self.session_id
-        if resolved_id and resolved_id != self.session_id:
-            self._console_print(
-                f"[dim]Session {self.session_id} was compressed into "
-                f"{resolved_id}; resuming the descendant with your transcript.[/]"
-            )
-            self.session_id = resolved_id
-            resolved_meta = self._session_db.get_session(self.session_id)
-            if resolved_meta:
-                session_meta = resolved_meta
+        if not exact:
+            # If the requested session is the (empty) head of a compression
+            # chain, walk to the descendant that actually holds the messages.
+            # Supervised starts deliberately disable this fuzzy resolution:
+            # their nonce contract binds one exact pre-created session.
+            try:
+                resolved_id = self._session_db.resolve_resume_session_id(self.session_id)
+            except Exception:
+                resolved_id = self.session_id
+            if resolved_id and resolved_id != self.session_id:
+                self._console_print(
+                    f"[dim]Session {self.session_id} was compressed into "
+                    f"{resolved_id}; resuming the descendant with your transcript.[/]"
+                )
+                self.session_id = resolved_id
+                resolved_meta = self._session_db.get_session(self.session_id)
+                if resolved_meta:
+                    session_meta = resolved_meta
+
+        self._resume_session_validated = True
 
         model_history, display_history = self._session_db.get_resume_conversations(self.session_id)
         restored = model_history

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10628,7 +10628,7 @@ def publish_provider_recovery_event(
             WHERE w.profile = ?
               AND w.provider = ?
               AND w.credential_generation = ?
-              AND w.waiting_at <= ?
+              AND w.waiting_at < ?
             """,
             (
                 event_id,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9242,7 +9242,7 @@ def _precreate_supervised_worker_session(
     try:
         session_db.create_session(
             session_id,
-            source="cli",
+            source="kanban",
             cwd=canonical_workspace,
             profile_name=profile_name,
             git_repo_root=canonical_workspace,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -86,6 +86,7 @@ import logging
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
 
@@ -1142,6 +1143,154 @@ class Event:
     run_id: Optional[int] = None
 
 
+class ProviderRecoveryProofKind(str, Enum):
+    """Successful live observations that are sufficient recovery proof."""
+
+    LIVE_REQUEST_SUCCEEDED = "live_request_succeeded"
+    LIVE_VALIDATION_SUCCEEDED = "live_validation_succeeded"
+
+
+class ProviderRecoveryDeliveryState(str, Enum):
+    PENDING = "pending"
+    DELIVERED = "delivered"
+    STALE = "stale"
+
+
+_RECOVERY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+def _strict_recovery_id(value: object, *, field_name: str) -> str:
+    """Normalize a non-secret metadata identifier to a narrow safe alphabet."""
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} cannot be empty")
+    if not _RECOVERY_ID_RE.fullmatch(normalized):
+        raise ValueError(f"{field_name} must be a non-secret identifier")
+    return normalized
+
+
+def _strict_recovery_timestamp(value: object, *, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an integer Unix timestamp")
+    if value <= 0:
+        raise ValueError(f"{field_name} must be positive")
+    return value
+
+
+@dataclass(frozen=True)
+class ProviderRecoveryScope:
+    """Normalized recovery identity without any credential material.
+
+    The generation is a positive monotonic number, not a credential
+    fingerprint. Its integer type makes values and hashes structurally
+    impossible to persist in the scope.
+    """
+
+    profile: str
+    provider: str
+    credential_generation: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.profile, str) or not self.profile.strip():
+            raise ValueError("profile must be a nonempty string")
+        from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+        profile = normalize_profile_name(self.profile)
+        validate_profile_name(profile)
+
+        if not isinstance(self.provider, str) or not self.provider.strip():
+            raise ValueError("provider must be a nonempty string")
+        from hermes_cli.models import normalize_provider
+
+        provider = _strict_recovery_id(
+            normalize_provider(self.provider), field_name="provider"
+        ).lower()
+        # ``open-router`` is a common display spelling but the durable Hermes
+        # provider id is ``openrouter``. Keep hyphens in all other provider ids
+        # because several canonical providers legitimately use them.
+        if provider == "open-router":
+            provider = "openrouter"
+        if provider == "auto":
+            raise ValueError("provider recovery scope requires a concrete provider")
+
+        generation = self.credential_generation
+        if isinstance(generation, bool) or not isinstance(generation, int):
+            raise TypeError("credential_generation must be a positive integer")
+        if generation <= 0:
+            raise ValueError("credential_generation must be positive")
+
+        object.__setattr__(self, "profile", profile)
+        object.__setattr__(self, "provider", provider)
+
+
+@dataclass(frozen=True)
+class ProviderRecoveryProof:
+    """Successful live proof with no payload or secret-bearing fields."""
+
+    stable_proof_id: str
+    scope: ProviderRecoveryScope
+    kind: ProviderRecoveryProofKind
+    provider_observed_at: int
+    publisher_id: str
+    publisher_version: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope, ProviderRecoveryScope):
+            raise TypeError("scope must be ProviderRecoveryScope")
+        if not isinstance(self.kind, ProviderRecoveryProofKind):
+            raise ValueError("kind must be a successful live provider proof kind")
+        object.__setattr__(
+            self, "stable_proof_id",
+            _strict_recovery_id(self.stable_proof_id, field_name="stable_proof_id"),
+        )
+        object.__setattr__(
+            self, "provider_observed_at",
+            _strict_recovery_timestamp(
+                self.provider_observed_at, field_name="provider_observed_at"
+            ),
+        )
+        object.__setattr__(
+            self, "publisher_id",
+            _strict_recovery_id(self.publisher_id, field_name="publisher_id"),
+        )
+        object.__setattr__(
+            self, "publisher_version",
+            _strict_recovery_id(self.publisher_version, field_name="publisher_version"),
+        )
+
+
+@dataclass(frozen=True)
+class ProviderRecoveryEvent:
+    id: int
+    stable_proof_id: str
+    scope: ProviderRecoveryScope
+    kind: ProviderRecoveryProofKind
+    provider_observed_at: int
+    publisher_id: str
+    publisher_version: str
+    inserted_at: int
+
+
+@dataclass(frozen=True)
+class ProviderRecoveryDelivery:
+    event_id: int
+    task_id: str
+    run_id: int
+    session_id: str
+    state: ProviderRecoveryDeliveryState
+    created_at: int
+    claim_owner: Optional[str]
+    claim_expires: Optional[int]
+    resolved_at: Optional[int]
+    scope: ProviderRecoveryScope
+    proof_kind: ProviderRecoveryProofKind
+    provider_observed_at: int
+    publisher_id: str
+    publisher_version: str
+
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -1324,6 +1473,52 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Exact-run registrations awaiting a successful live provider observation.
+-- No credential, header, token, request, or response material belongs here.
+CREATE TABLE IF NOT EXISTS provider_recovery_waits (
+    task_id               TEXT NOT NULL,
+    run_id                INTEGER NOT NULL,
+    session_id            TEXT NOT NULL,
+    profile               TEXT NOT NULL,
+    provider              TEXT NOT NULL,
+    credential_generation INTEGER NOT NULL CHECK (credential_generation > 0),
+    waiting_at             INTEGER NOT NULL,
+    PRIMARY KEY (task_id, run_id, session_id)
+);
+
+-- Append-only successful live provider proofs. stable_proof_id makes retries
+-- idempotent while the complete row comparison rejects identity collisions.
+CREATE TABLE IF NOT EXISTS provider_recovery_events (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    stable_proof_id       TEXT NOT NULL UNIQUE,
+    profile               TEXT NOT NULL,
+    provider              TEXT NOT NULL,
+    credential_generation INTEGER NOT NULL CHECK (credential_generation > 0),
+    proof_kind            TEXT NOT NULL CHECK (
+        proof_kind IN ('live_request_succeeded', 'live_validation_succeeded')
+    ),
+    provider_observed_at  INTEGER NOT NULL,
+    publisher_id          TEXT NOT NULL,
+    publisher_version     TEXT NOT NULL,
+    inserted_at           INTEGER NOT NULL
+);
+
+-- Per-event fanout. An event is never globally consumed: every exact waiter
+-- has an independently leased pending/delivered/stale delivery.
+CREATE TABLE IF NOT EXISTS provider_recovery_deliveries (
+    event_id      INTEGER NOT NULL,
+    task_id       TEXT NOT NULL,
+    run_id        INTEGER NOT NULL,
+    session_id    TEXT NOT NULL,
+    state         TEXT NOT NULL DEFAULT 'pending'
+                  CHECK (state IN ('pending', 'delivered', 'stale')),
+    created_at    INTEGER NOT NULL,
+    claim_owner   TEXT,
+    claim_expires INTEGER,
+    resolved_at   INTEGER,
+    PRIMARY KEY (event_id, task_id, run_id, session_id)
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -1334,6 +1529,12 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_provider_recovery_wait_scope
+    ON provider_recovery_waits(profile, provider, credential_generation, waiting_at);
+CREATE INDEX IF NOT EXISTS idx_provider_recovery_event_scope
+    ON provider_recovery_events(profile, provider, credential_generation, id);
+CREATE INDEX IF NOT EXISTS idx_provider_recovery_delivery_claim
+    ON provider_recovery_deliveries(state, claim_expires, event_id);
 """
 
 
@@ -8274,6 +8475,8 @@ def _dispatch_once_locked(
     reap_worker_zombies()
 
     result = DispatchResult()
+    if not dry_run:
+        _consume_provider_recovery_deliveries(conn, board=board)
     result.reclaimed = release_stale_claims(conn)
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
@@ -8901,6 +9104,9 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
 
 
 _dispatcher_worker_supervisors: dict[str, Any] = {}
+_provider_recovery_consumer_id = (
+    f"dispatcher-{os.getpid()}-{secrets.token_hex(8)}"
+)
 
 
 def _dispatcher_worker_supervisor(*, board: Optional[str] = None):
@@ -8918,11 +9124,23 @@ def _dispatcher_worker_supervisor(*, board: Optional[str] = None):
     return supervisor
 
 
+def _supervised_worker_profile_state_db(task: Task) -> tuple[str, Path]:
+    """Return the exact assignee profile and state DB used by its worker."""
+    from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+
+    if not task.assignee:
+        raise ValueError(f"task {task.id} has no assignee")
+    profile_name = normalize_profile_name(task.assignee)
+    return profile_name, Path(resolve_profile_env(profile_name)) / "state.db"
+
+
 def signal_worker_recovery(
     task_id: str,
     reason: str,
     *,
     board: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
+    expected_session_id: Optional[str] = None,
 ) -> bool:
     """Deliver recovery only to the board's exact current supervised run."""
     from hermes_cli.worker_supervisor import WorkerIdentity
@@ -8936,9 +9154,18 @@ def signal_worker_recovery(
         task = get_task(conn, task_id)
     finally:
         conn.close()
-    if task is None or task.current_run_id is None or not task.workspace_path:
+    if (
+        task is None
+        or task.status != "running"
+        or task.current_run_id is None
+        or not task.workspace_path
+    ):
         return False
     session_id = task.session_id or f"kanban:{task.id}:{task.current_run_id}"
+    if expected_run_id is not None and task.current_run_id != expected_run_id:
+        return False
+    if expected_session_id is not None and session_id != expected_session_id:
+        return False
     identity = WorkerIdentity(
         task.id,
         session_id,
@@ -8948,11 +9175,90 @@ def signal_worker_recovery(
     return bool(supervisor.signal_recovery(identity, reason))
 
 
+def _consume_provider_recovery_deliveries(
+    conn: sqlite3.Connection,
+    *,
+    board: Optional[str] = None,
+) -> None:
+    """Lease and deliver durable recovery proof to exact waiting runs only."""
+    claimed = claim_provider_recovery_deliveries(
+        conn,
+        consumer_id=_provider_recovery_consumer_id,
+    )
+    for delivery in claimed:
+        delivered = signal_worker_recovery(
+            delivery.task_id,
+            "provider_recovered",
+            board=board,
+            expected_run_id=delivery.run_id,
+            expected_session_id=delivery.session_id,
+        )
+        marker = (
+            mark_provider_recovery_delivery_delivered
+            if delivered
+            else mark_provider_recovery_delivery_stale
+        )
+        marker(
+            conn,
+            event_id=delivery.event_id,
+            task_id=delivery.task_id,
+            run_id=delivery.run_id,
+            session_id=delivery.session_id,
+            consumer_id=_provider_recovery_consumer_id,
+        )
+
+
 def _record_supervised_worker_exit(attempt_exit) -> None:
     """Retain a Popen.wait return code for existing crash classification."""
     returncode = int(attempt_exit.exit_code)
     raw_status = returncode << 8 if returncode >= 0 else -returncode
     _record_worker_exit(int(attempt_exit.pid), raw_status)
+
+
+def _precreate_supervised_worker_session(
+    task: Task,
+    workspace: str,
+    *,
+    board: Optional[str] = None,
+) -> str:
+    """Create and project the durable CLI session bound to this worker run."""
+    import uuid
+
+    from hermes_state import SessionDB
+
+    if not task.assignee:
+        raise ValueError(f"task {task.id} has no assignee")
+    if task.current_run_id is None:
+        raise RuntimeError(f"task {task.id} has no current run")
+
+    profile_name, state_db_path = _supervised_worker_profile_state_db(task)
+    canonical_workspace = str(Path(workspace).resolve())
+    session_id = f"worker_{uuid.uuid4().hex}"
+    session_db = SessionDB(state_db_path)
+    try:
+        session_db.create_session(
+            session_id,
+            source="cli",
+            cwd=canonical_workspace,
+            profile_name=profile_name,
+            git_repo_root=canonical_workspace,
+        )
+    finally:
+        session_db.close()
+
+    conn = connect(kanban_db_path(board=board).resolve())
+    try:
+        with write_txn(conn):
+            cur = conn.execute(
+                "UPDATE tasks SET session_id = ? "
+                "WHERE id = ? AND status = 'running' AND current_run_id IS ?",
+                (session_id, task.id, task.current_run_id),
+            )
+            if cur.rowcount != 1:
+                raise RuntimeError("worker session projection lost exact run ownership")
+    finally:
+        conn.close()
+    return session_id
 
 
 def _start_supervised_worker(
@@ -8962,9 +9268,22 @@ def _start_supervised_worker(
     board: Optional[str] = None,
 ) -> Optional[int]:
     """Launch and retain a real dispatcher child under lifecycle supervision."""
-    from hermes_cli.worker_supervisor import WorkerIdentity
+    from hermes_cli.worker_supervisor import (
+        SessionCompressionLineageResolver,
+        WorkerIdentity,
+    )
 
-    session_id = task.session_id or f"kanban:{task.id}:{task.current_run_id or 0}"
+    lineage_resolver = None
+    if _default_spawn is _PRODUCTION_DEFAULT_SPAWN:
+        _, state_db_path = _supervised_worker_profile_state_db(task)
+        session_id = _precreate_supervised_worker_session(
+            task, workspace, board=board,
+        )
+        lineage_resolver = SessionCompressionLineageResolver(state_db_path)
+    else:
+        # Keep the existing monkeypatch/injection seam behaviorally unchanged;
+        # durable prebinding belongs to the production CLI launch only.
+        session_id = task.session_id or f"{task.id}-run-{task.current_run_id}"
     identity = WorkerIdentity(
         task.id,
         session_id,
@@ -8974,9 +9293,21 @@ def _start_supervised_worker(
     db_path = kanban_db_path(board=board).resolve()
     stable_run_id = task.current_run_id
 
-    def launch(_identity, attempt: int, event_path: Path):
+    def launch(
+        _identity,
+        attempt: int,
+        event_path: Path,
+        *,
+        start_nonce: Optional[str] = None,
+    ):
         return _spawn_supervised_attempt(
-            task, workspace, identity, attempt, event_path, board=board
+            task,
+            workspace,
+            identity,
+            attempt,
+            event_path,
+            board=board,
+            start_nonce=start_nonce,
         )
 
     def on_exit(attempt_exit) -> None:
@@ -8988,6 +9319,28 @@ def _start_supervised_worker(
                     event_conn, task.id, "worker_attempt_exit",
                     attempt_exit.as_dict(), run_id=stable_run_id,
                 )
+            if attempt_exit.classification == "transient_provider":
+                terminal_events = [
+                    event
+                    for event in attempt_exit.events
+                    if isinstance(event, dict) and event.get("kind") == "terminal"
+                ]
+                if len(terminal_events) == 1:
+                    terminal_event = terminal_events[0]
+                    try:
+                        scope = ProviderRecoveryScope(
+                            terminal_event.get("profile"),
+                            terminal_event.get("provider"),
+                            terminal_event.get("credential_generation"),
+                        )
+                    except (TypeError, ValueError):
+                        pass
+                    else:
+                        register_provider_recovery_wait(
+                            event_conn,
+                            evidence=attempt_exit,
+                            scope=scope,
+                        )
         finally:
             event_conn.close()
 
@@ -9022,18 +9375,13 @@ def _start_supervised_worker(
             event_conn.close()
 
     supervisor = _dispatcher_worker_supervisor(board=board)
-    initial_event_path = supervisor.allocate_event_path(identity, 1)
-    initial_proc = _spawn_supervised_attempt(
-        task, workspace, identity, 1, initial_event_path, board=board
-    )
     handle = supervisor.start(
         identity,
         launch,
         on_exit=on_exit,
         on_pid=on_pid,
         notifier=notify,
-        initial_proc=initial_proc,
-        initial_event_path=initial_event_path,
+        lineage_resolver=lineage_resolver,
     )
     return handle.pid
 
@@ -9046,6 +9394,7 @@ def _spawn_supervised_attempt(
     event_path: Path,
     *,
     board: Optional[str],
+    start_nonce: Optional[str] = None,
 ):
     """Invoke production spawn while preserving older injected test seams."""
     import inspect
@@ -9056,10 +9405,16 @@ def _spawn_supervised_attempt(
         "lifecycle_attempt": attempt,
     }
     parameters = inspect.signature(_default_spawn).parameters
+    accepts_kwargs = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
     if "worker_session_id" in parameters:
         kwargs["worker_session_id"] = identity.session_id
-    if attempt > 1 and "resume_session_id" in parameters:
+    if "resume_session_id" in parameters:
         kwargs["resume_session_id"] = identity.session_id
+    if "start_nonce" in parameters or accepts_kwargs:
+        kwargs["start_nonce"] = start_nonce
     return _default_spawn(task, workspace, **kwargs)
 
 
@@ -9072,6 +9427,10 @@ def _default_spawn(
     lifecycle_attempt: int = 1,
     worker_session_id: Optional[str] = None,
     resume_session_id: Optional[str] = None,
+    start_nonce: Optional[str] = None,
+    provider_recovery_db_path: Optional[Path] = None,
+    provider_recovery_profile: Optional[str] = None,
+    provider_credential_generation: Optional[int] = None,
 ):
     """Spawn ``hermes -p <profile> chat -q ...`` and return its live handle.
 
@@ -9099,6 +9458,10 @@ def _default_spawn(
     from gateway.session_context import _VAR_MAP
     for key in _VAR_MAP:
         env.pop(key, None)
+    # Recovery proof authority must never leak from a dispatcher's inherited
+    # environment. R2a does not create a generation; a later dispatcher slice
+    # may pass the complete trusted scope explicitly through these arguments.
+    env.pop("HERMES_PROVIDER_CREDENTIAL_GENERATION", None)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root
@@ -9121,7 +9484,7 @@ def _default_spawn(
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
-    env["HERMES_KANBAN_WORKSPACE"] = workspace
+    env["HERMES_KANBAN_WORKSPACE"] = str(Path(workspace).resolve())
     # Tag the worker's session so it lands in state.db as `kanban`, not as an
     # untitled `cli` row. A worker is a dispatcher-owned run whose transcript is
     # read on the board and in `hermes kanban log` — it is not a conversation
@@ -9131,8 +9494,11 @@ def _default_spawn(
     # ("work kanban task t_…").
     env["HERMES_SESSION_SOURCE"] = "kanban"
     if lifecycle_event_path is not None:
+        if not start_nonce:
+            raise ValueError("supervised worker launch requires a start nonce")
         env["HERMES_WORKER_LIFECYCLE_EVENT_PATH"] = str(lifecycle_event_path)
         env["HERMES_WORKER_LIFECYCLE_ATTEMPT"] = str(int(lifecycle_attempt))
+        env["HERMES_WORKER_START_NONCE"] = str(start_nonce)
     if worker_session_id:
         env["HERMES_WORKER_SESSION_ID"] = str(worker_session_id)
     # Pin TERMINAL_CWD to the task's workspace so the worker's file tools and
@@ -9193,6 +9559,32 @@ def _default_spawn(
     # what the tool reads — set it explicitly here so comments are
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
+
+    recovery_scope_args = (
+        provider_recovery_db_path,
+        provider_recovery_profile,
+        provider_credential_generation,
+    )
+    if any(value is not None for value in recovery_scope_args):
+        if not all(value is not None for value in recovery_scope_args):
+            raise ValueError("provider recovery launch scope must be complete")
+        recovery_db_path = Path(provider_recovery_db_path)
+        recovery_profile = normalize_profile_name(str(provider_recovery_profile))
+        if not recovery_db_path.is_absolute():
+            raise ValueError("provider recovery DB path must be absolute")
+        if recovery_profile != provider_recovery_profile or recovery_profile != profile_arg:
+            raise ValueError("provider recovery profile must be the normalized worker profile")
+        if (
+            isinstance(provider_credential_generation, bool)
+            or not isinstance(provider_credential_generation, int)
+            or provider_credential_generation <= 0
+        ):
+            raise ValueError("provider credential generation must be a positive integer")
+        env["HERMES_KANBAN_DB"] = str(recovery_db_path)
+        env["HERMES_PROFILE"] = recovery_profile
+        env["HERMES_PROVIDER_CREDENTIAL_GENERATION"] = str(
+            provider_credential_generation
+        )
 
     # A worker must NEVER boot the interactive TUI: an inherited HERMES_TUI=1
     # or a `display.interface: tui` in the profile's config would send the
@@ -9274,6 +9666,9 @@ def _default_spawn(
     # reference goes out of scope and is GC'd, but the OS-level FD stays
     # open in the child until the child exits.
     return proc
+
+
+_PRODUCTION_DEFAULT_SPAWN = _default_spawn
 
 
 # ---------------------------------------------------------------------------
@@ -10016,6 +10411,484 @@ def rewind_notify_cursor(
             ),
         )
     return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Durable provider recovery
+# ---------------------------------------------------------------------------
+
+def register_provider_recovery_wait(
+    conn: sqlite3.Connection,
+    *,
+    evidence: object,
+    scope: ProviderRecoveryScope,
+    waiting_at: Optional[int] = None,
+) -> bool:
+    """Register one exact running attempt after typed provider failure evidence.
+
+    ``AttemptExit`` is the supervisor's validated terminal evidence type. The
+    registration CAS proves that its task/run/session triple is still the exact
+    running attempt in both ``tasks`` and ``task_runs``. Re-registration of the
+    same exact scope is idempotent and never replaces the original timestamp.
+    """
+    from hermes_cli.worker_supervisor import AttemptExit
+
+    if not isinstance(scope, ProviderRecoveryScope):
+        raise TypeError("scope must be ProviderRecoveryScope")
+    if not isinstance(evidence, AttemptExit):
+        raise TypeError("evidence must be typed AttemptExit terminal evidence")
+    if evidence.classification != "transient_provider":
+        return False
+    if not evidence.task_id or not evidence.session_id:
+        return False
+    if isinstance(evidence.run_id, bool) or int(evidence.run_id) <= 0:
+        return False
+    wait_time = _strict_recovery_timestamp(
+        int(time.time()) if waiting_at is None else waiting_at,
+        field_name="waiting_at",
+    )
+
+    with write_txn(conn):
+        current = conn.execute(
+            """
+            SELECT 1
+            FROM tasks AS t
+            JOIN task_runs AS r
+              ON r.id = t.current_run_id AND r.task_id = t.id
+            WHERE t.id = ?
+              AND t.current_run_id = ?
+              AND t.session_id = ?
+              AND t.status = 'running'
+              AND r.status = 'running'
+              AND r.ended_at IS NULL
+            """,
+            (evidence.task_id, evidence.run_id, evidence.session_id),
+        ).fetchone()
+        if current is None:
+            return False
+
+        existing = conn.execute(
+            """
+            SELECT profile, provider, credential_generation
+            FROM provider_recovery_waits
+            WHERE task_id = ? AND run_id = ? AND session_id = ?
+            """,
+            (evidence.task_id, evidence.run_id, evidence.session_id),
+        ).fetchone()
+        if existing is not None:
+            return (
+                existing["profile"] == scope.profile
+                and existing["provider"] == scope.provider
+                and int(existing["credential_generation"])
+                == scope.credential_generation
+            )
+
+        conn.execute(
+            """
+            INSERT INTO provider_recovery_waits (
+                task_id, run_id, session_id,
+                profile, provider, credential_generation, waiting_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                evidence.task_id,
+                evidence.run_id,
+                evidence.session_id,
+                scope.profile,
+                scope.provider,
+                scope.credential_generation,
+                wait_time,
+            ),
+        )
+        return True
+
+
+def close_provider_recovery_wait(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    run_id: int,
+    session_id: str,
+) -> bool:
+    """Remove only the specified exact wait registration."""
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            DELETE FROM provider_recovery_waits
+            WHERE task_id = ? AND run_id = ? AND session_id = ?
+            """,
+            (task_id, run_id, session_id),
+        )
+    return cur.rowcount == 1
+
+
+def _provider_recovery_event_from_row(row: sqlite3.Row) -> ProviderRecoveryEvent:
+    return ProviderRecoveryEvent(
+        id=int(row["id"]),
+        stable_proof_id=row["stable_proof_id"],
+        scope=ProviderRecoveryScope(
+            row["profile"], row["provider"], int(row["credential_generation"])
+        ),
+        kind=ProviderRecoveryProofKind(row["proof_kind"]),
+        provider_observed_at=int(row["provider_observed_at"]),
+        publisher_id=row["publisher_id"],
+        publisher_version=row["publisher_version"],
+        inserted_at=int(row["inserted_at"]),
+    )
+
+
+def _provider_recovery_event_matches_proof(
+    event: ProviderRecoveryEvent, proof: ProviderRecoveryProof
+) -> bool:
+    return (
+        event.stable_proof_id == proof.stable_proof_id
+        and event.scope == proof.scope
+        and event.kind == proof.kind
+        and event.provider_observed_at == proof.provider_observed_at
+        and event.publisher_id == proof.publisher_id
+        and event.publisher_version == proof.publisher_version
+    )
+
+
+def publish_provider_recovery_event(
+    conn: sqlite3.Connection,
+    proof: ProviderRecoveryProof,
+    *,
+    inserted_at: Optional[int] = None,
+) -> ProviderRecoveryEvent:
+    """Append one successful proof and atomically materialize its fanout.
+
+    A stable proof id retry returns the original immutable event. Reusing that
+    id for different proof metadata is rejected instead of conflating proofs.
+    """
+    if not isinstance(proof, ProviderRecoveryProof):
+        raise TypeError("proof must be ProviderRecoveryProof")
+    insertion_time = _strict_recovery_timestamp(
+        int(time.time()) if inserted_at is None else inserted_at,
+        field_name="inserted_at",
+    )
+
+    with write_txn(conn):
+        existing_row = conn.execute(
+            "SELECT * FROM provider_recovery_events WHERE stable_proof_id = ?",
+            (proof.stable_proof_id,),
+        ).fetchone()
+        if existing_row is not None:
+            existing = _provider_recovery_event_from_row(existing_row)
+            if not _provider_recovery_event_matches_proof(existing, proof):
+                raise ValueError("stable proof id already identifies a different proof")
+            return existing
+
+        cur = conn.execute(
+            """
+            INSERT INTO provider_recovery_events (
+                stable_proof_id, profile, provider, credential_generation,
+                proof_kind, provider_observed_at,
+                publisher_id, publisher_version, inserted_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                proof.stable_proof_id,
+                proof.scope.profile,
+                proof.scope.provider,
+                proof.scope.credential_generation,
+                proof.kind.value,
+                proof.provider_observed_at,
+                proof.publisher_id,
+                proof.publisher_version,
+                insertion_time,
+            ),
+        )
+        event_id = int(cur.lastrowid)
+
+        # Fanout is part of the event insertion transaction. Only waiters that
+        # existed before the provider observation and still identify the exact
+        # current running attempt receive a delivery.
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO provider_recovery_deliveries (
+                event_id, task_id, run_id, session_id, state, created_at
+            )
+            SELECT ?, w.task_id, w.run_id, w.session_id, 'pending', ?
+            FROM provider_recovery_waits AS w
+            JOIN tasks AS t
+              ON t.id = w.task_id
+             AND t.current_run_id = w.run_id
+             AND t.session_id = w.session_id
+             AND t.status = 'running'
+            JOIN task_runs AS r
+              ON r.id = w.run_id
+             AND r.task_id = w.task_id
+             AND r.status = 'running'
+             AND r.ended_at IS NULL
+            WHERE w.profile = ?
+              AND w.provider = ?
+              AND w.credential_generation = ?
+              AND w.waiting_at <= ?
+            """,
+            (
+                event_id,
+                insertion_time,
+                proof.scope.profile,
+                proof.scope.provider,
+                proof.scope.credential_generation,
+                proof.provider_observed_at,
+            ),
+        )
+        row = conn.execute(
+            "SELECT * FROM provider_recovery_events WHERE id = ?", (event_id,)
+        ).fetchone()
+        return _provider_recovery_event_from_row(row)
+
+
+_PROVIDER_RECOVERY_DELIVERY_SELECT = """
+    SELECT
+        d.event_id, d.task_id, d.run_id, d.session_id, d.state,
+        d.created_at, d.claim_owner, d.claim_expires, d.resolved_at,
+        e.profile, e.provider, e.credential_generation, e.proof_kind,
+        e.provider_observed_at, e.publisher_id, e.publisher_version
+    FROM provider_recovery_deliveries AS d
+    JOIN provider_recovery_events AS e ON e.id = d.event_id
+"""
+
+
+def _provider_recovery_delivery_from_row(
+    row: sqlite3.Row,
+) -> ProviderRecoveryDelivery:
+    return ProviderRecoveryDelivery(
+        event_id=int(row["event_id"]),
+        task_id=row["task_id"],
+        run_id=int(row["run_id"]),
+        session_id=row["session_id"],
+        state=ProviderRecoveryDeliveryState(row["state"]),
+        created_at=int(row["created_at"]),
+        claim_owner=row["claim_owner"],
+        claim_expires=(
+            int(row["claim_expires"])
+            if row["claim_expires"] is not None
+            else None
+        ),
+        resolved_at=(
+            int(row["resolved_at"]) if row["resolved_at"] is not None else None
+        ),
+        scope=ProviderRecoveryScope(
+            row["profile"], row["provider"], int(row["credential_generation"])
+        ),
+        proof_kind=ProviderRecoveryProofKind(row["proof_kind"]),
+        provider_observed_at=int(row["provider_observed_at"]),
+        publisher_id=row["publisher_id"],
+        publisher_version=row["publisher_version"],
+    )
+
+
+def list_provider_recovery_deliveries(
+    conn: sqlite3.Connection,
+    *,
+    event_id: Optional[int] = None,
+    state: Optional[ProviderRecoveryDeliveryState] = None,
+) -> list[ProviderRecoveryDelivery]:
+    """List durable deliveries without claiming or consuming them."""
+    clauses: list[str] = []
+    params: list[object] = []
+    if event_id is not None:
+        clauses.append("d.event_id = ?")
+        params.append(int(event_id))
+    if state is not None:
+        if not isinstance(state, ProviderRecoveryDeliveryState):
+            raise TypeError("state must be ProviderRecoveryDeliveryState")
+        clauses.append("d.state = ?")
+        params.append(state.value)
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    rows = conn.execute(
+        _PROVIDER_RECOVERY_DELIVERY_SELECT
+        + where
+        + " ORDER BY d.event_id, d.task_id, d.run_id, d.session_id",
+        params,
+    ).fetchall()
+    return [_provider_recovery_delivery_from_row(row) for row in rows]
+
+
+def claim_provider_recovery_deliveries(
+    conn: sqlite3.Connection,
+    *,
+    consumer_id: str,
+    limit: int = 100,
+    lease_seconds: int = 60,
+    now: Optional[int] = None,
+) -> list[ProviderRecoveryDelivery]:
+    """Exclusively lease pending deliveries, reclaiming expired leases."""
+    owner = _strict_recovery_id(consumer_id, field_name="consumer_id")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 1000:
+        raise ValueError("limit must be an integer from 1 to 1000")
+    if (
+        isinstance(lease_seconds, bool)
+        or not isinstance(lease_seconds, int)
+        or not 1 <= lease_seconds <= 86_400
+    ):
+        raise ValueError("lease_seconds must be an integer from 1 to 86400")
+    claim_time = _strict_recovery_timestamp(
+        int(time.time()) if now is None else now, field_name="now"
+    )
+    lease_expires = claim_time + lease_seconds
+
+    with write_txn(conn):
+        keys = conn.execute(
+            """
+            SELECT event_id, task_id, run_id, session_id
+            FROM provider_recovery_deliveries
+            WHERE state = 'pending'
+              AND (
+                    claim_owner IS NULL
+                 OR claim_expires IS NULL
+                 OR claim_expires <= ?
+              )
+            ORDER BY event_id, task_id, run_id, session_id
+            LIMIT ?
+            """,
+            (claim_time, limit),
+        ).fetchall()
+        claimed: list[ProviderRecoveryDelivery] = []
+        for key in keys:
+            cur = conn.execute(
+                """
+                UPDATE provider_recovery_deliveries
+                SET claim_owner = ?, claim_expires = ?
+                WHERE event_id = ? AND task_id = ? AND run_id = ? AND session_id = ?
+                  AND state = 'pending'
+                  AND (
+                        claim_owner IS NULL
+                     OR claim_expires IS NULL
+                     OR claim_expires <= ?
+                  )
+                """,
+                (
+                    owner,
+                    lease_expires,
+                    key["event_id"],
+                    key["task_id"],
+                    key["run_id"],
+                    key["session_id"],
+                    claim_time,
+                ),
+            )
+            if cur.rowcount != 1:
+                continue
+            row = conn.execute(
+                _PROVIDER_RECOVERY_DELIVERY_SELECT
+                + " WHERE d.event_id = ? AND d.task_id = ? AND d.run_id = ? "
+                "AND d.session_id = ?",
+                (
+                    key["event_id"], key["task_id"],
+                    key["run_id"], key["session_id"],
+                ),
+            ).fetchone()
+            claimed.append(_provider_recovery_delivery_from_row(row))
+        return claimed
+
+
+def mark_provider_recovery_delivery_delivered(
+    conn: sqlite3.Connection,
+    *,
+    event_id: int,
+    task_id: str,
+    run_id: int,
+    session_id: str,
+    consumer_id: str,
+    now: Optional[int] = None,
+) -> bool:
+    """Resolve a claimed delivery only while its exact run remains current."""
+    owner = _strict_recovery_id(consumer_id, field_name="consumer_id")
+    resolved = _strict_recovery_timestamp(
+        int(time.time()) if now is None else now, field_name="now"
+    )
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE provider_recovery_deliveries AS d
+            SET state = 'delivered', resolved_at = ?,
+                claim_owner = NULL, claim_expires = NULL
+            WHERE d.event_id = ? AND d.task_id = ?
+              AND d.run_id = ? AND d.session_id = ?
+              AND d.state = 'pending'
+              AND d.claim_owner = ? AND d.claim_expires > ?
+              AND EXISTS (
+                  SELECT 1
+                  FROM tasks AS t
+                  JOIN task_runs AS r
+                    ON r.id = t.current_run_id AND r.task_id = t.id
+                  WHERE t.id = d.task_id
+                    AND t.current_run_id = d.run_id
+                    AND t.session_id = d.session_id
+                    AND t.status = 'running'
+                    AND r.status = 'running'
+                    AND r.ended_at IS NULL
+              )
+            """,
+            (resolved, event_id, task_id, run_id, session_id, owner, resolved),
+        )
+        if cur.rowcount != 1:
+            return False
+        conn.execute(
+            """
+            DELETE FROM provider_recovery_waits
+            WHERE task_id = ? AND run_id = ? AND session_id = ?
+            """,
+            (task_id, run_id, session_id),
+        )
+        return True
+
+
+def mark_provider_recovery_delivery_stale(
+    conn: sqlite3.Connection,
+    *,
+    event_id: int,
+    task_id: str,
+    run_id: int,
+    session_id: str,
+    consumer_id: str,
+    now: Optional[int] = None,
+) -> bool:
+    """Resolve only an old exact delivery whose run is no longer current."""
+    owner = _strict_recovery_id(consumer_id, field_name="consumer_id")
+    resolved = _strict_recovery_timestamp(
+        int(time.time()) if now is None else now, field_name="now"
+    )
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE provider_recovery_deliveries AS d
+            SET state = 'stale', resolved_at = ?,
+                claim_owner = NULL, claim_expires = NULL
+            WHERE d.event_id = ? AND d.task_id = ?
+              AND d.run_id = ? AND d.session_id = ?
+              AND d.state = 'pending'
+              AND d.claim_owner = ? AND d.claim_expires > ?
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM tasks AS t
+                  JOIN task_runs AS r
+                    ON r.id = t.current_run_id AND r.task_id = t.id
+                  WHERE t.id = d.task_id
+                    AND t.current_run_id = d.run_id
+                    AND t.session_id = d.session_id
+                    AND t.status = 'running'
+                    AND r.status = 'running'
+                    AND r.ended_at IS NULL
+              )
+            """,
+            (resolved, event_id, task_id, run_id, session_id, owner, resolved),
+        )
+        if cur.rowcount != 1:
+            return False
+        # Exact-key deletion cannot touch a successor wait registration.
+        conn.execute(
+            """
+            DELETE FROM provider_recovery_waits
+            WHERE task_id = ? AND run_id = ? AND session_id = ?
+            """,
+            (task_id, run_id, session_id),
+        )
+        return True
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6818,6 +6818,16 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     if entry is None:
         return ("unknown", None)
     raw, _ = entry
+    if os.name == "nt":
+        # Windows has no waitpid/WIFEXITED helpers. Supervised Popen.wait()
+        # callbacks encode their direct return code in the POSIX-compatible
+        # high byte before storing it in this shared registry.
+        code = int(raw) >> 8
+        if code == 0:
+            return ("clean_exit", 0)
+        if code == KANBAN_RATE_LIMIT_EXIT_CODE:
+            return ("rate_limited", code)
+        return ("nonzero_exit", code)
     try:
         if os.WIFEXITED(raw):
             code = os.WEXITSTATUS(raw)
@@ -7459,13 +7469,30 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # counter (see the post-txn loop below).
     crash_details: list[tuple[str, int, str, bool, str]] = []
     # (task_id, pid, claimer, protocol_violation, error_text)
+    main_db_row = next(
+        (row for row in conn.execute("PRAGMA database_list") if row[1] == "main"),
+        None,
+    )
+    main_db_path = str(Path(main_db_row[2]).resolve()) if main_db_row and main_db_row[2] else None
+    supervisor = (
+        _dispatcher_worker_supervisors.get(main_db_path) if main_db_path else None
+    )
     with write_txn(conn):
         rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
+            "SELECT id, worker_pid, claim_lock, started_at, current_run_id FROM tasks "
             "WHERE status = 'running' AND worker_pid IS NOT NULL"
         ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
         for row in rows:
+            active_pid = supervisor.active_pid(row["id"]) if supervisor is not None else None
+            if active_pid is not None:
+                if int(row["worker_pid"]) != active_pid:
+                    conn.execute(
+                        "UPDATE tasks SET worker_pid = ? "
+                        "WHERE id = ? AND status = 'running' AND current_run_id IS ?",
+                        (active_pid, row["id"], row["current_run_id"]),
+                    )
+                continue
             # Only check liveness for claims owned by this host.
             lock = row["claim_lock"] or ""
             if not lock.startswith(host_prefix):
@@ -8177,6 +8204,29 @@ def dispatch_once(
         return result
 
 
+def _invoke_dispatch_spawn(
+    spawn_fn,
+    task: Task,
+    workspace: str,
+    *,
+    board: Optional[str],
+) -> Optional[int]:
+    """Invoke the test seam or the dispatcher-owned production supervisor."""
+    if spawn_fn is None:
+        return _start_supervised_worker(task, workspace, board=board)
+
+    # Back-compat: older spawn_fn signatures accept only (task, workspace).
+    # Introspect the callable and pass `board` only when supported.
+    import inspect
+    try:
+        sig = inspect.signature(spawn_fn)
+        if "board" in sig.parameters:
+            return spawn_fn(task, workspace, board=board)
+        return spawn_fn(task, workspace)
+    except (TypeError, ValueError):
+        return spawn_fn(task, workspace)
+
+
 def _dispatch_once_locked(
     conn: sqlite3.Connection,
     *,
@@ -8456,20 +8506,10 @@ def _dispatch_once_locked(
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
-            # Back-compat: older spawn_fn signatures accept only
-            # (task, workspace). Test stubs in the suite rely on that.
-            # Introspect the callable and pass `board` only when supported.
-            import inspect
-            try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
+            pid = _invoke_dispatch_spawn(
+                spawn_fn, claimed, str(workspace), board=board,
+            )
             if pid:
                 _set_worker_pid(conn, claimed.id, int(pid))
             # NOTE: we intentionally do NOT reset consecutive_failures
@@ -8554,17 +8594,10 @@ def _dispatch_once_locked(
         # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
         # review agent needs.
         claimed.skills = ["sdlc-review"]
-        _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
-            import inspect
-            try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
+            pid = _invoke_dispatch_spawn(
+                spawn_fn, claimed, str(workspace), board=board,
+            )
             if pid:
                 _set_worker_pid(conn, claimed.id, int(pid))
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
@@ -8867,18 +8900,121 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
         _log.debug("kanban worker: legacy session retag skipped (%s)", exc)
 
 
-def _default_spawn(
+_dispatcher_worker_supervisors: dict[str, Any] = {}
+
+
+def _dispatcher_worker_supervisor(*, board: Optional[str] = None):
+    """Return the long-lived process owner for one resolved board."""
+    from hermes_cli.worker_supervisor import DispatcherWorkerSupervisor
+
+    db_path = kanban_db_path(board=board).resolve()
+    key = str(db_path)
+    supervisor = _dispatcher_worker_supervisors.get(key)
+    if supervisor is None:
+        supervisor = DispatcherWorkerSupervisor(
+            event_root=db_path.parent / "worker-lifecycle",
+        )
+        _dispatcher_worker_supervisors[key] = supervisor
+    return supervisor
+
+
+def signal_worker_recovery(
+    task_id: str,
+    reason: str,
+    *,
+    board: Optional[str] = None,
+) -> bool:
+    """Deliver one explicit recovery signal to a supervised board worker."""
+    key = str(kanban_db_path(board=board).resolve())
+    supervisor = _dispatcher_worker_supervisors.get(key)
+    return bool(supervisor and supervisor.signal_recovery(task_id, reason))
+
+
+def _record_supervised_worker_exit(attempt_exit) -> None:
+    """Retain a Popen.wait return code for existing crash classification."""
+    returncode = int(attempt_exit.exit_code)
+    raw_status = returncode << 8 if returncode >= 0 else -returncode
+    _record_worker_exit(int(attempt_exit.pid), raw_status)
+
+
+def _start_supervised_worker(
     task: Task,
     workspace: str,
     *,
     board: Optional[str] = None,
 ) -> Optional[int]:
-    """Fire-and-forget ``hermes -p <profile> chat -q ...`` subprocess.
+    """Launch and retain a real dispatcher child under lifecycle supervision."""
+    from hermes_cli.worker_supervisor import WorkerIdentity
 
-    Returns the spawned child's PID so the dispatcher can detect crashes
-    before the claim TTL expires. The child's completion is still observed
-    via the ``complete`` / ``block`` transitions the worker writes itself;
-    the PID check is a safety net for crashes, OOM kills, and Ctrl+C.
+    session_id = task.session_id or f"kanban:{task.id}:{task.current_run_id or 0}"
+    identity = WorkerIdentity(task.id, session_id, Path(workspace))
+    db_path = kanban_db_path(board=board).resolve()
+    stable_run_id = task.current_run_id
+
+    def launch(_identity, attempt: int, event_path: Path):
+        proc = _default_spawn(
+            task,
+            workspace,
+            board=board,
+            lifecycle_event_path=event_path,
+            lifecycle_attempt=attempt,
+        )
+        if attempt > 1:
+            retry_conn = connect(db_path)
+            try:
+                with write_txn(retry_conn):
+                    retry_conn.execute(
+                        "UPDATE tasks SET worker_pid = ? "
+                        "WHERE id = ? AND status = 'running' AND current_run_id IS ?",
+                        (int(proc.pid), task.id, stable_run_id),
+                    )
+            finally:
+                retry_conn.close()
+        return proc
+
+    def on_exit(attempt_exit) -> None:
+        _record_supervised_worker_exit(attempt_exit)
+        event_conn = connect(db_path)
+        try:
+            with write_txn(event_conn):
+                _append_event(
+                    event_conn, task.id, "worker_attempt_exit",
+                    attempt_exit.as_dict(), run_id=stable_run_id,
+                )
+        finally:
+            event_conn.close()
+
+    supervisor = _dispatcher_worker_supervisor(board=board)
+    initial_event_path = supervisor.allocate_event_path(identity, 1)
+    initial_proc = _default_spawn(
+        task,
+        workspace,
+        board=board,
+        lifecycle_event_path=initial_event_path,
+        lifecycle_attempt=1,
+    )
+    handle = supervisor.start(
+        identity,
+        launch,
+        on_exit=on_exit,
+        initial_proc=initial_proc,
+        initial_event_path=initial_event_path,
+    )
+    return handle.pid
+
+
+def _default_spawn(
+    task: Task,
+    workspace: str,
+    *,
+    board: Optional[str] = None,
+    lifecycle_event_path: Optional[Path] = None,
+    lifecycle_attempt: int = 1,
+):
+    """Spawn ``hermes -p <profile> chat -q ...`` and return its live handle.
+
+    The child is started in a new session/process group so it survives gateway
+    restarts and can be cleanly killed as a unit.
 
     ``board`` pins the child's kanban context to that board: the child's
     ``HERMES_KANBAN_DB`` / ``HERMES_KANBAN_BOARD`` / workspaces_root env
@@ -8932,6 +9068,9 @@ def _default_spawn(
     # sidebar renders one row per attempt, labeled with the worker's own prompt
     # ("work kanban task t_…").
     env["HERMES_SESSION_SOURCE"] = "kanban"
+    if lifecycle_event_path is not None:
+        env["HERMES_WORKER_LIFECYCLE_EVENT_PATH"] = str(lifecycle_event_path)
+        env["HERMES_WORKER_LIFECYCLE_ATTEMPT"] = str(int(lifecycle_attempt))
     # Pin TERMINAL_CWD to the task's workspace so the worker's file tools and
     # context-file loader anchor on the workspace, not whatever cwd the
     # dispatching gateway happened to export. The worker subprocess is already
@@ -9074,7 +9213,7 @@ def _default_spawn(
     # handle is kept alive by the child's inheritance.  The parent's
     # reference goes out of scope and is GC'd, but the OS-level FD stays
     # open in the child until the child exits.
-    return proc.pid
+    return proc
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8924,10 +8924,28 @@ def signal_worker_recovery(
     *,
     board: Optional[str] = None,
 ) -> bool:
-    """Deliver one explicit recovery signal to a supervised board worker."""
+    """Deliver recovery only to the board's exact current supervised run."""
+    from hermes_cli.worker_supervisor import WorkerIdentity
+
     key = str(kanban_db_path(board=board).resolve())
     supervisor = _dispatcher_worker_supervisors.get(key)
-    return bool(supervisor and supervisor.signal_recovery(task_id, reason))
+    if supervisor is None:
+        return False
+    conn = connect(Path(key))
+    try:
+        task = get_task(conn, task_id)
+    finally:
+        conn.close()
+    if task is None or task.current_run_id is None or not task.workspace_path:
+        return False
+    session_id = task.session_id or f"kanban:{task.id}:{task.current_run_id}"
+    identity = WorkerIdentity(
+        task.id,
+        session_id,
+        Path(task.workspace_path),
+        run_id=task.current_run_id,
+    )
+    return bool(supervisor.signal_recovery(identity, reason))
 
 
 def _record_supervised_worker_exit(attempt_exit) -> None:
@@ -8947,30 +8965,19 @@ def _start_supervised_worker(
     from hermes_cli.worker_supervisor import WorkerIdentity
 
     session_id = task.session_id or f"kanban:{task.id}:{task.current_run_id or 0}"
-    identity = WorkerIdentity(task.id, session_id, Path(workspace))
+    identity = WorkerIdentity(
+        task.id,
+        session_id,
+        Path(workspace),
+        run_id=task.current_run_id,
+    )
     db_path = kanban_db_path(board=board).resolve()
     stable_run_id = task.current_run_id
 
     def launch(_identity, attempt: int, event_path: Path):
-        proc = _default_spawn(
-            task,
-            workspace,
-            board=board,
-            lifecycle_event_path=event_path,
-            lifecycle_attempt=attempt,
+        return _spawn_supervised_attempt(
+            task, workspace, identity, attempt, event_path, board=board
         )
-        if attempt > 1:
-            retry_conn = connect(db_path)
-            try:
-                with write_txn(retry_conn):
-                    retry_conn.execute(
-                        "UPDATE tasks SET worker_pid = ? "
-                        "WHERE id = ? AND status = 'running' AND current_run_id IS ?",
-                        (int(proc.pid), task.id, stable_run_id),
-                    )
-            finally:
-                retry_conn.close()
-        return proc
 
     def on_exit(attempt_exit) -> None:
         _record_supervised_worker_exit(attempt_exit)
@@ -8984,23 +8991,76 @@ def _start_supervised_worker(
         finally:
             event_conn.close()
 
+    def on_pid(_identity, attempt: int, pid: int) -> None:
+        if attempt == 1:
+            return
+        retry_conn = connect(db_path)
+        try:
+            with write_txn(retry_conn):
+                cur = retry_conn.execute(
+                    "UPDATE tasks SET worker_pid = ? "
+                    "WHERE id = ? AND status = 'running' AND current_run_id IS ?",
+                    (int(pid), task.id, stable_run_id),
+                )
+                if cur.rowcount != 1:
+                    raise RuntimeError("retry PID projection lost exact run ownership")
+        finally:
+            retry_conn.close()
+
+    def notify(failure) -> None:
+        event_conn = connect(db_path)
+        try:
+            with write_txn(event_conn):
+                _append_event(
+                    event_conn,
+                    task.id,
+                    "worker_supervision_failed",
+                    failure.as_dict(),
+                    run_id=stable_run_id,
+                )
+        finally:
+            event_conn.close()
+
     supervisor = _dispatcher_worker_supervisor(board=board)
     initial_event_path = supervisor.allocate_event_path(identity, 1)
-    initial_proc = _default_spawn(
-        task,
-        workspace,
-        board=board,
-        lifecycle_event_path=initial_event_path,
-        lifecycle_attempt=1,
+    initial_proc = _spawn_supervised_attempt(
+        task, workspace, identity, 1, initial_event_path, board=board
     )
     handle = supervisor.start(
         identity,
         launch,
         on_exit=on_exit,
+        on_pid=on_pid,
+        notifier=notify,
         initial_proc=initial_proc,
         initial_event_path=initial_event_path,
     )
     return handle.pid
+
+
+def _spawn_supervised_attempt(
+    task: Task,
+    workspace: str,
+    identity,
+    attempt: int,
+    event_path: Path,
+    *,
+    board: Optional[str],
+):
+    """Invoke production spawn while preserving older injected test seams."""
+    import inspect
+
+    kwargs: dict[str, Any] = {
+        "board": board,
+        "lifecycle_event_path": event_path,
+        "lifecycle_attempt": attempt,
+    }
+    parameters = inspect.signature(_default_spawn).parameters
+    if "worker_session_id" in parameters:
+        kwargs["worker_session_id"] = identity.session_id
+    if attempt > 1 and "resume_session_id" in parameters:
+        kwargs["resume_session_id"] = identity.session_id
+    return _default_spawn(task, workspace, **kwargs)
 
 
 def _default_spawn(
@@ -9010,6 +9070,8 @@ def _default_spawn(
     board: Optional[str] = None,
     lifecycle_event_path: Optional[Path] = None,
     lifecycle_attempt: int = 1,
+    worker_session_id: Optional[str] = None,
+    resume_session_id: Optional[str] = None,
 ):
     """Spawn ``hermes -p <profile> chat -q ...`` and return its live handle.
 
@@ -9071,6 +9133,8 @@ def _default_spawn(
     if lifecycle_event_path is not None:
         env["HERMES_WORKER_LIFECYCLE_EVENT_PATH"] = str(lifecycle_event_path)
         env["HERMES_WORKER_LIFECYCLE_ATTEMPT"] = str(int(lifecycle_attempt))
+    if worker_session_id:
+        env["HERMES_WORKER_SESSION_ID"] = str(worker_session_id)
     # Pin TERMINAL_CWD to the task's workspace so the worker's file tools and
     # context-file loader anchor on the workspace, not whatever cwd the
     # dispatching gateway happened to export. The worker subprocess is already
@@ -9168,17 +9232,13 @@ def _default_spawn(
     worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
     if worker_toolsets:
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
+    if resume_session_id:
+        cmd.extend(["--resume", str(resume_session_id)])
     cmd.extend([
         "chat",
         "-q", prompt,
+        "-Q",
     ])
-    if task.goal_mode:
-        # Goal-mode workers must take the fully-quiet single-query path:
-        # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
-        # cli.py's quiet branch. Without -Q the worker gets exactly one
-        # turn, prints text, exits rc=0, and the dispatcher records a
-        # protocol violation (incident 2026-06-09 t_d9cbe312).
-        cmd.append("-Q")
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4134,6 +4134,10 @@ def _end_run(
         ),
     )
     conn.execute(
+        "DELETE FROM provider_recovery_waits WHERE task_id = ? AND run_id = ?",
+        (task_id, run_id),
+    )
+    conn.execute(
         "UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,),
     )
     return run_id

--- a/hermes_cli/worker_lifecycle.py
+++ b/hermes_cli/worker_lifecycle.py
@@ -4,11 +4,252 @@ from __future__ import annotations
 
 import json
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 3
 TRANSIENT_PROVIDER = "transient_provider"
+
+_EVENT_PATH_ENV = "HERMES_WORKER_LIFECYCLE_EVENT_PATH"
+_ATTEMPT_ENV = "HERMES_WORKER_LIFECYCLE_ATTEMPT"
+_NONCE_ENV = "HERMES_WORKER_START_NONCE"
+_TASK_ENV = "HERMES_KANBAN_TASK"
+_RUN_ENV = "HERMES_KANBAN_RUN_ID"
+_SESSION_ENV = "HERMES_WORKER_SESSION_ID"
+_WORKTREE_ENV = "HERMES_KANBAN_WORKSPACE"
+_PROFILE_ENV = "HERMES_PROFILE"
+_PROVIDER_ENV = "HERMES_PROVIDER"
+_CREDENTIAL_GENERATION_ENV = "HERMES_PROVIDER_CREDENTIAL_GENERATION"
+
+
+class LifecycleEventType(str, Enum):
+    TERMINAL = "terminal"
+    IDENTITY = "identity"
+    OWNED_PROCESS = "owned_process"
+    FAILURE = "failure"
+    TASK_DONE = "task_done"
+
+
+class TerminalClassification(str, Enum):
+    SUCCESS = "success"
+    TRANSIENT_PROVIDER = TRANSIENT_PROVIDER
+    RATE_LIMITED = "rate_limited"
+    BILLING = "billing"
+    FAILED = "failed"
+    SUPERVISOR_FAILURE = "supervisor_failure"
+    OWNERSHIP_LOSS = "ownership_loss"
+
+
+class FailureReason(str, Enum):
+    NONE = "none"
+    TRANSIENT_PROVIDER = TRANSIENT_PROVIDER
+    RATE_LIMIT = "rate_limit"
+    BILLING = "billing"
+    WORKER_FAILURE = "worker_failure"
+    SUPERVISOR_FAILURE = "supervisor_failure"
+    OWNERSHIP_LOSS = "ownership_loss"
+
+
+class ExitKind(str, Enum):
+    CODE = "code"
+    SIGNAL = "signal"
+
+
+def process_birth_token(pid: int) -> Optional[str]:
+    """Return an OS-backed process birth identity, or fail closed."""
+    try:
+        process_id = int(pid)
+        if process_id <= 0:
+            return None
+
+        if os.name == "nt":
+            import ctypes
+            from ctypes import wintypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            open_process = kernel32.OpenProcess
+            open_process.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+            open_process.restype = wintypes.HANDLE
+            get_process_times = kernel32.GetProcessTimes
+            get_process_times.argtypes = (
+                wintypes.HANDLE,
+                ctypes.POINTER(wintypes.FILETIME),
+                ctypes.POINTER(wintypes.FILETIME),
+                ctypes.POINTER(wintypes.FILETIME),
+                ctypes.POINTER(wintypes.FILETIME),
+            )
+            get_process_times.restype = wintypes.BOOL
+            close_handle = kernel32.CloseHandle
+            close_handle.argtypes = (wintypes.HANDLE,)
+            close_handle.restype = wintypes.BOOL
+
+            handle = open_process(0x1000, False, process_id)
+            if not handle:
+                return None
+            try:
+                creation = wintypes.FILETIME()
+                exit_time = wintypes.FILETIME()
+                kernel_time = wintypes.FILETIME()
+                user_time = wintypes.FILETIME()
+                if not get_process_times(
+                    handle,
+                    ctypes.byref(creation),
+                    ctypes.byref(exit_time),
+                    ctypes.byref(kernel_time),
+                    ctypes.byref(user_time),
+                ):
+                    return None
+                creation_ticks = (
+                    int(creation.dwHighDateTime) << 32
+                ) | int(creation.dwLowDateTime)
+                return f"win32-filetime:{creation_ticks}"
+            finally:
+                close_handle(handle)
+
+        if os.name == "posix":
+            stat = Path(f"/proc/{process_id}/stat").read_text(encoding="ascii")
+            closing_paren = stat.rfind(")")
+            if closing_paren < 0:
+                return None
+            fields = stat[closing_paren + 1 :].split()
+            start_ticks = fields[19]
+            if not start_ticks.isdecimal():
+                return None
+            try:
+                boot_id = Path("/proc/sys/kernel/random/boot_id").read_text(
+                    encoding="ascii"
+                ).strip()
+            except OSError:
+                boot_id = ""
+            if boot_id:
+                return f"proc-start:{boot_id}:{start_ticks}"
+            return f"proc-start:{start_ticks}"
+    except Exception:
+        return None
+    return None
+
+
+def exit_kind_and_value(exit_code: int) -> tuple[ExitKind, int]:
+    code = int(exit_code)
+    if code < 0:
+        return ExitKind.SIGNAL, -code
+    return ExitKind.CODE, code
+
+
+def worker_start_contract_configured() -> bool:
+    """Return whether this process received any supervised-start contract."""
+
+    return any(
+        os.environ.get(name, "").strip()
+        for name in (
+            _EVENT_PATH_ENV,
+            _ATTEMPT_ENV,
+            _NONCE_ENV,
+            _SESSION_ENV,
+        )
+    )
+
+
+def _worker_contract() -> Optional[dict[str, Any]]:
+    values = {
+        "path": os.environ.get(_EVENT_PATH_ENV, "").strip(),
+        "attempt": os.environ.get(_ATTEMPT_ENV, "").strip(),
+        "nonce": os.environ.get(_NONCE_ENV, "").strip(),
+        "task_id": os.environ.get(_TASK_ENV, "").strip(),
+        "run_id": os.environ.get(_RUN_ENV, "").strip(),
+        "session_id": os.environ.get(_SESSION_ENV, "").strip(),
+        "worktree": os.environ.get(_WORKTREE_ENV, "").strip(),
+    }
+    if not all(values.values()):
+        return None
+    try:
+        run_id = int(values["run_id"])
+        attempt = int(values["attempt"])
+    except (TypeError, ValueError):
+        return None
+    if run_id <= 0 or attempt <= 0:
+        return None
+    try:
+        worktree = str(Path(values["worktree"]).resolve())
+    except OSError:
+        return None
+    return {
+        "path": Path(values["path"]),
+        "attempt": attempt,
+        "nonce": values["nonce"],
+        "task_id": values["task_id"],
+        "run_id": run_id,
+        "session_id": values["session_id"],
+        "worktree": worktree,
+    }
+
+
+def _append_jsonl_record(target: Path, event: Mapping[str, Any]) -> None:
+    """Append one complete JSONL record without replacing prior evidence."""
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (
+        json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    descriptor = os.open(target, flags, 0o600)
+    try:
+        written = os.write(descriptor, encoded)
+        if written != len(encoded):
+            raise OSError("short lifecycle JSONL append")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def emit_start_identity_event(*, session_id: Optional[str] = None) -> bool:
+    """Emit the one child-start identity after exact resume preload."""
+
+    contract = _worker_contract()
+    if contract is None:
+        return False
+    actual_session = str(session_id or "").strip()
+    if actual_session != contract["session_id"]:
+        return False
+    try:
+        actual_worktree = str(Path.cwd().resolve())
+    except OSError:
+        return False
+    if actual_worktree != contract["worktree"]:
+        return False
+    root_pid = os.getpid()
+    birth_token = process_birth_token(root_pid)
+    if birth_token is None:
+        return False
+
+    target = contract["path"]
+    if target.exists():
+        try:
+            for line in target.read_text(encoding="utf-8").splitlines():
+                record = json.loads(line)
+                if isinstance(record, dict) and record.get("kind") == "identity":
+                    return False
+        except (OSError, TypeError, ValueError):
+            return False
+    _append_jsonl_record(
+        target,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "kind": LifecycleEventType.IDENTITY.value,
+            "nonce": contract["nonce"],
+            "task_id": contract["task_id"],
+            "run_id": contract["run_id"],
+            "attempt": contract["attempt"],
+            "worktree": actual_worktree,
+            "observed_session_id": actual_session,
+            "root_pid": root_pid,
+            "process_birth_token": birth_token,
+        },
+    )
+    return True
 
 
 def build_terminal_event(
@@ -18,51 +259,71 @@ def build_terminal_event(
     exit_code: Optional[int] = None,
 ) -> Optional[dict[str, Any]]:
     """Build identity-bound terminal evidence when a worker contract is present."""
-    path = os.environ.get("HERMES_WORKER_LIFECYCLE_EVENT_PATH", "").strip()
-    task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
-    run_raw = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
-    attempt_raw = os.environ.get("HERMES_WORKER_LIFECYCLE_ATTEMPT", "").strip()
-    expected_session = os.environ.get("HERMES_WORKER_SESSION_ID", "").strip()
-    workspace_raw = os.environ.get("HERMES_KANBAN_WORKSPACE", "").strip()
-    if not all((path, task_id, run_raw, attempt_raw, expected_session, workspace_raw)):
-        return None
-    try:
-        run_id = int(run_raw)
-        attempt = int(attempt_raw)
-    except (TypeError, ValueError):
+    contract = _worker_contract()
+    if contract is None:
         return None
     actual_session = str(session_id or "").strip()
-    if run_id <= 0 or attempt <= 0 or actual_session != expected_session:
+    if not actual_session:
+        return None
+    try:
+        actual_worktree = str(Path.cwd().resolve())
+    except OSError:
+        return None
+    if actual_worktree != contract["worktree"]:
         return None
 
     failed = bool(isinstance(result, Mapping) and result.get("failed"))
-    failure_reason = (
-        str(result.get("failure_reason") or "").strip() if failed else ""
-    )
+    raw_reason = str(result.get("failure_reason") or "").strip() if failed else ""
     if not failed:
-        classification = "success"
-    elif failure_reason == TRANSIENT_PROVIDER:
-        classification = TRANSIENT_PROVIDER
-    elif failure_reason == "rate_limit":
-        classification = "rate_limited"
-    elif failure_reason == "billing":
-        classification = "billing"
+        classification = TerminalClassification.SUCCESS
+        failure_reason = FailureReason.NONE
+    elif raw_reason == FailureReason.TRANSIENT_PROVIDER.value:
+        classification = TerminalClassification.TRANSIENT_PROVIDER
+        failure_reason = FailureReason.TRANSIENT_PROVIDER
+    elif raw_reason == FailureReason.RATE_LIMIT.value:
+        classification = TerminalClassification.RATE_LIMITED
+        failure_reason = FailureReason.RATE_LIMIT
+    elif raw_reason == FailureReason.BILLING.value:
+        classification = TerminalClassification.BILLING
+        failure_reason = FailureReason.BILLING
     else:
-        classification = "failed"
+        classification = TerminalClassification.FAILED
+        failure_reason = FailureReason.WORKER_FAILURE
     actual_exit = int(exit_code if exit_code is not None else (1 if failed else 0))
-    return {
+    exit_kind, exit_value = exit_kind_and_value(actual_exit)
+    root_pid = os.getpid()
+    birth_token = process_birth_token(root_pid)
+    if birth_token is None:
+        return None
+    event = {
         "schema_version": SCHEMA_VERSION,
-        "kind": "terminal",
-        "task_id": task_id,
-        "run_id": run_id,
-        "attempt": attempt,
-        "session_id": actual_session,
-        "worktree": str(Path(workspace_raw).resolve()),
-        "owner_pid": os.getpid(),
-        "exit_code": actual_exit,
-        "failure_reason": failure_reason,
-        "classification": classification,
+        "kind": LifecycleEventType.TERMINAL.value,
+        "nonce": contract["nonce"],
+        "task_id": contract["task_id"],
+        "run_id": contract["run_id"],
+        "attempt": contract["attempt"],
+        "expected_session_id": contract["session_id"],
+        "observed_session_id": actual_session,
+        "worktree": actual_worktree,
+        "root_pid": root_pid,
+        "process_birth_token": birth_token,
+        "exit_kind": exit_kind.value,
+        "exit_value": exit_value,
+        "failure_reason": failure_reason.value,
+        "classification": classification.value,
     }
+    profile = os.environ.get(_PROFILE_ENV, "").strip()
+    provider = os.environ.get(_PROVIDER_ENV, "").strip()
+    raw_generation = os.environ.get(_CREDENTIAL_GENERATION_ENV, "").strip()
+    if profile and provider and raw_generation.isdecimal():
+        generation = int(raw_generation)
+        if generation > 0:
+            event.update(
+                profile=profile,
+                provider=provider,
+                credential_generation=generation,
+            )
+    return event
 
 
 def emit_terminal_event(
@@ -71,18 +332,12 @@ def emit_terminal_event(
     session_id: Optional[str] = None,
     exit_code: Optional[int] = None,
 ) -> bool:
-    """Atomically write a terminal lifecycle event for a supervised worker."""
+    """Safely append terminal evidence after the child-start identity."""
     event = build_terminal_event(
         result, session_id=session_id, exit_code=exit_code
     )
     if event is None:
         return False
-    target = Path(os.environ["HERMES_WORKER_LIFECYCLE_EVENT_PATH"])
-    target.parent.mkdir(parents=True, exist_ok=True)
-    temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
-    temporary.write_text(
-        json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n",
-        encoding="utf-8",
-    )
-    os.replace(temporary, target)
+    target = Path(os.environ[_EVENT_PATH_ENV])
+    _append_jsonl_record(target, event)
     return True

--- a/hermes_cli/worker_lifecycle.py
+++ b/hermes_cli/worker_lifecycle.py
@@ -1,0 +1,88 @@
+"""Typed terminal lifecycle evidence for dispatcher-supervised workers."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+SCHEMA_VERSION = 1
+TRANSIENT_PROVIDER = "transient_provider"
+
+
+def build_terminal_event(
+    result: Any,
+    *,
+    session_id: Optional[str] = None,
+    exit_code: Optional[int] = None,
+) -> Optional[dict[str, Any]]:
+    """Build identity-bound terminal evidence when a worker contract is present."""
+    path = os.environ.get("HERMES_WORKER_LIFECYCLE_EVENT_PATH", "").strip()
+    task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    run_raw = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+    attempt_raw = os.environ.get("HERMES_WORKER_LIFECYCLE_ATTEMPT", "").strip()
+    expected_session = os.environ.get("HERMES_WORKER_SESSION_ID", "").strip()
+    workspace_raw = os.environ.get("HERMES_KANBAN_WORKSPACE", "").strip()
+    if not all((path, task_id, run_raw, attempt_raw, expected_session, workspace_raw)):
+        return None
+    try:
+        run_id = int(run_raw)
+        attempt = int(attempt_raw)
+    except (TypeError, ValueError):
+        return None
+    actual_session = str(session_id or "").strip()
+    if run_id <= 0 or attempt <= 0 or actual_session != expected_session:
+        return None
+
+    failed = bool(isinstance(result, Mapping) and result.get("failed"))
+    failure_reason = (
+        str(result.get("failure_reason") or "").strip() if failed else ""
+    )
+    if not failed:
+        classification = "success"
+    elif failure_reason == TRANSIENT_PROVIDER:
+        classification = TRANSIENT_PROVIDER
+    elif failure_reason == "rate_limit":
+        classification = "rate_limited"
+    elif failure_reason == "billing":
+        classification = "billing"
+    else:
+        classification = "failed"
+    actual_exit = int(exit_code if exit_code is not None else (1 if failed else 0))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "terminal",
+        "task_id": task_id,
+        "run_id": run_id,
+        "attempt": attempt,
+        "session_id": actual_session,
+        "worktree": str(Path(workspace_raw).resolve()),
+        "owner_pid": os.getpid(),
+        "exit_code": actual_exit,
+        "failure_reason": failure_reason,
+        "classification": classification,
+    }
+
+
+def emit_terminal_event(
+    result: Any,
+    *,
+    session_id: Optional[str] = None,
+    exit_code: Optional[int] = None,
+) -> bool:
+    """Atomically write a terminal lifecycle event for a supervised worker."""
+    event = build_terminal_event(
+        result, session_id=session_id, exit_code=exit_code
+    )
+    if event is None:
+        return False
+    target = Path(os.environ["HERMES_WORKER_LIFECYCLE_EVENT_PATH"])
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, target)
+    return True

--- a/hermes_cli/worker_supervisor.py
+++ b/hermes_cli/worker_supervisor.py
@@ -1,0 +1,383 @@
+"""Event-driven ownership and bounded recovery for dispatcher worker processes.
+
+The dispatcher keeps the :class:`subprocess.Popen` handle instead of abandoning
+it after launch.  A dedicated monitor thread blocks in ``Popen.wait()`` (an OS
+child-terminal event), parses the worker's JSONL evidence file, cleans only the
+processes that worker registered as owned, and permits one continuation after
+an explicit recovery signal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import ctypes
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import threading
+import time
+from typing import Callable, Optional
+import uuid
+
+
+TRANSIENT_PROVIDER = "transient_provider"
+
+
+@dataclass(frozen=True)
+class WorkerIdentity:
+    """Identity that must not change across a supervised continuation."""
+
+    task_id: str
+    session_id: str
+    worktree: Path
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "worktree", Path(self.worktree).resolve())
+
+
+@dataclass(frozen=True)
+class OwnedProcess:
+    pid: int
+    role: str
+    port: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class AttemptExit:
+    task_id: str
+    attempt: int
+    pid: int
+    exit_code: int
+    classification: str
+    events: tuple[dict, ...]
+    owned_processes: tuple[OwnedProcess, ...]
+
+    def as_dict(self) -> dict:
+        return {
+            "task_id": self.task_id,
+            "attempt": self.attempt,
+            "pid": self.pid,
+            "exit_code": self.exit_code,
+            "classification": self.classification,
+            "owned_processes": [
+                {"pid": item.pid, "role": item.role, "port": item.port}
+                for item in self.owned_processes
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class LifecycleFailure:
+    task_id: str
+    attempts: int
+    classification: str
+    exit_code: int
+    reason: str
+
+
+LaunchWorker = Callable[[WorkerIdentity, int, Path], subprocess.Popen]
+ExitCallback = Callable[[AttemptExit], None]
+SuccessCallback = Callable[[AttemptExit], None]
+Notifier = Callable[[LifecycleFailure], None]
+
+
+def pid_is_alive(pid: int) -> bool:
+    """Return whether one exact host PID is alive without signaling it."""
+
+    if not pid or pid <= 0:
+        return False
+    if os.name == "nt":
+        process_query_limited_information = 0x1000
+        synchronize = 0x00100000
+        handle = ctypes.windll.kernel32.OpenProcess(  # type: ignore[attr-defined]
+            process_query_limited_information | synchronize,
+            False,
+            int(pid),
+        )
+        if not handle:
+            return False
+        try:
+            return ctypes.windll.kernel32.WaitForSingleObject(handle, 0) == 0x102  # type: ignore[attr-defined]
+        finally:
+            ctypes.windll.kernel32.CloseHandle(handle)  # type: ignore[attr-defined]
+    try:
+        os.kill(int(pid), 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _read_events(path: Path) -> tuple[dict, ...]:
+    if not path.exists():
+        return ()
+    events: list[dict] = []
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            event = json.loads(raw_line)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return tuple(events)
+
+
+def _attempt_exit(identity: WorkerIdentity, attempt: int, proc: subprocess.Popen, path: Path) -> AttemptExit:
+    events = _read_events(path)
+    failure = next(
+        (event for event in reversed(events) if event.get("kind") == "failure"),
+        None,
+    )
+    classification = (
+        str(failure.get("classification"))
+        if failure and failure.get("classification")
+        else ("success" if proc.returncode == 0 else "process_exit")
+    )
+    owned: list[OwnedProcess] = []
+    seen: set[int] = set()
+    for event in events:
+        if event.get("kind") != "owned_process":
+            continue
+        try:
+            pid = int(event["pid"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if pid <= 0 or pid in seen:
+            continue
+        seen.add(pid)
+        try:
+            port = int(event["port"]) if event.get("port") is not None else None
+        except (TypeError, ValueError):
+            port = None
+        owned.append(OwnedProcess(pid=pid, role=str(event.get("role") or "background"), port=port))
+    return AttemptExit(
+        task_id=identity.task_id,
+        attempt=attempt,
+        pid=int(proc.pid),
+        exit_code=int(proc.returncode),
+        classification=classification,
+        events=events,
+        owned_processes=tuple(owned),
+    )
+
+
+def _terminate_exact_pid(pid: int, *, force: bool) -> None:
+    if not pid_is_alive(pid):
+        return
+    if os.name == "nt":
+        command = ["taskkill", "/PID", str(pid), "/T"]
+        if force:
+            command.append("/F")
+        subprocess.run(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=5,
+        )
+        return
+    try:
+        os.kill(pid, signal.SIGKILL if force else signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+
+
+def _cleanup_owned_tree(attempt_exit: AttemptExit, timeout: float) -> None:
+    """Terminate only this launch's process group and registered owned PIDs."""
+
+    pids = {item.pid for item in attempt_exit.owned_processes if item.pid != attempt_exit.pid}
+    if os.name != "nt":
+        try:
+            os.killpg(attempt_exit.pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+    for pid in pids:
+        _terminate_exact_pid(pid, force=False)
+
+    deadline = time.monotonic() + max(0.1, timeout)
+    while time.monotonic() < deadline and any(pid_is_alive(pid) for pid in pids):
+        time.sleep(0.02)
+    for pid in pids:
+        _terminate_exact_pid(pid, force=True)
+
+    deadline = time.monotonic() + max(0.1, timeout)
+    while time.monotonic() < deadline and any(pid_is_alive(pid) for pid in pids):
+        time.sleep(0.02)
+
+
+class WorkerLifecycleHandle:
+    def __init__(self, task_id: str) -> None:
+        self.task_id = task_id
+        self._recovery = threading.Event()
+        self._finished = threading.Event()
+        self._recovery_reason = ""
+        self._thread: Optional[threading.Thread] = None
+        self._pid: Optional[int] = None
+
+    def signal_recovery(self, reason: str) -> None:
+        if reason:
+            self._recovery_reason = str(reason)
+            self._recovery.set()
+
+    def wait(self, timeout: Optional[float] = None) -> bool:
+        return self._finished.wait(timeout)
+
+    @property
+    def recovery_reason(self) -> str:
+        return self._recovery_reason
+
+    @property
+    def pid(self) -> Optional[int]:
+        return self._pid
+
+
+class DispatcherWorkerSupervisor:
+    """Own worker handles and perform at most one signaled continuation."""
+
+    def __init__(
+        self,
+        *,
+        event_root: Path,
+        recovery_timeout: float = 300.0,
+        cleanup_timeout: float = 5.0,
+    ) -> None:
+        self._event_root = Path(event_root)
+        self._recovery_timeout = max(0.1, float(recovery_timeout))
+        self._cleanup_timeout = max(0.1, float(cleanup_timeout))
+        self._active: dict[str, WorkerLifecycleHandle] = {}
+        self._lock = threading.Lock()
+
+    @property
+    def active_count(self) -> int:
+        with self._lock:
+            return len(self._active)
+
+    def active_pid(self, task_id: str) -> Optional[int]:
+        """Return the current PID while this supervisor owns task_id."""
+        with self._lock:
+            handle = self._active.get(task_id)
+            if handle is None or handle._pid is None:
+                return None
+            return int(handle._pid)
+
+    def start(
+        self,
+        identity: WorkerIdentity,
+        launch: LaunchWorker,
+        *,
+        on_exit: ExitCallback,
+        on_success: Optional[SuccessCallback] = None,
+        notifier: Optional[Notifier] = None,
+        initial_proc: Optional[subprocess.Popen] = None,
+        initial_event_path: Optional[Path] = None,
+    ) -> WorkerLifecycleHandle:
+        if (initial_proc is None) != (initial_event_path is None):
+            raise ValueError("initial_proc and initial_event_path must be provided together")
+        with self._lock:
+            if identity.task_id in self._active:
+                raise RuntimeError(f"worker {identity.task_id} is already supervised")
+            handle = WorkerLifecycleHandle(identity.task_id)
+            self._active[identity.task_id] = handle
+
+        self._event_root.mkdir(parents=True, exist_ok=True)
+        try:
+            if initial_proc is None:
+                first_proc, first_path = self._launch_attempt(identity, launch, 1)
+            else:
+                assert initial_event_path is not None
+                first_proc = initial_proc
+                first_path = Path(initial_event_path)
+            with self._lock:
+                handle._pid = int(first_proc.pid)
+        except Exception:
+            with self._lock:
+                self._active.pop(identity.task_id, None)
+            raise
+        thread = threading.Thread(
+            target=self._monitor,
+            name=f"worker-supervisor-{identity.task_id}",
+            args=(identity, launch, handle, first_proc, first_path, on_exit, on_success, notifier),
+            daemon=True,
+        )
+        handle._thread = thread
+        thread.start()
+        return handle
+
+    def signal_recovery(self, task_id: str, reason: str) -> bool:
+        with self._lock:
+            handle = self._active.get(task_id)
+        if handle is None:
+            return False
+        handle.signal_recovery(reason)
+        return True
+
+    def _launch_attempt(
+        self,
+        identity: WorkerIdentity,
+        launch: LaunchWorker,
+        attempt: int,
+    ) -> tuple[subprocess.Popen, Path]:
+        event_path = self.allocate_event_path(identity, attempt)
+        return launch(identity, attempt, event_path), event_path
+
+    def allocate_event_path(self, identity: WorkerIdentity, attempt: int) -> Path:
+        self._event_root.mkdir(parents=True, exist_ok=True)
+        event_path = self._event_root / (
+            f"{identity.task_id}.attempt-{attempt}.{uuid.uuid4().hex}.jsonl"
+        )
+        return event_path
+
+    def _monitor(
+        self,
+        identity: WorkerIdentity,
+        launch: LaunchWorker,
+        handle: WorkerLifecycleHandle,
+        proc: subprocess.Popen,
+        event_path: Path,
+        on_exit: ExitCallback,
+        on_success: Optional[SuccessCallback],
+        notifier: Optional[Notifier],
+    ) -> None:
+        attempts = 0
+        last_exit: Optional[AttemptExit] = None
+        try:
+            for attempt in (1, 2):
+                attempts = attempt
+                proc.wait()
+                last_exit = _attempt_exit(identity, attempt, proc, event_path)
+                try:
+                    on_exit(last_exit)
+                finally:
+                    _cleanup_owned_tree(last_exit, self._cleanup_timeout)
+
+                if last_exit.classification == "success":
+                    if on_success is not None:
+                        on_success(last_exit)
+                    return
+                if attempt == 1 and last_exit.classification == TRANSIENT_PROVIDER:
+                    if not handle._recovery.wait(self._recovery_timeout):
+                        break
+                    proc, event_path = self._launch_attempt(identity, launch, 2)
+                    with self._lock:
+                        handle._pid = int(proc.pid)
+                    continue
+                break
+
+            if notifier is not None and last_exit is not None:
+                notifier(
+                    LifecycleFailure(
+                        task_id=identity.task_id,
+                        attempts=attempts,
+                        classification=last_exit.classification,
+                        exit_code=last_exit.exit_code,
+                        reason=handle.recovery_reason or "recovery_timeout",
+                    )
+                )
+        finally:
+            with self._lock:
+                self._active.pop(identity.task_id, None)
+            handle._finished.set()

--- a/hermes_cli/worker_supervisor.py
+++ b/hermes_cli/worker_supervisor.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import ctypes
+import inspect
 import json
 import os
 from pathlib import Path
+import secrets
 import signal
 import subprocess
 import threading
@@ -21,6 +23,15 @@ import time
 from typing import Callable, Optional
 import uuid
 
+from hermes_cli.worker_lifecycle import (
+    SCHEMA_VERSION,
+    ExitKind,
+    FailureReason,
+    LifecycleEventType,
+    TerminalClassification,
+    exit_kind_and_value,
+    process_birth_token,
+)
 
 TRANSIENT_PROVIDER = "transient_provider"
 
@@ -40,6 +51,35 @@ class WorkerIdentity:
     @property
     def key(self) -> tuple[str, object]:
         return self.task_id, self.run_id
+
+
+@dataclass(frozen=True)
+class SessionCompressionLineageResolver:
+    """Verify terminal-session lineage in one exact profile state database."""
+
+    state_db_path: Path
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "state_db_path", Path(self.state_db_path).resolve())
+
+    def verifies(self, expected_session_id: str, observed_session_id: str) -> bool:
+        try:
+            if not self.state_db_path.is_file():
+                return False
+            from hermes_state import SessionDB
+
+            session_db = SessionDB(self.state_db_path, read_only=True)
+            try:
+                return session_db.is_verified_compression_descendant(
+                    expected_session_id,
+                    observed_session_id,
+                )
+            finally:
+                session_db.close()
+        except Exception:
+            # State identity is a security boundary: unavailable, unreadable,
+            # malformed, or otherwise unprovable lineage always fails closed.
+            return False
 
 
 @dataclass(frozen=True)
@@ -90,7 +130,7 @@ class LifecycleFailure:
     reason: str
 
 
-LaunchWorker = Callable[[WorkerIdentity, int, Path], subprocess.Popen]
+LaunchWorker = Callable[..., subprocess.Popen]
 ExitCallback = Callable[[AttemptExit], None]
 SuccessCallback = Callable[[AttemptExit], None]
 Notifier = Callable[[LifecycleFailure], None]
@@ -124,18 +164,131 @@ def pid_is_alive(pid: int) -> bool:
     return True
 
 
-def _read_events(path: Path) -> tuple[dict, ...]:
+def _read_events(path: Path) -> tuple[tuple[dict, ...], bool]:
     if not path.exists():
-        return ()
+        return (), True
     events: list[dict] = []
     for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         try:
             event = json.loads(raw_line)
         except (TypeError, ValueError):
-            continue
-        if isinstance(event, dict):
-            events.append(event)
-    return tuple(events)
+            return tuple(events), False
+        if not isinstance(event, dict):
+            return tuple(events), False
+        try:
+            LifecycleEventType(event["kind"])
+        except (KeyError, TypeError, ValueError):
+            return tuple(events), False
+        events.append(event)
+    return tuple(events), True
+
+
+_TERMINAL_MATRIX = {
+    TerminalClassification.SUCCESS: FailureReason.NONE,
+    TerminalClassification.TRANSIENT_PROVIDER: FailureReason.TRANSIENT_PROVIDER,
+    TerminalClassification.RATE_LIMITED: FailureReason.RATE_LIMIT,
+    TerminalClassification.BILLING: FailureReason.BILLING,
+    TerminalClassification.FAILED: FailureReason.WORKER_FAILURE,
+    TerminalClassification.SUPERVISOR_FAILURE: FailureReason.SUPERVISOR_FAILURE,
+    TerminalClassification.OWNERSHIP_LOSS: FailureReason.OWNERSHIP_LOSS,
+}
+
+
+def _bind_process_birth(proc: subprocess.Popen) -> str:
+    """Capture birth identity while the exact process handle is still live."""
+    token = getattr(proc, "_hermes_process_birth_token", None)
+    if not isinstance(token, str) or not token:
+        token = process_birth_token(int(proc.pid))
+    if token is None:
+        raise RuntimeError(f"could not obtain process birth identity for PID {proc.pid}")
+    proc._hermes_process_birth_token = token  # type: ignore[attr-defined]
+    return token
+
+
+@dataclass(frozen=True)
+class _AttemptOwnership:
+    nonce: str
+    launcher_pid: int
+    launcher_birth_token: str
+    root_pid: int
+    root_birth_token: str
+
+
+def _is_live_launcher_or_descendant(
+    proc: subprocess.Popen,
+    launcher_birth_token: str,
+    observed_pid: int,
+) -> bool:
+    """Prove the observed interpreter belongs to the still-live launcher."""
+
+    if proc.poll() is not None:
+        return False
+    launcher_pid = int(proc.pid)
+    if observed_pid == launcher_pid:
+        return process_birth_token(launcher_pid) == launcher_birth_token
+    try:
+        import psutil
+
+        current = psutil.Process(observed_pid)
+        while True:
+            current = current.parent()
+            if current is None:
+                return False
+            if int(current.pid) == launcher_pid:
+                return (
+                    proc.poll() is None
+                    and process_birth_token(launcher_pid) == launcher_birth_token
+                )
+    except Exception:
+        return False
+
+
+def _start_identity_matches(
+    event: dict,
+    identity: WorkerIdentity,
+    attempt: int,
+    nonce: str,
+) -> bool:
+    try:
+        event_worktree = event["worktree"]
+        return (
+            type(event.get("schema_version")) is int
+            and event["schema_version"] == SCHEMA_VERSION
+            and LifecycleEventType(event["kind"]) is LifecycleEventType.IDENTITY
+            and isinstance(event.get("nonce"), str)
+            and secrets.compare_digest(event["nonce"], nonce)
+            and isinstance(event.get("task_id"), str)
+            and event["task_id"] == identity.task_id
+            and type(event.get("run_id")) is int
+            and event["run_id"] > 0
+            and event["run_id"] == identity.run_id
+            and type(event.get("attempt")) is int
+            and event["attempt"] == attempt
+            and isinstance(event_worktree, str)
+            and event_worktree == str(identity.worktree)
+            and str(Path(event_worktree).resolve()) == event_worktree
+            and isinstance(event.get("observed_session_id"), str)
+            and event["observed_session_id"] == identity.session_id
+            and type(event.get("root_pid")) is int
+            and event["root_pid"] > 0
+            and isinstance(event.get("process_birth_token"), str)
+            and bool(event["process_birth_token"])
+        )
+    except (KeyError, TypeError, ValueError, OSError):
+        return False
+
+
+def _identity_matches_ownership(
+    event: dict,
+    identity: WorkerIdentity,
+    attempt: int,
+    ownership: _AttemptOwnership,
+) -> bool:
+    return (
+        _start_identity_matches(event, identity, attempt, ownership.nonce)
+        and event.get("root_pid") == ownership.root_pid
+        and event.get("process_birth_token") == ownership.root_birth_token
+    )
 
 
 def _terminal_event_matches(
@@ -143,24 +296,68 @@ def _terminal_event_matches(
     identity: WorkerIdentity,
     attempt: int,
     proc: subprocess.Popen,
-    owned_pids: set[int],
+    ownership: _AttemptOwnership,
+    lineage_resolver: Optional[SessionCompressionLineageResolver] = None,
 ) -> bool:
     """Validate typed terminal evidence against the exact owned attempt."""
 
     try:
-        return (
-            event.get("schema_version") == 1
-            and event.get("kind") == "terminal"
-            and event.get("task_id") == identity.task_id
-            and event.get("run_id") == identity.run_id
-            and int(event.get("attempt")) == attempt
-            and event.get("session_id") == identity.session_id
-            and Path(str(event.get("worktree"))).resolve() == identity.worktree
-            and int(event.get("owner_pid")) in ({int(proc.pid)} | owned_pids)
-            and int(event.get("exit_code")) == int(proc.returncode)
-            and isinstance(event.get("classification"), str)
+        classification = TerminalClassification(event["classification"])
+        failure_reason = FailureReason(event["failure_reason"])
+        exit_kind = ExitKind(event["exit_kind"])
+        exit_value = event["exit_value"]
+        event_worktree = event["worktree"]
+        expected_kind, expected_value = exit_kind_and_value(int(proc.returncode))
+        successful_exit = exit_kind is ExitKind.CODE and exit_value == 0
+        matrix_valid = _TERMINAL_MATRIX[classification] is failure_reason
+        observed_session_id = event.get("observed_session_id")
+        session_valid = (
+            isinstance(observed_session_id, str)
+            and (
+                observed_session_id == identity.session_id
+                or (
+                    lineage_resolver is not None
+                    and lineage_resolver.verifies(
+                        identity.session_id,
+                        observed_session_id,
+                    )
+                )
+            )
         )
-    except (TypeError, ValueError, OSError):
+        if classification is TerminalClassification.SUCCESS:
+            matrix_valid = matrix_valid and successful_exit
+        else:
+            matrix_valid = matrix_valid and not successful_exit
+        return (
+            type(event.get("schema_version")) is int
+            and event["schema_version"] == SCHEMA_VERSION
+            and LifecycleEventType(event["kind"]) is LifecycleEventType.TERMINAL
+            and isinstance(event.get("nonce"), str)
+            and secrets.compare_digest(event["nonce"], ownership.nonce)
+            and isinstance(event.get("task_id"), str)
+            and event["task_id"] == identity.task_id
+            and type(event.get("run_id")) is int
+            and event["run_id"] > 0
+            and event["run_id"] == identity.run_id
+            and type(event.get("attempt")) is int
+            and event["attempt"] == attempt
+            and isinstance(event.get("expected_session_id"), str)
+            and event["expected_session_id"] == identity.session_id
+            and session_valid
+            and isinstance(event_worktree, str)
+            and event_worktree == str(identity.worktree)
+            and str(Path(event_worktree).resolve()) == event_worktree
+            and type(event.get("root_pid")) is int
+            and event["root_pid"] == ownership.root_pid
+            and isinstance(event.get("process_birth_token"), str)
+            and event["process_birth_token"] == ownership.root_birth_token
+            and type(exit_value) is int
+            and exit_value >= 0
+            and exit_kind is expected_kind
+            and exit_value == expected_value
+            and matrix_valid
+        )
+    except (KeyError, TypeError, ValueError, OSError):
         return False
 
 
@@ -169,23 +366,43 @@ def _attempt_exit(
     attempt: int,
     proc: subprocess.Popen,
     path: Path,
+    ownership: _AttemptOwnership,
     owned_pids: Optional[set[int]] = None,
+    lineage_resolver: Optional[SessionCompressionLineageResolver] = None,
 ) -> AttemptExit:
-    events = _read_events(path)
-    terminal = next(
-        (
-            event
-            for event in reversed(events)
-            if _terminal_event_matches(
-                event, identity, attempt, proc, owned_pids or set()
-            )
-        ),
-        None,
+    events, events_valid = _read_events(path)
+    identity_events = [
+        event for event in events if event.get("kind") == LifecycleEventType.IDENTITY.value
+    ]
+    terminal_events = [
+        event for event in events if event.get("kind") == LifecycleEventType.TERMINAL.value
+    ]
+    terminal = (
+        terminal_events[0]
+        if events_valid
+        and len(identity_events) == 1
+        and _identity_matches_ownership(
+            identity_events[0], identity, attempt, ownership
+        )
+        and len(terminal_events) == 1
+        and _terminal_event_matches(
+            terminal_events[0],
+            identity,
+            attempt,
+            proc,
+            ownership,
+            lineage_resolver,
+        )
+        else None
     )
     classification = (
         str(terminal["classification"])
         if terminal is not None
-        else ("success" if proc.returncode == 0 else "process_exit")
+        else (
+            "invalid_evidence"
+            if not events_valid or terminal_events or len(identity_events) != 1
+            else "process_exit"
+        )
     )
     owned: list[OwnedProcess] = []
     seen: set[int] = set()
@@ -210,7 +427,7 @@ def _attempt_exit(
         session_id=identity.session_id,
         worktree=identity.worktree,
         attempt=attempt,
-        pid=int(proc.pid),
+        pid=ownership.root_pid,
         exit_code=int(proc.returncode),
         classification=classification,
         events=events,
@@ -304,6 +521,28 @@ def _terminate_process_tree(proc: subprocess.Popen) -> bool:
     return not any(pid_is_alive(pid) for pid in tracked) and not pid_is_alive(int(proc.pid))
 
 
+def _cleanup_failed_start(proc: subprocess.Popen, timeout: float) -> None:
+    """Clean only through the retained handle after handshake rejection."""
+
+    expected_birth = getattr(proc, "_hermes_process_birth_token", None)
+    try:
+        if proc.poll() is not None:
+            return
+        if (
+            not isinstance(expected_birth, str)
+            or process_birth_token(int(proc.pid)) != expected_birth
+        ):
+            return
+        proc.terminate()
+        try:
+            proc.wait(timeout=max(0.1, timeout))
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=max(0.1, timeout))
+    except Exception:
+        return
+
+
 def _cleanup_owned_tree(
     attempt_exit: AttemptExit,
     proc: subprocess.Popen,
@@ -378,12 +617,14 @@ class DispatcherWorkerSupervisor:
         event_root: Path,
         recovery_timeout: float = 300.0,
         cleanup_timeout: float = 5.0,
+        start_timeout: float = 5.0,
         poll_interval: float = 0.01,
         cleanup_fn: Optional[Callable[[subprocess.Popen], bool]] = None,
     ) -> None:
         self._event_root = Path(event_root)
         self._recovery_timeout = max(0.1, float(recovery_timeout))
         self._cleanup_timeout = max(0.1, float(cleanup_timeout))
+        self._start_timeout = max(0.05, float(start_timeout))
         self._poll_interval = max(0.001, float(poll_interval))
         self._cleanup_fn = cleanup_fn or _terminate_process_tree
         self._active: dict[tuple[str, object], WorkerLifecycleHandle] = {}
@@ -438,6 +679,7 @@ class DispatcherWorkerSupervisor:
         gate_advance: Optional[Callable[[WorkerIdentity], None]] = None,
         initial_proc: Optional[subprocess.Popen] = None,
         initial_event_path: Optional[Path] = None,
+        lineage_resolver: Optional[SessionCompressionLineageResolver] = None,
     ) -> WorkerLifecycleHandle:
         if (initial_proc is None) != (initial_event_path is None):
             raise ValueError("initial_proc and initial_event_path must be provided together")
@@ -450,18 +692,37 @@ class DispatcherWorkerSupervisor:
         self._event_root.mkdir(parents=True, exist_ok=True)
         try:
             if initial_proc is None:
-                first_proc, first_path = self._launch_attempt(identity, launch, 1)
+                first_proc, first_path, first_ownership = self._launch_attempt(
+                    identity, launch, 1
+                )
             else:
                 assert initial_event_path is not None
                 first_proc = initial_proc
                 first_path = Path(initial_event_path)
+                launcher_birth = _bind_process_birth(first_proc)
+                initial_nonce = getattr(first_proc, "_hermes_worker_start_nonce", None)
+                if not isinstance(initial_nonce, str) or not initial_nonce:
+                    raise RuntimeError("initial process has no pre-spawn start nonce")
+                first_ownership = self._await_start_identity(
+                    identity,
+                    1,
+                    first_proc,
+                    first_path,
+                    initial_nonce,
+                    launcher_birth,
+                )
             with self._lock:
-                handle._pid = int(first_proc.pid)
+                handle._pid = first_ownership.root_pid
             if on_pid is not None:
-                on_pid(identity, 1, int(first_proc.pid))
+                on_pid(identity, 1, first_ownership.root_pid)
         except Exception as exc:
             if "first_proc" in locals():
-                _terminate_process_tree(first_proc)
+                _cleanup_failed_start(first_proc, self._cleanup_timeout)
+            if "first_path" in locals():
+                try:
+                    first_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
             self._notify_once(
                 handle, notifier, 1, "setup_failure", -1, str(exc)
             )
@@ -474,7 +735,8 @@ class DispatcherWorkerSupervisor:
             name=f"worker-supervisor-{identity.task_id}",
             args=(
                 identity, launch, handle, first_proc, first_path, on_exit,
-                on_success, notifier, on_pid, gate_advance,
+                first_ownership, on_success, notifier, on_pid, gate_advance,
+                lineage_resolver,
             ),
             daemon=True,
         )
@@ -517,9 +779,85 @@ class DispatcherWorkerSupervisor:
         identity: WorkerIdentity,
         launch: LaunchWorker,
         attempt: int,
-    ) -> tuple[subprocess.Popen, Path]:
+    ) -> tuple[subprocess.Popen, Path, _AttemptOwnership]:
         event_path = self.allocate_event_path(identity, attempt)
-        return launch(identity, attempt, event_path), event_path
+        nonce = secrets.token_urlsafe(32)
+        parameters = inspect.signature(launch).parameters
+        supports_nonce = "start_nonce" in parameters or any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+        proc = (
+            launch(identity, attempt, event_path, start_nonce=nonce)
+            if supports_nonce
+            else launch(identity, attempt, event_path)
+        )
+        proc._hermes_worker_start_nonce = nonce  # type: ignore[attr-defined]
+        launcher_birth = _bind_process_birth(proc)
+        try:
+            ownership = self._await_start_identity(
+                identity, attempt, proc, event_path, nonce, launcher_birth
+            )
+        except Exception:
+            _cleanup_failed_start(proc, self._cleanup_timeout)
+            try:
+                event_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+        return proc, event_path, ownership
+
+    def _await_start_identity(
+        self,
+        identity: WorkerIdentity,
+        attempt: int,
+        proc: subprocess.Popen,
+        event_path: Path,
+        nonce: str,
+        launcher_birth: str,
+    ) -> _AttemptOwnership:
+        deadline = time.monotonic() + self._start_timeout
+        while True:
+            events, valid = _read_events(event_path)
+            if not valid:
+                raise RuntimeError("malformed child-start identity record")
+            identity_events = [
+                event
+                for event in events
+                if event.get("kind") == LifecycleEventType.IDENTITY.value
+            ]
+            if len(identity_events) > 1:
+                raise RuntimeError("duplicate child-start identity records")
+            if identity_events:
+                start_event = identity_events[0]
+                if events[0] is not start_event or not _start_identity_matches(
+                    start_event, identity, attempt, nonce
+                ):
+                    raise RuntimeError("child-start identity contract mismatch")
+                observed_pid = int(start_event["root_pid"])
+                observed_birth = str(start_event["process_birth_token"])
+                if process_birth_token(observed_pid) != observed_birth:
+                    raise RuntimeError("child-start process birth mismatch")
+                if not _is_live_launcher_or_descendant(
+                    proc, launcher_birth, observed_pid
+                ):
+                    raise RuntimeError("child-start PID is not owned by launcher")
+                if process_birth_token(observed_pid) != observed_birth:
+                    raise RuntimeError("child-start process identity changed")
+                return _AttemptOwnership(
+                    nonce=nonce,
+                    launcher_pid=int(proc.pid),
+                    launcher_birth_token=launcher_birth,
+                    root_pid=observed_pid,
+                    root_birth_token=observed_birth,
+                )
+            if events:
+                raise RuntimeError("child-start identity was not the first record")
+            if proc.poll() is not None:
+                raise RuntimeError("worker exited before child-start identity")
+            if time.monotonic() >= deadline:
+                raise RuntimeError("timed out waiting for child-start identity")
+            time.sleep(self._poll_interval)
 
     def allocate_event_path(self, identity: WorkerIdentity, attempt: int) -> Path:
         self._event_root.mkdir(parents=True, exist_ok=True)
@@ -536,10 +874,12 @@ class DispatcherWorkerSupervisor:
         proc: subprocess.Popen,
         event_path: Path,
         on_exit: Optional[ExitCallback],
+        ownership: _AttemptOwnership,
         on_success: Optional[SuccessCallback],
         notifier: Optional[Notifier],
         on_pid: Optional[Callable[[WorkerIdentity, int, int], None]],
         gate_advance: Optional[Callable[[WorkerIdentity], None]],
+        lineage_resolver: Optional[SessionCompressionLineageResolver],
     ) -> None:
         attempts = 0
         last_exit: Optional[AttemptExit] = None
@@ -548,7 +888,13 @@ class DispatcherWorkerSupervisor:
                 attempts = attempt
                 tracked = _wait_with_descendant_tracking(proc, self._poll_interval)
                 last_exit = _attempt_exit(
-                    identity, attempt, proc, event_path, owned_pids=tracked
+                    identity,
+                    attempt,
+                    proc,
+                    event_path,
+                    ownership,
+                    owned_pids=tracked,
+                    lineage_resolver=lineage_resolver,
                 )
                 callback_error: Optional[Exception] = None
                 try:
@@ -601,14 +947,16 @@ class DispatcherWorkerSupervisor:
                         )
                         return
                     try:
-                        proc, event_path = self._launch_attempt(identity, launch, 2)
+                        proc, event_path, ownership = self._launch_attempt(
+                            identity, launch, 2
+                        )
                         with self._lock:
-                            handle._pid = int(proc.pid)
+                            handle._pid = ownership.root_pid
                         if on_pid is not None:
-                            on_pid(identity, 2, int(proc.pid))
+                            on_pid(identity, 2, ownership.root_pid)
                     except Exception as exc:
                         if "proc" in locals() and proc.poll() is None:
-                            _terminate_process_tree(proc)
+                            _cleanup_failed_start(proc, self._cleanup_timeout)
                         self._notify_once(
                             handle, notifier, 2, "retry_setup_failure", -1, str(exc)
                         )

--- a/hermes_cli/worker_supervisor.py
+++ b/hermes_cli/worker_supervisor.py
@@ -32,9 +32,14 @@ class WorkerIdentity:
     task_id: str
     session_id: str
     worktree: Path
+    run_id: object = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "worktree", Path(self.worktree).resolve())
+
+    @property
+    def key(self) -> tuple[str, object]:
+        return self.task_id, self.run_id
 
 
 @dataclass(frozen=True)
@@ -47,6 +52,9 @@ class OwnedProcess:
 @dataclass(frozen=True)
 class AttemptExit:
     task_id: str
+    run_id: object
+    session_id: str
+    worktree: Path
     attempt: int
     pid: int
     exit_code: int
@@ -57,6 +65,9 @@ class AttemptExit:
     def as_dict(self) -> dict:
         return {
             "task_id": self.task_id,
+            "run_id": self.run_id,
+            "session_id": self.session_id,
+            "worktree": str(self.worktree),
             "attempt": self.attempt,
             "pid": self.pid,
             "exit_code": self.exit_code,
@@ -71,6 +82,8 @@ class AttemptExit:
 @dataclass(frozen=True)
 class LifecycleFailure:
     task_id: str
+    run_id: object
+    session_id: str
     attempts: int
     classification: str
     exit_code: int
@@ -125,20 +138,58 @@ def _read_events(path: Path) -> tuple[dict, ...]:
     return tuple(events)
 
 
-def _attempt_exit(identity: WorkerIdentity, attempt: int, proc: subprocess.Popen, path: Path) -> AttemptExit:
+def _terminal_event_matches(
+    event: dict,
+    identity: WorkerIdentity,
+    attempt: int,
+    proc: subprocess.Popen,
+    owned_pids: set[int],
+) -> bool:
+    """Validate typed terminal evidence against the exact owned attempt."""
+
+    try:
+        return (
+            event.get("schema_version") == 1
+            and event.get("kind") == "terminal"
+            and event.get("task_id") == identity.task_id
+            and event.get("run_id") == identity.run_id
+            and int(event.get("attempt")) == attempt
+            and event.get("session_id") == identity.session_id
+            and Path(str(event.get("worktree"))).resolve() == identity.worktree
+            and int(event.get("owner_pid")) in ({int(proc.pid)} | owned_pids)
+            and int(event.get("exit_code")) == int(proc.returncode)
+            and isinstance(event.get("classification"), str)
+        )
+    except (TypeError, ValueError, OSError):
+        return False
+
+
+def _attempt_exit(
+    identity: WorkerIdentity,
+    attempt: int,
+    proc: subprocess.Popen,
+    path: Path,
+    owned_pids: Optional[set[int]] = None,
+) -> AttemptExit:
     events = _read_events(path)
-    failure = next(
-        (event for event in reversed(events) if event.get("kind") == "failure"),
+    terminal = next(
+        (
+            event
+            for event in reversed(events)
+            if _terminal_event_matches(
+                event, identity, attempt, proc, owned_pids or set()
+            )
+        ),
         None,
     )
     classification = (
-        str(failure.get("classification"))
-        if failure and failure.get("classification")
+        str(terminal["classification"])
+        if terminal is not None
         else ("success" if proc.returncode == 0 else "process_exit")
     )
     owned: list[OwnedProcess] = []
     seen: set[int] = set()
-    for event in events:
+    for event in events if terminal is not None else ():
         if event.get("kind") != "owned_process":
             continue
         try:
@@ -155,6 +206,9 @@ def _attempt_exit(identity: WorkerIdentity, attempt: int, proc: subprocess.Popen
         owned.append(OwnedProcess(pid=pid, role=str(event.get("role") or "background"), port=port))
     return AttemptExit(
         task_id=identity.task_id,
+        run_id=identity.run_id,
+        session_id=identity.session_id,
+        worktree=identity.worktree,
         attempt=attempt,
         pid=int(proc.pid),
         exit_code=int(proc.returncode),
@@ -164,64 +218,144 @@ def _attempt_exit(identity: WorkerIdentity, attempt: int, proc: subprocess.Popen
     )
 
 
-def _terminate_exact_pid(pid: int, *, force: bool) -> None:
-    if not pid_is_alive(pid):
-        return
-    if os.name == "nt":
-        command = ["taskkill", "/PID", str(pid), "/T"]
-        if force:
-            command.append("/F")
-        subprocess.run(
-            command,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-            timeout=5,
-        )
-        return
+def _descendant_pids(pid: int) -> set[int]:
+    """Snapshot descendants using the project's cross-platform process API."""
+
     try:
-        os.kill(pid, signal.SIGKILL if force else signal.SIGTERM)
-    except ProcessLookupError:
-        pass
+        import psutil
+
+        return {int(child.pid) for child in psutil.Process(int(pid)).children(recursive=True)}
+    except Exception:
+        return set()
 
 
-def _cleanup_owned_tree(attempt_exit: AttemptExit, timeout: float) -> None:
-    """Terminate only this launch's process group and registered owned PIDs."""
+def _wait_with_descendant_tracking(proc: subprocess.Popen, interval: float) -> set[int]:
+    """Wait on the exact handle while retaining descendants seen before exit."""
 
-    pids = {item.pid for item in attempt_exit.owned_processes if item.pid != attempt_exit.pid}
-    if os.name != "nt":
+    stopped = threading.Event()
+    observed: set[int] = set()
+
+    def track() -> None:
+        while not stopped.is_set():
+            observed.update(_descendant_pids(int(proc.pid)))
+            stopped.wait(interval)
+
+    tracker = threading.Thread(target=track, name=f"worker-tree-{proc.pid}", daemon=True)
+    tracker.start()
+    try:
+        returncode = proc.wait()
+        if getattr(proc, "returncode", None) is None:
+            proc.returncode = returncode
+    finally:
+        observed.update(_descendant_pids(int(proc.pid)))
+        stopped.set()
+        tracker.join(timeout=max(0.1, interval * 4))
+    return observed
+
+
+def _terminate_process_tree(proc: subprocess.Popen) -> bool:
+    """Terminate the owned root and only descendants observed from that root."""
+
+    tracked = set(getattr(proc, "_hermes_owned_descendants", ()))
+    tracked.update(_descendant_pids(int(proc.pid)))
+    try:
+        import psutil
+
+        processes = []
+        for pid in sorted(tracked, reverse=True):
+            try:
+                processes.append(psutil.Process(pid))
+            except psutil.Error:
+                pass
         try:
-            os.killpg(attempt_exit.pid, signal.SIGTERM)
-        except (ProcessLookupError, PermissionError):
-            pass
-    for pid in pids:
-        _terminate_exact_pid(pid, force=False)
+            root = psutil.Process(int(proc.pid))
+        except psutil.Error:
+            root = None
+        for process in processes:
+            try:
+                process.terminate()
+            except psutil.Error:
+                pass
+        if root is not None:
+            try:
+                root.terminate()
+            except psutil.Error:
+                pass
+        _, survivors = psutil.wait_procs(
+            processes + ([root] if root is not None else []), timeout=1.0
+        )
+        for process in survivors:
+            try:
+                process.kill()
+            except psutil.Error:
+                pass
+        psutil.wait_procs(survivors, timeout=1.0)
+    except Exception:
+        try:
+            if proc.poll() is None:
+                proc.terminate()
+                proc.wait(timeout=1.0)
+        except Exception:
+            try:
+                proc.kill()
+                proc.wait(timeout=1.0)
+            except Exception:
+                pass
+    return not any(pid_is_alive(pid) for pid in tracked) and not pid_is_alive(int(proc.pid))
 
-    deadline = time.monotonic() + max(0.1, timeout)
-    while time.monotonic() < deadline and any(pid_is_alive(pid) for pid in pids):
-        time.sleep(0.02)
-    for pid in pids:
-        _terminate_exact_pid(pid, force=True)
 
+def _cleanup_owned_tree(
+    attempt_exit: AttemptExit,
+    proc: subprocess.Popen,
+    tracked: set[int],
+    timeout: float,
+    cleanup_fn: Callable[[subprocess.Popen], bool],
+) -> bool:
+    """Clean a verified tree; never signal an unverified registered PID."""
+
+    proc._hermes_owned_descendants = tuple(tracked)  # type: ignore[attr-defined]
+    try:
+        reported_clean = bool(cleanup_fn(proc))
+    except Exception:
+        reported_clean = False
+    registered = {
+        item.pid for item in attempt_exit.owned_processes if item.pid != attempt_exit.pid
+    }
     deadline = time.monotonic() + max(0.1, timeout)
-    while time.monotonic() < deadline and any(pid_is_alive(pid) for pid in pids):
+    while time.monotonic() < deadline:
+        if not any(pid_is_alive(pid) for pid in tracked | registered):
+            break
         time.sleep(0.02)
+    # A live PID reported by the worker but never observed as a descendant is
+    # evidence mismatch.  It blocks retry but is deliberately never signaled.
+    unverified_survivor = any(
+        pid not in tracked and pid_is_alive(pid) for pid in registered
+    )
+    survivor = any(pid_is_alive(pid) for pid in tracked)
+    return reported_clean and not survivor and not unverified_survivor
 
 
 class WorkerLifecycleHandle:
-    def __init__(self, task_id: str) -> None:
-        self.task_id = task_id
+    def __init__(self, supervisor: "DispatcherWorkerSupervisor", identity: WorkerIdentity) -> None:
+        self.task_id = identity.task_id
+        self.identity = identity
+        self._supervisor = supervisor
         self._recovery = threading.Event()
         self._finished = threading.Event()
         self._recovery_reason = ""
+        self._waiting_since: Optional[float] = None
         self._thread: Optional[threading.Thread] = None
         self._pid: Optional[int] = None
 
-    def signal_recovery(self, reason: str) -> None:
-        if reason:
-            self._recovery_reason = str(reason)
-            self._recovery.set()
+    def signal_recovery(self, reason: str) -> bool:
+        # Compatibility for callers holding a handle: wait briefly for the
+        # on-exit callback/cleanup boundary, then use the same exact gate.
+        deadline = time.monotonic() + self._supervisor._cleanup_timeout
+        while self._waiting_since is None and not self._finished.is_set():
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(self._supervisor._poll_interval)
+        return self._supervisor.signal_recovery(self.identity, reason)
 
     def wait(self, timeout: Optional[float] = None) -> bool:
         return self._finished.wait(timeout)
@@ -244,11 +378,15 @@ class DispatcherWorkerSupervisor:
         event_root: Path,
         recovery_timeout: float = 300.0,
         cleanup_timeout: float = 5.0,
+        poll_interval: float = 0.01,
+        cleanup_fn: Optional[Callable[[subprocess.Popen], bool]] = None,
     ) -> None:
         self._event_root = Path(event_root)
         self._recovery_timeout = max(0.1, float(recovery_timeout))
         self._cleanup_timeout = max(0.1, float(cleanup_timeout))
-        self._active: dict[str, WorkerLifecycleHandle] = {}
+        self._poll_interval = max(0.001, float(poll_interval))
+        self._cleanup_fn = cleanup_fn or _terminate_process_tree
+        self._active: dict[tuple[str, object], WorkerLifecycleHandle] = {}
         self._lock = threading.Lock()
 
     @property
@@ -256,32 +394,58 @@ class DispatcherWorkerSupervisor:
         with self._lock:
             return len(self._active)
 
-    def active_pid(self, task_id: str) -> Optional[int]:
-        """Return the current PID while this supervisor owns task_id."""
+    def active_pids(self) -> set[int]:
+        """Return exact live-handle PIDs owned by this supervisor."""
         with self._lock:
-            handle = self._active.get(task_id)
+            return {
+                int(handle._pid)
+                for handle in self._active.values()
+                if handle._pid is not None
+            }
+
+    def active_pid(self, task_id: str, run_id: object = None) -> Optional[int]:
+        """Return the PID for one exact run (or one unambiguous legacy task)."""
+        with self._lock:
+            if run_id is not None:
+                handle = self._active.get((task_id, run_id))
+            else:
+                matches = [
+                    item for key, item in self._active.items() if key[0] == task_id
+                ]
+                handle = matches[0] if len(matches) == 1 else None
             if handle is None or handle._pid is None:
                 return None
             return int(handle._pid)
+
+    def is_waiting_for_recovery(self, identity: WorkerIdentity) -> bool:
+        with self._lock:
+            handle = self._active.get(identity.key)
+            return bool(
+                handle is not None
+                and handle.identity == identity
+                and handle._waiting_since is not None
+            )
 
     def start(
         self,
         identity: WorkerIdentity,
         launch: LaunchWorker,
         *,
-        on_exit: ExitCallback,
+        on_exit: Optional[ExitCallback] = None,
         on_success: Optional[SuccessCallback] = None,
         notifier: Optional[Notifier] = None,
+        on_pid: Optional[Callable[[WorkerIdentity, int, int], None]] = None,
+        gate_advance: Optional[Callable[[WorkerIdentity], None]] = None,
         initial_proc: Optional[subprocess.Popen] = None,
         initial_event_path: Optional[Path] = None,
     ) -> WorkerLifecycleHandle:
         if (initial_proc is None) != (initial_event_path is None):
             raise ValueError("initial_proc and initial_event_path must be provided together")
         with self._lock:
-            if identity.task_id in self._active:
-                raise RuntimeError(f"worker {identity.task_id} is already supervised")
-            handle = WorkerLifecycleHandle(identity.task_id)
-            self._active[identity.task_id] = handle
+            if identity.key in self._active:
+                raise RuntimeError(f"worker {identity.key!r} is already supervised")
+            handle = WorkerLifecycleHandle(self, identity)
+            self._active[identity.key] = handle
 
         self._event_root.mkdir(parents=True, exist_ok=True)
         try:
@@ -293,27 +457,60 @@ class DispatcherWorkerSupervisor:
                 first_path = Path(initial_event_path)
             with self._lock:
                 handle._pid = int(first_proc.pid)
-        except Exception:
+            if on_pid is not None:
+                on_pid(identity, 1, int(first_proc.pid))
+        except Exception as exc:
+            if "first_proc" in locals():
+                _terminate_process_tree(first_proc)
+            self._notify_once(
+                handle, notifier, 1, "setup_failure", -1, str(exc)
+            )
             with self._lock:
-                self._active.pop(identity.task_id, None)
+                self._active.pop(identity.key, None)
+            handle._finished.set()
             raise
         thread = threading.Thread(
             target=self._monitor,
             name=f"worker-supervisor-{identity.task_id}",
-            args=(identity, launch, handle, first_proc, first_path, on_exit, on_success, notifier),
+            args=(
+                identity, launch, handle, first_proc, first_path, on_exit,
+                on_success, notifier, on_pid, gate_advance,
+            ),
             daemon=True,
         )
         handle._thread = thread
         thread.start()
         return handle
 
-    def signal_recovery(self, task_id: str, reason: str) -> bool:
+    def signal_recovery(
+        self,
+        identity: WorkerIdentity | str,
+        reason: str,
+        *,
+        signaled_at: Optional[float] = None,
+    ) -> bool:
         with self._lock:
-            handle = self._active.get(task_id)
-        if handle is None:
-            return False
-        handle.signal_recovery(reason)
-        return True
+            if isinstance(identity, WorkerIdentity):
+                handle = self._active.get(identity.key)
+                if handle is not None and handle.identity != identity:
+                    handle = None
+            else:
+                matches = [
+                    item for key, item in self._active.items() if key[0] == identity
+                ]
+                handle = matches[0] if len(matches) == 1 else None
+            now = time.monotonic() if signaled_at is None else float(signaled_at)
+            if (
+                handle is None
+                or not reason
+                or handle._waiting_since is None
+                or now < handle._waiting_since
+                or handle._recovery.is_set()
+            ):
+                return False
+            handle._recovery_reason = str(reason)
+            handle._recovery.set()
+            return True
 
     def _launch_attempt(
         self,
@@ -327,7 +524,7 @@ class DispatcherWorkerSupervisor:
     def allocate_event_path(self, identity: WorkerIdentity, attempt: int) -> Path:
         self._event_root.mkdir(parents=True, exist_ok=True)
         event_path = self._event_root / (
-            f"{identity.task_id}.attempt-{attempt}.{uuid.uuid4().hex}.jsonl"
+            f"attempt-{attempt}.{uuid.uuid4().hex}.jsonl"
         )
         return event_path
 
@@ -338,46 +535,126 @@ class DispatcherWorkerSupervisor:
         handle: WorkerLifecycleHandle,
         proc: subprocess.Popen,
         event_path: Path,
-        on_exit: ExitCallback,
+        on_exit: Optional[ExitCallback],
         on_success: Optional[SuccessCallback],
         notifier: Optional[Notifier],
+        on_pid: Optional[Callable[[WorkerIdentity, int, int], None]],
+        gate_advance: Optional[Callable[[WorkerIdentity], None]],
     ) -> None:
         attempts = 0
         last_exit: Optional[AttemptExit] = None
         try:
             for attempt in (1, 2):
                 attempts = attempt
-                proc.wait()
-                last_exit = _attempt_exit(identity, attempt, proc, event_path)
+                tracked = _wait_with_descendant_tracking(proc, self._poll_interval)
+                last_exit = _attempt_exit(
+                    identity, attempt, proc, event_path, owned_pids=tracked
+                )
+                callback_error: Optional[Exception] = None
                 try:
-                    on_exit(last_exit)
+                    if on_exit is not None:
+                        on_exit(last_exit)
+                except Exception as exc:
+                    callback_error = exc
                 finally:
-                    _cleanup_owned_tree(last_exit, self._cleanup_timeout)
+                    clean = _cleanup_owned_tree(
+                        last_exit, proc, tracked, self._cleanup_timeout, self._cleanup_fn
+                    )
+                    try:
+                        event_path.unlink(missing_ok=True)
+                    except OSError:
+                        clean = False
+
+                if callback_error is not None or not clean:
+                    self._notify_once(
+                        handle,
+                        notifier,
+                        attempts,
+                        last_exit.classification,
+                        last_exit.exit_code,
+                        str(callback_error) if callback_error else "cleanup_not_verified",
+                    )
+                    return
 
                 if last_exit.classification == "success":
-                    if on_success is not None:
-                        on_success(last_exit)
+                    try:
+                        if on_success is not None:
+                            on_success(last_exit)
+                        if attempt == 2 and gate_advance is not None:
+                            gate_advance(identity)
+                    except Exception as exc:
+                        self._notify_once(
+                            handle, notifier, attempts, "callback_failure",
+                            last_exit.exit_code, str(exc),
+                        )
                     return
                 if attempt == 1 and last_exit.classification == TRANSIENT_PROVIDER:
-                    if not handle._recovery.wait(self._recovery_timeout):
-                        break
-                    proc, event_path = self._launch_attempt(identity, launch, 2)
                     with self._lock:
-                        handle._pid = int(proc.pid)
+                        handle._waiting_since = time.monotonic()
+                    recovered = handle._recovery.wait(self._recovery_timeout)
+                    with self._lock:
+                        handle._waiting_since = None
+                    if not recovered:
+                        self._notify_once(
+                            handle, notifier, attempts, last_exit.classification,
+                            last_exit.exit_code, "recovery_timeout",
+                        )
+                        return
+                    try:
+                        proc, event_path = self._launch_attempt(identity, launch, 2)
+                        with self._lock:
+                            handle._pid = int(proc.pid)
+                        if on_pid is not None:
+                            on_pid(identity, 2, int(proc.pid))
+                    except Exception as exc:
+                        if "proc" in locals() and proc.poll() is None:
+                            _terminate_process_tree(proc)
+                        self._notify_once(
+                            handle, notifier, 2, "retry_setup_failure", -1, str(exc)
+                        )
+                        return
                     continue
                 break
 
-            if notifier is not None and last_exit is not None:
-                notifier(
-                    LifecycleFailure(
-                        task_id=identity.task_id,
-                        attempts=attempts,
-                        classification=last_exit.classification,
-                        exit_code=last_exit.exit_code,
-                        reason=handle.recovery_reason or "recovery_timeout",
-                    )
+            if last_exit is not None:
+                self._notify_once(
+                    handle, notifier, attempts, last_exit.classification,
+                    last_exit.exit_code,
+                    handle.recovery_reason or last_exit.classification,
                 )
         finally:
             with self._lock:
-                self._active.pop(identity.task_id, None)
+                if self._active.get(identity.key) is handle:
+                    self._active.pop(identity.key, None)
             handle._finished.set()
+
+    def _notify_once(
+        self,
+        handle: WorkerLifecycleHandle,
+        notifier: Optional[Notifier],
+        attempts: int,
+        classification: str,
+        exit_code: int,
+        reason: str,
+    ) -> None:
+        if getattr(handle, "_notified", False):
+            return
+        handle._notified = True  # type: ignore[attr-defined]
+        if notifier is None:
+            return
+        try:
+            notifier(
+                LifecycleFailure(
+                    task_id=handle.identity.task_id,
+                    run_id=handle.identity.run_id,
+                    session_id=handle.identity.session_id,
+                    attempts=attempts,
+                    classification=classification,
+                    exit_code=exit_code,
+                    reason=reason,
+                )
+            )
+        except Exception:
+            # Notification is a terminal seam; a broken notifier must not keep
+            # ownership alive or cause a duplicate notification attempt.
+            pass

--- a/hermes_cli/worker_supervisor.py
+++ b/hermes_cli/worker_supervisor.py
@@ -129,6 +129,34 @@ class LifecycleFailure:
     exit_code: int
     reason: str
 
+    def as_dict(self) -> dict:
+        classifications = {
+            *(item.value for item in TerminalClassification),
+            "callback_failure",
+            "invalid_evidence",
+            "process_exit",
+            "retry_setup_failure",
+        }
+        reasons = classifications | {
+            "cleanup_not_verified",
+            "credential_recovered",
+            "provider_recovered",
+            "recovery_timeout",
+        }
+        return {
+            "task_id": self.task_id,
+            "run_id": self.run_id,
+            "session_id": self.session_id,
+            "attempts": self.attempts,
+            "classification": (
+                self.classification
+                if self.classification in classifications
+                else TerminalClassification.SUPERVISOR_FAILURE.value
+            ),
+            "exit_code": self.exit_code,
+            "reason": self.reason if self.reason in reasons else "unspecified",
+        }
+
 
 LaunchWorker = Callable[..., subprocess.Popen]
 ExitCallback = Callable[[AttemptExit], None]

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7908,6 +7908,61 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return int(self._execute_write(_do))
 
+    def rotate_provider_credential_generation(
+        self,
+        profile: str,
+        provider: str,
+        *,
+        expected_generation: int,
+    ) -> int:
+        """Rotate an auth scope generation if its current value is expected.
+
+        A stale observer receives the already-current generation instead of
+        rotating it again. Tokens remain random profile/provider metadata and
+        are never derived from credential bytes.
+        """
+        scope_part = re.compile(r"[a-z0-9][a-z0-9._:-]{0,127}\Z")
+        if not isinstance(profile, str) or scope_part.fullmatch(profile) is None:
+            raise ValueError("provider credential profile must be normalized")
+        if not isinstance(provider, str) or scope_part.fullmatch(provider) is None:
+            raise ValueError("provider credential provider must be normalized")
+        if (
+            not isinstance(expected_generation, int)
+            or isinstance(expected_generation, bool)
+            or expected_generation <= 0
+        ):
+            raise ValueError("expected provider credential generation is malformed")
+        key = f"provider_credential_generation:{profile}:{provider}"
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?", (key,)
+            ).fetchone()
+            if row is None:
+                raise ValueError("provider credential generation does not exist")
+            raw = row["value"] if isinstance(row, sqlite3.Row) else row[0]
+            try:
+                generation = int(raw)
+            except (TypeError, ValueError):
+                raise ValueError("provider credential generation is malformed")
+            if generation <= 0:
+                raise ValueError("provider credential generation is malformed")
+            if generation != expected_generation:
+                return generation
+
+            rotated_generation = generation
+            while rotated_generation == generation:
+                rotated_generation = secrets.randbits(63) or 1
+            cursor = conn.execute(
+                "UPDATE state_meta SET value = ? WHERE key = ? AND value = ?",
+                (str(rotated_generation), key, raw),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("provider credential generation rotation lost CAS")
+            return rotated_generation
+
+        return int(self._execute_write(_do))
+
     def apply_telegram_topic_migration(self) -> None:
         """Create Telegram DM topic-mode tables on explicit /topic opt-in.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,6 +21,7 @@ import logging
 import os
 import random
 import re
+import secrets
 import sqlite3
 import sys
 import threading
@@ -7031,7 +7032,90 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # Continue to include later compression tips only when the
                 # requested session itself was compacted.
                 continue
-        return lineage if session_id in lineage else [session_id]
+        return lineage
+
+    def is_verified_compression_descendant(
+        self,
+        expected_session_id: str,
+        observed_session_id: str,
+    ) -> bool:
+        """Prove that ``observed`` is an unambiguous compression descendant.
+
+        This is deliberately stricter than the UI-oriented lineage helpers:
+        every parent must have ended via compression and must have exactly one
+        non-branch, non-delegate continuation.  Missing, malformed, cyclic, or
+        ambiguous persisted state fails closed.
+        """
+        if (
+            not isinstance(expected_session_id, str)
+            or not expected_session_id
+            or not isinstance(observed_session_id, str)
+            or not observed_session_id
+            or expected_session_id == observed_session_id
+        ):
+            return False
+
+        def _is_continuation(row: sqlite3.Row) -> Optional[bool]:
+            if row["source"] == "tool":
+                return False
+            raw_config = row["model_config"]
+            if raw_config in (None, ""):
+                config: Dict[str, Any] = {}
+            else:
+                try:
+                    config = json.loads(raw_config)
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    return None
+                if not isinstance(config, dict):
+                    return None
+            if config.get("_branched_from") or config.get("_delegated_from"):
+                return False
+            return True
+
+        current_id = observed_session_id
+        visited: set[str] = set()
+        with self._lock:
+            for _ in range(100):
+                if current_id in visited:
+                    return False
+                visited.add(current_id)
+
+                current = self._conn.execute(
+                    "SELECT id, parent_session_id, source, model_config "
+                    "FROM sessions WHERE id = ?",
+                    (current_id,),
+                ).fetchone()
+                if current is None or _is_continuation(current) is not True:
+                    return False
+
+                parent_id = current["parent_session_id"]
+                if not isinstance(parent_id, str) or not parent_id:
+                    return False
+                parent = self._conn.execute(
+                    "SELECT end_reason FROM sessions WHERE id = ?",
+                    (parent_id,),
+                ).fetchone()
+                if parent is None or parent["end_reason"] != "compression":
+                    return False
+
+                children = self._conn.execute(
+                    "SELECT id, source, model_config FROM sessions "
+                    "WHERE parent_session_id = ?",
+                    (parent_id,),
+                ).fetchall()
+                continuations: List[str] = []
+                for child in children:
+                    is_continuation = _is_continuation(child)
+                    if is_continuation is None:
+                        return False
+                    if is_continuation:
+                        continuations.append(child["id"])
+                if continuations != [current_id]:
+                    return False
+                if parent_id == expected_session_id:
+                    return True
+                current_id = parent_id
+        return False
 
     def clear_messages(self, session_id: str) -> None:
         """Delete all messages for a session and reset its counters."""
@@ -7782,6 +7866,47 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return retagged
 
         return self._execute_write(_do)
+
+    def get_or_create_provider_credential_generation(
+        self,
+        profile: str,
+        provider: str,
+    ) -> int:
+        """Return one opaque, non-secret generation for a loaded auth scope.
+
+        The caller is the credential-loading authority and must invoke this
+        only after a usable credential has been resolved. The random token is
+        profile/provider metadata; it is never derived from credential bytes.
+        """
+        scope_part = re.compile(r"[a-z0-9][a-z0-9._:-]{0,127}\Z")
+        if not isinstance(profile, str) or scope_part.fullmatch(profile) is None:
+            raise ValueError("provider credential profile must be normalized")
+        if not isinstance(provider, str) or scope_part.fullmatch(provider) is None:
+            raise ValueError("provider credential provider must be normalized")
+        key = f"provider_credential_generation:{profile}:{provider}"
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?", (key,)
+            ).fetchone()
+            if row is not None:
+                raw = row["value"] if isinstance(row, sqlite3.Row) else row[0]
+                try:
+                    generation = int(raw)
+                except (TypeError, ValueError):
+                    raise ValueError("provider credential generation is malformed")
+                if generation <= 0:
+                    raise ValueError("provider credential generation is malformed")
+                return generation
+
+            generation = secrets.randbits(63) or 1
+            conn.execute(
+                "INSERT INTO state_meta (key, value) VALUES (?, ?)",
+                (key, str(generation)),
+            )
+            return generation
+
+        return int(self._execute_write(_do))
 
     def apply_telegram_topic_migration(self) -> None:
         """Create Telegram DM topic-mode tables on explicit /topic opt-in.

--- a/tests/fixtures/worker_lifecycle_fixture.py
+++ b/tests/fixtures/worker_lifecycle_fixture.py
@@ -1,0 +1,137 @@
+"""Synthetic subprocess fixture for dispatcher-owned worker supervision tests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import socket
+import sqlite3
+import subprocess
+import sys
+import time
+
+
+def emit(path: Path, **payload: object) -> None:
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(payload, sort_keys=True) + "\n")
+        stream.flush()
+
+
+def run_listener(event_path: Path) -> int:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    emit(
+        event_path,
+        kind="owned_process",
+        pid=os.getpid(),
+        role="listener",
+        port=listener.getsockname()[1],
+    )
+    while True:
+        time.sleep(1)
+
+
+def run_attempt(args: argparse.Namespace) -> int:
+    emit(
+        args.event_path,
+        kind="identity",
+        attempt=args.attempt,
+        task_id=args.task_id,
+        run_id=args.run_id,
+        session_id=args.session_id,
+        worktree=str(args.worktree),
+    )
+    if args.attempt == 1:
+        subprocess.Popen(
+            [sys.executable, __file__, "listener", "--event-path", str(args.event_path)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if args.event_path.exists() and '"role": "listener"' in args.event_path.read_text(encoding="utf-8"):
+                break
+            time.sleep(0.02)
+        else:
+            emit(args.event_path, kind="failure", classification="fixture_timeout")
+            return 70
+        emit(
+            args.event_path,
+            kind="failure",
+            classification="transient_provider",
+            provider="fixture",
+        )
+        return 75
+
+    if args.outcome == "fail":
+        emit(
+            args.event_path,
+            kind="failure",
+            classification="transient_provider",
+            provider="fixture",
+        )
+        return 76
+
+    bounded_file = args.worktree / "recovered.txt"
+    bounded_file.write_text("recovered\n", encoding="utf-8")
+    subprocess.run(["git", "add", "recovered.txt"], cwd=args.worktree, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Hermes Fixture",
+            "-c",
+            "user.email=fixture@invalid",
+            "commit",
+            "-m",
+            "fixture: recovered worker",
+        ],
+        cwd=args.worktree,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect(args.board_db)
+    try:
+        completed = kb.complete_task(
+            conn,
+            args.task_id,
+            result="worker lifecycle fixture recovered",
+            expected_run_id=args.run_id if args.run_id is not None else None,
+        )
+    finally:
+        conn.close()
+    if not completed:
+        emit(args.event_path, kind="failure", classification="completion_rejected")
+        return 71
+    emit(args.event_path, kind="task_done", task_id=args.task_id)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("attempt", "listener"))
+    parser.add_argument("--event-path", type=Path, required=True)
+    parser.add_argument("--attempt", type=int)
+    parser.add_argument("--session-id")
+    parser.add_argument("--worktree", type=Path)
+    parser.add_argument("--board-db", type=Path)
+    parser.add_argument("--task-id")
+    parser.add_argument("--run-id", type=int)
+    parser.add_argument("--outcome", choices=("success", "fail"), default="success")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    parsed = parse_args()
+    raise SystemExit(run_listener(parsed.event_path) if parsed.mode == "listener" else run_attempt(parsed))

--- a/tests/fixtures/worker_lifecycle_fixture.py
+++ b/tests/fixtures/worker_lifecycle_fixture.py
@@ -12,6 +12,16 @@ import subprocess
 import sys
 import time
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from hermes_cli.worker_lifecycle import (
+    emit_start_identity_event,
+    emit_terminal_event,
+    process_birth_token,
+)
+
 
 def emit(path: Path, **payload: object) -> None:
     with path.open("a", encoding="utf-8") as stream:
@@ -25,17 +35,26 @@ def emit_terminal(
     exit_code: int,
     classification: str,
 ) -> None:
+    birth_token = process_birth_token(os.getpid())
+    if birth_token is None:
+        raise RuntimeError("could not obtain fixture process birth identity")
+    failure_reason = "none" if classification == "success" else "transient_provider"
     emit(
         args.event_path,
-        schema_version=1,
+        schema_version=3,
         kind="terminal",
+        nonce=args.start_nonce,
         task_id=args.task_id,
         run_id=args.run_id,
         attempt=args.attempt,
-        session_id=args.session_id,
+        expected_session_id=args.session_id,
+        observed_session_id=args.session_id,
         worktree=str(args.worktree.resolve()),
-        owner_pid=os.getpid(),
-        exit_code=exit_code,
+        root_pid=os.getpid(),
+        process_birth_token=birth_token,
+        exit_kind="code",
+        exit_value=exit_code,
+        failure_reason=failure_reason,
         classification=classification,
     )
 
@@ -57,14 +76,22 @@ def run_listener(event_path: Path) -> int:
 
 
 def run_attempt(args: argparse.Namespace) -> int:
+    birth_token = process_birth_token(os.getpid())
+    if birth_token is None:
+        raise RuntimeError("could not obtain fixture process birth identity")
     emit(
         args.event_path,
+        schema_version=3,
         kind="identity",
+        nonce=args.start_nonce,
         attempt=args.attempt,
         task_id=args.task_id,
         run_id=args.run_id,
-        session_id=args.session_id,
-        worktree=str(args.worktree),
+        expected_session_id=args.session_id,
+        observed_session_id=args.session_id,
+        worktree=str(args.worktree.resolve()),
+        root_pid=os.getpid(),
+        process_birth_token=birth_token,
     )
     if args.attempt == 1:
         subprocess.Popen(
@@ -92,6 +119,9 @@ def run_attempt(args: argparse.Namespace) -> int:
         return 75
 
     if args.outcome == "fail":
+        # Keep the interpreter live long enough for the supervisor to bind the
+        # emitted identity to the retained launcher handle.
+        time.sleep(0.1)
         emit(
             args.event_path,
             kind="failure",
@@ -120,9 +150,6 @@ def run_attempt(args: argparse.Namespace) -> int:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    repo_root = Path(__file__).resolve().parents[2]
-    if str(repo_root) not in sys.path:
-        sys.path.insert(0, str(repo_root))
     from hermes_cli import kanban_db as kb
 
     conn = kb.connect(args.board_db)
@@ -144,6 +171,21 @@ def run_attempt(args: argparse.Namespace) -> int:
     return 0
 
 
+def run_owned_default() -> int:
+    """Exercise the real default-spawn argv/env contract without a provider."""
+    session_id = os.environ.get("HERMES_WORKER_SESSION_ID")
+    if not emit_start_identity_event(session_id=session_id):
+        return 72
+    time.sleep(1)
+    if not emit_terminal_event(
+        {"failed": False},
+        session_id=session_id,
+        exit_code=0,
+    ):
+        return 73
+    return 0
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("mode", choices=("attempt", "listener"))
@@ -154,10 +196,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--board-db", type=Path)
     parser.add_argument("--task-id")
     parser.add_argument("--run-id", type=int)
+    parser.add_argument("--start-nonce", required=False)
     parser.add_argument("--outcome", choices=("success", "fail"), default="success")
     return parser.parse_args()
 
 
 if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "owned-default":
+        raise SystemExit(run_owned_default())
     parsed = parse_args()
     raise SystemExit(run_listener(parsed.event_path) if parsed.mode == "listener" else run_attempt(parsed))

--- a/tests/fixtures/worker_lifecycle_fixture.py
+++ b/tests/fixtures/worker_lifecycle_fixture.py
@@ -19,6 +19,27 @@ def emit(path: Path, **payload: object) -> None:
         stream.flush()
 
 
+def emit_terminal(
+    args: argparse.Namespace,
+    *,
+    exit_code: int,
+    classification: str,
+) -> None:
+    emit(
+        args.event_path,
+        schema_version=1,
+        kind="terminal",
+        task_id=args.task_id,
+        run_id=args.run_id,
+        attempt=args.attempt,
+        session_id=args.session_id,
+        worktree=str(args.worktree.resolve()),
+        owner_pid=os.getpid(),
+        exit_code=exit_code,
+        classification=classification,
+    )
+
+
 def run_listener(event_path: Path) -> int:
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -59,6 +80,7 @@ def run_attempt(args: argparse.Namespace) -> int:
             time.sleep(0.02)
         else:
             emit(args.event_path, kind="failure", classification="fixture_timeout")
+            emit_terminal(args, exit_code=70, classification="fixture_timeout")
             return 70
         emit(
             args.event_path,
@@ -66,6 +88,7 @@ def run_attempt(args: argparse.Namespace) -> int:
             classification="transient_provider",
             provider="fixture",
         )
+        emit_terminal(args, exit_code=75, classification="transient_provider")
         return 75
 
     if args.outcome == "fail":
@@ -75,6 +98,7 @@ def run_attempt(args: argparse.Namespace) -> int:
             classification="transient_provider",
             provider="fixture",
         )
+        emit_terminal(args, exit_code=76, classification="transient_provider")
         return 76
 
     bounded_file = args.worktree / "recovered.txt"
@@ -113,8 +137,10 @@ def run_attempt(args: argparse.Namespace) -> int:
         conn.close()
     if not completed:
         emit(args.event_path, kind="failure", classification="completion_rejected")
+        emit_terminal(args, exit_code=71, classification="completion_rejected")
         return 71
     emit(args.event_path, kind="task_done", task_id=args.task_id)
+    emit_terminal(args, exit_code=0, classification="success")
     return 0
 
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1409,3 +1409,62 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         conn.close()
 
 
+def test_supervised_worker_failure_persists_one_exact_run_event(
+    kanban_home, monkeypatch, tmp_path
+):
+    from hermes_cli.worker_supervisor import DispatcherWorkerSupervisor
+
+    workspace = tmp_path / "supervision-worktree"
+    workspace.mkdir()
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="supervision failure",
+            assignee="worker",
+            session_id="session-supervision",
+        )
+        task = kb.claim_task(conn, task_id, claimer="test:supervision")
+        assert task is not None and task.current_run_id is not None
+
+    real_supervisor = DispatcherWorkerSupervisor(
+        event_root=tmp_path / "lifecycle-events"
+    )
+
+    class FailingSupervisor:
+        def start(self, identity, _launch, *, notifier, **_kwargs):
+            handle = SimpleNamespace(identity=identity)
+            for _ in range(2):
+                real_supervisor._notify_once(
+                    handle,
+                    notifier,
+                    2,
+                    "retry_setup_failure",
+                    -1,
+                    "do-not-persist-credential-bytes",
+                )
+            return SimpleNamespace(pid=4242)
+
+    monkeypatch.setattr(kb, "_default_spawn", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        kb, "_dispatcher_worker_supervisor", lambda **_kwargs: FailingSupervisor()
+    )
+
+    assert kb._start_supervised_worker(task, str(workspace)) == 4242
+    with kb.connect() as conn:
+        failures = [
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "worker_supervision_failed"
+        ]
+
+    assert len(failures) == 1
+    assert failures[0].run_id == task.current_run_id
+    assert failures[0].payload == {
+        "attempts": 2,
+        "classification": "retry_setup_failure",
+        "exit_code": -1,
+        "reason": "unspecified",
+        "run_id": task.current_run_id,
+        "session_id": "session-supervision",
+        "task_id": task_id,
+    }

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -723,8 +723,9 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
                              assignee="some-profile")
         task = kb.get_task(conn, tid)
         workspace = kb.resolve_workspace(task)
-        pid = kb._default_spawn(task, str(workspace))
-        assert pid == 99999
+        proc = kb._default_spawn(task, str(workspace))
+        assert isinstance(proc, FakeProc)
+        assert proc.pid == 99999
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -122,6 +122,44 @@ def test_migration_is_idempotent(tmp_path, monkeypatch):
         assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2
 
 
+def test_provider_recovery_schema_is_added_to_legacy_database(tmp_path, monkeypatch):
+    """Recovery durability is an additive migration for existing boards."""
+    db_path = _setup_home(tmp_path, monkeypatch)
+    _make_legacy_db(db_path)
+
+    with kb.connect(db_path) as conn:
+        tables = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        assert {
+            "provider_recovery_waits",
+            "provider_recovery_events",
+            "provider_recovery_deliveries",
+        } <= tables
+
+        event_indexes = {
+            row["name"]
+            for row in conn.execute("PRAGMA index_list(provider_recovery_events)")
+        }
+        assert "idx_provider_recovery_event_scope" in event_indexes
+        assert any(
+            row["unique"]
+            for row in conn.execute("PRAGMA index_list(provider_recovery_events)")
+        )
+
+        delivery_pk = {
+            row["name"]: row["pk"]
+            for row in conn.execute("PRAGMA table_info(provider_recovery_deliveries)")
+        }
+        assert delivery_pk["event_id"] == 1
+        assert delivery_pk["task_id"] == 2
+        assert delivery_pk["run_id"] == 3
+        assert delivery_pk["session_id"] == 4
+
+
 def test_unseen_events_for_sub_survives_migrated_db(tmp_path, monkeypatch):
     """The crash that motivated #35096 — ``int(None)`` on a NULL cursor — is
     gone after migration; the notifier query returns an integer cursor."""

--- a/tests/hermes_cli/test_kanban_provider_recovery.py
+++ b/tests/hermes_cli/test_kanban_provider_recovery.py
@@ -450,6 +450,12 @@ def test_exact_wait_cleanup_cannot_remove_successor_registration(recovery_db):
     )
 
     assert kb.reclaim_task(conn, task_id, reason="test successor")
+    old_wait = conn.execute(
+        "SELECT 1 FROM provider_recovery_waits WHERE task_id = ? AND run_id = ?",
+        (task_id, old_run_id),
+    ).fetchone()
+    assert old_wait is None
+
     successor = kb.claim_task(conn, task_id, claimer="test:successor")
     assert successor is not None and successor.current_run_id is not None
     new_run_id = int(successor.current_run_id)
@@ -464,7 +470,7 @@ def test_exact_wait_cleanup_cannot_remove_successor_registration(recovery_db):
         waiting_at=200,
     )
 
-    assert kb.close_provider_recovery_wait(
+    assert not kb.close_provider_recovery_wait(
         conn, task_id=task_id, run_id=old_run_id, session_id="old-session"
     )
     waits = conn.execute(
@@ -474,9 +480,6 @@ def test_exact_wait_cleanup_cannot_remove_successor_registration(recovery_db):
     assert [(row["run_id"], row["session_id"]) for row in waits] == [
         (new_run_id, "new-session")
     ]
-    assert not kb.close_provider_recovery_wait(
-        conn, task_id=task_id, run_id=old_run_id, session_id="old-session"
-    )
 
 
 def test_proof_api_and_storage_have_no_secret_payload_surface(recovery_db):

--- a/tests/hermes_cli/test_kanban_provider_recovery.py
+++ b/tests/hermes_cli/test_kanban_provider_recovery.py
@@ -1,0 +1,542 @@
+"""Durable, exact-run provider recovery substrate tests."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import dataclasses
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.worker_supervisor import AttemptExit
+
+
+@pytest.fixture
+def recovery_db(tmp_path: Path) -> tuple[Path, object]:
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path)
+    try:
+        yield db_path, conn
+    finally:
+        conn.close()
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+
+def _running(conn, *, title: str, session_id: str, assignee: str = "alpha"):
+    task_id = kb.create_task(conn, title=title, assignee=assignee)
+    task = kb.claim_task(conn, task_id, claimer=f"test:{title}")
+    assert task is not None and task.current_run_id is not None
+    conn.execute(
+        "UPDATE tasks SET session_id = ? WHERE id = ? AND current_run_id = ?",
+        (session_id, task_id, task.current_run_id),
+    )
+    return task_id, int(task.current_run_id)
+
+
+def _terminal_evidence(
+    task_id: str,
+    run_id: int,
+    session_id: str,
+    *,
+    classification: str = "transient_provider",
+) -> AttemptExit:
+    return AttemptExit(
+        task_id=task_id,
+        run_id=run_id,
+        session_id=session_id,
+        worktree=Path.cwd().resolve(),
+        attempt=1,
+        pid=123,
+        exit_code=1,
+        classification=classification,
+        events=(),
+        owned_processes=(),
+    )
+
+
+def _proof(
+    scope,
+    *,
+    stable_proof_id: str = "proof-001",
+    observed_at: int = 1_900_000_000,
+    kind=None,
+):
+    return kb.ProviderRecoveryProof(
+        stable_proof_id=stable_proof_id,
+        scope=scope,
+        kind=kind or kb.ProviderRecoveryProofKind.LIVE_REQUEST_SUCCEEDED,
+        provider_observed_at=observed_at,
+        publisher_id="provider-runtime",
+        publisher_version="1.2.3",
+    )
+
+
+def test_scope_is_immutable_strict_and_normalized():
+    scope = kb.ProviderRecoveryScope(" Alpha ", " OPEN-ROUTER ", 7)
+
+    assert scope == kb.ProviderRecoveryScope("alpha", "openrouter", 7)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        scope.provider = "other"
+    for args in (("", "openrouter", 1), ("alpha", "", 1), ("alpha", "auto", 1)):
+        with pytest.raises(ValueError):
+            kb.ProviderRecoveryScope(*args)
+    for generation in (None, "1", 0, -1, True):
+        with pytest.raises((TypeError, ValueError)):
+            kb.ProviderRecoveryScope("alpha", "openrouter", generation)
+
+
+def test_register_waiter_requires_current_running_exact_typed_provider_evidence(recovery_db):
+    _, conn = recovery_db
+    scope = kb.ProviderRecoveryScope("alpha", "openrouter", 1)
+    task_id, run_id = _running(conn, title="eligible", session_id="session-1")
+    evidence = _terminal_evidence(task_id, run_id, "session-1")
+
+    assert kb.register_provider_recovery_wait(
+        conn, evidence=evidence, scope=scope, waiting_at=100
+    )
+    assert not kb.register_provider_recovery_wait(
+        conn,
+        evidence=_terminal_evidence(task_id, run_id + 1, "session-1"),
+        scope=scope,
+        waiting_at=101,
+    )
+    assert not kb.register_provider_recovery_wait(
+        conn,
+        evidence=_terminal_evidence(task_id, run_id, "wrong-session"),
+        scope=scope,
+        waiting_at=101,
+    )
+    assert not kb.register_provider_recovery_wait(
+        conn,
+        evidence=_terminal_evidence(
+            task_id, run_id, "session-1", classification="rate_limited"
+        ),
+        scope=scope,
+        waiting_at=101,
+    )
+
+    conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (task_id,))
+    assert not kb.register_provider_recovery_wait(
+        conn, evidence=evidence, scope=scope, waiting_at=102
+    )
+
+    row = conn.execute("SELECT * FROM provider_recovery_waits").fetchone()
+    assert (row["task_id"], row["run_id"], row["session_id"]) == (
+        task_id,
+        run_id,
+        "session-1",
+    )
+    assert row["waiting_at"] == 100  # idempotent registration never replaces it
+
+
+def test_real_supervised_exit_registers_exact_scoped_waiter(monkeypatch, tmp_path):
+    root = tmp_path / "hermes"
+    (root / "profiles" / "alpha").mkdir(parents=True)
+    workspace = tmp_path / "worktree"
+    workspace.mkdir()
+    board_db = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(board_db))
+    kb.init_db(board_db)
+    conn = kb.connect(board_db)
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="scoped transient",
+            assignee="alpha",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+            initial_status="running",
+        )
+        task = kb.claim_task(conn, task_id)
+        assert task is not None and task.current_run_id is not None
+    finally:
+        conn.close()
+
+    class FakeSupervisor:
+        def start(self, identity, _launch, *, on_exit, **_kwargs):
+            on_exit(
+                AttemptExit(
+                    task_id=identity.task_id,
+                    run_id=identity.run_id,
+                    session_id=identity.session_id,
+                    worktree=identity.worktree,
+                    attempt=1,
+                    pid=123,
+                    exit_code=75,
+                    classification="transient_provider",
+                    events=(
+                        {
+                            "kind": "terminal",
+                            "profile": "alpha",
+                            "provider": "openrouter",
+                            "credential_generation": 7,
+                        },
+                    ),
+                    owned_processes=(),
+                )
+            )
+            return SimpleNamespace(pid=123)
+
+    monkeypatch.setattr(
+        kb, "_dispatcher_worker_supervisor", lambda **_kwargs: FakeSupervisor()
+    )
+
+    assert kb._start_supervised_worker(task, str(workspace)) == 123
+    with kb.connect(board_db) as check:
+        row = check.execute("SELECT * FROM provider_recovery_waits").fetchone()
+        assert row is not None
+        assert (
+            row["task_id"],
+            row["run_id"],
+            row["session_id"],
+            row["profile"],
+            row["provider"],
+            row["credential_generation"],
+        ) == (
+            task_id,
+            task.current_run_id,
+            kb.get_task(check, task_id).session_id,
+            "alpha",
+            "openrouter",
+            7,
+        )
+
+
+def test_one_event_fans_out_only_to_all_exact_scope_waiters(recovery_db):
+    _, conn = recovery_db
+    target = kb.ProviderRecoveryScope("alpha", "openrouter", 4)
+    identities = [
+        _running(conn, title=f"task-{index}", session_id=f"session-{index}")
+        for index in range(5)
+    ]
+    scopes = (
+        target,
+        kb.ProviderRecoveryScope("ALPHA", "OPEN-ROUTER", 4),
+        kb.ProviderRecoveryScope("beta", "openrouter", 4),
+        kb.ProviderRecoveryScope("alpha", "anthropic", 4),
+        kb.ProviderRecoveryScope("alpha", "openrouter", 5),
+    )
+    for index, ((task_id, run_id), scope) in enumerate(zip(identities, scopes)):
+        assert kb.register_provider_recovery_wait(
+            conn,
+            evidence=_terminal_evidence(task_id, run_id, f"session-{index}"),
+            scope=scope,
+            waiting_at=100,
+        )
+
+    event = kb.publish_provider_recovery_event(conn, _proof(target, observed_at=101))
+    deliveries = kb.list_provider_recovery_deliveries(conn, event_id=event.id)
+
+    assert {
+        (delivery.task_id, delivery.run_id, delivery.session_id)
+        for delivery in deliveries
+    } == {
+        (identities[0][0], identities[0][1], "session-0"),
+        (identities[1][0], identities[1][1], "session-1"),
+    }
+    assert {delivery.state for delivery in deliveries} == {
+        kb.ProviderRecoveryDeliveryState.PENDING
+    }
+
+
+def test_dispatcher_consumes_delivery_and_signals_only_the_matching_run(
+    recovery_db, monkeypatch
+):
+    db_path, conn = recovery_db
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    scope = kb.ProviderRecoveryScope("alpha", "openrouter", 4)
+    task_id, run_id = _running(
+        conn, title="dispatcher-consumer", session_id="session-consumer"
+    )
+    assert kb.register_provider_recovery_wait(
+        conn,
+        evidence=_terminal_evidence(task_id, run_id, "session-consumer"),
+        scope=scope,
+        waiting_at=100,
+    )
+    event = kb.publish_provider_recovery_event(
+        conn, _proof(scope, observed_at=101)
+    )
+    signalled = []
+
+    def signal(
+        exact_task_id,
+        reason,
+        *,
+        board=None,
+        expected_run_id=None,
+        expected_session_id=None,
+    ):
+        signalled.append(
+            (
+                exact_task_id,
+                expected_run_id,
+                expected_session_id,
+                reason,
+                board,
+            )
+        )
+        return True
+
+    monkeypatch.setattr(kb, "signal_worker_recovery", signal)
+
+    kb.dispatch_once(conn, max_spawn=0)
+
+    assert signalled == [
+        (task_id, run_id, "session-consumer", "provider_recovered", None)
+    ]
+    deliveries = kb.list_provider_recovery_deliveries(conn, event_id=event.id)
+    assert [delivery.state for delivery in deliveries] == [
+        kb.ProviderRecoveryDeliveryState.DELIVERED
+    ]
+
+
+def test_stable_proof_publication_is_idempotent_and_collision_safe(recovery_db):
+    _, conn = recovery_db
+    scope = kb.ProviderRecoveryScope("alpha", "openrouter", 2)
+    task_id, run_id = _running(conn, title="one", session_id="session-one")
+    assert kb.register_provider_recovery_wait(
+        conn,
+        evidence=_terminal_evidence(task_id, run_id, "session-one"),
+        scope=scope,
+        waiting_at=100,
+    )
+    proof = _proof(scope, observed_at=101)
+
+    first = kb.publish_provider_recovery_event(conn, proof)
+    second = kb.publish_provider_recovery_event(conn, proof)
+
+    assert second == first
+    assert conn.execute("SELECT COUNT(*) FROM provider_recovery_events").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM provider_recovery_deliveries").fetchone()[0] == 1
+    with pytest.raises(ValueError, match="stable proof id"):
+        kb.publish_provider_recovery_event(
+            conn,
+            _proof(scope, stable_proof_id=proof.stable_proof_id, observed_at=102),
+        )
+
+
+def test_delivery_claims_are_exclusive_and_expired_leases_are_reclaimable(recovery_db):
+    db_path, conn = recovery_db
+    scope = kb.ProviderRecoveryScope("alpha", "openrouter", 3)
+    task_id, run_id = _running(conn, title="lease", session_id="session-lease")
+    assert kb.register_provider_recovery_wait(
+        conn,
+        evidence=_terminal_evidence(task_id, run_id, "session-lease"),
+        scope=scope,
+        waiting_at=100,
+    )
+    event = kb.publish_provider_recovery_event(conn, _proof(scope, observed_at=101))
+
+    def compete(consumer_id: str):
+        with kb.connect(db_path) as contender:
+            return kb.claim_provider_recovery_deliveries(
+                contender,
+                consumer_id=consumer_id,
+                limit=1,
+                lease_seconds=10,
+                now=200,
+            )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(compete, ("dispatcher-a", "dispatcher-b")))
+
+    assert sorted(len(result) for result in results) == [0, 1]
+    winner = next(result[0].claim_owner for result in results if result)
+    assert winner in {"dispatcher-a", "dispatcher-b"}
+    with kb.connect(db_path) as contender:
+        assert kb.claim_provider_recovery_deliveries(
+            contender,
+            consumer_id="dispatcher-c",
+            limit=1,
+            lease_seconds=10,
+            now=209,
+        ) == []
+        reclaimed = kb.claim_provider_recovery_deliveries(
+            contender,
+            consumer_id="dispatcher-c",
+            limit=1,
+            lease_seconds=10,
+            now=210,
+        )
+    assert [(item.event_id, item.claim_owner) for item in reclaimed] == [
+        (event.id, "dispatcher-c")
+    ]
+
+
+def test_delivered_and_stale_marks_are_exact_run_cas(recovery_db):
+    _, conn = recovery_db
+    scope = kb.ProviderRecoveryScope("alpha", "openrouter", 5)
+    first = _running(conn, title="deliver", session_id="session-deliver")
+    second = _running(conn, title="stale", session_id="session-stale")
+    for (task_id, run_id), session_id in zip(
+        (first, second), ("session-deliver", "session-stale")
+    ):
+        assert kb.register_provider_recovery_wait(
+            conn,
+            evidence=_terminal_evidence(task_id, run_id, session_id),
+            scope=scope,
+            waiting_at=100,
+        )
+    event = kb.publish_provider_recovery_event(conn, _proof(scope, observed_at=101))
+    claimed = kb.claim_provider_recovery_deliveries(
+        conn, consumer_id="dispatcher", limit=10, lease_seconds=30, now=200
+    )
+    assert len(claimed) == 2
+
+    assert not kb.mark_provider_recovery_delivery_delivered(
+        conn,
+        event_id=event.id,
+        task_id=first[0],
+        run_id=first[1] + 999,
+        session_id="session-deliver",
+        consumer_id="dispatcher",
+        now=201,
+    )
+    assert kb.mark_provider_recovery_delivery_delivered(
+        conn,
+        event_id=event.id,
+        task_id=first[0],
+        run_id=first[1],
+        session_id="session-deliver",
+        consumer_id="dispatcher",
+        now=201,
+    )
+    assert not kb.mark_provider_recovery_delivery_stale(
+        conn,
+        event_id=event.id,
+        task_id=second[0],
+        run_id=second[1],
+        session_id="session-stale",
+        consumer_id="dispatcher",
+        now=201,
+    )
+
+    assert kb.reclaim_task(conn, second[0], reason="test successor")
+    successor = kb.claim_task(conn, second[0], claimer="test:successor")
+    assert successor is not None and successor.current_run_id != second[1]
+    conn.execute(
+        "UPDATE tasks SET session_id = ? WHERE id = ? AND current_run_id = ?",
+        ("session-successor", second[0], successor.current_run_id),
+    )
+    assert kb.mark_provider_recovery_delivery_stale(
+        conn,
+        event_id=event.id,
+        task_id=second[0],
+        run_id=second[1],
+        session_id="session-stale",
+        consumer_id="dispatcher",
+        now=202,
+    )
+    states = {
+        row["task_id"]: row["state"]
+        for row in conn.execute("SELECT task_id, state FROM provider_recovery_deliveries")
+    }
+    assert states == {first[0]: "delivered", second[0]: "stale"}
+
+
+def test_exact_wait_cleanup_cannot_remove_successor_registration(recovery_db):
+    _, conn = recovery_db
+    scope = kb.ProviderRecoveryScope("alpha", "openrouter", 6)
+    task_id, old_run_id = _running(conn, title="successor", session_id="old-session")
+    assert kb.register_provider_recovery_wait(
+        conn,
+        evidence=_terminal_evidence(task_id, old_run_id, "old-session"),
+        scope=scope,
+        waiting_at=100,
+    )
+
+    assert kb.reclaim_task(conn, task_id, reason="test successor")
+    successor = kb.claim_task(conn, task_id, claimer="test:successor")
+    assert successor is not None and successor.current_run_id is not None
+    new_run_id = int(successor.current_run_id)
+    conn.execute(
+        "UPDATE tasks SET session_id = ? WHERE id = ? AND current_run_id = ?",
+        ("new-session", task_id, new_run_id),
+    )
+    assert kb.register_provider_recovery_wait(
+        conn,
+        evidence=_terminal_evidence(task_id, new_run_id, "new-session"),
+        scope=scope,
+        waiting_at=200,
+    )
+
+    assert kb.close_provider_recovery_wait(
+        conn, task_id=task_id, run_id=old_run_id, session_id="old-session"
+    )
+    waits = conn.execute(
+        "SELECT run_id, session_id FROM provider_recovery_waits WHERE task_id = ?",
+        (task_id,),
+    ).fetchall()
+    assert [(row["run_id"], row["session_id"]) for row in waits] == [
+        (new_run_id, "new-session")
+    ]
+    assert not kb.close_provider_recovery_wait(
+        conn, task_id=task_id, run_id=old_run_id, session_id="old-session"
+    )
+
+
+def test_proof_api_and_storage_have_no_secret_payload_surface(recovery_db):
+    _, conn = recovery_db
+    secret = "Bearer sk-super-secret-value"
+    scope = kb.ProviderRecoveryScope("alpha", "openrouter", 8)
+
+    for forbidden in (
+        {"kind": "retry_after"},
+        {"kind": "elapsed_timeout"},
+        {"kind": "credential_file_changed"},
+        {"kind": "manual_timestamp"},
+    ):
+        with pytest.raises((TypeError, ValueError)):
+            _proof(scope, **forbidden)
+    with pytest.raises((TypeError, ValueError)):
+        kb.ProviderRecoveryScope("alpha", "openrouter", secret)
+    with pytest.raises(TypeError):
+        kb.ProviderRecoveryProof(
+            stable_proof_id="proof-secret-attempt",
+            scope=scope,
+            kind=kb.ProviderRecoveryProofKind.LIVE_VALIDATION_SUCCEEDED,
+            provider_observed_at=101,
+            publisher_id="provider-runtime",
+            publisher_version="1.2.3",
+            response_body=secret,
+        )
+
+    event = kb.publish_provider_recovery_event(
+        conn,
+        _proof(
+            scope,
+            kind=kb.ProviderRecoveryProofKind.LIVE_VALIDATION_SUCCEEDED,
+            observed_at=101,
+        ),
+    )
+    schema = "\n".join(
+        row["sql"] or ""
+        for row in conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name LIKE 'provider_recovery_%'"
+        )
+    )
+    rows = "\n".join(
+        repr(tuple(row))
+        for table in (
+            "provider_recovery_waits",
+            "provider_recovery_events",
+            "provider_recovery_deliveries",
+        )
+        for row in conn.execute(f"SELECT * FROM {table}")
+    )
+    representations = "\n".join((repr(scope), repr(event), schema, rows)).lower()
+
+    assert secret.lower() not in representations
+    for forbidden_name in (
+        "credential_value",
+        "credential_hash",
+        "auth_header",
+        "request_body",
+        "response_body",
+        "token",
+    ):
+        assert forbidden_name not in schema.lower()

--- a/tests/hermes_cli/test_kanban_provider_recovery.py
+++ b/tests/hermes_cli/test_kanban_provider_recovery.py
@@ -242,6 +242,37 @@ def test_one_event_fans_out_only_to_all_exact_scope_waiters(recovery_db):
     }
 
 
+def test_recovery_proof_must_be_strictly_later_than_wait_registration(recovery_db):
+    _, conn = recovery_db
+    scope = kb.ProviderRecoveryScope("alpha", "openrouter", 4)
+    task_id, run_id = _running(
+        conn, title="strict-ordering", session_id="session-strict-ordering"
+    )
+    assert kb.register_provider_recovery_wait(
+        conn,
+        evidence=_terminal_evidence(
+            task_id, run_id, "session-strict-ordering"
+        ),
+        scope=scope,
+        waiting_at=100,
+    )
+
+    equal = kb.publish_provider_recovery_event(
+        conn,
+        _proof(scope, stable_proof_id="proof-equal", observed_at=100),
+    )
+    assert kb.list_provider_recovery_deliveries(conn, event_id=equal.id) == []
+
+    later = kb.publish_provider_recovery_event(
+        conn,
+        _proof(scope, stable_proof_id="proof-later", observed_at=101),
+    )
+    assert [
+        (delivery.task_id, delivery.run_id, delivery.session_id)
+        for delivery in kb.list_provider_recovery_deliveries(conn, event_id=later.id)
+    ] == [(task_id, run_id, "session-strict-ordering")]
+
+
 def test_dispatcher_consumes_delivery_and_signals_only_the_matching_run(
     recovery_db, monkeypatch
 ):

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -78,9 +78,9 @@ agent:
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    pid = kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+    process = kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
 
-    assert pid == 4242
+    assert process.pid == 4242
     assert captured["env"]["HERMES_HOME"] == str(profile)
     assert captured["env"]["HERMES_KANBAN_TASK"] == "t_spawn_tools"
     assert "--toolsets" in captured["cmd"]

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -134,8 +134,10 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
     assert args.query == "work kanban task t_spawn_tools"
 
 
-def test_supervised_attempt_one_precreates_and_resumes_exact_session(monkeypatch, tmp_path):
-    """Attempt one is durably selected by --resume, not its evidence env."""
+def test_supervised_attempt_one_precreates_kanban_session_and_preserves_ownership(
+    monkeypatch, tmp_path
+):
+    """Attempt one durably owns a hidden Kanban session selected by --resume."""
     root = tmp_path / ".hermes"
     profile = root / "profiles" / "elias"
     profile.mkdir(parents=True)
@@ -199,6 +201,8 @@ def test_supervised_attempt_one_precreates_and_resumes_exact_session(monkeypatch
 
     assert kb._start_supervised_worker(task, str(workspace)) == FakeProc.pid
     session_id = captured["identity"].session_id
+    assert captured["identity"].task_id == task_id
+    assert captured["identity"].run_id == task.current_run_id
     assert captured["env"]["HERMES_WORKER_SESSION_ID"] == session_id
     assert captured["cmd"].count("--resume") == 1
     assert captured["cmd"][captured["cmd"].index("--resume") + 1] == session_id
@@ -211,10 +215,15 @@ def test_supervised_attempt_one_precreates_and_resumes_exact_session(monkeypatch
     session_db = SessionDB(profile / "state.db")
     try:
         stored = session_db.get_session(session_id)
-        assert stored["source"] == "cli"
+        assert stored["source"] == "kanban"
         assert stored["profile_name"] == "elias"
         assert stored["cwd"] == str(workspace.resolve())
         assert stored["git_repo_root"] == str(workspace.resolve())
+
+        # The resumed worker creates the same row when its CLI startup runs.
+        # SessionDB conflict handling intentionally preserves the first source.
+        session_db.create_session(session_id, source="kanban")
+        assert session_db.get_session(session_id)["source"] == "kanban"
 
         output = []
         probe = CLIAgentSetupMixin()
@@ -232,7 +241,10 @@ def test_supervised_attempt_one_precreates_and_resumes_exact_session(monkeypatch
 
     conn = kb.connect(board_db)
     try:
-        assert kb.get_task(conn, task_id).session_id == session_id
+        projected = kb.get_task(conn, task_id)
+        assert projected.id == task_id
+        assert projected.current_run_id == task.current_run_id
+        assert projected.session_id == session_id
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -134,6 +134,113 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
     assert args.query == "work kanban task t_spawn_tools"
 
 
+def test_supervised_attempt_one_precreates_and_resumes_exact_session(monkeypatch, tmp_path):
+    """Attempt one is durably selected by --resume, not its evidence env."""
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    board_db = tmp_path / "kanban.db"
+    workspace = tmp_path / "worktree"
+    workspace.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(board_db))
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli._parser import build_top_level_parser
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+    from hermes_state import SessionDB
+
+    kb.init_db(board_db)
+    conn = kb.connect(board_db)
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="bound worker",
+            assignee="elias",
+            workspace_kind="worktree",
+            workspace_path=str(workspace),
+            initial_status="running",
+        )
+        task = kb.claim_task(conn, task_id)
+        assert task is not None
+    finally:
+        conn.close()
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4245
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = dict(kwargs["env"])
+        return FakeProc()
+
+    class FakeSupervisor:
+        def allocate_event_path(self, identity, attempt):
+            captured["identity"] = identity
+            assert attempt == 1
+            return tmp_path / "attempt-1.jsonl"
+
+        def start(self, identity, launch, **kwargs):
+            event_path = self.allocate_event_path(identity, 1)
+            proc = launch(
+                identity, 1, event_path, start_nonce="test-nonce",
+            )
+            assert isinstance(proc, FakeProc)
+            captured["proc"] = proc
+            return proc
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(kb, "_dispatcher_worker_supervisor", lambda **kwargs: FakeSupervisor())
+
+    assert kb._start_supervised_worker(task, str(workspace)) == FakeProc.pid
+    session_id = captured["identity"].session_id
+    assert captured["env"]["HERMES_WORKER_SESSION_ID"] == session_id
+    assert captured["cmd"].count("--resume") == 1
+    assert captured["cmd"][captured["cmd"].index("--resume") + 1] == session_id
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+    assert captured["cmd"][1:3] == ["-p", "elias"]
+    parsed = parser.parse_args(captured["cmd"][3:])
+    assert parsed.resume == session_id
+
+    session_db = SessionDB(profile / "state.db")
+    try:
+        stored = session_db.get_session(session_id)
+        assert stored["source"] == "cli"
+        assert stored["profile_name"] == "elias"
+        assert stored["cwd"] == str(workspace.resolve())
+        assert stored["git_repo_root"] == str(workspace.resolve())
+
+        output = []
+        probe = CLIAgentSetupMixin()
+        probe._resumed = True
+        probe._session_db = session_db
+        probe.session_id = parsed.resume
+        probe.conversation_history = []
+        probe._console_print = output.append
+        probe._restore_session_cwd = lambda _meta: None
+        assert probe._preload_resumed_session() is False
+        assert any("found but has no messages" in line for line in output)
+        assert not any("Session not found" in line for line in output)
+    finally:
+        session_db.close()
+
+    conn = kb.connect(board_db)
+    try:
+        assert kb.get_task(conn, task_id).session_id == session_id
+    finally:
+        conn.close()
+
+    # Negative control: expected-evidence env does not populate parser.resume.
+    env_only = parser.parse_args(["--cli", "chat", "-q", "hello", "-Q"])
+    assert env_only.resume is None
+
+
 def test_resolve_worker_cli_toolsets_uses_profile_home_not_parent_config(monkeypatch, tmp_path):
     root = tmp_path / ".hermes"
     profile = root / "profiles" / "elias"

--- a/tests/run_agent/test_provider_recovery_publisher.py
+++ b/tests/run_agent/test_provider_recovery_publisher.py
@@ -78,6 +78,7 @@ def recovery_db(tmp_path: Path):
 def _set_supervised_env(monkeypatch, db_path: Path, *, profile="alpha", generation="7"):
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
     monkeypatch.setenv("HERMES_PROFILE", profile)
+    monkeypatch.setenv("HERMES_PROVIDER", "openrouter")
     monkeypatch.setenv(CREDENTIAL_GENERATION_ENV, generation)
 
 
@@ -200,6 +201,33 @@ def test_direct_publication_is_exact_and_idempotent(recovery_db, monkeypatch):
     assert rows[0]["provider_observed_at"] == 1_900_000_000
 
 
+def test_publication_requires_provider_matching_bound_generation(
+    recovery_db, monkeypatch
+):
+    _set_supervised_env(monkeypatch, recovery_db)
+
+    assert publish_successful_live_provider_request(
+        provider="anthropic",
+        request_id="fallback-request",
+        session_id="fallback-session",
+        provider_observed_at=1_900_000_000,
+    ) is False
+    assert _event_rows(recovery_db) == []
+
+    assert publish_successful_live_provider_request(
+        provider="open-router",
+        request_id="primary-request",
+        session_id="primary-session",
+        provider_observed_at=1_900_000_001,
+    ) is True
+    rows = _event_rows(recovery_db)
+    assert len(rows) == 1
+    assert (rows[0]["provider"], rows[0]["credential_generation"]) == (
+        "openrouter",
+        7,
+    )
+
+
 @pytest.mark.parametrize(
     ("db_value", "profile", "generation"),
     [
@@ -216,7 +244,12 @@ def test_direct_publication_is_exact_and_idempotent(recovery_db, monkeypatch):
 def test_missing_malformed_or_unsupervised_scope_publishes_nothing(
     recovery_db, monkeypatch, db_value, profile, generation
 ):
-    for name in ("HERMES_KANBAN_DB", "HERMES_PROFILE", CREDENTIAL_GENERATION_ENV):
+    for name in (
+        "HERMES_KANBAN_DB",
+        "HERMES_PROFILE",
+        "HERMES_PROVIDER",
+        CREDENTIAL_GENERATION_ENV,
+    ):
         monkeypatch.delenv(name, raising=False)
     if db_value is not None:
         monkeypatch.setenv(
@@ -225,6 +258,7 @@ def test_missing_malformed_or_unsupervised_scope_publishes_nothing(
         )
     if profile is not None:
         monkeypatch.setenv("HERMES_PROFILE", profile)
+    monkeypatch.setenv("HERMES_PROVIDER", "openrouter")
     if generation is not None:
         monkeypatch.setenv(CREDENTIAL_GENERATION_ENV, generation)
 

--- a/tests/run_agent/test_provider_recovery_publisher.py
+++ b/tests/run_agent/test_provider_recovery_publisher.py
@@ -1,0 +1,264 @@
+"""Success-only durable provider recovery publication tests."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.provider_recovery import (
+    CREDENTIAL_GENERATION_ENV,
+    publish_successful_live_provider_request,
+)
+from hermes_cli import kanban_db as kb
+from run_agent import AIAgent
+
+
+_SECRET = "do-not-persist-api-key-or-response"
+
+
+def _tool_defs() -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "test tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+@pytest.fixture
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            model="test/model",
+            provider="openrouter",
+            api_key=_SECRET,
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        instance.client = MagicMock()
+        instance.session_id = "session-r2a"
+        instance._cached_system_prompt = "You are helpful."
+        instance._use_prompt_caching = False
+        instance.tool_delay = 0
+        instance.compression_enabled = False
+        instance.save_trajectories = False
+        # One allowed attempt is required to exercise the real transport seam;
+        # zero means the production retry loop deliberately skips transport.
+        instance._api_max_retries = 1
+        return instance
+
+
+@pytest.fixture
+def recovery_db(tmp_path: Path):
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path)
+    conn.close()
+    try:
+        yield db_path
+    finally:
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+
+def _set_supervised_env(monkeypatch, db_path: Path, *, profile="alpha", generation="7"):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_PROFILE", profile)
+    monkeypatch.setenv(CREDENTIAL_GENERATION_ENV, generation)
+
+
+def _response(content: str = "provider response"):
+    message = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _event_rows(db_path: Path):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM provider_recovery_events ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def _run(agent):
+    def _fake_transport(api_kwargs):
+        return agent.client.chat.completions.create(**api_kwargs)
+
+    with (
+        patch.object(agent, "_interruptible_api_call", side_effect=_fake_transport),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation("hello")
+
+
+def test_real_normalized_response_publishes_exactly_one_safe_event(
+    agent, recovery_db, monkeypatch
+):
+    _set_supervised_env(monkeypatch, recovery_db)
+    agent.client.chat.completions.create.return_value = _response(_SECRET)
+
+    before = int(time.time())
+    result = _run(agent)
+    after = int(time.time())
+
+    assert agent.client.chat.completions.create.call_count == 1
+    assert result["completed"] is True
+    assert result["final_response"] == _SECRET
+    rows = _event_rows(recovery_db)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["profile"] == "alpha"
+    assert row["provider"] == "openrouter"
+    assert row["credential_generation"] == 7
+    assert row["proof_kind"] == "live_request_succeeded"
+    assert before <= row["provider_observed_at"] <= after
+    assert row["stable_proof_id"].startswith("provider-request:")
+    assert row["consumed_at"] is None if "consumed_at" in row.keys() else True
+    assert _SECRET not in " ".join(str(value) for value in row)
+
+
+def test_provider_failure_no_response_and_retry_after_publish_nothing(
+    agent, recovery_db, monkeypatch
+):
+    _set_supervised_env(monkeypatch, recovery_db)
+
+    class RateLimitWithRetryAfter(RuntimeError):
+        status_code = 429
+        response = SimpleNamespace(
+            status_code=429,
+            headers={"Retry-After": _SECRET},
+        )
+
+    for outcome in (None, RateLimitWithRetryAfter("rate limited")):
+        if isinstance(outcome, BaseException):
+            agent.client.chat.completions.create.side_effect = outcome
+            agent.client.chat.completions.create.return_value = None
+        else:
+            agent.client.chat.completions.create.side_effect = None
+            agent.client.chat.completions.create.return_value = outcome
+        _run(agent)
+
+    assert _event_rows(recovery_db) == []
+
+
+def test_synthetic_post_api_request_hook_cannot_publish(
+    recovery_db, monkeypatch
+):
+    _set_supervised_env(monkeypatch, recovery_db)
+    from hermes_cli.plugins import invoke_hook
+
+    invoke_hook(
+        "post_api_request",
+        session_id="session-r2a",
+        api_request_id="request-r2a",
+        provider="openrouter",
+        response={"content": _SECRET},
+        usage={"secret": _SECRET},
+    )
+
+    assert _event_rows(recovery_db) == []
+
+
+def test_direct_publication_is_exact_and_idempotent(recovery_db, monkeypatch):
+    _set_supervised_env(monkeypatch, recovery_db)
+    kwargs = {
+        "provider": "open-router",
+        "request_id": "request-42",
+        "session_id": "session-42",
+        "provider_observed_at": 1_900_000_000,
+    }
+
+    assert publish_successful_live_provider_request(**kwargs) is True
+    assert publish_successful_live_provider_request(**kwargs) is True
+
+    rows = _event_rows(recovery_db)
+    assert len(rows) == 1
+    assert dict(rows[0]) | {} == dict(rows[0])
+    assert rows[0]["profile"] == "alpha"
+    assert rows[0]["provider"] == "openrouter"
+    assert rows[0]["credential_generation"] == 7
+    assert rows[0]["provider_observed_at"] == 1_900_000_000
+
+
+@pytest.mark.parametrize(
+    ("db_value", "profile", "generation"),
+    [
+        (None, "alpha", "7"),
+        ("relative.db", "alpha", "7"),
+        ("valid", None, "7"),
+        ("valid", " Alpha ", "7"),
+        ("valid", "alpha", None),
+        ("valid", "alpha", "0"),
+        ("valid", "alpha", "+7"),
+        ("valid", "alpha", "not-an-int"),
+    ],
+)
+def test_missing_malformed_or_unsupervised_scope_publishes_nothing(
+    recovery_db, monkeypatch, db_value, profile, generation
+):
+    for name in ("HERMES_KANBAN_DB", "HERMES_PROFILE", CREDENTIAL_GENERATION_ENV):
+        monkeypatch.delenv(name, raising=False)
+    if db_value is not None:
+        monkeypatch.setenv(
+            "HERMES_KANBAN_DB",
+            str(recovery_db) if db_value == "valid" else db_value,
+        )
+    if profile is not None:
+        monkeypatch.setenv("HERMES_PROFILE", profile)
+    if generation is not None:
+        monkeypatch.setenv(CREDENTIAL_GENERATION_ENV, generation)
+
+    assert publish_successful_live_provider_request(
+        provider="openrouter",
+        request_id="request-42",
+        session_id="session-42",
+        provider_observed_at=1_900_000_000,
+    ) is False
+    assert _event_rows(recovery_db) == []
+
+
+def test_database_failure_is_bounded_non_secret_and_fail_open(
+    agent, recovery_db, monkeypatch, caplog
+):
+    _set_supervised_env(monkeypatch, recovery_db)
+    agent.client.chat.completions.create.return_value = _response("successful result")
+    caplog.set_level(logging.WARNING, logger="agent.provider_recovery")
+
+    with patch(
+        "agent.provider_recovery._open_recovery_db",
+        side_effect=sqlite3.OperationalError(_SECRET),
+    ):
+        result = _run(agent)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "successful result"
+    assert _event_rows(recovery_db) == []
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "agent.provider_recovery"
+    ]
+    assert messages == [
+        "Provider recovery proof publication failed (OperationalError)"
+    ]
+    assert _SECRET not in caplog.text

--- a/tests/unit/test_worker_lifecycle.py
+++ b/tests/unit/test_worker_lifecycle.py
@@ -1,0 +1,87 @@
+"""Focused tests for production worker lifecycle JSONL emission."""
+
+import json
+import os
+from pathlib import Path
+
+from hermes_cli.worker_lifecycle import emit_terminal_event
+
+
+def test_emit_terminal_event_writes_typed_identity_bound_failure(monkeypatch, tmp_path):
+    event_path = tmp_path / "events" / "attempt.jsonl"
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    monkeypatch.setenv("HERMES_WORKER_LIFECYCLE_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("HERMES_WORKER_LIFECYCLE_ATTEMPT", "1")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "17")
+    monkeypatch.setenv("HERMES_WORKER_SESSION_ID", "worker-session-1")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(worktree))
+
+    assert emit_terminal_event(
+        {"failed": True, "failure_reason": "transient_provider"},
+        session_id="worker-session-1",
+        exit_code=75,
+    )
+
+    event = json.loads(event_path.read_text(encoding="utf-8"))
+    assert event == {
+        "attempt": 1,
+        "classification": "transient_provider",
+        "exit_code": 75,
+        "failure_reason": "transient_provider",
+        "kind": "terminal",
+        "owner_pid": os.getpid(),
+        "run_id": 17,
+        "schema_version": 1,
+        "session_id": "worker-session-1",
+        "task_id": "task-1",
+        "worktree": str(worktree.resolve()),
+    }
+
+
+    event_path = tmp_path / "attempt.jsonl"
+    monkeypatch.delenv("HERMES_WORKER_LIFECYCLE_EVENT_PATH", raising=False)
+    emit_terminal_event(
+        {"failed": True, "failure_reason": "billing"},
+        session_id="session",
+        exit_code=75,
+    )
+    assert not event_path.exists()
+
+
+
+def test_terminal_event_schema_is_typed_and_identity_bound(tmp_path, monkeypatch):
+    event_path = tmp_path / "event.json"
+    monkeypatch.setenv("HERMES_WORKER_LIFECYCLE_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "17")
+    monkeypatch.setenv("HERMES_WORKER_LIFECYCLE_ATTEMPT", "2")
+    monkeypatch.setenv("HERMES_WORKER_SESSION_ID", "session-17")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+
+    assert emit_terminal_event(
+        {"failed": True, "failure_reason": "rate_limit"},
+        session_id="session-17",
+        exit_code=75,
+    )
+    payload = json.loads(event_path.read_text(encoding="utf-8"))
+    assert payload == {
+        "schema_version": 1,
+        "kind": "terminal",
+        "task_id": "task-1",
+        "run_id": 17,
+        "attempt": 2,
+        "session_id": "session-17",
+        "worktree": str(tmp_path.resolve()),
+        "owner_pid": os.getpid(),
+        "exit_code": 75,
+        "failure_reason": "rate_limit",
+        "classification": "rate_limited",
+    }
+
+    assert not emit_terminal_event(
+        {"failed": True, "failure_reason": "transient_provider"},
+        session_id="wrong-session",
+        exit_code=75,
+    )

--- a/tests/unit/test_worker_lifecycle.py
+++ b/tests/unit/test_worker_lifecycle.py
@@ -3,6 +3,7 @@
 import json
 import os
 from pathlib import Path
+import sqlite3
 import subprocess
 import sys
 from types import SimpleNamespace
@@ -113,6 +114,132 @@ def test_loaded_worker_credential_scope_reaches_typed_transient_exit(
         assert "fixture-secret-never-persist" not in json.dumps(event)
     finally:
         state_db.close()
+
+
+def test_loaded_worker_rotates_generation_when_effective_credential_changes(
+    monkeypatch, tmp_path
+):
+    """Credential reloads rotate recovery scope without persisting secrets."""
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+    from hermes_cli import runtime_provider
+    from hermes_state import SessionDB
+
+    first_credential = "synthetic-first-credential-never-persist"
+    second_credential = "synthetic-second-credential-never-persist"
+    runtime = {
+        "api_key": first_credential,
+        "base_url": "https://provider.invalid/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+    }
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    monkeypatch.setenv(
+        "HERMES_WORKER_LIFECYCLE_EVENT_PATH", str(tmp_path / "attempt.jsonl")
+    )
+    monkeypatch.setenv("HERMES_WORKER_LIFECYCLE_ATTEMPT", "1")
+    monkeypatch.setenv("HERMES_WORKER_START_NONCE", "nonce-credential-rotation")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-credential-rotation")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "18")
+    monkeypatch.setenv("HERMES_WORKER_SESSION_ID", "worker-session-rotation")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(worktree))
+    monkeypatch.setenv("HERMES_PROFILE", "alpha")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    monkeypatch.chdir(worktree)
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_kwargs: dict(runtime),
+    )
+
+    state_path = tmp_path / "profile" / "state.db"
+
+    def make_loader(state_db):
+        return SimpleNamespace(
+            requested_provider="openrouter",
+            _explicit_api_key=None,
+            _explicit_base_url=None,
+            _fallback_model=[],
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            provider="openrouter",
+            api_key=None,
+            base_url=None,
+            agent=None,
+            model="fixture-model",
+            _active_agent_route_signature=None,
+            _normalize_model_for_provider=lambda _provider: False,
+            _session_db=state_db,
+        )
+
+    state_db = SessionDB(state_path)
+    loader = make_loader(state_db)
+    stale_state_db = None
+    try:
+        assert CLIAgentSetupMixin._ensure_runtime_credentials(loader)
+        first_generation = int(
+            os.environ["HERMES_PROVIDER_CREDENTIAL_GENERATION"]
+        )
+        assert first_generation > 0
+
+        assert CLIAgentSetupMixin._ensure_runtime_credentials(loader)
+        assert int(os.environ["HERMES_PROVIDER_CREDENTIAL_GENERATION"]) == (
+            first_generation
+        )
+
+        stale_state_db = SessionDB(state_path)
+        stale_loader = make_loader(stale_state_db)
+        assert CLIAgentSetupMixin._ensure_runtime_credentials(stale_loader)
+        assert int(os.environ["HERMES_PROVIDER_CREDENTIAL_GENERATION"]) == (
+            first_generation
+        )
+
+        runtime["api_key"] = second_credential
+        assert CLIAgentSetupMixin._ensure_runtime_credentials(loader)
+        rotated_generation = int(
+            os.environ["HERMES_PROVIDER_CREDENTIAL_GENERATION"]
+        )
+        assert rotated_generation > 0
+        assert rotated_generation != first_generation
+
+        assert CLIAgentSetupMixin._ensure_runtime_credentials(stale_loader)
+        assert int(os.environ["HERMES_PROVIDER_CREDENTIAL_GENERATION"]) == (
+            rotated_generation
+        )
+    finally:
+        if stale_state_db is not None:
+            stale_state_db.close()
+        state_db.close()
+
+    fresh_state_db = SessionDB(state_path)
+    fresh_loader = make_loader(fresh_state_db)
+    try:
+        assert CLIAgentSetupMixin._ensure_runtime_credentials(fresh_loader)
+        assert int(os.environ["HERMES_PROVIDER_CREDENTIAL_GENERATION"]) == (
+            rotated_generation
+        )
+        event = build_terminal_event(
+            {"failed": True, "failure_reason": "transient_provider"},
+            session_id="worker-session-rotation",
+            exit_code=75,
+        )
+        assert event is not None
+        lifecycle_output = json.dumps(event)
+    finally:
+        fresh_state_db.close()
+
+    with sqlite3.connect(state_path) as connection:
+        durable_metadata = repr(
+            connection.execute("SELECT key, value FROM state_meta").fetchall()
+        )
+    durable_bytes = b"".join(
+        path.read_bytes() for path in state_path.parent.glob("state.db*")
+    )
+    for credential in (first_credential, second_credential):
+        assert credential not in lifecycle_output
+        assert credential not in durable_metadata
+        assert credential.encode() not in durable_bytes
 
 
 def test_emit_terminal_event_writes_typed_identity_bound_failure(monkeypatch, tmp_path):

--- a/tests/unit/test_worker_lifecycle.py
+++ b/tests/unit/test_worker_lifecycle.py
@@ -3,8 +3,116 @@
 import json
 import os
 from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
 
-from hermes_cli.worker_lifecycle import emit_terminal_event
+from hermes_cli.worker_lifecycle import (
+    build_terminal_event,
+    emit_start_identity_event,
+    emit_terminal_event,
+    process_birth_token,
+)
+
+
+def test_process_birth_token_is_identical_across_parent_and_child_queries():
+    pid = os.getpid()
+    parent_before = process_birth_token(pid)
+    child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from hermes_cli.worker_lifecycle import process_birth_token; "
+            "import sys; print(process_birth_token(int(sys.argv[1])) or '')",
+            str(pid),
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    parent_after = process_birth_token(pid)
+
+    assert parent_before
+    assert child.stdout.strip() == parent_before == parent_after
+
+
+def test_process_birth_token_returns_none_for_nonexistent_pid():
+    assert process_birth_token(2_147_483_647) is None
+
+
+def test_loaded_worker_credential_scope_reaches_typed_transient_exit(
+    monkeypatch, tmp_path
+):
+    """The trusted runtime load must bind non-secret scope to typed evidence."""
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+    from hermes_cli import runtime_provider
+    from hermes_state import SessionDB
+
+    event_path = tmp_path / "attempt.jsonl"
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    monkeypatch.setenv("HERMES_WORKER_LIFECYCLE_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("HERMES_WORKER_LIFECYCLE_ATTEMPT", "1")
+    monkeypatch.setenv("HERMES_WORKER_START_NONCE", "nonce-attempt-1")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-credential-scope")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "17")
+    monkeypatch.setenv("HERMES_WORKER_SESSION_ID", "worker-session-1")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(worktree))
+    monkeypatch.setenv("HERMES_PROFILE", "alpha")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    monkeypatch.chdir(worktree)
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "fixture-secret-never-persist",
+            "base_url": "https://provider.invalid/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    state_db = SessionDB(tmp_path / "profile" / "state.db")
+    cli = SimpleNamespace(
+        requested_provider="openrouter",
+        _explicit_api_key=None,
+        _explicit_base_url=None,
+        _fallback_model=[],
+        api_mode="chat_completions",
+        acp_command=None,
+        acp_args=[],
+        provider="openrouter",
+        api_key=None,
+        base_url=None,
+        agent=None,
+        model="fixture-model",
+        _active_agent_route_signature=None,
+        _normalize_model_for_provider=lambda _provider: False,
+        _session_db=state_db,
+    )
+
+    try:
+        assert CLIAgentSetupMixin._ensure_runtime_credentials(cli)
+        generation = os.environ["HERMES_PROVIDER_CREDENTIAL_GENERATION"]
+        assert generation.isdecimal() and int(generation) > 0
+        assert os.environ["HERMES_PROVIDER"] == "openrouter"
+
+        event = build_terminal_event(
+            {"failed": True, "failure_reason": "transient_provider"},
+            session_id="worker-session-1",
+            exit_code=75,
+        )
+
+        assert event is not None
+        assert (
+            event["profile"],
+            event["provider"],
+            event["credential_generation"],
+        ) == ("alpha", "openrouter", int(generation))
+        assert "fixture-secret-never-persist" not in json.dumps(event)
+    finally:
+        state_db.close()
 
 
 def test_emit_terminal_event_writes_typed_identity_bound_failure(monkeypatch, tmp_path):
@@ -13,28 +121,40 @@ def test_emit_terminal_event_writes_typed_identity_bound_failure(monkeypatch, tm
     worktree.mkdir()
     monkeypatch.setenv("HERMES_WORKER_LIFECYCLE_EVENT_PATH", str(event_path))
     monkeypatch.setenv("HERMES_WORKER_LIFECYCLE_ATTEMPT", "1")
+    monkeypatch.setenv("HERMES_WORKER_START_NONCE", "nonce-attempt-1")
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "17")
     monkeypatch.setenv("HERMES_WORKER_SESSION_ID", "worker-session-1")
     monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(worktree))
+    monkeypatch.chdir(worktree)
 
+    assert emit_start_identity_event(session_id="worker-session-1")
     assert emit_terminal_event(
         {"failed": True, "failure_reason": "transient_provider"},
         session_id="worker-session-1",
         exit_code=75,
     )
 
-    event = json.loads(event_path.read_text(encoding="utf-8"))
+    records = [
+        json.loads(line)
+        for line in event_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["kind"] for record in records] == ["identity", "terminal"]
+    event = records[1]
     assert event == {
         "attempt": 1,
         "classification": "transient_provider",
-        "exit_code": 75,
+        "exit_kind": "code",
+        "exit_value": 75,
         "failure_reason": "transient_provider",
         "kind": "terminal",
-        "owner_pid": os.getpid(),
+        "root_pid": os.getpid(),
+        "process_birth_token": process_birth_token(os.getpid()),
         "run_id": 17,
-        "schema_version": 1,
-        "session_id": "worker-session-1",
+        "schema_version": 3,
+        "nonce": "nonce-attempt-1",
+        "expected_session_id": "worker-session-1",
+        "observed_session_id": "worker-session-1",
         "task_id": "task-1",
         "worktree": str(worktree.resolve()),
     }
@@ -57,31 +177,46 @@ def test_terminal_event_schema_is_typed_and_identity_bound(tmp_path, monkeypatch
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
     monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "17")
     monkeypatch.setenv("HERMES_WORKER_LIFECYCLE_ATTEMPT", "2")
+    monkeypatch.setenv("HERMES_WORKER_START_NONCE", "nonce-attempt-2")
     monkeypatch.setenv("HERMES_WORKER_SESSION_ID", "session-17")
     monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
 
+    assert emit_start_identity_event(session_id="session-17")
     assert emit_terminal_event(
         {"failed": True, "failure_reason": "rate_limit"},
         session_id="session-17",
         exit_code=75,
     )
-    payload = json.loads(event_path.read_text(encoding="utf-8"))
+    records = [
+        json.loads(line)
+        for line in event_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["kind"] for record in records] == ["identity", "terminal"]
+    payload = records[1]
     assert payload == {
-        "schema_version": 1,
+        "schema_version": 3,
         "kind": "terminal",
+        "nonce": "nonce-attempt-2",
         "task_id": "task-1",
         "run_id": 17,
         "attempt": 2,
-        "session_id": "session-17",
+        "expected_session_id": "session-17",
+        "observed_session_id": "session-17",
         "worktree": str(tmp_path.resolve()),
-        "owner_pid": os.getpid(),
-        "exit_code": 75,
+        "root_pid": os.getpid(),
+        "process_birth_token": process_birth_token(os.getpid()),
+        "exit_kind": "code",
+        "exit_value": 75,
         "failure_reason": "rate_limit",
         "classification": "rate_limited",
     }
 
-    assert not emit_terminal_event(
+    successor_payload = build_terminal_event(
         {"failed": True, "failure_reason": "transient_provider"},
-        session_id="wrong-session",
+        session_id="compression-successor",
         exit_code=75,
     )
+    assert successor_payload is not None
+    assert successor_payload["expected_session_id"] == "session-17"
+    assert successor_payload["observed_session_id"] == "compression-successor"

--- a/tests/unit/test_worker_supervisor.py
+++ b/tests/unit/test_worker_supervisor.py
@@ -60,6 +60,37 @@ def _listener_closed(port: int) -> bool:
         return probe.connect_ex(("127.0.0.1", port)) != 0
 
 
+def _wait_for(predicate, *, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return bool(predicate())
+
+
+class _FakeProc:
+    def __init__(self, pid: int, *, returncode: int | None = None) -> None:
+        self.pid = pid
+        self.returncode = returncode
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+
 def _build_board(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     board_db = tmp_path / "board" / "kanban.db"
     board_db.parent.mkdir()
@@ -507,9 +538,9 @@ def test_raw_rate_limit_exit_does_not_enter_transient_provider_retry(tmp_path):
 
     raw_path = tmp_path / "raw.jsonl"
     typed_path = tmp_path / "typed.jsonl"
-    typed_path.write_text(
-        json.dumps({"kind": "failure", "classification": "transient_provider"}) + "\n",
-        encoding="utf-8",
+    _write_bound_event(
+        typed_path, identity, 1, 45102,
+        classification="transient_provider",
     )
     raw_exit = ws._attempt_exit(identity, 1, RateLimitedProc(45101), raw_path)
     typed_exit = ws._attempt_exit(identity, 1, RateLimitedProc(45102), typed_path)
@@ -533,3 +564,140 @@ def test_raw_rate_limit_exit_does_not_enter_transient_provider_retry(tmp_path):
     assert launches == [1]
     assert [(item.exit_code, item.classification) for item in exits] == [(75, "process_exit")]
     assert supervisor.active_count == 0
+
+def _exact_identity(tmp_path, *, run_id=7):
+    return WorkerIdentity(
+        task_id="task_exact",
+        run_id=run_id,
+        session_id="worker_session",
+        worktree=tmp_path / "worktree",
+    )
+
+
+def _write_bound_event(path, identity, attempt, pid, *, classification):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "kind": "terminal",
+        "task_id": identity.task_id,
+        "run_id": identity.run_id,
+        "attempt": attempt,
+        "session_id": identity.session_id,
+        "worktree": str(identity.worktree.resolve()),
+        "owner_pid": pid,
+        "exit_code": 75 if classification == "transient_provider" else 0,
+        "classification": classification,
+    }
+    path.write_text(json.dumps(payload) + chr(10), encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("task_id", "other_task"),
+        ("run_id", 8),
+        ("attempt", 2),
+        ("session_id", "other_session"),
+        ("worktree", "other/worktree"),
+    ],
+)
+def test_transient_terminal_evidence_rejects_identity_mismatch(
+    tmp_path, field, replacement,
+):
+    identity = _exact_identity(tmp_path)
+    launches = []
+    notices = []
+
+    def launch(_identity, attempt, event_path):
+        launches.append(attempt)
+        proc = _FakeProc(7000 + attempt, returncode=75)
+        _write_bound_event(
+            event_path, identity, attempt, proc.pid,
+            classification="transient_provider",
+        )
+        rows = [json.loads(line) for line in event_path.read_text().splitlines()]
+        rows[-1][field] = replacement
+        event_path.write_text(json.dumps(rows[-1]) + chr(10), encoding="utf-8")
+        return proc
+
+    supervisor = DispatcherWorkerSupervisor(event_root=tmp_path / "events")
+    handle = supervisor.start(identity, launch=launch, notifier=notices.append)
+    assert handle.wait(2)
+    assert launches == [1]
+    assert len(notices) == 1
+    assert supervisor.active_count == 0
+
+
+def test_exact_fresh_recovery_signal_releases_one_resume_and_no_third(tmp_path):
+    identity = _exact_identity(tmp_path)
+    launches = []
+    exits = []
+    gates = []
+
+    def launch(_identity, attempt, event_path):
+        launches.append(attempt)
+        classification = "transient_provider" if attempt == 1 else "success"
+        proc = _FakeProc(7100 + attempt, returncode=75 if attempt == 1 else 0)
+        _write_bound_event(
+            event_path, identity, attempt, proc.pid,
+            classification=classification,
+        )
+        return proc
+
+    supervisor = DispatcherWorkerSupervisor(
+        event_root=tmp_path / "events", recovery_timeout=1,
+    )
+    handle = supervisor.start(
+        identity,
+        launch=launch,
+        on_exit=exits.append,
+        gate_advance=lambda _identity: gates.append("advance"),
+    )
+    assert supervisor.signal_recovery(identity, "too-early", signaled_at=0) is False
+    assert _wait_for(lambda: supervisor.is_waiting_for_recovery(identity), timeout=2)
+    stale = WorkerIdentity(
+        task_id=identity.task_id,
+        run_id=identity.run_id + 1,
+        session_id=identity.session_id,
+        worktree=identity.worktree,
+    )
+    assert supervisor.signal_recovery(stale, "wrong-run") is False
+    assert supervisor.signal_recovery(identity, "fresh") is True
+    assert handle.wait(2)
+    assert launches == [1, 2]
+    assert [item.attempt for item in exits] == [1, 2]
+    assert gates == ["advance"]
+    assert supervisor.signal_recovery(identity, "third") is False
+
+
+def test_pid_projection_failure_cleans_and_notifies_once(tmp_path, monkeypatch):
+    identity = _exact_identity(tmp_path)
+    killed = []
+    notices = []
+
+    class RunningProc(_FakeProc):
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.returncode = -15
+            return self.returncode
+
+    proc = RunningProc(7201)
+    monkeypatch.setattr(ws, "_terminate_process_tree", lambda item: killed.append(item) or True)
+
+    def bad_projection(_identity, _attempt, _pid):
+        raise RuntimeError("projection failed")
+
+    supervisor = DispatcherWorkerSupervisor(event_root=tmp_path / "events")
+    with pytest.raises(RuntimeError, match="projection failed"):
+        supervisor.start(
+            identity,
+            launch=lambda *_args: proc,
+            on_pid=bad_projection,
+            notifier=notices.append,
+        )
+    assert killed == [proc]
+    assert len(notices) == 1
+    assert supervisor.active_count == 0
+    assert supervisor.active_pid(identity.task_id, identity.run_id) is None

--- a/tests/unit/test_worker_supervisor.py
+++ b/tests/unit/test_worker_supervisor.py
@@ -18,11 +18,29 @@ from hermes_cli import kanban_db as kb
 from hermes_cli import worker_supervisor as ws
 from hermes_cli.worker_supervisor import (
     DispatcherWorkerSupervisor,
+    SessionCompressionLineageResolver,
     WorkerIdentity,
     pid_is_alive,
 )
+from hermes_state import SessionDB
 
 FIXTURE = Path(__file__).parents[1] / "fixtures" / "worker_lifecycle_fixture.py"
+_FAKE_BIRTH_TOKENS: dict[int, str] = {}
+
+
+@pytest.fixture(autouse=True)
+def _fake_native_birth_tokens(monkeypatch):
+    """Resolve only PIDs explicitly registered by synthetic process doubles."""
+
+    real_process_birth_token = ws.process_birth_token
+
+    def resolve(pid: int):
+        return _FAKE_BIRTH_TOKENS[int(pid)] if int(pid) in _FAKE_BIRTH_TOKENS else real_process_birth_token(pid)
+
+    _FAKE_BIRTH_TOKENS.clear()
+    monkeypatch.setattr(ws, "process_birth_token", resolve)
+    yield
+    _FAKE_BIRTH_TOKENS.clear()
 
 
 def _init_git_worktree(tmp_path: Path) -> tuple[Path, Path]:
@@ -72,14 +90,19 @@ def _wait_for(predicate, *, timeout: float) -> bool:
 class _FakeProc:
     def __init__(self, pid: int, *, returncode: int | None = None) -> None:
         self.pid = pid
-        self.returncode = returncode
+        self.returncode = None
+        self._configured_returncode = returncode
         self.terminated = False
         self.killed = False
+        self._hermes_process_birth_token = f"test-birth-{pid}"
+        _FAKE_BIRTH_TOKENS[pid] = self._hermes_process_birth_token
 
     def poll(self):
         return self.returncode
 
     def wait(self, timeout=None):
+        if self.returncode is None:
+            self.returncode = self._configured_returncode
         return self.returncode
 
     def terminate(self):
@@ -105,7 +128,7 @@ def _build_board(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     kb.recompute_ready(conn)
     with kb.write_txn(conn):
         conn.execute(
-            "UPDATE tasks SET status='running', session_id=?, workspace_path=? WHERE id=?",
+            "UPDATE tasks SET status='running', session_id=?, workspace_path=?, current_run_id=1 WHERE id=?",
             ("session-stable", str(tmp_path / "worktree"), task_id),
         )
     return conn, board_db, task_id, next_id, final_id
@@ -126,7 +149,13 @@ def _persist_exit(board_db: Path, task_id: str, observed: list, event: threading
 
 
 def _launcher(board_db: Path, task_id: str, outcome: str, launches: list[dict]):
-    def launch(identity: WorkerIdentity, attempt: int, event_path: Path):
+    def launch(
+        identity: WorkerIdentity,
+        attempt: int,
+        event_path: Path,
+        *,
+        start_nonce: str,
+    ):
         if attempt == 2:
             first = launches[0]
             assert not pid_is_alive(first["listener_pid"])
@@ -148,8 +177,11 @@ def _launcher(board_db: Path, task_id: str, outcome: str, launches: list[dict]):
                 str(board_db),
                 "--task-id",
                 task_id,
+                "--run-id",
+                str(identity.run_id),
                 "--outcome",
                 outcome,
+                f"--start-nonce={start_nonce}",
             ],
             cwd=identity.worktree,
             stdin=subprocess.DEVNULL,
@@ -173,6 +205,9 @@ def _capture_first_owned(observed: list, launches: list[dict]) -> None:
 def test_transient_provider_recovers_once_and_advances_one_gate(monkeypatch, tmp_path):
     _, worktree = _init_git_worktree(tmp_path)
     conn, board_db, task_id, next_id, final_id = _build_board(monkeypatch, tmp_path)
+    # token_urlsafe() encodes this prefix as "-Pj4"; opaque nonces must remain
+    # valid when transported through the fixture command line.
+    monkeypatch.setattr(ws.secrets, "token_bytes", lambda size: b"\xf8" * size)
     exits: list = []
     launches: list[dict] = []
     first_exit = threading.Event()
@@ -193,7 +228,7 @@ def test_transient_provider_recovers_once_and_advances_one_gate(monkeypatch, tmp
         cleanup_timeout=5,
     )
     handle = supervisor.start(
-        WorkerIdentity(task_id, "session-stable", worktree),
+        WorkerIdentity(task_id, "session-stable", worktree, run_id=1),
         _launcher(board_db, task_id, "success", launches),
         on_exit=on_exit,
         on_success=on_success,
@@ -214,7 +249,7 @@ def test_transient_provider_recovers_once_and_advances_one_gate(monkeypatch, tmp
         for event in item.events
         if event.get("kind") == "identity"
     ]
-    assert [(item["session_id"], item["worktree"]) for item in identities] == [
+    assert [(item["observed_session_id"], item["worktree"]) for item in identities] == [
         ("session-stable", str(worktree)),
         ("session-stable", str(worktree)),
     ]
@@ -259,7 +294,7 @@ def test_transient_provider_retry_failure_notifies_once(monkeypatch, tmp_path):
         cleanup_timeout=5,
     )
     handle = supervisor.start(
-        WorkerIdentity(task_id, "session-stable", worktree),
+        WorkerIdentity(task_id, "session-stable", worktree, run_id=1),
         _launcher(board_db, task_id, "fail", launches),
         on_exit=on_exit,
         notifier=notifications.append,
@@ -307,6 +342,7 @@ def test_dispatch_once_production_path_recovers_once_and_advances_one_serial_gat
         board: str | None = None,
         lifecycle_event_path: Path | None = None,
         lifecycle_attempt: int = 1,
+        start_nonce: str | None = None,
     ):
         assert lifecycle_event_path is not None
         if lifecycle_attempt == 2:
@@ -332,6 +368,7 @@ def test_dispatch_once_production_path_recovers_once_and_advances_one_serial_gat
             str(board_db),
             "--outcome",
             "success",
+            f"--start-nonce={start_nonce}",
         ]
         proc = subprocess.Popen(
             command,
@@ -472,7 +509,6 @@ def test_dispatch_once_default_spawn_is_owned_by_supervisor(monkeypatch, tmp_pat
     popen_type = subprocess.Popen
     launched: list[subprocess.Popen] = []
     waited: list[subprocess.Popen] = []
-    default_spawn_returns: list[object] = []
 
     def tracking_popen(*args, **kwargs):
         proc = popen_type(*args, **kwargs)
@@ -486,21 +522,15 @@ def test_dispatch_once_default_spawn_is_owned_by_supervisor(monkeypatch, tmp_pat
         proc.wait = tracking_wait
         return proc
 
-    original_default_spawn = kb._default_spawn
-
-    def tracking_default_spawn(*args, **kwargs):
-        proc = original_default_spawn(*args, **kwargs)
-        default_spawn_returns.append(proc)
-        return proc
-
     monkeypatch.setattr(subprocess, "Popen", tracking_popen)
+    (tmp_path / "hermes" / "profiles" / "fixture").mkdir(parents=True)
     monkeypatch.setattr(
         kb,
         "_resolve_hermes_argv",
-        lambda: [sys.executable, "-c", "import time; time.sleep(1)"],
+        lambda: [sys.executable, str(FIXTURE), "owned-default"],
     )
     monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", lambda _home: None)
-    monkeypatch.setattr(kb, "_default_spawn", tracking_default_spawn)
+    supervisor = kb._dispatcher_worker_supervisor()
     conn = kb.connect()
     try:
         task_id = kb.create_task(conn, title="supervised", assignee="fixture")
@@ -510,49 +540,66 @@ def test_dispatch_once_default_spawn_is_owned_by_supervisor(monkeypatch, tmp_pat
         proc = launched[0]
         assert isinstance(proc, popen_type)
         assert proc.poll() is None
-        assert default_spawn_returns == [proc]
-        assert kb.get_task(conn, task_id).worker_pid == proc.pid
+        task = kb.get_task(conn, task_id)
+        worker_pid = task.worker_pid
+        assert worker_pid == supervisor.active_pid(task_id, task.current_run_id)
     finally:
         conn.close()
 
     deadline = time.monotonic() + 5
-    supervisor = kb._dispatcher_worker_supervisor()
     while supervisor.active_count and time.monotonic() < deadline:
         time.sleep(0.01)
     assert waited == [proc]
     assert supervisor.active_count == 0
-    assert kb._classify_worker_exit(proc.pid) == ("clean_exit", 0)
+    assert kb._classify_worker_exit(worker_pid) == ("clean_exit", 0)
 
 
 def test_raw_rate_limit_exit_does_not_enter_transient_provider_retry(tmp_path):
-    identity = WorkerIdentity("task-rate-limit", "session-rate-limit", tmp_path)
+    identity = WorkerIdentity("task-rate-limit", "session-rate-limit", tmp_path, run_id=1)
 
     class RateLimitedProc:
         returncode = 75
 
         def __init__(self, pid):
             self.pid = pid
+            self._hermes_process_birth_token = f"test-birth-{pid}"
+            _FAKE_BIRTH_TOKENS[pid] = self._hermes_process_birth_token
+
+        def poll(self):
+            return None
 
         def wait(self):
             return self.returncode
 
     raw_path = tmp_path / "raw.jsonl"
     typed_path = tmp_path / "typed.jsonl"
+    raw_proc = RateLimitedProc(45101)
+    typed_proc = RateLimitedProc(45102)
+    _write_start_identity(raw_path, identity, 1, raw_proc.pid, "raw-nonce")
     _write_bound_event(
-        typed_path, identity, 1, 45102,
+        typed_path, identity, 1, typed_proc.pid,
         classification="transient_provider",
+        start_nonce="typed-nonce",
     )
-    raw_exit = ws._attempt_exit(identity, 1, RateLimitedProc(45101), raw_path)
-    typed_exit = ws._attempt_exit(identity, 1, RateLimitedProc(45102), typed_path)
+    raw_exit = ws._attempt_exit(
+        identity, 1, raw_proc, raw_path,
+        _ownership(raw_proc, "raw-nonce"),
+    )
+    typed_exit = ws._attempt_exit(
+        identity, 1, typed_proc, typed_path,
+        _ownership(typed_proc, "typed-nonce"),
+    )
     assert (raw_exit.exit_code, raw_exit.classification) == (75, "process_exit")
     assert (typed_exit.exit_code, typed_exit.classification) == (75, "transient_provider")
 
     launches: list[int] = []
     exits: list = []
 
-    def launch(_identity, attempt, _event_path):
+    def launch(_identity, attempt, event_path, *, start_nonce):
         launches.append(attempt)
-        return RateLimitedProc(45200 + attempt)
+        proc = RateLimitedProc(45200 + attempt)
+        _write_start_identity(event_path, identity, attempt, proc.pid, start_nonce)
+        return proc
 
     supervisor = DispatcherWorkerSupervisor(
         event_root=tmp_path / "events",
@@ -574,21 +621,387 @@ def _exact_identity(tmp_path, *, run_id=7):
     )
 
 
-def _write_bound_event(path, identity, attempt, pid, *, classification):
+def _ownership(proc, start_nonce, *, root_pid=None, root_birth_token=None):
+    root_pid = proc.pid if root_pid is None else root_pid
+    return ws._AttemptOwnership(
+        nonce=start_nonce,
+        launcher_pid=proc.pid,
+        launcher_birth_token=proc._hermes_process_birth_token,
+        root_pid=root_pid,
+        root_birth_token=(
+            f"test-birth-{root_pid}"
+            if root_birth_token is None
+            else root_birth_token
+        ),
+    )
+
+
+def _write_start_identity(path, identity, attempt, pid, start_nonce):
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
-        "schema_version": 1,
-        "kind": "terminal",
+        "schema_version": 3,
+        "kind": "identity",
+        "nonce": start_nonce,
         "task_id": identity.task_id,
         "run_id": identity.run_id,
         "attempt": attempt,
-        "session_id": identity.session_id,
+        "expected_session_id": identity.session_id,
+        "observed_session_id": identity.session_id,
         "worktree": str(identity.worktree.resolve()),
-        "owner_pid": pid,
-        "exit_code": 75 if classification == "transient_provider" else 0,
-        "classification": classification,
+        "root_pid": pid,
+        "process_birth_token": f"test-birth-{pid}",
     }
     path.write_text(json.dumps(payload) + chr(10), encoding="utf-8")
+    return payload
+
+
+def _write_bound_event(
+    path,
+    identity,
+    attempt,
+    pid,
+    *,
+    classification,
+    start_nonce="test-start-nonce",
+):
+    _write_start_identity(path, identity, attempt, pid, start_nonce)
+    payload = {
+        "schema_version": 3,
+        "kind": "terminal",
+        "nonce": start_nonce,
+        "task_id": identity.task_id,
+        "run_id": identity.run_id,
+        "attempt": attempt,
+        "expected_session_id": identity.session_id,
+        "observed_session_id": identity.session_id,
+        "worktree": str(identity.worktree.resolve()),
+        "root_pid": pid,
+        "process_birth_token": f"test-birth-{pid}",
+        "exit_kind": "code",
+        "exit_value": 75 if classification == "transient_provider" else 0,
+        "failure_reason": "transient_provider" if classification == "transient_provider" else "none",
+        "classification": classification,
+    }
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(payload) + chr(10))
+    return payload
+
+
+_MISSING = object()
+
+
+def _classified_event(
+    tmp_path,
+    *,
+    returncode,
+    classification,
+    mutate=None,
+    duplicate=False,
+    identity=None,
+    lineage_resolver=None,
+):
+    identity = identity or _exact_identity(tmp_path)
+    proc = _FakeProc(7601, returncode=returncode)
+    path = tmp_path / "closed-event.jsonl"
+    nonce = "classified-nonce"
+    payload = _write_bound_event(
+        path,
+        identity,
+        1,
+        proc.pid,
+        classification=classification,
+        start_nonce=nonce,
+    )
+    if mutate is not None:
+        if isinstance(mutate, dict):
+            payload.update(mutate)
+        else:
+            field, replacement = mutate
+            if replacement is _MISSING:
+                payload.pop(field, None)
+            else:
+                payload[field] = replacement
+        identity_row = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+        path.write_text(
+            json.dumps(identity_row) + chr(10) + json.dumps(payload) + chr(10),
+            encoding="utf-8",
+        )
+    if duplicate:
+        with path.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(payload) + chr(10))
+    proc.wait()
+    return ws._attempt_exit(
+        identity,
+        1,
+        proc,
+        path,
+        _ownership(proc, nonce),
+        lineage_resolver=lineage_resolver,
+    )
+
+
+def _persist_compression_chain(db: SessionDB, *session_ids: str) -> None:
+    for index, session_id in enumerate(session_ids):
+        parent_id = session_ids[index - 1] if index else None
+        db.create_session(session_id, source="cli", parent_session_id=parent_id)
+        if parent_id is not None:
+            db.end_session(parent_id, "compression")
+
+
+def test_terminal_evidence_accepts_exact_root_with_real_session_db(tmp_path):
+    identity = _exact_identity(tmp_path)
+    db_path = tmp_path / "profile" / "state.db"
+    db = SessionDB(db_path)
+    try:
+        db.create_session(identity.session_id, source="cli")
+    finally:
+        db.close()
+
+    observed = _classified_event(
+        tmp_path,
+        returncode=0,
+        classification="success",
+        lineage_resolver=SessionCompressionLineageResolver(db_path),
+    )
+
+    assert observed.classification == "success"
+
+
+@pytest.mark.parametrize("observed_session_id", ["successor", "tip"])
+def test_terminal_evidence_accepts_persisted_compression_descendant(
+    tmp_path, observed_session_id,
+):
+    identity = _exact_identity(tmp_path)
+    db_path = tmp_path / "profile" / "state.db"
+    db = SessionDB(db_path)
+    try:
+        _persist_compression_chain(db, identity.session_id, "successor", "tip")
+    finally:
+        db.close()
+
+    observed = _classified_event(
+        tmp_path,
+        returncode=0,
+        classification="success",
+        mutate=("observed_session_id", observed_session_id),
+        lineage_resolver=SessionCompressionLineageResolver(db_path),
+    )
+
+    assert observed.classification == "success"
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "sibling",
+        "ancestor",
+        "unrelated",
+        "merely_existing",
+        "missing_db",
+        "malformed_db",
+        "ambiguous",
+    ],
+)
+def test_terminal_evidence_rejects_unproven_compression_lineage(tmp_path, case):
+    db_path = tmp_path / "profile" / "state.db"
+    identity = _exact_identity(tmp_path)
+    observed_session_id = "observed"
+
+    if case == "missing_db":
+        resolver = SessionCompressionLineageResolver(db_path)
+    elif case == "malformed_db":
+        db_path.parent.mkdir(parents=True)
+        db_path.write_text("not sqlite", encoding="utf-8")
+        resolver = SessionCompressionLineageResolver(db_path)
+    else:
+        db = SessionDB(db_path)
+        try:
+            if case == "ancestor":
+                _persist_compression_chain(db, "observed", identity.session_id)
+            elif case == "unrelated":
+                db.create_session(identity.session_id, source="cli")
+                db.create_session("observed", source="cli")
+            elif case == "merely_existing":
+                db.create_session(identity.session_id, source="cli")
+                db.create_session(
+                    "observed", source="cli", parent_session_id=identity.session_id,
+                )
+            else:
+                _persist_compression_chain(db, identity.session_id, "successor")
+                if case == "sibling":
+                    db.create_session(
+                        "observed",
+                        source="cli",
+                        parent_session_id=identity.session_id,
+                        model_config={"_branched_from": identity.session_id},
+                    )
+                else:
+                    db.create_session(
+                        "observed", source="cli", parent_session_id=identity.session_id,
+                    )
+        finally:
+            db.close()
+        resolver = SessionCompressionLineageResolver(db_path)
+
+    observed = _classified_event(
+        tmp_path,
+        returncode=0,
+        classification="success",
+        mutate=("observed_session_id", observed_session_id),
+        identity=identity,
+        lineage_resolver=resolver,
+    )
+
+    assert observed.classification == "invalid_evidence"
+
+
+def test_start_identity_still_rejects_compression_successor(tmp_path):
+    identity = _exact_identity(tmp_path)
+    event = _write_start_identity(
+        tmp_path / "start.jsonl", identity, 1, 7601, "start-nonce",
+    )
+    event["observed_session_id"] = "successor"
+
+    assert ws._start_identity_matches(event, identity, 1, "start-nonce") is False
+
+
+def test_terminal_evidence_rejects_forged_expected_session_env(tmp_path):
+    identity = _exact_identity(tmp_path)
+    db_path = tmp_path / "profile" / "state.db"
+    db = SessionDB(db_path)
+    try:
+        _persist_compression_chain(db, identity.session_id, "successor")
+    finally:
+        db.close()
+
+    observed = _classified_event(
+        tmp_path,
+        returncode=0,
+        classification="success",
+        mutate={
+            "expected_session_id": "successor",
+            "observed_session_id": "successor",
+        },
+        identity=identity,
+        lineage_resolver=SessionCompressionLineageResolver(db_path),
+    )
+
+    assert observed.classification == "invalid_evidence"
+
+
+@pytest.mark.parametrize(
+    ("returncode", "classification"),
+    [(0, "success"), (75, "transient_provider")],
+)
+def test_closed_terminal_evidence_accepts_valid_completed_and_provider_failure(
+    tmp_path, returncode, classification,
+):
+    observed = _classified_event(
+        tmp_path, returncode=returncode, classification=classification,
+    )
+    assert observed.classification == classification
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("kind", "unknown_event"),
+        ("kind", _MISSING),
+        ("classification", "unknown_classification"),
+        ("classification", _MISSING),
+        ("failure_reason", "unknown_reason"),
+        ("failure_reason", _MISSING),
+        ("exit_kind", "unknown_exit"),
+        ("exit_kind", _MISSING),
+    ],
+)
+def test_closed_terminal_evidence_rejects_unknown_or_missing_enums(
+    tmp_path, field, replacement,
+):
+    observed = _classified_event(
+        tmp_path,
+        returncode=75,
+        classification="transient_provider",
+        mutate=(field, replacement),
+    )
+    assert observed.classification == "invalid_evidence"
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("schema_version", _MISSING),
+        ("task_id", _MISSING),
+        ("run_id", _MISSING),
+        ("attempt", _MISSING),
+        ("expected_session_id", _MISSING),
+        ("observed_session_id", _MISSING),
+        ("worktree", _MISSING),
+        ("root_pid", _MISSING),
+        ("process_birth_token", _MISSING),
+        ("exit_value", _MISSING),
+        ("schema_version", 1),
+        ("task_id", "other_task"),
+        ("run_id", 8),
+        ("attempt", 2),
+        ("expected_session_id", "other_session"),
+        ("observed_session_id", "other_session"),
+        ("worktree", "other/worktree"),
+        ("root_pid", 7602),
+        ("process_birth_token", "other-birth"),
+        ("exit_value", 76),
+    ],
+)
+def test_closed_terminal_evidence_requires_exact_attempt_identity(
+    tmp_path, field, replacement,
+):
+    observed = _classified_event(
+        tmp_path,
+        returncode=75,
+        classification="transient_provider",
+        mutate=(field, replacement),
+    )
+    assert observed.classification == "invalid_evidence"
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("classification", "success"),
+        ("failure_reason", "none"),
+        ("failure_reason", "billing"),
+        ("failure_reason", "supervisor_failure"),
+        ("failure_reason", "ownership_loss"),
+        ("exit_kind", "signal"),
+    ],
+)
+def test_closed_terminal_evidence_rejects_inconsistent_recoverable_claims(
+    tmp_path, field, replacement,
+):
+    observed = _classified_event(
+        tmp_path,
+        returncode=75,
+        classification="transient_provider",
+        mutate=(field, replacement),
+    )
+    assert observed.classification == "invalid_evidence"
+
+
+def test_closed_terminal_evidence_rejects_provider_failure_with_success_exit(tmp_path):
+    observed = _classified_event(
+        tmp_path, returncode=0, classification="transient_provider",
+    )
+    assert observed.classification == "invalid_evidence"
+
+
+def test_closed_terminal_evidence_rejects_duplicate_terminal_record(tmp_path):
+    observed = _classified_event(
+        tmp_path,
+        returncode=75,
+        classification="transient_provider",
+        duplicate=True,
+    )
+    assert observed.classification == "invalid_evidence"
 
 
 @pytest.mark.parametrize(
@@ -597,7 +1010,8 @@ def _write_bound_event(path, identity, attempt, pid, *, classification):
         ("task_id", "other_task"),
         ("run_id", 8),
         ("attempt", 2),
-        ("session_id", "other_session"),
+        ("expected_session_id", "other_session"),
+        ("observed_session_id", "other_session"),
         ("worktree", "other/worktree"),
     ],
 )
@@ -608,16 +1022,20 @@ def test_transient_terminal_evidence_rejects_identity_mismatch(
     launches = []
     notices = []
 
-    def launch(_identity, attempt, event_path):
+    def launch(_identity, attempt, event_path, *, start_nonce):
         launches.append(attempt)
         proc = _FakeProc(7000 + attempt, returncode=75)
         _write_bound_event(
             event_path, identity, attempt, proc.pid,
             classification="transient_provider",
+            start_nonce=start_nonce,
         )
         rows = [json.loads(line) for line in event_path.read_text().splitlines()]
         rows[-1][field] = replacement
-        event_path.write_text(json.dumps(rows[-1]) + chr(10), encoding="utf-8")
+        event_path.write_text(
+            "".join(json.dumps(row) + chr(10) for row in rows),
+            encoding="utf-8",
+        )
         return proc
 
     supervisor = DispatcherWorkerSupervisor(event_root=tmp_path / "events")
@@ -634,13 +1052,14 @@ def test_exact_fresh_recovery_signal_releases_one_resume_and_no_third(tmp_path):
     exits = []
     gates = []
 
-    def launch(_identity, attempt, event_path):
+    def launch(_identity, attempt, event_path, *, start_nonce):
         launches.append(attempt)
         classification = "transient_provider" if attempt == 1 else "success"
         proc = _FakeProc(7100 + attempt, returncode=75 if attempt == 1 else 0)
         _write_bound_event(
             event_path, identity, attempt, proc.pid,
             classification=classification,
+            start_nonce=start_nonce,
         )
         return proc
 
@@ -684,16 +1103,24 @@ def test_pid_projection_failure_cleans_and_notifies_once(tmp_path, monkeypatch):
             return self.returncode
 
     proc = RunningProc(7201)
-    monkeypatch.setattr(ws, "_terminate_process_tree", lambda item: killed.append(item) or True)
+
+    def cleanup_failed_start(item, timeout):
+        killed.append(item)
+
+    monkeypatch.setattr(ws, "_cleanup_failed_start", cleanup_failed_start)
 
     def bad_projection(_identity, _attempt, _pid):
         raise RuntimeError("projection failed")
+
+    def launch(identity, attempt, event_path, *, start_nonce):
+        _write_start_identity(event_path, identity, attempt, proc.pid, start_nonce)
+        return proc
 
     supervisor = DispatcherWorkerSupervisor(event_root=tmp_path / "events")
     with pytest.raises(RuntimeError, match="projection failed"):
         supervisor.start(
             identity,
-            launch=lambda *_args: proc,
+            launch=launch,
             on_pid=bad_projection,
             notifier=notices.append,
         )

--- a/tests/unit/test_worker_supervisor.py
+++ b/tests/unit/test_worker_supervisor.py
@@ -1,0 +1,535 @@
+"""Deterministic recovery proof for dispatcher-owned worker subprocesses."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import socket
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import worker_supervisor as ws
+from hermes_cli.worker_supervisor import (
+    DispatcherWorkerSupervisor,
+    WorkerIdentity,
+    pid_is_alive,
+)
+
+FIXTURE = Path(__file__).parents[1] / "fixtures" / "worker_lifecycle_fixture.py"
+
+
+def _init_git_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "base.txt"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Hermes Fixture",
+            "-c",
+            "user.email=fixture@invalid",
+            "commit",
+            "-qm",
+            "fixture base",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "worktree", "add", "-qb", "fixture-recovery", str(worktree)],
+        cwd=repo,
+        check=True,
+    )
+    return repo, worktree
+
+
+def _listener_closed(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.2)
+        return probe.connect_ex(("127.0.0.1", port)) != 0
+
+
+def _build_board(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    board_db = tmp_path / "board" / "kanban.db"
+    board_db.parent.mkdir()
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(board_db))
+    kb.init_db()
+    conn = kb.connect()
+    task_id = kb.create_task(conn, title="recover worker", assignee="fixture")
+    next_id = kb.create_task(conn, title="serial gate 2", assignee="fixture")
+    final_id = kb.create_task(conn, title="serial gate 3", assignee="fixture")
+    kb.link_tasks(conn, task_id, next_id)
+    kb.link_tasks(conn, next_id, final_id)
+    kb.recompute_ready(conn)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='running', session_id=?, workspace_path=? WHERE id=?",
+            ("session-stable", str(tmp_path / "worktree"), task_id),
+        )
+    return conn, board_db, task_id, next_id, final_id
+
+
+def _persist_exit(board_db: Path, task_id: str, observed: list, event: threading.Event):
+    def callback(attempt_exit) -> None:
+        observed.append(attempt_exit)
+        with sqlite3.connect(board_db) as conn:
+            conn.execute(
+                "INSERT INTO task_events(task_id, kind, payload, created_at) "
+                "VALUES (?, 'worker_attempt_exit', ?, strftime('%s','now'))",
+                (task_id, json.dumps(attempt_exit.as_dict(), sort_keys=True)),
+            )
+        event.set()
+
+    return callback
+
+
+def _launcher(board_db: Path, task_id: str, outcome: str, launches: list[dict]):
+    def launch(identity: WorkerIdentity, attempt: int, event_path: Path):
+        if attempt == 2:
+            first = launches[0]
+            assert not pid_is_alive(first["listener_pid"])
+            assert _listener_closed(first["listener_port"])
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(FIXTURE),
+                "attempt",
+                "--event-path",
+                str(event_path),
+                "--attempt",
+                str(attempt),
+                "--session-id",
+                identity.session_id,
+                "--worktree",
+                str(identity.worktree),
+                "--board-db",
+                str(board_db),
+                "--task-id",
+                task_id,
+                "--outcome",
+                outcome,
+            ],
+            cwd=identity.worktree,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        launches.append({"attempt": attempt, "pid": proc.pid})
+        return proc
+
+    return launch
+
+
+def _capture_first_owned(observed: list, launches: list[dict]) -> None:
+    first = observed[0]
+    listener = next(resource for resource in first.owned_processes if resource.role == "listener")
+    launches[0]["listener_pid"] = listener.pid
+    launches[0]["listener_port"] = listener.port
+
+
+def test_transient_provider_recovers_once_and_advances_one_gate(monkeypatch, tmp_path):
+    _, worktree = _init_git_worktree(tmp_path)
+    conn, board_db, task_id, next_id, final_id = _build_board(monkeypatch, tmp_path)
+    exits: list = []
+    launches: list[dict] = []
+    first_exit = threading.Event()
+    notifications: list = []
+
+    def on_exit(attempt_exit) -> None:
+        _persist_exit(board_db, task_id, exits, first_exit)(attempt_exit)
+        if attempt_exit.attempt == 1:
+            _capture_first_owned(exits, launches)
+
+    def on_success(_attempt_exit) -> None:
+        with kb.connect() as gate_conn:
+            kb.recompute_ready(gate_conn)
+
+    supervisor = DispatcherWorkerSupervisor(
+        event_root=tmp_path / "events",
+        recovery_timeout=5,
+        cleanup_timeout=5,
+    )
+    handle = supervisor.start(
+        WorkerIdentity(task_id, "session-stable", worktree),
+        _launcher(board_db, task_id, "success", launches),
+        on_exit=on_exit,
+        on_success=on_success,
+        notifier=notifications.append,
+    )
+
+    assert first_exit.wait(5)
+    assert exits[0].exit_code == 75
+    assert exits[0].classification == "transient_provider"
+    handle.signal_recovery("credential_recovered")
+    assert handle.wait(10)
+
+    assert [item["attempt"] for item in launches] == [1, 2]
+    assert [item.classification for item in exits] == ["transient_provider", "success"]
+    identities = [
+        event
+        for item in exits
+        for event in item.events
+        if event.get("kind") == "identity"
+    ]
+    assert [(item["session_id"], item["worktree"]) for item in identities] == [
+        ("session-stable", str(worktree)),
+        ("session-stable", str(worktree)),
+    ]
+    assert notifications == []
+    assert supervisor.active_count == 0
+    assert all(not pid_is_alive(item["pid"]) for item in launches)
+    assert not pid_is_alive(launches[0]["listener_pid"])
+    assert _listener_closed(launches[0]["listener_port"])
+    assert (worktree / "recovered.txt").read_text(encoding="utf-8") == "recovered\n"
+    assert subprocess.run(
+        ["git", "log", "-1", "--format=%s"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip() == "fixture: recovered worker"
+    assert kb.get_task(conn, task_id).status == "done"
+    assert kb.get_task(conn, next_id).status == "ready"
+    assert kb.get_task(conn, final_id).status == "todo"
+    persisted = [event for event in kb.list_events(conn, task_id) if event.kind == "worker_attempt_exit"]
+    assert len(persisted) == 2
+    assert persisted[0].payload["exit_code"] == 75
+    assert persisted[0].payload["classification"] == "transient_provider"
+
+
+def test_transient_provider_retry_failure_notifies_once(monkeypatch, tmp_path):
+    _, worktree = _init_git_worktree(tmp_path)
+    conn, board_db, task_id, next_id, final_id = _build_board(monkeypatch, tmp_path)
+    exits: list = []
+    launches: list[dict] = []
+    first_exit = threading.Event()
+    notifications: list = []
+
+    def on_exit(attempt_exit) -> None:
+        _persist_exit(board_db, task_id, exits, first_exit)(attempt_exit)
+        if attempt_exit.attempt == 1:
+            _capture_first_owned(exits, launches)
+
+    supervisor = DispatcherWorkerSupervisor(
+        event_root=tmp_path / "events",
+        recovery_timeout=5,
+        cleanup_timeout=5,
+    )
+    handle = supervisor.start(
+        WorkerIdentity(task_id, "session-stable", worktree),
+        _launcher(board_db, task_id, "fail", launches),
+        on_exit=on_exit,
+        notifier=notifications.append,
+    )
+
+    assert first_exit.wait(5)
+    handle.signal_recovery("credential_recovered")
+    assert handle.wait(10)
+
+    assert [item["attempt"] for item in launches] == [1, 2]
+    assert [item.exit_code for item in exits] == [75, 76]
+    assert len(notifications) == 1
+    assert notifications[0].task_id == task_id
+    assert notifications[0].attempts == 2
+    assert notifications[0].classification == "transient_provider"
+    assert supervisor.active_count == 0
+    assert all(not pid_is_alive(item["pid"]) for item in launches)
+    assert not pid_is_alive(launches[0]["listener_pid"])
+    assert _listener_closed(launches[0]["listener_port"])
+    assert kb.get_task(conn, task_id).status == "running"
+    assert kb.get_task(conn, next_id).status == "todo"
+    assert kb.get_task(conn, final_id).status == "todo"
+
+
+def test_dispatch_once_production_path_recovers_once_and_advances_one_serial_gate(
+    monkeypatch, tmp_path
+):
+    _, worktree = _init_git_worktree(tmp_path)
+    board_db = tmp_path / "board" / "kanban.db"
+    board_db.parent.mkdir()
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(board_db))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    kb.init_db()
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+    kb._dispatcher_worker_supervisors.clear()
+
+    launches: list[dict] = []
+    waited: list[subprocess.Popen] = []
+    first_listener: dict[str, int] = {}
+
+    def fixture_default_spawn(
+        task: kb.Task,
+        workspace: str,
+        *,
+        board: str | None = None,
+        lifecycle_event_path: Path | None = None,
+        lifecycle_attempt: int = 1,
+    ):
+        assert lifecycle_event_path is not None
+        if lifecycle_attempt == 2:
+            assert not pid_is_alive(first_listener["pid"])
+            assert _listener_closed(first_listener["port"])
+        command = [
+            sys.executable,
+            str(FIXTURE),
+            "attempt",
+            "--event-path",
+            str(lifecycle_event_path),
+            "--attempt",
+            str(lifecycle_attempt),
+            "--task-id",
+            task.id,
+            "--run-id",
+            str(task.current_run_id),
+            "--session-id",
+            str(task.session_id),
+            "--worktree",
+            workspace,
+            "--board-db",
+            str(board_db),
+            "--outcome",
+            "success",
+        ]
+        proc = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        original_wait = proc.wait
+
+        def tracking_wait(*args, **kwargs):
+            waited.append(proc)
+            return original_wait(*args, **kwargs)
+
+        proc.wait = tracking_wait
+        launches.append(
+            {
+                "attempt": lifecycle_attempt,
+                "proc": proc,
+                "task_id": task.id,
+                "run_id": task.current_run_id,
+                "session_id": task.session_id,
+                "worktree": workspace,
+                "board": board,
+            }
+        )
+        return proc
+
+    monkeypatch.setattr(kb, "_default_spawn", fixture_default_spawn)
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="serial gate 1",
+            assignee="fixture",
+            workspace_kind="dir",
+            workspace_path=str(worktree),
+            session_id="session-stable",
+        )
+        next_id = kb.create_task(
+            conn, title="serial gate 2", assignee="fixture"
+        )
+        final_id = kb.create_task(
+            conn, title="serial gate 3", assignee="fixture"
+        )
+        kb.link_tasks(conn, task_id, next_id)
+        kb.link_tasks(conn, next_id, final_id)
+        kb.recompute_ready(conn)
+
+        result = kb.dispatch_once(conn)
+        assert [item[0] for item in result.spawned] == [task_id]
+        run_id = kb.get_task(conn, task_id).current_run_id
+        assert run_id is not None
+
+        deadline = time.monotonic() + 5
+        persisted = []
+        while time.monotonic() < deadline:
+            persisted = [
+                event
+                for event in kb.list_events(conn, task_id)
+                if event.kind == "worker_attempt_exit"
+            ]
+            if persisted:
+                break
+            time.sleep(0.01)
+        assert len(persisted) == 1
+        assert (
+            persisted[0].payload["exit_code"],
+            persisted[0].payload["classification"],
+        ) == (75, "transient_provider")
+        listener = next(
+            item
+            for item in persisted[0].payload["owned_processes"]
+            if item["role"] == "listener"
+        )
+        first_listener.update(pid=listener["pid"], port=listener["port"])
+
+        kb.dispatch_once(conn)
+        task = kb.get_task(conn, task_id)
+        assert (task.status, task.current_run_id) == ("running", run_id)
+        assert not any(
+            event.kind in {"rate_limited", "crashed"}
+            for event in kb.list_events(conn, task_id)
+        )
+        assert len(launches) == 1
+
+        assert kb.signal_worker_recovery(task_id, "credential_recovered")
+        deadline = time.monotonic() + 10
+        supervisor = kb._dispatcher_worker_supervisors[str(board_db.resolve())]
+        while supervisor.active_count and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert supervisor.active_count == 0
+
+        assert len(launches) == 2
+        assert [item["attempt"] for item in launches] == [1, 2]
+        assert [
+            (item["task_id"], item["run_id"], item["session_id"], item["worktree"])
+            for item in launches
+        ] == [
+            (task_id, run_id, "session-stable", str(worktree)),
+            (task_id, run_id, "session-stable", str(worktree)),
+        ]
+        assert waited[0] is launches[0]["proc"]
+        assert all(not pid_is_alive(item["proc"].pid) for item in launches)
+        assert not pid_is_alive(first_listener["pid"])
+        assert _listener_closed(first_listener["port"])
+        assert (worktree / "recovered.txt").read_text(encoding="utf-8") == 'recovered\n'
+        assert [kb.get_task(conn, item).status for item in (task_id, next_id, final_id)] == [
+            "done",
+            "ready",
+            "todo",
+        ]
+        persisted = [
+            event.payload
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "worker_attempt_exit"
+        ]
+        assert [(item["exit_code"], item["classification"]) for item in persisted] == [
+            (75, "transient_provider"),
+            (0, "success"),
+        ]
+    finally:
+        conn.close()
+        kb._dispatcher_worker_supervisors.clear()
+
+
+def test_dispatch_once_default_spawn_is_owned_by_supervisor(monkeypatch, tmp_path):
+    board_db = tmp_path / "board" / "kanban.db"
+    board_db.parent.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local-app-data"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "user-profile"))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(board_db))
+    kb.init_db()
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+    kb._dispatcher_worker_supervisors.clear()
+
+    popen_type = subprocess.Popen
+    launched: list[subprocess.Popen] = []
+    waited: list[subprocess.Popen] = []
+    default_spawn_returns: list[object] = []
+
+    def tracking_popen(*args, **kwargs):
+        proc = popen_type(*args, **kwargs)
+        launched.append(proc)
+        original_wait = proc.wait
+
+        def tracking_wait(*wait_args, **wait_kwargs):
+            waited.append(proc)
+            return original_wait(*wait_args, **wait_kwargs)
+
+        proc.wait = tracking_wait
+        return proc
+
+    original_default_spawn = kb._default_spawn
+
+    def tracking_default_spawn(*args, **kwargs):
+        proc = original_default_spawn(*args, **kwargs)
+        default_spawn_returns.append(proc)
+        return proc
+
+    monkeypatch.setattr(subprocess, "Popen", tracking_popen)
+    monkeypatch.setattr(
+        kb,
+        "_resolve_hermes_argv",
+        lambda: [sys.executable, "-c", "import time; time.sleep(1)"],
+    )
+    monkeypatch.setattr(kb, "_resolve_worker_cli_toolsets", lambda _home: None)
+    monkeypatch.setattr(kb, "_default_spawn", tracking_default_spawn)
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="supervised", assignee="fixture")
+        result = kb.dispatch_once(conn)
+        assert result.spawned[0][0] == task_id
+        assert len(launched) == 1
+        proc = launched[0]
+        assert isinstance(proc, popen_type)
+        assert proc.poll() is None
+        assert default_spawn_returns == [proc]
+        assert kb.get_task(conn, task_id).worker_pid == proc.pid
+    finally:
+        conn.close()
+
+    deadline = time.monotonic() + 5
+    supervisor = kb._dispatcher_worker_supervisor()
+    while supervisor.active_count and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert waited == [proc]
+    assert supervisor.active_count == 0
+    assert kb._classify_worker_exit(proc.pid) == ("clean_exit", 0)
+
+
+def test_raw_rate_limit_exit_does_not_enter_transient_provider_retry(tmp_path):
+    identity = WorkerIdentity("task-rate-limit", "session-rate-limit", tmp_path)
+
+    class RateLimitedProc:
+        returncode = 75
+
+        def __init__(self, pid):
+            self.pid = pid
+
+        def wait(self):
+            return self.returncode
+
+    raw_path = tmp_path / "raw.jsonl"
+    typed_path = tmp_path / "typed.jsonl"
+    typed_path.write_text(
+        json.dumps({"kind": "failure", "classification": "transient_provider"}) + "\n",
+        encoding="utf-8",
+    )
+    raw_exit = ws._attempt_exit(identity, 1, RateLimitedProc(45101), raw_path)
+    typed_exit = ws._attempt_exit(identity, 1, RateLimitedProc(45102), typed_path)
+    assert (raw_exit.exit_code, raw_exit.classification) == (75, "process_exit")
+    assert (typed_exit.exit_code, typed_exit.classification) == (75, "transient_provider")
+
+    launches: list[int] = []
+    exits: list = []
+
+    def launch(_identity, attempt, _event_path):
+        launches.append(attempt)
+        return RateLimitedProc(45200 + attempt)
+
+    supervisor = DispatcherWorkerSupervisor(
+        event_root=tmp_path / "events",
+        recovery_timeout=1,
+    )
+    handle = supervisor.start(identity, launch, on_exit=exits.append)
+    handle.signal_recovery("must-not-retry-rate-limit")
+    assert handle.wait(2)
+    assert launches == [1]
+    assert [(item.exit_code, item.classification) for item in exits] == [(75, "process_exit")]
+    assert supervisor.active_count == 0


### PR DESCRIPTION
## Summary

- supervise Kanban worker subprocesses with durable lifecycle state, exact run ownership, bounded restart handling, and one sanitized terminal failure event
- persist provider-recovery proofs and waiters with profile/provider/credential-generation scoping so only a newer trusted proof can resume the exact live run
- rotate opaque credential generations atomically, clean up stale recovery waiters, and keep worker sessions tagged as Kanban sessions

## Test plan

- [x] 104 focused worker lifecycle, supervisor, provider recovery, spawn, database-init, reclaim, and durable-event tests
- [x] `py_compile` on changed Python paths
- [x] Ruff on changed Python paths
- [x] `git diff --check`, merge-marker scan, and focused added-line security scans
- [x] independent exact-commit review approved revision `d225fd5203f1fbc0965b3d3b251a4578e330a7ce` with no blocking findings

## Notes

Provider and credential material are not written to lifecycle events, durable metadata, or review artifacts.