### PR TITLE
fix(photon): coalesce split attachment events

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -182,7 +182,10 @@ def _sidecar_pid_alive(pid: Any) -> bool:
 _DEDUP_MAX_SIZE = 4000
 _DEDUP_WINDOW_SECONDS = 48 * 3600
 
-_FFFC_WAIT_SECONDS = 15.0  # Timeout for waiting on an attachment after a U+FFFC placeholder.
+# Apple may split one mixed iMessage bubble into a text precursor and a later
+# attachment event. Keep the window short so ordinary text is not delayed.
+_OBJECT_REPLACEMENT_CHAR = "\ufffc"
+_MIXED_EVENT_COALESCE_SECONDS = 4.0
 
 # Resolved lazily on first use: the installed plugin tree when writable (dev
 # installs), or a mirror on the durable data volume when the install tree
@@ -795,7 +798,22 @@ class PhotonAdapter(BasePlatformAdapter):
         # Last time we sent a typing indicator per chat, for cooldown gating.
         self._typing_last_sent: Dict[str, float] = {}
 
-        self._pending_fffc: Dict[str, tuple[float, Any]] = {}  # chat_key → (timestamp, asyncio.Task)
+        # Pending marker-bearing captions or empty attachment precursors keyed
+        # by (space, sender). A matching media event consumes the precursor so
+        # the gateway receives one turn with both text and bytes.
+        self._pending_attachment_text: Dict[
+            tuple[str, str], Dict[str, Any]
+        ] = {}
+        self._mixed_event_coalesce_seconds = max(
+            0.0,
+            _coerce_float(
+                _first_set(
+                    extra.get("mixed_event_coalesce_seconds"),
+                    os.getenv("PHOTON_MIXED_EVENT_COALESCE_SECONDS"),
+                ),
+                _MIXED_EVENT_COALESCE_SECONDS,
+            ),
+        )
 
         # Group-chat mention gating (parity with BlueBubbles). When enabled,
         # group messages are ignored unless they match a wake word; DMs are
@@ -945,11 +963,12 @@ class PhotonAdapter(BasePlatformAdapter):
                     pass
                 except Exception:
                     pass
-        # Cancel any pending U+FFFC placeholder tasks.
-        for chat_key, (_, fffc_task) in list(self._pending_fffc.items()):
-            if fffc_task and not fffc_task.done():
-                fffc_task.cancel()
-        self._pending_fffc.clear()
+        # Cancel any pending split-message coalescing tasks.
+        for pending in self._pending_attachment_text.values():
+            task = pending.get("task")
+            if isinstance(task, asyncio.Task) and not task.done():
+                task.cancel()
+        self._pending_attachment_text.clear()
         await self._stop_sidecar()
         if self._http_client is not None:
             try:
@@ -1138,13 +1157,36 @@ class PhotonAdapter(BasePlatformAdapter):
                 del seen[old]
         return False
 
-    async def _fffc_timeout_handler(self, chat_key: str, message_id: str) -> None:
-        await asyncio.sleep(_FFFC_WAIT_SECONDS)
-        if self._pending_fffc.pop(chat_key, None):
-            logger.warning(
-                "[photon] wait for attachment was too long, can't retrieve attachment data "
-                "(message %s, chat %s)", message_id, chat_key,
-            )
+    @staticmethod
+    def _clean_object_replacement_marker(text: str) -> str:
+        """Remove Apple's invisible attachment placeholder from a caption."""
+        return text.replace(_OBJECT_REPLACEMENT_CHAR, "").strip()
+
+    async def _flush_pending_attachment_text(
+        self, key: tuple[str, str]
+    ) -> None:
+        """Dispatch a held caption when no matching media event arrives."""
+        try:
+            await asyncio.sleep(self._mixed_event_coalesce_seconds)
+        except asyncio.CancelledError:
+            return
+
+        pending = self._pending_attachment_text.get(key)
+        if not pending or pending.get("task") is not asyncio.current_task():
+            return
+        self._pending_attachment_text.pop(key, None)
+
+        # An empty event only has meaning as an attachment precursor. A real
+        # caption remains useful on its own and must not be lost.
+        if pending.get("drop_if_unmatched"):
+            logger.info("[photon] suppressing unmatched empty attachment precursor")
+            return
+        message_event = pending["event"]
+        self._record_last_inbound(key[0], message_event.message_id)
+        try:
+            await self.handle_message(message_event)
+        except Exception:
+            logger.exception("[photon] delayed attachment caption dispatch failed")
 
     async def _dispatch_inbound(self, event: Dict[str, Any]) -> None:
         """Normalize a sidecar inbound event and dispatch it to the gateway.
@@ -1281,27 +1323,14 @@ class PhotonAdapter(BasePlatformAdapter):
                 )
             )
             return
-        # U+FFFC placeholder — wait for the real attachment instead of
-        # dispatching. Detected before _record_last_inbound so the placeholder
-        # is not recorded as the reaction target — the real attachment will be.
-        if ctype == "text" and (content.get("text") or "").strip() == "\ufffc":
-            chat_key = space_id
-            prev = self._pending_fffc.pop(chat_key, None)
-            if prev and prev[1] and not prev[1].done():
-                prev[1].cancel()
-            task = asyncio.create_task(
-                self._fffc_timeout_handler(chat_key, event.get("messageId") or "")
-            )
-            self._pending_fffc[chat_key] = (time.monotonic(), task)
-            logger.debug("[photon] U+FFFC placeholder received — waiting for attachment")
-            return
-
-        # Cancel any pending U+FFFC timeout — the real message arrived.
-        if ctype in {"attachment", "voice"}:
-            prev = self._pending_fffc.pop(space_id, None)
-            if prev and prev[1] and not prev[1].done():
-                prev[1].cancel()
-                logger.debug("[photon] attachment arrived — cancelling U+FFFC timeout")
+        raw_text = content.get("text") or "" if ctype == "text" else ""
+        has_object_replacement_marker = (
+            ctype == "text" and _OBJECT_REPLACEMENT_CHAR in raw_text
+        )
+        is_empty_text_precursor = ctype == "text" and not raw_text.strip()
+        is_attachment_precursor = (
+            has_object_replacement_marker or is_empty_text_precursor
+        )
 
         # Preview art for an immediately preceding URL/richlink should not
         # become a second user prompt. Suppress before recording it as the
@@ -1316,7 +1345,8 @@ class PhotonAdapter(BasePlatformAdapter):
         # the chat's latest inbound so `add_reaction` can target it when the
         # caller doesn't pass an explicit message id. Recorded before the
         # mention gate: a reaction to a non-wake-word group message is valid.
-        self._record_last_inbound(space_id, event.get("messageId"))
+        if not is_attachment_precursor:
+            self._record_last_inbound(space_id, event.get("messageId"))
         if ctype == "poll_option":
             # A native poll vote. A *selection* carries the chosen option text
             # straight to the agent as if the user had typed it — the gateway's
@@ -1349,7 +1379,7 @@ class PhotonAdapter(BasePlatformAdapter):
             )
             return
         if ctype == "text":
-            text = content.get("text") or ""
+            text = self._clean_object_replacement_marker(raw_text)
             mtype = MessageType.TEXT
         elif ctype in {"attachment", "voice"}:
             text, mtype, media_urls, media_types = _normalize_binary_payload(content)
@@ -1396,18 +1426,56 @@ class PhotonAdapter(BasePlatformAdapter):
             text = f"[Photon content type not handled: {ctype}]"
             mtype = MessageType.TEXT
 
+        pending_key = (space_id, sender_id)
+        is_media_event = ctype in {"attachment", "voice"} or (
+            ctype == "group" and bool(media_urls)
+        )
+        raw_message: Dict[str, Any] = event
+        pending_mention_authorized = False
+
+        # A caption and its media may arrive as separate Photon events. Merge
+        # them before mention gating so a group attachment inherits the wake
+        # word decision already made for its held caption.
+        if is_media_event:
+            pending = self._pending_attachment_text.pop(pending_key, None)
+            if pending:
+                task = pending.get("task")
+                if isinstance(task, asyncio.Task):
+                    task.cancel()
+                pending_event = pending["event"]
+                pending_mention_authorized = bool(
+                    pending.get("mention_authorized")
+                )
+                caption = (pending_event.text or "").strip()
+                if caption:
+                    if text in {"", "(attachment)", "(voice)"}:
+                        text = caption
+                    elif caption not in text:
+                        text = f"{caption}\n{text}"
+                if pending_event.timestamp < timestamp:
+                    timestamp = pending_event.timestamp
+                raw_message = {
+                    "coalescedPhotonEvents": True,
+                    "textEvent": pending_event.raw_message,
+                    "mediaEvent": event,
+                }
+
         # Group-mention gating (parity with BlueBubbles). In group chats with
         # require_mention enabled, drop messages that don't hit a wake word;
         # strip the leading wake word from the ones that do. DMs are never
         # gated.
+        mention_authorized = chat_type != "group" or not self.require_mention
         if chat_type == "group" and self.require_mention:
-            if not self._message_matches_mention_patterns(text):
+            mention_matched = self._message_matches_mention_patterns(text)
+            if not pending_mention_authorized and not mention_matched:
                 logger.debug(
                     "[photon] ignoring group message "
                     "(require_mention=true, no mention pattern matched)"
                 )
                 return
-            text = self._clean_mention_text(text)
+            if not pending_mention_authorized:
+                text = self._clean_mention_text(text)
+            mention_authorized = True
 
         self._record_recent_richlink(space_id, _richlink_url_from_content(content) or text)
 
@@ -1423,11 +1491,34 @@ class PhotonAdapter(BasePlatformAdapter):
             message_type=mtype,
             source=source,
             message_id=event.get("messageId"),
-            raw_message=event,
+            raw_message=raw_message,
             timestamp=timestamp,
             media_urls=media_urls,
             media_types=media_types,
         )
+
+        if is_attachment_precursor:
+            previous = self._pending_attachment_text.pop(pending_key, None)
+            if previous:
+                task = previous.get("task")
+                if isinstance(task, asyncio.Task):
+                    task.cancel()
+                if not previous.get("drop_if_unmatched"):
+                    previous_event = previous["event"]
+                    self._record_last_inbound(pending_key[0], previous_event.message_id)
+                    await self.handle_message(previous_event)
+            task = asyncio.get_running_loop().create_task(
+                self._flush_pending_attachment_text(pending_key)
+            )
+            self._pending_attachment_text[pending_key] = {
+                "event": message_event,
+                "task": task,
+                "drop_if_unmatched": not bool(text.strip()),
+                "mention_authorized": mention_authorized,
+            }
+            logger.debug("[photon] attachment text precursor received; waiting for media")
+            return
+
         await self.handle_message(message_event)
 
     # -- Sidecar lifecycle -------------------------------------------------

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -130,7 +130,7 @@ def test_check_requirements_without_node(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 # ---------------------------------------------------------------------------
-# CAF attachment promotion + U+FFFC placeholder tests
+# CAF attachment promotion + split attachment event tests
 # ---------------------------------------------------------------------------
 
 _CAF_BYTES = b"caff" + b"\x00" * 60  # Minimal CAF header magic
@@ -191,15 +191,15 @@ async def test_fffc_placeholder_no_dispatch(
     captured = _capture(adapter, monkeypatch)
 
     event = _dm_event("\ufffc", msg_id="spc-msg-fffc")
-    chat_key = event["space"]["id"]
+    pending_key = (event["space"]["id"], event["sender"]["id"])
     await adapter._dispatch_inbound(event)
 
     assert len(captured) == 0
-    assert chat_key in adapter._pending_fffc
+    assert pending_key in adapter._pending_attachment_text
 
 
 @pytest.mark.asyncio
-async def test_disconnect_cancels_pending_fffc_tasks(
+async def test_disconnect_cancels_pending_attachment_tasks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """disconnect() cancels any pending U+FFFC placeholder tasks."""
@@ -207,7 +207,7 @@ async def test_disconnect_cancels_pending_fffc_tasks(
     _capture(adapter, monkeypatch)
 
     await adapter._dispatch_inbound(_dm_event("\ufffc", msg_id="spc-msg-fffc"))
-    assert len(adapter._pending_fffc) == 1
+    assert len(adapter._pending_attachment_text) == 1
 
     async def _noop_stop_sidecar():
         pass
@@ -220,4 +220,136 @@ async def test_disconnect_cancels_pending_fffc_tasks(
 
     await adapter.disconnect()
 
-    assert len(adapter._pending_fffc) == 0
+    assert len(adapter._pending_attachment_text) == 0
+
+
+@pytest.mark.asyncio
+async def test_split_caption_and_attachment_dispatch_as_one_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A marker-bearing caption is preserved on the later image event."""
+    monkeypatch.setenv("PHOTON_MIXED_EVENT_COALESCE_SECONDS", "0.05")
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    raw = base64.b64decode(_PNG_1X1_B64)
+
+    await adapter._dispatch_inbound(
+        _dm_event("\ufffcRead this label", msg_id="spc-msg-caption")
+    )
+    assert captured == []
+
+    await adapter._dispatch_inbound(
+        _attachment_event(
+            {
+                "name": "label.png",
+                "mimeType": "image/png",
+                "size": len(raw),
+                "data": _PNG_1X1_B64,
+                "encoding": "base64",
+            },
+            msg_id="spc-msg-media",
+        )
+    )
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.text == "Read this label"
+    assert event.message_type == MessageType.PHOTO
+    assert event.raw_message["coalescedPhotonEvents"] is True
+    assert event.raw_message["textEvent"]["messageId"] == "spc-msg-caption"
+    cached = Path(event.media_urls[0])
+    try:
+        assert cached.read_bytes() == raw
+    finally:
+        cached.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_split_caption_flushes_when_attachment_never_arrives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real caption survives when Photon never emits its media event."""
+    monkeypatch.setenv("PHOTON_MIXED_EVENT_COALESCE_SECONDS", "0.01")
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(
+        _dm_event("Keep this caption\ufffc", msg_id="spc-msg-caption-only")
+    )
+    await asyncio.sleep(0.03)
+
+    assert len(captured) == 1
+    assert captured[0].text == "Keep this caption"
+
+
+@pytest.mark.asyncio
+async def test_empty_precursor_and_attachment_dispatch_as_one_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuinely empty precursor is suppressed but still pairs with media."""
+    monkeypatch.setenv("PHOTON_MIXED_EVENT_COALESCE_SECONDS", "0.05")
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    raw = base64.b64decode(_PNG_1X1_B64)
+
+    await adapter._dispatch_inbound(_dm_event("", msg_id="spc-msg-empty"))
+    await adapter._dispatch_inbound(
+        _attachment_event(
+            {
+                "name": "delayed.png",
+                "mimeType": "image/png",
+                "size": len(raw),
+                "data": _PNG_1X1_B64,
+                "encoding": "base64",
+            },
+            msg_id="spc-msg-delayed-media",
+        )
+    )
+
+    assert len(captured) == 1
+    assert captured[0].message_type == MessageType.PHOTO
+    assert captured[0].raw_message["coalescedPhotonEvents"] is True
+    cached = Path(captured[0].media_urls[0])
+    cached.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_unmatched_empty_precursor_is_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOTON_MIXED_EVENT_COALESCE_SECONDS", "0.01")
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_dm_event("", msg_id="spc-msg-empty-only"))
+    await asyncio.sleep(0.03)
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_repeated_empty_precursors_do_not_dispatch_empty_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOTON_MIXED_EVENT_COALESCE_SECONDS", "0.01")
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_dm_event("", msg_id="spc-msg-empty-one"))
+    await adapter._dispatch_inbound(_dm_event("", msg_id="spc-msg-empty-two"))
+    await asyncio.sleep(0.03)
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_plain_text_is_not_delayed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_dm_event("ordinary text"))
+
+    assert len(captured) == 1
+    assert captured[0].text == "ordinary text"

--- a/tests/plugins/platforms/photon/test_mention_gating.py
+++ b/tests/plugins/platforms/photon/test_mention_gating.py
@@ -10,12 +10,14 @@ on what reaches ``handle_message``.
 """
 from __future__ import annotations
 
+import base64
+from pathlib import Path
 from typing import List
 
 import pytest
 
 from gateway.config import PlatformConfig
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, MessageType
 from plugins.platforms.photon.adapter import PhotonAdapter
 
 
@@ -45,6 +47,30 @@ def _dm_payload(text: str) -> dict:
         "sender": {"id": "+15551234567"},
         "content": {"type": "text", "text": text},
         "timestamp": "2026-05-14T19:06:32.000Z",
+    }
+
+
+_PNG_1X1_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhf"
+    "DwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+def _group_attachment_payload() -> dict:
+    raw = base64.b64decode(_PNG_1X1_B64)
+    return {
+        "messageId": "grp-media",
+        "space": {"id": "group-guid-xyz", "type": "group", "phone": None},
+        "sender": {"id": "+15551234567"},
+        "content": {
+            "type": "attachment",
+            "name": "label.png",
+            "mimeType": "image/png",
+            "size": len(raw),
+            "data": _PNG_1X1_B64,
+            "encoding": "base64",
+        },
+        "timestamp": "2026-05-14T19:06:33.000Z",
     }
 
 
@@ -82,6 +108,33 @@ async def test_dm_never_gated(monkeypatch: pytest.MonkeyPatch) -> None:
     await adapter._dispatch_inbound(_dm_payload("no wake word here"))
     assert len(captured) == 1
     assert captured[0].text == "no wake word here"
+
+
+@pytest.mark.asyncio
+async def test_group_split_caption_authorizes_later_attachment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(
+        monkeypatch,
+        extra={"require_mention": True, "mixed_event_coalesce_seconds": 0.05},
+    )
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_group_payload("\ufffcHermes read this label"))
+    assert captured == []
+
+    await adapter._dispatch_inbound(_group_attachment_payload())
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.text == "read this label"
+    assert event.message_type == MessageType.PHOTO
+    assert event.raw_message["coalescedPhotonEvents"] is True
+    cached = Path(event.media_urls[0])
+    try:
+        assert cached.read_bytes() == base64.b64decode(_PNG_1X1_B64)
+    finally:
+        cached.unlink(missing_ok=True)
 
 
 def test_custom_mention_patterns_from_config(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -146,6 +146,12 @@ Both keys also accept env vars (`PHOTON_REQUIRE_MENTION`,
 `PHOTON_MENTION_PATTERNS`). This is the same mention-gating model the
 BlueBubbles iMessage channel uses.
 
+Photon may deliver a mixed text-and-attachment bubble as two events. Hermes
+briefly holds a marker-bearing caption so it can combine the caption and media
+into one turn. The default four-second window can be adjusted with
+`mixed_event_coalesce_seconds` under `gateway.platforms.photon` or with
+`PHOTON_MIXED_EVENT_COALESCE_SECONDS`.
+
 ## Start the gateway
 
 ```bash
@@ -243,6 +249,7 @@ Common issues:
 | `PHOTON_ALLOW_ALL_USERS`  | `false`            | Dev only — accept any sender               |
 | `PHOTON_REQUIRE_MENTION`  | `false`            | Require a wake word before responding in groups |
 | `PHOTON_MENTION_PATTERNS` | Hermes wake words  | JSON list / comma / newline regex patterns for group mentions |
+| `PHOTON_MIXED_EVENT_COALESCE_SECONDS` | `4` | Seconds to wait for media after a split attachment caption |
 | `PHOTON_DASHBOARD_HOST`   | `app.photon.codes` | Override the dashboard / device-login host |
 | `PHOTON_SPECTRUM_HOST`    | `spectrum.photon.codes` | Override the Spectrum API host |
 


### PR DESCRIPTION
## Summary

- coalesce Photon text precursors and their shortly delayed attachment/voice events into one gateway turn
- preserve U+FFFC-bearing captions while stripping the object-replacement marker
- suppress unmatched empty precursors instead of starting empty model turns
- keep ordinary non-empty text immediate and cancel pending timers during disconnect

Photon can represent one mixed iMessage bubble as two inbound events: a text event (sometimes empty, sometimes a caption containing U+FFFC) followed by the actual media event. The existing adapter only suppresses a message whose entire text is U+FFFC, so captioned and empty split events can become separate or incomplete agent turns.

The pending window defaults to four seconds and is configurable with `platforms.photon.extra.mixed_event_coalesce_seconds` or `PHOTON_MIXED_EVENT_COALESCE_SECONDS`.

## Tests

- `python3 -m py_compile plugins/platforms/photon/adapter.py tests/plugins/platforms/photon/test_inbound.py`
- `git diff --check`
- focused production-environment harness covering caption + media, caption timeout, empty precursor + media, repeated empty precursor suppression, and immediate plain text

The repository's pytest dependency was not installed in the production environment, so the focused scenarios were executed directly against its existing Hermes virtualenv.
