### PR TITLE
feat(mcp): make keepalive probe configurable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1085,6 +1085,8 @@ platform_toolsets:
 #     Lower it below the server's session TTL for servers that expire idle
 #     sessions quickly (e.g. Unreal Engine editor MCP, ~15s), otherwise idle
 #     tool calls hit an expired session and pay a slow reconnect. Floored at 5s.
+#   keepalive_probe: auto (default) or list_tools. Use list_tools only for a
+#     tool-capable legacy server whose transport rejects the optional MCP ping.
 #
 # mcp_servers:
 #   time:

--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -227,6 +227,39 @@ class TestKeepaliveProbeFallback:
         assert task._ping_unsupported is False
 
 
+    async def test_configured_list_tools_probe_skips_ping(self):
+        """Legacy servers can opt out before a hostile ping closes the stream."""
+        task = MCPServerTask("legacy-sse")
+        task._config = {"keepalive_probe": "list_tools"}
+        task.initialize_result = _caps(tools=SimpleNamespace())
+        task.session = SimpleNamespace(
+            send_ping=AsyncMock(),
+            list_tools=AsyncMock(return_value=SimpleNamespace(tools=[])),
+        )
+
+        await task._keepalive_probe()
+
+        task.session.send_ping.assert_not_called()
+        task.session.list_tools.assert_awaited_once()
+
+
+    async def test_list_tools_probe_falls_back_for_prompt_only_server(self):
+        """A capability mismatch must not reconnect-loop on tools/list."""
+        task = MCPServerTask("prompt-only")
+        task._config = {"keepalive_probe": "list_tools"}
+        task.initialize_result = _caps(prompts=SimpleNamespace())
+        task.session = SimpleNamespace(
+            send_ping=AsyncMock(),
+            list_tools=AsyncMock(),
+        )
+
+        await task._keepalive_probe()
+
+        task.session.send_ping.assert_awaited_once()
+        task.session.list_tools.assert_not_called()
+        assert task._config["keepalive_probe"] == "auto"
+
+
     async def test_falls_back_on_unknown_method_string(self):
         """Regression for #50028: a server that surfaces method-not-found as a
         plain "Unknown method: ping" string (no structural -32601 code) must
@@ -289,5 +322,4 @@ class TestKeepaliveProbeFallback:
         await task._discover_tools()
 
         assert task._ping_unsupported is False
-
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -23,6 +23,8 @@ Example config::
                                 # 180). Set below the server's session TTL for
                                 # servers that GC idle sessions quickly (e.g.
                                 # Unreal Engine editor MCP, ~15s). Floored at 5s.
+        keepalive_probe: list_tools  # optional compatibility mode for legacy
+                                     # servers whose transport rejects ping
         idle_timeout_seconds: 3600      # optional stdio recycle after idle
         max_lifetime_seconds: 86400     # optional stdio recycle after age
         # The recycle settings may also live under lifecycle: {...}.
@@ -2168,7 +2170,9 @@ class MCPServerTask:
     async def _keepalive_probe(self) -> None:
         """Exercise the session to detect a stale/expired connection.
 
-        Uses ``ping`` (cheap, transport-agnostic liveness) by default. ``ping``
+        Uses ``ping`` (cheap, transport-agnostic liveness) by default. Servers
+        that close their transport when they receive the optional ping utility
+        can opt into ``keepalive_probe: list_tools``. ``ping``
         is an OPTIONAL MCP utility: a server that doesn't implement it answers
         JSON-RPC -32601. The first time that happens we latch
         ``_ping_unsupported`` and fall back to the pre-ping probe — capability
@@ -2181,6 +2185,23 @@ class MCPServerTask:
         Raises on a genuine connection failure so the caller triggers a
         reconnect; returns normally when the session is alive.
         """
+        probe_mode = str(
+            self._config.get("keepalive_probe", "auto") or "auto"
+        ).strip().lower()
+        if probe_mode == "list_tools":
+            if self._advertises_tools():
+                await asyncio.wait_for(self.session.list_tools(), timeout=30.0)
+                return
+            # A prompt/resource-only server cannot use tools/list. Recover to
+            # the universal ping path and latch the correction so this warning
+            # is emitted once rather than on every keepalive interval.
+            logger.warning(
+                "MCP server '%s': keepalive_probe=list_tools requires the "
+                "tools capability; falling back to ping.",
+                self.name,
+            )
+            self._config["keepalive_probe"] = "auto"
+
         if not self._ping_unsupported:
             try:
                 await asyncio.wait_for(self.session.send_ping(), timeout=30.0)
@@ -3055,7 +3076,19 @@ class MCPServerTask:
         Includes automatic reconnection with exponential backoff if the
         connection drops unexpectedly (unless shutdown was requested).
         """
-        self._config = config
+        self._config = dict(config)
+        keepalive_probe = str(
+            self._config.get("keepalive_probe", "auto") or "auto"
+        ).strip().lower()
+        if keepalive_probe not in {"auto", "list_tools"}:
+            logger.warning(
+                "MCP server '%s': invalid keepalive_probe=%r; using auto. "
+                "Expected 'auto' or 'list_tools'.",
+                self.name,
+                self._config.get("keepalive_probe"),
+            )
+            keepalive_probe = "auto"
+        self._config["keepalive_probe"] = keepalive_probe
         self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
         self._auth_type = (config.get("auth") or "").lower().strip()
         self._idle_timeout_seconds = _get_lifecycle_seconds(config, "idle_timeout_seconds")

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -60,6 +60,7 @@ mcp_servers:
 | `skip_preflight` | bool | HTTP | Bypass the fail-fast content-type probe for valid Streamable HTTP endpoints whose HEAD/GET answers a non-MCP content type (default: `false`) |
 | `transport` | string | HTTP | Set to `sse` to use the SSE transport instead of Streamable HTTP |
 | `keepalive_interval` | number | both | Liveness ping cadence in seconds (default: `180`, floored at 5s). Set below the server's session TTL for servers that GC idle sessions quickly |
+| `keepalive_probe` | string | both | Keepalive request: `auto` (default, ping with capability-aware fallback) or `list_tools` for a tool-capable legacy server whose transport rejects MCP ping |
 | `idle_timeout_seconds` | number | stdio | Optional stdio server recycle after idle time (`0` disables). May also live under a `lifecycle:` mapping |
 | `max_lifetime_seconds` | number | stdio | Optional stdio server recycle after age (`0` disables). May also live under a `lifecycle:` mapping |
 | `tools` | mapping | both | Filtering and utility-tool policy |


### PR DESCRIPTION
## Summary

- add per-server `keepalive_probe: auto | list_tools`
- preserve the current ping-first behavior as the default
- let tool-capable legacy MCP servers avoid ping when that request closes their transport before Hermes can detect method-not-found
- safely fall back to ping when `list_tools` is configured for a prompt/resource-only server
- document the option in the example config and MCP reference

The existing automatic fallback works when a server returns JSON-RPC `-32601`, but some legacy SSE implementations reject ping at the HTTP message endpoint and close the session. A transport-wide SSE exception would be too broad because compliant SSE servers and prompt-only servers still benefit from ping. This opt-in keeps the compatibility behavior scoped to the affected server.

Example:

```yaml
mcp_servers:
  legacy_service:
    url: https://example.test/sse
    transport: sse
    keepalive_probe: list_tools
```

## Tests

- `git diff --check`
- Python 3.11 `py_compile` for `tools/mcp_tool.py` and `tests/tools/test_mcp_capability_gating.py`
- focused production-environment execution covering explicit `list_tools`, prompt-only fallback, and unchanged default ping behavior

The repository's pytest dependency was not installed in the production environment, so the focused async scenarios were executed directly against its existing Hermes virtualenv with the branch worktree on `PYTHONPATH`.
