### PR TITLE
fix(teams): stop dropping attachments without a trace

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -898,7 +898,26 @@ class TeamsAdapter(BasePlatformAdapter):
         media_urls = []
         media_types = []
         media_kinds = []
-        for att in getattr(activity, "attachments", None) or []:
+        raw_attachments = list(getattr(activity, "attachments", None) or [])
+        # "The bot never received it" and "the bot dropped it" look identical
+        # from the outside: the sender asks about a file and the agent answers
+        # that it sees nothing. Record what arrived so the two can be told
+        # apart from the log alone.
+        if raw_attachments:
+            logger.info(
+                "[teams] inbound attachments (%d): %s",
+                len(raw_attachments),
+                "; ".join(
+                    "type=%s name=%s url=%s"
+                    % (
+                        getattr(a, "content_type", None) or "-",
+                        getattr(a, "name", None) or "-",
+                        "yes" if getattr(a, "content_url", None) else "no",
+                    )
+                    for a in raw_attachments
+                ),
+            )
+        for att in raw_attachments:
             content_url = getattr(att, "content_url", None)
             content_type = (getattr(att, "content_type", None) or "").lower()
             att_name = getattr(att, "name", None) or ""
@@ -920,6 +939,10 @@ class TeamsAdapter(BasePlatformAdapter):
                 download_url = content.get("downloadUrl") or content.get("download_url")
                 file_type = (content.get("fileType") or content.get("file_type") or "").lstrip(".")
                 if not download_url:
+                    logger.warning(
+                        "[teams] File attachment '%s' carried no downloadUrl, skipping",
+                        att_name or "-",
+                    )
                     continue
                 filename = att_name or (f"document.{file_type}" if file_type else "document")
                 try:
@@ -965,6 +988,15 @@ class TeamsAdapter(BasePlatformAdapter):
                         "[teams] Failed to cache attachment '%s' (%s): %s",
                         att_name or content_url, content_type, e,
                     )
+            else:
+                # No content_url and no branch above claimed it. A file
+                # attached in a channel arrives this way (contentType
+                # "reference"), and falling out of the loop here is what made
+                # the file invisible with nothing in the log to show for it.
+                logger.warning(
+                    "[teams] Attachment '%s' (%s) has no downloadable URL, skipping",
+                    att_name or "-", content_type or "-",
+                )
 
         # Classification: DOCUMENT wins over PHOTO/VIDEO/AUDIO for mixed
         # attachments — run.py's image handling keys off the per-path image/*

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -1,6 +1,7 @@
 """Tests for the Microsoft Teams platform adapter plugin."""
 
 import json
+import logging
 import sys
 import types
 from types import SimpleNamespace
@@ -561,6 +562,56 @@ class TestTeamsAttachmentClassification:
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.DOCUMENT
         assert len(event.media_urls) == 2
+
+    def _reference_attachment(self, name="notes.md"):
+        # A file attached in a Teams channel arrives as a SharePoint
+        # reference: named, but with no URL this adapter can fetch.
+        att = MagicMock()
+        att.content_type = "reference"
+        att.content_url = None
+        att.name = name
+        att.content = None
+        return att
+
+    @pytest.mark.anyio
+    async def test_unfetchable_attachment_is_logged(self, caplog):
+        """An attachment we cannot fetch must not vanish without a trace."""
+
+        adapter = self._make_adapter()
+        activity = self._make_activity([self._reference_attachment()])
+
+        with caplog.at_level(logging.WARNING):
+            await adapter._on_message(self._make_ctx(activity))
+
+        assert "notes.md" in caplog.text
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls == []
+
+    @pytest.mark.anyio
+    async def test_file_info_without_download_url_is_logged(self, caplog):
+        adapter = self._make_adapter()
+        attachment = self._file_download_attachment()
+        attachment.content = {"fileType": "pdf"}
+        activity = self._make_activity([attachment])
+
+        with caplog.at_level(logging.WARNING):
+            await adapter._on_message(self._make_ctx(activity))
+
+        assert "report.pdf" in caplog.text
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls == []
+
+    @pytest.mark.anyio
+    async def test_attachment_inventory_is_logged(self, caplog):
+        adapter = self._make_adapter()
+        activity = self._make_activity([self._reference_attachment()])
+
+        with caplog.at_level(logging.INFO):
+            await adapter._on_message(self._make_ctx(activity))
+
+        assert "inbound attachments (1)" in caplog.text
+        assert "type=reference" in caplog.text
+        assert "url=no" in caplog.text
 
 
 # ── _standalone_send (out-of-process cron delivery) ──────────────────────


### PR DESCRIPTION
## What

Two paths in the Teams attachment loop discard an attachment silently:

1. a `file.download.info` whose `content` carries no `downloadUrl` hits a bare `continue`
2. an attachment with no `content_url` falls out of the bottom of the loop, because the last branch has no `else`

Neither logs anything.

## Why it matters

A file attached in a Teams **channel** takes the second path. Teams represents it as a SharePoint reference the bot has no fetchable URL for, so the sender sees their file attached while the agent answers that it cannot see any document — and the log offers nothing to explain the gap.

From the outside, "Teams never delivered it" and "the adapter dropped it" look identical. That ambiguity is what makes this expensive to diagnose. Here is the log from a real channel post carrying one `.md` file, before this change — the only trace of the attachment is the mirrored HTML body, and the file itself leaves nothing at all:

```
INFO gateway.run: inbound message: platform=teams user=<user> chat=<conversation> msg='can you read this document?'
```

With this change the same message shows what actually arrived:

```
INFO  [teams] inbound attachments (1): type=reference name=<file>.md url=no
WARN  [teams] Attachment '<file>.md' (reference) has no downloadable URL, skipping
```

That single line is the difference between "the platform never sent it" and "we received it and threw it away".

## What this changes

- log the attachment inventory on every message that has one: content type, name, and whether a URL is present
- warn on each attachment the loop cannot fetch

Behaviour is otherwise unchanged. This only makes the existing drop visible; it does not attempt to fetch anything new.

## Tests

Three added to `TestTeamsAttachmentClassification`:

- an unfetchable `reference` attachment is logged
- a `file.download.info` without a `downloadUrl` is logged
- the inventory line records type / name / URL presence

Removing either warning makes the first two fail. `tests/gateway/test_teams.py` passes (23).

## Related

Surfacing this to the agent as a user-visible notice needs the dropped-attachment bookkeeping proposed in #73685; that part is deliberately not in this PR, so this one applies on its own.