### PR TITLE
fix(whatsapp): harden bridge reconnection supervision

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -796,6 +796,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             logger.error("[%s] %s", self.name, message)
             self._set_fatal_error("whatsapp_bridge_exited", message, retryable=True)
             self._close_bridge_log()
+            # The poll task is the owner reporting this fatal error. Runner
+            # teardown calls disconnect() in a child task; if _poll_task still
+            # points at this task, disconnect() cancels its parent while the
+            # parent is awaiting the fatal handler, aborting before the runner
+            # can queue background reconnection.
+            if self._poll_task is asyncio.current_task():
+                self._poll_task = None
             await self._notify_fatal_error()
         return self.fatal_error_message or message
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -34,6 +34,12 @@ import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
+  createCachedVersionResolver,
+  createConnectionWatchdog,
+  createReconnectScheduler,
+  reconnectDelayForReason,
+} from './reconnect.js';
+import {
   buildPollPayload,
   buildLocationPayload,
   buildTextSendPayload,
@@ -385,6 +391,22 @@ function rememberSentId(id) {
 
 let sock = null;
 let connectionState = 'disconnected';
+const resolveBaileysVersion = createCachedVersionResolver(
+  fetchLatestBaileysVersion,
+  {
+    timeoutMs: 10_000,
+    onFallback: (error) => {
+      logger.warn({ err: error }, 'Baileys version discovery failed; using packaged default');
+    },
+  },
+);
+const reconnectScheduler = createReconnectScheduler({
+  onError: (error) => {
+    logger.error({ err: error }, 'WhatsApp reconnect failed; exiting for supervisor recovery');
+    process.exit(1);
+  },
+});
+const connectionWatchdog = createConnectionWatchdog();
 
 function emitPairEvent(event) {
   if (!PAIR_JSON) return;
@@ -395,10 +417,9 @@ function emitPairEvent(event) {
 
 async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
-  const { version } = await fetchLatestBaileysVersion();
+  const version = await resolveBaileysVersion();
 
-  sock = makeWASocket({
-    version,
+  const socketOptions = {
     auth: state,
     logger,
     printQRInTerminal: false,
@@ -412,11 +433,19 @@ async function startSocket() {
       // This is enough for Baileys to complete the retry handshake.
       return { conversation: '' };
     },
-  });
+  };
+  if (version) socketOptions.version = version;
+  const currentSock = makeWASocket(socketOptions);
+  sock = currentSock;
+  connectionWatchdog.arm(() => {
+    if (sock !== currentSock || connectionState === 'connected') return;
+    logger.error('WhatsApp socket did not settle within 45s; exiting for supervisor recovery');
+    process.exit(1);
+  }, 45_000);
 
-  sock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });
+  currentSock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });
 
-  sock.ev.on('connection.update', (update) => {
+  currentSock.ev.on('connection.update', (update) => {
     const { connection, lastDisconnect, qr } = update;
 
     if (qr) {
@@ -430,6 +459,8 @@ async function startSocket() {
     }
 
     if (connection === 'close') {
+      if (sock !== currentSock) return;
+      connectionWatchdog.cancel();
       const reason = new Boom(lastDisconnect?.error)?.output?.statusCode;
       connectionState = 'disconnected';
 
@@ -449,14 +480,17 @@ async function startSocket() {
             console.log(`⚠️  Connection closed (reason: ${reason}). Reconnecting in 3s...`);
           }
         }
-        setTimeout(startSocket, reason === 515 ? 1000 : 3000);
+        reconnectScheduler.schedule(startSocket, reconnectDelayForReason(reason));
       }
     } else if (connection === 'open') {
+      if (sock !== currentSock) return;
+      connectionWatchdog.cancel();
+      reconnectScheduler.cancel();
       connectionState = 'connected';
-      const connectedUser = sock?.user
+      const connectedUser = currentSock?.user
         ? {
-            id: sock.user.id || null,
-            name: sock.user.name || sock.user.verifiedName || null,
+            id: currentSock.user.id || null,
+            name: currentSock.user.name || currentSock.user.verifiedName || null,
           }
         : null;
       emitPairEvent({ event: 'connected', user: connectedUser });
@@ -1145,6 +1179,9 @@ if (PAIR_ONLY) {
       console.log(`👤 WHATSAPP_FORWARD_OWNER_MESSAGES=true — owner-typed messages will be forwarded with fromOwner:true`);
     }
     console.log();
-    startSocket();
+    startSocket().catch((error) => {
+      logger.error({ err: error }, 'WhatsApp socket startup failed');
+      process.exit(1);
+    });
   });
 }

--- a/scripts/whatsapp-bridge/reconnect.js
+++ b/scripts/whatsapp-bridge/reconnect.js
@@ -1,0 +1,108 @@
+export function withTimeout(promise, timeoutMs, label, timers = globalThis) {
+  let timeoutId;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = timers.setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    timers.clearTimeout(timeoutId);
+  });
+}
+
+export function createCachedVersionResolver(
+  discoverVersion,
+  { timeoutMs = 10_000, onFallback = () => {} } = {},
+) {
+  let cachedVersion;
+  let hasResolved = false;
+
+  return async function resolveVersion() {
+    if (hasResolved) return cachedVersion;
+
+    try {
+      const result = await withTimeout(
+        Promise.resolve().then(discoverVersion),
+        timeoutMs,
+        'Baileys version discovery',
+      );
+      cachedVersion = Array.isArray(result?.version) ? result.version : null;
+    } catch (error) {
+      cachedVersion = null;
+      onFallback(error);
+    }
+    hasResolved = true;
+    return cachedVersion;
+  };
+}
+
+export function createConnectionWatchdog({
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+} = {}) {
+  let timerId = null;
+
+  return {
+    arm(onTimeout, timeoutMs) {
+      if (timerId !== null) clearTimer(timerId);
+      timerId = setTimer(() => {
+        timerId = null;
+        onTimeout();
+      }, timeoutMs);
+    },
+    cancel() {
+      if (timerId === null) return;
+      clearTimer(timerId);
+      timerId = null;
+    },
+  };
+}
+
+export function reconnectDelayForReason(reason) {
+  return reason === 515 ? 1000 : 3000;
+}
+
+export function createReconnectScheduler({
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+  onError,
+} = {}) {
+  let timerId = null;
+  let inFlight = false;
+  let queuedRetry = null;
+
+  const schedule = (start, delayMs) => {
+    if (timerId !== null) return false;
+    if (inFlight) {
+      if (queuedRetry === null) queuedRetry = { start, delayMs };
+      return false;
+    }
+    timerId = setTimer(async () => {
+      timerId = null;
+      inFlight = true;
+      try {
+        await start();
+      } catch (error) {
+        onError?.(error);
+      } finally {
+        inFlight = false;
+        const retry = queuedRetry;
+        queuedRetry = null;
+        if (retry !== null) schedule(retry.start, retry.delayMs);
+      }
+    }, delayMs);
+    return true;
+  };
+
+  return {
+    schedule,
+    cancel() {
+      queuedRetry = null;
+      if (timerId === null) return;
+      clearTimer(timerId);
+      timerId = null;
+    },
+  };
+}

--- a/scripts/whatsapp-bridge/reconnect.test.js
+++ b/scripts/whatsapp-bridge/reconnect.test.js
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createCachedVersionResolver,
+  createConnectionWatchdog,
+  createReconnectScheduler,
+  reconnectDelayForReason,
+  withTimeout,
+} from './reconnect.js';
+
+test('withTimeout rejects a stalled operation', async () => {
+  const never = new Promise(() => {});
+
+  await assert.rejects(
+    withTimeout(never, 10, 'version discovery'),
+    /version discovery timed out after 10ms/,
+  );
+});
+
+test('version resolver caches the first successful discovery', async () => {
+  let calls = 0;
+  const resolveVersion = createCachedVersionResolver(async () => {
+    calls += 1;
+    return { version: [2, 3000, 1] };
+  }, { timeoutMs: 50 });
+
+  assert.deepEqual(await resolveVersion(), [2, 3000, 1]);
+  assert.deepEqual(await resolveVersion(), [2, 3000, 1]);
+  assert.equal(calls, 1);
+});
+
+test('version resolver falls back instead of wedging when discovery stalls', async () => {
+  const resolveVersion = createCachedVersionResolver(
+    async () => new Promise(() => {}),
+    { timeoutMs: 10 },
+  );
+
+  assert.equal(await resolveVersion(), null);
+});
+
+test('close code 428 uses the bounded normal reconnect path', () => {
+  assert.equal(reconnectDelayForReason(428), 3000);
+  assert.equal(reconnectDelayForReason(515), 1000);
+});
+
+test('reconnect scheduler deduplicates close events and surfaces start failure', async () => {
+  const callbacks = [];
+  const errors = [];
+  let starts = 0;
+  const scheduler = createReconnectScheduler({
+    setTimer: (callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    },
+    clearTimer: () => {},
+    onError: (error) => errors.push(error),
+  });
+
+  scheduler.schedule(async () => {
+    starts += 1;
+    throw new Error('socket start failed');
+  }, 3000);
+  scheduler.schedule(async () => {
+    starts += 1;
+  }, 3000);
+
+  assert.equal(callbacks.length, 1);
+  await callbacks[0]();
+  assert.equal(starts, 1);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0].message, /socket start failed/);
+});
+
+test('reconnect scheduler coalesces one retry while start is in flight', async () => {
+  const callbacks = [];
+  let releaseStart;
+  let starts = 0;
+  const scheduler = createReconnectScheduler({
+    setTimer: (callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    },
+    clearTimer: () => {},
+  });
+
+  assert.equal(scheduler.schedule(async () => {
+    starts += 1;
+    await new Promise((resolve) => { releaseStart = resolve; });
+  }, 3000), true);
+
+  const firstAttempt = callbacks[0]();
+  await Promise.resolve();
+  assert.equal(starts, 1);
+  assert.equal(scheduler.schedule(async () => { starts += 1; }, 3000), false);
+  assert.equal(scheduler.schedule(async () => { starts += 100; }, 3000), false);
+  assert.equal(callbacks.length, 1);
+
+  releaseStart();
+  await firstAttempt;
+  assert.equal(callbacks.length, 2);
+  await callbacks[1]();
+  assert.equal(starts, 2);
+});
+
+test('reconnect scheduler cancel drops a retry queued during start', async () => {
+  const callbacks = [];
+  let releaseStart;
+  const scheduler = createReconnectScheduler({
+    setTimer: (callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    },
+    clearTimer: () => {},
+  });
+
+  scheduler.schedule(
+    async () => new Promise((resolve) => { releaseStart = resolve; }),
+    3000,
+  );
+  const firstAttempt = callbacks[0]();
+  await Promise.resolve();
+  scheduler.schedule(async () => {}, 3000);
+  scheduler.cancel();
+
+  releaseStart();
+  await firstAttempt;
+  assert.equal(callbacks.length, 1);
+});
+
+test('connection watchdog fails a socket that never opens or closes', () => {
+  const callbacks = [];
+  const cleared = [];
+  const watchdog = createConnectionWatchdog({
+    setTimer: (callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    },
+    clearTimer: (id) => cleared.push(id),
+  });
+  let timedOut = false;
+
+  watchdog.arm(() => {
+    timedOut = true;
+  }, 30_000);
+  assert.equal(callbacks.length, 1);
+  callbacks[0]();
+  assert.equal(timedOut, true);
+
+  watchdog.arm(() => {}, 30_000);
+  watchdog.cancel();
+  assert.deepEqual(cleared, [2]);
+});

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -66,6 +66,8 @@ def _make_adapter():
     adapter._auto_tts_disabled_chats = set()
     adapter._message_queue = asyncio.Queue()
     adapter._http_session = None
+    adapter._poll_task = None
+    adapter._shutting_down = False
     return adapter
 
 
@@ -478,3 +480,62 @@ class TestNoCredsPreflight:
         # but the fatal-error code is NOT the "not paired" one.
         assert result is False
         assert adapter._fatal_error_code != "whatsapp_not_paired"
+
+
+class TestDisconnectFromPollTask:
+    @pytest.mark.asyncio
+    async def test_disconnect_does_not_cancel_or_await_current_poll_task(self, tmp_path):
+        adapter = _make_adapter()
+        adapter._session_path = tmp_path
+        adapter._bridge_process = None
+        adapter._http_session = None
+        adapter._release_platform_lock = MagicMock()
+        adapter._mark_disconnected = MagicMock()
+        adapter._close_bridge_log = MagicMock()
+
+        async def invoke_disconnect_from_poll_task():
+            adapter._poll_task = asyncio.current_task()
+            await adapter.disconnect()
+
+        task = asyncio.create_task(invoke_disconnect_from_poll_task())
+        await asyncio.wait_for(task, timeout=1)
+
+        assert adapter._poll_task is None
+        adapter._mark_disconnected.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_poll_fatal_handoff_reaches_runner_reconnect_queue(self, tmp_path):
+        from gateway.config import GatewayConfig, PlatformConfig
+        from gateway.run import GatewayRunner
+
+        adapter = _make_adapter()
+        adapter._session_path = tmp_path
+        adapter._running = True
+        adapter._release_platform_lock = MagicMock()
+        adapter._mark_disconnected = MagicMock()
+        adapter._close_bridge_log = MagicMock()
+        dead_proc = MagicMock()
+        dead_proc.pid = 999_999_999
+        dead_proc.poll.return_value = -15
+        dead_proc.returncode = -15
+        adapter._bridge_process = dead_proc
+
+        config = GatewayConfig(
+            platforms={Platform.WHATSAPP: PlatformConfig(enabled=True, token="token")},
+            sessions_dir=tmp_path / "sessions",
+        )
+        runner = GatewayRunner(config)
+        runner.adapters = {Platform.WHATSAPP: adapter}
+        runner.delivery_router.adapters = runner.adapters
+        adapter.set_fatal_error_handler(runner._handle_adapter_fatal_error)
+
+        async def report_fatal_from_poll_task():
+            adapter._poll_task = asyncio.current_task()
+            return await adapter._check_managed_bridge_exit()
+
+        task = asyncio.create_task(report_fatal_from_poll_task())
+        result = await asyncio.gather(task, return_exceptions=True)
+
+        assert result == ["WhatsApp bridge process exited unexpectedly (code -15)."]
+        assert runner.adapters == {}
+        assert Platform.WHATSAPP in runner._failed_platforms


### PR DESCRIPTION
## Summary

- Let a managed WhatsApp bridge exit hand off to `GatewayRunner` without the poll task cancelling itself during teardown.
- Bound and cache Baileys version discovery, with packaged-version fallback when discovery stalls or fails.
- Add a 45-second socket settle watchdog and fail back to the process supervisor when startup/reconnect fails.
- Fence stale socket events and coalesce reconnect requests so only one timer, one in-flight start, and one deferred retry can exist.

## Problem

When the managed Node bridge exits inside the adapter poll task, the fatal-error handler tears the adapter down from a child task. `disconnect()` then cancels the still-recorded poll task, aborting the parent before `GatewayRunner` can queue background reconnection.

The Node bridge also had unbounded version discovery and raw `setTimeout(startSocket, ...)` calls. A stalled discovery or repeated/early close event could wedge startup, overlap sockets, or silently drop the next reconnect.

## Behavior

- The current poll task clears its ownership marker before invoking the fatal callback.
- Version discovery has a 10-second ceiling and one cached result.
- A socket that neither opens nor closes within 45 seconds exits for supervisor recovery.
- Duplicate close events share one reconnect timer.
- A close emitted while a reconnect start is in flight becomes one deferred retry, rather than starting concurrently or being discarded.
- A successful open cancels pending and deferred retries.
- Events from stale socket generations cannot overwrite current state.

## Verification

- `./scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py -q` (14 passed)
- `node --test reconnect.test.js allowlist.test.mjs bridge.sendqueue.test.mjs outbound_ids.test.mjs owner_message_gate.test.mjs` (28 passed)
- `node bridge.native.test.mjs`
- `node --check scripts/whatsapp-bridge/bridge.js`
- `node --check scripts/whatsapp-bridge/reconnect.js`
- Ruff check on changed Python files
- `git diff --check`
- Added-line secret/unsafe-execution scan
- Independent fail-closed review of exact diff SHA-256 `14d789fcc3394ea53403e2b2f61c36cb881faf1c50073a27d19d9b4e27a661f2`: no security or logic findings

## Related work

#73795 changes which WhatsApp Web version resolver is preferred. This PR is complementary: its cache/timeout wrapper can bound whichever resolver wins. If #73795 lands first, the overlap is limited to the version-discovery call site.

No package manifest or lockfile changes are included.
