### PR TITLE
fix(process): add supersession context to delayed notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3081,33 +3081,10 @@ def _parse_session_key(session_key: str) -> "dict | None":
 def _format_gateway_process_notification(evt: dict) -> "str | None":
     """Format a watch pattern event from completion_queue into a [IMPORTANT:] message."""
     evt_type = evt.get("type", "completion")
-    _sid = evt.get("session_id", "unknown")
-    _cmd = evt.get("command", "unknown")
-
-    if evt_type == "watch_disabled":
-        return f"[IMPORTANT: {evt.get('message', '')}]"
-
-    if evt_type == "watch_match":
-        _pat = evt.get("pattern", "?")
-        _out = evt.get("output", "")
-        _sup = evt.get("suppressed", 0)
-        text = (
-            f"[IMPORTANT: Background process {_sid} matched "
-            f"watch pattern \"{_pat}\".\n"
-            f"Command: {_cmd}\n"
-            f"Matched output:\n{_out}"
-        )
-        if _sup:
-            text += f"\n({_sup} earlier matches were suppressed by rate limit)"
-        text += "]"
-        return text
-
-    if evt_type == "async_delegation":
-        # Reuse the shared rich formatter (self-contained task-source block).
-        from tools.process_registry import format_process_notification
-        return format_process_notification(evt)
-
-    return None
+    if evt_type not in {"watch_match", "watch_disabled", "async_delegation"}:
+        return None
+    from tools.process_registry import format_process_notification
+    return format_process_notification(evt)
 
 
 def _drain_gateway_watch_events(completion_queue) -> "list[dict]":

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -720,6 +720,24 @@ def test_gateway_formatter_renders_async_block():
     assert "Investigate flaky test" in txt
 
 
+def test_gateway_watch_formatter_preserves_supersession_context(monkeypatch):
+    from gateway.run import _format_gateway_process_notification
+
+    monkeypatch.setattr("tools.process_registry.time.time", lambda: 1300.0)
+    txt = _format_gateway_process_notification({
+        "type": "watch_match",
+        "session_id": "proc_old_watch",
+        "command": "watch old task",
+        "pattern": "READY",
+        "output": "READY",
+        "started_at": 1000.0,
+    })
+
+    assert txt is not None
+    assert "this process started 5m ago" in txt
+    assert "newer user instructions take precedence" in txt
+
+
 def test_gateway_cli_origin_event_left_unrouted():
     """An empty session_key (CLI origin) is left without routing fields."""
     from gateway.run import GatewayRunner

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -907,6 +907,58 @@ class TestProcessToolHandler:
 from tools.process_registry import format_process_notification
 
 
+def test_completion_notification_carries_supersession_context(monkeypatch):
+    """Delayed completions must defer to newer conversation instructions."""
+    monkeypatch.setattr("tools.process_registry.time.time", lambda: 1300.0)
+
+    text = format_process_notification({
+        "type": "completion",
+        "session_id": "proc_old_completion",
+        "command": "run old task",
+        "exit_code": 0,
+        "output": "done",
+        "started_at": 1000.0,
+    })
+
+    assert text is not None
+    assert "this process started 5m ago" in text
+    assert "Reconcile this result with the current conversation before acting" in text
+    assert "newer user instructions take precedence" in text
+
+
+def test_legacy_completion_without_timing_still_carries_supersession_context():
+    """Recovered/legacy events cannot bypass the newer-instructions boundary."""
+    text = format_process_notification({
+        "type": "completion",
+        "session_id": "proc_legacy",
+        "command": "run old task",
+        "exit_code": 0,
+        "output": "done",
+    })
+
+    assert text is not None
+    assert "may relate to an earlier turn" in text
+    assert "newer user instructions take precedence" in text
+
+
+def test_watch_notification_carries_supersession_context(monkeypatch):
+    """Delayed watch matches have the same precedence contract as completions."""
+    monkeypatch.setattr("tools.process_registry.time.time", lambda: 1300.0)
+
+    text = format_process_notification({
+        "type": "watch_match",
+        "session_id": "proc_old_watch",
+        "command": "watch old task",
+        "pattern": "READY",
+        "output": "READY",
+        "started_at": 1000.0,
+    })
+
+    assert text is not None
+    assert "this process started 5m ago" in text
+    assert "newer user instructions take precedence" in text
+
+
 def test_drain_notifications_completion_callback_exception_fails_closed(registry):
     event = {
         "type": "completion",

--- a/tests/tools/test_watch_patterns.py
+++ b/tests/tools/test_watch_patterns.py
@@ -84,6 +84,7 @@ class TestCheckWatchPatterns:
         assert evt["pattern"] == "ERROR"
         assert "disk full" in evt["output"]
         assert evt["session_id"] == "proc_test_watch"
+        assert evt["started_at"] == session.started_at
 
 
     def test_output_truncation(self, registry):
@@ -133,6 +134,23 @@ class TestPerSessionRateLimit:
         assert evt["type"] == "watch_match"
         assert evt["suppressed"] == 4
         assert session._watch_suppressed == 0  # reset after delivery
+
+    def test_watch_disabled_event_keeps_process_start_time(self, registry):
+        """Rate-limit promotion retains timing for supersession context."""
+        session = _make_session(watch_patterns=["E"])
+
+        for index in range(3):
+            registry._check_watch_patterns(session, f"E emit {index}\n")
+            registry._check_watch_patterns(session, f"E drop {index}\n")
+            session._watch_cooldown_until = time.time() - 0.01
+
+        events = []
+        while not registry.completion_queue.empty():
+            events.append(registry.completion_queue.get_nowait())
+        disabled = [event for event in events if event["type"] == "watch_disabled"]
+
+        assert len(disabled) == 1
+        assert disabled[0]["started_at"] == session.started_at
 
 
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -318,6 +318,7 @@ class ProcessRegistry:
                     "session_id": session.id,
                     "session_key": session.session_key,
                     "command": session.command,
+                    "started_at": session.started_at,
                     "type": "watch_disabled",
                     "suppressed": session._watch_suppressed,
                     "platform": session.watcher_platform,
@@ -349,6 +350,7 @@ class ProcessRegistry:
             "session_id": session.id,
             "session_key": session.session_key,
             "command": session.command,
+            "started_at": session.started_at,
             "type": "watch_match",
             "pattern": matched_pattern,
             "output": output,
@@ -2278,6 +2280,24 @@ def _format_async_delegation(evt: dict) -> str:
     return "\n".join(lines)
 
 
+def _format_process_supersession_context(evt: dict) -> str:
+    """Return the precedence boundary for a delayed process notification."""
+    started_at = evt.get("started_at")
+    if (
+        isinstance(started_at, (int, float))
+        and not isinstance(started_at, bool)
+        and started_at > 0
+    ):
+        timing = f"this process started {_format_age(time.time() - started_at)} ago and "
+    else:
+        timing = "this process "
+    return (
+        f"Supersession context: {timing}may relate to an earlier turn. "
+        "Reconcile this result with the current conversation before acting; "
+        "newer user instructions take precedence."
+    )
+
+
 def format_process_notification(evt: dict) -> "str | None":
     """Format a process notification event into a [IMPORTANT: ...] message.
 
@@ -2287,9 +2307,10 @@ def format_process_notification(evt: dict) -> "str | None":
     evt_type = evt.get("type", "completion")
     _sid = evt.get("session_id", "unknown")
     _cmd = evt.get("command", "unknown")
+    _supersession = _format_process_supersession_context(evt)
 
     if evt_type == "watch_disabled":
-        return f"[IMPORTANT: {evt.get('message', '')}]"
+        return f"[IMPORTANT: {evt.get('message', '')}\n{_supersession}]"
 
     if evt_type == "watch_match":
         _pat = evt.get("pattern", "?")
@@ -2298,6 +2319,7 @@ def format_process_notification(evt: dict) -> "str | None":
         text = (
             f"[IMPORTANT: Background process {_sid} matched "
             f"watch pattern \"{_pat}\".\n"
+            f"{_supersession}\n"
             f"Command: {_cmd}\n"
             f"Matched output:\n{_out}"
         )
@@ -2329,6 +2351,7 @@ def format_process_notification(evt: dict) -> "str | None":
     return (
         f"[IMPORTANT: Background process {_sid} {_status} "
         f"(exit code {_exit}{_signal}).\n"
+        f"{_supersession}\n"
         f"Command: {_cmd}\n"
         f"Output:\n{_out}]"
     )


### PR DESCRIPTION
## Summary
- add explicit supersession context to delayed process completion and watch notifications
- include process-start age when available, while keeping a safe fallback for legacy events
- route gateway watch formatting through the shared formatter used by CLI/TUI

Each notification now tells the agent to reconcile the result with the current conversation and that newer user instructions take precedence. Delivery is preserved; this does not silently suppress useful background results.

## Why
Older background completions can arrive after the user has cancelled, redirected, or completed the underlying task. The existing notification text carries output but no authority boundary, so a delayed synthetic turn can resurrect superseded work.

This is complementary to:
- #32242 (consumed/killed stale-event suppression)
- #41903 (CLI display-vs-input routing)
- #36210 (deterministic killed-session suppression)

Related behavior: #36184. This PR adds the shared reasoning boundary but does not claim to replace deterministic cancellation suppression.

## Verification
- strict RED/GREEN regression cycle: 5 expected failures before implementation, then 5/5 passed
- `HERMES_HOME=<temp> uv run --extra dev pytest ...`: 110 passed, 1 existing Python `forkpty()` deprecation warning
- `uv run --extra dev ruff check ...`: passed
- `uv run python -m compileall -q ...`: passed
- `git diff --check`: passed
- added-line security scan: zero findings
- independent read-only review: Blockers: No; no actionable findings
