### PR TITLE
fix(backup): don't treat every .db file as SQLite in full backups

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1002,6 +1002,51 @@ _QUICK_STATE_FILES = (
 _QUICK_SNAPSHOTS_DIR = "state-snapshots"
 _QUICK_DEFAULT_KEEP = 20
 
+# File names of the databases Hermes owns.  Matched by name rather than by full
+# relative path: the same stores appear at different depths (non-root profiles
+# resolve outside HERMES_HOME, and each non-default Kanban board keeps its own
+# kanban.db under kanban/boards/<slug>/), and a Hermes database must stay
+# fail-closed wherever it lives.
+_KNOWN_HERMES_DB_NAMES = frozenset(
+    Path(entry).name for entry in _QUICK_STATE_FILES if entry.endswith(".db")
+)
+
+
+def _is_known_hermes_db(rel_path: Path) -> bool:
+    """True when *rel_path* names a database Hermes itself manages."""
+    return rel_path.name in _KNOWN_HERMES_DB_NAMES
+
+
+def _looks_like_sqlite(path: Path) -> bool:
+    """True unless *path* is positively identified as *not* SQLite.
+
+    Deliberately conservative: ``read_header_bytes_preopen`` refuses the read
+    and returns ``None`` when a live connection holds *path*, and that must not
+    be mistaken for "foreign file". Only a header we actually read, and which
+    lacks the magic bytes, downgrades a file off the SQLite backup path.
+    """
+    from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
+
+    head = read_header_bytes_preopen(path, length=len(_SQLITE_HEADER))
+    if head is None:
+        return True
+    return head.startswith(_SQLITE_HEADER)
+
+
+def _use_sqlite_backup_api(abs_path: Path, rel_path: Path) -> bool:
+    """True when *abs_path* should be copied through the SQLite backup API.
+
+    ``.db`` is not a reserved suffix. Unrelated files use it — the report in
+    #75724 was a Windows ``cversions.2.db`` cache blob copied into a Kanban
+    workspace — and routing one of those through ``sqlite3`` raises "file is
+    not a database", which used to abort and delete the entire archive. Hermes'
+    own databases are still matched by name so a corrupt one keeps failing
+    closed rather than being captured as an opaque blob.
+    """
+    if abs_path.suffix != ".db":
+        return False
+    return _is_known_hermes_db(rel_path) or _looks_like_sqlite(abs_path)
+
 
 def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
     home = hermes_home or get_hermes_home()
@@ -1518,7 +1563,16 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
         with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
             for abs_path, rel_path in files_to_add:
                 try:
-                    if abs_path.suffix == ".db":
+                    if abs_path.suffix == ".db" and not _use_sqlite_backup_api(
+                        abs_path, rel_path
+                    ):
+                        logger.warning(
+                            "Full-zip backup: %s has a .db suffix but is not a "
+                            "SQLite database; archiving it as a regular file",
+                            rel_path,
+                        )
+                        zf.write(abs_path, arcname=str(rel_path))
+                    elif abs_path.suffix == ".db":
                         # Stage the snapshot alongside the output zip so that the
                         # temp file lives on the same filesystem.  The system
                         # default (/tmp) may be a small tmpfs that cannot hold

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2410,7 +2410,11 @@ def _run_pre_update_backup(args) -> Optional[str]:
     elapsed = _time.monotonic() - t0
 
     if out_path is None:
-        print("  ⚠ Backup skipped (no files found or write failed); continuing update.")
+        print(
+            "  ⚠ No full pre-update backup was created (no files found or write "
+            "failed); there is no full rollback archive for this update."
+        )
+        print("  Continuing with update.")
         print()
         return snapshot_id
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -201,8 +201,107 @@ class TestBackup:
         assert staged_dirs, "no SQLite snapshot was staged"
         assert all(d == str(out_zip.parent) for d in staged_dirs), staged_dirs
 
+    def test_foreign_db_suffix_does_not_abort_full_zip(self, tmp_path, monkeypatch):
+        """A non-SQLite file that merely ends in .db must be archived as a
+        regular file instead of aborting and deleting the whole backup
+        (#75724). Windows cache blobs land in Kanban workspaces this way."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        foreign = hermes_home / "kanban" / "boards" / "b1" / "workspaces" / "w1"
+        foreign.mkdir(parents=True)
+        (foreign / "cversions.2.db").write_bytes(b"not a database at all")
 
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
+        out_zip = hermes_home / "backups" / "pre-update-test.zip"
+        out_zip.parent.mkdir(parents=True, exist_ok=True)
+
+        import hermes_cli.backup as backup_mod
+        result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
+
+        assert result is not None, "foreign .db aborted the archive"
+        assert out_zip.exists()
+        with zipfile.ZipFile(out_zip) as zf:
+            names = zf.namelist()
+            arc = "kanban/boards/b1/workspaces/w1/cversions.2.db"
+            assert any(n.replace("\\", "/") == arc for n in names), names
+            stored = zf.read(
+                next(n for n in names if n.replace("\\", "/") == arc)
+            )
+        # Copied verbatim, not run through the SQLite backup API.
+        assert stored == b"not a database at all"
+
+    def test_real_sqlite_still_uses_backup_api(self, tmp_path, monkeypatch):
+        """Genuine databases must keep the consistent-snapshot path."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        (hermes_home / "foreign.db").write_bytes(b"not a database at all")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = hermes_home / "backups" / "pre-update-test.zip"
+        out_zip.parent.mkdir(parents=True, exist_ok=True)
+
+        import hermes_cli.backup as backup_mod
+        copied = []
+        real_copy = backup_mod._safe_copy_db
+
+        def _spy(src, dst, *a, **kw):
+            copied.append(Path(src).name)
+            return real_copy(src, dst, *a, **kw)
+
+        monkeypatch.setattr(backup_mod, "_safe_copy_db", _spy)
+        result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
+
+        assert result is not None
+        assert "memory_store.db" in copied, copied
+        # The foreign file must never reach the SQLite backup API.
+        assert "foreign.db" not in copied, copied
+
+    def test_corrupt_known_hermes_db_still_fails_closed(self, tmp_path, monkeypatch):
+        """A Hermes-owned database that cannot be snapshotted must still abort
+        the archive rather than be captured as an opaque blob."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        (hermes_home / "state.db").write_bytes(b"corrupt, no sqlite header")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = hermes_home / "backups" / "pre-update-test.zip"
+        out_zip.parent.mkdir(parents=True, exist_ok=True)
+
+        import hermes_cli.backup as backup_mod
+        result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
+
+        assert result is None, "corrupt state.db must fail closed"
+        assert not out_zip.exists()
+
+    def test_nested_known_db_still_fails_closed(self, tmp_path, monkeypatch):
+        """Hermes databases are matched by name, so a per-board kanban.db is
+        still fail-closed even though it is nested under kanban/boards/."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        board = hermes_home / "kanban" / "boards" / "b1"
+        board.mkdir(parents=True)
+        (board / "kanban.db").write_bytes(b"corrupt, no sqlite header")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = hermes_home / "backups" / "pre-update-test.zip"
+        out_zip.parent.mkdir(parents=True, exist_ok=True)
+
+        import hermes_cli.backup as backup_mod
+        result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
+
+        assert result is None, "nested corrupt kanban.db must fail closed"
 
 
 


### PR DESCRIPTION
## What does this PR do?

`_write_full_zip_backup()` selected the SQLite-safe-copy path with nothing but a suffix test:

```python
if abs_path.suffix == ".db":
```

`.db` is not a reserved suffix. When an unrelated file that merely uses it lands under `HERMES_HOME` — the report was a Windows `cversions.2.db` cache blob copied into a Kanban workspace — `sqlite3`'s `conn.backup()` raises `file is not a database`. `_write_full_zip_backup()` then set `sqlite_snapshot_failed`, **broke out of the archive loop, deleted the partial zip, and returned `None`**.

So one foreign file destroyed the entire backup. `_run_pre_update_backup()` reads that `None` as "no files found or write failed" and continues the update, which means an explicitly requested full pre-update backup can leave **no rollback artifact at all**. In the reported occurrence a ~4.5 GB partial archive was discarded and the update proceeded — worst case when the quick snapshot has also skipped an oversized `state.db`.

The fix routes a `.db` file through the SQLite backup API only when it is positively a database:

- **One of Hermes' own databases**, matched by name against the existing `_QUICK_STATE_FILES` list, or
- **A file whose header carries the SQLite magic** (`_SQLITE_HEADER`, already defined in this module).

Anything else is archived as a regular file with a warning instead of destroying the backup.

Two deliberate design points, since this touches a fail-closed path:

1. **The header probe never weakens fail-closed.** It uses `read_header_bytes_preopen()` — the module's sanctioned byte-level read, whose docstring names this exact use ("is this file a real SQLite database"). It returns `None` both when a live connection holds the file *and* on `OSError`, and both cases are treated as SQLite. Only a header we actually read, and which lacks the magic bytes, moves a file off the SQLite path.
2. **Hermes databases are matched by name, not relative path.** The same stores appear at different depths — each non-default Kanban board has its own `kanban.db` under `kanban/boards/<slug>/`, and non-root profile stores resolve outside `HERMES_HOME`. Name matching keeps a corrupt Hermes database fail-closed wherever it lives, rather than letting a nested one silently downgrade to a raw copy.

This preserves the existing invariant the issue asked to protect: a genuine Hermes database whose consistent snapshot cannot be created still aborts the archive.

## Related Issue

Fixes #75724

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py` — added `_KNOWN_HERMES_DB_NAMES` (derived from the existing `_QUICK_STATE_FILES`), `_is_known_hermes_db()`, `_looks_like_sqlite()`, and `_use_sqlite_backup_api()`; `_write_full_zip_backup()` now consults the classifier instead of testing the suffix alone.
- `hermes_cli/update_cmd.py` — the `out_path is None` branch previously printed "⚠ Backup skipped (no files found or write failed)", which reads as benign. It now states that no full rollback archive exists for this update. (Item 4 of the issue's suggested coverage.)
- `tests/hermes_cli/test_backup.py` — four regression tests, covering the issue's suggested cases.

## How to Test

The issue's reproduction, run verbatim against this branch:

```python
from pathlib import Path
from tempfile import TemporaryDirectory
from hermes_cli.backup import _write_full_zip_backup

with TemporaryDirectory() as td:
    td = Path(td); home = td / "home"; home.mkdir()
    (home / "foreign.db").write_text("not sqlite", encoding="utf-8")
    out = td / "pre-update.zip"
    print(_write_full_zip_backup(out, home), out.exists())
```

Before — the archive is destroyed:

```
WARNING hermes_cli.backup: SQLite safe copy failed for .../foreign.db: file is not a database
WARNING hermes_cli.backup: Full-zip backup aborted: SQLite snapshot failed for foreign.db
None False
```

After — the foreign file is archived and the backup survives:

```
WARNING hermes_cli.backup: Full-zip backup: foreign.db has a .db suffix but is not a SQLite database; archiving it as a regular file
/tmp/.../pre-update.zip True
```

Automated coverage, mapped to the four cases the issue asked for:

| Test | Case |
| --- | --- |
| `test_foreign_db_suffix_does_not_abort_full_zip` | 1 — foreign `.db` neither aborts nor deletes the archive; asserts it is stored byte-for-byte |
| `test_real_sqlite_still_uses_backup_api` | 2 — genuine databases still go through `_safe_copy_db`, and the foreign file never reaches it |
| `test_corrupt_known_hermes_db_still_fails_closed` | 3 — a corrupt `state.db` still returns `None` and removes the zip |
| `test_nested_known_db_still_fails_closed` | 3 — same for a per-board `kanban.db`, guarding the name-matching decision |

Tests 1 and 2 fail on `main` and pass here. Tests 3 and 4 pass both before and after **by design** — they are guards proving the fix does not weaken the fail-closed contract, not demonstrations of the bug.

```
tests/hermes_cli/test_backup.py                     44 passed
+ test_update_check / test_update_autostash /
  test_update_concurrent_quarantine /
  test_update_venv_health / test_state_db_guard      64 passed total
ruff 0.15.10 check                                   All checks passed
```

I could not run the full `pytest tests/ -q` locally: ~117 unrelated modules fail collection in my environment on missing optional extras (`starlette`, provider SDKs). I ran every test file that touches backup, update, snapshot, and pre-update-backup paths instead. CI is the real check for the rest.

`ruff format` is not applied — all three files are already unformatted against it on `main`, so reformatting would have buried the fix in an unrelated sweep. `ruff check` passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see the note above; ran all related suites
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CachyOS, kernel 7.1.1), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helpers) — no user docs affected
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform impact considered — see below
- [x] N/A — no tool behavior change

## Notes for reviewers

**On platform.** The report is from Windows 11, but nothing in the mechanism is Windows-specific: it is suffix-based dispatch in portable Python. The Windows angle is only *why* a foreign `.db` appears in `HERMES_HOME` (a cache blob copied into a workspace). I reproduced it unmodified on Linux with the reporter's script and the identical log signature, so the fix is verified on the actual failure, not inferred. The classification itself uses no platform-dependent behavior.

**A second, related bug I did not fix.** `run_backup()` (the manual `hermes backup` command, `backup.py:600`) has the same suffix-only dispatch. It does *not* abort the archive — it appends to `errors` and continues — so a foreign `.db` is instead **silently dropped from the backup** rather than destroying it. Milder, but the same misclassification, and `_use_sqlite_backup_api()` would drop straight in. I left it alone to keep this PR to the reported issue; happy to extend it here or in a follow-up, whichever you prefer.

**Open question.** Name-based matching means a foreign file that happens to be called `state.db` or `kanban.db` would still be treated as a Hermes database and fail the archive closed. I judged that the correct direction to err, given the issue explicitly asked to preserve fail-closed for genuine databases — but if you would rather that case degrade to a plain copy too, dropping `_is_known_hermes_db()` from the condition and relying on the header probe alone is a one-line change.
