### PR TITLE
fix(acp): preserve session enabled/disabled toolsets across model switches

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2330,6 +2330,8 @@ class HermesACPAgent(acp.Agent):
 
         current_provider = getattr(state.agent, "provider", None) or "openrouter"
         target_provider, new_model = self._resolve_model_selection(args, current_provider)
+        current_enabled_toolsets = list(getattr(state.agent, "enabled_toolsets", None) or [])
+        current_disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
 
         state.model = new_model
         state.agent = self.session_manager._make_agent(
@@ -2337,6 +2339,8 @@ class HermesACPAgent(acp.Agent):
             cwd=state.cwd,
             model=new_model,
             requested_provider=target_provider,
+            enabled_toolsets=current_enabled_toolsets or None,
+            disabled_toolsets=list(current_disabled_toolsets) if current_disabled_toolsets else None,
         )
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
@@ -2582,6 +2586,8 @@ class HermesACPAgent(acp.Agent):
             provider_changed = bool(current_provider and requested_provider != current_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
+            current_enabled_toolsets = list(getattr(state.agent, "enabled_toolsets", None) or [])
+            current_disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
             state.agent = self.session_manager._make_agent(
                 session_id=session_id,
                 cwd=state.cwd,
@@ -2589,6 +2595,8 @@ class HermesACPAgent(acp.Agent):
                 requested_provider=requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
+                enabled_toolsets=current_enabled_toolsets or None,
+                disabled_toolsets=list(current_disabled_toolsets) if current_disabled_toolsets else None,
             )
             self.session_manager.save_session(session_id)
             logger.info(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2330,7 +2330,8 @@ class HermesACPAgent(acp.Agent):
 
         current_provider = getattr(state.agent, "provider", None) or "openrouter"
         target_provider, new_model = self._resolve_model_selection(args, current_provider)
-        current_enabled_toolsets = list(getattr(state.agent, "enabled_toolsets", None) or [])
+        raw_enabled_toolsets = getattr(state.agent, "enabled_toolsets", None)
+        current_enabled_toolsets = None if raw_enabled_toolsets is None else list(raw_enabled_toolsets)
         current_disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
 
         state.model = new_model
@@ -2339,7 +2340,7 @@ class HermesACPAgent(acp.Agent):
             cwd=state.cwd,
             model=new_model,
             requested_provider=target_provider,
-            enabled_toolsets=current_enabled_toolsets or None,
+            enabled_toolsets=current_enabled_toolsets,
             disabled_toolsets=list(current_disabled_toolsets) if current_disabled_toolsets else None,
         )
         self.session_manager.save_session(state.session_id)
@@ -2586,7 +2587,8 @@ class HermesACPAgent(acp.Agent):
             provider_changed = bool(current_provider and requested_provider != current_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
-            current_enabled_toolsets = list(getattr(state.agent, "enabled_toolsets", None) or [])
+            raw_enabled_toolsets = getattr(state.agent, "enabled_toolsets", None)
+            current_enabled_toolsets = None if raw_enabled_toolsets is None else list(raw_enabled_toolsets)
             current_disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
             state.agent = self.session_manager._make_agent(
                 session_id=session_id,
@@ -2595,7 +2597,7 @@ class HermesACPAgent(acp.Agent):
                 requested_provider=requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
-                enabled_toolsets=current_enabled_toolsets or None,
+                enabled_toolsets=current_enabled_toolsets,
                 disabled_toolsets=list(current_disabled_toolsets) if current_disabled_toolsets else None,
             )
             self.session_manager.save_session(session_id)

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2322,6 +2322,23 @@ class HermesACPAgent(acp.Agent):
         lines.append("Unrecognized /commands are sent to the model as normal messages.")
         return "\n".join(lines)
 
+    @staticmethod
+    def _capture_session_toolset_state(agent: Any) -> tuple[list[str] | None, list[str] | None]:
+        """Snapshot the current agent's enabled/disabled toolsets for a rebuild.
+
+        Both values preserve the explicit ``None``/``[]`` distinction so a
+        deliberately toolless session (enabled_toolsets=[] / disabled_toolsets=[])
+        stays toolless across a model switch instead of falling back to
+        ``_make_agent``'s config.yaml-derived defaults.
+
+        Returns defensive copies so the rebuilt agent owns its own lists.
+        """
+        raw_enabled = getattr(agent, "enabled_toolsets", None)
+        raw_disabled = getattr(agent, "disabled_toolsets", None)
+        enabled = None if raw_enabled is None else list(raw_enabled)
+        disabled = None if raw_disabled is None else list(raw_disabled)
+        return enabled, disabled
+
     def _cmd_model(self, args: str, state: SessionState) -> str:
         if not args:
             model = state.model or getattr(state.agent, "model", "unknown")
@@ -2330,9 +2347,7 @@ class HermesACPAgent(acp.Agent):
 
         current_provider = getattr(state.agent, "provider", None) or "openrouter"
         target_provider, new_model = self._resolve_model_selection(args, current_provider)
-        raw_enabled_toolsets = getattr(state.agent, "enabled_toolsets", None)
-        current_enabled_toolsets = None if raw_enabled_toolsets is None else list(raw_enabled_toolsets)
-        current_disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
+        current_enabled_toolsets, current_disabled_toolsets = self._capture_session_toolset_state(state.agent)
 
         state.model = new_model
         state.agent = self.session_manager._make_agent(
@@ -2341,7 +2356,7 @@ class HermesACPAgent(acp.Agent):
             model=new_model,
             requested_provider=target_provider,
             enabled_toolsets=current_enabled_toolsets,
-            disabled_toolsets=list(current_disabled_toolsets) if current_disabled_toolsets else None,
+            disabled_toolsets=current_disabled_toolsets,
         )
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
@@ -2587,9 +2602,7 @@ class HermesACPAgent(acp.Agent):
             provider_changed = bool(current_provider and requested_provider != current_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
-            raw_enabled_toolsets = getattr(state.agent, "enabled_toolsets", None)
-            current_enabled_toolsets = None if raw_enabled_toolsets is None else list(raw_enabled_toolsets)
-            current_disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
+            current_enabled_toolsets, current_disabled_toolsets = self._capture_session_toolset_state(state.agent)
             state.agent = self.session_manager._make_agent(
                 session_id=session_id,
                 cwd=state.cwd,
@@ -2598,7 +2611,7 @@ class HermesACPAgent(acp.Agent):
                 base_url=current_base_url,
                 api_mode=current_api_mode,
                 enabled_toolsets=current_enabled_toolsets,
-                disabled_toolsets=list(current_disabled_toolsets) if current_disabled_toolsets else None,
+                disabled_toolsets=current_disabled_toolsets,
             )
             self.session_manager.save_session(session_id)
             logger.info(

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -611,6 +611,19 @@ class SessionManager:
         enabled_toolsets: list[str] | None = None,
         disabled_toolsets: list[str] | None = None,
     ):
+        """Build a fresh ``AIAgent`` for the session.
+
+        Explicit ``enabled_toolsets`` / ``disabled_toolsets`` are passed through
+        verbatim — the rebuild deliberately does NOT re-run
+        ``_expand_acp_enabled_toolsets`` against the current config. This trades
+        config freshness for session fidelity: MCP toolsets the ACP client
+        registered at session creation stay bound even after a ``/model``
+        switch, while servers added to ``config.yaml`` after creation only
+        appear on the *next* new session (the ``_make_agent`` cold path, with
+        both ``enabled_toolsets`` and ``disabled_toolsets`` left as ``None``).
+        See the corresponding docs on ``_capture_session_toolset_state`` in
+        ``acp_adapter.server`` for the explicit ``None``/``[]`` invariant.
+        """
         if self._agent_factory is not None:
             return self._agent_factory()
 

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -608,6 +608,8 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        enabled_toolsets: list[str] | None = None,
+        disabled_toolsets: list[str] | None = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -634,9 +636,18 @@ class SessionManager:
 
         kwargs = {
             "platform": "acp",
-            "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
-                mcp_server_names=configured_mcp_servers,
+            "enabled_toolsets": (
+                list(enabled_toolsets)
+                if enabled_toolsets is not None
+                else _expand_acp_enabled_toolsets(
+                    ["hermes-acp"],
+                    mcp_server_names=configured_mcp_servers,
+                )
+            ),
+            "disabled_toolsets": (
+                list(disabled_toolsets)
+                if disabled_toolsets is not None
+                else None
             ),
             "quiet_mode": True,
             "session_id": session_id,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -178,6 +178,52 @@ class TestAuthenticate:
 class TestSessionOps:
 
     @pytest.mark.asyncio
+    async def test_set_session_model_preserves_enabled_and_disabled_toolsets(self, monkeypatch):
+        """Regression sibling to /model: the async ACP session/set_model
+        entrypoint also rebuilds state.agent via _make_agent and must pass
+        through the pre-switch agent's enabled_toolsets/disabled_toolsets so
+        session-scoped MCP toolsets survive the switch."""
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model="gpt-5.4",
+                provider="openai-codex",
+                base_url="https://api.openai.com/v1",
+                enabled_toolsets=["hermes-acp", "mcp-demo-search"],
+                disabled_toolsets=["browser"],
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+
+        captured = {}
+
+        def fake_make_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("requested_provider") or "openai-codex",
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                disabled_toolsets=kwargs.get("disabled_toolsets"),
+            )
+
+        monkeypatch.setattr(manager, "_make_agent", fake_make_agent)
+        monkeypatch.setattr(
+            "acp_adapter.server.HermesACPAgent._resolve_model_selection",
+            staticmethod(lambda raw, current: (current, raw.strip())),
+        )
+
+        result = await acp_agent.set_session_model(
+            model_id="anthropic:claude-sonnet-4-6",
+            session_id=state.session_id,
+        )
+
+        assert isinstance(result, SetSessionModelResponse)
+        assert captured["enabled_toolsets"] == ["hermes-acp", "mcp-demo-search"]
+        assert captured["disabled_toolsets"] == ["browser"]
+        assert state.agent.enabled_toolsets == ["hermes-acp", "mcp-demo-search"]
+        assert state.agent.disabled_toolsets == ["browser"]
+
+    @pytest.mark.asyncio
     async def test_new_session_returns_authenticated_cross_provider_model_state(self):
         manager = SessionManager(
             agent_factory=lambda: SimpleNamespace(
@@ -502,6 +548,66 @@ class TestSlashCommands:
         state = self._make_state(mock_manager)
         result = agent._handle_slash_command("/model", state)
         assert "test-model" in result
+
+    def test_cmd_model_preserves_enabled_and_disabled_toolsets_across_switch(self, agent, mock_manager, monkeypatch):
+        """Regression: /model rebuilds state.agent via _make_agent, which
+        previously always recomputed enabled_toolsets from config.yaml alone
+        (session.py::_make_agent), silently dropping any session-scoped MCP
+        toolset the ACP client had registered before the switch. _make_agent
+        now accepts enabled_toolsets/disabled_toolsets and _cmd_model must
+        pass the pre-switch agent's values through."""
+        state = self._make_state(mock_manager)
+        state.agent.enabled_toolsets = ["hermes-acp", "mcp-demo-search"]
+        state.agent.disabled_toolsets = ["browser"]
+
+        captured = {}
+
+        def fake_make_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("requested_provider") or "openrouter",
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                disabled_toolsets=kwargs.get("disabled_toolsets"),
+            )
+
+        monkeypatch.setattr(mock_manager, "_make_agent", fake_make_agent)
+        monkeypatch.setattr(
+            "acp_adapter.server.HermesACPAgent._resolve_model_selection",
+            staticmethod(lambda raw, current: (current, raw.strip())),
+        )
+
+        agent._handle_slash_command("/model anthropic:claude-sonnet-4-6", state)
+
+        assert captured["enabled_toolsets"] == ["hermes-acp", "mcp-demo-search"]
+        assert captured["disabled_toolsets"] == ["browser"]
+        assert state.agent.enabled_toolsets == ["hermes-acp", "mcp-demo-search"]
+        assert state.agent.disabled_toolsets == ["browser"]
+
+    def test_cmd_model_passes_none_toolsets_when_agent_has_none(self, agent, mock_manager, monkeypatch):
+        """A session with no session-scoped toolsets yet must not force an
+        empty enabled_toolsets list onto the rebuilt agent — _make_agent's
+        own config.yaml-derived default should still apply."""
+        state = self._make_state(mock_manager)
+        state.agent.enabled_toolsets = None
+        state.agent.disabled_toolsets = None
+
+        captured = {}
+
+        def fake_make_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(model=kwargs.get("model"), provider="openrouter")
+
+        monkeypatch.setattr(mock_manager, "_make_agent", fake_make_agent)
+        monkeypatch.setattr(
+            "acp_adapter.server.HermesACPAgent._resolve_model_selection",
+            staticmethod(lambda raw, current: (current, raw.strip())),
+        )
+
+        agent._handle_slash_command("/model anthropic:claude-sonnet-4-6", state)
+
+        assert captured["enabled_toolsets"] is None
+        assert captured["disabled_toolsets"] is None
 
 
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -224,6 +224,51 @@ class TestSessionOps:
         assert state.agent.disabled_toolsets == ["browser"]
 
     @pytest.mark.asyncio
+    async def test_set_session_model_preserves_explicit_empty_toolsets(self, monkeypatch):
+        """Regression sibling to the /model empty-toolset case: session/set_model
+        must also keep a deliberately toolless session (enabled_toolsets == [])
+        toolless across the switch, instead of collapsing [] into None and
+        letting _make_agent restore its config.yaml-derived default toolset."""
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model="gpt-5.4",
+                provider="openai-codex",
+                base_url="https://api.openai.com/v1",
+                enabled_toolsets=[],
+                disabled_toolsets=None,
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+
+        captured = {}
+
+        def fake_make_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("requested_provider") or "openai-codex",
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                disabled_toolsets=kwargs.get("disabled_toolsets"),
+            )
+
+        monkeypatch.setattr(manager, "_make_agent", fake_make_agent)
+        monkeypatch.setattr(
+            "acp_adapter.server.HermesACPAgent._resolve_model_selection",
+            staticmethod(lambda raw, current: (current, raw.strip())),
+        )
+
+        result = await acp_agent.set_session_model(
+            model_id="anthropic:claude-sonnet-4-6",
+            session_id=state.session_id,
+        )
+
+        assert isinstance(result, SetSessionModelResponse)
+        assert captured["enabled_toolsets"] == []
+        assert captured["enabled_toolsets"] is not None
+        assert state.agent.enabled_toolsets == []
+
+    @pytest.mark.asyncio
     async def test_new_session_returns_authenticated_cross_provider_model_state(self):
         manager = SessionManager(
             agent_factory=lambda: SimpleNamespace(
@@ -609,7 +654,38 @@ class TestSlashCommands:
         assert captured["enabled_toolsets"] is None
         assert captured["disabled_toolsets"] is None
 
+    def test_cmd_model_preserves_explicit_empty_toolsets_across_switch(self, agent, mock_manager, monkeypatch):
+        """Regression: a deliberately toolless session (enabled_toolsets == [])
+        must stay toolless across a /model switch. `current_enabled_toolsets or
+        None` previously collapsed an explicit [] into None, which made
+        _make_agent fall back to its config.yaml-derived default toolset —
+        silently re-enabling tools for a session that had them turned off."""
+        state = self._make_state(mock_manager)
+        state.agent.enabled_toolsets = []
+        state.agent.disabled_toolsets = None
 
+        captured = {}
+
+        def fake_make_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("requested_provider") or "openrouter",
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                disabled_toolsets=kwargs.get("disabled_toolsets"),
+            )
+
+        monkeypatch.setattr(mock_manager, "_make_agent", fake_make_agent)
+        monkeypatch.setattr(
+            "acp_adapter.server.HermesACPAgent._resolve_model_selection",
+            staticmethod(lambda raw, current: (current, raw.strip())),
+        )
+
+        agent._handle_slash_command("/model anthropic:claude-sonnet-4-6", state)
+
+        assert captured["enabled_toolsets"] == []
+        assert captured["enabled_toolsets"] is not None
+        assert state.agent.enabled_toolsets == []
 
 
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -269,6 +269,53 @@ class TestSessionOps:
         assert state.agent.enabled_toolsets == []
 
     @pytest.mark.asyncio
+    async def test_set_session_model_preserves_explicit_empty_disabled_toolsets(self, monkeypatch):
+        """Regression: a session with disabled_toolsets == [] must keep that
+        explicitly-empty list across session/set_model. The pre-PR code
+        collapsed `[]` into `None` via `list(...) if current_disabled_toolsets
+        else None`, which would silently let _make_agent restore any
+        config-derived disabled toolsets in the future the same way the
+        enabled_toolsets regression did for enabled toolsets."""
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model="gpt-5.4",
+                provider="openai-codex",
+                base_url="https://api.openai.com/v1",
+                enabled_toolsets=["hermes-acp"],
+                disabled_toolsets=[],
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+
+        captured = {}
+
+        def fake_make_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("requested_provider") or "openai-codex",
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                disabled_toolsets=kwargs.get("disabled_toolsets"),
+            )
+
+        monkeypatch.setattr(manager, "_make_agent", fake_make_agent)
+        monkeypatch.setattr(
+            "acp_adapter.server.HermesACPAgent._resolve_model_selection",
+            staticmethod(lambda raw, current: (current, raw.strip())),
+        )
+
+        result = await acp_agent.set_session_model(
+            model_id="anthropic:claude-sonnet-4-6",
+            session_id=state.session_id,
+        )
+
+        assert isinstance(result, SetSessionModelResponse)
+        assert captured["disabled_toolsets"] == []
+        assert captured["disabled_toolsets"] is not None
+        assert state.agent.disabled_toolsets == []
+
+    @pytest.mark.asyncio
     async def test_new_session_returns_authenticated_cross_provider_model_state(self):
         manager = SessionManager(
             agent_factory=lambda: SimpleNamespace(
@@ -686,6 +733,40 @@ class TestSlashCommands:
         assert captured["enabled_toolsets"] == []
         assert captured["enabled_toolsets"] is not None
         assert state.agent.enabled_toolsets == []
+
+    def test_cmd_model_preserves_explicit_empty_disabled_toolsets_across_switch(self, agent, mock_manager, monkeypatch):
+        """Regression sibling to the enabled_toolsets==[] case: a session with
+        disabled_toolsets == [] must keep that explicitly-empty list across a
+        /model switch. The pre-PR `list(...) if current_disabled_toolsets else
+        None` collapsed [] into None; mirrored fix on the disabled side
+        prevents the same latent bug class from biting once /model's
+        disabled_toolsets handling starts to mean anything beyond a no-op."""
+        state = self._make_state(mock_manager)
+        state.agent.enabled_toolsets = ["hermes-acp"]
+        state.agent.disabled_toolsets = []
+
+        captured = {}
+
+        def fake_make_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("requested_provider") or "openrouter",
+                enabled_toolsets=kwargs.get("enabled_toolsets"),
+                disabled_toolsets=kwargs.get("disabled_toolsets"),
+            )
+
+        monkeypatch.setattr(mock_manager, "_make_agent", fake_make_agent)
+        monkeypatch.setattr(
+            "acp_adapter.server.HermesACPAgent._resolve_model_selection",
+            staticmethod(lambda raw, current: (current, raw.strip())),
+        )
+
+        agent._handle_slash_command("/model anthropic:claude-sonnet-4-6", state)
+
+        assert captured["disabled_toolsets"] == []
+        assert captured["disabled_toolsets"] is not None
+        assert state.agent.disabled_toolsets == []
 
 
 


### PR DESCRIPTION
## What does this PR do?

Consolidates and rebases #42753 (by @izumi0uu) onto current `main`, closing the actual gap in the #42719 model-switch failure mode: `acp_adapter/server.py`'s two model-switch entrypoints — `_cmd_model` (the `/model` slash command) and `set_session_model` (the ACP `session/set_model` protocol method) — both rebuild `state.agent` via `SessionManager._make_agent`. `_make_agent` always recomputed `enabled_toolsets` from `config.yaml`'s `mcp_servers` alone, with no way to carry forward a session's runtime `enabled_toolsets`/`disabled_toolsets`. Any MCP server an ACP client registered live via `session/new` (never present in `config.yaml`) was silently dropped from the rebuilt agent's tool schema on every model switch.

This does **not** touch the #42719 cold-start symptom — that's already handled correctly by `_register_session_mcp_servers`, which patches `state.agent.tools`/`enabled_toolsets` directly right after `session/new`, before any prompt is served.

## Why a new PR instead of continuing #42753 / #67540 / #75713

- **#42753** (original, by @izumi0uu) implements the right approach but is stale (0 reviews since 2026-06-09) and is now `CONFLICTING` against current `main` — the test file it touches (`tests/acp/test_server.py`) has drifted enough that the diff no longer applies cleanly. This PR is a rebase of that same diff (verified byte-identical for `acp_adapter/server.py` / `acp_adapter/session.py`) plus fresh regression tests written against the current test file structure.
- **#67540** re-registers MCP servers wholesale after rebuild instead of preserving toolset state, and review flagged a real bug (blocking the ACP event loop up to 120s via a synchronous `register_mcp_servers` call) — and was itself redirected by review to prefer this approach.
- **#75713** (mine) tried unioning a process-wide MCP-server registry into `_make_agent`. Review correctly rejected it: that lookup runs before the current request's servers are registered (so it doesn't fix the case it claims to), and it leaks MCP servers across unrelated concurrent sessions on the same daemon with no removal path.

## Related Issue

Relates to #42719 (model-switch failure mode). Supersedes #75713. Consolidates #42753 and #67540.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `acp_adapter/session.py` — `SessionManager._make_agent` gains optional `enabled_toolsets`/`disabled_toolsets` kwargs. When provided, used verbatim instead of being recomputed from `config.yaml`; existing config.yaml-derived behavior is the default when omitted (no regression for callers that don't pass them).
- `acp_adapter/server.py` — `_cmd_model` and `set_session_model` both capture the pre-switch agent's `enabled_toolsets`/`disabled_toolsets` and pass them through to `_make_agent`.
- `tests/acp/test_server.py`:
  - `test_cmd_model_preserves_enabled_and_disabled_toolsets_across_switch`
  - `test_cmd_model_passes_none_toolsets_when_agent_has_none` (no regression when a session has no session-scoped toolsets yet)
  - `test_set_session_model_preserves_enabled_and_disabled_toolsets`

All three were verified to **fail** against the pre-fix code (reverting each call site's toolset pass-through individually) before being added, confirming they actually exercise the bug rather than trivially agreeing with the implementation.

## How to Test

```
pytest tests/acp/ -q
```
128 passed.

Manual repro (IntelliJ / Zed):
1. Open an ACP session with a client-registered MCP server (e.g. `default_mcp_settings.use_idea_mcp: true`).
2. Confirm the MCP tool works on the first prompt.
3. Switch model via `/model` or the ACP model picker.
4. Before this fix: the MCP tool is gone from the next prompt's tool schema. After: it's preserved.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(acp):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate — see "Why a new PR" above
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/acp/ -q` — all 128 tests pass
- [x] I've added tests for my changes, and verified they fail without the fix
- [x] I've tested on my platform: macOS 26.6 (M4)
- [x] Cross-platform impact: N/A — Python-only change, no platform-specific code paths touched
- [x] Tool descriptions/schemas: N/A
- [x] Documentation: N/A
