### PR TITLE
fix(skills): preserve underscores in skill slash commands

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -28,6 +28,29 @@ _skill_commands_platform: Optional[str] = None
 # into a different command name (#75620).
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9_-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+# Mirror hermes_cli.commands._sanitize_telegram_name for collision policy.
+_TG_SKILL_INVALID = re.compile(r"[^a-z0-9_]")
+_TG_SKILL_MULTI_UNDERSCORE = re.compile(r"_{2,}")
+
+
+def skill_command_slug(name: str) -> str:
+    """Normalize a skill frontmatter/dir name to a slash-command bare slug."""
+    cmd_name = name.lower().replace(" ", "-")
+    cmd_name = _SKILL_INVALID_CHARS.sub("", cmd_name)
+    cmd_name = _SKILL_MULTI_HYPHEN.sub("-", cmd_name).strip("-")
+    return cmd_name
+
+
+def telegram_bot_command_form(bare: str) -> str:
+    """Telegram Bot API form of a skill slug (hyphens → underscores, strip invalid).
+
+    Used for menu collision policy: two distinct skill keys that collapse to the
+    same Telegram command name must resolve deterministically (#75620).
+    """
+    name = bare.lower().lstrip("/").replace("-", "_")
+    name = _TG_SKILL_INVALID.sub("", name)
+    name = _TG_SKILL_MULTI_UNDERSCORE.sub("_", name)
+    return name.strip("_")
 
 # ---------------------------------------------------------------------------
 # Skill-scaffolding markers and the canonical extractor.
@@ -424,13 +447,9 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                                 description = line[:80]
                                 break
                     seen_names.add(name)
-                    # Normalize to a Telegram-safe slug: spaces → hyphens,
-                    # strip chars outside [a-z0-9_-]. Underscores are kept so
-                    # intentional names (``__demo``, ``git_helper``) stay
-                    # distinct from hyphenated siblings (#75620).
-                    cmd_name = name.lower().replace(" ", "-")
-                    cmd_name = _SKILL_INVALID_CHARS.sub("", cmd_name)
-                    cmd_name = _SKILL_MULTI_HYPHEN.sub("-", cmd_name).strip("-")
+                    # Spaces → hyphens; keep underscores so intentional names
+                    # (``__demo``, ``git_helper``) stay distinct (#75620).
+                    cmd_name = skill_command_slug(name)
                     if not cmd_name:
                         continue
                     # Skip if this skill's auto-generated /command collides
@@ -554,11 +573,15 @@ def reload_skills() -> Dict[str, Any]:
 def resolve_skill_command_key(command: str) -> Optional[str]:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
-    Keys preserve intentional underscores from the skill name (#75620). Exact
-    match is tried first so ``/__demo`` and ``/git_helper`` resolve to those
-    keys. When the exact key is missing, underscores are rewritten to hyphens
-    so Telegram clients that forbid hyphens in bot commands can still hit a
-    hyphenated skill key (``/claude_code`` → ``/claude-code``).
+    Keys preserve intentional underscores from the skill name (#75620).
+
+    Telegram bot commands cannot contain hyphens, so a skill registered as
+    ``/claude-code`` arrives as ``claude_code``. When **both** ``/git_helper``
+    and ``/git-helper`` exist they collapse to the same Telegram menu name
+    ``git_helper`` (menu first-wins via ``sorted`` key order in
+    ``telegram_menu_commands``). Dispatch must use the same first-wins rule:
+    among all keys whose Telegram form matches the input, pick the
+    lexicographically first ``/key``.
 
     Returns the matching ``/slug`` key from ``get_skill_commands()`` or
     ``None`` if no match.
@@ -566,11 +589,27 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     if not command:
         return None
     commands = get_skill_commands()
-    exact = f"/{command}"
+    bare = command.lstrip("/")
+    tg = telegram_bot_command_form(bare)
+    if not tg:
+        return None
+
+    # All registered keys that Telegram would present as the same bot command.
+    collisions = sorted(
+        key
+        for key in commands
+        if telegram_bot_command_form(key.lstrip("/")) == tg
+    )
+    if collisions:
+        # Deterministic first-wins — matches sorted(skill_cmds) menu build order.
+        return collisions[0]
+
+    # No telegram-form match: allow direct key when the bare token is already
+    # a stored slug (e.g. CLI typed exactly).
+    exact = f"/{bare}"
     if exact in commands:
         return exact
-    # Telegram may swap hyphens for underscores in bot-command names.
-    hyphenated = f"/{command.replace('_', '-')}"
+    hyphenated = f"/{bare.replace('_', '-')}"
     if hyphenated != exact and hyphenated in commands:
         return hyphenated
     return None

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -22,8 +22,11 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
-# Patterns for sanitizing skill names into clean hyphen-separated slugs.
-_SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
+# Patterns for sanitizing skill names into slash-command slugs.
+# Telegram bot commands allow a-z, 0-9, and underscore — keep intentional
+# underscores (e.g. ``__spec-driven``) so they are not silently collapsed
+# into a different command name (#75620).
+_SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9_-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 
 # ---------------------------------------------------------------------------
@@ -421,12 +424,13 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                                 description = line[:80]
                                 break
                     seen_names.add(name)
-                    # Normalize to hyphen-separated slug, stripping
-                    # non-alnum chars (e.g. +, /) to avoid invalid
-                    # Telegram command names downstream.
-                    cmd_name = name.lower().replace(' ', '-').replace('_', '-')
-                    cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)
-                    cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
+                    # Normalize to a Telegram-safe slug: spaces → hyphens,
+                    # strip chars outside [a-z0-9_-]. Underscores are kept so
+                    # intentional names (``__demo``, ``git_helper``) stay
+                    # distinct from hyphenated siblings (#75620).
+                    cmd_name = name.lower().replace(" ", "-")
+                    cmd_name = _SKILL_INVALID_CHARS.sub("", cmd_name)
+                    cmd_name = _SKILL_MULTI_HYPHEN.sub("-", cmd_name).strip("-")
                     if not cmd_name:
                         continue
                     # Skip if this skill's auto-generated /command collides
@@ -443,8 +447,8 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                         )
                         continue
                     # Dedup on the resolved slug, not just the raw name: two
-                    # distinct frontmatter names can normalize to the same
-                    # slug (e.g. "git_helper" vs "git-helper"). First-wins
+                    # distinct frontmatter names can still normalize to the
+                    # same slug (e.g. "git helper" vs "git-helper"). First-wins
                     # preserves local-before-external precedence.
                     cmd_key = f"/{cmd_name}"
                     if cmd_key in _skill_commands:
@@ -550,20 +554,26 @@ def reload_skills() -> Dict[str, Any]:
 def resolve_skill_command_key(command: str) -> Optional[str]:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
-    Skills are always stored with hyphens — ``scan_skill_commands`` normalizes
-    spaces and underscores to hyphens when building the key. Hyphens and
-    underscores are treated interchangeably in user input: this matches
-    ``_check_unavailable_skill`` and accommodates Telegram bot-command names
-    (which disallow hyphens, so ``/claude-code`` is registered as
-    ``/claude_code`` and comes back in the underscored form).
+    Keys preserve intentional underscores from the skill name (#75620). Exact
+    match is tried first so ``/__demo`` and ``/git_helper`` resolve to those
+    keys. When the exact key is missing, underscores are rewritten to hyphens
+    so Telegram clients that forbid hyphens in bot commands can still hit a
+    hyphenated skill key (``/claude_code`` → ``/claude-code``).
 
     Returns the matching ``/slug`` key from ``get_skill_commands()`` or
     ``None`` if no match.
     """
     if not command:
         return None
-    cmd_key = f"/{command.replace('_', '-')}"
-    return cmd_key if cmd_key in get_skill_commands() else None
+    commands = get_skill_commands()
+    exact = f"/{command}"
+    if exact in commands:
+        return exact
+    # Telegram may swap hyphens for underscores in bot-command names.
+    hyphenated = f"/{command.replace('_', '-')}"
+    if hyphenated != exact and hyphenated in commands:
+        return hyphenated
+    return None
 
 
 def build_skill_invocation_message(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3046,11 +3046,15 @@ def _skill_slug_from_frontmatter(skill_md: Path) -> tuple[str | None, str | None
             break
     if not declared_name:
         return None, None
-    slug = declared_name.lower().replace(" ", "-").replace("_", "-")
-    # Mirror _SKILL_INVALID_CHARS and _SKILL_MULTI_HYPHEN from skill_commands
-    import re as _re
-    slug = _re.sub(r"[^a-z0-9-]", "", slug)
-    slug = _re.sub(r"-{2,}", "-", slug).strip("-")
+    # Mirror agent.skill_commands.skill_command_slug (keep underscores, #75620).
+    try:
+        from agent.skill_commands import skill_command_slug
+        slug = skill_command_slug(declared_name)
+    except Exception:
+        import re as _re
+        slug = declared_name.lower().replace(" ", "-")
+        slug = _re.sub(r"[^a-z0-9_-]", "", slug)
+        slug = _re.sub(r"-{2,}", "-", slug).strip("-")
     if not slug:
         return None, declared_name
     return slug, declared_name
@@ -3070,11 +3074,16 @@ def _check_unavailable_skill(command_name: str) -> str | None:
     directory name would miss that slug entirely and fall through to the
     generic "unknown command" path.
     """
-    # Normalize: command uses hyphens, skill names may use hyphens or underscores
-    normalized = command_name.lower().replace("_", "-")
+    # Match by Telegram bot-command form so hyphenated skills still match when
+    # Telegram sends underscores, without collapsing intentional underscore
+    # names into a different skill (#75620).
     try:
+        from agent.skill_commands import telegram_bot_command_form
         from tools.skills_tool import _get_disabled_skill_names
         from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+        command_tg = telegram_bot_command_form(command_name)
+        if not command_tg:
+            return None
         disabled = _get_disabled_skill_names()
 
         # Check disabled skills across all dirs (local + external)
@@ -3089,7 +3098,10 @@ def _check_unavailable_skill(command_name: str) -> str | None:
                     continue
                 # disabled is keyed by the declared frontmatter name (what
                 # skills.disabled / skills.platform_disabled store).
-                if slug == normalized and declared_name in disabled:
+                if (
+                    telegram_bot_command_form(slug) == command_tg
+                    and declared_name in disabled
+                ):
                     return (
                         f"The **{command_name}** skill is installed but disabled.\n"
                         f"Enable it with: `hermes skills config`"
@@ -3106,7 +3118,7 @@ def _check_unavailable_skill(command_name: str) -> str | None:
                 slug, _declared = _skill_slug_from_frontmatter(skill_md)
                 if not slug:
                     continue
-                if slug == normalized:
+                if telegram_bot_command_form(slug) == command_tg:
                     # Build install path: official/<category>/<name>
                     rel = skill_md.parent.relative_to(optional_dir)
                     parts = list(rel.parts)

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -370,6 +370,41 @@ class TestResolveSkillCommandKey:
             assert resolve_skill_command_key("git_helper") == "/git-helper"
             assert resolve_skill_command_key("git-helper") == "/git-helper"
 
+    def test_telegram_collision_menu_entry_dispatches_to_same_skill(self, tmp_path):
+        """The registered menu label and inbound dispatch must choose one skill.
+
+        This crosses the real menu builder and resolver boundary: Telegram
+        receives only ``git_helper`` after sanitization, so its description and
+        the skill invoked when that token comes back must both belong to the
+        lexicographically first canonical key.
+        """
+        from hermes_cli.commands import telegram_menu_commands
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_disabled_skill_names", return_value=set()),
+        ):
+            hyphen = tmp_path / "hyphen"
+            hyphen.mkdir()
+            (hyphen / "SKILL.md").write_text(
+                "---\nname: git-helper\ndescription: Hyphen winner.\n---\n\nBody.\n"
+            )
+            underscore = tmp_path / "underscore"
+            underscore.mkdir()
+            (underscore / "SKILL.md").write_text(
+                "---\nname: git_helper\ndescription: Underscore runner-up.\n---\n\nBody.\n"
+            )
+
+            commands = scan_skill_commands()
+            menu, _hidden = telegram_menu_commands(max_commands=100)
+            matching = [(name, desc) for name, desc in menu if name == "git_helper"]
+            resolved = resolve_skill_command_key("git_helper")
+
+        assert matching == [("git_helper", "Hyphen winner.")]
+        assert resolved == "/git-helper"
+        assert commands[resolved]["name"] == "git-helper"
+
     def test_unknown_command_returns_none(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "claude-code")

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -355,6 +355,21 @@ class TestResolveSkillCommandKey:
             assert resolve_skill_command_key("git_helper") == "/git_helper"
             assert resolve_skill_command_key("__missing") is None
 
+    def test_telegram_collision_first_wins_hyphen_over_underscore_pair(self, tmp_path):
+        """When /git-helper and /git_helper both exist, Telegram form git_helper
+        dispatches to the lexicographically first key (menu first-wins, #75620)."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            for name in ("git_helper", "git-helper"):
+                d = tmp_path / name
+                d.mkdir()
+                (d / "SKILL.md").write_text(
+                    f"---\nname: {name}\ndescription: {name}.\n---\n\nBody.\n"
+                )
+            scan_skill_commands()
+            # sorted keys: /git-helper before /git_helper
+            assert resolve_skill_command_key("git_helper") == "/git-helper"
+            assert resolve_skill_command_key("git-helper") == "/git-helper"
+
     def test_unknown_command_returns_none(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "claude-code")

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -248,16 +248,13 @@ class TestScanSkillCommands:
 
     # -- inter-skill slug collision dedup (#50304 / #63305) ------------------
 
-    def test_slug_collision_keeps_first_skill(self, tmp_path):
-        """Two skills whose names normalize to the same slug do not clobber.
+    def test_underscore_and_hyphen_names_are_distinct_commands(self, tmp_path):
+        """Underscores are preserved so ``git_helper`` ≠ ``git-helper`` (#75620).
 
-        ``git_helper`` and ``git-helper`` are distinct frontmatter names but
-        both reduce to the ``/git-helper`` command. The first one scanned must
-        keep the command rather than being silently overwritten by the second.
+        Collapsing ``_`` → ``-`` used to register both as ``/git-helper`` and
+        silently drop the second skill (first-wins). They must stay distinct.
         """
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
-            # ``a-first`` sorts before ``z-second`` so the index walk visits the
-            # underscore-named skill first; that one must win the slash command.
             first = tmp_path / "a-first"
             first.mkdir()
             (first / "SKILL.md").write_text(
@@ -269,25 +266,61 @@ class TestScanSkillCommands:
                 "---\nname: git-helper\ndescription: Second skill.\n---\n\nBody.\n"
             )
             result = scan_skill_commands()
+        assert "/git_helper" in result
         assert "/git-helper" in result
-        # First-wins: the entry resolves to the first skill, not the shadowing one.
-        assert result["/git-helper"]["name"] == "git_helper"
-        assert result["/git-helper"]["skill_dir"] == str(first)
+        assert result["/git_helper"]["name"] == "git_helper"
+        assert result["/git-helper"]["name"] == "git-helper"
+
+    def test_leading_underscores_preserved_in_slash_command(self, tmp_path):
+        """``__spec-driven`` must register as ``/__spec-driven``, not ``/spec-driven``."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill = tmp_path / "__spec-driven"
+            skill.mkdir()
+            (skill / "SKILL.md").write_text(
+                "---\nname: __spec-driven\ndescription: Spec workflow.\n---\n\nBody.\n"
+            )
+            # Collision risk: a plain name that the old normalizer would alias to.
+            other = tmp_path / "spec-driven"
+            other.mkdir()
+            (other / "SKILL.md").write_text(
+                "---\nname: spec-driven\ndescription: Other.\n---\n\nBody.\n"
+            )
+            result = scan_skill_commands()
+        assert "/__spec-driven" in result
+        assert "/spec-driven" in result
+        assert result["/__spec-driven"]["name"] == "__spec-driven"
+        assert result["/spec-driven"]["name"] == "spec-driven"
+
+    def test_slug_collision_from_space_normalization_keeps_first(self, tmp_path):
+        """Space→hyphen can still collide; first-wins remains."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            first = tmp_path / "a-first"
+            first.mkdir()
+            (first / "SKILL.md").write_text(
+                "---\nname: my skill\ndescription: First.\n---\n\nBody.\n"
+            )
+            second = tmp_path / "z-second"
+            second.mkdir()
+            (second / "SKILL.md").write_text(
+                "---\nname: my-skill\ndescription: Second.\n---\n\nBody.\n"
+            )
+            result = scan_skill_commands()
+        assert "/my-skill" in result
+        assert result["/my-skill"]["name"] == "my skill"
 
     def test_slug_collision_warns(self, tmp_path, caplog):
-        """A slug collision emits a warning so the user can diagnose the
-        shadowed skill."""
+        """A remaining slug collision emits a warning for diagnosis."""
         import logging as _logging
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             first = tmp_path / "a-first"
             first.mkdir()
             (first / "SKILL.md").write_text(
-                "---\nname: my-skill\ndescription: First.\n---\n\nBody.\n"
+                "---\nname: my skill\ndescription: First.\n---\n\nBody.\n"
             )
             second = tmp_path / "z-second"
             second.mkdir()
             (second / "SKILL.md").write_text(
-                "---\nname: my_skill\ndescription: Second.\n---\n\nBody.\n"
+                "---\nname: my-skill\ndescription: Second.\n---\n\nBody.\n"
             )
             with caplog.at_level(_logging.WARNING, logger="agent.skill_commands"):
                 scan_skill_commands()
@@ -295,10 +328,7 @@ class TestScanSkillCommands:
 
 
 class TestResolveSkillCommandKey:
-    """Telegram bot-command names disallow hyphens, so the menu registers
-    skills with hyphens swapped for underscores. When Telegram autocomplete
-    sends the underscored form back, we need to find the hyphenated key.
-    """
+    """Resolve typed slash tokens to the canonical skill-command key."""
 
     def test_hyphenated_form_matches_directly(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -306,7 +336,24 @@ class TestResolveSkillCommandKey:
             scan_skill_commands()
             assert resolve_skill_command_key("claude-code") == "/claude-code"
 
+    def test_telegram_underscore_form_maps_to_hyphenated_skill(self, tmp_path):
+        """Telegram forbids hyphens in bot commands; underscore form still hits hyphen key."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "claude-code")
+            scan_skill_commands()
+            assert resolve_skill_command_key("claude_code") == "/claude-code"
 
+    def test_exact_underscore_skill_key_preferred(self, tmp_path):
+        """Intentional underscore skill keys must not be rewritten away (#75620)."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill = tmp_path / "git_helper"
+            skill.mkdir()
+            (skill / "SKILL.md").write_text(
+                "---\nname: git_helper\ndescription: Helper.\n---\n\nBody.\n"
+            )
+            scan_skill_commands()
+            assert resolve_skill_command_key("git_helper") == "/git_helper"
+            assert resolve_skill_command_key("__missing") is None
 
     def test_unknown_command_returns_none(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tests/gateway/test_unavailable_skill_hint.py
+++ b/tests/gateway/test_unavailable_skill_hint.py
@@ -100,3 +100,50 @@ def test_unknown_command_still_returns_none(
         assert gateway_run._check_unavailable_skill("no-such-skill") is None
 
 
+def test_disabled_leading_underscore_skill_matches_telegram_form(
+    tmp_skills: Path,
+) -> None:
+    """Disabled skills keep intentional leading underscores in gateway hints."""
+    from gateway import run as gateway_run
+
+    _write_skill(tmp_skills, "spec-driven", "__spec-driven")
+
+    # The command arrives in Telegram's underscore form. The pre-fix slug
+    # normalizer stripped the leading underscores, so this fell through to the
+    # generic unknown-command response instead of the actionable disabled hint.
+    with patch(
+        "tools.skills_tool._get_disabled_skill_names",
+        return_value={"__spec-driven"},
+    ), patch(
+        "agent.skill_utils.get_all_skills_dirs",
+        return_value=[tmp_skills],
+    ):
+        msg = gateway_run._check_unavailable_skill("__spec-driven")
+
+    assert msg is not None
+    assert "disabled" in msg.lower()
+    assert "hermes skills config" in msg
+
+
+def test_optional_leading_underscore_skill_matches_telegram_form(
+    tmp_skills: Path, tmp_path: Path
+) -> None:
+    """Optional skills with leading underscores produce the install hint."""
+    from gateway import run as gateway_run
+
+    optional_root = tmp_path / "optional-skills"
+    _write_skill(optional_root, "research/__spec-driven", "__spec-driven")
+
+    with patch(
+        "tools.skills_tool._get_disabled_skill_names", return_value=set()
+    ), patch(
+        "agent.skill_utils.get_all_skills_dirs", return_value=[tmp_skills]
+    ), patch(
+        "hermes_constants.get_optional_skills_dir", return_value=optional_root
+    ):
+        msg = gateway_run._check_unavailable_skill("__spec-driven")
+
+    assert msg is not None
+    assert "available but not installed" in msg
+    assert "hermes skills install official/research/__spec-driven" in msg
+


### PR DESCRIPTION
## What does this PR do?

Preserves intentional underscores in skill slash commands and defines a deterministic Telegram collision policy.

`scan_skill_commands` rewrote `_` → `-`, so `__spec-driven` became `/spec-driven` and collided with other skills. Underscores are valid Telegram bot-command characters and are kept in registered keys.

Telegram cannot put hyphens in bot commands, so `/git-helper` and `/git_helper` both surface as menu name `git_helper`. Dispatch now picks the **lexicographically first** matching key among all keys that share that Telegram form — the same order `telegram_menu_commands` uses when building the menu (first-wins). Gateway unavailable/disabled skill matching uses the same Telegram-form comparison and the shared skill slug helper (underscores preserved).

## Related Issue

Fixes #75620

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_commands.py`: preserve `_` in slugs; `telegram_bot_command_form` and first-wins `resolve_slash_key`, used by `resolve_skill_command_key`.
- `gateway/run.py`: unavailable-skill slug path uses shared slug helper + Telegram-form match.
- Tests: distinct underscore/hyphen registration; Telegram collision pair; leading `__` preserved; disabled and optional gateway hints.

## How to Test

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 1 tests/agent/test_skill_commands.py tests/gateway/test_unavailable_skill_hint.py
```

The selected tests cover the real Telegram menu builder and resolver together, plus disabled and optional gateway hints from temporary skill files.

## Checklist

### Code

- [x] Contributing Guide / Conventional Commits
- [x] Searched for existing PRs
- [x] Scoped change only
- [x] Tests pass via `scripts/run_tests.sh`
- [x] Tests added
- [x] Platform: macOS

### Documentation & Housekeeping

- [x] Docstrings on resolve/collision policy
- [x] N/A config / AGENTS
- [x] Cross-platform: pure slug logic
