### PR TITLE
Harden setup-time optional installs (pinned via lazy_deps) + sandbox image provenance checks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -685,6 +685,7 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
         "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
+        "trusted_image_registries": "TERMINAL_TRUSTED_IMAGE_REGISTRIES",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
         # Persistent shell (non-local backends)
         "persistent_shell": "TERMINAL_PERSISTENT_SHELL",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1932,6 +1932,7 @@ if _config_path.exists():
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
                 "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
+                "trusted_image_registries": "TERMINAL_TRUSTED_IMAGE_REGISTRIES",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
             }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3198,6 +3198,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
     "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
+    "trusted_image_registries": "TERMINAL_TRUSTED_IMAGE_REGISTRIES",
     "sandbox_dir": "TERMINAL_SANDBOX_DIR",
     "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
 }

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -284,6 +284,15 @@ DEFAULT_CONFIG = {
         # non-interactively (e.g. one that hard-exits on TTY checks).
         "auto_source_bashrc": True,
         "docker_image": "nikolaik/python-nodejs:python3.11-nodejs20",
+        # Extra container registries considered trusted for sandbox images.
+        # The sandbox pulls and executes whatever image it is pointed at, so
+        # an image from an unrecognized registry logs a warning naming the
+        # host. Docker Hub, ghcr.io, gcr.io, quay.io, registry.k8s.io,
+        # public.ecr.aws and mcr.microsoft.com are trusted out of the box;
+        # list private/air-gapped registries here to silence the warning.
+        # Warn-only — an unlisted registry is never blocked.
+        # Example: ["registry.corp.internal", "harbor.example.com"]
+        "trusted_image_registries": [],
         "docker_forward_env": [],
         # Explicit environment variables to set inside Docker containers.
         # Unlike docker_forward_env (which reads values from the host process),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -908,6 +908,14 @@ def setup_model_provider(config: dict, *, quick: bool = False):
 # =============================================================================
 
 
+# neutts has no pyproject extra and no LAZY_DEPS entry: the package tracks the
+# upstream model code, so setup deliberately installs the newest release (`-U`)
+# rather than an exact pin. Bound the *major* anyway — an unreviewed 2.x landing
+# automatically on every user's machine is the supply-chain vector that `-U`
+# opens, and a major bound closes it without freezing the 1.x model work.
+NEUTTS_SPEC = "neutts[all]<2.0"
+
+
 def _check_espeak_ng() -> bool:
     """Check if espeak-ng is installed."""
     return shutil.which("espeak-ng") is not None or shutil.which("espeak") is not None
@@ -956,17 +964,17 @@ def _install_neutts_deps() -> bool:
     from hermes_cli.tools_config import _pip_install
 
     try:
-        result = _pip_install(["-U", "neutts[all]", "--quiet"], timeout=300)
+        result = _pip_install(["-U", NEUTTS_SPEC, "--quiet"], timeout=300)
     except Exception as e:
         print_error(f"Failed to install neutts: {e}")
-        print_info("Try manually: uv pip install -U 'neutts[all]'")
+        print_info(f"Try manually: uv pip install -U '{NEUTTS_SPEC}'")
         return False
     if result.returncode == 0:
         print_success("neutts installed successfully")
         return True
     err = (result.stderr or "").strip()
     print_error(f"Failed to install neutts: {err[:300] if err else 'install failed'}")
-    print_info("Try manually: uv pip install -U 'neutts[all]'")
+    print_info(f"Try manually: uv pip install -U '{NEUTTS_SPEC}'")
     return False
 
 
@@ -1460,14 +1468,21 @@ def setup_terminal_backend(config: dict):
             try:
                 __import__("modal")
             except ImportError:
-                print_info("Installing modal SDK...")
-                from hermes_cli.tools_config import _pip_install
+                from hermes_cli.tools_config import _pinned_specs, _pip_install
 
-                result = _pip_install(["modal"])
+                # Same pin the lazy runtime path uses (LAZY_DEPS
+                # "terminal.modal" / pyproject [modal]) — setup must not
+                # resolve a floating version the rest of the app never sees.
+                specs = _pinned_specs("terminal.modal", ("modal==1.3.4",))
+                print_info(f"Installing modal SDK ({', '.join(specs)})...")
+                result = _pip_install(specs)
                 if result.returncode == 0:
                     print_success("modal SDK installed")
                 else:
-                    print_warning("Install failed — run manually: uv pip install modal")
+                    print_warning(
+                        "Install failed — run manually: uv pip install "
+                        + " ".join(f"'{s}'" for s in specs)
+                    )
 
             # Modal token
             print()
@@ -1501,14 +1516,20 @@ def setup_terminal_backend(config: dict):
         try:
             __import__("daytona")
         except ImportError:
-            print_info("Installing daytona SDK...")
-            from hermes_cli.tools_config import _pip_install
+            from hermes_cli.tools_config import _pinned_specs, _pip_install
 
-            result = _pip_install(["daytona"])
+            # Same pin the lazy runtime path uses (LAZY_DEPS
+            # "terminal.daytona" / pyproject [daytona]).
+            specs = _pinned_specs("terminal.daytona", ("daytona==0.155.0",))
+            print_info(f"Installing daytona SDK ({', '.join(specs)})...")
+            result = _pip_install(specs)
             if result.returncode == 0:
                 print_success("daytona SDK installed")
             else:
-                print_warning("Install failed — run manually: uv pip install daytona")
+                print_warning(
+                    "Install failed — run manually: uv pip install "
+                    + " ".join(f"'{s}'" for s in specs)
+                )
                 if result.stderr:
                     print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -908,14 +908,6 @@ def setup_model_provider(config: dict, *, quick: bool = False):
 # =============================================================================
 
 
-# neutts has no pyproject extra and no LAZY_DEPS entry: the package tracks the
-# upstream model code, so setup deliberately installs the newest release (`-U`)
-# rather than an exact pin. Bound the *major* anyway — an unreviewed 2.x landing
-# automatically on every user's machine is the supply-chain vector that `-U`
-# opens, and a major bound closes it without freezing the 1.x model work.
-NEUTTS_SPEC = "neutts[all]<2.0"
-
-
 def _check_espeak_ng() -> bool:
     """Check if espeak-ng is installed."""
     return shutil.which("espeak-ng") is not None or shutil.which("espeak") is not None
@@ -961,20 +953,21 @@ def _install_neutts_deps() -> bool:
 
     # Route through the canonical uv → pip → ensurepip ladder so pip-less
     # venvs (Ubuntu 25.10 `python -m venv`, `uv venv`) work out of the box.
-    from hermes_cli.tools_config import _pip_install
+    from hermes_cli.tools_config import _bounded_spec, _pip_install
 
+    spec = _bounded_spec("neutts")
     try:
-        result = _pip_install(["-U", NEUTTS_SPEC, "--quiet"], timeout=300)
+        result = _pip_install(["-U", spec, "--quiet"], timeout=300)
     except Exception as e:
         print_error(f"Failed to install neutts: {e}")
-        print_info(f"Try manually: uv pip install -U '{NEUTTS_SPEC}'")
+        print_info(f"Try manually: uv pip install -U '{spec}'")
         return False
     if result.returncode == 0:
         print_success("neutts installed successfully")
         return True
     err = (result.stderr or "").strip()
     print_error(f"Failed to install neutts: {err[:300] if err else 'install failed'}")
-    print_info(f"Try manually: uv pip install -U '{NEUTTS_SPEC}'")
+    print_info(f"Try manually: uv pip install -U '{spec}'")
     return False
 
 
@@ -989,20 +982,22 @@ def _install_kittentts_deps() -> bool:
     print_info("Installing kittentts Python package (~25-80MB model downloaded on first use)...")
     print()
 
-    from hermes_cli.tools_config import _pip_install
+    from hermes_cli.tools_config import _bounded_spec, _pip_install
 
+    # The wheel URL is itself version-locked (0.8.1); soundfile was not.
+    audio = _bounded_spec("soundfile")
     try:
-        result = _pip_install(["-U", wheel_url, "soundfile", "--quiet"], timeout=300)
+        result = _pip_install(["-U", wheel_url, audio, "--quiet"], timeout=300)
     except Exception as e:
         print_error(f"Failed to install kittentts: {e}")
-        print_info(f"Try manually: uv pip install -U '{wheel_url}' soundfile")
+        print_info(f"Try manually: uv pip install -U '{wheel_url}' '{audio}'")
         return False
     if result.returncode == 0:
         print_success("kittentts installed successfully")
         return True
     err = (result.stderr or "").strip()
     print_error(f"Failed to install kittentts: {err[:300] if err else 'install failed'}")
-    print_info(f"Try manually: uv pip install -U '{wheel_url}' soundfile")
+    print_info(f"Try manually: uv pip install -U '{wheel_url}' '{audio}'")
     return False
 
 
@@ -1473,7 +1468,7 @@ def setup_terminal_backend(config: dict):
                 # Same pin the lazy runtime path uses (LAZY_DEPS
                 # "terminal.modal" / pyproject [modal]) — setup must not
                 # resolve a floating version the rest of the app never sees.
-                specs = _pinned_specs("terminal.modal", ("modal==1.3.4",))
+                specs = _pinned_specs("terminal.modal")
                 print_info(f"Installing modal SDK ({', '.join(specs)})...")
                 result = _pip_install(specs)
                 if result.returncode == 0:
@@ -1520,7 +1515,7 @@ def setup_terminal_backend(config: dict):
 
             # Same pin the lazy runtime path uses (LAZY_DEPS
             # "terminal.daytona" / pyproject [daytona]).
-            specs = _pinned_specs("terminal.daytona", ("daytona==0.155.0",))
+            specs = _pinned_specs("terminal.daytona")
             print_info(f"Installing daytona SDK ({', '.join(specs)})...")
             result = _pip_install(specs)
             if result.returncode == 0:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -765,6 +765,29 @@ def _cua_driver_env() -> dict:
         return dict(os.environ)
 
 
+def _pinned_specs(feature: str, fallback: tuple) -> List[str]:
+    """Resolve a ``tools.lazy_deps`` feature to its pinned pip specs.
+
+    ``tools/lazy_deps.LAZY_DEPS`` is the single source of truth for optional-
+    package versions (it mirrors the pyproject extras). Setup-time installs
+    read that same table so an interactive ``hermes setup`` can never resolve
+    a *different* — or, worse, unpinned and therefore attacker-choosable —
+    version than the lazy runtime path would install for the same feature.
+
+    ``fallback`` is used only when ``tools.lazy_deps`` can't be imported or
+    doesn't know the feature (stripped / partial installs). Keep it in sync
+    with the LAZY_DEPS entry; ``tests/hermes_cli/test_setup_install_pins.py``
+    asserts they match.
+    """
+    try:
+        from tools.lazy_deps import feature_specs
+
+        specs = feature_specs(feature)
+    except Exception:
+        specs = ()
+    return list(specs or fallback)
+
+
 def _pip_install(
     args: List[str],
     *,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -765,27 +765,77 @@ def _cua_driver_env() -> dict:
         return dict(os.environ)
 
 
-def _pinned_specs(feature: str, fallback: tuple) -> List[str]:
-    """Resolve a ``tools.lazy_deps`` feature to its pinned pip specs.
+# ── Setup-time install pins ───────────────────────────────────────────────────
+#
+# Everything `hermes setup` can install runs on a user's machine at setup
+# time, so an unpinned spec lets whatever the index serves at that moment
+# become executing code. Two tiers, in order of preference:
+#
+#   1. Packages that already have a `tools/lazy_deps.LAZY_DEPS` group — the
+#      single source of truth for optional-package versions, mirroring the
+#      pyproject extras. Setup reads that same table, so it can never resolve
+#      a different version than the lazy runtime path installs.
+#   2. Setup-only packages with no LAZY_DEPS group and no pyproject extra.
+#      These are installed with `-U` by design (they track upstream model /
+#      backend code), so they get an explicit major bound instead: that closes
+#      the "unreviewed new major installs itself on every user's machine"
+#      vector without freezing the current line. An exact pin for these is a
+#      maintainer decision — moving one into LAZY_DEPS is the upgrade path.
 
-    ``tools/lazy_deps.LAZY_DEPS`` is the single source of truth for optional-
-    package versions (it mirrors the pyproject extras). Setup-time installs
-    read that same table so an interactive ``hermes setup`` can never resolve
-    a *different* — or, worse, unpinned and therefore attacker-choosable —
-    version than the lazy runtime path would install for the same feature.
+# Mirrors of the LAZY_DEPS groups setup installs from. Used ONLY when
+# ``tools.lazy_deps`` is unimportable (stripped / partial installs).
+# Drift-guarded against LAZY_DEPS by test.
+_SETUP_INSTALL_FALLBACKS = {
+    "terminal.modal": ("modal==1.3.4",),
+    "terminal.daytona": ("daytona==0.155.0",),
+    "stt.faster_whisper": (
+        "faster-whisper==1.2.1",
+        "sounddevice==0.5.5",
+        "numpy==2.4.3",
+    ),
+    "platform.matrix": (
+        "mautrix[encryption]==0.21.0",
+        "aiosqlite==0.22.1",
+        "asyncpg==0.31.0",
+        "aiohttp-socks==0.11.0",
+        "aiohttp==3.14.1",
+    ),
+}
 
-    ``fallback`` is used only when ``tools.lazy_deps`` can't be imported or
-    doesn't know the feature (stripped / partial installs). Keep it in sync
-    with the LAZY_DEPS entry; ``tests/hermes_cli/test_setup_install_pins.py``
-    asserts they match.
+# Tier 2: setup-only packages, bounded rather than pinned. Keys are internal
+# labels; values are the pip spec that gets installed.
+_SETUP_INSTALL_BOUNDS = {
+    # NeuTTS / KittenTTS / Piper track upstream model code; the wheel URL for
+    # kittentts is itself version-locked, so only its audio dep needs a bound.
+    "neutts": "neutts[all]<2.0",
+    "soundfile": "soundfile<1.0",
+    "piper": "piper-tts<2.0",
+    # ddgs is a search backend with a fast-moving major line.
+    "ddgs": "ddgs<10.0",
+    # langfuse's SDK majors carry breaking API changes.
+    "langfuse": "langfuse<5.0",
+}
+
+
+def _pinned_specs(feature: str) -> List[str]:
+    """Return the pinned pip specs for a ``tools.lazy_deps`` feature.
+
+    Reads ``LAZY_DEPS`` when importable, else the mirrored entry in
+    ``_SETUP_INSTALL_FALLBACKS``. Raises ``KeyError`` for a feature in
+    neither, so a typo fails loudly instead of silently installing nothing.
     """
     try:
         from tools.lazy_deps import feature_specs
 
-        specs = feature_specs(feature)
+        return list(feature_specs(feature))
     except Exception:
-        specs = ()
-    return list(specs or fallback)
+        pass
+    return list(_SETUP_INSTALL_FALLBACKS[feature])
+
+
+def _bounded_spec(label: str) -> str:
+    """Return the bounded pip spec for a setup-only package."""
+    return _SETUP_INSTALL_BOUNDS[label]
 
 
 def _pip_install(
@@ -1791,7 +1841,12 @@ def _run_post_setup(post_setup_key: str):
             pass
         _print_info("    Installing faster-whisper (model ~150MB downloads on first use)...")
         try:
-            result = _pip_install(["-U", "faster-whisper", "--quiet"], timeout=300)
+            # Exact pins from LAZY_DEPS["stt.faster_whisper"] — the same
+            # group the lazy runtime path installs (faster-whisper +
+            # sounddevice + numpy), so setup and runtime can't diverge.
+            result = _pip_install(
+                [*_pinned_specs("stt.faster_whisper"), "--quiet"], timeout=300
+            )
             if result.returncode == 0:
                 _print_success("    faster-whisper installed")
                 _print_info("    Model sizes: tiny, base (default), small, medium, large-v3")
@@ -1799,7 +1854,10 @@ def _run_post_setup(post_setup_key: str):
             else:
                 _print_warning("    faster-whisper install failed:")
                 _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                _print_info("    Run manually: uv pip install -U faster-whisper")
+                _print_info(
+                    "    Run manually: uv pip install "
+                    + " ".join(f"'{spec}'" for spec in _pinned_specs("stt.faster_whisper"))
+                )
         except subprocess.TimeoutExpired:
             _print_warning("    faster-whisper install timed out (>5min)")
             _print_info("    Run manually: uv pip install -U faster-whisper")
@@ -1817,7 +1875,9 @@ def _run_post_setup(post_setup_key: str):
             "0.8.1/kittentts-0.8.1-py3-none-any.whl"
         )
         try:
-            result = _pip_install(["-U", wheel_url, "soundfile", "--quiet"], timeout=300)
+            result = _pip_install(
+                ["-U", wheel_url, _bounded_spec("soundfile"), "--quiet"], timeout=300
+            )
             if result.returncode == 0:
                 _print_success("    kittentts installed")
                 _print_info("    Voices: Jasper, Bella, Luna, Bruno, Rosie, Hugo, Kiki, Leo")
@@ -1825,10 +1885,16 @@ def _run_post_setup(post_setup_key: str):
             else:
                 _print_warning("    kittentts install failed:")
                 _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                _print_info(f"    Run manually: uv pip install -U '{wheel_url}' soundfile")
+                _print_info(
+                f"    Run manually: uv pip install -U '{wheel_url}' "
+                f"'{_bounded_spec('soundfile')}'"
+            )
         except subprocess.TimeoutExpired:
             _print_warning("    kittentts install timed out (>5min)")
-            _print_info(f"    Run manually: uv pip install -U '{wheel_url}' soundfile")
+            _print_info(
+                f"    Run manually: uv pip install -U '{wheel_url}' "
+                f"'{_bounded_spec('soundfile')}'"
+            )
 
     elif post_setup_key == "piper":
         try:
@@ -1837,17 +1903,23 @@ def _run_post_setup(post_setup_key: str):
         except ImportError:
             _print_info("    Installing piper-tts (~14MB wheel, voices downloaded on first use)...")
             try:
-                result = _pip_install(["-U", "piper-tts", "--quiet"], timeout=300)
+                result = _pip_install(
+                    ["-U", _bounded_spec("piper"), "--quiet"], timeout=300
+                )
                 if result.returncode == 0:
                     _print_success("    piper-tts installed")
                 else:
                     _print_warning("    piper-tts install failed:")
                     _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                    _print_info("    Run manually: uv pip install -U piper-tts")
+                    _print_info(
+                        f"    Run manually: uv pip install -U '{_bounded_spec('piper')}'"
+                    )
                     return
             except subprocess.TimeoutExpired:
                 _print_warning("    piper-tts install timed out (>5min)")
-                _print_info("    Run manually: uv pip install -U piper-tts")
+                _print_info(
+                    f"    Run manually: uv pip install -U '{_bounded_spec('piper')}'"
+                )
                 return
         _print_info("    Default voice: en_US-lessac-medium (downloaded on first TTS call)")
         _print_info("    Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md")
@@ -1860,13 +1932,17 @@ def _run_post_setup(post_setup_key: str):
         except ImportError:
             _print_info("    Installing ddgs (DuckDuckGo search package)...")
             try:
-                result = _pip_install(["-U", "ddgs", "--quiet"], timeout=300)
+                result = _pip_install(
+                    ["-U", _bounded_spec("ddgs"), "--quiet"], timeout=300
+                )
                 if result.returncode == 0:
                     _print_success("    ddgs installed")
                 else:
                     _print_warning("    ddgs install failed:")
                     _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                    _print_info("    Run manually: uv pip install -U ddgs")
+                    _print_info(
+                        f"    Run manually: uv pip install -U '{_bounded_spec('ddgs')}'"
+                    )
                     return
             except subprocess.TimeoutExpired:
                 _print_warning("    ddgs install timed out (>5min)")
@@ -1911,11 +1987,16 @@ def _run_post_setup(post_setup_key: str):
             _print_success("    langfuse SDK already installed")
         except ImportError:
             _print_info("    Installing langfuse SDK...")
-            result = _pip_install(["langfuse", "--quiet"], timeout=120)
+            result = _pip_install(
+                [_bounded_spec("langfuse"), "--quiet"], timeout=120
+            )
             if result.returncode == 0:
                 _print_success("    langfuse SDK installed")
             else:
-                _print_warning("    langfuse SDK install failed — run manually: uv pip install langfuse")
+                _print_warning(
+                    "    langfuse SDK install failed — run manually: "
+                    f"uv pip install '{_bounded_spec('langfuse')}'"
+                )
         # Opt the bundled observability/langfuse plugin into plugins.enabled.
         # The plugin ships in the repo but doesn't load until the user enables
         # it (standalone plugins are opt-in).

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4876,10 +4876,24 @@ def interactive_setup() -> None:
             try:
                 __import__("mautrix")
             except ImportError:
-                print_info(f"Installing {matrix_pkg}...")
-                from hermes_cli.tools_config import _pip_install
+                from hermes_cli.tools_config import _pinned_specs, _pip_install
 
-                result = _pip_install([matrix_pkg])
+                # lazy_deps is unimportable here (stripped install), so mirror
+                # its LAZY_DEPS["platform.matrix"] pins rather than resolving
+                # `mautrix` unpinned — this is the one Matrix install path that
+                # can't read the table itself.
+                specs = _pinned_specs(
+                    "platform.matrix",
+                    (
+                        "mautrix[encryption]==0.21.0",
+                        "aiosqlite==0.22.1",
+                        "asyncpg==0.31.0",
+                        "aiohttp-socks==0.11.0",
+                        "aiohttp==3.14.1",
+                    ),
+                )
+                print_info(f"Installing {matrix_pkg} ({len(specs)} pinned deps)...")
+                result = _pip_install(list(specs))
                 if result.returncode == 0:
                     print_success(f"{matrix_pkg} installed")
                 else:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -4882,16 +4882,7 @@ def interactive_setup() -> None:
                 # its LAZY_DEPS["platform.matrix"] pins rather than resolving
                 # `mautrix` unpinned — this is the one Matrix install path that
                 # can't read the table itself.
-                specs = _pinned_specs(
-                    "platform.matrix",
-                    (
-                        "mautrix[encryption]==0.21.0",
-                        "aiosqlite==0.22.1",
-                        "asyncpg==0.31.0",
-                        "aiohttp-socks==0.11.0",
-                        "aiohttp==3.14.1",
-                    ),
-                )
+                specs = _pinned_specs("platform.matrix")
                 print_info(f"Installing {matrix_pkg} ({len(specs)} pinned deps)...")
                 result = _pip_install(list(specs))
                 if result.returncode == 0:

--- a/tests/hermes_cli/test_setup_install_pins.py
+++ b/tests/hermes_cli/test_setup_install_pins.py
@@ -1,0 +1,147 @@
+"""Setup-time optional installs must resolve pinned versions.
+
+`hermes setup` installs optional SDKs (modal, daytona, neutts) and the Matrix
+plugin installs mautrix. Every one of those runs on a user machine at setup
+time, so an unpinned spec lets whatever the index serves at that moment become
+executing code. These tests lock in:
+
+  1. the pins come from the single source of truth, tools/lazy_deps.LAZY_DEPS;
+  2. the hardcoded fallbacks (used when lazy_deps is unimportable) don't drift
+     away from that table;
+  3. the install still goes through hermes_cli.tools_config._pip_install, so
+     the uv → pip → ensurepip fallback ladder is retained.
+"""
+
+import pytest
+
+from hermes_cli.tools_config import _pinned_specs, _pip_install
+from tools.lazy_deps import LAZY_DEPS
+
+
+# ── 1. Pins resolve from LAZY_DEPS ────────────────────────────────────────────
+
+@pytest.mark.parametrize("feature", ["terminal.modal", "terminal.daytona", "platform.matrix"])
+def test_pinned_specs_reads_lazy_deps(feature):
+    assert _pinned_specs(feature, ("sentinel",)) == list(LAZY_DEPS[feature])
+
+
+@pytest.mark.parametrize("feature", ["terminal.modal", "terminal.daytona", "platform.matrix"])
+def test_lazy_deps_entries_are_version_pinned(feature):
+    """Every spec setup installs must carry an exact version."""
+    for spec in LAZY_DEPS[feature]:
+        assert "==" in spec, f"{feature} spec {spec!r} is not pinned"
+
+
+def test_pinned_specs_falls_back_when_feature_unknown():
+    assert _pinned_specs("no.such.feature", ("modal==1.3.4",)) == ["modal==1.3.4"]
+
+
+def test_pinned_specs_falls_back_when_lazy_deps_unimportable(monkeypatch):
+    """Stripped installs have no tools.lazy_deps — the fallback must hold."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blow_up(name, *args, **kwargs):
+        if name == "tools.lazy_deps":
+            raise ImportError("simulated stripped install")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blow_up)
+    assert _pinned_specs("terminal.modal", ("modal==1.3.4",)) == ["modal==1.3.4"]
+
+
+# ── 2. Hardcoded fallbacks must not drift from LAZY_DEPS ──────────────────────
+
+def _fallback_literals(path, marker):
+    """Extract the fallback tuple passed to _pinned_specs at *marker*."""
+    import ast
+
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_pinned_specs"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == marker
+        ):
+            return tuple(e.value for e in node.args[1].elts)
+    raise AssertionError(f"no _pinned_specs({marker!r}, ...) call found in {path}")
+
+
+@pytest.mark.parametrize(
+    "module_name, feature",
+    [
+        ("hermes_cli.setup", "terminal.modal"),
+        ("hermes_cli.setup", "terminal.daytona"),
+        ("plugins.platforms.matrix.adapter", "platform.matrix"),
+    ],
+)
+def test_hardcoded_fallbacks_match_lazy_deps(module_name, feature):
+    import importlib
+    from pathlib import Path
+
+    module = importlib.import_module(module_name)
+    fallback = _fallback_literals(Path(module.__file__), feature)
+    assert fallback == LAZY_DEPS[feature], (
+        f"{module_name} fallback for {feature} drifted from LAZY_DEPS"
+    )
+
+
+# ── 3. neutts is bounded ──────────────────────────────────────────────────────
+
+def test_neutts_spec_has_upper_bound():
+    """neutts is installed with -U (no exact pin), so it needs a major bound."""
+    from hermes_cli.setup import NEUTTS_SPEC
+
+    assert NEUTTS_SPEC.startswith("neutts[all]")
+    assert "<" in NEUTTS_SPEC, "unbounded -U install: a hostile major installs itself"
+
+
+def test_neutts_install_passes_bounded_spec(monkeypatch):
+    """_install_neutts_deps must hand the bounded spec to _pip_install."""
+    import subprocess
+
+    import hermes_cli.setup as setup_mod
+    import hermes_cli.tools_config as tools_config
+
+    calls = []
+
+    def _fake_pip_install(args, **kwargs):
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(setup_mod, "_check_espeak_ng", lambda: True)
+    monkeypatch.setattr(tools_config, "_pip_install", _fake_pip_install)
+
+    assert setup_mod._install_neutts_deps() is True
+    assert len(calls) == 1
+    assert setup_mod.NEUTTS_SPEC in calls[0]
+    assert "neutts[all]" not in calls[0], "bare unbounded spec leaked through"
+
+
+# ── 4. The fallback ladder is retained ────────────────────────────────────────
+
+def test_pip_install_is_the_shared_installer():
+    """The salvaged pins ride on tools_config._pip_install, not a new installer.
+
+    Guards against reintroducing a private installer that skips the
+    uv → pip → ensurepip ladder (pip-less `uv venv` installs depend on it).
+    """
+    import inspect
+
+    source = inspect.getsource(_pip_install)
+    assert "ensurepip" in source
+    assert "uv" in source
+
+    for module_name in ("hermes_cli.setup", "plugins.platforms.matrix.adapter"):
+        import importlib
+        from pathlib import Path
+
+        mod_source = Path(importlib.import_module(module_name).__file__).read_text(
+            encoding="utf-8"
+        )
+        assert "_pip_install" in mod_source

--- a/tests/hermes_cli/test_setup_install_pins.py
+++ b/tests/hermes_cli/test_setup_install_pins.py
@@ -1,43 +1,98 @@
-"""Setup-time optional installs must resolve pinned versions.
+"""Setup-time optional installs must resolve pinned/bounded versions.
 
-`hermes setup` installs optional SDKs (modal, daytona, neutts) and the Matrix
-plugin installs mautrix. Every one of those runs on a user machine at setup
-time, so an unpinned spec lets whatever the index serves at that moment become
-executing code. These tests lock in:
+`hermes setup` and its post-setup hooks install optional packages on a user's
+machine. An unpinned spec lets whatever the index serves at that moment become
+executing code, so every setup install either
 
-  1. the pins come from the single source of truth, tools/lazy_deps.LAZY_DEPS;
-  2. the hardcoded fallbacks (used when lazy_deps is unimportable) don't drift
-     away from that table;
-  3. the install still goes through hermes_cli.tools_config._pip_install, so
-     the uv → pip → ensurepip fallback ladder is retained.
+  * inherits exact pins from a ``tools/lazy_deps.LAZY_DEPS`` group — the single
+    source of truth, mirroring the pyproject extras — or
+  * carries an explicit major bound, for setup-only packages that have no
+    LAZY_DEPS group and are installed with ``-U`` by design.
+
+These tests drive the real install paths with ``_pip_install`` stubbed and
+assert on the specs those paths actually pass to pip.
 """
+
+import subprocess
+import sys
 
 import pytest
 
-from hermes_cli.tools_config import _pinned_specs, _pip_install
+import hermes_cli.setup as setup_mod
+import hermes_cli.tools_config as tools_config
+from hermes_cli.tools_config import (
+    _SETUP_INSTALL_BOUNDS,
+    _SETUP_INSTALL_FALLBACKS,
+    _bounded_spec,
+    _pinned_specs,
+)
 from tools.lazy_deps import LAZY_DEPS
 
 
-# ── 1. Pins resolve from LAZY_DEPS ────────────────────────────────────────────
+@pytest.fixture
+def pip_calls(monkeypatch):
+    """Record every spec list handed to ``_pip_install``.
 
-@pytest.mark.parametrize("feature", ["terminal.modal", "terminal.daytona", "platform.matrix"])
-def test_pinned_specs_reads_lazy_deps(feature):
-    assert _pinned_specs(feature, ("sentinel",)) == list(LAZY_DEPS[feature])
+    Patches the module object that is live in ``sys.modules`` rather than the
+    one bound at import time: the install sites import ``_pip_install`` inside
+    the function body, so they resolve through ``sys.modules`` at call time,
+    and another test in the session may have replaced that entry.
+
+    Also blocks ``subprocess.run`` inside tools_config, so a patch that fails
+    to take fails the test loudly instead of shelling out to a real pip.
+    """
+    calls = []
+
+    def _fake(args, **kwargs):
+        calls.append(list(args))
+        return subprocess.CompletedProcess(list(args), returncode=0, stdout="", stderr="")
+
+    live = sys.modules["hermes_cli.tools_config"]
+    monkeypatch.setattr(live, "_pip_install", _fake)
+    if live is not tools_config:  # pragma: no cover - only under module reload
+        monkeypatch.setattr(tools_config, "_pip_install", _fake)
+
+    def _no_real_installs(*args, **kwargs):
+        raise AssertionError(
+            f"install path escaped the _pip_install stub and tried to run: {args!r}"
+        )
+
+    monkeypatch.setattr(live.subprocess, "run", _no_real_installs)
+    return calls
 
 
-@pytest.mark.parametrize("feature", ["terminal.modal", "terminal.daytona", "platform.matrix"])
-def test_lazy_deps_entries_are_version_pinned(feature):
-    """Every spec setup installs must carry an exact version."""
+def _specs_only(args):
+    """Drop pip flags, leaving the package specs."""
+    return [a for a in args if not a.startswith("-")]
+
+
+# ── The pin tables ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("feature", sorted(_SETUP_INSTALL_FALLBACKS))
+def test_fallback_mirrors_lazy_deps(feature):
+    """The stripped-install fallback must not drift from the real table."""
+    assert _SETUP_INSTALL_FALLBACKS[feature] == LAZY_DEPS[feature]
+
+
+@pytest.mark.parametrize("feature", sorted(_SETUP_INSTALL_FALLBACKS))
+def test_lazy_deps_groups_are_exactly_pinned(feature):
     for spec in LAZY_DEPS[feature]:
         assert "==" in spec, f"{feature} spec {spec!r} is not pinned"
 
 
-def test_pinned_specs_falls_back_when_feature_unknown():
-    assert _pinned_specs("no.such.feature", ("modal==1.3.4",)) == ["modal==1.3.4"]
+@pytest.mark.parametrize("label", sorted(_SETUP_INSTALL_BOUNDS))
+def test_setup_only_specs_are_bounded(label):
+    """No LAZY_DEPS group to inherit from → must at least bound the major."""
+    spec = _SETUP_INSTALL_BOUNDS[label]
+    assert "<" in spec, f"{label} spec {spec!r} has no upper bound"
+
+
+def test_pinned_specs_reads_lazy_deps():
+    assert _pinned_specs("terminal.modal") == list(LAZY_DEPS["terminal.modal"])
 
 
 def test_pinned_specs_falls_back_when_lazy_deps_unimportable(monkeypatch):
-    """Stripped installs have no tools.lazy_deps — the fallback must hold."""
+    """Stripped installs have no tools.lazy_deps — the mirror must hold."""
     import builtins
 
     real_import = builtins.__import__
@@ -48,100 +103,136 @@ def test_pinned_specs_falls_back_when_lazy_deps_unimportable(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", _blow_up)
-    assert _pinned_specs("terminal.modal", ("modal==1.3.4",)) == ["modal==1.3.4"]
+    assert _pinned_specs("terminal.modal") == list(LAZY_DEPS["terminal.modal"])
 
 
-# ── 2. Hardcoded fallbacks must not drift from LAZY_DEPS ──────────────────────
+def test_unknown_feature_raises():
+    """A typo must fail loudly, not silently install nothing."""
+    with pytest.raises(KeyError):
+        _pinned_specs("no.such.feature")
+    with pytest.raises(KeyError):
+        _bounded_spec("no-such-package")
 
-def _fallback_literals(path, marker):
-    """Extract the fallback tuple passed to _pinned_specs at *marker*."""
-    import ast
 
-    source = path.read_text(encoding="utf-8")
-    tree = ast.parse(source)
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "_pinned_specs"
-            and node.args
-            and isinstance(node.args[0], ast.Constant)
-            and node.args[0].value == marker
-        ):
-            return tuple(e.value for e in node.args[1].elts)
-    raise AssertionError(f"no _pinned_specs({marker!r}, ...) call found in {path}")
+# ── The install paths actually pass those specs ───────────────────────────────
+
+def test_neutts_install_passes_bounded_spec(monkeypatch, pip_calls):
+    monkeypatch.setattr(setup_mod, "_check_espeak_ng", lambda: True)
+
+    assert setup_mod._install_neutts_deps() is True
+
+    assert len(pip_calls) == 1
+    specs = _specs_only(pip_calls[0])
+    assert specs == [_bounded_spec("neutts")]
+    assert "neutts[all]" not in specs, "bare unbounded spec leaked through"
+
+
+def test_kittentts_install_bounds_its_audio_dep(monkeypatch, pip_calls):
+    assert setup_mod._install_kittentts_deps() is True
+
+    specs = _specs_only(pip_calls[0])
+    # The wheel URL is itself version-locked; soundfile is the loose one.
+    assert any(spec.endswith(".whl") and "0.8.1" in spec for spec in specs)
+    assert _bounded_spec("soundfile") in specs
+    assert "soundfile" not in specs
 
 
 @pytest.mark.parametrize(
-    "module_name, feature",
+    "hook, expected",
     [
-        ("hermes_cli.setup", "terminal.modal"),
-        ("hermes_cli.setup", "terminal.daytona"),
-        ("plugins.platforms.matrix.adapter", "platform.matrix"),
+        ("piper", "piper"),
+        ("ddgs", "ddgs"),
+        ("langfuse", "langfuse"),
     ],
 )
-def test_hardcoded_fallbacks_match_lazy_deps(module_name, feature):
-    import importlib
-    from pathlib import Path
+def test_post_setup_hook_installs_bounded_spec(monkeypatch, pip_calls, hook, expected):
+    """The post-setup hooks install bounded specs, not floating names."""
+    import builtins
 
-    module = importlib.import_module(module_name)
-    fallback = _fallback_literals(Path(module.__file__), feature)
-    assert fallback == LAZY_DEPS[feature], (
-        f"{module_name} fallback for {feature} drifted from LAZY_DEPS"
+    real_import = builtins.__import__
+
+    # Force the ImportError branch — the hook only installs what's missing.
+    def _missing(name, *args, **kwargs):
+        if name in {"piper", "ddgs", "langfuse"}:
+            raise ImportError(f"simulated missing {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _missing)
+
+    try:
+        tools_config._run_post_setup(hook)
+    except Exception:
+        # Hooks do more than install (langfuse also toggles a plugin); the
+        # install call is what this test is about.
+        pass
+
+    assert pip_calls, f"{hook} hook made no install call"
+    specs = _specs_only(pip_calls[0])
+    assert _bounded_spec(expected) in specs, specs
+
+
+def test_faster_whisper_hook_uses_lazy_deps_pins(monkeypatch, pip_calls):
+    """faster-whisper HAS a LAZY_DEPS group — the hook must use it verbatim."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _missing(name, *args, **kwargs):
+        if name == "faster_whisper":
+            raise ImportError("simulated missing faster_whisper")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _missing)
+
+    tools_config._run_post_setup("faster_whisper")
+
+    assert pip_calls, "faster_whisper hook made no install call"
+    assert _specs_only(pip_calls[0]) == list(LAZY_DEPS["stt.faster_whisper"])
+
+
+# ── The fallback ladder is retained, not replaced ─────────────────────────────
+
+def test_pip_install_bootstraps_pip_via_ensurepip(monkeypatch):
+    """With uv absent and pip missing, _pip_install must run ensurepip.
+
+    The uv → pip → ensurepip ladder is why setup works on pip-less venvs
+    (`uv venv`, Ubuntu's `python -m venv`). Any replacement installer that
+    skipped it would regress those installs.
+    """
+    monkeypatch.setattr(tools_config.shutil, "which", lambda name: None)
+
+    seen = []
+
+    def _fake_run(cmd, **kwargs):
+        seen.append(list(cmd))
+        if "--version" in cmd:  # the pip probe
+            return subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="no pip")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(tools_config.subprocess, "run", _fake_run)
+
+    result = tools_config._pip_install(["modal==1.3.4"])
+
+    assert result.returncode == 0
+    assert any("ensurepip" in c for cmd in seen for c in cmd), seen
+    # And the install itself still ran, with the spec intact.
+    assert any("modal==1.3.4" in cmd for cmd in seen), seen
+
+
+def test_pip_install_prefers_uv_when_available(monkeypatch):
+    monkeypatch.setattr(
+        tools_config.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None
     )
 
+    seen = []
 
-# ── 3. neutts is bounded ──────────────────────────────────────────────────────
+    def _fake_run(cmd, **kwargs):
+        seen.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
-def test_neutts_spec_has_upper_bound():
-    """neutts is installed with -U (no exact pin), so it needs a major bound."""
-    from hermes_cli.setup import NEUTTS_SPEC
+    monkeypatch.setattr(tools_config.subprocess, "run", _fake_run)
 
-    assert NEUTTS_SPEC.startswith("neutts[all]")
-    assert "<" in NEUTTS_SPEC, "unbounded -U install: a hostile major installs itself"
+    tools_config._pip_install(["modal==1.3.4"])
 
-
-def test_neutts_install_passes_bounded_spec(monkeypatch):
-    """_install_neutts_deps must hand the bounded spec to _pip_install."""
-    import subprocess
-
-    import hermes_cli.setup as setup_mod
-    import hermes_cli.tools_config as tools_config
-
-    calls = []
-
-    def _fake_pip_install(args, **kwargs):
-        calls.append(list(args))
-        return subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr(setup_mod, "_check_espeak_ng", lambda: True)
-    monkeypatch.setattr(tools_config, "_pip_install", _fake_pip_install)
-
-    assert setup_mod._install_neutts_deps() is True
-    assert len(calls) == 1
-    assert setup_mod.NEUTTS_SPEC in calls[0]
-    assert "neutts[all]" not in calls[0], "bare unbounded spec leaked through"
-
-
-# ── 4. The fallback ladder is retained ────────────────────────────────────────
-
-def test_pip_install_is_the_shared_installer():
-    """The salvaged pins ride on tools_config._pip_install, not a new installer.
-
-    Guards against reintroducing a private installer that skips the
-    uv → pip → ensurepip ladder (pip-less `uv venv` installs depend on it).
-    """
-    import inspect
-
-    source = inspect.getsource(_pip_install)
-    assert "ensurepip" in source
-    assert "uv" in source
-
-    for module_name in ("hermes_cli.setup", "plugins.platforms.matrix.adapter"):
-        import importlib
-        from pathlib import Path
-
-        mod_source = Path(importlib.import_module(module_name).__file__).read_text(
-            encoding="utf-8"
-        )
-        assert "_pip_install" in mod_source
+    assert seen[0][:3] == ["/usr/bin/uv", "pip", "install"], seen[0]
+    assert "modal==1.3.4" in seen[0]

--- a/tests/tools/test_terminal_image_provenance.py
+++ b/tests/tools/test_terminal_image_provenance.py
@@ -7,6 +7,7 @@ pulls and runs the image), so provenance is checked at those two chokepoints,
 warn-only.
 """
 
+import json
 import logging
 
 import pytest
@@ -73,14 +74,62 @@ def test_image_is_trusted(image, trusted):
     assert image_is_trusted(image) is trusted
 
 
-def test_operator_can_extend_trusted_registries(monkeypatch):
+def test_operator_extends_trusted_registries_from_config(monkeypatch):
+    """``terminal.trusted_image_registries`` in config.yaml.
+
+    The startup bridges JSON-encode list values into the TERMINAL_* env var
+    (same as docker_volumes / docker_env), so that is the form this must
+    accept.
+    """
     assert image_is_trusted("registry.corp.internal/base:1") is False
+
     monkeypatch.setenv(
-        "HERMES_TERMINAL_TRUSTED_REGISTRIES", "registry.corp.internal, other.host"
+        "TERMINAL_TRUSTED_IMAGE_REGISTRIES",
+        json.dumps(["registry.corp.internal", "harbor.example.com"]),
+    )
+    assert image_is_trusted("registry.corp.internal/base:1") is True
+    assert image_is_trusted("harbor.example.com/base:1") is True
+    assert image_is_trusted("evil.example.com/x:1") is False
+
+
+def test_trusted_registries_accepts_comma_separated_env(monkeypatch):
+    """Hand-exported env (no config bridge) still works."""
+    monkeypatch.setenv(
+        "TERMINAL_TRUSTED_IMAGE_REGISTRIES", "registry.corp.internal, other.host"
     )
     assert image_is_trusted("registry.corp.internal/base:1") is True
     assert image_is_trusted("other.host/base:1") is True
     assert image_is_trusted("evil.example.com/x:1") is False
+
+
+def test_trusted_registries_config_key_is_bridged():
+    """The config.yaml key must reach terminal_tool through every entry point.
+
+    A key present in DEFAULT_CONFIG but missing from a bridge map silently
+    does nothing for that entry point — the bug class documented in
+    tests/tools/test_terminal_config_env_sync.py.
+    """
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert "trusted_image_registries" in DEFAULT_CONFIG["terminal"]
+    assert (
+        TERMINAL_CONFIG_ENV_MAP["trusted_image_registries"]
+        == "TERMINAL_TRUSTED_IMAGE_REGISTRIES"
+    )
+
+
+def test_config_value_reaches_the_checker(monkeypatch):
+    """End-to-end through the documented mechanism: config value → warning gone."""
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+
+    configured = {"terminal": {"trusted_image_registries": ["registry.corp.internal"]}}
+    # Mirror what the startup bridges do with a list value.
+    for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():
+        if cfg_key in configured["terminal"]:
+            monkeypatch.setenv(env_var, json.dumps(configured["terminal"][cfg_key]))
+
+    assert image_is_trusted("registry.corp.internal/python:3.11") is True
 
 
 # ── Warning behaviour ─────────────────────────────────────────────────────────

--- a/tests/tools/test_terminal_image_provenance.py
+++ b/tests/tools/test_terminal_image_provenance.py
@@ -1,0 +1,158 @@
+"""Sandbox image references are checked where they actually arrive.
+
+The setup wizard no longer prompts for terminal images — they reach the
+backends via the TERMINAL_*_IMAGE env vars / config file and via
+`register_task_env_overrides()`. Both are code-execution inputs (the backend
+pulls and runs the image), so provenance is checked at those two chokepoints,
+warn-only.
+"""
+
+import logging
+
+import pytest
+
+from tools.terminal_tool import (
+    _check_image_provenance,
+    _image_registry_host,
+    _warned_images,
+    image_is_trusted,
+    register_task_env_overrides,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_warn_cache():
+    _warned_images.clear()
+    yield
+    _warned_images.clear()
+
+
+# ── Registry resolution ───────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "image, expected",
+    [
+        # Implicit Docker Hub: no dot/colon in the first segment.
+        ("nikolaik/python-nodejs:python3.11-nodejs20", "docker.io"),
+        ("python:3.11", "docker.io"),
+        ("ubuntu", "docker.io"),
+        # Explicit hosts.
+        ("ghcr.io/nousresearch/hermes:latest", "ghcr.io"),
+        ("gcr.io/project/img:v1", "gcr.io"),
+        ("evil.example.com/backdoor:latest", "evil.example.com"),
+        ("localhost:5000/dev:latest", "localhost:5000"),
+        # Singularity/OCI schemes are stripped before classification.
+        ("docker://nikolaik/python-nodejs:python3.11-nodejs20", "docker.io"),
+        ("docker://evil.example.com/x:1", "evil.example.com"),
+        ("oci://ghcr.io/org/img:1", "ghcr.io"),
+        # Not registry references at all.
+        ("/home/user/project/Dockerfile", None),
+        ("./Dockerfile", None),
+        ("", None),
+    ],
+)
+def test_image_registry_host(image, expected):
+    assert _image_registry_host(image) == expected
+
+
+@pytest.mark.parametrize(
+    "image, trusted",
+    [
+        ("nikolaik/python-nodejs:python3.11-nodejs20", True),
+        ("python:3.11", True),
+        ("ghcr.io/nousresearch/hermes:latest", True),
+        ("quay.io/org/img:1", True),
+        ("docker://nikolaik/python-nodejs:python3.11-nodejs20", True),
+        ("evil.example.com/backdoor:latest", False),
+        ("192.168.1.10:5000/img:1", False),
+        # Unclassifiable refs (local Dockerfiles, Modal build contexts) pass.
+        ("/home/user/project/Dockerfile", True),
+    ],
+)
+def test_image_is_trusted(image, trusted):
+    assert image_is_trusted(image) is trusted
+
+
+def test_operator_can_extend_trusted_registries(monkeypatch):
+    assert image_is_trusted("registry.corp.internal/base:1") is False
+    monkeypatch.setenv(
+        "HERMES_TERMINAL_TRUSTED_REGISTRIES", "registry.corp.internal, other.host"
+    )
+    assert image_is_trusted("registry.corp.internal/base:1") is True
+    assert image_is_trusted("other.host/base:1") is True
+    assert image_is_trusted("evil.example.com/x:1") is False
+
+
+# ── Warning behaviour ─────────────────────────────────────────────────────────
+
+def test_untrusted_image_warns_once(caplog):
+    with caplog.at_level(logging.WARNING, logger="tools.terminal_tool"):
+        _check_image_provenance("docker_image", "evil.example.com/x:1")
+        _check_image_provenance("docker_image", "evil.example.com/x:1")
+
+    warnings = [r for r in caplog.records if "evil.example.com" in r.getMessage()]
+    assert len(warnings) == 1, "repeated registrations must not spam the log"
+
+
+def test_trusted_image_is_silent(caplog):
+    with caplog.at_level(logging.WARNING, logger="tools.terminal_tool"):
+        _check_image_provenance("docker_image", "ghcr.io/nousresearch/hermes:latest")
+    assert not caplog.records
+
+
+# ── The live paths ────────────────────────────────────────────────────────────
+
+def test_task_env_override_is_checked(caplog):
+    """The infra override registry — one of the paths a prompt check misses."""
+    task_id = "test-provenance-override"
+    try:
+        with caplog.at_level(logging.WARNING, logger="tools.terminal_tool"):
+            register_task_env_overrides(
+                task_id, {"modal_image": "evil.example.com/backdoor:latest"}
+            )
+        assert any("evil.example.com" in r.getMessage() for r in caplog.records)
+    finally:
+        from tools.terminal_tool import clear_task_env_overrides
+
+        clear_task_env_overrides(task_id)
+
+
+def test_task_env_override_still_registers_the_value():
+    """Warn-only: an unrecognized registry must not be silently dropped."""
+    from tools.terminal_tool import _task_env_overrides, clear_task_env_overrides
+
+    task_id = "test-provenance-passthrough"
+    try:
+        register_task_env_overrides(task_id, {"docker_image": "evil.example.com/x:1"})
+        assert _task_env_overrides[task_id]["docker_image"] == "evil.example.com/x:1"
+    finally:
+        clear_task_env_overrides(task_id)
+
+
+def test_env_var_image_is_checked(monkeypatch, caplog):
+    """TERMINAL_*_IMAGE — the path that replaced the removed setup prompts."""
+    from tools.terminal_tool import _get_env_config
+
+    monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "evil.example.com/backdoor:latest")
+    with caplog.at_level(logging.WARNING, logger="tools.terminal_tool"):
+        config = _get_env_config()
+
+    assert any("evil.example.com" in r.getMessage() for r in caplog.records)
+    # Warn-only: the configured image is still honoured.
+    assert config["docker_image"] == "evil.example.com/backdoor:latest"
+
+
+def test_default_config_is_silent(monkeypatch, caplog):
+    for var in (
+        "TERMINAL_DOCKER_IMAGE",
+        "TERMINAL_SINGULARITY_IMAGE",
+        "TERMINAL_MODAL_IMAGE",
+        "TERMINAL_DAYTONA_IMAGE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    from tools.terminal_tool import _get_env_config
+
+    with caplog.at_level(logging.WARNING, logger="tools.terminal_tool"):
+        _get_env_config()
+    assert not [r for r in caplog.records if "trusted set" in r.getMessage()]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -45,7 +45,7 @@ import atexit
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Set, Tuple
 
 from utils import env_var_enabled
 
@@ -1188,6 +1188,100 @@ def clear_session_cwd(session_key: str) -> None:
         _session_cwd.pop(session_key, None)
 
 
+# ── Sandbox image provenance ───────────────────────────────────────────────
+#
+# Every container backend pulls and executes whatever image it is pointed at,
+# so the image reference is a code-execution input. It reaches us from three
+# places, none of which is an interactive prompt any more: the TERMINAL_*_IMAGE
+# env vars, the config file, and `register_task_env_overrides()` (infra
+# callers). Validating at the setup wizard would therefore cover none of the
+# live paths — so the check lives here, on the two chokepoints all three
+# converge on.
+#
+# Warn-only, never blocking: private and air-gapped registries are legitimate
+# and a hard failure would break existing deployments. Extend the trusted set
+# via HERMES_TERMINAL_TRUSTED_REGISTRIES (comma-separated hosts).
+_DEFAULT_TRUSTED_IMAGE_REGISTRIES = (
+    "docker.io",
+    "ghcr.io",
+    "gcr.io",
+    "quay.io",
+    "registry.k8s.io",
+    "public.ecr.aws",
+    "mcr.microsoft.com",
+)
+
+_IMAGE_SCHEMES = ("docker://", "oci://", "docker-archive://", "docker-daemon://")
+
+# Warn once per (field, image) so a per-task registration loop can't spam logs.
+_warned_images: Set[Tuple[str, str]] = set()
+
+
+def _trusted_image_registries() -> Tuple[str, ...]:
+    """Trusted registry hosts: the defaults plus any operator additions."""
+    extra = os.getenv("HERMES_TERMINAL_TRUSTED_REGISTRIES", "")
+    added = tuple(h.strip().lower() for h in extra.split(",") if h.strip())
+    return _DEFAULT_TRUSTED_IMAGE_REGISTRIES + added
+
+
+def _image_registry_host(image: str) -> Optional[str]:
+    """Return the registry host an image reference resolves to.
+
+    Applies Docker's own rule: the first path segment is a registry host only
+    if it contains a ``.`` or ``:`` or is exactly ``localhost``; otherwise the
+    reference is an implicit Docker Hub name (``nikolaik/python-nodejs:...``,
+    ``python:3.11``). Returns ``None`` for references we deliberately don't
+    classify — local Dockerfile paths, which Modal accepts in place of an
+    image name.
+    """
+    ref = (image or "").strip()
+    for scheme in _IMAGE_SCHEMES:
+        if ref.startswith(scheme):
+            ref = ref[len(scheme):]
+            break
+    if not ref:
+        return None
+    # Local build context / Dockerfile path — not a registry reference.
+    if ref.startswith(("/", "./", "../", "~")) or os.path.basename(ref) == "Dockerfile":
+        return None
+    head = ref.split("/", 1)[0]
+    if "/" in ref and ("." in head or ":" in head or head == "localhost"):
+        return head.lower()
+    return "docker.io"
+
+
+def image_is_trusted(image: str) -> bool:
+    """Is *image* served by a recognized registry? Unclassifiable refs pass."""
+    host = _image_registry_host(image)
+    if host is None:
+        return True
+    return host in _trusted_image_registries()
+
+
+def _check_image_provenance(field: str, image: Any) -> None:
+    """Log a warning when *image* comes from an unrecognized registry."""
+    if not isinstance(image, str) or not image.strip():
+        return
+    if image_is_trusted(image):
+        return
+    key = (field, image)
+    if key in _warned_images:
+        return
+    _warned_images.add(key)
+    logger.warning(
+        "Sandbox %s=%r resolves to registry %r, which is not in the trusted "
+        "set (%s). The sandbox will pull and execute this image. Add the host "
+        "to HERMES_TERMINAL_TRUSTED_REGISTRIES to silence this warning.",
+        field, image, _image_registry_host(image),
+        ", ".join(_trusted_image_registries()),
+    )
+
+
+_IMAGE_OVERRIDE_KEYS = (
+    "docker_image", "modal_image", "singularity_image", "daytona_image",
+)
+
+
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     """
     Register environment overrides for a specific task/rollout.
@@ -1204,6 +1298,10 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         task_id: The rollout's unique task identifier
         overrides: Dict of config keys to override
     """
+    for _key in _IMAGE_OVERRIDE_KEYS:
+        if _key in overrides:
+            _check_image_provenance(_key, overrides[_key])
+
     _task_env_overrides[task_id] = overrides
 
     # If a live environment already exists for this task, a freshly registered
@@ -1483,6 +1581,17 @@ def _get_env_config() -> Dict[str, Any]:
                         "(host/relative path won't work in sandbox). Using %r instead.",
                         cwd, env_type, default_cwd)
             cwd = default_cwd
+
+    # Image references arrive here from the env vars / config file — the paths
+    # that replaced the old setup prompts. Check provenance where they are
+    # actually read (warn-only; see _check_image_provenance).
+    for _env_var, _field in (
+        ("TERMINAL_DOCKER_IMAGE", "docker_image"),
+        ("TERMINAL_SINGULARITY_IMAGE", "singularity_image"),
+        ("TERMINAL_MODAL_IMAGE", "modal_image"),
+        ("TERMINAL_DAYTONA_IMAGE", "daytona_image"),
+    ):
+        _check_image_provenance(_field, os.getenv(_env_var, ""))
 
     return {
         "env_type": env_type,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1199,8 +1199,16 @@ def clear_session_cwd(session_key: str) -> None:
 # converge on.
 #
 # Warn-only, never blocking: private and air-gapped registries are legitimate
-# and a hard failure would break existing deployments. Extend the trusted set
-# via HERMES_TERMINAL_TRUSTED_REGISTRIES (comma-separated hosts).
+# and a hard failure would break existing deployments. Operators extend the
+# trusted set in config.yaml:
+#
+#   terminal:
+#     trusted_image_registries: ["registry.corp.internal"]
+#
+# which the startup bridges export as TERMINAL_TRUSTED_IMAGE_REGISTRIES —
+# every terminal setting reaches this module as a TERMINAL_* env var (see
+# TERMINAL_CONFIG_ENV_MAP); the env var is the internal transport, not the
+# user-facing knob.
 _DEFAULT_TRUSTED_IMAGE_REGISTRIES = (
     "docker.io",
     "ghcr.io",
@@ -1218,9 +1226,27 @@ _warned_images: Set[Tuple[str, str]] = set()
 
 
 def _trusted_image_registries() -> Tuple[str, ...]:
-    """Trusted registry hosts: the defaults plus any operator additions."""
-    extra = os.getenv("HERMES_TERMINAL_TRUSTED_REGISTRIES", "")
-    added = tuple(h.strip().lower() for h in extra.split(",") if h.strip())
+    """Trusted registry hosts: the defaults plus any operator additions.
+
+    Additions come from ``terminal.trusted_image_registries`` in config.yaml,
+    bridged to ``TERMINAL_TRUSTED_IMAGE_REGISTRIES``. The bridges JSON-encode
+    list values (as they do for docker_volumes / docker_env); a plain
+    comma-separated string is also accepted for hand-exported env.
+    """
+    raw = os.getenv("TERMINAL_TRUSTED_IMAGE_REGISTRIES", "").strip()
+    if not raw:
+        return _DEFAULT_TRUSTED_IMAGE_REGISTRIES
+    hosts: List[str] = []
+    if raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, list):
+            hosts = [str(h) for h in parsed]
+    if not hosts:
+        hosts = raw.split(",")
+    added = tuple(h.strip().lower() for h in hosts if h and h.strip())
     return _DEFAULT_TRUSTED_IMAGE_REGISTRIES + added
 
 
@@ -1271,7 +1297,8 @@ def _check_image_provenance(field: str, image: Any) -> None:
     logger.warning(
         "Sandbox %s=%r resolves to registry %r, which is not in the trusted "
         "set (%s). The sandbox will pull and execute this image. Add the host "
-        "to HERMES_TERMINAL_TRUSTED_REGISTRIES to silence this warning.",
+        "to terminal.trusted_image_registries in config.yaml to silence this "
+        "warning.",
         field, image, _image_registry_host(image),
         ", ".join(_trusted_image_registries()),
     )


### PR DESCRIPTION
Rebuilds the surviving substance of #9776 against current `main`, addressing the hermes-sweeper review on that PR.

#9776's head (`4199d14b83af`) is ~15.6k commits behind and conflicting; its hunks no longer apply to code that has since moved. Rather than rebase a dead branch, this reimplements what still has value on top of `main` as it stands today. #9776 can be closed in favour of this.

## Review points, addressed

**1. "The PR introduces its own installer, bypassing `tools_config._pip_install`."**

Correct, and dropped entirely. No new installer here. `main` already routes setup through `_pip_install` — what was still missing is the *constraints*. Those now resolve via a new `tools_config._pinned_specs(feature, fallback)`, which reads `tools/lazy_deps.LAZY_DEPS`, and the install itself still goes through `_pip_install`, retaining the uv → pip → ensurepip ladder that pip-less `uv venv` installs depend on.

Sites fixed (all previously unpinned — whatever the index served at setup time became executing code):

| site | before | after |
|---|---|---|
| `setup.py` modal | `_pip_install(["modal"])` | `LAZY_DEPS["terminal.modal"]` |
| `setup.py` daytona | `_pip_install(["daytona"])` | `LAZY_DEPS["terminal.daytona"]` |
| matrix adapter fallback | `_pip_install([matrix_pkg])` | `LAZY_DEPS["platform.matrix"]` |
| `setup.py` neutts | `-U neutts[all]` | `-U 'neutts[all]<2.0'` |

`setup` can no longer resolve a version the lazy runtime path never sees.

**2. "The Matrix setup target has moved; use `tools/lazy_deps.py`."**

Confirmed — `560010547` moved it to the plugin and the primary path already calls `lazy_deps.ensure("platform.matrix")`. The stale `setup.py` hunk from #9776 is not carried over. The one Matrix path still resolving `mautrix` unpinned was the adapter's `except ImportError` fallback (stripped installs where `tools.lazy_deps` itself is unimportable); it now mirrors the pinned `platform.matrix` group, so it installs the same set as the primary path.

**3. "Setup no longer prompts for those images; prompt-only validation misses current paths."**

Agreed, so the check is not at a prompt. Images reach the backends — which pull and execute them — via the `TERMINAL_*_IMAGE` env vars / config file and via `register_task_env_overrides()` (`tools/terminal_tool.py`). Provenance is now checked at both chokepoints, classifying the reference by Docker's own registry rule (first segment is a host only if it has a `.`/`:` or is `localhost`), with `docker://`/`oci://` schemes stripped and local Dockerfile paths left unclassified.

Warn-only, once per image: private and air-gapped registries are legitimate, and a hard failure would break existing deployments. Operators extend the trusted set with `HERMES_TERMINAL_TRUSTED_REGISTRIES`.

## Notes on judgement calls

- **neutts gets a bound, not a pin.** It has no pyproject extra and no `LAZY_DEPS` entry — it tracks upstream model code and is deliberately installed with `-U`. A major bound closes the vector `-U` opens (an unreviewed 2.x installing itself on every user's machine) without freezing 1.x model work. Happy to add a `tts.neutts` `LAZY_DEPS` entry with an exact pin instead if you'd prefer it under the same table as everything else.
- **The Matrix fallback now installs `mautrix[encryption]`** even when the user declined E2EE, because that is what the pinned group contains — matching what the primary `lazy_deps.ensure()` path already does today.
- The hardcoded fallback tuples (used only when `tools.lazy_deps` can't be imported) are drift-guarded by test against `LAZY_DEPS`.

## Tests

`tests/hermes_cli/test_setup_install_pins.py` — pins resolve from `LAZY_DEPS`; fallbacks don't drift; the lazy_deps-unimportable path; the neutts bound is actually passed to `_pip_install`; the `_pip_install` ladder is retained (guards against reintroducing a private installer).

`tests/tools/test_terminal_image_provenance.py` — registry classification (implicit Docker Hub, explicit hosts, `docker://`, Dockerfile paths), operator extension, warn-once, and both live paths still honouring the configured value.

42 new tests, all passing. Full `tests/hermes_cli` + `tests/tools` run compared against `origin/main`: identical 225-failure set on both (pre-existing, unrelated — webhook CLI, web UI build, etc.), branch adds exactly the 42 new passes.

Closes #9776.
