### PR TITLE
fix(tui_gateway): refuse config.set writes to administrator-managed keys (supersedes #71815)

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -425,6 +425,183 @@ def test_config_roundtrip(server, tmp_path):
     assert server._load_cfg()["model"] == "test/model"
 
 
+# ── config.set managed-scope write guard ─────────────────────────────
+
+
+@pytest.fixture()
+def managed_gw(server, tmp_path, monkeypatch):
+    """Gateway pointed at a throwaway HERMES_HOME plus a managed scope.
+
+    ``seed()`` rewrites both config files and drops every cache that would
+    otherwise serve a stale (empty) managed config — without the
+    ``invalidate_managed_cache()`` call these tests pass for the wrong reason.
+    """
+    from hermes_cli import managed_scope
+
+    home = tmp_path / "home"
+    home.mkdir()
+    managed = tmp_path / "managed"
+    managed.mkdir()
+
+    previous_home = server._hermes_home
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    server._hermes_home = home
+
+    def _reset_caches():
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+        managed_scope.invalidate_managed_cache()
+
+    def seed(user_yaml="theme: dark\n", managed_yaml=""):
+        (home / "config.yaml").write_text(user_yaml, encoding="utf-8")
+        (managed / "config.yaml").write_text(managed_yaml, encoding="utf-8")
+        _reset_caches()
+
+    def user_text():
+        return (home / "config.yaml").read_text(encoding="utf-8")
+
+    seed()
+    yield types.SimpleNamespace(
+        home=home, managed=managed, seed=seed, user_text=user_text
+    )
+    server._hermes_home = previous_home
+    _reset_caches()
+
+
+def _set(server, **params):
+    return server.handle_request({"id": "r1", "method": "config.set", "params": params})
+
+
+@pytest.mark.parametrize(
+    ("managed_yaml", "params", "blocked_key"),
+    [
+        # Funnel path: every _write_config_key() call site at once.
+        (
+            "display:\n  tui_theme: corporate\n",
+            {"key": "theme", "value": "light"},
+            "display.tui_theme",
+        ),
+        # The exact case the review named: `reasoning` mutates and saves
+        # directly, bypassing _write_config_key().
+        (
+            "display:\n  sections:\n    thinking: hidden\n",
+            {"key": "reasoning", "value": "show"},
+            "display.sections.thinking",
+        ),
+        # Second leaf of the same branch.
+        (
+            "display:\n  show_reasoning: false\n",
+            {"key": "reasoning", "value": "hide"},
+            "display.show_reasoning",
+        ),
+        # reasoning_full leaf, written by the full/clamp sub-branches.
+        (
+            "display:\n  reasoning_full: false\n",
+            {"key": "reasoning", "value": "full"},
+            "display.reasoning_full",
+        ),
+        # details_mode fans out to every section leaf — a pinned leaf must
+        # block it even though the head key (display.details_mode) is free.
+        (
+            "display:\n  sections:\n    tools: collapsed\n",
+            {"key": "details_mode", "value": "expanded"},
+            "display.sections.tools",
+        ),
+        # Per-section override, set path.
+        (
+            "display:\n  sections:\n    activity: collapsed\n",
+            {"key": "details_mode.activity", "value": "expanded"},
+            "display.sections.activity",
+        ),
+        # Per-section override, empty-value CLEAR path — clearing a pinned
+        # leaf is just as much a write.
+        (
+            "display:\n  sections:\n    activity: collapsed\n",
+            {"key": "details_mode.activity", "value": ""},
+            "display.sections.activity",
+        ),
+        # Top-level leaf (not under display.).
+        (
+            "custom_prompt: policy prompt\n",
+            {"key": "prompt", "value": "mine"},
+            "custom_prompt",
+        ),
+        # The `prompt` clear path pops the key — still a write.
+        (
+            "custom_prompt: policy prompt\n",
+            {"key": "prompt", "value": "clear"},
+            "custom_prompt",
+        ),
+        # Sibling site: a global model switch persists model.* through
+        # cli.save_config_value, which has no managed guard of its own.
+        (
+            "model:\n  default: acme/pinned\n",
+            {"key": "model", "value": "other/model --global"},
+            "model.default",
+        ),
+    ],
+)
+def test_config_set_refuses_managed_key(
+    server, managed_gw, managed_yaml, params, blocked_key
+):
+    """A managed-pinned leaf must yield 4030 and leave config.yaml untouched."""
+    managed_gw.seed(managed_yaml=managed_yaml)
+    before = managed_gw.user_text()
+
+    resp = _set(server, **params)
+
+    assert "error" in resp, f"expected a refusal, got {resp}"
+    assert resp["error"]["code"] == 4030
+    assert blocked_key in resp["error"]["message"]
+    assert "managed by your administrator" in resp["error"]["message"]
+    # The refusal must be a no-write, not a write plus a warning.
+    assert managed_gw.user_text() == before
+
+
+def test_config_set_allows_unpinned_key_with_managed_scope_present(server, managed_gw):
+    """Negative control: a managed scope that pins something else must not block.
+
+    Without this the suite cannot tell "the guard works" apart from "writes are
+    broken".
+    """
+    managed_gw.seed(managed_yaml="display:\n  tui_theme: corporate\n")
+
+    resp = _set(server, key="density", value="on")
+
+    assert "error" not in resp, resp
+    assert resp["result"]["value"] == "on"
+    assert server._load_cfg_raw()["display"]["tui_compact"] is True
+
+
+def test_config_set_writes_normally_without_managed_scope(
+    server, managed_gw, monkeypatch
+):
+    """Fail-open control: no managed scope configured → unchanged behavior."""
+    monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
+    managed_gw.seed(managed_yaml="")
+
+    resp = _set(server, key="theme", value="light")
+
+    assert "error" not in resp, resp
+    assert server._load_cfg_raw()["display"]["tui_theme"] == "light"
+
+
+def test_managed_guard_matches_exact_leaf_only(server, managed_gw):
+    """A pinned sibling leaf must not block an unpinned one.
+
+    ``is_key_managed`` is exact dotted-leaf matching, so a managed
+    ``display.show_reasoning`` leaves ``display.tui_theme`` writable.
+    """
+    managed_gw.seed(managed_yaml="display:\n  show_reasoning: true\n")
+
+    resp = _set(server, key="theme", value="light")
+
+    assert "error" not in resp, resp
+    assert server._load_cfg_raw()["display"]["tui_theme"] == "light"
+
+
 # ── _cli_exec_blocked ────────────────────────────────────────────────
 
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -602,6 +602,118 @@ def test_managed_guard_matches_exact_leaf_only(server, managed_gw):
     assert server._load_cfg_raw()["display"]["tui_theme"] == "light"
 
 
+def _running_session(server, sid="managed-running"):
+    """Register a session that reports a turn in flight."""
+    server._sessions[sid] = {"session_key": sid, "agent": None, "running": True}
+    return sid
+
+
+@pytest.mark.parametrize(
+    ("managed_yaml", "user_yaml", "value", "blocked_key"),
+    [
+        # Explicit --global during a running turn: the deferred branch stashes
+        # the pick and acks it, so without a pre-stash guard the persisting
+        # write is accepted and only fails (as a generic error event) next turn.
+        (
+            "model:\n  default: acme/pinned\n",
+            "theme: dark\n",
+            "other/model --global",
+            "model.default",
+        ),
+        # Sibling leaves of the same persisted triple.
+        (
+            "model:\n  provider: acme\n",
+            "theme: dark\n",
+            "other/model --global",
+            "model.provider",
+        ),
+        (
+            "model:\n  base_url: https://acme.example/v1\n",
+            "theme: dark\n",
+            "other/model --global",
+            "model.base_url",
+        ),
+        # No --global at all: model.persist_switch_by_default makes a bare
+        # `/model X` persist (resolve_persist_behavior rule 5), which a
+        # parsed.is_global check would miss.
+        (
+            "model:\n  default: acme/pinned\n",
+            "model:\n  persist_switch_by_default: true\n",
+            "other/model",
+            "model.default",
+        ),
+    ],
+)
+def test_config_set_model_refuses_managed_key_while_running(
+    server, managed_gw, managed_yaml, user_yaml, value, blocked_key
+):
+    """A persisting mid-turn /model must 4030 instead of being queued."""
+    managed_gw.seed(user_yaml=user_yaml, managed_yaml=managed_yaml)
+    sid = _running_session(server)
+    before = managed_gw.user_text()
+
+    resp = _set(server, key="model", value=value, session_id=sid)
+
+    assert "error" in resp, f"expected a refusal, got {resp}"
+    assert resp["error"]["code"] == 4030
+    assert blocked_key in resp["error"]["message"]
+    assert "managed by your administrator" in resp["error"]["message"]
+    # The refusal must happen BEFORE the stash — a queued switch would apply
+    # the pinned-over model at the next turn start.
+    assert "pending_model_switch" not in server._sessions[sid]
+    assert managed_gw.user_text() == before
+
+
+@pytest.mark.parametrize("value", ["other/model --session", "other/model --once"])
+def test_config_set_model_defers_non_persisting_switch_while_running(
+    server, managed_gw, value
+):
+    """Negative control: session-/once-scoped picks never persist, so they queue.
+
+    Without this the suite cannot tell "the guard is scoped to persisting
+    writes" apart from "every mid-turn /model is now refused".
+    """
+    managed_gw.seed(managed_yaml="model:\n  default: acme/pinned\n")
+    sid = _running_session(server)
+
+    resp = _set(server, key="model", value=value, session_id=sid)
+
+    assert "error" not in resp, resp
+    assert resp["result"]["deferred"] is True
+    assert server._sessions[sid]["pending_model_switch"]["raw"] == value
+
+
+def test_config_set_model_defers_global_switch_without_managed_scope(
+    server, managed_gw, monkeypatch
+):
+    """Fail-open control: no managed scope → a mid-turn --global still queues."""
+    monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
+    managed_gw.seed(managed_yaml="")
+    sid = _running_session(server)
+
+    resp = _set(server, key="model", value="other/model --global", session_id=sid)
+
+    assert "error" not in resp, resp
+    assert resp["result"]["deferred"] is True
+    assert server._sessions[sid]["pending_model_switch"]["raw"] == (
+        "other/model --global"
+    )
+
+
+def test_managed_key_error_message_is_descriptive(server):
+    """str(ManagedKeyError) must not be the bare dotted key.
+
+    ``_apply_pending_model_switch`` and the live-session slash mirror both
+    interpolate the exception into user-facing copy.
+    """
+    exc = server.ManagedKeyError("model.default")
+
+    assert exc.key == "model.default"
+    assert str(exc) == (
+        "'model.default' is managed by your administrator and cannot be changed"
+    )
+
+
 # ── _cli_exec_blocked ────────────────────────────────────────────────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3608,7 +3608,65 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         logger.debug("failed to persist model switch marker", exc_info=True)
 
 
+class ManagedKeyError(Exception):
+    """A config key pinned by the managed (administrator) scope was written.
+
+    Raised by the write primitives rather than returned, so every
+    ``_write_config_key`` call site inside ``config.set`` is covered by a
+    single handler wrapper instead of one guard apiece.
+    """
+
+    def __init__(self, key: str):
+        super().__init__(key)
+        self.key = key
+
+
+def _managed_block(*key_paths: str) -> str | None:
+    """First dotted key in *key_paths* pinned by the managed scope, else None.
+
+    Fail-open on any managed-scope error, mirroring :func:`_apply_managed`: a
+    broken/absent managed scope must never block a write the administrator did
+    not actually pin.
+    """
+    try:
+        from hermes_cli import managed_scope
+
+        for key_path in key_paths:
+            if managed_scope.is_key_managed(key_path):
+                return key_path
+    except Exception:
+        return None
+    return None
+
+
+def _managed_err(rid, key: str) -> dict:
+    """4030 refusal naming the managed source, mirroring hermes_cli/config.py."""
+    try:
+        from hermes_cli import managed_scope
+
+        managed_dir = managed_scope.get_managed_dir()
+    except Exception:
+        managed_dir = None
+    src = (
+        str(managed_dir / "config.yaml")
+        if managed_dir is not None
+        else "the managed scope"
+    )
+    return _err(
+        rid,
+        4030,
+        f"Cannot set '{key}': it is managed by your administrator ({src}) "
+        f"and cannot be changed. Contact your administrator to modify it.",
+    )
+
+
 def _write_config_key(key_path: str, value):
+    # Administrator policy is enforced on the CLI surface (hermes_cli/config.py
+    # set_config_value/unset_config_value); without this the TUI/desktop wrote
+    # the pinned key, reported success, and the next read re-applied the managed
+    # value anyway — the control silently lied.
+    if (blocked := _managed_block(key_path)) is not None:
+        raise ManagedKeyError(blocked)
     # Write-back round-trip: raw read is mandatory — saving the managed-
     # overlaid / env-expanded view would persist those values into the file.
     cfg = _load_cfg_raw()
@@ -4078,6 +4136,18 @@ def _apply_model_switch(
             explicit_provider=explicit_provider,
         )
     )
+    # A global switch persists model.default/provider/base_url through
+    # cli.save_config_value, which has no managed-scope guard of its own.
+    # Refuse HERE, before switch_model()/agent.switch_model() mutate the live
+    # session, so a pinned model can't leave the session switched while
+    # config.yaml keeps the administrator's value. Session- and once-scoped
+    # switches never persist, so they stay allowed.
+    if persist_global:
+        blocked_model = _managed_block(
+            "model.default", "model.provider", "model.base_url"
+        )
+        if blocked_model is not None:
+            raise ManagedKeyError(blocked_model)
     if not model_input:
         raise ValueError("model value required")
 
@@ -10018,8 +10088,7 @@ def _respond(rid, params, key, *, allow_expired=False):
 # NOTE: config.set intentionally stays in server.py for now — the in-flight
 # opt/model-resolution-core PR touches its body; move it to methods_config.py
 # in a follow-up once that PR lands.
-@method("config.set")
-def _(rid, params: dict) -> dict:
+def _config_set(rid, params: dict) -> dict:
     key, value = params.get("key", ""), params.get("value", "")
     session = _sessions.get(params.get("session_id", ""))
 
@@ -10111,6 +10180,8 @@ def _(rid, params: dict) -> dict:
                     "scope": result.get("scope", "session"),
                 },
             )
+        except ManagedKeyError:
+            raise  # surfaced as 4030 by the config.set wrapper
         except Exception as e:
             return _err(rid, 5001, str(e))
 
@@ -10390,6 +10461,8 @@ def _(rid, params: dict) -> dict:
                     os.environ.pop("HERMES_YOLO_MODE", None)
                     nv = "0"
             return _ok(rid, {"key": key, "value": nv, "scope": "session"})
+        except ManagedKeyError:
+            raise  # surfaced as 4030 by the config.set wrapper
         except Exception as e:
             return _err(rid, 5001, str(e))
 
@@ -10401,6 +10474,12 @@ def _(rid, params: dict) -> dict:
             scope = str(params.get("scope") or "").strip().lower()
             global_scope = scope == "global"
             if arg in {"show", "on"}:
+                if (
+                    blocked := _managed_block(
+                        "display.show_reasoning", "display.sections.thinking"
+                    )
+                ) is not None:
+                    return _managed_err(rid, blocked)
                 cfg = _load_cfg_raw()  # write-back round-trip
                 display = (
                     cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
@@ -10419,6 +10498,12 @@ def _(rid, params: dict) -> dict:
                     session["show_reasoning"] = True
                 return _ok(rid, {"key": key, "value": "show"})
             if arg in {"hide", "off"}:
+                if (
+                    blocked := _managed_block(
+                        "display.show_reasoning", "display.sections.thinking"
+                    )
+                ) is not None:
+                    return _managed_err(rid, blocked)
                 cfg = _load_cfg_raw()  # write-back round-trip
                 display = (
                     cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
@@ -10444,6 +10529,12 @@ def _(rid, params: dict) -> dict:
             # display.reasoning_full is persisted too so the config key stays
             # consistent across the CLI and TUI surfaces.
             if arg in {"full", "all"}:
+                if (
+                    blocked := _managed_block(
+                        "display.reasoning_full", "display.sections.thinking"
+                    )
+                ) is not None:
+                    return _managed_err(rid, blocked)
                 cfg = _load_cfg_raw()  # write-back round-trip
                 display = (
                     cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
@@ -10460,6 +10551,12 @@ def _(rid, params: dict) -> dict:
                 _save_cfg(cfg)
                 return _ok(rid, {"key": key, "value": "full"})
             if arg in {"clamp", "collapse", "short"}:
+                if (
+                    blocked := _managed_block(
+                        "display.reasoning_full", "display.sections.thinking"
+                    )
+                ) is not None:
+                    return _managed_err(rid, blocked)
                 cfg = _load_cfg_raw()  # write-back round-trip
                 display = (
                     cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
@@ -10499,6 +10596,8 @@ def _(rid, params: dict) -> dict:
                     _session_info(session["agent"], session),
                 )
             return _ok(rid, {"key": key, "value": arg})
+        except ManagedKeyError:
+            raise  # surfaced as 4030 by the config.set wrapper
         except Exception as e:
             return _err(rid, 5001, str(e))
 
@@ -10506,6 +10605,15 @@ def _(rid, params: dict) -> dict:
         nv = str(value or "").strip().lower()
         if nv not in _DETAIL_MODES:
             return _err(rid, 4002, f"unknown details_mode: {value}")
+        # This branch fans out to every section leaf, so each one has to be
+        # validated — not just the head key.
+        if (
+            blocked := _managed_block(
+                "display.details_mode",
+                *(f"display.sections.{s}" for s in _DETAIL_SECTION_NAMES),
+            )
+        ) is not None:
+            return _managed_err(rid, blocked)
         cfg = _load_cfg_raw()  # write-back round-trip
         display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
         sections = (
@@ -10527,6 +10635,11 @@ def _(rid, params: dict) -> dict:
         section = key.split(".", 1)[1]
         if section not in _DETAIL_SECTION_NAMES:
             return _err(rid, 4002, f"unknown section: {section}")
+
+        # Covers both the set path and the empty-value clear path below —
+        # clearing a pinned leaf is just as much a write.
+        if (blocked := _managed_block(f"display.sections.{section}")) is not None:
+            return _managed_err(rid, blocked)
 
         cfg = _load_cfg_raw()  # write-back round-trip
         display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
@@ -10672,6 +10785,12 @@ def _(rid, params: dict) -> dict:
         )
 
     if key in {"prompt", "personality", "skin"}:
+        # Only "prompt" mutates-and-saves directly (top-level custom_prompt, not
+        # under display.). "personality"/"skin" route through
+        # _write_config_key and are covered by the wrapper, so guarding the
+        # whole branch here would refuse them with the wrong key name.
+        if key == "prompt" and (blocked := _managed_block("custom_prompt")) is not None:
+            return _managed_err(rid, blocked)
         try:
             cfg = _load_cfg_raw()  # write-back round-trip ("prompt" saves cfg)
             if key == "prompt":
@@ -10706,10 +10825,28 @@ def _(rid, params: dict) -> dict:
                 if info is not None:
                     resp["info"] = info
             return _ok(rid, resp)
+        except ManagedKeyError:
+            raise  # surfaced as 4030 by the config.set wrapper
         except Exception as e:
             return _err(rid, 5001, str(e))
 
     return _err(rid, 4002, f"unknown config key: {key}")
+
+
+@method("config.set")
+def _(rid, params: dict) -> dict:
+    """Map an administrator-managed-key write to a 4030 refusal.
+
+    Every ``_write_config_key()`` call in the body raises ManagedKeyError
+    rather than persisting a pinned key, so the funnel call sites are covered
+    in one place. Branches that mutate-and-save directly pre-check their own
+    leaves with ``_managed_block`` (they write several leaves per call, so a
+    refusal has to happen before the first mutation).
+    """
+    try:
+        return _config_set(rid, params)
+    except ManagedKeyError as exc:
+        return _managed_err(rid, exc.key)
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3617,7 +3617,14 @@ class ManagedKeyError(Exception):
     """
 
     def __init__(self, key: str):
-        super().__init__(key)
+        # A descriptive message, not the bare key: paths that stringify the
+        # exception (``_apply_pending_model_switch``, the live-session slash
+        # mirror) would otherwise render "Could not switch model: model.default".
+        # ``.key`` stays authoritative for the structured 4030 mapping in
+        # ``_managed_err``, which never reads str(exc).
+        super().__init__(
+            f"'{key}' is managed by your administrator and cannot be changed"
+        )
         self.key = key
 
 
@@ -10097,7 +10104,10 @@ def _config_set(rid, params: dict) -> dict:
             if not value:
                 return _err(rid, 4002, "model value required")
             if session:
-                from hermes_cli.model_switch import parse_model_switch_args
+                from hermes_cli.model_switch import (
+                    parse_model_switch_args,
+                    resolve_persist_behavior,
+                )
 
                 # A live swap can't run in-place while a turn streams:
                 # agent.switch_model() mutates self.model / self.provider /
@@ -10111,6 +10121,26 @@ def _config_set(rid, params: dict) -> dict:
                 # the new model without waiting for the swap or interrupting.
                 if session.get("running"):
                     parsed = parse_model_switch_args(value)
+                    # Refuse a persisting pick BEFORE it is stashed. Deferring
+                    # first would ack the write with {"deferred": true}, and the
+                    # ManagedKeyError would not surface until the next turn, where
+                    # _apply_pending_model_switch's blanket handler downgrades it
+                    # to a generic error event — the caller never sees 4030.
+                    # Resolve the full persistence policy rather than testing
+                    # parsed.is_global: with model.persist_switch_by_default set,
+                    # a bare `/model X` persists too (resolve_persist_behavior
+                    # rule 5), and a --global-only check would let it through.
+                    if resolve_persist_behavior(
+                        parsed.is_global,
+                        parsed.is_session,
+                        is_once=parsed.is_once,
+                        explicit_provider=parsed.explicit_provider,
+                    ):
+                        blocked_model = _managed_block(
+                            "model.default", "model.provider", "model.base_url"
+                        )
+                        if blocked_model is not None:
+                            raise ManagedKeyError(blocked_model)
                     try:
                         pending_model = parsed.model_input
                     except Exception:


### PR DESCRIPTION
## What does this PR do?

Makes the TUI/desktop gateway honor the managed (administrator) scope on
`config.set`, the way the classic CLI already does.

`hermes_cli/config.py` hard-rejects a write to a managed-pinned key in both
`set_config_value` and `unset_config_value`. The gateway did not — on `main`,
`git grep is_key_managed -- tui_gateway/` is **empty** — so every write path
under `@method("config.set")` persisted the user's value and returned `_ok(...)`.

The failure mode is worse than a missing feature. `_load_cfg()` re-applies
`_apply_managed()` over the raw read on every behavioral read, so the
administrator's value keeps winning: the toggle **reports success**, writes the
value into the user's `config.yaml`, and then **has no effect**. Administrator
policy was enforceable on one surface and silently bypassable on the other.
That asymmetry is the severity argument here — it is a policy-enforcement
bypass, not a cosmetic defect.

The refusal uses error code **4030**, which was unused in `server.py`
(existing 40xx codes: 4001, 4002, 4009, 4013, 4014, 4015, 4019, 4020).

`supersedes #71815`

#71815 identified the same gap but is unmergeable as written: it is
`CONFLICTING` against current `main`, and it carries a `_load_cfg_for_write()`
primitive that `main` has since superseded with `_load_cfg_raw()` — a second
raw-write primitive that should not be transplanted. Its guard also covered only
part of the surface: the reasoning/display paths mutate and save config directly
rather than going through `_write_config_key()`, so a managed
`display.show_reasoning` or `display.sections.thinking` could still be written
and returned as success. This PR salvages the guard against current `main`'s
`_load_cfg_raw()` and validates every leaf in the direct mutate-and-save
branches.

## Related Issue

No filed issue — `supersedes #71815`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

`tui_gateway/server.py`

- Added `ManagedKeyError`, `_managed_block(*key_paths)` and `_managed_err(rid, key)`
  next to `_write_config_key`. Lookup is **fail-open**, mirroring `_apply_managed`:
  a broken or absent managed scope must never block a write nobody pinned.
- `_write_config_key()` now raises `ManagedKeyError` instead of persisting a
  pinned key. The `config.set` body was renamed to `_config_set` and a thin
  registered wrapper maps that exception to a 4030 refusal — so **all 22
  funnel call sites** are covered in one place rather than 22 individual guards.
  Four in-handler `except Exception` blocks re-raise `ManagedKeyError` so the
  refusal surfaces as 4030 rather than being swallowed into a generic 5001.
- Explicit multi-leaf guards on the branches that bypass the funnel and write
  several leaves per call, each placed **before the first mutation**:

  | branch | leaves validated |
  |---|---|
  | `reasoning` = `show`/`on` | `display.show_reasoning`, `display.sections.thinking` |
  | `reasoning` = `hide`/`off` | `display.show_reasoning`, `display.sections.thinking` |
  | `reasoning` = `full`/`all` | `display.reasoning_full`, `display.sections.thinking` |
  | `reasoning` = `clamp`/`collapse`/`short` | `display.reasoning_full`, `display.sections.thinking` |
  | `details_mode` | `display.details_mode` + `display.sections.{thinking,tools,subagents,activity}` |
  | `details_mode.<section>` (set **and** empty-value clear) | `display.sections.<section>` |
  | `prompt` (set **and** `clear`) | `custom_prompt` |

  The `details_mode` fan-out builds its leaf list from `_DETAIL_SECTION_NAMES`
  rather than hardcoding it, so a new section is covered automatically.
- `_apply_model_switch()` refuses a **global** switch that would persist a pinned
  `model.default` / `model.provider` / `model.base_url`. These go through
  `cli.save_config_value`, which has no managed guard of its own (it is a
  different function from `hermes_cli.config.set_config_value`, which does).
  The check sits right after `persist_global` is resolved and **before**
  `switch_model()` / `agent.switch_model()` mutate the live session, so a pinned
  model cannot leave the session switched while `config.yaml` keeps the
  administrator's value. Session- and once-scoped switches never persist and
  stay allowed.

`is_key_managed` is **exact dotted-leaf** matching, so the guards name precise
leaves — a managed `display.show_reasoning` does not freeze the rest of
`display.`, and a managed `display:` subtree pinning only `show_reasoning` does
not make `display.sections.thinking` managed. There is a test for exactly this.

### Sibling-site sweep

Every config-write site in `tui_gateway/` was enumerated, so this is the complete
surface rather than a subset:

- `git grep '_save_cfg(\|_write_config_key(' -- tui_gateway/` — every write site
  is in `server.py`. `methods_tools.py`, `methods_session.py`, `methods_prompt.py`
  and `methods_complete.py` have zero.
- `tui_gateway/methods_config.py` registers only `config.get` plus `projects.*` /
  `setup.*` — read-only, nothing to guard.
- `config.set` is registered exactly once. The only other reference is
  `methods_tools.py`, which invokes it via `_methods["config.set"]` for the
  `/focus` slash command; it routes through the new wrapper automatically and
  already does `if "error" in _res: return _res`, so the 4030 propagates to the
  slash surface unchanged. **No edit needed there.**
- The three `cli.save_config_value` call sites were checked individually:
  `_persist_model_switch` (covered above), `_finish_reload`'s
  `approvals.mcp_reload_confirm`, and `_persist_wake_enabled`'s
  `wake_word.enabled`. The latter two are single-key operator opt-outs rather
  than `config.set` surface and are left for a follow-up rather than widened into
  this PR.

## How to Test

1. Point a managed scope at a directory and pin a display leaf:
   ```
   mkdir -p /tmp/mgd && printf 'display:\n  sections:\n    thinking: hidden\n' > /tmp/mgd/config.yaml
   export HERMES_MANAGED_DIR=/tmp/mgd
   ```
2. From the TUI/desktop, toggle reasoning on (`config.set key=reasoning value=show`).
   - **Before:** returns success, writes `display.show_reasoning` +
     `display.sections.thinking` into `config.yaml`, and the setting still has no
     effect because the managed overlay wins on the next read.
   - **After:** returns error **4030** — `Cannot set 'display.sections.thinking':
     it is managed by your administrator (/tmp/mgd/config.yaml) and cannot be
     changed.` — and `config.yaml` is byte-for-byte unchanged.
3. Confirm an unpinned key still writes normally, and that with no managed scope
   configured nothing changes at all.

Automated coverage — `tests/tui_gateway/test_protocol.py`:

- 10 parametrized refusal cases, one per guarded path (funnel, all four
  `reasoning` sub-branches, `details_mode` fan-out, `details_mode.<section>` set
  **and** clear, `prompt` set **and** clear, global model switch). Each asserts
  both the 4030 code *and* that the raw `config.yaml` text is unchanged — a
  refusal must be a no-write, not a write plus a warning.
- **Negative control**: with a managed scope present that pins an *unrelated*
  key, an ordinary `config.set` still succeeds and persists. Without this the
  suite could not tell "the guard works" from "writes are broken".
- **Fail-open control**: no managed scope configured → writes behave exactly as
  before.
- **Exact-leaf control**: a pinned `display.show_reasoning` leaves
  `display.tui_theme` writable.

Verified in both directions: with the production hunk reverted, all 10 refusal
cases fail and the three controls still pass; restored, all 13 pass.

Results, run per-file the way `scripts/run_tests.sh` does in CI:

| file | result |
|---|---|
| `tests/tui_gateway/test_protocol.py` | 50 passed |
| `tests/test_tui_gateway_server.py` | 496 passed |
| `tests/hermes_cli/test_managed_scope.py` | 2 passed |
| `tests/hermes_cli/test_managed_scope_writeguard.py` | 2 passed |
| `tests/hermes_cli/test_managed_scope_loaders.py` | 2 passed |
| `tests/hermes_cli/test_config_loader_e2e.py` | 2 passed |
| `tests/hermes_cli/test_set_config_value.py` | 71 passed |
| `tests/hermes_cli/test_apply_model_switch_result_context.py` | 3 passed |

Also green as directories: `tests/tui_gateway/` 318 passed / 1 skipped, and
`tests/hermes_cli/ -k "managed or model_switch"` 195 passed / 1 skipped.
`ruff check` is clean, and both files sit at exact `ruff format` parity with
their `main` baselines (no incidental reformatting in the diff).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — run per-file (CI's `scripts/run_tests.sh` isolation model) across the touched and adjacent files; see results above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(no new config keys)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(no platform-specific code; managed-dir resolution is unchanged)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Contract Protected

**Invariant:** a config key pinned by the managed scope can never be persisted by
the TUI/desktop gateway, and the caller is told so explicitly (4030) rather than
receiving a success that silently does nothing.

- **Known-bad inputs covered:** managed `display.tui_theme` (funnel),
  `display.sections.thinking` / `display.show_reasoning` / `display.reasoning_full`
  (reasoning branches), `display.sections.tools` (fan-out leaf, where the head key
  `display.details_mode` is itself unpinned), `display.sections.activity` (per-section
  set *and* clear), `custom_prompt` (set *and* clear), `model.default` (global switch).
- **Future-input coverage:** the `details_mode` guard derives its leaves from
  `_DETAIL_SECTION_NAMES`, and every `_write_config_key()` call site — including
  ones added later — is guarded by the primitive itself rather than at the call site.
- **Negative case:** a managed scope pinning an unrelated key must not block an
  ordinary write, and an absent/broken managed scope must fail open. Both are
  asserted, as is exact-leaf matching (a pinned sibling leaf does not over-block).
