### PR TITLE
fix(cli): untrack sqlite connections only after close succeeds

### DIFF
--- a/hermes_cli/sqlite_safe_read.py
+++ b/hermes_cli/sqlite_safe_read.py
@@ -40,7 +40,7 @@ lifecycle**. ``_live_lock`` is therefore held across three critical sections,
 each of which spans the syscall *and* the registry mutation:
 
 * open + register (:func:`connect_tracked`)
-* unregister + close (:meth:`TrackedConnection.close`)
+* close + unregister (:meth:`TrackedConnection.close`)
 * check + ``open``/``read``/``close`` (:func:`read_header_bytes_preopen`)
 
 Without that, a thread could pass the "no live connection" check, a second
@@ -154,10 +154,14 @@ class _TrackingMixin:
     def close(self) -> None:  # type: ignore[misc]
         with _live_lock:
             path = getattr(self, "_hermes_tracked_path", None)
+            # Close first; untrack only once the descriptor is actually gone.
+            # Untracking before a failing close (e.g. cross-thread
+            # ProgrammingError) leaves the FD open while the byte-probe
+            # guard thinks nothing is live — see #75629.
+            super().close()  # type: ignore[misc]
             if path is not None:
                 self._hermes_tracked_path = None
                 untrack_connection(path)
-            super().close()  # type: ignore[misc]
 
 
 class TrackedConnection(_TrackingMixin, sqlite3.Connection):
@@ -169,9 +173,11 @@ class TrackedConnection(_TrackingMixin, sqlite3.Connection):
     method every close path must go through — keeps the registry from
     drifting upward and permanently disabling byte-probes.
 
-    The unregister and the real ``close()`` happen together under
+    The real ``close()`` and the unregister happen together under
     ``_live_lock`` so a concurrent probe can never observe "no live
-    connection" while this descriptor is still open.
+    connection" while this descriptor is still open. Unregister runs only
+    after ``close()`` succeeds; a raising close leaves the connection
+    tracked so the byte-probe guard keeps refusing.
 
     Note ``with conn:`` does NOT close a sqlite3 connection (it only commits or
     rolls back), so this hook is not fired spuriously by transaction scopes.

--- a/tests/test_sqlite_lock_safe_inspection.py
+++ b/tests/test_sqlite_lock_safe_inspection.py
@@ -162,6 +162,44 @@ def test_tracking_registry_does_not_leak_across_close_paths(tmp_path, clean_regi
     assert not has_live_connection(db)
 
 
+def test_failed_close_keeps_connection_tracked(tmp_path, clean_registry):
+    """A raising close must not release the registry (#75629).
+
+    Untracking before ``super().close()`` leaves the descriptor open while
+    ``has_live_connection`` reports false, so the byte-probe guard permits
+    ``open``/``close`` on a live database — cancelling POSIX advisory locks.
+    """
+    from hermes_cli.sqlite_safe_read import connect_tracked
+
+    class ControllableConnection(sqlite3.Connection):
+        def close(self):
+            if getattr(self, "_hermes_fail_close", False):
+                raise sqlite3.ProgrammingError(
+                    "SQLite objects created in a thread can only be used in "
+                    "that same thread"
+                )
+            return super().close()
+
+    db = tmp_path / "state.db"
+    _make_db(db, "WAL")
+
+    conn = connect_tracked(db, factory=ControllableConnection)
+    assert has_live_connection(db)
+    assert read_header_bytes_preopen(db, length=16) is None
+
+    conn._hermes_fail_close = True
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.close()
+
+    assert has_live_connection(db), "failed close must leave the registry entry"
+    assert read_header_bytes_preopen(db, length=16) is None
+
+    conn._hermes_fail_close = False
+    conn.close()
+    assert not has_live_connection(db)
+    assert read_header_bytes_preopen(db, length=16) is not None
+
+
 def test_probe_and_connect_do_not_race(tmp_path, clean_registry, monkeypatch):
     """The check and the raw read must be atomic w.r.t. connection lifecycle.
 


### PR DESCRIPTION
## What does this PR do?

`TrackedConnection.close()` previously decremented the live-connection registry **before** calling `super().close()`. If close raised (e.g. cross-thread `ProgrammingError`), the FD stayed open while `has_live_connection()` reported false, so `read_header_bytes_preopen()` incorrectly allowed a byte-level open/close on a live database — the POSIX advisory-lock cancellation path this module exists to prevent.

This PR inverts the order: close first, untrack only on success. The entire transition stays under `_live_lock`.

## Related Issue

Fixes #75629

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/sqlite_safe_read.py` — `_TrackingMixin.close()` closes before untracking; docs updated for close+unregister ordering
- `tests/test_sqlite_lock_safe_inspection.py` — regression test that a raising close leaves the registry entry and keeps the byte-probe refused

## How to Test

1. `uv run --extra dev pytest tests/test_sqlite_lock_safe_inspection.py -v`
2. Confirm `test_failed_close_keeps_connection_tracked` passes (simulated `ProgrammingError` from a controllable connection factory)
3. Optional integration: open a tracked connection on a worker thread, close it from the main thread with default `check_same_thread=True`, assert `has_live_connection()` stays true after the swallowed `ProgrammingError`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_sqlite_lock_safe_inspection.py` and all tests pass (7 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (module/class docstrings updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (lock/registry logic is cross-platform; no OS-specific APIs added)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — unit/regression coverage in `tests/test_sqlite_lock_safe_inspection.py`.
