### PR TITLE
fix(mem0): honor gateway session memory scope

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -345,14 +345,20 @@ class Mem0MemoryProvider(MemoryProvider):
         #   2. Gateway-native id from kwargs (Telegram numeric id, Discord
         #      snowflake, etc.) — preserves per-platform isolation when no
         #      override is configured.
-        #   3. Hardcoded fallback _DEFAULT_USER_ID (CLI with no auth).
+        #   3. Stable gateway session key (API clients without a native user id).
+        #   4. Hardcoded fallback _DEFAULT_USER_ID (CLI with no auth).
         # The literal _DEFAULT_USER_ID string is treated as unset so users who
         # ran the setup wizard with the suggested default still get gateway-
         # native ids instead of being silently bucketed together.
         configured = self._config.get("user_id")
         if configured == _DEFAULT_USER_ID:
             configured = None
-        self._user_id = configured or kwargs.get("user_id") or _DEFAULT_USER_ID
+        self._user_id = (
+            configured
+            or kwargs.get("user_id")
+            or kwargs.get("gateway_session_key")
+            or _DEFAULT_USER_ID
+        )
         self._agent_id = self._config.get("agent_id", "hermes")
         # Persisted rerank preference (setup wizard / mem0.json). Used as the
         # DEFAULT for mem0_search when the model doesn't pass ``rerank``

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -289,7 +289,7 @@ class TestMem0ModeSwitch:
 
 
 class TestMem0UserIdResolution:
-    """user_id resolution: configured override > gateway-native id > placeholder.
+    """user_id resolution: configured > gateway user > stable gateway key > placeholder.
 
     Same human across CLI / Telegram / Discord / Slack / etc. should map to
     the same memory store when MEM0_USER_ID is set, and only fall back to the
@@ -307,7 +307,12 @@ class TestMem0UserIdResolution:
     def test_env_override_beats_gateway_native_id(self, monkeypatch, tmp_path):
         monkeypatch.setenv("MEM0_USER_ID", "ryan@example.com")
         provider = self._provider(monkeypatch, tmp_path)
-        provider.initialize("test", user_id="123456789", platform="telegram")
+        provider.initialize(
+            "test",
+            user_id="123456789",
+            gateway_session_key="agent:main:telegram:dm:123456789",
+            platform="telegram",
+        )
         assert provider._user_id == "ryan@example.com"
 
     def test_file_override_beats_gateway_native_id(self, monkeypatch, tmp_path):
@@ -320,9 +325,31 @@ class TestMem0UserIdResolution:
     def test_unset_falls_back_to_gateway_native_id(self, monkeypatch, tmp_path):
         monkeypatch.delenv("MEM0_USER_ID", raising=False)
         provider = self._provider(monkeypatch, tmp_path)
-        provider.initialize("test", user_id="123456789", platform="telegram")
+        provider.initialize(
+            "test",
+            user_id="123456789",
+            gateway_session_key="agent:main:telegram:dm:123456789",
+            platform="telegram",
+        )
         assert provider._user_id == "123456789"
 
+    def test_api_session_key_scopes_user_when_gateway_user_id_is_absent(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        provider = self._provider(monkeypatch, tmp_path)
+        provider.initialize(
+            "test",
+            gateway_session_key="agent:main:webui:dm:user-42",
+            platform="api_server",
+        )
+        assert provider._user_id == "agent:main:webui:dm:user-42"
+
+    def test_no_gateway_identity_keeps_cli_placeholder(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MEM0_USER_ID", raising=False)
+        provider = self._provider(monkeypatch, tmp_path)
+        provider.initialize("test", platform="cli")
+        assert provider._user_id == "hermes-user"
 
     def test_legacy_placeholder_in_config_does_not_override_kwargs(self, monkeypatch, tmp_path):
         # Setup wizard historically wrote {"user_id": "hermes-user"} as the
@@ -407,5 +434,3 @@ class TestSelfHostedConfig:
     def test_load_config_reads_mem0_host_env(self, monkeypatch):
         monkeypatch.setenv("MEM0_HOST", "http://localhost:8888")
         assert mem0_plugin._load_config()["host"] == "http://localhost:8888"
-
-


### PR DESCRIPTION
## Summary

- use the stable `gateway_session_key` as Mem0's user scope when no configured or gateway-native user ID is available
- preserve the existing precedence for `MEM0_USER_ID` and native platform user IDs
- add regression coverage for all identity fallback levels

## Root Cause

The API server already forwards `X-Hermes-Session-Key` to memory providers as `gateway_session_key`, but `Mem0MemoryProvider.initialize()` ignored it and fell through to the shared `hermes-user` placeholder. As a result, API clients with distinct stable session keys shared the same Mem0 principal.

## Tests

- `scripts/run_tests.sh tests/plugins/memory/test_mem0_v3.py tests/agent/test_memory_user_id.py -- -q` — 34 passed
- `scripts/run_tests.sh tests/gateway/test_api_server.py -- -q -k 'session_key_threads_into_create_agent or responses_endpoint_accepts_session_key'` — 2 passed
- `python3 -m py_compile plugins/memory/mem0/__init__.py tests/plugins/memory/test_mem0_v3.py`
- `git diff --check`

Fixes #75708