### PR TITLE
fix(tests): prevent test runs from playing live audio

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -939,10 +939,12 @@ def _wal_is_usable() -> bool:
 #    gateway call sites late-import, so patching the module attribute catches
 #    them wherever they import it from.
 #  • ``hermes_cli.voice.play_audio_file`` — the module-level binding
-#    ``speak_text`` actually plays through. Patching the binding inside
-#    ``hermes_cli.voice`` (not ``tools.voice_mode``) keeps the real function
-#    available to the tests that legitimately exercise it with a mocked
-#    audio backend (``tests/tools/test_voice_mode.py``).
+#    ``speak_text`` actually plays through.
+#  • sounddevice output primitives and system audio-player subprocesses —
+#    ``tools.tts_tool``'s streaming paths import these directly, bypassing both
+#    bindings above. The guards block real OutputStreams / ``play`` calls and
+#    ``afplay`` / ``ffplay`` / ``aplay`` processes while tests that replace
+#    the lazy imports or mock ``subprocess.Popen`` can still exercise them.
 #
 # Config cannot re-open this hole: the ``tts:`` section of ``config.yaml``
 # only selects *which* provider speaks, never *whether* to speak — that gate
@@ -950,6 +952,35 @@ def _wal_is_usable() -> bool:
 
 _AUDIO_GUARD_BYPASS_MARK = "real_audio_playback"
 _ALLOW_MACOS_KEYCHAIN_MARK = "allow_macos_keychain"
+
+
+class _SounddeviceOutputGuard:
+    """Delegate sounddevice input APIs while refusing every output primitive."""
+
+    _OUTPUT_PRIMITIVES = {
+        "OutputStream",
+        "RawOutputStream",
+        "RawStream",
+        "Stream",
+        "play",
+        "playrec",
+    }
+
+    def __init__(self, sounddevice):
+        self._sounddevice = sounddevice
+
+    def __getattr__(self, name):
+        if name in self._OUTPUT_PRIMITIVES:
+            def _blocked_output(*args, **kwargs):
+                raise RuntimeError(
+                    "tests/conftest.py audio-playback guard: blocked "
+                    f"sounddevice.{name}() — unit tests must mock the audio output. "
+                    "Mark with @pytest.mark.real_audio_playback only for an "
+                    "explicit live-audio integration test."
+                )
+
+            return _blocked_output
+        return getattr(self._sounddevice, name)
 
 
 def pytest_configure(config):  # noqa: D401 — pytest hook
@@ -1029,9 +1060,9 @@ def _live_system_guard(request, monkeypatch):
     are all caught. ``pkill``/``killall``/``taskkill`` invocations
     targeting hermes/python patterns are also blocked.
     """
-    if request.node.get_closest_marker(_LIVE_SYSTEM_GUARD_BYPASS_MARK):
-        yield
-        return
+    live_system_bypass = request.node.get_closest_marker(
+        _LIVE_SYSTEM_GUARD_BYPASS_MARK
+    ) is not None
 
     import os as _os
     import shlex as _shlex
@@ -1099,14 +1130,15 @@ def _live_system_guard(request, monkeypatch):
             "delivery is genuinely required."
         )
 
-    monkeypatch.setattr(_os, "kill", _guarded_kill)
+    if not live_system_bypass:
+        monkeypatch.setattr(_os, "kill", _guarded_kill)
 
     # ``os.killpg`` is the same risk class — sends a signal to every
     # process in a group. The gateway is a session leader (its own
     # PGID == its PID), so killpg(gateway_pid, SIGTERM) is a one-shot
     # kill of the live process. Allow it only when the target PGID is
     # the test process's own group.
-    if hasattr(_os, "killpg"):
+    if not live_system_bypass and hasattr(_os, "killpg"):
         real_killpg = _os.killpg
         own_pgid = _os.getpgrp()
 
@@ -1139,6 +1171,7 @@ def _live_system_guard(request, monkeypatch):
         "daemon-reload", "try-restart", "reload-or-restart",
     )
     _PROCESS_KILLERS = ("pkill", "killall", "taskkill", "skill", "fuser")
+    _AUDIO_PLAYERS = ("afplay", "ffplay", "aplay")
     # Shell/launcher executables whose arguments are themselves commands —
     # argv[0]-only scanning must not exempt what they wrap.
     _WRAPPER_COMMANDS = (
@@ -1212,7 +1245,51 @@ def _live_system_guard(request, monkeypatch):
                     return True
         return False
 
+    def _is_audio_player(cmd) -> bool:
+        cmd_str = _cmd_to_string(cmd)
+        try:
+            tokens = _shlex.split(cmd_str)
+        except ValueError:
+            tokens = cmd_str.split()
+        if not tokens:
+            return False
+
+        head = tokens[0].rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+        if head in _AUDIO_PLAYERS:
+            return True
+        if head not in _WRAPPER_COMMANDS:
+            return False
+
+        # Shell payloads stay grouped after the outer split (for example,
+        # ``bash -c 'afplay sample.wav'``). Split each argument once more so
+        # quoted payloads cannot hide the player executable.
+        nested_tokens = []
+        for token in tokens[1:]:
+            try:
+                nested_tokens.extend(_shlex.split(token))
+            except ValueError:
+                nested_tokens.extend(token.split())
+
+        # Shell-wrapped playback also includes the WSL Media.SoundPlayer path.
+        normalized = {
+            token.strip("()'\";&|").rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+            for token in nested_tokens
+        }
+        return bool(set(_AUDIO_PLAYERS) & normalized) or "Media.SoundPlayer" in cmd_str
+
     def _check_subprocess_cmd(name, cmd):
+        if (
+            request.node.get_closest_marker(_AUDIO_GUARD_BYPASS_MARK) is None
+            and _is_audio_player(cmd)
+        ):
+            raise RuntimeError(
+                f"tests/conftest.py audio-playback guard: blocked "
+                f"subprocess.{name}({cmd!r}) — unit tests must mock the "
+                "audio player. Mark with @pytest.mark.real_audio_playback "
+                "only for an explicit live-audio integration test."
+            )
+        if live_system_bypass:
+            return
         if _is_blocked_systemctl(cmd):
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
@@ -1412,6 +1489,38 @@ def _audio_playback_guard(request, monkeypatch):
         monkeypatch.setattr(_voice, "speak_text", _blocked_speak_text)
     if hasattr(_voice, "play_audio_file"):
         monkeypatch.setattr(_voice, "play_audio_file", _blocked_play_audio_file)
+
+    # Both output paths lazy-import sounddevice. Wrap those imports instead of
+    # importing sounddevice here (which can itself initialize host audio), and
+    # delegate input-only APIs so microphone tests remain unaffected. Tests
+    # that explicitly replace a lazy importer after fixture setup keep using
+    # their fake sounddevice module as intended.
+    try:
+        import tools.voice_mode as _voice_mode
+
+        real_import_audio = _voice_mode._import_audio
+
+        def _guarded_import_audio():
+            sounddevice, numpy = real_import_audio()
+            return _SounddeviceOutputGuard(sounddevice), numpy
+
+        monkeypatch.setattr(_voice_mode, "_import_audio", _guarded_import_audio)
+    except Exception:
+        pass
+
+    try:
+        import tools.tts_tool as _tts_tool
+
+        real_import_sounddevice = _tts_tool._import_sounddevice
+
+        def _guarded_import_sounddevice():
+            return _SounddeviceOutputGuard(real_import_sounddevice())
+
+        monkeypatch.setattr(
+            _tts_tool, "_import_sounddevice", _guarded_import_sounddevice
+        )
+    except Exception:
+        pass
 
     yield
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1009,13 +1009,19 @@ class TestAutoTtsEmptyTextGuard:
 class TestStreamTtsToSpeaker:
     """Functional tests for the streaming TTS pipeline."""
 
-    def test_none_sentinel_flushes_buffer(self):
+    def test_none_sentinel_flushes_buffer(self, monkeypatch):
         """None sentinel causes remaining buffer to be spoken."""
         from tools.tts_tool import stream_tts_to_speaker
         text_q = queue.Queue()
         stop_evt = threading.Event()
         done_evt = threading.Event()
         spoken = []
+        synthesized = []
+
+        monkeypatch.setattr(
+            "tools.tts_tool.text_to_speech_tool",
+            lambda **kwargs: synthesized.append(kwargs["text"]),
+        )
 
         def display(text):
             spoken.append(text)
@@ -1026,6 +1032,7 @@ class TestStreamTtsToSpeaker:
         stream_tts_to_speaker(text_q, stop_evt, done_evt, display_callback=display)
         assert done_evt.is_set()
         assert any("Hello" in s for s in spoken)
+        assert synthesized == ["Hello world."]
 
     def test_stop_event_aborts_early(self):
         """Setting stop_event causes early exit."""

--- a/tests/test_audio_playback_guard.py
+++ b/tests/test_audio_playback_guard.py
@@ -16,23 +16,31 @@ leaked shell variable, so ``scripts/run_tests.sh``'s ``env -i`` was no help:
   4. ``speak_text`` needs no API key to be audible — ``tools/tts_tool.py``
      defaults to the keyless ``edge`` provider.
 
-Two independent defences in ``tests/conftest.py``, one test each below:
+Four independent defences in ``tests/conftest.py``:
 
   * ``_HERMES_BEHAVIORAL_VARS`` now blanks ``HERMES_VOICE`` /
     ``HERMES_VOICE_TTS`` at every test setup, so step 2 cannot cross a test
     boundary.
   * ``_audio_playback_guard`` stubs ``speak_text`` outright, so step 3 stays
     silent even *within* the test that set the flag itself.
+  * the guard wraps Hermes's lazy sounddevice imports so output streams and
+    direct ``play`` calls are blocked without disabling microphone input.
+  * ``_live_system_guard`` blocks system audio-player subprocesses, covering
+    direct ``tools.voice_mode.play_audio_file`` imports that bypass the
+    ``hermes_cli.voice`` bindings.
 
 The second is the load-bearing one: env blanking alone cannot stop code under
 test from re-setting the variable mid-test.
 """
 
 import os
+import subprocess
 import sys
 import types
 
 import pytest
+
+from tests.conftest import _SounddeviceOutputGuard
 
 from tui_gateway import server
 
@@ -113,6 +121,49 @@ def test_guard_can_be_opted_out_of_explicitly():
     import hermes_cli.voice as voice
 
     assert voice.speak_text.__name__ == "_blocked_speak_text"
+
+
+@pytest.mark.parametrize("player", ["afplay", "ffplay", "aplay"])
+def test_guard_blocks_direct_system_audio_players(player):
+    """The shared voice-mode fallback cannot bypass the TTS entry-point stub."""
+    with pytest.raises(RuntimeError, match="audio-playback guard"):
+        subprocess.Popen([f"/definitely-not-installed/{player}", "/tmp/test.mp3"])
+
+
+@pytest.mark.live_system_guard_bypass
+def test_audio_guard_survives_live_system_bypass():
+    """Process-guard opt-out must not double as permission for live audio."""
+    with pytest.raises(RuntimeError, match="audio-playback guard"):
+        subprocess.Popen(["/definitely-not-installed/afplay", "/tmp/test.mp3"])
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["bash", "-c", "afplay /tmp/test.mp3"],
+        "bash -c 'ffplay -nodisp /tmp/test.mp3'",
+    ],
+)
+def test_guard_blocks_quoted_shell_audio_players(command):
+    """A shell payload cannot hide an audio player from the guard."""
+    with pytest.raises(RuntimeError, match="audio-playback guard"):
+        subprocess.run(command, shell=isinstance(command, str), check=False)
+
+
+@pytest.mark.parametrize("primitive", ["play", "OutputStream"])
+def test_guard_blocks_sounddevice_output_primitives(primitive):
+    """sounddevice playback is blocked without hiding input-only APIs."""
+    fake_sounddevice = types.SimpleNamespace(
+        InputStream=object(),
+        play=lambda *args, **kwargs: None,
+        OutputStream=lambda *args, **kwargs: None,
+    )
+    guarded = _SounddeviceOutputGuard(fake_sounddevice)
+
+    with pytest.raises(RuntimeError, match="audio-playback guard"):
+        getattr(guarded, primitive)()
+
+    assert guarded.InputStream is fake_sounddevice.InputStream
 
 
 @pytest.mark.real_audio_playback


### PR DESCRIPTION
## What

Hermes's test suite can still synthesize and play real audio despite the existing autouse audio guard.

The remaining route is the streaming sync fallback:

```text
stream_tts_to_speaker
  -> text_to_speech_tool (keyless Edge TTS by default)
  -> tools.voice_mode.play_audio_file
  -> afplay / ffplay / aplay
```

`_audio_playback_guard` patches the bindings in `hermes_cli.voice`, but this path imports `tools.voice_mode.play_audio_file` directly. On macOS, `TestStreamTtsToSpeaker::test_none_sentinel_flushes_buffer` therefore synthesized `"Hello world."`, wrote an MP3, and launched the real `afplay` process during an ordinary `scripts/run_tests.sh` run.

This PR closes the bypass at both levels:

- the streaming regression test stubs `text_to_speech_tool` and asserts the exact sentence sent for synthesis, so the unit test no longer performs a network request or creates real audio;
- the suite-wide guard blocks system audio players (`afplay`, `ffplay`, `aplay`, and WSL's `Media.SoundPlayer`) for direct, launcher-wrapped, and quoted-shell subprocess calls;
- Hermes's lazy `sounddevice` imports are wrapped so output primitives (`play`, `playrec`, output/full-duplex streams) are refused while microphone-only APIs remain available;
- `live_system_guard_bypass` no longer doubles as an accidental audio opt-out — real playback still requires the dedicated `real_audio_playback` marker.

Mocked player and sounddevice tests continue to exercise the real implementation by replacing the relevant lazy import or subprocess binding inside the test.

## Why this matters beyond tidiness

A default unit-test run should not produce an external physical side effect. Unexpected speech is disruptive, can expose fixture or generated text to anyone nearby, and makes a supposedly hermetic suite depend on network availability, local audio software, and the host speaker configuration.

The existing guard already establishes the intended invariant: no real audio without an explicit `real_audio_playback` marker. This fixes the direct-import and cross-platform primitives that sat below its original interception point.

## How to test

Reproduce on current `main` on macOS:

```bash
scripts/run_tests.sh tests/gateway/test_voice_command.py -k none_sentinel_flushes_buffer
```

The test reaches keyless Edge synthesis and launches `afplay`. With this branch, the synthesis helper is mocked and the suite-wide fallback guard independently refuses any real player process.

Verification performed with the project Python 3.13 environment:

- focused audio, streaming, voice-wrapper, gateway, and guard suites: **165 passed**;
- every current `live_system_guard_bypass` consumer plus guard self-tests: **112 passed**;
- `ruff check` and `git diff --check`: clean;
- an `afplay` trace wrapper recorded **108 lines before and 108 after** the focused run — zero new playback attempts;
- independent hard review exercised forced-Linux sounddevice/WSL paths and finished with no actionable findings.

The repository-wide runner also completed: **22,991 passed / 30 failed** with 10 collection-error files. None of the changed files failed; the failures are in unrelated platform/dependency-sensitive suites (ACP imports, service management, wake word, execution-flag detection, and existing macOS/WSL assumptions in `test_voice_mode.py`).

## Platforms tested

macOS (Apple Silicon, Python 3.13). Linux/WSL player and sounddevice branches were exercised through their mocked platform paths. The guard recognizes the native players used by macOS, Linux, Windows/WSL, and the cross-platform ffplay fallback.

## Related

Follow-up to `63be8ce86` (`fix(tests): stop the test suite speaking aloud and launching a browser`), which added the original audio guard. This closes the lower-level streaming path that bypassed its `hermes_cli.voice` bindings.

## Backward compatibility

**Backward compatible.** The change is confined to pytest fixtures and tests. Runtime code, wire contracts, configuration, persisted state, and package behavior are unchanged. Existing unit tests that mock playback continue to work; only unmarked attempts to touch real speaker output are newly rejected.
