### PR TITLE
fix(sqlite): close connection before untracking on failure (#75629)

### DIFF
--- a/hermes_cli/sqlite_safe_read.py
+++ b/hermes_cli/sqlite_safe_read.py
@@ -40,7 +40,10 @@ lifecycle**. ``_live_lock`` is therefore held across three critical sections,
 each of which spans the syscall *and* the registry mutation:
 
 * open + register (:func:`connect_tracked`)
-* unregister + close (:meth:`TrackedConnection.close`)
+* close + unregister (:meth:`TrackedConnection.close`) -- in that order, so a
+  failed ``close()`` (e.g. cross-thread use with ``check_same_thread=True``)
+  leaves the entry registered rather than untracking a descriptor that is
+  still open
 * check + ``open``/``read``/``close`` (:func:`read_header_bytes_preopen`)
 
 Without that, a thread could pass the "no live connection" check, a second
@@ -154,10 +157,10 @@ class _TrackingMixin:
     def close(self) -> None:  # type: ignore[misc]
         with _live_lock:
             path = getattr(self, "_hermes_tracked_path", None)
+            super().close()  # type: ignore[misc]
             if path is not None:
                 self._hermes_tracked_path = None
                 untrack_connection(path)
-            super().close()  # type: ignore[misc]
 
 
 class TrackedConnection(_TrackingMixin, sqlite3.Connection):

--- a/tests/test_sqlite_lock_safe_inspection.py
+++ b/tests/test_sqlite_lock_safe_inspection.py
@@ -253,6 +253,60 @@ def test_session_db_read_only_is_tracked(tmp_path, clean_registry, monkeypatch):
 
 
 
+def test_close_failure_keeps_connection_tracked(tmp_path, clean_registry):
+    """A failed close() must not untrack a descriptor that is still open.
+
+    ``sqlite3`` raises ``ProgrammingError`` when ``close()`` is called from a
+    thread other than the one that created the connection (the default
+    ``check_same_thread=True``). If the registry entry were removed before
+    the real ``close()`` runs, ``has_live_connection`` would go false while
+    the fd -- and its POSIX locks -- are still live, reopening the exact
+    byte-probe race this module exists to prevent.
+    """
+    import threading
+
+    from hermes_cli.sqlite_safe_read import connect_tracked
+
+    db = tmp_path / "state.db"
+    _make_db(db, "DELETE")
+
+    holder: dict = {}
+    ready = threading.Event()
+    may_close = threading.Event()
+    closed_ok = threading.Event()
+
+    def worker():
+        holder["conn"] = connect_tracked(db)
+        ready.set()
+        # Stay on this thread so a later close() from here succeeds --
+        # check_same_thread=True binds the connection to the thread that
+        # created it, not just to "some thread that isn't main".
+        may_close.wait(10)
+        holder["conn"].close()
+        closed_ok.set()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    ready.wait(10)
+
+    conn = holder["conn"]
+    assert has_live_connection(db)
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn.close()
+
+    # Failed close: registry must still reflect the live descriptor.
+    assert has_live_connection(db)
+    assert read_header_bytes_preopen(db, length=16) is None
+
+    may_close.set()
+    t.join(10)
+
+    assert closed_ok.is_set()
+    assert not has_live_connection(db)
+    assert read_header_bytes_preopen(db, length=16) is not None
+
+
 def test_page_count_bytes_matches_on_disk_size(tmp_path):
     """The PRAGMA route reports the same size the header field encodes."""
     db = tmp_path / "state.db"


### PR DESCRIPTION
## Summary

`_TrackingMixin.close()` in `hermes_cli/sqlite_safe_read.py` removed a
connection's entry from the live-connection registry **before** calling the
real `close()`. When the real close failed — e.g. cross-thread use under
SQLite's default `check_same_thread=True` — the registry entry was already
gone, so `has_live_connection()` reported `False` for a file descriptor that
was still open. That let `read_header_bytes_preopen()` byte-probe a live
database, which on POSIX cancels every advisory lock this process holds on
that file (including a running `VACUUM`'s exclusive lock), reopening the
exact corruption path this module exists to prevent
(`"database disk image is malformed"`).

Fixes #75629.

## Root cause

```python
# hermes_cli/sqlite_safe_read.py — _TrackingMixin.close(), before
def close(self) -> None:
    with _live_lock:
        path = getattr(self, "_hermes_tracked_path", None)
        if path is not None:
            self._hermes_tracked_path = None
            untrack_connection(path)   # registry entry gone...
        super().close()                # ...even if this raises
```

## Fix

Close first, untrack only on success — a failed `close()` now fails
*closed*, leaving the registry (and therefore the byte-probe guard) honest:

```python
# hermes_cli/sqlite_safe_read.py — _TrackingMixin.close(), after
def close(self) -> None:
    with _live_lock:
        path = getattr(self, "_hermes_tracked_path", None)
        super().close()                # attempt the real close first
        if path is not None:
            self._hermes_tracked_path = None
            untrack_connection(path)   # only on success
```

Behavior on a successful close is unchanged. On a failed close, the
exception still propagates to the caller exactly as before — the only
change is that the registry entry survives, so `has_live_connection()` and
`read_header_bytes_preopen()` keep telling the truth.

## Regression test

`tests/test_sqlite_lock_safe_inspection.py::test_close_failure_keeps_connection_tracked`:

1. A connection is opened via `connect_tracked()` on a worker thread that
   then blocks (stays alive).
2. The main thread calls `close()` on it — SQLite raises
   `ProgrammingError` (cross-thread, default `check_same_thread=True`).
3. Assert `has_live_connection()` is still `True` and
   `read_header_bytes_preopen()` still returns `None` (refused).
4. The owning worker thread closes it for real — assert both release.

The same assertion fails on `main` before this change: step 3 sees
`has_live_connection() == False` while the descriptor is still open.

## Test plan

- [x] `pytest tests/test_sqlite_lock_safe_inspection.py` — 7/7 passed
      (6 pre-existing + 1 new regression test)
- [x] `tests/hermes_cli/test_session_recovery.py`,
      `tests/hermes_cli/test_kanban_db.py` — no new failures. Two failures
      present in `test_kanban_db.py`
      (`test_rate_limit_exit_requeues_without_counting_failure`,
      `test_worktree_workspace_explicit_target_materializes_linked_worktree`)
      are pre-existing on `main` (confirmed via `git stash` + rerun before
      this diff), unrelated to `sqlite_safe_read.py`.

## Scope

Only two files touched: `hermes_cli/sqlite_safe_read.py` (5-line reorder +
one docstring clarification) and the test file above. `hermes_state.py` is
untouched.

## Not fixed here — related, complementary, tracked separately

This PR closes the registry's lie; it does not address *why* a close can
fail in the first place, or reap connections nobody ever retries closing:

- **#74304** — `SessionDB`'s per-thread read connections open with the
  default `check_same_thread=True`, which is the concrete trigger for the
  failure this PR guards against on that path. That PR opens readers with
  `check_same_thread=False` instead, so the close succeeds and the guard
  never has to fire there.
- **#75269** — long-lived processes can accumulate read connections from
  worker threads that finished long ago, none of them reaped until final
  shutdown (`RLIMIT_NOFILE` pressure, not a registry lie).

All three are independent fixes for independent bugs; this one stands on
its own and should merge regardless of the other two.

 
## Infographic

![Guild Quest #75629 — Safe SQLite Connection Closing](https://raw.githubusercontent.com/JoaoMarcos44/hermes-agent/pr-75629-infographic-asset/pr-75629-infographic.png)

*(Rendered locally and hosted on an isolated, never-merged asset branch —
per `.gitignore`'s PR-infographic policy, the binary never enters this
PR's history or `main`.)*
