### PR TITLE
fix(desktop): stop pin/unpin sidebar races against lagging session pages

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/hermes', () => ({
 import { $pinnedSessionIds } from '@/store/layout'
 import { $sessions } from '@/store/session'
 
-import { watchSessionPins } from './session-pin-sync'
+import { watchSessionPins, __resetSessionPinSyncForTests } from './session-pin-sync'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
@@ -28,12 +28,15 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
+  __resetSessionPinSyncForTests()
   $sessions.set([])
   $pinnedSessionIds.set([])
   patch.mockClear()
+  patch.mockImplementation(() => Promise.resolve({ ok: true }))
 })
 
 afterEach(() => {
+  __resetSessionPinSyncForTests()
   $sessions.set([])
   $pinnedSessionIds.set([])
 })
@@ -120,6 +123,9 @@ describe('watchSessionPins remote pull', () => {
     $pinnedSessionIds.set(['gone'])
     $sessions.set([row('gone', { pinned: true })])
     await flush()
+    // Server has confirmed the pin; sticky intent is cleared.
+    $sessions.set([row('gone', { pinned: true })])
+    await flush()
     patch.mockClear()
 
     // Another app unpinned it; our next refresh carries the new truth.
@@ -155,14 +161,114 @@ describe('watchSessionPins remote pull', () => {
 
     expect($pinnedSessionIds.get()).toContain('race')
 
-    // Once the write is acked, later server truth is honoured again.
     settle({ ok: true })
     await flush()
     await flush()
 
+    // After ack, lagging false pages still must not strip a just-pinned chat.
     $sessions.set([row('race', { pinned: false }), row('other')])
     await flush()
+    expect($pinnedSessionIds.get()).toContain('race')
 
+    // Server confirmation clears sticky; later remote unpin can win.
+    $sessions.set([row('race', { pinned: true }), row('other')])
+    await flush()
+    $sessions.set([row('race', { pinned: false }), row('other')])
+    await flush()
     expect($pinnedSessionIds.get()).not.toContain('race')
+  })
+
+  it('does not re-adopt a just-unpinned chat from a still-true server page', async () => {
+    // Repro: user unpins while the session list still carries pinned=true.
+    // Pull used to run before the unpin write, put the id back, and the
+    // sidebar Pinned section never dropped the row.
+    $sessions.set([row('sticky', { pinned: true, profile: 'dewey' })])
+    $pinnedSessionIds.set(['sticky'])
+    await flush()
+    $sessions.set([row('sticky', { pinned: true, profile: 'dewey' })])
+    await flush()
+    patch.mockClear()
+
+    let settle: (v: { ok: boolean }) => void = () => {}
+    patch.mockImplementationOnce(() => new Promise(resolve => (settle = resolve)))
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('sticky', false, 'dewey')
+    // Stale list refresh while the unpin PATCH is still in flight.
+    $sessions.set([row('sticky', { pinned: true, profile: 'dewey' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).not.toContain('sticky')
+
+    settle({ ok: true })
+    await flush()
+    // Server still lagging one more tick must not bounce the pin back.
+    $sessions.set([row('sticky', { pinned: true, profile: 'dewey' })])
+    await flush()
+    expect($pinnedSessionIds.get()).not.toContain('sticky')
+
+    // Once the backend agrees, stay unpinned.
+    $sessions.set([row('sticky', { pinned: false, profile: 'dewey' })])
+    await flush()
+    expect($pinnedSessionIds.get()).not.toContain('sticky')
+  })
+
+  it('unpins a lineage-root id even when the live tip still reports pinned', async () => {
+    $sessions.set([row('tip', { _lineage_root_id: 'root', pinned: true, profile: 'dewey' })])
+    $pinnedSessionIds.set(['root'])
+    await flush()
+    $sessions.set([row('tip', { _lineage_root_id: 'root', pinned: true, profile: 'dewey' })])
+    await flush()
+    patch.mockClear()
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('root', false, 'dewey')
+    expect($pinnedSessionIds.get()).not.toContain('root')
+    expect($pinnedSessionIds.get()).not.toContain('tip')
+
+    // Stale tip page must not re-pin under the durable root.
+    $sessions.set([row('tip', { _lineage_root_id: 'root', pinned: true, profile: 'dewey' })])
+    await flush()
+    expect($pinnedSessionIds.get()).toEqual([])
+  })
+
+  it('does not strip a just-pinned chat from a still-false server page', async () => {
+    // Symmetric race to the sticky-unpin bug: user pins while the list still
+    // carries pinned=false. Pull must not delete the local pin before/while
+    // the PATCH lands.
+    $sessions.set([row('fresh', { pinned: false, profile: 'dewey' })])
+    await flush()
+    patch.mockClear()
+
+    let settle: (v: { ok: boolean }) => void = () => {}
+    patch.mockImplementationOnce(() => new Promise(resolve => (settle = resolve)))
+
+    $pinnedSessionIds.set(['fresh'])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('fresh', true, 'dewey')
+    expect($pinnedSessionIds.get()).toContain('fresh')
+
+    // Stale list refresh while the pin PATCH is still in flight.
+    $sessions.set([row('fresh', { pinned: false, profile: 'dewey' })])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('fresh')
+
+    settle({ ok: true })
+    await flush()
+
+    // Still lagging false after ack must not strip the pin.
+    $sessions.set([row('fresh', { pinned: false, profile: 'dewey' })])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('fresh')
+
+    // Server confirmation clears sticky; pin remains via local + server true.
+    $sessions.set([row('fresh', { pinned: true, profile: 'dewey' })])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('fresh')
   })
 })

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -18,6 +18,12 @@
  * server says are gone. Only rows actually present in the payload are
  * consulted, so a backend predating the flag (`pinned === undefined`) leaves
  * the local set untouched.
+ *
+ * Order matters for BOTH directions. Local intent (pin and unpin) must be
+ * written and guarded BEFORE pull runs. Otherwise a lagging list page wins the
+ * same tick:
+ *   - still-true page re-adopts a just-unpinned chat
+ *   - still-false page strips a just-pinned chat
  */
 
 import { setSessionPinnedRemote } from '@/hermes'
@@ -30,35 +36,233 @@ const mirrored = new Set<string>()
 const pending = new Set<string>()
 // Writes we've issued but not yet had acked, id -> value written. A list page
 // already in flight when we PATCH still carries the old value, so it must not
-// be read as the server disagreeing with us. Cleared when the write settles —
-// the request's own lifetime is the guard, so nothing can leave one open.
+// be read as the server disagreeing with us. Cleared when the write settles.
 const unconfirmed = new Map<string, boolean>()
+// Local unpin intent. Survives lagging pinned=true pages until the server
+// reports false (or the user pins again).
+const unpinSticky = new Set<string>()
+const unpinAcked = new Set<string>()
+// Local pin intent. Survives lagging pinned=false pages until the server
+// reports true (or the user unpins).
+const pinSticky = new Set<string>()
+const pinAcked = new Set<string>()
 
 function profileFor(pinId: string): null | string | undefined {
   return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
 }
 
+/** Every id that should travel with a pin write for this conversation. */
+function aliasIdsFor(pinId: string): string[] {
+  const ids = new Set<string>([pinId])
+  for (const row of $sessions.get()) {
+    if (sessionMatchesStoredId(row, pinId)) {
+      ids.add(row.id)
+      ids.add(sessionPinId(row))
+    }
+  }
+  return [...ids]
+}
+
+function markUnconfirmed(id: string, pinned: boolean): void {
+  for (const alias of aliasIdsFor(id)) {
+    unconfirmed.set(alias, pinned)
+  }
+}
+
+function clearUnconfirmed(id: string): void {
+  for (const alias of aliasIdsFor(id)) {
+    unconfirmed.delete(alias)
+  }
+}
+
+function markUnpinSticky(id: string): void {
+  for (const alias of aliasIdsFor(id)) {
+    unpinSticky.add(alias)
+    unpinAcked.delete(alias)
+    pinSticky.delete(alias)
+    pinAcked.delete(alias)
+  }
+}
+
+function markUnpinAcked(id: string): void {
+  for (const alias of aliasIdsFor(id)) {
+    unpinAcked.add(alias)
+  }
+}
+
+function clearUnpinSticky(id: string): void {
+  for (const alias of aliasIdsFor(id)) {
+    unpinSticky.delete(alias)
+    unpinAcked.delete(alias)
+  }
+}
+
+function markPinSticky(id: string): void {
+  for (const alias of aliasIdsFor(id)) {
+    pinSticky.add(alias)
+    pinAcked.delete(alias)
+    unpinSticky.delete(alias)
+    unpinAcked.delete(alias)
+  }
+}
+
+function markPinAcked(id: string): void {
+  for (const alias of aliasIdsFor(id)) {
+    pinAcked.add(alias)
+  }
+}
+
+function clearPinSticky(id: string): void {
+  for (const alias of aliasIdsFor(id)) {
+    pinSticky.delete(alias)
+    pinAcked.delete(alias)
+  }
+}
+
+function isUnpinSticky(pinId: string, liveId: string): boolean {
+  return unpinSticky.has(pinId) || unpinSticky.has(liveId)
+}
+
+function isPinSticky(pinId: string, liveId: string): boolean {
+  return pinSticky.has(pinId) || pinSticky.has(liveId)
+}
+
+function guardedValue(pinId: string, liveId: string): boolean | undefined {
+  if (unconfirmed.has(pinId)) {
+    return unconfirmed.get(pinId)
+  }
+  if (unconfirmed.has(liveId)) {
+    return unconfirmed.get(liveId)
+  }
+  return undefined
+}
+
 /** PATCH the flag, guarding reads against pages that predate the write. */
 function writePin(id: string, pinned: boolean, profile?: null | string): Promise<void> {
-  unconfirmed.set(id, pinned)
+  markUnconfirmed(id, pinned)
+  if (pinned) {
+    markPinSticky(id)
+  } else {
+    markUnpinSticky(id)
+  }
 
   return setSessionPinnedRemote(id, pinned, profile).then(
     () => {
-      unconfirmed.delete(id)
+      clearUnconfirmed(id)
+      if (pinned) {
+        markPinAcked(id)
+      } else {
+        markUnpinAcked(id)
+      }
     },
     (err: unknown) => {
-      unconfirmed.delete(id)
+      clearUnconfirmed(id)
       throw err
     }
   )
 }
 
 /**
+ * Push local removals to the backend.
+ *
+ * Must run before pull: a session list still carrying `pinned: true` would
+ * otherwise re-adopt the id in the same reconcile tick and swallow the unpin.
+ */
+function pushLocalUnpins(current: Set<string>): void {
+  const toUnpin = new Set<string>()
+
+  for (const id of [...mirrored, ...pending]) {
+    if (!current.has(id)) {
+      mirrored.delete(id)
+      pending.delete(id)
+      toUnpin.add(id)
+    }
+  }
+
+  // Retry sticky unpins that never got an ack (failed PATCH).
+  for (const id of [...unpinSticky]) {
+    if (!current.has(id) && !unconfirmed.has(id) && !unpinAcked.has(id)) {
+      toUnpin.add(id)
+    }
+  }
+
+  for (const id of toUnpin) {
+    if (unconfirmed.has(id)) {
+      continue
+    }
+
+    void writePin(id, false, profileFor(id)).catch(() => {
+      // unpinSticky remains; next reconcile retries.
+    })
+  }
+}
+
+/**
+ * Push local additions to the backend.
+ *
+ * Must run before pull: a session list still carrying `pinned: false` would
+ * otherwise strip a just-pinned id in the same tick.
+ */
+function pushLocalPins(current: Set<string>): void {
+  for (const id of current) {
+    if (!mirrored.has(id)) {
+      pending.add(id)
+      // Guard immediately so pull in this same reconcile cannot drop it.
+      markPinSticky(id)
+    }
+  }
+
+  for (const id of [...pending]) {
+    // Sticky unpin that the user has not re-added must not be flipped true.
+    if (unpinSticky.has(id) && !current.has(id)) {
+      pending.delete(id)
+      continue
+    }
+
+    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
+
+    if (!row) {
+      continue
+    }
+
+    // Already mirrored and acked: nothing to do unless a prior write failed.
+    if (mirrored.has(id) && pinAcked.has(id) && !unconfirmed.has(id)) {
+      pending.delete(id)
+      continue
+    }
+
+    pending.delete(id)
+    mirrored.add(id)
+    void writePin(id, true, row.profile).catch(() => {
+      mirrored.delete(id)
+      pending.add(id)
+    })
+  }
+
+  // Retry sticky pins that never got an ack (failed PATCH).
+  for (const id of [...pinSticky]) {
+    if (!current.has(id) || unconfirmed.has(id) || pinAcked.has(id) || pending.has(id)) {
+      continue
+    }
+
+    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
+    if (!row) {
+      continue
+    }
+
+    mirrored.add(id)
+    void writePin(id, true, row.profile).catch(() => {
+      mirrored.delete(id)
+      pending.add(id)
+    })
+  }
+}
+
+/**
  * Adopt the server's pin state for every row in the current page.
  *
- * Runs before the push pass so a remote pin is already in the local set by the
- * time we reconcile — it gets marked as mirrored rather than echoed straight
- * back as a redundant PATCH.
+ * Runs after local push so in-flight / sticky intent always beats a lagging
+ * page. Remote-only changes still flow in once intent is cleared.
  */
 function pullRemotePins(): void {
   const local = new Set($pinnedSessionIds.get())
@@ -75,20 +279,45 @@ function pullRemotePins(): void {
     const heldLocally = local.has(pinId) || local.has(row.id)
 
     // A write of ours the page hasn't caught up to yet is newer than the page.
-    const awaited = unconfirmed.has(pinId) ? unconfirmed.get(pinId) : unconfirmed.get(row.id)
+    const awaited = guardedValue(pinId, row.id)
 
     if (awaited !== undefined && awaited !== row.pinned) {
       continue
+    }
+
+    // Local unpin intent: ignore lagging pinned=true until the server agrees.
+    if (isUnpinSticky(pinId, row.id)) {
+      if (row.pinned) {
+        continue
+      }
+      clearUnpinSticky(pinId)
+      clearUnpinSticky(row.id)
+    }
+
+    // Local pin intent: ignore lagging pinned=false until the server agrees.
+    if (isPinSticky(pinId, row.id)) {
+      if (!row.pinned) {
+        continue
+      }
+      clearPinSticky(pinId)
+      clearPinSticky(row.id)
     }
 
     if (row.pinned && !heldLocally) {
       pinSession(pinId)
       // Already true server-side; record it so the push pass doesn't re-PATCH.
       mirrored.add(pinId)
+      local.add(pinId)
     } else if (!row.pinned && heldLocally) {
-      unpinSession(local.has(pinId) ? pinId : row.id)
+      // Drop every alias that names this conversation (legacy live-id pins and
+      // durable lineage-root pins both count).
+      unpinSession(pinId, row.id)
       mirrored.delete(pinId)
       mirrored.delete(row.id)
+      local.delete(pinId)
+      local.delete(row.id)
+      clearPinSticky(pinId)
+      clearPinSticky(row.id)
     }
   }
 }
@@ -99,43 +328,13 @@ function reconcile(): void {
     return
   }
 
-  pullRemotePins()
-
   const current = new Set($pinnedSessionIds.get())
 
-  // Unpinned: anything we were tracking that's no longer in the set.
-  for (const id of [...mirrored, ...pending]) {
-    if (!current.has(id)) {
-      mirrored.delete(id)
-      pending.delete(id)
-      void writePin(id, false, profileFor(id)).catch(() => {})
-    }
-  }
-
-  // Newly pinned: hold until we can resolve the row (for its profile).
-  for (const id of current) {
-    if (!mirrored.has(id)) {
-      pending.add(id)
-    }
-  }
-
-  // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
-  // retry on the next $sessions change.
-  for (const id of [...pending]) {
-    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
-
-    if (!row) {
-      continue
-    }
-
-    pending.delete(id)
-    mirrored.add(id)
-    void writePin(id, true, row.profile).catch(() => {
-      // Let a later reconcile retry the mirror.
-      mirrored.delete(id)
-      pending.add(id)
-    })
-  }
+  // 1) Push local intent first (sets unconfirmed + sticky guards).
+  pushLocalUnpins(current)
+  pushLocalPins(new Set($pinnedSessionIds.get()))
+  // 2) Then adopt remote truth for ids we have no opposing local intent about.
+  pullRemotePins()
 }
 
 // Sync once, then re-sync on pin-set and session-list changes. Call once per app.
@@ -143,4 +342,15 @@ export function watchSessionPins(): void {
   reconcile()
   $pinnedSessionIds.listen(reconcile)
   $sessions.listen(reconcile)
+}
+
+/** Test-only: wipe module mirrors so cases don't bleed across tests. */
+export function __resetSessionPinSyncForTests(): void {
+  mirrored.clear()
+  pending.clear()
+  unconfirmed.clear()
+  unpinSticky.clear()
+  unpinAcked.clear()
+  pinSticky.clear()
+  pinAcked.clear()
 }


### PR DESCRIPTION
## Summary
Fixes the Desktop sidebar pin/unpin race where a lagging sessions list page undoes the user click in the same tick.

## Root cause
`pullRemotePins()` treated the current page as authoritative before local pin/unpin intent was pushed. A page still carrying `pinned: false` stripped brand-new pins; a page still carrying `pinned: true` resurrected just-unpinned chats. The PATCH never stuck.

## Fix
- Push local pin and unpin intent first (with sticky guards until backend confirms).
- Only then pull remote truth for ids with no opposing local intent.
- Regression coverage for pin, unpin, boot re-assert, and lagging-page cases.

## Test plan
- [x] `cd apps/desktop && npm test -- --run src/store/session-pin-sync.test.ts` → 14/14 pass
- [ ] Manual: pin a recents chat → stays in PINNED across list refresh
- [ ] Manual: unpin a pinned chat → stays out of PINNED across list refresh
- [ ] Manual: quit/relaunch Desktop → pin state survives

Related open reports/PRs: #75342, #74638, #75295