### PR TITLE
fix(gateway): steer image follow-ups into busy turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8321,7 +8321,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._enqueue_fifo(session_key, event, adapter)
 
     async def _prepare_busy_steer_text(self, event: MessageEvent) -> str:
-        """Return steerable text for a busy follow-up, transcribing voice first.
+        """Return steerable text for a busy follow-up, enriching media first.
 
         Fresh and queued voice messages reach the normal inbound STT pipeline,
         but successful steer messages intentionally bypass that queue. Without
@@ -8340,8 +8340,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         echo respects the count-based ledger.  If steering later falls back
         to queue mode, the drain path reuses the cached transcript instead of
         paying for a second STT call or re-echoing the same line.
+
+        Image-only follow-ups are represented as an explicit instruction to
+        inspect their cached paths with ``vision_analyze``. Mixed media keeps
+        its original event and falls back to the normal queue pipeline.
         """
         text = (event.text or "").strip()
+        media_urls = list(getattr(event, "media_urls", None) or [])
+        all_images = bool(media_urls) and all(
+            _event_media_is_image(event, index)
+            for index in range(len(media_urls))
+        )
+        if all_images:
+            # A steer is text-only, so point the active agent at the cached
+            # files and require inspection at its next tool boundary. This is
+            # faster and less lossy than pre-analyzing the image while the
+            # current run may be about to finish. vision_analyze performs its
+            # own format normalization, including HEIC/AVIF when supported.
+            if text.lower() in {
+                "(attachment)",
+                "[attachment]",
+                "(image)",
+                "[image]",
+                "(the user sent a message with no text content)",
+            }:
+                text = ""
+            image_note = (
+                "[The user sent image attachment(s) during this run. "
+                "Inspect each image with vision_analyze before answering. "
+                "Do not ask the user to resend them.]\n"
+                + _build_media_placeholder(event)
+            )
+            return f"{text}\n\n{image_note}".strip() if text else image_note
+
         if not self._pending_event_audio_paths(event):
             return text
 
@@ -8554,6 +8585,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _steer_all_voice = bool(_steer_media_urls) and (
                 len(self._pending_event_audio_paths(event)) == len(_steer_media_urls)
             )
+            _steer_all_images = bool(_steer_media_urls) and all(
+                _event_media_is_image(event, index)
+                for index in range(len(_steer_media_urls))
+            )
             can_steer = (
                 steer_text
                 and (
@@ -8563,6 +8598,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         and not event.media_types
                     )
                     or _steer_all_voice
+                    or _steer_all_images
                 )
                 and running_agent is not None
                 and running_agent is not _AGENT_PENDING_SENTINEL
@@ -14028,7 +14064,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     event, _cmd_def_inner, _quick_key, source,
                 )
 
-            if event.message_type == MessageType.PHOTO:
+            if (
+                event.message_type == MessageType.PHOTO
+                and self._busy_input_mode != "steer"
+            ):
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
                 adapter = self._adapter_for_source(source)
                 if adapter:
@@ -14099,15 +14138,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return None
             if self._busy_input_mode == "steer":
                 # Steer mode: inject text into the running agent mid-run via
-                # agent.steer().  Falls back to queue semantics if the payload
-                # is empty, the agent lacks steer(), or steer() rejects.
-                steer_text = (event.text or "").strip()
+                # agent.steer(). Voice and image-only payloads are converted to
+                # steerable text first; mixed/other media stays queued.
+                steer_text = await self._prepare_busy_steer_text(event)
+                _steer_media_urls = getattr(event, "media_urls", None) or []
+                _steer_all_voice = bool(_steer_media_urls) and (
+                    len(self._pending_event_audio_paths(event))
+                    == len(_steer_media_urls)
+                )
+                _steer_all_images = bool(_steer_media_urls) and all(
+                    _event_media_is_image(event, index)
+                    for index in range(len(_steer_media_urls))
+                )
                 steered = False
                 if (
-                    event.message_type == MessageType.TEXT
-                    and not event.media_urls
-                    and not event.media_types
-                    and steer_text
+                    steer_text
+                    and (
+                        (
+                            event.message_type == MessageType.TEXT
+                            and not event.media_urls
+                            and not event.media_types
+                        )
+                        or _steer_all_voice
+                        or _steer_all_images
+                    )
                     and hasattr(running_agent, "steer")
                 ):
                     try:

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -263,6 +263,68 @@ class TestBusySessionAck:
         assert "Steered" in content
         assert "Queued" not in content
 
+    @pytest.mark.asyncio
+    async def test_steer_mode_injects_image_paths_for_vision(self, monkeypatch):
+        """A busy image follow-up steers the current run instead of queueing."""
+        import gateway.run as _gr
+
+        monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="(attachment)")
+        event.message_type = MessageType.PHOTO
+        event.media_urls = ["/tmp/photon-label.heic"]
+        event.media_types = ["image/heic"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        steer_text = agent.steer.call_args.args[0]
+        assert "vision_analyze" in steer_text
+        assert "/tmp/photon-label.heic" in steer_text
+        assert "resend" in steer_text
+        agent.interrupt.assert_not_called()
+        assert sk not in adapter._pending_messages
+        content = adapter._send_with_retry.call_args.kwargs["content"]
+        assert "Steered" in content
+        assert "Queued" not in content
+
+    @pytest.mark.asyncio
+    async def test_steer_mode_keeps_mixed_media_queued(self, monkeypatch):
+        """A mixed image/document event retains normal queued processing."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="compare these")
+        event.message_type = MessageType.PHOTO
+        event.media_urls = ["/tmp/photo.png", "/tmp/notes.pdf"]
+        event.media_types = ["image/png", "application/pdf"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_not_called()
+        assert adapter._pending_messages[sk] is event
+        content = adapter._send_with_retry.call_args.kwargs["content"]
+        assert "Queued" in content
+
 
     @pytest.mark.asyncio
     async def test_steer_mode_falls_back_to_queue_when_agent_rejects(self):
@@ -469,5 +531,4 @@ class TestLongRunningNotificationOwnership:
         assert runner._should_emit_long_running_notification(
             "sess", original_agent, executor_task=None
         ) is False
-
 

--- a/tests/gateway/test_telegram_photo_interrupts.py
+++ b/tests/gateway/test_telegram_photo_interrupts.py
@@ -46,3 +46,36 @@ async def test_handle_message_does_not_priority_interrupt_photo_followup():
     assert result is None
     running_agent.interrupt.assert_not_called()
     assert runner.adapters[Platform.TELEGRAM]._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
+async def test_handle_message_priority_path_steers_photo_followup():
+    runner = _make_runner()
+    runner._busy_input_mode = "steer"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+    )
+    session_key = build_session_key(source)
+    running_agent = MagicMock()
+    running_agent.steer.return_value = True
+    runner._running_agents[session_key] = running_agent
+
+    event = MessageEvent(
+        text="(attachment)",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/tmp/photo-a.heic"],
+        media_types=["image/heic"],
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    steer_text = running_agent.steer.call_args.args[0]
+    assert "vision_analyze" in steer_text
+    assert "/tmp/photo-a.heic" in steer_text
+    running_agent.interrupt.assert_not_called()
+    assert session_key not in runner.adapters[Platform.TELEGRAM]._pending_messages


### PR DESCRIPTION
## Summary

- allow image-only follow-ups to use `busy_input_mode: steer` instead of always falling back to the next-turn queue
- inject cached image paths into the active turn with an explicit `vision_analyze` instruction
- preserve the existing queue behavior for mixed image/document media and for photo bursts outside steer mode
- cover both the normal busy-session handler and the earlier priority fast path

Voice follow-ups already have a media-to-text preparation path before `agent.steer()`, but image events are currently excluded from steering. This means an image sent as a separate messaging event is acknowledged as queued even when the user configured steering, and the active run cannot incorporate it.

This patch uses the public `agent.steer()` API only. It does not mutate the agent's private pending-steer buffer. The image files remain in the gateway cache, and `vision_analyze` retains responsibility for format normalization such as HEIC/AVIF.

## Tests

- `python3 -m py_compile gateway/run.py tests/gateway/test_busy_session_ack.py tests/gateway/test_telegram_photo_interrupts.py`
- `git diff --check`
- focused production-environment execution covering image steering, mixed-media queue fallback, and priority-path photo steering

The repository's pytest dependency was not installed in the production environment, so the focused async test functions were executed directly against its existing Hermes virtualenv with the branch worktree on `PYTHONPATH`.
