### PR TITLE
fix(wake): install openWakeWord on modern Linux Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,13 +198,21 @@ voice = [
 # [wake]+[voice] so the ear works instantly; CLI-only installs lazy-install on
 # first /wake; mirrored in tools/lazy_deps.py.
 wake = [
-  "openwakeword==0.6.0",
+  # Linux uses ONNX, but openWakeWord 0.6.0's PyPI metadata still requires
+  # tflite-runtime there. It has no CPython 3.12/3.13 wheels, so the official
+  # installers and lazy_deps install openwakeword with --no-deps on Linux after
+  # this resolver-safe runtime set is installed.
+  "openwakeword==0.6.0; platform_system != 'Linux'",
   "onnxruntime==1.27.0",
   "sherpa-onnx==1.13.4",
   "sentencepiece==0.2.2",
   "pvporcupine==4.0.3",
   "sounddevice==0.5.5",
   "numpy==2.4.3",
+  "scipy>=1.3,<2",
+  "scikit-learn>=1,<2",
+  "requests>=2,<3",
+  "tqdm>=4,<5",
   # openWakeWord's onnx embedding model scores near-zero on macOS ARM64
   # (dscripka/openWakeWord#336), so the wake word runs on tflite there.
   # Upstream declares tflite-runtime for Linux only; ai-edge-litert is the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2938,7 +2938,17 @@ install_desktop_voice_deps() {
         return 0
     fi
     log_info "Installing voice + wake-word dependencies (onnxruntime, faster-whisper — 1-3min)..."
-    if (cd "$INSTALL_DIR" && $UV_CMD pip install -e ".[wake,voice]") ; then
+    local wake_ok=true
+    if ! (cd "$INSTALL_DIR" && $UV_CMD pip install -e ".[wake,voice]") ; then
+        wake_ok=false
+    fi
+    # openWakeWord 0.6.0 incorrectly requires tflite-runtime on every Linux
+    # install, although Hermes uses ONNX there. PyPI has no tflite-runtime
+    # wheels for CPython 3.12/3.13, so install the parent wheel separately.
+    if [ "$(uname -s)" = "Linux" ] && ! $UV_CMD pip install --no-deps "openwakeword==0.6.0"; then
+        wake_ok=false
+    fi
+    if [ "$wake_ok" = true ]; then
         log_success "Voice + wake-word dependencies installed"
     else
         log_warn "Voice/wake dependency install failed — they will lazy-install at first use"

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -176,13 +176,6 @@ def test_linux_wake_extra_avoids_openwakeword_tflite_metadata():
         assert any(spec.startswith(runtime_dep) for spec in wake)
 
 
-def test_linux_desktop_installer_adds_openwakeword_without_dependencies():
-    installer = Path(__file__).resolve().parents[1] / "scripts" / "install.sh"
-    text = installer.read_text(encoding="utf-8")
-
-    assert 'pip install --no-deps "openwakeword==0.6.0"' in text
-
-
 
 
 

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -166,6 +166,23 @@ def test_dingtalk_extra_includes_qrcode_for_qr_auth():
     assert any(dep.startswith("qrcode") for dep in dingtalk_extra)
 
 
+def test_linux_wake_extra_avoids_openwakeword_tflite_metadata():
+    """Linux installs must not resolve openWakeWord's unavailable TFLite wheel."""
+    wake = _load_optional_dependencies()["wake"]
+    openwakeword = next(spec for spec in wake if spec.startswith("openwakeword=="))
+
+    assert "platform_system != 'Linux'" in openwakeword
+    for runtime_dep in ("onnxruntime", "scipy", "scikit-learn", "requests", "tqdm"):
+        assert any(spec.startswith(runtime_dep) for spec in wake)
+
+
+def test_linux_desktop_installer_adds_openwakeword_without_dependencies():
+    installer = Path(__file__).resolve().parents[1] / "scripts" / "install.sh"
+    text = installer.read_text(encoding="utf-8")
+
+    assert 'pip install --no-deps "openwakeword==0.6.0"' in text
+
+
 
 
 

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -98,6 +98,20 @@ class TestAllowlist:
         # Same spec tail on both forms.
         assert venv.split(" -m pip install ", 1)[1] == default.split("uv pip install ", 1)[1]
 
+    def test_openwakeword_linux_manual_command_bypasses_tflite_metadata(self, monkeypatch):
+        monkeypatch.setattr(ld.sys, "platform", "linux")
+        command = ld.feature_install_command("wake.openwakeword")
+
+        assert command is not None
+        assert "uv pip install --no-deps 'openwakeword==0.6.0'" in command
+        assert "; uv pip install " in command
+        assert "onnxruntime==" in command
+
+        error = ld.FeatureUnavailable(
+            "wake.openwakeword", ld.LAZY_DEPS["wake.openwakeword"], "test failure"
+        )
+        assert f"{ld.sys.executable} -m pip install --no-deps" in str(error)
+
 
 # ---------------------------------------------------------------------------
 # allow_lazy_installs gating
@@ -155,6 +169,33 @@ class TestEnsure:
         )
         with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
             ld.ensure("test.cache", prompt=False)
+
+    def test_dependency_bypass_installs_anchor_separately(self, monkeypatch):
+        feature = "test.no-deps"
+        anchor = "broken-parent==1.0"
+        dependency = "working-dependency==2.0"
+        monkeypatch.setitem(ld.LAZY_DEPS, feature, (anchor, dependency))
+        monkeypatch.setitem(ld.NO_DEPS_SPECS, feature, (anchor,))
+        monkeypatch.setattr(ld.sys, "platform", "linux")
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+
+        installed = set()
+        calls = []
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: spec in installed)
+
+        def fake_install(specs, *, timeout=300, no_deps=False):
+            calls.append((specs, no_deps))
+            installed.update(specs)
+            return ld._InstallResult(True, "ok", "")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", fake_install)
+
+        ld.ensure(feature, prompt=False)
+
+        assert calls == [
+            ((anchor,), True),
+            ((dependency,), False),
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -170,6 +170,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "onnxruntime==1.27.0",
         "sounddevice==0.5.5",
         "numpy==2.4.3",
+        "scipy>=1.3,<2",
+        "scikit-learn>=1,<2",
+        "requests>=2,<3",
+        "tqdm>=4,<5",
     ),
     # Open-vocabulary keyword spotting: any typed phrase, zero training.
     # sentencepiece is required by sherpa_onnx.text2token (runtime phrase
@@ -322,6 +326,16 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "tool.trace_upload": ("huggingface-hub==1.24.0",),
 }
 
+# Specs whose upstream dependency metadata must be bypassed on Linux. The
+# openWakeWord 0.6.0 wheel requires tflite-runtime there even when Hermes uses
+# its ONNX backend. PyPI only publishes tflite-runtime for CPython 3.11, so
+# normal resolution fails on supported Python 3.12/3.13. Install the universal
+# parent wheel with --no-deps, then install the explicit ONNX runtime set above.
+# This remains feature-scoped: arbitrary callers cannot suppress resolution.
+NO_DEPS_SPECS: dict[str, tuple[str, ...]] = {
+    "wake.openwakeword": ("openwakeword==0.6.0",),
+}
+
 
 # Conservative regex for spec validation — package name plus optional
 # version range. Reject anything that looks like a URL, file path, or shell
@@ -348,11 +362,17 @@ class FeatureUnavailable(RuntimeError):
         super().__init__(self._format())
 
     def _format(self) -> str:
-        spec_list = " ".join(repr(s) for s in self.missing)
+        command = _feature_install_command(self.feature, self.missing)
+        if command is None:
+            spec_list = " ".join(repr(s) for s in self.missing)
+            command = f"uv pip install {spec_list}"
+        pip_command = _feature_install_command(
+            self.feature, self.missing, installer=f"{sys.executable} -m pip"
+        )
         return (
             f"Feature {self.feature!r} unavailable: {self.reason}. "
-            f"To enable manually: uv pip install {spec_list}  "
-            f"(or: pip install {spec_list})."
+            f"To enable manually: {command}"
+            + (f"  (or: {pip_command})." if pip_command else ".")
         )
 
 
@@ -698,7 +718,9 @@ def _core_constraints_file() -> Optional[Path]:
         return None
 
 
-def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
+def _venv_pip_install(
+    specs: tuple[str, ...], *, timeout: int = 300, no_deps: bool = False
+) -> _InstallResult:
     """Install ``specs`` using the uv → pip → ensurepip ladder.
 
     Two modes:
@@ -733,6 +755,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
     constraint_args: list[str] = []
     if constraints is not None:
         constraint_args = ["--constraint", str(constraints)]
+    dependency_args = ["--no-deps"] if no_deps else []
 
     try:
         venv_root = Path(sys.executable).parent.parent
@@ -756,7 +779,10 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         if uv_bin:
             try:
                 r = subprocess.run(
-                    [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
+                    [
+                        uv_bin, "pip", "install", *target_args,
+                        *constraint_args, *dependency_args, *specs,
+                    ],
                     capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
                     creationflags=windows_hide_flags(),
@@ -794,7 +820,10 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
 
         try:
             r = subprocess.run(
-                pip_cmd + ["install", *target_args, *constraint_args, *specs],
+                pip_cmd + [
+                    "install", *target_args, *constraint_args,
+                    *dependency_args, *specs,
+                ],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
                 stdin=subprocess.DEVNULL,
                 creationflags=windows_hide_flags(),
@@ -829,6 +858,35 @@ def feature_specs(feature: str) -> tuple[str, ...]:
 def feature_missing(feature: str) -> tuple[str, ...]:
     """Return the subset of specs for ``feature`` not currently installed."""
     return tuple(s for s in feature_specs(feature) if not _is_satisfied(s))
+
+
+def _feature_no_deps_specs(feature: str, specs: tuple[str, ...]) -> tuple[str, ...]:
+    """Return the feature-approved subset that bypasses dependency metadata."""
+    if not sys.platform.startswith("linux"):
+        return ()
+    approved = set(NO_DEPS_SPECS.get(feature, ()))
+    return tuple(spec for spec in specs if spec in approved)
+
+
+def _feature_install_command(
+    feature: str, specs: tuple[str, ...], *, installer: str = "uv pip"
+) -> Optional[str]:
+    """Build an executable manual uv command for the requested feature specs."""
+    if feature not in LAZY_DEPS:
+        return None
+    no_deps = _feature_no_deps_specs(feature, specs)
+    regular = tuple(spec for spec in specs if spec not in set(no_deps))
+    commands = []
+    if no_deps:
+        commands.append(
+            f"{installer} install --no-deps "
+            + " ".join(repr(spec) for spec in no_deps)
+        )
+    if regular:
+        commands.append(
+            f"{installer} install " + " ".join(repr(spec) for spec in regular)
+        )
+    return "; ".join(commands)
 
 
 def ensure(feature: str, *, prompt: bool = True) -> None:
@@ -931,7 +989,22 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             )
 
     logger.info("Lazy-installing %s for feature %r", " ".join(missing), feature)
-    result = _venv_pip_install(missing)
+    no_deps = _feature_no_deps_specs(feature, missing)
+    regular = tuple(spec for spec in missing if spec not in set(no_deps))
+    batches = []
+    if no_deps:
+        batches.append((no_deps, True))
+    if regular:
+        batches.append((regular, False))
+
+    result = _InstallResult(True, "", "")
+    for batch, bypass_dependencies in batches:
+        if bypass_dependencies:
+            result = _venv_pip_install(batch, no_deps=True)
+        else:
+            result = _venv_pip_install(batch)
+        if not result.success:
+            break
     if not result.success:
         # Surface the actual pip error so the user can debug PyPI-side
         # issues (404 quarantine, network down, etc.).
@@ -971,23 +1044,7 @@ def is_available(feature: str) -> bool:
     return not feature_missing(feature)
 
 
-def feature_install_command(feature: str, *, venv_pip: bool = False) -> Optional[str]:
-    """Return the ``pip install`` command a user could run manually, or None.
 
-    ``venv_pip=True`` targets the running interpreter's pip
-    (``{sys.executable} -m pip install …``) — correct in every layout
-    (default install, ``HERMES_HOME`` overrides, profile installs) and
-    immune to Ubuntu 24.04's PEP 668 ``externally-managed-environment``
-    failure that a bare/system ``pip install`` hint invites.  The default
-    ``uv pip install`` form is kept for contexts that document uv usage.
-    """
-    if feature not in LAZY_DEPS:
-        return None
-    specs = LAZY_DEPS[feature]
-    joined = " ".join(repr(s) for s in specs)
-    if venv_pip:
-        return f"{sys.executable} -m pip install {joined}"
-    return "uv pip install " + joined
 
 
 @dataclass

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -1047,6 +1047,22 @@ def is_available(feature: str) -> bool:
 
 
 
+def feature_install_command(feature: str, *, venv_pip: bool = False) -> Optional[str]:
+    """Return the ``pip install`` command a user could run manually, or None.
+
+    ``venv_pip=True`` targets the running interpreter's pip
+    (``{sys.executable} -m pip install …``) — correct in every layout
+    (default install, ``HERMES_HOME`` overrides, profile installs) and
+    immune to Ubuntu 24.04's PEP 668 ``externally-managed-environment``
+    failure that a bare/system ``pip install`` hint invites.  The default
+    ``uv pip install`` form is kept for contexts that document uv usage.
+    """
+    if feature not in LAZY_DEPS:
+        return None
+    installer = f"{sys.executable} -m pip" if venv_pip else "uv pip"
+    return _feature_install_command(feature, LAZY_DEPS[feature], installer=installer)
+
+
 @dataclass
 class InstallSpecsResult:
     """Outcome of :func:`install_specs` for one batch of pip specs.

--- a/uv.lock
+++ b/uv.lock
@@ -1779,11 +1779,16 @@ wake = [
     { name = "ai-edge-litert", marker = "sys_platform == 'darwin'" },
     { name = "numpy" },
     { name = "onnxruntime" },
-    { name = "openwakeword" },
+    { name = "openwakeword", marker = "sys_platform != 'linux'" },
     { name = "pvporcupine" },
+    { name = "requests" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sentencepiece" },
     { name = "sherpa-onnx" },
     { name = "sounddevice" },
+    { name = "tqdm" },
 ]
 web = [
     { name = "fastapi" },
@@ -1882,7 +1887,7 @@ requires-dist = [
     { name = "openai", specifier = "==2.24.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otlp'", specifier = "==1.39.1" },
     { name = "opentelemetry-sdk", marker = "extra == 'otlp'", specifier = "==1.39.1" },
-    { name = "openwakeword", marker = "extra == 'wake'", specifier = "==0.6.0" },
+    { name = "openwakeword", marker = "sys_platform != 'linux' and extra == 'wake'", specifier = "==0.6.0" },
     { name = "packaging", specifier = "==26.0" },
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
@@ -1908,9 +1913,12 @@ requires-dist = [
     { name = "qrcode", marker = "extra == 'feishu'", specifier = "==7.4.2" },
     { name = "qrcode", marker = "extra == 'messaging'", specifier = "==7.4.2" },
     { name = "requests", specifier = "==2.33.0" },
+    { name = "requests", marker = "extra == 'wake'", specifier = ">=2,<3" },
     { name = "rich", specifier = "==14.3.3" },
     { name = "ruamel-yaml", specifier = "==0.18.17" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.10" },
+    { name = "scikit-learn", marker = "extra == 'wake'", specifier = ">=1,<2" },
+    { name = "scipy", marker = "extra == 'wake'", specifier = ">=1.3,<2" },
     { name = "sentencepiece", marker = "extra == 'wake'", specifier = "==0.2.2" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = "==83.0.0" },
     { name = "sherpa-onnx", marker = "extra == 'wake'", specifier = "==1.13.4" },
@@ -1927,6 +1935,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'web'", specifier = "==1.3.1" },
     { name = "supermemory", marker = "extra == 'supermemory'", specifier = "==3.50.0" },
     { name = "tenacity", specifier = "==9.1.4" },
+    { name = "tqdm", marker = "extra == 'wake'", specifier = ">=4,<5" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.21" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
     { name = "urllib3", specifier = ">=2.7.0,<3" },
@@ -3017,7 +3026,6 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "tflite-runtime", marker = "sys_platform == 'linux'" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/9b/73b7d98b07f4e1f525ad39703e0c5f30ff61c3fa16c8bfe4d99eadc0567a/openwakeword-0.6.0.tar.gz", hash = "sha256:36858d90f1183e307485597a912a4e3c3384b14ea9923f83feaffae7c1565565", size = 70830, upload-time = "2024-02-11T20:56:17.854Z" }
@@ -4352,19 +4360,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
-]
-
-[[package]]
-name = "tflite-runtime"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/a6/02d68cb62cd221589a0ff055073251d883936237c9c990e34a1d7cecd06f/tflite_runtime-2.14.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:195ab752e7e57329a68e54dd3dd5439fad888b9bff1be0f0dc042a3237a90e4d", size = 2414486, upload-time = "2023-10-03T21:15:44.331Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/e9/5fc0435129c23c17551fcfadc82bd0d5482276213dfbc641f07b4420cb6d/tflite_runtime-2.14.0-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ce9fa5d770a9725c746dcbf6f59f3178233b3759f09982e8b2db8d2234c333b0", size = 2325913, upload-time = "2023-10-03T21:15:46.348Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/76/e246c39d92929655bac8878d76406d6fb0293c678237e55621e7ece4a269/tflite_runtime-2.14.0-cp311-cp311-manylinux_2_34_armv7l.whl", hash = "sha256:c4e66a74165b18089c86788400af19fa551768ac782d231a9beae2f6434f7949", size = 1820588, upload-time = "2023-10-03T21:15:48.399Z" },
 ]
 
 [[package]]

--- a/website/docs/user-guide/features/wake-word.md
+++ b/website/docs/user-guide/features/wake-word.md
@@ -89,8 +89,14 @@ installs made with `--include-desktop` pre-install them, so the ear works
 instantly). To install ahead of time:
 
 ```bash
-cd ~/.hermes/hermes-agent && uv pip install -e ".[wake]"
+cd ~/.hermes/hermes-agent
+uv pip install -e ".[wake]"
+# Linux only: openWakeWord's published metadata requires an unavailable
+# tflite-runtime wheel even though Hermes uses its ONNX backend.
+[ "$(uname -s)" != "Linux" ] || uv pip install --no-deps "openwakeword==0.6.0"
 ```
+
+The official desktop installer performs both Linux steps automatically.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

Fix openWakeWord installation on Linux when Hermes runs on supported Python 3.12/3.13. `openwakeword==0.6.0` publishes a universal wheel but its Linux metadata unconditionally requires `tflite-runtime`, whose PyPI wheels stop at CPython 3.11. Hermes uses the ONNX backend on Linux, so the TFLite runtime is both unavailable and unnecessary.

The fix keeps dependency suppression narrow and allowlisted: on Linux only, Hermes installs the openWakeWord parent wheel with `--no-deps`, then installs and verifies an explicit ONNX runtime dependency set. The desktop installer, lazy installer, manual remediation, `[wake]` metadata, lockfile, tests, and docs now agree on that contract.

## RED proof

Against current `main` before the fix:

```text
$ HERMES_PYTHON=/tmp/hermes-pr70124/.venv/bin/python scripts/run_tests.sh tests/tools/test_lazy_deps.py -q --tb=short
FAILED TestAllowlist.test_openwakeword_linux_manual_command_bypasses_tflite_metadata
  assert "uv pip install --no-deps 'openwakeword==0.6.0'" in
  "uv pip install 'openwakeword==0.6.0' 'onnxruntime==1.27.0' ..."
FAILED TestEnsure.test_dependency_bypass_installs_anchor_separately
  AttributeError: module 'tools.lazy_deps' has no attribute 'NO_DEPS_SPECS'
2 failed, 55 passed
```

The real resolver failure on Linux / CPython 3.13 was:

```text
ERROR: Could not find a version that satisfies the requirement
  tflite-runtime<3,>=2.8.0; platform_system == "Linux"
ERROR: No matching distribution found for tflite-runtime<3,>=2.8.0
```

After the fix:

```text
92 passed, 0 failed
```

## Code path trace

1. **Symptom:** first `/wake on` or Desktop wake dependency setup fails on Linux/Python 3.12–3.13 before `openwakeword` is installed.
2. **Intermediate:** `lazy_deps.ensure("wake.openwakeword")` and `.[wake]` both ask the resolver to install `openwakeword==0.6.0` normally; its Linux metadata adds `tflite-runtime` even though `tools/wake_word.py` selects ONNX on Linux.
3. **Root cause:** PyPI only publishes `tflite-runtime==2.14.0` wheels for CPython 3.11, while Hermes supports and currently installs Python 3.13. A universal parent wheel and a valid lockfile therefore did not prove the marked binary dependency was installable.

## What changed

- Add a feature-scoped `NO_DEPS_SPECS` allowlist; arbitrary packages cannot opt out of dependency resolution.
- Split approved lazy installs into a `--no-deps` parent batch followed by a normal explicit runtime-dependency batch.
- Make generated `uv` and interpreter-targeted `pip` remediation commands preserve the same two-step behavior.
- Keep `openwakeword` out of Linux `[wake]` resolution while retaining normal package resolution on Windows/macOS.
- Have the Linux desktop installer add `openwakeword==0.6.0` separately with `--no-deps`.
- Keep tests at the behavior/metadata boundary; no test reads `install.sh` to pin a literal command spelling.
- Remove the incompatible `tflite-runtime` artifact from `uv.lock`.
- Document the Linux pre-install sequence.

## Widening audit

- **CLI/TUI lazy first use:** affected → fixed by the feature-scoped split install.
- **Linux Desktop eager install:** affected → `[wake,voice]` installs the resolver-safe runtime set, then the installer adds openWakeWord with `--no-deps`.
- **Manual remediation emitted after failure:** affected → now prints executable two-step `uv` and active-interpreter `pip` commands instead of repeating the failing resolver request.
- **`.[wake]` Linux resolution:** affected → now resolver-safe on Python 3.12/3.13; the official installer performs the required parent-wheel step.
- **Windows and Intel macOS:** not affected by the Linux `tflite-runtime` marker → retain normal openWakeWord resolution.
- **Apple Silicon:** not affected by this resolver failure → retains the existing `ai-edge-litert` TFLite bridge.
- **sherpa / Porcupine:** separate engines and dependency features → unchanged.
- **PortAudio/device readiness:** separate native-runtime gate after Python package installation → intentionally unchanged.

## Verification

Canonical targeted suite:

```text
$ HERMES_PYTHON=/tmp/hermes-pr70124/.venv/bin/python scripts/run_tests.sh \
    tests/tools/test_lazy_deps.py \
    tests/tools/test_wake_word.py \
    tests/test_project_metadata.py \
    tests/test_install_lockfile_churn.py \
    -q --tb=short
92 passed, 0 failed
```

Real clean-environment validation on Ubuntu 24.04 x86_64 / CPython 3.13.13:

```text
$ uv pip install -e ".[wake]"
Installed 75 packages
$ uv pip install --no-deps openwakeword==0.6.0
Installed openwakeword==0.6.0

tflite-runtime: absent (expected for Linux ONNX)
python: 3.13.13
openwakeword: 0.6.0
onnxruntime: 1.27.0
model labels: ['hey_hermes']
prediction keys: ['hey_hermes']
```

The real lazy path was also exercised from a clean core-only venv:

```text
lazy_deps.ensure('wake.openwakeword', prompt=False)
openwakeword: 0.6.0
onnxruntime: 1.27.0
tflite-runtime: absent (expected)
```

Additional gates:

- `ruff check` on changed Python files: passed
- `py_compile` on changed Python files: passed
- `bash -n scripts/install.sh`: passed
- `uv lock --check`: passed
- `git diff --check`: passed