### PR TITLE
fix(update): force stat-cache invalidation to catch all EOL churn

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3071,10 +3071,39 @@ def _normalize_managed_eol(git_cmd, repo_root):
     # -c, not config: evaluate the tree as it WOULD look pinned, without
     # persisting anything we might not be able to follow through on.
     probe = git_cmd + ["-c", "core.autocrlf=false"]
+    index_path = None
 
-    def _dirty(*extra):
+    def _force_content_scan():
+        # Git skips re-hashing any file whose on-disk stat matches the index's
+        # cached stat, assuming it unchanged. The checkout that renormalized this
+        # tree wrote that cache, so with core.autocrlf flipped the CRLF worktree
+        # still reads clean and the churn stays hidden -- only "racily clean"
+        # entries (mtime >= the index timestamp) are re-hashed, which is why a
+        # large tree enumerates partially and nondeterministically. Backdating
+        # the index timestamp makes every entry racily clean, forcing a content
+        # scan so the churn is seen in full. Best-effort: failure only degrades
+        # to the old racy behavior, never blocks the update.
+        nonlocal index_path
+        try:
+            if index_path is None:
+                resolved = subprocess.run(
+                    git_cmd + ["rev-parse", "--git-path", "index"],
+                    cwd=repo_root,
+                    capture_output=True,
+                    text=True, encoding="utf-8", errors="replace",
+                )
+                if resolved.returncode != 0:
+                    return
+                candidate = Path(resolved.stdout.strip())
+                index_path = candidate if candidate.is_absolute() else Path(repo_root) / candidate
+            os.utime(index_path, (1, 1))
+        except OSError:
+            pass
+
+    def _dirty(autocrlf="false"):
+        _force_content_scan()
         out = subprocess.run(
-            probe + ["diff", "-z", "--name-only", *extra],
+            git_cmd + ["-c", f"core.autocrlf={autocrlf}", "diff", "-z", "--name-only"],
             cwd=repo_root,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
@@ -3084,7 +3113,13 @@ def _normalize_managed_eol(git_cmd, repo_root):
         return {p for p in out.stdout.split("\0") if p}
 
     def _eol_only():
-        all_dirty, real_dirty = _dirty(), _dirty("--ignore-cr-at-eol")
+        # autocrlf=false exposes every file the flip would touch (churn plus any
+        # real edits); autocrlf=true compares normalized content, so pure churn
+        # reads clean and only genuine edits remain. The difference is the
+        # churn-only set. --ignore-cr-at-eol cannot stand in for the second probe:
+        # git's --name-only still lists a file whose only change the flag ignores,
+        # so it would swallow the churn and leave nothing to clean.
+        all_dirty, real_dirty = _dirty("false"), _dirty("true")
         if all_dirty is None or real_dirty is None:
             return None
         return all_dirty - real_dirty

--- a/tests/hermes_cli/test_update_eol_churn.py
+++ b/tests/hermes_cli/test_update_eol_churn.py
@@ -13,6 +13,7 @@ the whole tree as modified. These tests pin down that coupling.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -62,7 +63,20 @@ def _managed_repo(tmp_path: Path, files: dict[str, bytes]) -> Path:
     return repo
 
 
+def _force_content_scan(repo: Path) -> None:
+    """Backdate the index so git re-hashes content instead of trusting its stat
+    cache (the same race ``_normalize_managed_eol`` works around). Without this the
+    oracle below reads a settled checkout clean and the assertions go
+    nondeterministic: a plain diff only re-hashes "racily clean" entries, so
+    leftover CRLF churn can be invisible and a broken repair would read clean."""
+    try:
+        os.utime(repo / ".git" / "index", (1, 1))
+    except OSError:
+        pass
+
+
 def _dirty(repo: Path) -> set[str]:
+    _force_content_scan(repo)
     out = subprocess.run(
         ["git", "-c", "core.autocrlf=false", "diff", "--name-only"],
         cwd=repo,


### PR DESCRIPTION
## Problem

`test_churn_across_more_files_than_fit_in_one_argv` fails nondeterministically on CI and Windows — `assert 708 == 1200` (count varies per run).

## Root Cause

`git checkout -- .` under `core.autocrlf=true` renormalizes the working tree to CRLF and caches matching stat info (size, mtime) in the index. A subsequent `git diff -c core.autocrlf=false` then skips the content comparison for any entry whose cached stat matches the worktree file — so CRLF churn is invisible for those entries.

This is the classic "racy git" stat-cache problem. The missed count is nondeterministic (depends on filesystem mtime resolution) and worst on large trees.

A second bug compounded it: `--name-only --ignore-cr-at-eol` is unreliable once the stat cache is busted — it lists CRLF-only files as dirty regardless of the flag, so `_eol_only()` computed an empty set and the cleanup was skipped entirely.

## Fix

**1. Stat-cache invalidation** (`hermes_cli/update_cmd.py`)
Backdate the index mtime to epoch before every `git diff`, forcing git to re-lstat and re-hash every entry ("racily clean" entries).

**2. Reliable EOL-only detection** (`hermes_cli/update_cmd.py`)
Replace the broken `_dirty('--ignore-cr-at-eol')` approach with a dual-autocrlf diff: `autocrlf=false` exposes all churn; `autocrlf=true` normalizes it away; the set difference is the churn-only files.

**3. Test oracle** (`tests/hermes_cli/test_update_eol_churn.py`)
Apply the same index backdate in the test helper `_dirty()` so assertions read the tree reliably.

## Verification

- All 9 tests pass (8 passed, 1 skipped on win32 as designed)
- 3 consecutive runs — no flakiness
- Reproduced the original failure locally before fixing (`631/1200`)