### PR TITLE
fix(whatsapp): don't prefix slash commands with [owner reply]

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -41,6 +41,15 @@ logger = logging.getLogger(__name__)
 _OWNER_REPLY_PREFIX = "[owner reply] "
 
 
+def _is_command_text(body: str) -> bool:
+    """Mirror MessageEvent.get_command() grammar: /cmd or /cmd@bot, never /path."""
+    stripped = body.lstrip()
+    if not stripped.startswith("/"):
+        return False
+    token = stripped.split(maxsplit=1)[0][1:].split("@", 1)[0]
+    return "/" not in token
+
+
 def _listener_pids_on_port(port: int) -> list:
     """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
 
@@ -1557,7 +1566,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # so a future producer can set it without adapter changes.
             if data.get("fromOwner"):
                 metadata["whatsapp_from_owner"] = True
-                if not body.startswith(_OWNER_REPLY_PREFIX):
+                # Don't prefix slash commands: "[owner reply] /new" breaks
+                # MessageEvent.is_command() and routes the command to the
+                # LLM as free text. Mirror get_command() grammar so slash
+                # paths like /tmp/file keep the tag. Metadata above still
+                # marks owner-typed.
+                if not _is_command_text(body) and not body.startswith(_OWNER_REPLY_PREFIX):
                     body = f"{_OWNER_REPLY_PREFIX}{body}"
 
             return MessageEvent(

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -93,3 +93,38 @@ def test_from_owner_does_not_double_prefix_when_already_tagged():
     assert event.text == "[owner reply] already tagged"
 
 
+def test_from_owner_does_not_prefix_slash_command():
+    adapter = _make_adapter()
+    payload = _dm_payload(fromOwner=True, body="/new")
+
+    event = asyncio.run(adapter._build_message_event(payload))
+
+    assert event is not None
+    assert event.metadata.get("whatsapp_from_owner") is True
+    assert event.text == "/new"
+    assert event.is_command() is True
+
+
+def test_from_owner_does_not_prefix_whitespace_leading_command():
+    adapter = _make_adapter()
+    payload = _dm_payload(fromOwner=True, body="  /model")
+
+    event = asyncio.run(adapter._build_message_event(payload))
+
+    assert event is not None
+    assert event.metadata.get("whatsapp_from_owner") is True
+    assert event.text == "  /model"
+    assert event.is_command() is True
+
+
+def test_from_owner_keeps_prefix_on_slash_path():
+    adapter = _make_adapter()
+    payload = _dm_payload(fromOwner=True, body="/tmp/file")
+
+    event = asyncio.run(adapter._build_message_event(payload))
+
+    assert event is not None
+    assert event.metadata.get("whatsapp_from_owner") is True
+    assert event.text == "[owner reply] /tmp/file"
+
+


### PR DESCRIPTION
## Problem

Commit `a61cf774c` tags owner-typed inbound text with an `[owner reply] ` prefix. With `WHATSAPP_FORWARD_OWNER_MESSAGES=true`, slash commands typed by the owner arrive as `[owner reply] /new`. The body no longer starts with `/`, so `MessageEvent.is_command()` fails and the command is routed to the LLM as free text instead of being executed natively.

## Repro

1. Set `WHATSAPP_FORWARD_OWNER_MESSAGES=true`
2. Owner types `/new` in WhatsApp
3. Gateway receives `[owner reply] /new` → treated as text → LLM call (visible in logs as api_calls=1 for a command message)

## Fix

Skip the prefix when the body starts with `/` (after optional leading whitespace). The `whatsapp_from_owner` metadata still marks owner-typed messages, so the tagging intent is preserved.

## Validation

Simulated the adapter prefix logic + `is_command()` for 7 cases: command, plain text, leading whitespace, non-command slash paths, and prefix idempotency — all pass. Live-verified on the reporter's gateway: `/new` and `/model` now execute natively (no LLM call).