### PR TITLE
fix(desktop): prevent minimized tool panes from expanding Files

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/tool-panel-close.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tool-panel-close.test.tsx
@@ -164,6 +164,26 @@ describe('⌘W over a focused tool panel', () => {
     expect(allPaneIds($layoutTree.get()!)).toContain('logs')
   })
 
+  it('returns to workspace when terminal shares a zone with files', async () => {
+    const { allPaneIds, findGroupOfPane } = await import('../model')
+    const { setPaneCollapsed } = await import('../store')
+
+    declareDefaultTree(
+      split('column', [
+        group(['workspace', 'files', 'terminal'], { active: 'files', id: 'grp-shared' })
+      ])
+    )
+
+    setPaneCollapsed('terminal', true)
+
+    const tree = $layoutTree.get()!
+    const main = findGroupOfPane(tree, 'workspace')
+
+    expect(allPaneIds(tree)).toContain('workspace')
+    expect(main?.active).toBe('workspace')
+    expect(main?.active).not.toBe('files')
+  })
+
   it('leaves the uncloseable workspace zone to the chat rung', async () => {
     const { allPaneIds } = await import('../model')
     const { closeFocusedToolTab } = await import('../store')

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -149,13 +149,18 @@ export const cssMax = (values: (string | null | undefined)[]): string | undefine
  *  are both 28px thick. */
 export const MINIMIZED_TRACK = '1.75rem'
 
-export function fixedTrackSize(node: LayoutNode, axis: 'row' | 'column', ctx: TrackContext): string | null {
+export function fixedTrackSize(
+  node: LayoutNode,
+  axis: 'row' | 'column',
+  ctx: TrackContext,
+  includeMinimized = true
+): string | null {
   if (node.type === 'group') {
     // Ancestor splits must size a minimized zone as its strip, not as its
     // panes' declared widths — otherwise the outer track keeps reserving the
     // full sidebar width and the collapsed rail floats in a dead column.
     if (node.minimized) {
-      return MINIMIZED_TRACK
+      return includeMinimized ? MINIMIZED_TRACK : null
     }
 
     const overrideKey = axis === 'row' ? 'widthOverride' : 'heightOverride'
@@ -204,7 +209,7 @@ export function fixedTrackSize(node: LayoutNode, axis: 'row' | 'column', ctx: Tr
   }
 
   const visible = node.children.filter(child => !subtreeGone(child, ctx))
-  const sizes = visible.map(child => fixedTrackSize(child, axis, ctx))
+  const sizes = visible.map(child => fixedTrackSize(child, axis, ctx, true))
 
   if (node.orientation === axis) {
     if (sizes.length === 0 || sizes.some(size => size === null)) {
@@ -215,7 +220,14 @@ export function fixedTrackSize(node: LayoutNode, axis: 'row' | 'column', ctx: Tr
   }
 
   // Across the axis a flex child just stretches; the fixed ones set the size.
-  return cssMax(sizes) ?? null
+  // A minimized pane contributes its rail only along the split axis that
+  // contains the rail. Across the perpendicular axis it has no meaningful
+  // width/height. Otherwise a minimized terminal's 28px height can make its
+  // whole parent column look fixed-width, causing the final root track (Files)
+  // to absorb the entire remaining window.
+  const acrossAxisSizes = visible.map(child => fixedTrackSize(child, axis, ctx, false))
+
+  return cssMax(acrossAxisSizes) ?? null
 }
 
 /** True when every pane in the subtree is hidden/narrow-collapsed. */

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1288,16 +1288,19 @@ export function setPaneCollapsed(paneId: string, collapsed: boolean) {
   // inactive toggle folding its visible sibling is what re-collapsed the zone
   // on every boot (broke collapse persistence).
   if (group.panes.length > 1) {
-    if (collapsed && group.active === paneId) {
-      if (group.panes.some(isUncloseablePane)) {
-        // Workspace can't minimize (strands the app) → tab-switch to a sibling
-        // (guaranteed to exist by length > 1).
-        const at = group.panes.indexOf(paneId)
+    if (collapsed && group.panes.some(isUncloseablePane)) {
+      // Workspace can't minimize (strands the app). A tool toggle can fire
+      // after another tab (typically files) became active, so do not require
+      // the tool to still be the active tab here. Any shared group containing
+      // workspace must return to chat when the tool closes; otherwise the
+      // sibling pane expands into the main surface and chat appears to vanish.
+      const workspace = group.panes.find(isUncloseablePane)
 
-        activateTreePane(group.id, group.panes[at - 1] ?? group.panes[at + 1])
-      } else {
-        setTreeGroupMinimized(group.id, true) // pure tool zone folds as a unit
+      if (workspace && group.active !== workspace) {
+        activateTreePane(group.id, workspace)
       }
+    } else if (collapsed && group.active === paneId) {
+      setTreeGroupMinimized(group.id, true) // pure tool zone folds as a unit
     } else if (!collapsed) {
       revealTreePane(paneId)
     }


### PR DESCRIPTION
## Summary

Fixes a Desktop pane-tree layout bug where closing/minimizing the bottom terminal could make the main chat surface appear to disappear and expand the Files sidebar across most of the window.

## Universal explanation

Hermes lays out panes as nested row/column splits. A minimized tool pane is rendered as a narrow rail: terminal/logs use a small vertical height rail when they are below the chat. The track-sizing code correctly used that rail size on the pane's own split axis, but also reused it when calculating the perpendicular axis. As a result, a minimized terminal's small height was incorrectly interpreted as a fixed width for its entire parent column.

Once the root row saw all columns as fixed, the flex layout assigned the remaining space to the final root track. In the affected layouts that track was Files, so Files expanded into the available window and the chat surface looked lost. This was a geometry/state interaction, not data loss or a session disappearance.

## Changes

- Make minimized panes contribute their rail size only along the axis that contains the rail.
- Prevent shared tool-pane close handling from leaving a non-chat sibling active when the workspace is present.
- Add regression coverage for a shared workspace/files/terminal zone.

## Verification

- Pane-tree UI tests: 12 passed.
- Production renderer/Electron build passed.
- Packaged macOS app build passed.
- Reproduced and verified against the persisted custom layout shape.
