### PR TITLE
fix(flux3): scrub plural signed delivery URLs

### DIFF
--- a/tests/tools/test_flux3_video_tool.py
+++ b/tests/tools/test_flux3_video_tool.py
@@ -624,7 +624,12 @@ class TestPollTransport:
         # re-keyed into a shell command by hand, dropping characters. Neither
         # can happen if the model never sees it.
         signed = "https://cdn.example/container/flux3-clip.mp4?sig=abc%2Bdef%3D&se=2026"
-        response = _FakeResponse(200, {"id": "bfl_job_1", "status": "Ready", "result": {"sample": signed}, "guidance": "Deliver the saved file."})
+        response = _FakeResponse(200, {
+            "id": "bfl_job_1",
+            "status": "Ready",
+            "result": {"sample": signed, "samples": [signed]},
+            "guidance": "Deliver the saved file.",
+        })
 
         with _fake_download(b"x" * (128 * 1024)) as fetched:
             parsed, _requests = _call(
@@ -637,11 +642,33 @@ class TestPollTransport:
         assert saved.read_bytes() == b"x" * (128 * 1024)
         assert parsed["details"]["saved_path"] == str(saved)
         assert parsed["details"]["result"].get("sample") is None
+        assert parsed["details"]["result"].get("samples") is None
         assert signed not in json.dumps(parsed)
         # The gateway still owns the delivery wording; the client only supplies
         # the path it cannot know.
         assert parsed["result"].startswith(f"Saved to {saved}.")
         assert "Deliver the saved file." in parsed["result"]
+        assert fetched == [signed]
+
+    def test_ready_saves_a_clip_from_plural_samples(self, tmp_path):
+        signed = "https://cdn.example/container/flux3-clip.mp4?sig=abc%2Bdef%3D&se=2026"
+        response = _FakeResponse(200, {
+            "id": "bfl_job_1",
+            "status": "Ready",
+            "result": {"samples": [signed]},
+            "guidance": "Deliver the saved file.",
+        })
+
+        with _fake_download(b"x" * (128 * 1024)) as fetched:
+            parsed, _requests = _call(
+                flux3._handle_get_result,
+                {"id": "bfl_job_1", "save_to": str(tmp_path)},
+                response,
+            )
+
+        assert parsed["details"]["saved_path"] == str(tmp_path / "flux3-clip.mp4")
+        assert parsed["details"]["result"].get("samples") is None
+        assert signed not in json.dumps(parsed)
         assert fetched == [signed]
 
     def test_ready_never_overwrites_an_existing_file(self, tmp_path):
@@ -775,7 +802,13 @@ class TestPollTransport:
         # The original bug: a bad signature returns an XML error body, curl
         # writes it to the .mp4 and exits 0, and it reads as success. A short
         # body is not a video whatever the status code said.
-        response = _FakeResponse(200, {"id": "bfl_job_1", "status": "Ready", "result": {"sample": "https://cdn.example/x/flux3-clip.mp4?sig=bad"}, "guidance": "g"})
+        signed = "https://cdn.example/x/flux3-clip.mp4?sig=bad"
+        response = _FakeResponse(200, {
+            "id": "bfl_job_1",
+            "status": "Ready",
+            "result": {"samples": [signed]},
+            "guidance": "g",
+        })
 
         with _fake_download(b"<?xml version='1.0'?><Error>AuthenticationFailed</Error>"):
             parsed, _requests = _call(flux3._handle_get_result, {"id": "bfl_job_1", "save_to": str(tmp_path)}, response)
@@ -785,6 +818,7 @@ class TestPollTransport:
         # Neither a half-written .part nor a plausible-looking .mp4 survives.
         assert [p.name for p in tmp_path.glob("*.mp4*")] == []
         assert "saved_path" not in parsed["details"]
+        assert signed not in json.dumps(parsed)
 
     def test_poll_requires_an_id(self):
         parsed, requests = _call(flux3._handle_get_result, {}, _FakeResponse(200, {}))

--- a/tools/flux3_video_tool.py
+++ b/tools/flux3_video_tool.py
@@ -466,13 +466,21 @@ async def _save_if_ready(raw: str, save_to, started: float) -> str:
         return raw
 
     result = details.get("result")
-    url = result.get("sample") if isinstance(result, dict) else None
+    if not isinstance(result, dict):
+        return raw
+
+    url = result.get("sample")
+    if not isinstance(url, str) or not url.strip():
+        samples = result.get("samples")
+        if isinstance(samples, list):
+            url = next((sample for sample in samples if isinstance(sample, str) and sample.strip()), None)
     if not isinstance(url, str) or not url.strip():
         return raw
 
     # Dropped whether or not the save succeeds. A retry re-polls, which mints a
     # fresh URL, so nothing is lost by not handing this one to the model.
     result.pop("sample", None)
+    result.pop("samples", None)
 
     try:
         target, size = await _download_video(url.strip(), save_to, started)


### PR DESCRIPTION
## Related Issue

Fixes #75667

## What does this PR do?

Flux 3 can return a finished clip URL in both `result.sample` and `result.samples`. The existing save path only read and removed `result.sample`, so the copy in `result.samples` could still be sent to the model and stored in the conversation.

This change uses the first non-empty string from `result.samples` when `result.sample` is missing. It removes both fields before the download starts, so the temporary URL is not returned after either a successful or failed save. Existing `result.sample` responses keep the same behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `tools/flux3_video_tool.py` to accept the plural `samples` response shape and remove both URL fields.
- Update `tests/tools/test_flux3_video_tool.py` to cover singular and plural fields together, plural-only responses, and failed downloads.

## How to Test

1. Run `python -m pytest -q tests/tools/test_flux3_video_tool.py` (`76 passed`).
2. Run `uvx --from ruff==0.15.10 ruff check tools/flux3_video_tool.py tests/tools/test_flux3_video_tool.py`.
3. Run `python scripts/check-windows-footguns.py tools/flux3_video_tool.py tests/tools/test_flux3_video_tool.py`.
4. Confirm the returned payload has no `sample` or `samples` URL after both successful and failed downloads.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64 with focused pytest

### Documentation & Housekeeping

- [x] User documentation is N/A; no user-facing command or setting changed
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; the change only reads a JSON list using standard Python
- [x] Tool descriptions and schemas are N/A; the model-facing tool contract did not change
