### PR TITLE
fix(skills): preserve underscores in generated commands

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -22,8 +22,9 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
-# Patterns for sanitizing skill names into clean hyphen-separated slugs.
-_SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
+# Patterns for sanitizing skill names into command-safe slugs.
+# Telegram accepts underscores in bot command names, so preserve them.
+_SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9_-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 
 # ---------------------------------------------------------------------------
@@ -424,7 +425,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     # Normalize to hyphen-separated slug, stripping
                     # non-alnum chars (e.g. +, /) to avoid invalid
                     # Telegram command names downstream.
-                    cmd_name = name.lower().replace(' ', '-').replace('_', '-')
+                    cmd_name = name.lower().replace(' ', '-')
                     cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
@@ -550,20 +551,21 @@ def reload_skills() -> Dict[str, Any]:
 def resolve_skill_command_key(command: str) -> Optional[str]:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
-    Skills are always stored with hyphens — ``scan_skill_commands`` normalizes
-    spaces and underscores to hyphens when building the key. Hyphens and
-    underscores are treated interchangeably in user input: this matches
-    ``_check_unavailable_skill`` and accommodates Telegram bot-command names
-    (which disallow hyphens, so ``/claude-code`` is registered as
-    ``/claude_code`` and comes back in the underscored form).
+    Commands preserve valid underscores from skill names. Existing hyphenated
+    command keys remain resolvable from Telegram's underscored form, whose bot
+    commands cannot contain hyphens.
 
     Returns the matching ``/slug`` key from ``get_skill_commands()`` or
     ``None`` if no match.
     """
     if not command:
         return None
-    cmd_key = f"/{command.replace('_', '-')}"
-    return cmd_key if cmd_key in get_skill_commands() else None
+    commands = get_skill_commands()
+    exact_key = f"/{command}"
+    if exact_key in commands:
+        return exact_key
+    hyphenated_key = f"/{command.replace('_', '-')}"
+    return hyphenated_key if hyphenated_key in commands else None
 
 
 def build_skill_invocation_message(

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -258,16 +258,9 @@ class TestScanSkillCommands:
         assert result["/__demo"]["name"] == "__demo"
         assert result["/__demo"]["skill_dir"] == str(skill_dir)
 
-    def test_slug_collision_keeps_first_skill(self, tmp_path):
-        """Two skills whose names normalize to the same slug do not clobber.
-
-        ``git_helper`` and ``git-helper`` are distinct frontmatter names but
-        both reduce to the ``/git-helper`` command. The first one scanned must
-        keep the command rather than being silently overwritten by the second.
-        """
+    def test_underscore_and_hyphen_skill_names_get_distinct_commands(self, tmp_path):
+        """Preserving underscores prevents normalization-induced collisions."""
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
-            # ``a-first`` sorts before ``z-second`` so the index walk visits the
-            # underscore-named skill first; that one must win the slash command.
             first = tmp_path / "a-first"
             first.mkdir()
             (first / "SKILL.md").write_text(
@@ -279,29 +272,10 @@ class TestScanSkillCommands:
                 "---\nname: git-helper\ndescription: Second skill.\n---\n\nBody.\n"
             )
             result = scan_skill_commands()
-        assert "/git-helper" in result
-        # First-wins: the entry resolves to the first skill, not the shadowing one.
-        assert result["/git-helper"]["name"] == "git_helper"
-        assert result["/git-helper"]["skill_dir"] == str(first)
 
-    def test_slug_collision_warns(self, tmp_path, caplog):
-        """A slug collision emits a warning so the user can diagnose the
-        shadowed skill."""
-        import logging as _logging
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
-            first = tmp_path / "a-first"
-            first.mkdir()
-            (first / "SKILL.md").write_text(
-                "---\nname: my-skill\ndescription: First.\n---\n\nBody.\n"
-            )
-            second = tmp_path / "z-second"
-            second.mkdir()
-            (second / "SKILL.md").write_text(
-                "---\nname: my_skill\ndescription: Second.\n---\n\nBody.\n"
-            )
-            with caplog.at_level(_logging.WARNING, logger="agent.skill_commands"):
-                scan_skill_commands()
-        assert any("already claimed" in r.message for r in caplog.records)
+        assert result["/git_helper"]["name"] == "git_helper"
+        assert result["/git-helper"]["name"] == "git-helper"
+
 
 
 class TestResolveSkillCommandKey:
@@ -316,6 +290,13 @@ class TestResolveSkillCommandKey:
             scan_skill_commands()
             assert resolve_skill_command_key("claude-code") == "/claude-code"
 
+
+
+    def test_underscore_command_matches_directly(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "__demo")
+            scan_skill_commands()
+            assert resolve_skill_command_key("__demo") == "/__demo"
 
 
     def test_unknown_command_returns_none(self, tmp_path):

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -248,6 +248,16 @@ class TestScanSkillCommands:
 
     # -- inter-skill slug collision dedup (#50304 / #63305) ------------------
 
+    def test_preserves_underscores_in_generated_command(self, tmp_path):
+        """Skill command names retain valid underscores from frontmatter."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "__demo")
+            result = scan_skill_commands()
+
+        assert "/__demo" in result
+        assert result["/__demo"]["name"] == "__demo"
+        assert result["/__demo"]["skill_dir"] == str(skill_dir)
+
     def test_slug_collision_keeps_first_skill(self, tmp_path):
         """Two skills whose names normalize to the same slug do not clobber.
 


### PR DESCRIPTION
Fixes #75620.

Draft opened after a reproducer-first commit. The first commit adds the failing regression; the follow-up will preserve underscores, which are valid Telegram command characters, and retain cross-platform input resolution.