### PR TITLE
feat(lsp): add laravel-lsp for .blade.php files

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -88,6 +88,8 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
         "bin": "bash-language-server",
     },
     "intelephense": {"strategy": "npm", "pkg": "intelephense", "bin": "intelephense"},
+    # Laravel Blade — manual (composer global require laravel/lsp)
+    "laravel-lsp": {"strategy": "manual", "pkg": "", "bin": "laravel-lsp"},
     "dockerfile-language-server-nodejs": {
         "strategy": "npm",
         "pkg": "dockerfile-language-server-nodejs",

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -75,6 +75,7 @@ LANGUAGE_BY_EXT: Dict[str, str] = {
     ".jsonc": "jsonc",
     ".lua": "lua",
     ".php": "php",
+    ".blade.php": "blade",
     ".prisma": "prisma",
     ".dart": "dart",
     ".ml": "ocaml",
@@ -182,6 +183,13 @@ def _file_ext_or_basename(path: str) -> str:
     files match by extension (``.py``, ``.ts``).
     """
     base = os.path.basename(path)
+    # Handle multi-part extensions like ``.blade.php`` — ``os.path.splitext``
+    # only returns the last segment (``.php``), which would match the wrong
+    # server.  Check for known double extensions first.
+    lower = base.lower()
+    for double_ext in (".blade.php",):
+        if lower.endswith(double_ext):
+            return double_ext
     _root, ext = os.path.splitext(base)
     if ext:
         return ext.lower()
@@ -406,6 +414,7 @@ def _spawn_intelephense(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "intelephense") or _which("intelephense")
     if bin_path is None:
         from agent.lsp.install import try_install
+
         bin_path = try_install("intelephense", ctx.install_strategy)
         if bin_path is None:
             return None
@@ -417,6 +426,29 @@ def _spawn_intelephense(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
         cwd=root,
         env=ctx.env_overrides.get("intelephense", {}),
         initialization_options=init,
+    )
+
+
+def _spawn_laravel_lsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+    """Spawn laravel-lsp — a Laravel-aware LSP server for Blade templates.
+
+    Installed via ``composer global require laravel/lsp``.  The binary is
+    ``laravel-lsp`` and the LSP stdio mode is the default ``lsp`` subcommand.
+    No auto-install recipe — manual install only (like rust-analyzer, clangd).
+    """
+    bin_path = _resolve_override(ctx, "laravel-lsp") or _which("laravel-lsp")
+    if bin_path is None:
+        from agent.lsp.install import try_install
+
+        bin_path = try_install("laravel-lsp", ctx.install_strategy)
+        if bin_path is None:
+            return None
+    return SpawnSpec(
+        command=[bin_path, "lsp"],
+        workspace_root=root,
+        cwd=root,
+        env=ctx.env_overrides.get("laravel-lsp", {}),
+        initialization_options=ctx.init_overrides.get("laravel-lsp", {}),
     )
 
 
@@ -1046,6 +1078,13 @@ SERVERS: List[ServerDef] = [
         resolve_root=_root_lua,
         build_spawn=_spawn_lua_ls,
         description="Lua — lua-language-server",
+    ),
+    ServerDef(
+        server_id="laravel-lsp",
+        extensions=(".blade.php",),
+        resolve_root=_root_php,
+        build_spawn=_spawn_laravel_lsp,
+        description="Laravel Blade — laravel-lsp (manual install via composer)",
     ),
     ServerDef(
         server_id="intelephense",

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -441,8 +441,12 @@ def _spawn_laravel_lsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
         from agent.lsp.install import try_install
 
         bin_path = try_install("laravel-lsp", ctx.install_strategy)
-        if bin_path is None:
-            return None
+    if bin_path is None:
+        # laravel-lsp is manual-install only and rarely present.  Fall back
+        # to intelephense so ``.blade.php`` files don't lose all diagnostics
+        # when the Laravel server isn't installed (they matched intelephense
+        # via ``.php`` before the multi-part extension handling).
+        return _spawn_intelephense(root, ctx)
     return SpawnSpec(
         command=[bin_path, "lsp"],
         workspace_root=root,

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -441,12 +441,8 @@ def _spawn_laravel_lsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
         from agent.lsp.install import try_install
 
         bin_path = try_install("laravel-lsp", ctx.install_strategy)
-    if bin_path is None:
-        # laravel-lsp is manual-install only and rarely present.  Fall back
-        # to intelephense so ``.blade.php`` files don't lose all diagnostics
-        # when the Laravel server isn't installed (they matched intelephense
-        # via ``.php`` before the multi-part extension handling).
-        return _spawn_intelephense(root, ctx)
+        if bin_path is None:
+            return None
     return SpawnSpec(
         command=[bin_path, "lsp"],
         workspace_root=root,

--- a/tests/agent/lsp/test_laravel_lsp.py
+++ b/tests/agent/lsp/test_laravel_lsp.py
@@ -1,0 +1,79 @@
+"""Tests for laravel-lsp server registration and .blade.php matching.
+
+Verifies that:
+- ``.blade.php`` files route to ``laravel-lsp``, not ``intelephense``.
+- ``.php`` files still route to ``intelephense`` (no regression).
+- ``_file_ext_or_basename`` returns the full ``.blade.php`` double extension.
+- ``language_id_for`` returns ``"blade"`` for ``.blade.php`` files.
+- ``_spawn_laravel_lsp`` builds the correct command when the binary is on PATH.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agent.lsp.servers import (
+    SERVERS,
+    ServerContext,
+    _file_ext_or_basename,
+    _spawn_laravel_lsp,
+    find_server_for_file,
+    language_id_for,
+)
+
+
+def test_blade_php_routes_to_laravel_lsp():
+    """find_server_for_file must return laravel-lsp for .blade.php files."""
+    srv = find_server_for_file("/project/resources/views/welcome.blade.php")
+    assert srv is not None
+    assert srv.server_id == "laravel-lsp"
+
+
+def test_php_still_routes_to_intelephense():
+    """Plain .php files must still match intelephense, not laravel-lsp."""
+    srv = find_server_for_file("/project/app/Models/User.php")
+    assert srv is not None
+    assert srv.server_id == "intelephense"
+
+
+def test_file_ext_or_basename_blade_php():
+    """Double extension .blade.php must be returned in full."""
+    assert _file_ext_or_basename("/x/welcome.blade.php") == ".blade.php"
+    assert _file_ext_or_basename("/x/UPPER.blade.php") == ".blade.php"
+
+
+def test_file_ext_or_basename_regular_php():
+    """Regular .php extension must still work."""
+    assert _file_ext_or_basename("/x/User.php") == ".php"
+
+
+def test_language_id_for_blade():
+    """language_id_for must return 'blade' for .blade.php files."""
+    assert language_id_for("/x/welcome.blade.php") == "blade"
+    assert language_id_for("/x/User.php") == "php"
+
+
+def test_laravel_lsp_spawn_command(monkeypatch):
+    """_spawn_laravel_lsp must produce [bin, 'lsp'] when binary is on PATH."""
+    monkeypatch.setattr(
+        "agent.lsp.servers._which", lambda *names: "/fake/bin/laravel-lsp"
+    )
+    ctx = ServerContext(workspace_root="/project", install_strategy="manual")
+    spec = _spawn_laravel_lsp("/project", ctx)
+    assert spec is not None
+    assert spec.command == ["/fake/bin/laravel-lsp", "lsp"]
+    assert spec.cwd == "/project"
+
+
+def test_laravel_lsp_spawn_returns_none_when_missing(monkeypatch):
+    """When binary is not on PATH and install is manual, must return None."""
+    monkeypatch.setattr("agent.lsp.servers._which", lambda *names: None)
+    ctx = ServerContext(workspace_root="/project", install_strategy="manual")
+    spec = _spawn_laravel_lsp("/project", ctx)
+    assert spec is None
+
+
+def test_laravel_lsp_in_servers_registry():
+    """laravel-lsp must be registered in SERVERS before intelephense."""
+    ids = [s.server_id for s in SERVERS]
+    assert "laravel-lsp" in ids
+    assert ids.index("laravel-lsp") < ids.index("intelephense")

--- a/tests/agent/lsp/test_laravel_lsp.py
+++ b/tests/agent/lsp/test_laravel_lsp.py
@@ -67,9 +67,29 @@ def test_laravel_lsp_spawn_command(monkeypatch):
 def test_laravel_lsp_spawn_returns_none_when_missing(monkeypatch):
     """When binary is not on PATH and install is manual, must return None."""
     monkeypatch.setattr("agent.lsp.servers._which", lambda *names: None)
+    # _spawn_laravel_lsp falls back to try_install (manual → _existing_binary),
+    # which probes the real PATH; patch it so the test is hermetic even on a
+    # machine where laravel-lsp happens to be installed. With both servers'
+    # binaries absent, the fallback gives up and returns None.
+    monkeypatch.setattr("agent.lsp.install.try_install", lambda pkg, strategy: None)
     ctx = ServerContext(workspace_root="/project", install_strategy="manual")
     spec = _spawn_laravel_lsp("/project", ctx)
     assert spec is None
+
+
+def test_laravel_lsp_falls_back_to_intelephense_when_missing(monkeypatch):
+    """Confirm that a missing laravel-lsp with intelephense present no longer
+    loses diagnostics: it falls back to intelephense's spawn spec."""
+    monkeypatch.setattr("agent.lsp.install.try_install", lambda pkg, strategy: None)
+    # _which returns None for laravel-lsp but finds intelephense.
+    monkeypatch.setattr(
+        "agent.lsp.servers._which",
+        lambda *names: "/fake/bin/intelephense" if names[0] == "intelephense" else None,
+    )
+    ctx = ServerContext(workspace_root="/project", install_strategy="manual")
+    spec = _spawn_laravel_lsp("/project", ctx)
+    assert spec is not None
+    assert spec.command[0] == "/fake/bin/intelephense"
 
 
 def test_laravel_lsp_in_servers_registry():

--- a/tests/agent/lsp/test_laravel_lsp.py
+++ b/tests/agent/lsp/test_laravel_lsp.py
@@ -69,27 +69,11 @@ def test_laravel_lsp_spawn_returns_none_when_missing(monkeypatch):
     monkeypatch.setattr("agent.lsp.servers._which", lambda *names: None)
     # _spawn_laravel_lsp falls back to try_install (manual → _existing_binary),
     # which probes the real PATH; patch it so the test is hermetic even on a
-    # machine where laravel-lsp happens to be installed. With both servers'
-    # binaries absent, the fallback gives up and returns None.
+    # machine where laravel-lsp happens to be installed.
     monkeypatch.setattr("agent.lsp.install.try_install", lambda pkg, strategy: None)
     ctx = ServerContext(workspace_root="/project", install_strategy="manual")
     spec = _spawn_laravel_lsp("/project", ctx)
     assert spec is None
-
-
-def test_laravel_lsp_falls_back_to_intelephense_when_missing(monkeypatch):
-    """Confirm that a missing laravel-lsp with intelephense present no longer
-    loses diagnostics: it falls back to intelephense's spawn spec."""
-    monkeypatch.setattr("agent.lsp.install.try_install", lambda pkg, strategy: None)
-    # _which returns None for laravel-lsp but finds intelephense.
-    monkeypatch.setattr(
-        "agent.lsp.servers._which",
-        lambda *names: "/fake/bin/intelephense" if names[0] == "intelephense" else None,
-    )
-    ctx = ServerContext(workspace_root="/project", install_strategy="manual")
-    spec = _spawn_laravel_lsp("/project", ctx)
-    assert spec is not None
-    assert spec.command[0] == "/fake/bin/intelephense"
 
 
 def test_laravel_lsp_in_servers_registry():

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -72,6 +72,7 @@ agent sees a syntax-clean file with semantic problems as
 | YAML | `yaml-language-server` | npm |
 | Lua | `lua-language-server` | manual (GitHub releases) |
 | PHP | `intelephense` | npm |
+| Laravel Blade | `laravel-lsp` | manual (composer) |
 | OCaml | `ocaml-lsp` | manual (opam) |
 | Dockerfile | `dockerfile-language-server-nodejs` | npm |
 | Terraform | `terraform-ls` | manual |

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -94,6 +94,18 @@ manager makes sense for that language (rustup, ghcup, opam, brew,
 …). Hermes auto-detects the binary on PATH or in
 `<HERMES_HOME>/lsp/bin/`.
 
+### Laravel Blade
+
+laravel-lsp is installed via Composer:
+
+```bash
+composer global require laravel/lsp
+```
+
+Hermes detects the `laravel-lsp` binary on PATH (typically at
+`~/.config/composer/vendor/bin/laravel-lsp`) and routes `.blade.php`
+files to it. Plain `.php` files continue to use intelephense.
+
 ### PowerShell
 
 PowerShellEditorServices isn't a single binary — it's a PowerShell

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/lsp.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/lsp.md
@@ -62,6 +62,7 @@ agent 对于语法正确但存在语义问题的文件，会看到 ``lint: ok`` 
 | YAML | `yaml-language-server` | npm |
 | Lua | `lua-language-server` | 手动（GitHub releases） |
 | PHP | `intelephense` | npm |
+| Laravel Blade | `laravel-lsp` | 手动（composer） |
 | OCaml | `ocaml-lsp` | 手动（opam） |
 | Dockerfile | `dockerfile-language-server-nodejs` | npm |
 | Terraform | `terraform-ls` | 手动 |


### PR DESCRIPTION
## Summary

Registers `laravel-lsp` ([laravel/lsp](https://github.com/laravel/lsp)) as a new LSP server for Blade template files (`.blade.php`), complementary to intelephense which continues to handle plain `.php` files.

Closes #75718.

## Problem

Hermes ships with intelephense for PHP, but `.blade.php` files get zero semantic diagnostics — `os.path.splitext("foo.blade.php")` returns `.php`, so Blade files match intelephense, which doesn't understand Blade directives. There's no coverage for Laravel Blade templates at all.

## Changes

- **`agent/lsp/servers.py`**:
  - `_file_ext_or_basename`: special-case `.blade.php` so the double extension is returned in full instead of being collapsed to `.php` by `os.path.splitext`. Placed in a loop over a tuple so future double extensions (`.test.ts`, `.spec.js`) can be added trivially.
  - `LANGUAGE_BY_EXT`: add `".blade.php": "blade"`.
  - `_spawn_laravel_lsp`: new spawn builder — resolves `laravel-lsp` binary via `_which` or `_resolve_override`, spawns with `["bin", "lsp"]` (the `lsp` subcommand is the stdio LSP mode, verified against `laravel/lsp`'s `LspCommand::$signature`). Manual install only.
  - `SERVERS`: register `laravel-lsp` **before** `intelephense` so `.blade.php` matches first.
- **`agent/lsp/install.py`**: add `"laravel-lsp": {"strategy": "manual", ...}` recipe (user installs via `composer global require laravel/lsp`).
- **`tests/agent/lsp/test_laravel_lsp.py`**: 8 tests covering:
  - `.blade.php` routes to `laravel-lsp`, not `intelephense`
  - `.php` still routes to `intelephense` (no regression)
  - `_file_ext_or_basename` returns `.blade.php` correctly (case-insensitive)
  - `language_id_for` returns `"blade"` for `.blade.php`
  - `_spawn_laravel_lsp` builds correct command `[bin, "lsp"]`
  - `_spawn_laravel_lsp` returns `None` when binary missing (manual install) — hermetic test (patches `try_install`, which probes the real PATH)
  - `laravel-lsp` appears in `SERVERS` before `intelephense`

## No conflict with intelephense

`find_server_for_file` returns the first matching `ServerDef`. By placing `laravel-lsp` (`.blade.php`) before `intelephense` (`.php`) in the `SERVERS` list, Blade files route to laravel-lsp and plain PHP files continue to route to intelephense. No architectural changes needed.

Note: we intentionally **do not** fall back to intelephense when `laravel-lsp` is missing — the manager keys clients by `server_id`, so a fallback spawn inside `_spawn_laravel_lsp` would start a second intelephense process under the `laravel-lsp` key (duplicate indexing) and bypass `lsp.servers.intelephense.disabled`, and the `"blade"` languageId is ignored by intelephense anyway. Without `laravel-lsp` installed, Blade files simply have no LSP server.

## Install

```bash
composer global require laravel/lsp
```

Binary at `~/.config/composer/vendor/bin/laravel-lsp` (shebang `#!/usr/bin/env php`). No npm/pip recipe — manual install, same pattern as `rust-analyzer`, `clangd`, `ocaml-lsp`.

## Test results

```
tests/agent/lsp/test_laravel_lsp.py: 8 passed
```

(The 4 async test failures in `test_client_e2e.py`, `test_protocol.py`, `test_stale_diagnostics.py` are pre-existing — missing `pytest-asyncio` in the test environment, unrelated to this change.)