### PR TITLE
fix(copilot): don't warn on classic PATs in shared GitHub env vars (#75687)

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -46,6 +46,11 @@ _SUPPORTED_PREFIXES = ("gho_", "github_pat_", "ghu_")
 # Env var search order (matches Copilot CLI)
 COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 
+# Copilot-dedicated env vars: an unsupported token here is a genuine Copilot
+# misconfiguration worth a warning. The remaining COPILOT_ENV_VARS are shared,
+# general-purpose GitHub vars whose classic PATs are demoted to debug (#75687).
+_DEDICATED_COPILOT_ENV_VARS = frozenset({"COPILOT_GITHUB_TOKEN"})
+
 # Polling constants
 _DEVICE_CODE_POLL_INTERVAL = 5  # seconds
 _DEVICE_CODE_POLL_SAFETY_MARGIN = 3  # seconds
@@ -86,9 +91,15 @@ def resolve_copilot_token() -> tuple[str, str]:
             any_env_var_set = True
             valid, msg = validate_copilot_token(val)
             if not valid:
-                logger.warning(
-                    "Token from %s is not supported: %s", env_var, msg
-                )
+                # ``GH_TOKEN``/``GITHUB_TOKEN`` are general-purpose GitHub vars
+                # commonly set for the ``gh`` CLI or API scripts, so a classic
+                # PAT there is expected and not a Copilot misconfiguration —
+                # resolution just skips to the next candidate. Warning loudly on
+                # every catalog probe is pure noise (#75687), so only the
+                # Copilot-dedicated ``COPILOT_GITHUB_TOKEN`` warrants a warning;
+                # the shared vars are logged at debug.
+                log = logger.warning if env_var in _DEDICATED_COPILOT_ENV_VARS else logger.debug
+                log("Token from %s is not supported: %s", env_var, msg)
                 continue
             return val, env_var
 

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -27,6 +27,12 @@ logger = logging.getLogger(__name__)
 COPILOT_OAUTH_CLIENT_ID = "Iv1.b507a08c87ecfe98"
 _CLASSIC_PAT_PREFIX = "ghp_"  # rejected by the Copilot API (gho_ / github_pat_ / ghu_ work)
 COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+
+# Copilot-dedicated env vars: an unsupported token here is a genuine Copilot
+# misconfiguration worth a warning. The remaining COPILOT_ENV_VARS are shared,
+# general-purpose GitHub vars whose classic PATs are demoted to debug (#75687).
+_DEDICATED_COPILOT_ENV_VARS = frozenset({"COPILOT_GITHUB_TOKEN"})
+
 _DEVICE_CODE_POLL_INTERVAL = 5  # seconds
 _DEVICE_CODE_POLL_SAFETY_MARGIN = 3  # seconds
 
@@ -60,7 +66,14 @@ def resolve_copilot_token() -> tuple[str, str]:
         valid, msg = validate_copilot_token(val)
         if valid:
             return val, env_var
-        logger.warning("Token from %s is not supported: %s", env_var, msg)
+        # ``GH_TOKEN``/``GITHUB_TOKEN`` are general-purpose GitHub vars commonly
+        # set for the ``gh`` CLI or API scripts, so a classic PAT there is
+        # expected and not a Copilot misconfiguration — resolution just skips to
+        # the next candidate. Warning loudly on every catalog probe is pure noise
+        # (#75687), so only the Copilot-dedicated ``COPILOT_GITHUB_TOKEN``
+        # warrants a warning; the shared vars are logged at debug.
+        log = logger.warning if env_var in _DEDICATED_COPILOT_ENV_VARS else logger.debug
+        log("Token from %s is not supported: %s", env_var, msg)
     # `gh auth token` fallback ONLY when no Copilot env var was set: an exported GITHUB_TOKEN
     # (even a classic PAT) means the user intends *that* token; skipping also avoids a slow
     # subprocess (up to 5s on Windows) on every cold start.

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -71,6 +71,41 @@ class TestResolveToken:
         assert source == ""
         mock_cli.assert_not_called()
 
+    def test_classic_pat_in_shared_var_does_not_warn(self, monkeypatch, caplog):
+        """A classic PAT in the general-purpose GITHUB_TOKEN/GH_TOKEN vars is
+        expected (they feed the gh CLI etc.), so it must not log at WARNING —
+        that was pure noise when Copilot was unused (#75687)."""
+        import logging
+
+        from hermes_cli.copilot_auth import resolve_copilot_token
+
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GH_TOKEN", "ghp_classic_shared")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.copilot_auth"):
+                token, source = resolve_copilot_token()
+
+        assert (token, source) == ("", "")
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_classic_pat_in_dedicated_var_warns(self, monkeypatch, caplog):
+        """A classic PAT in the Copilot-dedicated COPILOT_GITHUB_TOKEN is a real
+        misconfiguration, so it must still surface at WARNING (#75687)."""
+        import logging
+
+        from hermes_cli.copilot_auth import resolve_copilot_token
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "ghp_classic_dedicated")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.copilot_auth"):
+                resolve_copilot_token()
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("COPILOT_GITHUB_TOKEN" in r.getMessage() for r in warnings)
+
 
 class TestRequestHeaders:
     """Copilot API header generation."""

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -71,6 +71,41 @@ class TestResolveToken:
         assert source == ""
         mock_cli.assert_not_called()
 
+    def test_classic_pat_in_shared_var_does_not_warn(self, monkeypatch, caplog):
+        """A classic PAT in the general-purpose GITHUB_TOKEN/GH_TOKEN vars is
+        expected (they feed the gh CLI etc.), so it must not log at WARNING —
+        that was pure noise when Copilot was unused (#75687)."""
+        import logging
+
+        from hermes_cli.copilot_auth import resolve_copilot_token
+
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GH_TOKEN", "ghp_classic_shared")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.copilot_auth"):
+                token, source = resolve_copilot_token()
+
+        assert (token, source) == ("", "")
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_classic_pat_in_dedicated_var_warns(self, monkeypatch, caplog):
+        """A classic PAT in the Copilot-dedicated COPILOT_GITHUB_TOKEN is a real
+        misconfiguration, so it must still surface at WARNING (#75687)."""
+        import logging
+
+        from hermes_cli.copilot_auth import resolve_copilot_token
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "ghp_classic_dedicated")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.copilot_auth"):
+                resolve_copilot_token()
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("COPILOT_GITHUB_TOKEN" in r.getMessage() for r in warnings)
+
 
 class TestGhCliTokenCache:
     """The gh-CLI probe result is cached — a miss must not re-spawn gh.


### PR DESCRIPTION
## Problem

`hermes_cli.copilot_auth.resolve_copilot_token()` logs at **WARNING** whenever it finds a classic `ghp_*` PAT in any of its search vars — `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`:

```
Token from GITHUB_TOKEN is not supported: Classic PAT tokens are not accepted by the Copilot API
```

`GH_TOKEN`/`GITHUB_TOKEN` are general-purpose GitHub env vars routinely set for the `gh` CLI and API scripts, so a classic PAT there is expected — not a Copilot misconfiguration. But the Copilot model-catalog probe (`_resolve_copilot_catalog_api_key` → `resolve_api_key_provider_credentials("copilot")` → `resolve_copilot_token`, via `provider_model_ids("copilot")` in `hermes_cli/models.py:2803`) runs on session start regardless of whether Copilot is configured, so the warning floods `errors.log`. The reporter saw 28 such warnings over 3 days with Copilot unused (#75687).

## Fix

Keep the loud WARNING only for the Copilot-**dedicated** `COPILOT_GITHUB_TOKEN`, where an unsupported token is a genuine user misconfiguration. Demote the shared general-purpose vars (`GH_TOKEN`/`GITHUB_TOKEN`) to `debug`. Resolution behavior is unchanged — both cases still skip to the next candidate and fall through to `gh auth token`.

## Tests

- `test_classic_pat_in_shared_var_does_not_warn` — a classic PAT in `GH_TOKEN` emits no WARNING record (fails before this change).
- `test_classic_pat_in_dedicated_var_warns` — a classic PAT in `COPILOT_GITHUB_TOKEN` still surfaces at WARNING.
- Existing `tests/hermes_cli/test_copilot_auth.py` (12) plus the copilot model-list/catalog suites remain green.

Fixes #75687.
