### PR TITLE
fix(anthropic): never refresh an API-key session into Claude Code OAuth credentials (#75641)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5193,6 +5193,16 @@ class AIAgent:
         _base = getattr(self, "_anthropic_base_url", "") or ""
         if "azure.com" in _base:
             return False
+        # A session on a regular Console API key (sk-ant-api…) has nothing to
+        # refresh — API keys never expire. Re-resolving here would let
+        # resolve_anthropic_token() prefer Claude Code OAuth credentials
+        # (~/.claude/.credentials.json, priority 3) over the explicitly
+        # selected API key (priority 5), silently switching the user's billing
+        # identity after a transient 429/401 (#75641). Only OAuth/setup-token
+        # sessions may be refreshed.
+        from agent.anthropic_adapter import _is_oauth_token as _is_oauth_shape
+        if not _is_oauth_shape(getattr(self, "_anthropic_api_key", "") or ""):
+            return False
 
         try:
             from agent.anthropic_adapter import resolve_anthropic_token, build_anthropic_client

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5560,7 +5560,17 @@ class TestOAuthFlagAfterCredentialRefresh:
     """_is_anthropic_oauth must update when token type changes during refresh."""
 
     def test_oauth_flag_updates_api_key_to_oauth(self, agent):
-        """Refreshing from API key to OAuth token must set flag to True."""
+        """API-key session must NOT refresh into OAuth credentials (#75641).
+
+        ``_try_refresh_anthropic_client_credentials`` used to call
+        ``resolve_anthropic_token()`` unconditionally, which prefers Claude
+        Code OAuth credentials (~/.claude/.credentials.json, priority 3) over
+        the explicitly selected API key (priority 5). After a transient 429,
+        the retry's request-local client was silently rebuilt with the OAuth
+        token — switching the user's billing identity and producing
+        "extra usage" 400s. A plain API key never expires, so there is
+        nothing to refresh; the refresh must be a no-op for API-key sessions.
+        """
         agent.api_mode = "anthropic_messages"
         agent.provider = "anthropic"
         agent._anthropic_api_key = "sk-ant-api-old"
@@ -5575,8 +5585,9 @@ class TestOAuthFlagAfterCredentialRefresh:
         ):
             result = agent._try_refresh_anthropic_client_credentials()
 
-        assert result is True
-        assert agent._is_anthropic_oauth is True
+        # The API-key session must be preserved — no refresh, no OAuth swap.
+        assert result is False
+        assert agent._is_anthropic_oauth is False
 
     def test_oauth_flag_updates_oauth_to_api_key(self, agent):
         """Refreshing from OAuth to API key must set flag to False."""


### PR DESCRIPTION
## Summary

Fixes #75641: Anthropic API-key requests fail with a 429 and then a confusing OAuth "extra usage" 400 on retry.

## Root cause

`AIAgent._try_refresh_anthropic_client_credentials()` runs before **every** request-client build — including the retry after a transient 429 — and calls `resolve_anthropic_token()`. That resolver prioritizes:

1. `ANTHROPIC_TOKEN` env
2. `CLAUDE_CODE_OAUTH_TOKEN` env
3. **Claude Code credentials (`~/.claude.json` / `~/.claude/.credentials.json`)** ← wins when present
4. credential-pool OAuth entry
5. `ANTHROPIC_API_KEY` env

When the user explicitly selected a Console API key (the only credential in `hermes auth list`), but Claude Code's credential files still exist on disk (as in the report: "Claude Code's own credential files were not deleted"), the refresh swapped the API key for the Claude Code OAuth token, rebuilt the client, and the retry went out under OAuth billing — producing the `400 "Third-party apps now draw from your extra usage"` error.

## Fix

A plain Console API key (`sk-ant-api…`) never expires, so there is nothing to refresh for an API-key session. `_try_refresh_anthropic_client_credentials()` now returns `False` immediately unless the current credential is OAuth/setup-token shaped (`_is_oauth_token`). OAuth/setup-token sessions keep the existing refresh behavior (including the token-type-change flag updates).

## Tests

- `tests/run_agent/test_run_agent.py::TestOAuthFlagAfterCredentialRefresh` — rewrote `test_oauth_flag_updates_api_key_to_oauth` to assert the corrected behavior (API-key session is preserved; no OAuth swap, flag stays `False`).
- `test_run_agent.py` refresh/oauth selection + `test_anthropic_third_party_oauth_guard.py` + `test_anthropic_response_header_capture.py`: **227 passed**.
