### PR TITLE
fix(desktop): dedupe optimistic user turns for all wire references, not only images

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
+import { textWithoutReferenceLines, WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -615,6 +615,49 @@ describe('preserveLocalPendingTurnMessages', () => {
       expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
     }
   )
+
+  it('does not duplicate a directive-only file turn', () => {
+    const previous = [
+      msg('1-user', 'user', 'first'),
+      msg('2-assistant', 'assistant', 'first answer'),
+      msg('user-optimistic', 'user', '', {
+        attachmentRefs: ['@file:X']
+      })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'first'),
+      msg('2-assistant-stored', 'assistant', 'first answer'),
+      msg('3-user-stored', 'user', '@file:X')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it('does not duplicate a turn with multiple CRLF directives and Unicode payloads', () => {
+    const refs = ['@file:`資料/über notes.md`', '@url:`https://example.com/café?q=✓`']
+    const previous = [
+      msg('1-user', 'user', 'first'),
+      msg('2-assistant', 'assistant', 'first answer'),
+      msg('user-optimistic', 'user', 'text', {
+        attachmentRefs: refs
+      })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'first'),
+      msg('2-assistant-stored', 'assistant', 'first answer'),
+      msg('3-user-stored', 'user', `${refs.join('\r\n')}\r\n\r\ntext`)
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it('strips only complete reference lines from visible text', () => {
+    expect(textWithoutReferenceLines('see @file:X here')).toBe('see @file:X here')
+    expect(textWithoutReferenceLines('@file:X trailing prose')).toBe('@file:X trailing prose')
+    expect(textWithoutReferenceLines('  @file:X')).toBe('@file:X')
+  })
 
   it('still keeps a genuinely uncommitted optimistic image turn when the persisted text differs', () => {
     const previous = [

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -574,6 +575,46 @@ describe('preserveLocalPendingTurnMessages', () => {
 
     expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
   })
+
+  it('does not duplicate the optimistic file turn when the persisted turn carries @file refs', () => {
+    const previous = [
+      msg('1-user', 'user', 'first'),
+      msg('2-assistant', 'assistant', 'first answer'),
+      msg('user-optimistic', 'user', 'text', {
+        attachmentRefs: ['@file:X']
+      })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'first'),
+      msg('2-assistant-stored', 'assistant', 'first answer'),
+      msg('3-user-stored', 'user', '@file:X\n\ntext')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it.each(WIRE_REFERENCE_KINDS.filter(kind => kind !== 'file' && kind !== 'image'))(
+    'does not duplicate the optimistic %s turn when the persisted turn carries its directive',
+    kind => {
+      const ref = `@${kind}:X`
+      const previous = [
+        msg('1-user', 'user', 'first'),
+        msg('2-assistant', 'assistant', 'first answer'),
+        msg('user-optimistic', 'user', 'text', {
+          attachmentRefs: [ref]
+        })
+      ]
+
+      const next = [
+        msg('1-user-stored', 'user', 'first'),
+        msg('2-assistant-stored', 'assistant', 'first answer'),
+        msg('3-user-stored', 'user', `${ref}\n\ntext`)
+      ]
+
+      expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+    }
+  )
 
   it('still keeps a genuinely uncommitted optimistic image turn when the persisted text differs', () => {
     const previous = [

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,7 +1,8 @@
 import { getSession } from '@/hermes'
+import { textWithoutReferenceLines } from '@/components/assistant-ui/reference-kinds'
 import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
-import { embeddedImageUrls, textWithoutEmbeddedImages, textWithoutImageRefs } from '@/lib/embedded-images'
+import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
@@ -403,7 +404,8 @@ export function preserveLocalPendingTurnMessages(
     if (
       isOptimisticUser &&
       latestAuthoritativeUser &&
-      textWithoutImageRefs(chatMessageText(latestAuthoritativeUser)) === textWithoutImageRefs(chatMessageText(message))
+      textWithoutReferenceLines(chatMessageText(latestAuthoritativeUser)) ===
+        textWithoutReferenceLines(chatMessageText(message))
     ) {
       continue
     }
@@ -415,7 +417,9 @@ export function preserveLocalPendingTurnMessages(
         continue
       }
 
-      if (textWithoutImageRefs(chatMessageText(authoritative)) === textWithoutImageRefs(chatMessageText(message))) {
+      if (
+        textWithoutReferenceLines(chatMessageText(authoritative)) === textWithoutReferenceLines(chatMessageText(message))
+      ) {
         continue
       }
     }
@@ -484,7 +488,9 @@ export function appendLiveSessionProjection(
   }
 
   const persistedInLatestRun = (text: string): boolean =>
-    latestUserRun.some(message => textWithoutImageRefs(chatMessageText(message)) === textWithoutImageRefs(text))
+    latestUserRun.some(
+      message => textWithoutReferenceLines(chatMessageText(message)) === textWithoutReferenceLines(text)
+    )
 
   const inflightUserAlreadyPersisted = Boolean(inflightUser) && persistedInLatestRun(inflightUser)
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,5 +1,5 @@
-import { getSession } from '@/hermes'
 import { textWithoutReferenceLines } from '@/components/assistant-ui/reference-kinds'
+import { getSession } from '@/hermes'
 import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'

--- a/apps/desktop/src/components/assistant-ui/reference-kinds.ts
+++ b/apps/desktop/src/components/assistant-ui/reference-kinds.ts
@@ -157,3 +157,20 @@ const REFERENCE_PATTERN = /@(file|folder|url|image|tool|line|terminal|session):(
 export function referenceRe(): RegExp {
   return new RegExp(REFERENCE_PATTERN.source, 'g')
 }
+
+/** Remove reference-only lines when comparing visible message text. */
+export function textWithoutReferenceLines(text: string): string {
+  const matcher = referenceRe()
+
+  return text
+    .split('\n')
+    .filter(line => {
+      const candidate = line.trimEnd()
+      matcher.lastIndex = 0
+      const match = matcher.exec(candidate)
+
+      return !match || match.index !== 0 || match[0] !== candidate
+    })
+    .join('\n')
+    .trim()
+}


### PR DESCRIPTION
## What changed

Generalize optimistic versus authoritative user-turn reconciliation from image-only normalization to the centralized wire-reference vocabulary in `reference-kinds.ts`.

The new `textWithoutReferenceLines` helper removes complete reference-only lines before the existing equality checks. It uses the shared vocabulary for all 8 wire kinds instead of adding a hardcoded `@file:` path.

This fixes the case where an optimistic message stores a reference in `attachmentRefs` while authoritative history inlines the same directive in the body.

Fixes #75731

## How to test

Install workspace dependencies from the repository root with an engines-compatible npm. The local at-HEAD run used npm 12.0.1:

```sh
npx -y npm@12 ci
```

Run the focused suite at-HEAD:

```sh
npx -y npm@12 run --prefix apps/desktop test:ui -- \
  src/app/session/hooks/use-session-actions/utils.test.ts
```

Result at-HEAD: 54 of 54 tests passed.

Run the full desktop UI gate at-HEAD:

```sh
npx -y npm@12 run --prefix apps/desktop check:test:ui
```

Result at-HEAD: 3182 of 3182 tests passed across 360 files.

The Python wrapper was also run. It reported 56 pre-existing failures across 27 files. This change touches zero Python files, so the Python tree at-HEAD is identical to at-BASE for this range.

Manual reproduction on macOS 26.5.2:

1. Build and relaunch the desktop renderer.
2. Attach a Markdown file with the Files context action.
3. Send once and wait for the turn to complete.
4. Reload the session from authoritative history.
5. Confirm one matching user bubble.

The manual check used the clean production-code commit immediately below at-HEAD; at-HEAD adds tests only. It showed one file prompt bubble after hydration. The file chip moved from below the optimistic bubble to inside the authoritative bubble, confirming that both representations were exercised. An image attachment spot-check added exactly one additional user bubble and remained one bubble after authoritative reload.

## Platforms tested

- macOS 26.5.2 manual desktop exercise on the production-code commit immediately below at-HEAD
- Vitest desktop UI tests, platform-neutral, at-HEAD

## Security impact

None. This changes comparison normalization for renderer message text only. It adds no shell execution, filesystem access or path handling, secret handling, network access, or trust-boundary change.

## Reconciliation tradeoff

This keeps the existing visible-text equality tradeoff accepted for images in `d0f5ef704`. Two distinct adjacent sends with identical visible text but different references can compare equal after reference-only lines are removed. This change makes that existing rule uniform across the centralized wire vocabulary rather than introducing a second mechanism.

Reference identity hardening would change reconciliation semantics and should be evaluated separately with turn identity or ordering signals.
