### PR TITLE
fix(desktop): memoize sidebar flatRows and row renderers to prevent s…

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -155,5 +155,28 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
 
     const secondRowsRef = mockVirtualListPropsHistory[1].rows
     expect(secondRowsRef).not.toBe(firstRowsRef)
+
+    // Change sessions array identity
+    const updatedSessions = generateSessions(VIRTUALIZE_THRESHOLD + 4)
+    rerender(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        dateGrouped={true}
+        emptyState={<div>Empty</div>}
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        open={true}
+        pinned={false}
+        sessions={updatedSessions}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    const thirdRowsRef = mockVirtualListPropsHistory[2].rows
+    expect(thirdRowsRef).not.toBe(secondRowsRef)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -1,0 +1,159 @@
+import { cleanup, render } from '@testing-library/react'
+import type * as React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
+import type { VirtualSessionListProps } from './virtual-session-list'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        dateDivider: {
+          earlierThisMonth: 'Earlier this month',
+          lastMonth: 'Last month',
+          lastWeek: 'Last week',
+          older: 'Older',
+          today: 'Today',
+          yesterday: 'Yesterday'
+        }
+      }
+    }
+  })
+}))
+
+const mockVirtualListPropsHistory: VirtualSessionListProps[] = []
+
+vi.mock('./virtual-session-list', () => ({
+  VirtualSessionList: (props: VirtualSessionListProps) => {
+    mockVirtualListPropsHistory.push(props)
+    return <div data-testid="virtual-session-list">Virtual List ({props.rows.length} rows)</div>
+  }
+}))
+
+vi.mock('./session-row', () => ({
+  SidebarSessionRow: ({ session }: { session: SessionInfo }) => (
+    <div data-testid={`session-row-${session.id}`}>{session.id}</div>
+  )
+}))
+
+function makeSession(id: string, startedAt = 1000): SessionInfo {
+  return {
+    handoff_platform: null,
+    handoff_state: null,
+    id,
+    last_active: startedAt,
+    profile: 'default',
+    started_at: startedAt
+  } as unknown as SessionInfo
+}
+
+function generateSessions(count: number): SessionInfo[] {
+  return Array.from({ length: count }, (_, i) => makeSession(`session-${i + 1}`, 10000 - i * 100))
+}
+
+const noop = () => {}
+
+describe('SidebarSessionsSection memoization & virtualizer stability', () => {
+  it('memoizes flatRows and passes the exact same rows array reference across parent re-renders', () => {
+    mockVirtualListPropsHistory.length = 0
+
+    const sessions = generateSessions(VIRTUALIZE_THRESHOLD + 5)
+
+    const { rerender } = render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        open={true}
+        pinned={false}
+        sessions={sessions}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    expect(mockVirtualListPropsHistory.length).toBe(1)
+    const initialRowsRef = mockVirtualListPropsHistory[0].rows
+    expect(initialRowsRef.length).toBeGreaterThan(VIRTUALIZE_THRESHOLD)
+
+    // Re-render parent with the exact same sessions array and props
+    rerender(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        open={true}
+        pinned={false}
+        sessions={sessions}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    expect(mockVirtualListPropsHistory.length).toBe(2)
+    const nextRowsRef = mockVirtualListPropsHistory[1].rows
+
+    // Confirm that the flatRows array reference remains strictly identical across renders (useMemo proof)
+    expect(nextRowsRef).toBe(initialRowsRef)
+  })
+
+  it('re-computes flatRows reference when dateGrouped or sessions change', () => {
+    mockVirtualListPropsHistory.length = 0
+
+    const initialSessions = generateSessions(VIRTUALIZE_THRESHOLD + 2)
+
+    const { rerender } = render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        dateGrouped={false}
+        emptyState={<div>Empty</div>}
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        open={true}
+        pinned={false}
+        sessions={initialSessions}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    const firstRowsRef = mockVirtualListPropsHistory[0].rows
+
+    // Change dateGrouped to true
+    rerender(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        dateGrouped={true}
+        emptyState={<div>Empty</div>}
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        open={true}
+        pinned={false}
+        sessions={initialSessions}
+        workingSessionIdSet={new Set()}
+      />
+    )
+
+    const secondRowsRef = mockVirtualListPropsHistory[1].rows
+    expect(secondRowsRef).not.toBe(firstRowsRef)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -1,6 +1,6 @@
 import type { useSensors } from '@dnd-kit/core'
 import type * as React from 'react'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { SidebarPanelLabel } from '@/app/shell/sidebar-label'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
@@ -225,52 +225,77 @@ export function SidebarSessionsSection({
     [sessions, preserveInputOrder]
   )
 
-  const renderRow = (session: SessionInfo, draggable: boolean, branchStem?: string) => {
-    const rowProps = {
-      branchStem,
-      isPinned: pinned,
-      isSelected: session.id === activeSessionId,
-      isWorking: workingSessionIdSet.has(session.id),
-      onArchive: () => onArchiveSession(session.id),
-      onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
-      onDelete: () => onDeleteSession(session.id),
-      onPin: () => onTogglePin(sessionPinId(session)),
-      onResume: () => onResumeSession(session.id),
-      reorderable: draggable && !branchStem,
-      session,
-      showProfile: showProfileTags
-    }
+  const renderRow = useCallback(
+    (session: SessionInfo, draggable: boolean, branchStem?: string) => {
+      const rowProps = {
+        branchStem,
+        isPinned: pinned,
+        isSelected: session.id === activeSessionId,
+        isWorking: workingSessionIdSet.has(session.id),
+        onArchive: () => onArchiveSession(session.id),
+        onBranch: onBranchSession ? () => onBranchSession(session.id, session.profile) : undefined,
+        onDelete: () => onDeleteSession(session.id),
+        onPin: () => onTogglePin(sessionPinId(session)),
+        onResume: () => onResumeSession(session.id),
+        reorderable: draggable && !branchStem,
+        session,
+        showProfile: showProfileTags
+      }
 
-    return draggable && !branchStem ? (
-      <SortableSidebarSessionRow key={session.id} {...rowProps} />
-    ) : (
-      <SidebarSessionRow key={session.id} {...rowProps} />
-    )
-  }
+      return draggable && !branchStem ? (
+        <SortableSidebarSessionRow key={session.id} {...rowProps} />
+      ) : (
+        <SidebarSessionRow key={session.id} {...rowProps} />
+      )
+    },
+    [
+      activeSessionId,
+      onArchiveSession,
+      onBranchSession,
+      onDeleteSession,
+      onResumeSession,
+      onTogglePin,
+      pinned,
+      showProfileTags,
+      workingSessionIdSet
+    ]
+  )
 
   // A single flat/virtual/lane list row — either a date divider or a session.
-  const renderListRow = (row: SidebarListRow, draggable: boolean) =>
-    row.kind === 'divider' ? (
-      <SidebarDateDivider key={row.key} label={sessionBucketLabel(row.bucket, dividerLabels)} />
-    ) : (
-      renderRow(row.entry.session, draggable, row.entry.branchStem)
-    )
+  const renderListRow = useCallback(
+    (row: SidebarListRow, draggable: boolean) =>
+      row.kind === 'divider' ? (
+        <SidebarDateDivider key={row.key} label={sessionBucketLabel(row.bucket, dividerLabels)} />
+      ) : (
+        renderRow(row.entry.session, draggable, row.entry.branchStem)
+      ),
+    [dividerLabels, renderRow]
+  )
 
   // Sessions inside repos/worktrees are date-ordered and static.
-  const renderRows = (items: SessionInfo[]) =>
-    flattenSessionsWithBranches(items).map(({ branchStem, session }) => renderRow(session, false, branchStem))
+  const renderRows = useCallback(
+    (items: SessionInfo[]) =>
+      flattenSessionsWithBranches(items).map(({ branchStem, session }) => renderRow(session, false, branchStem)),
+    [renderRow]
+  )
 
   // Same as `renderRows`, but with date dividers folded in — used for
   // entered-project lanes so a lane spanning multiple days reads
   // chronologically, matching the flat recents list.
-  const renderRowsDated = (items: SessionInfo[]) => {
-    const entries = flattenSessionsWithBranches(items)
+  const renderRowsDated = useCallback(
+    (items: SessionInfo[]) => {
+      const entries = flattenSessionsWithBranches(items)
 
-    return (dateGrouped ? groupEntriesByRecency(entries) : toSessionRows(entries)).map(row => renderListRow(row, false))
-  }
+      return (dateGrouped ? groupEntriesByRecency(entries) : toSessionRows(entries)).map(row => renderListRow(row, false))
+    },
+    [dateGrouped, renderListRow]
+  )
 
   // Flat recents as list rows: grouped by recency when enabled, plain otherwise.
-  const flatRows: SidebarListRow[] = dateGrouped ? groupEntriesByRecency(displayEntries) : toSessionRows(displayEntries)
+  const flatRows: SidebarListRow[] = useMemo(
+    () => (dateGrouped ? groupEntriesByRecency(displayEntries) : toSessionRows(displayEntries)),
+    [dateGrouped, displayEntries]
+  )
 
   const flatVirtualized =
     !showEmptyState &&

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -27,7 +27,7 @@ interface SessionRowCommonProps {
   showProfile?: boolean
 }
 
-interface VirtualSessionListProps {
+export interface VirtualSessionListProps {
   activeSessionId: null | string
   className?: string
   rows: SidebarListRow[]


### PR DESCRIPTION
## What does this PR do?

Wraps `flatRows` in `useMemo` and row renderers (`renderRow`, `renderListRow`, `renderRows`, `renderRowsDated`) in `useCallback` in `sessions-section.tsx` to prevent continuous virtualizer jitter and re-render thrash during sidebar scrolling.

Includes fix direction inspired by PR #73674 by @drbronson, with added component unit tests in Vitest for `SessionsSection` memoization and virtualized list stability.

## Related Issue

Fixes #73629

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Tests added

## Verification

Ran Vitest unit tests in `apps/desktop`:
- `src/app/chat/sidebar/sessions-section.test.tsx`: 2 passed (2)