### PR TITLE
fix(managed_uv): report candidate stage failures precisely

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -782,11 +782,11 @@ def _stage_candidate_venv(
         logger.warning("candidate dependency sync refused: uv.lock is missing")
         _remove_tree(candidate, boundary=runtime_root)
         return None, "replacement environment dependency sync refused: uv.lock is missing"
-    # Do NOT pass ``--no-config`` with ``--locked``. ``[tool.uv] exclude-newer``
-    # (and related project settings) live in pyproject.toml; dropping them
-    # makes uv treat a valid lockfile as stale and hard-fail under --locked
-    # (#75655). Venv creation above still uses --no-config; only locked sync
-    # must see project config so resolution matches how uv.lock was written.
+    # Locked sync must see project config (``[tool.uv] exclude-newer`` etc.) so
+    # resolution matches how ``uv.lock`` was written (#75655). ``managed_python_env``
+    # sets ``UV_NO_CONFIG=1`` (env equivalent of ``--no-config``) for managed
+    # Python install/venv paths; that must not leak into this sync. Venv create
+    # above keeps the sanitized env + ``--no-config`` argv.
     sync_env = dict(env)
     sync_env.pop("UV_NO_CONFIG", None)
     synced = subprocess.run(

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -729,7 +729,13 @@ def _stage_candidate_venv(
     project_root: Path,
     generation: Path,
     python: Path,
-) -> Path | None:
+) -> tuple[Path | None, str]:
+    """Build a relocatable candidate venv and smoke-test it.
+
+    Returns ``(path, "")`` on success, or ``(None, detail)`` on failure so
+    callers can distinguish dependency-sync failures from import smoke
+    failures (#75655).
+    """
     runtime_root = project_root / _RUNTIME_DIR_NAME
     token = f"{int(time.time())}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
     candidate = runtime_root / f"venv-candidate-{token}"
@@ -770,14 +776,17 @@ def _stage_candidate_venv(
             (created.stderr or created.stdout or "").strip(),
         )
         _remove_tree(candidate, boundary=runtime_root)
-        return None
+        return None, "replacement environment venv creation failed"
 
     if not (project_root / "uv.lock").is_file():
         logger.warning("candidate dependency sync refused: uv.lock is missing")
         _remove_tree(candidate, boundary=runtime_root)
-        return None
-    # Locked sync must see project [tool.uv] exclude-newer; --no-config /
-    # UV_NO_CONFIG drops it and uv 0.12+ refuses --locked.
+        return None, "replacement environment dependency sync refused: uv.lock is missing"
+    # Do NOT pass ``--no-config`` with ``--locked``. ``[tool.uv] exclude-newer``
+    # (and related project settings) live in pyproject.toml; dropping them
+    # makes uv treat a valid lockfile as stale and hard-fail under --locked
+    # (#75655). Venv creation above still uses --no-config; only locked sync
+    # must see project config so resolution matches how uv.lock was written.
     sync_env = dict(env)
     sync_env.pop("UV_NO_CONFIG", None)
     synced = subprocess.run(
@@ -797,14 +806,18 @@ def _stage_candidate_venv(
     if synced.returncode != 0:
         logger.warning("candidate dependency sync failed (rc=%d)", synced.returncode)
         _remove_tree(candidate, boundary=runtime_root)
-        return None
+        return None, "replacement environment dependency sync failed (uv sync --locked)"
 
     healthy, detail, _ = _smoke_candidate_venv(candidate)
     if not healthy:
         logger.warning("candidate venv smoke failed: %s", detail)
         _remove_tree(candidate, boundary=runtime_root)
-        return None
-    return candidate
+        return (
+            None,
+            "replacement environment did not pass dependency and import smoke tests"
+            + (f": {detail}" if detail else ""),
+        )
+    return candidate, ""
 
 
 def _rename_with_retry(source: Path, destination: Path) -> None:
@@ -1182,7 +1195,7 @@ def repair_vulnerable_runtime(
             )
         generation, python, candidate_info = provisioned
 
-        candidate = _stage_candidate_venv(
+        candidate, stage_detail = _stage_candidate_venv(
             uv_bin,
             project_root=root,
             generation=generation,
@@ -1192,7 +1205,8 @@ def repair_vulnerable_runtime(
             _remove_tree(generation, boundary=managed_python_install_dir(root))
             return RuntimeRepairResult(
                 "failed",
-                "replacement environment did not pass dependency and import smoke tests",
+                stage_detail
+                or "replacement environment did not pass dependency and import smoke tests",
                 sqlite_before=current.sqlite_version_string,
                 sqlite_after=candidate_info.sqlite_version_string,
             )

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -457,12 +457,16 @@ class TestRuntimeRepair:
              ), \
              patch(
                  "hermes_cli.managed_uv._stage_candidate_venv",
-                 return_value=None,
+                 return_value=(
+                     None,
+                     "replacement environment dependency sync failed (uv sync --locked)",
+                 ),
              ):
             result = repair_vulnerable_runtime("uv", project_root=root)
 
         assert result.status == "failed"
-        assert "replacement environment" in result.detail
+        assert "dependency sync failed" in result.detail
+        assert "smoke tests" not in result.detail
         assert sentinel.read_text(encoding="utf-8") == "live"
         assert (live / "bin" / "python").read_text(encoding="utf-8") == (
             "live interpreter"
@@ -532,7 +536,7 @@ class TestRuntimeRepair:
              ), \
              patch(
                  "hermes_cli.managed_uv._stage_candidate_venv",
-                 return_value=candidate_venv,
+                 return_value=(candidate_venv, ""),
              ), \
              patch(
                  "hermes_cli.managed_uv._smoke_candidate_venv",
@@ -934,7 +938,7 @@ class TestRepairRetriesAfterUvRefresh:
              ) as mock_refresh, \
              patch(
                  "hermes_cli.managed_uv._stage_candidate_venv",
-                 return_value=None,
+                 return_value=(None, "replacement environment dependency sync failed"),
              ):
             result = repair_vulnerable_runtime("uv", project_root=root)
         return result, attempts, mock_refresh, sentinel
@@ -1100,3 +1104,74 @@ class TestVenvPythonUpdateBoundary:
             "/opt/hermes/venv/bin/python"
         )
 
+
+class TestStageCandidateVenvLockedSync:
+    """#75655: locked sync must not pass --no-config (exclude-newer)."""
+
+    def test_locked_sync_omits_no_config(self, tmp_path):
+        from hermes_cli.managed_uv import _stage_candidate_venv
+
+        root = tmp_path / "checkout"
+        root.mkdir()
+        (root / "uv.lock").write_text("# lock\n", encoding="utf-8")
+        (root / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+        generation = root / ".hermes-runtime" / "python" / "gen"
+        python = generation / "bin" / "python"
+        python.parent.mkdir(parents=True)
+        python.write_text("py", encoding="utf-8")
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run), \
+             patch(
+                 "hermes_cli.managed_uv._smoke_candidate_venv",
+                 return_value=(True, "", None),
+             ), \
+             patch("hermes_cli.managed_uv._remove_tree"):
+            path, detail = _stage_candidate_venv(
+                "uv",
+                project_root=root,
+                generation=generation,
+                python=python,
+            )
+
+        assert path is not None
+        assert detail == ""
+        sync_cmds = [c for c in calls if len(c) > 1 and c[1] == "sync"]
+        assert len(sync_cmds) == 1
+        sync = sync_cmds[0]
+        assert "--locked" in sync
+        assert "--no-config" not in sync
+
+    def test_sync_failure_detail_not_smoke(self, tmp_path):
+        from hermes_cli.managed_uv import _stage_candidate_venv
+
+        root = tmp_path / "checkout"
+        root.mkdir()
+        (root / "uv.lock").write_text("# lock\n", encoding="utf-8")
+        generation = root / ".hermes-runtime" / "python" / "gen"
+        python = generation / "bin" / "python"
+        python.parent.mkdir(parents=True)
+        python.write_text("py", encoding="utf-8")
+
+        def fake_run(cmd, **kwargs):
+            if len(cmd) > 1 and cmd[1] == "sync":
+                return MagicMock(returncode=1, stdout="", stderr="locked stale")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli.managed_uv._remove_tree"):
+            path, detail = _stage_candidate_venv(
+                "uv",
+                project_root=root,
+                generation=generation,
+                python=python,
+            )
+
+        assert path is None
+        assert "dependency sync failed" in detail
+        assert "smoke" not in detail.lower()

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -1106,9 +1106,9 @@ class TestVenvPythonUpdateBoundary:
 
 
 class TestStageCandidateVenvLockedSync:
-    """#75655: locked sync must not pass --no-config (exclude-newer)."""
+    """#75655: locked sync must see project config (no --no-config / UV_NO_CONFIG)."""
 
-    def test_locked_sync_omits_no_config(self, tmp_path):
+    def test_locked_sync_omits_no_config_flag_and_env(self, tmp_path):
         from hermes_cli.managed_uv import _stage_candidate_venv
 
         root = tmp_path / "checkout"
@@ -1120,10 +1120,10 @@ class TestStageCandidateVenvLockedSync:
         python.parent.mkdir(parents=True)
         python.write_text("py", encoding="utf-8")
 
-        calls: list[list[str]] = []
+        calls: list[tuple[list[str], dict]] = []
 
         def fake_run(cmd, **kwargs):
-            calls.append(list(cmd))
+            calls.append((list(cmd), kwargs))
             return MagicMock(returncode=0, stdout="", stderr="")
 
         with patch("hermes_cli.managed_uv.subprocess.run", side_effect=fake_run), \
@@ -1141,11 +1141,17 @@ class TestStageCandidateVenvLockedSync:
 
         assert path is not None
         assert detail == ""
-        sync_cmds = [c for c in calls if len(c) > 1 and c[1] == "sync"]
-        assert len(sync_cmds) == 1
-        sync = sync_cmds[0]
-        assert "--locked" in sync
-        assert "--no-config" not in sync
+        venv_calls = [(c, kw) for c, kw in calls if len(c) > 1 and c[1] == "venv"]
+        sync_calls = [(c, kw) for c, kw in calls if len(c) > 1 and c[1] == "sync"]
+        assert len(venv_calls) == 1
+        assert len(sync_calls) == 1
+        venv_cmd, venv_kw = venv_calls[0]
+        sync_cmd, sync_kw = sync_calls[0]
+        assert "--no-config" in venv_cmd
+        assert (venv_kw.get("env") or {}).get("UV_NO_CONFIG") == "1"
+        assert "--locked" in sync_cmd
+        assert "--no-config" not in sync_cmd
+        assert "UV_NO_CONFIG" not in (sync_kw.get("env") or {})
 
     def test_sync_failure_detail_not_smoke(self, tmp_path):
         from hermes_cli.managed_uv import _stage_candidate_venv


### PR DESCRIPTION
## What does this PR do?

Reports the exact phase that failed while staging a managed-runtime replacement instead of always blaming the dependency and import smoke test.

Current `main` already contains the project-config fix from #76493. The remaining problem is diagnostic: `_stage_candidate_venv` returns only `None`, so `repair_vulnerable_runtime` cannot distinguish venv creation, missing-lock, locked-sync, and import-smoke failures.

This changes the private staging helper to return `(path, detail)` and propagates its precise failure detail to the public repair result. No provisioning flags or unrelated runtime behavior change in this PR.

## Related Issue

Fixes #75655

The root config issue was fixed by #76493; this PR retains the separately tracked diagnostic correction.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/managed_uv.py`: return `(path | None, detail)` from `_stage_candidate_venv` and propagate creation, missing-lock, dependency-sync, and smoke-test failure details.
- `tests/hermes_cli/test_managed_uv.py`: update every helper caller and prove a locked-sync failure is reported as sync failure, not smoke failure.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_managed_uv.py
```

Regression proof: the new `test_sync_failure_detail_not_smoke` fails on current `origin/main` because the helper returns bare `None`; it passes on this branch and reports `dependency sync failed` without mentioning smoke.

Focused verification: `scripts/run_tests.sh tests/hermes_cli/test_managed_uv.py` passed 48 tests with one Windows-only skip on macOS after rebase onto `origin/main` `aea2daee2` (head `53e0fe335`). The rebase kept current main's Windows self-lock coverage and this PR's precise stage-failure regression.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite for the affected areas via `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — private helper contract documented
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral return-value propagation; existing Windows-only test remains in CI
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A