### PR TITLE
fix: harden Copilot routing fail-closed

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2614,7 +2614,29 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
             continue
         active_sources.add(source)
         base_url = env_url or pconfig.inference_base_url
-        if provider == "kimi-coding":
+        if provider == "copilot":
+            try:
+                from hermes_cli.copilot_auth import (
+                    get_copilot_api_token,
+                    validate_copilot_token,
+                )
+
+                valid, message = validate_copilot_token(token)
+                if not valid:
+                    logger.warning(
+                        "Token from %s is not supported for Copilot: %s",
+                        env_var,
+                        message,
+                    )
+                    continue
+                api_token, enterprise_base_url = get_copilot_api_token(token)
+                token = api_token
+                if enterprise_base_url:
+                    base_url = enterprise_base_url
+            except Exception as exc:
+                logger.debug("Copilot env token exchange failed for %s: %s", env_var, exc)
+                continue
+        elif provider == "kimi-coding":
             base_url = _resolve_kimi_base_url(token, pconfig.inference_base_url, env_url)
         elif provider == "zai":
             base_url = _resolve_zai_base_url(token, pconfig.inference_base_url, env_url)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -12,7 +12,7 @@ import re
 from dataclasses import dataclass, fields, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
@@ -1782,6 +1782,64 @@ class CredentialPool:
         entry = available[0]
         self._current_id = entry.id
         return entry
+
+    def select_from_sources(
+        self,
+        allowed_sources: Iterable[str],
+        *,
+        refresh: bool = True,
+    ) -> Optional[PooledCredential]:
+        """Select an available entry whose source is explicitly allowed.
+
+        Unlike ``entries()``, this uses the same availability filtering as
+        normal runtime selection, so exhausted or DEAD rows cannot satisfy a
+        constrained provider route. The selection and cursor update happen under
+        the pool lock so a rejected generic entry is never left as current.
+        """
+        sources = {str(source or "") for source in allowed_sources}
+        sources.discard("")
+        if not sources:
+            return None
+
+        with self._lock:
+            available = [
+                entry
+                for entry in self._available_entries(clear_expired=True, refresh=refresh)
+                if entry.source in sources
+            ]
+            if not available:
+                current = self._current_unlocked()
+                if current is not None and current.source not in sources:
+                    self._current_id = None
+                self._log_no_available_entries()
+                return None
+
+            self._last_no_entries_log_at = None
+
+            if self._strategy == STRATEGY_RANDOM:
+                entry = random.choice(available)
+                self._current_id = entry.id
+                return entry
+
+            if self._strategy == STRATEGY_LEAST_USED and len(available) > 1:
+                entry = min(available, key=lambda e: e.request_count)
+                updated = replace(entry, request_count=entry.request_count + 1)
+                self._replace_entry(entry, updated)
+                self._current_id = entry.id
+                return updated
+
+            if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
+                entry = available[0]
+                rotated = [candidate for candidate in self._entries if candidate.id != entry.id]
+                rotated.append(replace(entry, priority=len(self._entries) - 1))
+                self._entries = [replace(candidate, priority=idx) for idx, candidate in enumerate(rotated)]
+                self._persist()
+                self._current_id = entry.id
+                return self._current_unlocked() or entry
+
+            entry = available[0]
+            self._current_id = entry.id
+            return entry
 
     def peek(self) -> Optional[PooledCredential]:
         # Single lock acquisition for the whole read; call the unlocked

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -584,15 +584,54 @@ def has_usable_secret(value: Any, *, min_length: int = 4) -> bool:
     return True
 
 
+def _configured_copilot_token_env_vars() -> Optional[tuple[str, ...]]:
+    """Return the credential env policy for an explicitly configured Copilot route.
+
+    A profile with ``model.provider: copilot`` is an explicit routing choice, not
+    provider auto-discovery.  Keep that route fail-closed by defaulting to the
+    provider-owned ``COPILOT_GITHUB_TOKEN`` instead of borrowing generic GitHub
+    tool credentials (``GH_TOKEN`` / ``GITHUB_TOKEN`` / ``gh auth token``).  A
+    profile may override the env var with ``model.key_env`` / ``api_key_env``.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        model = (load_config() or {}).get("model")
+    except Exception:
+        return None
+    if not isinstance(model, dict):
+        return None
+    provider = str(model.get("provider") or "").strip().lower()
+    if provider not in {"copilot", "github", "github-copilot", "github-model", "github-models"}:
+        return None
+    for key in ("key_env", "api_key_env"):
+        env_name = str(model.get(key) or "").strip()
+        if env_name:
+            return (env_name,)
+    return ("COPILOT_GITHUB_TOKEN",)
+
+
+def _resolve_copilot_token_for_runtime() -> tuple[str, str]:
+    from hermes_cli.copilot_auth import resolve_copilot_token
+
+    env_vars = _configured_copilot_token_env_vars()
+    if env_vars:
+        return resolve_copilot_token(env_vars=env_vars, allow_gh_cli=False)
+    return resolve_copilot_token()
+
+
 def _resolve_api_key_provider_secret(
     provider_id: str, pconfig: ProviderConfig
 ) -> tuple[str, str]:
     """Resolve an API-key provider's token and indicate where it came from."""
     if provider_id == "copilot":
-        # Use the dedicated copilot auth module for proper token validation
+        # Use the dedicated copilot auth module for proper token validation.
+        # When config.yaml explicitly selects Copilot, keep credential routing
+        # fail-closed to the profile-owned Copilot token instead of falling
+        # through to generic GitHub tool credentials.
         try:
-            from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
-            token, source = resolve_copilot_token()
+            from hermes_cli.copilot_auth import get_copilot_api_token
+            token, source = _resolve_copilot_token_for_runtime()
             if token:
                 api_token, _base_url = get_copilot_api_token(token)
                 return api_token, source
@@ -6972,11 +7011,8 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
         # resolves an empty base URL (#50252).
         base_url = env_url.rstrip("/") if env_url else pconfig.inference_base_url
         try:
-            from hermes_cli.copilot_auth import (
-                resolve_copilot_token,
-                get_copilot_api_token,
-            )
-            raw_token, _ = resolve_copilot_token()
+            from hermes_cli.copilot_auth import get_copilot_api_token
+            raw_token, _ = _resolve_copilot_token_for_runtime()
             if raw_token:
                 _, resolved = get_copilot_api_token(raw_token)
                 resolved = (resolved or "").strip()

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -72,14 +72,22 @@ def validate_copilot_token(token: str) -> tuple[bool, str]:
     return True, "OK"
 
 
-def resolve_copilot_token() -> tuple[str, str]:
+def resolve_copilot_token(
+    *,
+    env_vars: tuple[str, ...] | None = None,
+    allow_gh_cli: bool = True,
+) -> tuple[str, str]:
     """Resolve a GitHub token suitable for Copilot API use.
 
     Returns (token, source) where source describes where the token came from.
+    By default this follows Copilot CLI compatibility order. Callers that are
+    enforcing a profile-pinned credential may pass ``env_vars`` and disable the
+    ``gh auth token`` fallback so generic GitHub credentials cannot be borrowed
+    silently.
     Raises ValueError if only a classic PAT is available.
     """
     # 1. Check env vars in priority order
-    for env_var in COPILOT_ENV_VARS:
+    for env_var in env_vars if env_vars is not None else COPILOT_ENV_VARS:
         val = os.getenv(env_var, "").strip()
         if val:
             valid, msg = validate_copilot_token(val)
@@ -89,6 +97,9 @@ def resolve_copilot_token() -> tuple[str, str]:
                 )
                 continue
             return val, env_var
+
+    if not allow_gh_cli:
+        return "", ""
 
     # 2. Fall back to gh auth token
     token = _try_gh_cli_token()

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -301,6 +301,72 @@ def _get_model_config() -> Dict[str, Any]:
     return {}
 
 
+_COPILOT_PROVIDER_ALIASES = frozenset({
+    "copilot",
+    "github",
+    "github-copilot",
+    "github-model",
+    "github-models",
+})
+
+
+def _canonical_provider_for_match(provider: Optional[str]) -> str:
+    normalized = (provider or "").strip().lower()
+    if normalized in _COPILOT_PROVIDER_ALIASES:
+        return "copilot"
+    return normalized
+
+
+def _configured_provider_matches(provider: str, configured_provider: Optional[str]) -> bool:
+    configured = (configured_provider or "").strip().lower()
+    if not configured:
+        return False
+    if provider == "custom":
+        return configured == "custom" or configured.startswith("custom:")
+    return _canonical_provider_for_match(configured) == _canonical_provider_for_match(provider)
+
+
+def _configured_copilot_pool_sources(model_cfg: Dict[str, Any]) -> Optional[set[str]]:
+    """Allowed pool sources for an explicitly configured Copilot route.
+
+    A profile that deliberately pins Copilot should not borrow generic GitHub
+    credentials from the pool.  Pool entries are still usable for the configured
+    Copilot env var itself, so already-exchanged COPILOT_GITHUB_TOKEN rows keep
+    working without allowing env:GITHUB_TOKEN / gh_cli fallthrough.
+    """
+    if not _configured_provider_matches("copilot", model_cfg.get("provider")):
+        return None
+    for key in ("key_env", "api_key_env"):
+        env_name = str(model_cfg.get(key) or "").strip()
+        if env_name:
+            return {f"env:{env_name}"}
+    return {"env:COPILOT_GITHUB_TOKEN"}
+
+
+def _select_pool_entry_for_runtime(
+    *,
+    provider: str,
+    pool: CredentialPool,
+    model_cfg: Dict[str, Any],
+) -> Optional[PooledCredential]:
+    entry = pool.select()
+    if provider != "copilot":
+        return entry
+
+    allowed_sources = _configured_copilot_pool_sources(model_cfg)
+    if allowed_sources is None:
+        return entry
+    if entry is not None and getattr(entry, "source", "") in allowed_sources:
+        return entry
+
+    for candidate in pool.entries():
+        if getattr(candidate, "source", "") not in allowed_sources:
+            continue
+        if getattr(candidate, "runtime_api_key", None) or getattr(candidate, "access_token", ""):
+            return candidate
+    return None
+
+
 def _provider_supports_explicit_api_mode(provider: Optional[str], configured_provider: Optional[str] = None) -> bool:
     """Check whether a persisted api_mode should be honored for a given provider.
 
@@ -313,9 +379,7 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     normalized_configured = (configured_provider or "").strip().lower()
     if not normalized_configured:
         return True
-    if normalized_provider == "custom":
-        return normalized_configured == "custom" or normalized_configured.startswith("custom:")
-    return normalized_configured == normalized_provider
+    return _configured_provider_matches(normalized_provider, normalized_configured)
 
 
 def _copilot_runtime_api_mode(
@@ -468,7 +532,11 @@ def _resolve_runtime_from_pool_entry(
             getattr(entry, "runtime_api_key", ""),
             target_model=effective_model,
         )
-        base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = ""
+        if _configured_provider_matches("copilot", cfg_provider):
+            cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+        base_url = cfg_base_url or base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
@@ -503,7 +571,7 @@ def _resolve_runtime_from_pool_entry(
         # fell back to the hardcoded default).  Env var overrides win (#6039).
         pconfig = PROVIDER_REGISTRY.get(provider)
         pool_url_is_default = pconfig and base_url.rstrip("/") == pconfig.inference_base_url.rstrip("/")
-        if configured_provider == provider and pool_url_is_default:
+        if _configured_provider_matches(provider, configured_provider) and pool_url_is_default:
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
             if cfg_base_url:
                 base_url = cfg_base_url
@@ -1559,20 +1627,36 @@ def _resolve_explicit_runtime(
         if pconfig.base_url_env_var:
             env_url = _getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
 
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = ""
+        if _configured_provider_matches(provider, cfg_provider):
+            cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+
         base_url = explicit_base_url
         if not base_url:
-            if provider in {"kimi-coding", "kimi-coding-cn"}:
+            if cfg_base_url:
+                base_url = cfg_base_url
+            elif provider in {"kimi-coding", "kimi-coding-cn"}:
                 creds = resolve_api_key_provider_credentials(provider)
                 base_url = creds.get("base_url", "").rstrip("/")
             else:
                 base_url = env_url or pconfig.inference_base_url
 
         api_key = explicit_api_key
+        creds = None
         if not api_key:
             creds = resolve_api_key_provider_credentials(provider)
             api_key = creds.get("api_key", "")
             if not base_url:
                 base_url = creds.get("base_url", "").rstrip("/")
+        if not has_usable_secret(api_key):
+            env_names = ", ".join(pconfig.api_key_env_vars)
+            hint = f" Set {env_names}." if env_names else ""
+            raise AuthError(
+                f"No usable credentials found for provider '{provider}'.{hint}",
+                provider=provider,
+                code="missing_api_key",
+            )
 
         api_mode = "chat_completions"
         if provider == "copilot":
@@ -1599,7 +1683,7 @@ def _resolve_explicit_runtime(
             "api_mode": api_mode,
             "base_url": base_url.rstrip("/"),
             "api_key": api_key,
-            "source": "explicit",
+            "source": (creds.get("source", "explicit") if isinstance(creds, dict) else "explicit"),
             "requested_provider": requested_provider,
         }
 
@@ -1812,7 +1896,11 @@ def resolve_runtime_provider(
     except Exception:
         pool = None
     if pool and pool.has_credentials():
-        entry = pool.select()
+        entry = _select_pool_entry_for_runtime(
+            provider=provider,
+            pool=pool,
+            model_cfg=model_cfg,
+        )
         pool_api_key = ""
         if entry is not None:
             pool_api_key = (
@@ -2152,7 +2240,7 @@ def resolve_runtime_provider(
         # (China endpoint) still get the hardcoded api.minimax.io default (#6039).
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = ""
-        if cfg_provider == provider:
+        if _configured_provider_matches(provider, cfg_provider):
             cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -349,21 +349,21 @@ def _select_pool_entry_for_runtime(
     pool: CredentialPool,
     model_cfg: Dict[str, Any],
 ) -> Optional[PooledCredential]:
-    entry = pool.select()
     if provider != "copilot":
-        return entry
+        return pool.select()
 
     allowed_sources = _configured_copilot_pool_sources(model_cfg)
     if allowed_sources is None:
-        return entry
-    if entry is not None and getattr(entry, "source", "") in allowed_sources:
-        return entry
+        return pool.select()
 
-    for candidate in pool.entries():
-        if getattr(candidate, "source", "") not in allowed_sources:
-            continue
-        if getattr(candidate, "runtime_api_key", None) or getattr(candidate, "access_token", ""):
-            return candidate
+    select_from_sources = getattr(pool, "select_from_sources", None)
+    if callable(select_from_sources):
+        return select_from_sources(allowed_sources)
+
+    entry = pool.select()
+    entry_source = getattr(entry, "source", "")
+    if entry is not None and (entry_source in allowed_sources or entry_source == "pool"):
+        return entry
     return None
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5158,9 +5158,13 @@ class AIAgent:
             return False
 
         try:
-            from hermes_cli.copilot_auth import resolve_copilot_token
+            from hermes_cli.auth import PROVIDER_REGISTRY, _resolve_copilot_token_for_runtime
+            from hermes_cli.copilot_auth import get_copilot_api_token
 
-            new_token, token_source = resolve_copilot_token()
+            raw_token, token_source = _resolve_copilot_token_for_runtime()
+            if not isinstance(raw_token, str) or not raw_token.strip():
+                return False
+            new_token, refreshed_base_url = get_copilot_api_token(raw_token)
         except Exception as exc:
             logger.debug("Copilot credential refresh failed: %s", exc)
             return False
@@ -5169,6 +5173,12 @@ class AIAgent:
             return False
 
         new_token = new_token.strip()
+        refreshed_base_url = (refreshed_base_url or "").strip().rstrip("/")
+        if refreshed_base_url:
+            default_base_url = PROVIDER_REGISTRY["copilot"].inference_base_url.rstrip("/")
+            current_base_url = str(self.base_url or "").strip().rstrip("/")
+            if not current_base_url or current_base_url == default_base_url:
+                self.base_url = refreshed_base_url
 
         self.api_key = new_token
         self._client_kwargs["api_key"] = self.api_key

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1,11 +1,36 @@
 import base64
 import json
+import os
 import time
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from hermes_cli import runtime_provider as rp
+
+
+def _write_model_config(model_cfg: dict) -> Path:
+    home = Path(os.environ["HERMES_HOME"])
+    config_path = home / "config.yaml"
+    lines = ["model:"]
+    for key, value in model_cfg.items():
+        lines.append(f"  {key}: {value}")
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    # This file intentionally carries several provider-resolution tests.  Clear
+    # config caches so each test sees its own per-test HERMES_HOME/config.yaml.
+    from hermes_cli import config as config_mod
+
+    for cache_name in (
+        "_LOAD_CONFIG_CACHE",
+        "_RAW_CONFIG_CACHE",
+        "_LAST_EXPANDED_CONFIG_BY_PATH",
+    ):
+        cache = getattr(config_mod, cache_name, None)
+        if cache is not None and hasattr(cache, "clear"):
+            cache.clear()
+    return config_path
 
 
 def test_configured_api_key_provider_without_key_fails_closed(monkeypatch):
@@ -47,6 +72,257 @@ def test_noauth_lmstudio_still_resolves(monkeypatch):
 
     assert resolved["provider"] == "lmstudio"
     assert resolved["api_key"]
+
+
+def test_configured_copilot_uses_only_copilot_github_token(monkeypatch):
+    """A profile pinned to Copilot must not borrow generic GitHub credentials."""
+    from hermes_cli import copilot_auth
+
+    model_cfg = {
+        "provider": "copilot",
+        "default": "gpt-5.5",
+        "api_mode": "codex_responses",
+        "base_url": "https://api.business.githubcopilot.com",
+    }
+    monkeypatch.setattr(rp, "_get_model_config", lambda: dict(model_cfg))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": dict(model_cfg)})
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False))
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "github_pat_generic_repo_token")
+    monkeypatch.setattr(copilot_auth, "_try_gh_cli_token", lambda: "gho_from_gh_cli")
+    exchanged = []
+
+    def _unexpected_exchange(raw_token):
+        exchanged.append(raw_token)
+        return "borrowed-api-token", "https://api.githubcopilot.com"
+
+    monkeypatch.setattr(copilot_auth, "get_copilot_api_token", _unexpected_exchange)
+
+    with pytest.raises(rp.AuthError, match="No usable credentials.*copilot"):
+        rp.resolve_runtime_provider(requested="copilot")
+    assert exchanged == []
+
+
+def test_configured_copilot_honors_pinned_endpoint_and_api_mode(monkeypatch):
+    """Provider/model/api_mode/base_url pinning produces a strict Copilot route."""
+    from hermes_cli import copilot_auth
+
+    model_cfg = {
+        "provider": "copilot",
+        "default": "gpt-5.5",
+        "api_mode": "codex_responses",
+        "base_url": "https://api.business.githubcopilot.com",
+    }
+    monkeypatch.setattr(rp, "_get_model_config", lambda: dict(model_cfg))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": dict(model_cfg)})
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False))
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_work_token")
+    monkeypatch.setenv("GITHUB_TOKEN", "github_pat_generic_repo_token")
+    exchanged = []
+
+    def _exchange(raw_token):
+        exchanged.append(raw_token)
+        return "copilot-api-token", "https://api.githubcopilot.com"
+
+    monkeypatch.setattr(copilot_auth, "get_copilot_api_token", _exchange)
+
+    resolved = rp.resolve_runtime_provider(requested="copilot")
+
+    assert exchanged == ["gho_work_token", "gho_work_token"]
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_key"] == "copilot-api-token"
+    assert resolved["source"] == "COPILOT_GITHUB_TOKEN"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.business.githubcopilot.com"
+
+
+def test_configured_copilot_pool_keeps_pinned_endpoint(monkeypatch):
+    """A Copilot credential pool entry must not override model.base_url."""
+    model_cfg = {
+        "provider": "copilot",
+        "default": "gpt-5.5",
+        "api_mode": "codex_responses",
+        "base_url": "https://api.business.githubcopilot.com",
+    }
+    entry = SimpleNamespace(
+        access_token="pool-token",
+        runtime_api_key="pool-api-token",
+        source="env:COPILOT_GITHUB_TOKEN",
+        base_url="https://api.githubcopilot.com",
+    )
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return entry
+
+    monkeypatch.setattr(rp, "_get_model_config", lambda: dict(model_cfg))
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: _Pool())
+    monkeypatch.setattr(rp, "credential_pool_matches_provider", lambda *a, **k: True)
+
+    resolved = rp.resolve_runtime_provider(requested="copilot")
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_key"] == "pool-api-token"
+    assert resolved["source"] == "env:COPILOT_GITHUB_TOKEN"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.business.githubcopilot.com"
+
+
+def test_configured_copilot_real_pool_rejects_github_token(monkeypatch):
+    """Strict Copilot config must not be satisfied by real pool GITHUB_TOKEN seeding."""
+    from hermes_cli import copilot_auth
+
+    _write_model_config(
+        {
+            "provider": "copilot",
+            "default": "gpt-5.5",
+            "api_mode": "codex_responses",
+            "base_url": "https://api.business.githubcopilot.com",
+        }
+    )
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "gho_generic_github_token")
+    monkeypatch.setattr(copilot_auth, "_try_gh_cli_token", lambda: "")
+    monkeypatch.setattr(
+        copilot_auth,
+        "get_copilot_api_token",
+        lambda raw_token: (f"api-for-{raw_token}", "https://api.githubcopilot.com"),
+    )
+
+    with pytest.raises(rp.AuthError, match="No usable credentials.*copilot"):
+        rp.resolve_runtime_provider()
+
+
+def test_configured_copilot_real_pool_rejects_gh_cli(monkeypatch):
+    """Strict Copilot config must not be satisfied by gh auth token seeding."""
+    from hermes_cli import copilot_auth
+
+    _write_model_config(
+        {
+            "provider": "copilot",
+            "default": "gpt-5.5",
+            "api_mode": "codex_responses",
+            "base_url": "https://api.business.githubcopilot.com",
+        }
+    )
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(copilot_auth, "_try_gh_cli_token", lambda: "gho_from_gh_cli")
+    monkeypatch.setattr(
+        copilot_auth,
+        "get_copilot_api_token",
+        lambda raw_token: (f"api-for-{raw_token}", "https://api.githubcopilot.com"),
+    )
+
+    with pytest.raises(rp.AuthError, match="No usable credentials.*copilot"):
+        rp.resolve_runtime_provider()
+
+
+def test_configured_copilot_real_pool_ignores_persisted_generic_sources(monkeypatch):
+    """Stale generic Copilot pool rows must not satisfy a strict Copilot profile."""
+    home = Path(os.environ["HERMES_HOME"])
+    _write_model_config(
+        {
+            "provider": "copilot",
+            "default": "gpt-5.5",
+            "api_mode": "codex_responses",
+            "base_url": "https://api.business.githubcopilot.com",
+        }
+    )
+    (home / "auth.json").write_text(
+        json.dumps(
+            {
+                "credential_pool": {
+                    "copilot": [
+                        {
+                            "id": "ghenv1",
+                            "source": "env:GITHUB_TOKEN",
+                            "auth_type": "api_key",
+                            "access_token": "api-from-github-token",
+                            "base_url": "https://api.githubcopilot.com",
+                        },
+                        {
+                            "id": "ghcli1",
+                            "source": "gh_cli",
+                            "auth_type": "api_key",
+                            "access_token": "api-from-gh-cli",
+                            "base_url": "https://api.githubcopilot.com",
+                        },
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    with pytest.raises(rp.AuthError, match="No usable credentials.*copilot"):
+        rp.resolve_runtime_provider()
+
+
+def test_configured_copilot_real_pool_uses_exchanged_copilot_token(monkeypatch):
+    """Allowed Copilot env pool rows keep exchanged API tokens, not raw GitHub tokens."""
+    from hermes_cli import copilot_auth
+
+    _write_model_config(
+        {
+            "provider": "copilot",
+            "default": "gpt-5.5",
+            "api_mode": "codex_responses",
+            "base_url": "https://api.business.githubcopilot.com",
+        }
+    )
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_work_token")
+    monkeypatch.setenv("GITHUB_TOKEN", "gho_generic_github_token")
+    monkeypatch.setattr(copilot_auth, "_try_gh_cli_token", lambda: "")
+    monkeypatch.setattr(
+        copilot_auth,
+        "get_copilot_api_token",
+        lambda raw_token: (f"api-for-{raw_token}", "https://api.githubcopilot.com"),
+    )
+
+    resolved = rp.resolve_runtime_provider()
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_key"] == "api-for-gho_work_token"
+    assert resolved["source"] == "env:COPILOT_GITHUB_TOKEN"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.business.githubcopilot.com"
+
+
+def test_configured_copilot_alias_real_pool_keeps_pinned_endpoint(monkeypatch):
+    """Copilot aliases must honor the same pinned endpoint/mode as provider: copilot."""
+    from hermes_cli import copilot_auth
+
+    _write_model_config(
+        {
+            "provider": "github-copilot",
+            "default": "gpt-5.5",
+            "api_mode": "codex_responses",
+            "base_url": "https://api.business.githubcopilot.com",
+        }
+    )
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_work_token")
+    monkeypatch.setattr(copilot_auth, "_try_gh_cli_token", lambda: "")
+    monkeypatch.setattr(
+        copilot_auth,
+        "get_copilot_api_token",
+        lambda raw_token: ("api-for-work-token", "https://api.githubcopilot.com"),
+    )
+
+    resolved = rp.resolve_runtime_provider()
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_key"] == "api-for-work-token"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.business.githubcopilot.com"
 
 
 def _fake_invoke_jwt(ttl_seconds=3600):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -158,6 +158,9 @@ def test_configured_copilot_pool_keeps_pinned_endpoint(monkeypatch):
         def select(self):
             return entry
 
+        def select_from_sources(self, _allowed_sources):
+            return entry
+
     monkeypatch.setattr(rp, "_get_model_config", lambda: dict(model_cfg))
     monkeypatch.setattr(rp, "load_pool", lambda _provider: _Pool())
     monkeypatch.setattr(rp, "credential_pool_matches_provider", lambda *a, **k: True)
@@ -169,6 +172,72 @@ def test_configured_copilot_pool_keeps_pinned_endpoint(monkeypatch):
     assert resolved["source"] == "env:COPILOT_GITHUB_TOKEN"
     assert resolved["api_mode"] == "codex_responses"
     assert resolved["base_url"] == "https://api.business.githubcopilot.com"
+
+
+def test_configured_copilot_pool_skips_unavailable_allowed_entry(monkeypatch):
+    """Strict Copilot pool selection must not pick exhausted/dead allowed rows."""
+    from agent.credential_pool import (
+        AUTH_TYPE_API_KEY,
+        CredentialPool,
+        PooledCredential,
+        STATUS_DEAD,
+        STATUS_EXHAUSTED,
+    )
+
+    model_cfg = {
+        "provider": "copilot",
+        "default": "gpt-5.5",
+        "api_mode": "codex_responses",
+        "base_url": "https://api.business.githubcopilot.com",
+    }
+    pool = CredentialPool(
+        provider="copilot",
+        entries=[
+            PooledCredential(
+                provider="copilot",
+                id="generic-github",
+                label="generic-github",
+                auth_type=AUTH_TYPE_API_KEY,
+                priority=0,
+                source="env:GITHUB_TOKEN",
+                access_token="generic-api-token",
+            ),
+            PooledCredential(
+                provider="copilot",
+                id="copilot-env-cooling-down",
+                label="copilot-env-cooling-down",
+                auth_type=AUTH_TYPE_API_KEY,
+                priority=1,
+                source="env:COPILOT_GITHUB_TOKEN",
+                access_token="copilot-api-token",
+                last_status=STATUS_EXHAUSTED,
+                last_status_at=time.time(),
+                last_error_reset_at=time.time() + 3600,
+            ),
+            PooledCredential(
+                provider="copilot",
+                id="copilot-env-dead",
+                label="copilot-env-dead",
+                auth_type=AUTH_TYPE_API_KEY,
+                priority=2,
+                source="env:COPILOT_GITHUB_TOKEN",
+                access_token="dead-copilot-api-token",
+                last_status=STATUS_DEAD,
+                last_status_at=time.time(),
+            ),
+        ],
+    )
+    monkeypatch.setattr(rp, "_get_model_config", lambda: dict(model_cfg))
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: pool)
+
+    selected = rp._select_pool_entry_for_runtime(
+        provider="copilot",
+        pool=pool,
+        model_cfg=model_cfg,
+    )
+
+    assert selected is None
+    assert pool.current() is None
 
 
 def test_configured_copilot_real_pool_rejects_github_token(monkeypatch):

--- a/tests/run_agent/test_copilot_refresh_credentials.py
+++ b/tests/run_agent/test_copilot_refresh_credentials.py
@@ -1,0 +1,104 @@
+"""Regression coverage for Copilot 401 credential refresh routing."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+
+def _write_model_config(model_cfg: dict) -> None:
+    home = Path(os.environ["HERMES_HOME"])
+    config_path = home / "config.yaml"
+    lines = ["model:"]
+    for key, value in model_cfg.items():
+        lines.append(f"  {key}: {value}")
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    from hermes_cli import config as config_mod
+
+    for cache_name in (
+        "_LOAD_CONFIG_CACHE",
+        "_RAW_CONFIG_CACHE",
+        "_LAST_EXPANDED_CONFIG_BY_PATH",
+    ):
+        cache = getattr(config_mod, cache_name, None)
+        if cache is not None and hasattr(cache, "clear"):
+            cache.clear()
+
+
+def _make_copilot_agent():
+    from run_agent import AIAgent
+
+    agent: Any = AIAgent.__new__(AIAgent)
+    agent.provider = "copilot"
+    agent.api_mode = "codex_responses"
+    agent.api_key = "stale-copilot-api-token"
+    agent.base_url = "https://api.business.githubcopilot.com"
+    agent._client_kwargs = {
+        "api_key": "stale-copilot-api-token",
+        "base_url": "https://api.business.githubcopilot.com",
+    }
+    agent._replace_primary_openai_client = MagicMock(return_value=True)
+    agent._apply_client_headers_for_base_url = MagicMock()
+    return agent
+
+
+def test_configured_copilot_refresh_does_not_borrow_generic_github_token(monkeypatch):
+    """A pinned Copilot route must fail closed during 401 refresh as well."""
+    from hermes_cli import copilot_auth
+
+    _write_model_config(
+        {
+            "provider": "copilot",
+            "default": "gpt-5.5",
+            "api_mode": "codex_responses",
+            "base_url": "https://api.business.githubcopilot.com",
+        }
+    )
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "gho_generic_github_token")
+    monkeypatch.setattr(copilot_auth, "_try_gh_cli_token", lambda: "gho_from_gh_cli")
+    monkeypatch.setattr(
+        copilot_auth,
+        "get_copilot_api_token",
+        lambda raw_token: (f"api-for-{raw_token}", "https://api.githubcopilot.com"),
+    )
+    agent = _make_copilot_agent()
+
+    assert agent._try_refresh_copilot_client_credentials() is False
+    assert agent.api_key == "stale-copilot-api-token"
+    agent._replace_primary_openai_client.assert_not_called()
+
+
+def test_configured_copilot_refresh_uses_exchanged_copilot_token(monkeypatch):
+    """401 refresh keeps using the configured Copilot token family."""
+    from hermes_cli import copilot_auth
+
+    _write_model_config(
+        {
+            "provider": "copilot",
+            "default": "gpt-5.5",
+            "api_mode": "codex_responses",
+            "base_url": "https://api.business.githubcopilot.com",
+        }
+    )
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_work_token")
+    monkeypatch.setenv("GITHUB_TOKEN", "gho_generic_github_token")
+    monkeypatch.setattr(copilot_auth, "_try_gh_cli_token", lambda: "")
+    monkeypatch.setattr(
+        copilot_auth,
+        "get_copilot_api_token",
+        lambda raw_token: (f"api-for-{raw_token}", "https://api.githubcopilot.com"),
+    )
+    agent = _make_copilot_agent()
+
+    assert agent._try_refresh_copilot_client_credentials() is True
+    assert agent.api_key == "api-for-gho_work_token"
+    assert agent._client_kwargs["api_key"] == "api-for-gho_work_token"
+    assert agent._client_kwargs["base_url"] == "https://api.business.githubcopilot.com"
+    agent._replace_primary_openai_client.assert_called_once_with(
+        reason="copilot_credential_refresh"
+    )


### PR DESCRIPTION
## Summary
- fail closed for explicit Copilot routes instead of accepting generic GitHub credentials
- preserve pinned Copilot business endpoints and api_mode for Copilot aliases
- add adversarial regression coverage for credential-pool and runtime-provider paths

## Validation
- `uv run --frozen --with pytest pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/test_windows_subprocess_no_window_flags.py -o 'addopts=' -q` -> 69 passed in 1.65s
- `uv run --frozen --with pytest pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/test_windows_subprocess_no_window_flags.py tests/agent/test_credential_pool.py tests/agent/test_credential_pool_provider_boundary.py tests/agent/test_credential_pool_routing.py tests/run_agent/test_63425_credential_pool_auto_detect.py tests/gateway/test_session_model_override_credential_pool.py tests/tools/test_credential_pool_env_fallback.py -o 'addopts=' -q` -> 156 passed in 9.33s
- `python -m py_compile hermes_cli/auth.py hermes_cli/copilot_auth.py hermes_cli/runtime_provider.py agent/credential_pool.py tests/hermes_cli/test_runtime_provider_resolution.py`
- `git diff --cached --check`

## Notes
- Reconciled from an independently reviewed local v2 patch onto current upstream `NousResearch/hermes-agent:main` without changing the security semantics.
- No live profiles, credentials, gateway, deployment, or local GPU models were touched.
