### PR TITLE
fix(filesystem): bound reads on unresponsive filesystems

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -16,6 +16,8 @@ Inspired by Block/goose's SubdirectoryHintTracker.
 import logging
 import os
 import shlex
+import subprocess
+import sys
 from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
@@ -35,6 +37,21 @@ _HINT_FILENAMES = [
 # Maximum chars per hint file to prevent context bloat
 _MAX_HINT_CHARS = 8_000
 
+# Hint discovery is best-effort and runs on the conversation's tool-result
+# path.  A cloud-backed placeholder or unhealthy filesystem can block open(2)
+# indefinitely even when stat(2) reports a tiny regular file.  Keep the read in
+# a disposable child so a single context file can never freeze the agent.
+_HINT_READ_TIMEOUT_SECONDS = 1.0
+_MAX_HINT_READ_BYTES = (_MAX_HINT_CHARS + 1) * 4
+_HINT_READER = (
+    "import sys; "
+    "path = sys.argv[1]; limit = int(sys.argv[2]); "
+    "stream = open(path, 'rb'); "
+    "data = stream.read(limit); "
+    "stream.close(); "
+    "sys.stdout.buffer.write(data)"
+)
+
 # Tool argument keys that typically contain file paths
 _PATH_ARG_KEYS = {"path", "file_path", "workdir"}
 
@@ -53,6 +70,57 @@ def _is_ancestor_or_same(a: Path, b: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _read_hint_text(path: Path) -> Optional[str]:
+    """Read one hint file without letting filesystem I/O stall the agent."""
+    try:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                _HINT_READER,
+                os.fspath(path),
+                str(_MAX_HINT_READ_BYTES),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=_HINT_READ_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Skipping subdirectory hint that did not open within %.1fs: %s",
+            _HINT_READ_TIMEOUT_SECONDS,
+            path,
+        )
+        return None
+    except (OSError, ValueError) as exc:
+        logger.debug("Could not start subdirectory hint reader for %s: %s", path, exc)
+        return None
+
+    if completed.returncode != 0:
+        logger.debug(
+            "Could not read subdirectory hint %s (reader exit %s)",
+            path,
+            completed.returncode,
+        )
+        return None
+    try:
+        return completed.stdout.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        # A valid UTF-8 file can end in a partial code point because the child
+        # intentionally caps bytes.  Only tolerate that boundary condition;
+        # malformed bytes in the body retain the previous skip-on-error behavior.
+        if exc.end != len(completed.stdout):
+            logger.debug("Could not decode subdirectory hint %s: %s", path, exc)
+            return None
+        try:
+            return completed.stdout[: exc.start].decode("utf-8")
+        except UnicodeDecodeError:
+            logger.debug("Could not decode subdirectory hint %s: %s", path, exc)
+            return None
 
 class SubdirectoryHintTracker:
     """Track which directories the agent visits and load hints on first access.
@@ -219,15 +287,24 @@ class SubdirectoryHintTracker:
                 return None
 
         found_hints = []
+        seen_files: Set[tuple[int, int]] = set()
         for filename in _HINT_FILENAMES:
             hint_path = directory / filename
             try:
                 if not hint_path.is_file():
                     continue
+                stat_result = hint_path.stat()
+                file_identity = (stat_result.st_dev, stat_result.st_ino)
+                if file_identity in seen_files:
+                    continue
+                seen_files.add(file_identity)
             except OSError:
                 continue
             try:
-                content = hint_path.read_text(encoding="utf-8").strip()
+                raw_content = _read_hint_text(hint_path)
+                if raw_content is None:
+                    continue
+                content = raw_content.strip()
                 if not content:
                     continue
                 # Same security scan as startup context loading

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -1,9 +1,12 @@
 """Tests for progressive subdirectory hint discovery."""
 
+import subprocess
+
 import pytest
 from pathlib import Path
 from unittest.mock import patch
 
+from agent import subdirectory_hints
 from agent.subdirectory_hints import SubdirectoryHintTracker
 
 
@@ -156,6 +159,44 @@ class TestPermissionErrorHandling:
             )
             # Result may be None (backend skipped) — the key point is no crash
             assert result is None or isinstance(result, str)
+
+
+class TestBoundedHintReads:
+    """Regression tests for filesystems that block while opening hint files."""
+
+    def test_timeout_skips_hint_instead_of_blocking_agent(self, tmp_path, caplog):
+        hint = tmp_path / "AGENTS.md"
+        hint.write_text("instructions")
+
+        with patch.object(
+            subdirectory_hints.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired("hint-reader", 1.0),
+        ):
+            assert subdirectory_hints._read_hint_text(hint) is None
+
+        assert "did not open within" in caplog.text
+
+    def test_case_alias_is_read_only_once(self, tmp_path):
+        sub = tmp_path / "project"
+        sub.mkdir()
+        hint = sub / "AGENTS.md"
+        hint.write_text("instructions")
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+
+        with patch.object(
+            subdirectory_hints,
+            "_HINT_FILENAMES",
+            ["AGENTS.md", "AGENTS.md"],
+        ), patch.object(
+            subdirectory_hints,
+            "_read_hint_text",
+            wraps=subdirectory_hints._read_hint_text,
+        ) as read_hint:
+            result = tracker._load_hints_for_directory(sub)
+
+        assert result is not None
+        assert read_hint.call_count == 1
 
 
 class TestOutsideWorkspaceRejection:

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -344,6 +344,53 @@ class TestShellFileOpsHelpers:
             "The file or its filesystem may be temporarily unavailable."
         )
 
+    def test_write_file_bounds_pre_content_read_and_aborts(self, mock_env):
+        def execute(command, **kwargs):
+            if command.startswith("cat "):
+                assert kwargs["timeout"] == 30
+                return {"output": "[Command timed out after 30s]", "returncode": 124}
+            raise AssertionError(f"unexpected command: {command}")
+
+        mock_env.execute.side_effect = execute
+
+        result = ShellFileOperations(mock_env).write_file(
+            "/mnt/remote/module.py", "print('updated')\n"
+        )
+
+        assert result.error == (
+            "Timed out reading /mnt/remote/module.py after 30 seconds. "
+            "The file or its filesystem may be temporarily unavailable. "
+            "The file was not modified."
+        )
+        assert not any(
+            call.kwargs.get("stdin_data") is not None
+            for call in mock_env.execute.call_args_list
+        )
+
+    @pytest.mark.parametrize("timeout_prefix", ["head -c 4096", "head -c 3"])
+    def test_write_file_bounds_metadata_reads_and_aborts(
+        self, mock_env, timeout_prefix
+    ):
+        def execute(command, **kwargs):
+            if command.startswith("head -c"):
+                assert kwargs["timeout"] == 30
+                if command.startswith(timeout_prefix):
+                    return {
+                        "output": "[Command timed out after 30s]",
+                        "returncode": 124,
+                    }
+                return {"output": "", "returncode": 0}
+            raise AssertionError(f"unexpected command: {command}")
+
+        mock_env.execute.side_effect = execute
+
+        result = ShellFileOperations(mock_env).write_file(
+            "/mnt/remote/notes.txt", "updated\n"
+        )
+
+        assert "Timed out reading /mnt/remote/notes.txt after 30 seconds" in result.error
+        assert "The file was not modified" in result.error
+
     def test_normalize_read_pagination_clamps_invalid_values(self):
         assert normalize_read_pagination(offset=0, limit=0) == (1, 1)
         assert normalize_read_pagination(offset=-10, limit=-5) == (1, 1)
@@ -558,6 +605,45 @@ class TestPatchReplacePostWriteVerification:
     appears to succeed but the bytes on disk don't match new_content) is
     surfaced as an error instead of being reported as a successful patch.
     """
+
+    def test_patch_replace_bounds_initial_read_and_aborts(self, mock_env):
+        def side_effect(command, **kwargs):
+            assert command.startswith("cat ")
+            assert kwargs["timeout"] == 30
+            return {"output": "[Command timed out after 30s]", "returncode": 124}
+
+        mock_env.execute.side_effect = side_effect
+
+        result = ShellFileOperations(mock_env).patch_replace(
+            "/mnt/remote/notes.md", "before", "after"
+        )
+
+        assert result.error == (
+            "Timed out reading /mnt/remote/notes.md after 30 seconds. "
+            "The file or its filesystem may be temporarily unavailable."
+        )
+
+    def test_patch_replace_bounds_verify_read(self, mock_env, monkeypatch):
+        cat_calls = 0
+
+        def side_effect(command, **kwargs):
+            nonlocal cat_calls
+            assert command.startswith("cat ")
+            assert kwargs["timeout"] == 30
+            cat_calls += 1
+            if cat_calls == 1:
+                return {"output": "before\n", "returncode": 0}
+            return {"output": "[Command timed out after 30s]", "returncode": 124}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        monkeypatch.setattr(ops, "write_file", lambda *_args: WriteResult(bytes_written=6))
+
+        result = ops.patch_replace("/mnt/remote/notes.md", "before", "after")
+
+        assert "Post-write verification timed out" in result.error
+        assert "The patch may have been applied" in result.error
+        assert cat_calls == 2
 
     def test_patch_replace_fails_when_file_not_persisted(self, mock_env):
         """write_file reports success but the re-read returns old content:

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -275,6 +275,75 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
 
 
 class TestShellFileOpsHelpers:
+    @pytest.mark.parametrize(
+        "timeout_prefix",
+        ["wc -c", "head -c", "sed -n", "wc -l"],
+    )
+    def test_read_file_bounds_each_shell_read(self, mock_env, timeout_prefix):
+        def execute(command, **kwargs):
+            assert kwargs["timeout"] == 30
+            if command.startswith(timeout_prefix):
+                return {"output": "[Command timed out after 30s]", "returncode": 124}
+            if command.startswith("wc -c"):
+                return {"output": "12", "returncode": 0}
+            if command.startswith("head -c"):
+                return {"output": "first\nsecond\n", "returncode": 0}
+            if command.startswith("sed -n"):
+                return {"output": "first\nsecond\n", "returncode": 0}
+            if command.startswith("wc -l"):
+                return {"output": "2", "returncode": 0}
+            raise AssertionError(f"unexpected command: {command}")
+
+        mock_env.execute.side_effect = execute
+
+        result = ShellFileOperations(mock_env).read_file("/mnt/remote/notes.md")
+
+        assert result.error == (
+            "Timed out reading /mnt/remote/notes.md after 30 seconds. "
+            "The file or its filesystem may be temporarily unavailable."
+        )
+
+    @pytest.mark.parametrize("timeout_prefix", ["wc -c", "head -c", "cat "])
+    def test_read_file_raw_bounds_each_shell_read(self, mock_env, timeout_prefix):
+        def execute(command, **kwargs):
+            assert kwargs["timeout"] == 30
+            if command.startswith(timeout_prefix):
+                return {"output": "[Command timed out after 30s]", "returncode": 124}
+            if command.startswith("wc -c"):
+                return {"output": "12", "returncode": 0}
+            if command.startswith("head -c"):
+                return {"output": "first\nsecond\n", "returncode": 0}
+            if command.startswith("cat "):
+                return {"output": "first\nsecond\n", "returncode": 0}
+            raise AssertionError(f"unexpected command: {command}")
+
+        mock_env.execute.side_effect = execute
+
+        result = ShellFileOperations(mock_env).read_file_raw("/mnt/remote/notes.md")
+
+        assert result.error == (
+            "Timed out reading /mnt/remote/notes.md after 30 seconds. "
+            "The file or its filesystem may be temporarily unavailable."
+        )
+
+    def test_missing_file_similarity_scan_is_bounded(self, mock_env):
+        def execute(command, **kwargs):
+            assert kwargs["timeout"] == 30
+            if command.startswith("wc -c"):
+                return {"output": "", "returncode": 1}
+            if command.startswith("ls -1"):
+                return {"output": "[Command timed out after 30s]", "returncode": 124}
+            raise AssertionError(f"unexpected command: {command}")
+
+        mock_env.execute.side_effect = execute
+
+        result = ShellFileOperations(mock_env).read_file("/mnt/remote/missing.md")
+
+        assert result.error == (
+            "Timed out reading /mnt/remote/missing.md after 30 seconds. "
+            "The file or its filesystem may be temporarily unavailable."
+        )
+
     def test_normalize_read_pagination_clamps_invalid_values(self):
         assert normalize_read_pagination(offset=0, limit=0) == (1, 1)
         assert normalize_read_pagination(offset=-10, limit=-5) == (1, 1)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -133,6 +133,17 @@ _UTF8_BOM = "\ufeff"
 _FILE_READ_TIMEOUT_SECONDS = 30
 
 
+def _file_read_timeout_message(path: str) -> str:
+    return (
+        f"Timed out reading {path} after {_FILE_READ_TIMEOUT_SECONDS} seconds. "
+        "The file or its filesystem may be temporarily unavailable."
+    )
+
+
+class _FileReadTimeout(RuntimeError):
+    """Raised when a bounded internal filesystem read reaches its deadline."""
+
+
 def _strip_bom(text: str) -> tuple[str, bool]:
     """Return (text-without-leading-BOM, had_bom).
 
@@ -872,12 +883,7 @@ class ShellFileOperations(FileOperations):
 
     @staticmethod
     def _read_timeout_result(path: str) -> ReadResult:
-        return ReadResult(
-            error=(
-                f"Timed out reading {path} after {_FILE_READ_TIMEOUT_SECONDS} seconds. "
-                "The file or its filesystem may be temporarily unavailable."
-            )
-        )
+        return ReadResult(error=_file_read_timeout_message(path))
     
     def _has_command(self, cmd: str) -> bool:
         """Check if a command exists in the environment (cached)."""
@@ -1072,7 +1078,9 @@ class ShellFileOperations(FileOperations):
         # File may not exist (new write) — `head` exits 0 with empty
         # stdout in that case which yields None below.  Cheap probe.
         head_cmd = f"head -c 4096 {self._escape_shell_arg(path)} 2>/dev/null"
-        head_result = self._exec(head_cmd)
+        head_result = self._exec(head_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+        if head_result.exit_code == 124:
+            raise _FileReadTimeout(_file_read_timeout_message(path))
         if head_result.exit_code != 0 or not head_result.stdout:
             return None
         return _detect_line_ending(head_result.stdout)
@@ -1088,7 +1096,9 @@ class ShellFileOperations(FileOperations):
         if pre_content is not None:
             return _has_bom(pre_content)
         head_cmd = f"head -c 3 {self._escape_shell_arg(path)} 2>/dev/null"
-        head_result = self._exec(head_cmd)
+        head_result = self._exec(head_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+        if head_result.exit_code == 124:
+            raise _FileReadTimeout(_file_read_timeout_message(path))
         if head_result.exit_code != 0 or not head_result.stdout:
             return False
         return _has_bom(head_result.stdout)
@@ -1503,7 +1513,11 @@ class ShellFileOperations(FileOperations):
             # degrade gracefully (lint reports all errors; LSP skips the
             # shift map).
             read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
-            read_result = self._exec(read_cmd)
+            read_result = self._exec(read_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+            if read_result.exit_code == 124:
+                return WriteResult(
+                    error=f"{_file_read_timeout_message(path)} The file was not modified."
+                )
             if read_result.exit_code == 0 and read_result.stdout:
                 pre_content = read_result.stdout
 
@@ -1514,21 +1528,20 @@ class ShellFileOperations(FileOperations):
         # produces mixed endings when only a substituted region changes).
         # Detect from a small head sample to avoid reading the full file
         # for line-ending purposes alone.
-        original_ending = self._detect_file_line_ending(path, pre_content)
-        if original_ending == "\r\n":
-            content = _normalize_line_endings(content, "\r\n")
+        try:
+            original_ending = self._detect_file_line_ending(path, pre_content)
+            if original_ending == "\r\n":
+                content = _normalize_line_endings(content, "\r\n")
 
-        # ── BOM preservation ──────────────────────────────────────────
-        # If the file on disk started with a UTF-8 BOM, keep it. read_file
-        # strips the BOM so the agent never sees it, which means the
-        # content it hands back to write_file / patch has no BOM either —
-        # without restoring it here a round-trip would silently strip the
-        # marker and change the file's byte signature (some Windows
-        # toolchains key on it). Only prepend when the original had a BOM
-        # and the new content doesn't already carry one (guards against
-        # double-BOM if a caller passed raw bytes).
-        if self._file_has_bom(path, pre_content) and not _has_bom(content):
-            content = _UTF8_BOM + content
+            # ── BOM preservation ──────────────────────────────────────
+            # If the file on disk started with a UTF-8 BOM, keep it.
+            # read_file strips the BOM so the agent never sees it, which
+            # means the content handed back to write_file / patch has no
+            # BOM either. Only prepend when the new content lacks one.
+            if self._file_has_bom(path, pre_content) and not _has_bom(content):
+                content = _UTF8_BOM + content
+        except _FileReadTimeout as exc:
+            return WriteResult(error=f"{exc} The file was not modified.")
 
         # Snapshot LSP diagnostics for this file (best-effort) so the
         # post-write LSP layer can return only diagnostics introduced
@@ -1569,7 +1582,7 @@ class ShellFileOperations(FileOperations):
 
         # Get bytes written (wc -c is POSIX, works on Linux + macOS)
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
-        stat_result = self._exec(stat_cmd)
+        stat_result = self._exec(stat_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
 
         try:
             bytes_written = int(stat_result.stdout.strip())
@@ -1628,7 +1641,10 @@ class ShellFileOperations(FileOperations):
 
         # Read current content
         read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
-        read_result = self._exec(read_cmd)
+        read_result = self._exec(read_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+
+        if read_result.exit_code == 124:
+            return PatchResult(error=_file_read_timeout_message(path))
         
         if read_result.exit_code != 0:
             return PatchResult(error=f"Failed to read file: {path}")
@@ -1680,7 +1696,13 @@ class ShellFileOperations(FileOperations):
         # pipe, etc.) that would otherwise return success-with-diff while the
         # file is unchanged on disk.
         verify_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
-        verify_result = self._exec(verify_cmd)
+        verify_result = self._exec(verify_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+        if verify_result.exit_code == 124:
+            return PatchResult(error=(
+                f"Post-write verification timed out for {path} after "
+                f"{_FILE_READ_TIMEOUT_SECONDS} seconds. The patch may have been "
+                "applied; re-read the file before retrying."
+            ))
         if verify_result.exit_code != 0:
             return PatchResult(error=f"Post-write verification failed: could not re-read {path}")
         # Normalize line endings before comparing.  On Windows, Python's
@@ -1786,7 +1808,7 @@ class ShellFileOperations(FileOperations):
             # Need content — either passed in or read from disk.
             if content is None:
                 read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
-                read_result = self._exec(read_cmd)
+                read_result = self._exec(read_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
                 if read_result.exit_code != 0:
                     return LintResult(skipped=True, message=f"Failed to read {path} for lint")
                 content = read_result.stdout

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -127,6 +127,11 @@ def _normalize_line_endings(text: str, target: str) -> str:
 # preservation above (detect on disk, preserve across the edit).
 _UTF8_BOM = "\ufeff"
 
+# Internal reads are interactive tool calls. Do not let an unresponsive cloud,
+# network, or FUSE filesystem inherit the much longer terminal/gateway timeout
+# and wedge the entire agent turn.
+_FILE_READ_TIMEOUT_SECONDS = 30
+
 
 def _strip_bom(text: str) -> tuple[str, bool]:
     """Return (text-without-leading-BOM, had_bom).
@@ -864,6 +869,15 @@ class ShellFileOperations(FileOperations):
             stdout=result.get("output", ""),
             exit_code=result.get("returncode", 0)
         )
+
+    @staticmethod
+    def _read_timeout_result(path: str) -> ReadResult:
+        return ReadResult(
+            error=(
+                f"Timed out reading {path} after {_FILE_READ_TIMEOUT_SECONDS} seconds. "
+                "The file or its filesystem may be temporarily unavailable."
+            )
+        )
     
     def _has_command(self, cmd: str) -> bool:
         """Check if a command exists in the environment (cached)."""
@@ -1114,7 +1128,10 @@ class ShellFileOperations(FileOperations):
         
         # Check if file exists and get size (wc -c is POSIX, works on Linux + macOS)
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
-        stat_result = self._exec(stat_cmd)
+        stat_result = self._exec(stat_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+
+        if stat_result.exit_code == 124:
+            return self._read_timeout_result(path)
         
         if stat_result.exit_code != 0:
             # File not found - try to suggest similar files
@@ -1145,7 +1162,9 @@ class ShellFileOperations(FileOperations):
         
         # Read a sample to check for binary content
         sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
-        sample_result = self._exec(sample_cmd)
+        sample_result = self._exec(sample_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+        if sample_result.exit_code == 124:
+            return self._read_timeout_result(path)
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
         
         if self._is_likely_binary(path, sample_output):
@@ -1158,7 +1177,10 @@ class ShellFileOperations(FileOperations):
         # Read with pagination using sed
         end_line = offset + limit - 1
         read_cmd = f"sed -n '{offset},{end_line}p' {self._escape_shell_arg(path)}"
-        read_result = self._exec(read_cmd)
+        read_result = self._exec(read_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+
+        if read_result.exit_code == 124:
+            return self._read_timeout_result(path)
         
         if read_result.exit_code != 0:
             return ReadResult(error=f"Failed to read file: {read_result.stdout}")
@@ -1171,7 +1193,9 @@ class ShellFileOperations(FileOperations):
         
         # Get total line count
         wc_cmd = f"wc -l < {self._escape_shell_arg(path)}"
-        wc_result = self._exec(wc_cmd)
+        wc_result = self._exec(wc_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+        if wc_result.exit_code == 124:
+            return self._read_timeout_result(path)
         wc_output = _strip_terminal_fence_leaks(wc_result.stdout)
         try:
             total_lines = int(wc_output.strip())
@@ -1202,7 +1226,10 @@ class ShellFileOperations(FileOperations):
 
         # List files in the target directory
         ls_cmd = f"ls -1 {self._escape_shell_arg(dir_path)} 2>/dev/null | head -50"
-        ls_result = self._exec(ls_cmd)
+        ls_result = self._exec(ls_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+
+        if ls_result.exit_code == 124:
+            return self._read_timeout_result(path)
 
         scored: list = []  # (score, filepath) — higher is better
         if ls_result.exit_code == 0 and ls_result.stdout.strip():
@@ -1252,7 +1279,9 @@ class ShellFileOperations(FileOperations):
         """
         path = self._expand_path(path)
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
-        stat_result = self._exec(stat_cmd)
+        stat_result = self._exec(stat_cmd, timeout=_FILE_READ_TIMEOUT_SECONDS)
+        if stat_result.exit_code == 124:
+            return self._read_timeout_result(path)
         if stat_result.exit_code != 0:
             return self._suggest_similar_files(path)
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
@@ -1262,14 +1291,24 @@ class ShellFileOperations(FileOperations):
             file_size = 0
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
-        sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
+        sample_result = self._exec(
+            f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null",
+            timeout=_FILE_READ_TIMEOUT_SECONDS,
+        )
+        if sample_result.exit_code == 124:
+            return self._read_timeout_result(path)
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
         if self._is_likely_binary(path, sample_output):
             return ReadResult(
                 is_binary=True, file_size=file_size,
                 error="Binary file — cannot display as text."
             )
-        cat_result = self._exec(f"cat {self._escape_shell_arg(path)}")
+        cat_result = self._exec(
+            f"cat {self._escape_shell_arg(path)}",
+            timeout=_FILE_READ_TIMEOUT_SECONDS,
+        )
+        if cat_result.exit_code == 124:
+            return self._read_timeout_result(path)
         if cat_result.exit_code != 0:
             return ReadResult(error=f"Failed to read file: {cat_result.stdout}")
         # Strip a leading UTF-8 BOM so patch's fuzzy matcher operates on


### PR DESCRIPTION
## Summary

- apply a 30-second bound to shell commands used by paginated and raw file reads
- extend the same bound to write pre-reads, metadata probes, patch reads, and post-write verification
- abort safely before writes on pre-read timeouts and warn when verification times out after a patch may have landed
- bound the missing-file similarity scan so directory lookup cannot wedge the turn
- read lazily discovered subdirectory instructions in a killable one-second helper
- avoid reading case-insensitive aliases of the same hint file more than once

## Root cause

Internal file operations inherited the much longer terminal-environment timeout. That included reads performed inside write and patch workflows. Separately, progressive context discovery opened files such as `AGENTS.md` synchronously on the conversation worker. A cloud, network, FUSE, or File Provider placeholder could therefore hold the entire turn indefinitely even when metadata reported a small regular file.

## Impact

Unavailable filesystems now fail cleanly instead of leaving the agent stuck. Write and patch pre-reads stop before modification, while a post-write verification timeout tells the caller that the patch may already have landed. Normal local and remote file operations retain their existing behavior, and optional subdirectory instructions are skipped when they cannot be opened promptly.

## Validation

- `scripts/run_tests.sh tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py` (75 passed)
- `scripts/run_tests.sh tests/agent/test_subdirectory_hints.py tests/agent/test_subdirectory_hints_tilde.py` (15 passed)
- `ruff check tools/file_operations.py tests/tools/test_file_operations.py agent/subdirectory_hints.py tests/agent/test_subdirectory_hints.py`
- `git diff --check`