### PR TITLE
feat(teams): let an adapter hand the stream consumer a message it posted

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5784,6 +5784,10 @@ class BasePlatformAdapter(ABC):
         # never spawned, so no "typing…" / "is thinking…" status is shown.
         # typing_task stays None; _stop_typing_refresh already no-ops on None.
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        _event_metadata = getattr(event, "metadata", None)
+        if isinstance(_event_metadata, dict) and _event_metadata.get("_stream_message_id"):
+            _thread_metadata = dict(_thread_metadata or {})
+            _thread_metadata["_stream_message_id"] = str(_event_metadata["_stream_message_id"])
         typing_task: Optional[asyncio.Task] = None
         if getattr(self.config, "typing_indicator", True):
             _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -340,6 +340,24 @@ def _seed_hygiene_system_prompt(
     return bool(stored_prompt)
 
 
+def _merge_stream_message_metadata(
+    metadata: Optional[Dict[str, Any]],
+    event: Any,
+) -> Optional[Dict[str, Any]]:
+    """Carry an adapter-created streaming message id into send/edit metadata."""
+    event_metadata = (
+        event if isinstance(event, dict) else getattr(event, "metadata", None)
+    )
+    if not isinstance(event_metadata, dict):
+        return metadata
+    stream_message_id = event_metadata.get("_stream_message_id")
+    if not stream_message_id:
+        return metadata
+    merged = dict(metadata or {})
+    merged["_stream_message_id"] = str(stream_message_id)
+    return merged
+
+
 def _is_transient_network_error(exc: BaseException) -> bool:
     """Return True for transient network errors safe to log + swallow.
 
@@ -22837,7 +22855,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else bool(_plat_streaming)
         )
 
-        _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
+        _thread_metadata: Optional[Dict[str, Any]] = _merge_stream_message_metadata(
+            self._thread_metadata_for_source(source, event_message_id),
+            event,
+        )
 
         if _streaming_enabled:
             try:
@@ -23644,6 +23665,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     reply_to_message_id=event_message_id,
                 )
             ) if _progress_thread_id else None
+        _status_thread_metadata = _merge_stream_message_metadata(
+            _status_thread_metadata,
+            event,
+        )
 
         # Bridge extracted to TurnRunner._status_callback_sync; publish the
         # status wiring computed above onto the shared TurnContext at the
@@ -24632,6 +24657,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # after streaming finished — when the response was transformed, always
             # send the final version so the appended content reaches the client.
             _transformed = bool(response.get("response_transformed"))
+            _stream_placeholder_id = None
+            if isinstance(_status_thread_metadata, dict):
+                _stream_placeholder_id = _status_thread_metadata.get("_stream_message_id")
             # Only suppress the normal send when the actual final reply reached
             # the user: the stream consumer streamed it (final_response_sent /
             # final_content_delivered), or the interim preview delivered that
@@ -24652,6 +24680,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _content_delivered,
                 )
                 response["already_sent"] = True
+            elif (
+                not _is_empty_sentinel
+                and not _transformed
+                and _stream_placeholder_id
+                and _sc is not None
+            ):
+                try:
+                    _placeholder_edit = await _sc.adapter.edit_message(
+                        chat_id=source.chat_id,
+                        message_id=str(_stream_placeholder_id),
+                        content=response["final_response"],
+                        finalize=True,
+                        metadata=_status_thread_metadata,
+                    )
+                    if getattr(_placeholder_edit, "success", False):
+                        response["already_sent"] = True
+                        logger.info(
+                            "Edited placeholder message %s with final response for session %s.",
+                            _stream_placeholder_id,
+                            session_key or "?",
+                        )
+                    else:
+                        logger.warning(
+                            "Placeholder final edit failed for session %s: %s",
+                            session_key or "?",
+                            getattr(_placeholder_edit, "error", None),
+                        )
+                except Exception as _edit_err:
+                    logger.warning(
+                        "Failed to edit placeholder final response for session %s: %s",
+                        session_key or "?",
+                        _edit_err,
+                    )
             elif not _is_empty_sentinel and _transformed and _sc is not None:
                 # Plugin hooks transformed the response after streaming — edit the
                 # existing streamed message instead of sending a duplicate.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -245,6 +245,9 @@ class GatewayStreamConsumer:
             self._message_created_ts = time.monotonic()
             self._preview_message_ids.add(self._message_id)
             self._segment_preview_message_ids.add(self._message_id)
+            logger.debug(
+                "stream: editing the adapter's message %s", self._message_id,
+            )
         self._already_sent = False
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0
@@ -475,6 +478,17 @@ class GatewayStreamConsumer:
     def _reset_segment_state(self, *, preserve_no_edit: bool = False) -> None:
         if preserve_no_edit and self._message_id == "__no_edit__":
             return
+        # A message we have never written to is not a finalized segment. An
+        # adapter-supplied acknowledgement is the case that matters: a turn
+        # that calls a tool before emitting any text hits this reset first, and
+        # dropping the id there strands the acknowledgement on screen while the
+        # answer arrives as a second message. Nothing was committed to it, so
+        # there is nothing to leave above the next segment.
+        keep_untouched_target = bool(
+            self._message_id
+            and self._message_id != "__no_edit__"
+            and not self._last_sent_text
+        )
         # Retain the finalized visible text of the current segment before
         # clearing ``_last_sent_text``, so ``has_delivered_text`` can still
         # match it after a segment break. (#65919 review)
@@ -482,14 +496,17 @@ class GatewayStreamConsumer:
             finalized = self._clean_for_display(self._last_sent_text).strip()
             if finalized:
                 self._delivered_segment_texts.append(finalized)
-        self._message_id = None
-        self._message_created_ts = None
+        if not keep_untouched_target:
+            self._message_id = None
+            self._message_created_ts = None
         self._accumulated = ""
         self._last_sent_text = ""
         self._fallback_final_send = False
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
-        self._segment_preview_message_ids = set()
+        self._segment_preview_message_ids = (
+            {self._message_id} if keep_untouched_target and self._message_id else set()
+        )
         # #29346: a tool/segment boundary means what we delivered was an interim
         # preamble, not the final answer — clear the flags so a premature setter
         # can't fool the gateway. Safe: got_done returns before any reset, and

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -237,6 +237,14 @@ class GatewayStreamConsumer:
         # the run-wide set for fresh-final bookkeeping, but a failure recovery
         # must never delete an earlier finalized preamble/commentary message.
         self._segment_preview_message_ids: "set[str]" = set()
+        initial_stream_message_id = None
+        if isinstance(metadata, dict):
+            initial_stream_message_id = metadata.get("_stream_message_id")
+        if initial_stream_message_id:
+            self._message_id = str(initial_stream_message_id)
+            self._message_created_ts = time.monotonic()
+            self._preview_message_ids.add(self._message_id)
+            self._segment_preview_message_ids.add(self._message_id)
         self._already_sent = False
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -701,6 +701,7 @@ class TeamsAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = 28000  # Teams text message limit (~28 KB)
     splits_long_messages = True  # send() chunks via truncate_message()
+    supports_status_text = True
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform("teams"))
@@ -982,6 +983,38 @@ class TeamsAdapter(BasePlatformAdapter):
         else:
             msg_type = MessageType.TEXT
 
+        metadata: Dict[str, Any] = {}
+        if (
+            self._streaming_placeholder_enabled()
+            and (text.strip() or media_urls)
+            and not text.lstrip().startswith("/")
+        ):
+            placeholder = await self.send(
+                conv.id,
+                self._streaming_placeholder_text(),
+                reply_to=msg_id,
+            )
+            if placeholder.success and placeholder.message_id:
+                metadata["_stream_message_id"] = str(placeholder.message_id)
+                logger.debug(
+                    "[teams] streaming placeholder id=%s (the answer edits it)",
+                    placeholder.message_id,
+                )
+            elif placeholder.success:
+                # Without the id the stream has nothing to edit: the answer
+                # lands in a second message and the placeholder stays on
+                # screen. Every requester sees that, so warn rather than
+                # swallow it.
+                logger.warning(
+                    "[teams] streaming placeholder sent but returned no message "
+                    "id; the answer will arrive as a separate message"
+                )
+            else:
+                logger.warning(
+                    "[teams] streaming placeholder send failed: %s",
+                    placeholder.error,
+                )
+
         event = MessageEvent(
             text=text,
             source=source,
@@ -989,6 +1022,7 @@ class TeamsAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
             message_id=msg_id,
+            metadata=metadata,
         )
         await self.handle_message(event)
 
@@ -1199,9 +1233,87 @@ class TeamsAdapter(BasePlatformAdapter):
         if not self._app:
             return
         try:
+            status_text = self._status_text_for_chat(chat_id)
+            stream_message_id = None
+            if isinstance(metadata, dict):
+                stream_message_id = metadata.get("_stream_message_id")
+            if status_text and stream_message_id:
+                result = await self.edit_message(
+                    chat_id,
+                    str(stream_message_id),
+                    f"🤔 {status_text}",
+                    metadata=metadata,
+                )
+                if result.success:
+                    return
             await self._app.send(chat_id, TypingActivityInput())
         except Exception:
             pass
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not self._app:
+            return SendResult(success=False, error="Teams app not initialized")
+        try:
+            from microsoft_teams.api import MessageActivityInput
+
+            activity = MessageActivityInput(text=self.format_message(content))
+            result = await self._app.api.conversations.activities(chat_id).update(
+                message_id,
+                activity,
+            )
+            return SendResult(
+                success=True,
+                message_id=str(getattr(result, "id", None) or message_id),
+            )
+        except Exception as e:
+            return SendResult(success=False, error=str(e), retryable=True)
+
+    def _status_text_for_chat(self, chat_id: str) -> Optional[str]:
+        store = getattr(self, "_status_text", None)
+        if not isinstance(store, dict):
+            return None
+        return store.get(str(chat_id))
+
+    def _streaming_placeholder_text(self) -> str:
+        extra = getattr(self.config, "extra", None) or {}
+        configured = extra.get("streaming_placeholder_text")
+        if isinstance(configured, str) and configured.strip():
+            return configured.strip()
+        return "Working on it..."
+
+    def _streaming_placeholder_enabled(self) -> bool:
+        extra = getattr(self.config, "extra", None) or {}
+        configured = extra.get("streaming_placeholder")
+        if configured is not None:
+            return _parse_bool(configured, default=True)
+
+        try:
+            from hermes_cli.config import load_config
+
+            raw_config = load_config()
+        except Exception:
+            return False
+
+        streaming = raw_config.get("streaming") if isinstance(raw_config, dict) else None
+        if not isinstance(streaming, dict):
+            gateway = raw_config.get("gateway") if isinstance(raw_config, dict) else None
+            streaming = gateway.get("streaming") if isinstance(gateway, dict) else None
+        if not isinstance(streaming, dict):
+            return False
+
+        enabled = _parse_bool(streaming.get("enabled"), default=False)
+        transport = str(
+            streaming.get("transport") or streaming.get("mode") or "edit"
+        ).strip().lower()
+        return enabled and transport not in {"0", "false", "off", "disabled", "none"}
 
     async def _send_media_attachment(
         self,

--- a/tests/gateway/test_teams_streaming_placeholder.py
+++ b/tests/gateway/test_teams_streaming_placeholder.py
@@ -1,0 +1,117 @@
+"""Regression tests for Teams placeholder edit-based streaming UX."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from plugins.platforms.teams.adapter import TeamsAdapter
+
+
+@pytest.mark.asyncio
+async def test_teams_inbound_message_sends_placeholder_and_carries_metadata():
+    adapter = TeamsAdapter(PlatformConfig(extra={}))
+    adapter._app = SimpleNamespace(id="bot-id")
+    adapter._streaming_placeholder_enabled = lambda: True
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=True, message_id="placeholder-1"),
+    )
+    captured_events = []
+
+    async def _capture(event):
+        captured_events.append(event)
+
+    adapter.handle_message = _capture
+
+    activity = SimpleNamespace(
+        id="incoming-1",
+        text="<at>本部AI エルメス</at> 今日の天気は？",
+        from_=SimpleNamespace(id="user-id", aad_object_id="aad-id", name="Yuta"),
+        conversation=SimpleNamespace(
+            id="conversation-1",
+            name="honbu hermes（TEST）",
+            conversation_type="channel",
+            tenant_id="tenant-1",
+        ),
+        attachments=[],
+    )
+    ctx = SimpleNamespace(activity=activity, conversation_ref=SimpleNamespace())
+
+    await adapter._on_message(ctx)
+
+    adapter.send.assert_awaited_once_with(
+        "conversation-1",
+        "🤔 考え中...",
+        reply_to="incoming-1",
+    )
+    assert captured_events
+    assert captured_events[0].text == "今日の天気は？"
+    assert captured_events[0].metadata["_stream_message_id"] == "placeholder-1"
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_edits_existing_placeholder_message():
+    adapter = SimpleNamespace()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.supports_draft_streaming = lambda chat_type=None, metadata=None: False
+    adapter.send = AsyncMock(
+        return_value=SendResult(success=True, message_id="unexpected-new-message"),
+    )
+    adapter.edit_message = AsyncMock(
+        return_value=SendResult(success=True, message_id="placeholder-1"),
+    )
+
+    cfg = StreamConsumerConfig(
+        transport="edit",
+        edit_interval=0.01,
+        buffer_threshold=1,
+        cursor=" ▉",
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-1",
+        cfg,
+        metadata={"_stream_message_id": "placeholder-1"},
+    )
+
+    consumer.on_delta("hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter.send.assert_not_called()
+    assert adapter.edit_message.await_args_list
+    assert adapter.edit_message.await_args_list[0].kwargs["message_id"] == "placeholder-1"
+    assert adapter.edit_message.await_args_list[-1].kwargs["finalize"] is True
+    assert consumer.final_response_sent is True
+
+
+@pytest.mark.asyncio
+async def test_teams_typing_status_edits_placeholder_message():
+    adapter = TeamsAdapter(PlatformConfig(extra={}))
+    adapter._app = SimpleNamespace(send=AsyncMock())
+    adapter.edit_message = AsyncMock(
+        return_value=SendResult(success=True, message_id="placeholder-1"),
+    )
+    adapter.set_status_text("chat-1", "Web で検索中...")
+
+    await adapter.send_typing(
+        "chat-1",
+        metadata={"_stream_message_id": "placeholder-1"},
+    )
+
+    adapter.edit_message.assert_awaited_once()
+    call = adapter.edit_message.await_args
+    assert call.args[:3] == (
+        "chat-1",
+        "placeholder-1",
+        "🤔 Web で検索中...",
+    )
+    adapter._app.send.assert_not_called()

--- a/tests/gateway/test_teams_streaming_placeholder.py
+++ b/tests/gateway/test_teams_streaming_placeholder.py
@@ -31,11 +31,11 @@ async def test_teams_inbound_message_sends_placeholder_and_carries_metadata():
 
     activity = SimpleNamespace(
         id="incoming-1",
-        text="<at>本部AI エルメス</at> 今日の天気は？",
+        text="<at>Assistant</at> what is the weather today?",
         from_=SimpleNamespace(id="user-id", aad_object_id="aad-id", name="Yuta"),
         conversation=SimpleNamespace(
             id="conversation-1",
-            name="honbu hermes（TEST）",
+            name="general",
             conversation_type="channel",
             tenant_id="tenant-1",
         ),
@@ -47,11 +47,11 @@ async def test_teams_inbound_message_sends_placeholder_and_carries_metadata():
 
     adapter.send.assert_awaited_once_with(
         "conversation-1",
-        "🤔 考え中...",
+        "Working on it...",
         reply_to="incoming-1",
     )
     assert captured_events
-    assert captured_events[0].text == "今日の天気は？"
+    assert captured_events[0].text == "what is the weather today?"
     assert captured_events[0].metadata["_stream_message_id"] == "placeholder-1"
 
 
@@ -115,3 +115,49 @@ async def test_teams_typing_status_edits_placeholder_message():
         "🤔 Web で検索中...",
     )
     adapter._app.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_placeholder_survives_a_tool_boundary():
+    """A turn that calls a tool before writing text must reuse the message.
+
+    The tool-boundary reset clears the edit target so the next text chunk lands
+    below any tool-progress messages.  When the model calls a tool first, that
+    reset runs while the adapter's acknowledgement is still untouched, and
+    dropping it there leaves the acknowledgement stranded above a second
+    message carrying the answer.
+    """
+
+    from unittest.mock import MagicMock
+
+    from gateway.stream_consumer import GatewayStreamConsumer
+
+    consumer = GatewayStreamConsumer(
+        adapter=MagicMock(),
+        chat_id="conversation-1",
+        metadata={"_stream_message_id": "placeholder-1"},
+    )
+
+    consumer._reset_segment_state()
+
+    assert consumer._message_id == "placeholder-1"
+    assert consumer._segment_preview_message_ids == {"placeholder-1"}
+
+
+@pytest.mark.asyncio
+async def test_message_that_already_showed_text_is_still_released():
+    from unittest.mock import MagicMock
+
+    from gateway.stream_consumer import GatewayStreamConsumer
+
+    consumer = GatewayStreamConsumer(
+        adapter=MagicMock(),
+        chat_id="conversation-1",
+        metadata={"_stream_message_id": "placeholder-1"},
+    )
+    consumer._last_sent_text = "partial answer"
+
+    consumer._reset_segment_state()
+
+    assert consumer._message_id is None
+    assert consumer._segment_preview_message_ids == set()


### PR DESCRIPTION
## Why

Teams shows no typing indicator for a bot in a channel. A request that takes twenty seconds looks like nothing happened, and people re-send.

The obvious answer is to post a short acknowledgement immediately. That does not work today: the stream consumer always creates its own message, so the acknowledgement stays on screen and the answer arrives below it as a second notification. Two messages per turn, every turn.

## What

Let an adapter pass the id of a message it already posted through the event metadata as `_stream_message_id`. The consumer adopts it as its edit target, so the acknowledgement *becomes* the answer in place.

The Teams adapter uses it behind `extra.streaming_placeholder`, with the text in `extra.streaming_placeholder_text` (default `Working on it...`). Adapters that do not set the metadata key are unaffected — the consumer creates its own message exactly as before.

```yaml
platforms:
  teams:
    extra:
      streaming_placeholder: true
      streaming_placeholder_text: "Working on it..."
```

## The second commit is the part worth reviewing

Adopting the message is not enough. The tool-boundary reset clears the edit target so the next text chunk lands below any tool-progress messages. When the model calls a tool **before** emitting any text, that reset runs while the adopted message is still untouched, so it is abandoned and the answer creates a new message anyway.

Measured on a live channel: turns answered without tools produced one message, edited in place. Every turn that called a tool produced two. Both ends logged the handoff as successful, which is what made it confusing:

```
[teams] streaming placeholder id=<id> (the answer edits it)
stream: editing the adapter's message <id>
```

The HTTP trace showed where it actually went — during the tool phase only typing indicators, then the edits targeting a message created *after* the acknowledgement:

```
POST   .../v3/conversations/<conversation>/activities            202   (typing, repeated)
PUT    .../v3/conversations/<conversation>/activities/<other id> 200   (edits, never the adopted id)
```

Nothing had ever been written to the adopted message, so there was no finalized segment to leave above the next one. The fix keeps it as the edit target while `_last_sent_text` is empty; a message that already showed text is released as before.

## Tests

`tests/gateway/test_teams_streaming_placeholder.py`:

- the adapter posts the acknowledgement and carries its id in the event metadata
- the consumer adopts that id instead of creating a message
- an untouched adopted message survives a tool boundary
- a message that already showed text is still released at the boundary

Removing the reset guard fails the third. Affected suites pass (110): `test_teams.py`, `test_teams_streaming_placeholder.py`, `test_stream_consumer*.py`.

## Note

Log lines and traces above are from a production deployment with identifiers redacted.