### PR TITLE
fix(whatsapp): normalize device-suffixed WhatsApp JIDs

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -141,7 +141,15 @@ class WhatsAppBehaviorMixin:
             return ""
         normalized = str(value).strip()
         if ":" in normalized and "@" in normalized:
-            normalized = normalized.replace(":", "@", 1)
+            # Baileys JIDs can carry a device suffix before the domain, e.g.
+            # "447397235771:12@s.whatsapp.net". A naive colon->@ swap produces
+            # a second "@" ("447397235771@12@s.whatsapp.net") that never
+            # matches the plain "447397235771@s.whatsapp.net" form used
+            # elsewhere (quotedParticipant, botIds), silently breaking
+            # reply-to-bot detection. Strip the whole ":<device>" segment
+            # instead, keeping only the bare id + domain. Mirrors the fix in
+            # scripts/whatsapp-bridge/bridge.js and bridge_helpers.js.
+            normalized = re.sub(r":[^@]*@", "@", normalized, count=1)
         return normalized
 
     @staticmethod

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -183,7 +183,15 @@ class WhatsAppBehaviorMixin:
             return ""
         normalized = str(value).strip()
         if ":" in normalized and "@" in normalized:
-            normalized = normalized.replace(":", "@", 1)
+            # Baileys JIDs can carry a device suffix before the domain, e.g.
+            # "447397235771:12@s.whatsapp.net". A naive colon->@ swap produces
+            # a second "@" ("447397235771@12@s.whatsapp.net") that never
+            # matches the plain "447397235771@s.whatsapp.net" form used
+            # elsewhere (quotedParticipant, botIds), silently breaking
+            # reply-to-bot detection. Strip the whole ":<device>" segment
+            # instead, keeping only the bare id + domain. Mirrors the fix in
+            # scripts/whatsapp-bridge/bridge.js and bridge_helpers.js.
+            normalized = re.sub(r":[^@]*@", "@", normalized, count=1)
         return normalized
 
     @staticmethod

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -203,7 +203,13 @@ function trackSentMessageId(sent) {
 
 function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  // Baileys JIDs can carry a device suffix before the domain, e.g.
+  // "447397235771:12@s.whatsapp.net". A naive colon->@ swap produces a
+  // second "@" ("447397235771@12@s.whatsapp.net") that never matches the
+  // plain "447397235771@s.whatsapp.net" form used elsewhere (quotedParticipant,
+  // botIds), silently breaking reply-to-bot detection. Strip the whole
+  // ":<device>" segment instead, keeping only the bare id + domain.
+  return String(value).replace(/:[^@]*@/, '@');
 }
 
 function redactWhatsAppId(value) {

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -205,7 +205,13 @@ function trackSentMessageId(sent) {
 
 function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  // Baileys JIDs can carry a device suffix before the domain, e.g.
+  // "447397235771:12@s.whatsapp.net". A naive colon->@ swap produces a
+  // second "@" ("447397235771@12@s.whatsapp.net") that never matches the
+  // plain "447397235771@s.whatsapp.net" form used elsewhere (quotedParticipant,
+  // botIds), silently breaking reply-to-bot detection. Strip the whole
+  // ":<device>" segment instead, keeping only the bare id + domain.
+  return String(value).replace(/:[^@]*@/, '@');
 }
 
 function redactWhatsAppId(value) {

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -158,6 +158,49 @@ import {
   console.log('  ✓ inbound document metadata preserves MIME and filename');
 }
 
+// -- device-suffixed JID normalization (swipe-reply / mention regression) --
+{
+  // Baileys can report a device-suffixed JID (e.g. "...:46@...") for the
+  // quoting participant while the bot's own id from sock.user is normalized
+  // the same way elsewhere. Both must collapse to the same bare-id form so
+  // reply-to-bot / mention matching in gateway/platforms/whatsapp_common.py
+  // actually fires.
+  const event = await extractBridgeEvent({
+    msg: {
+      key: {
+        id: 'incoming-2',
+        remoteJid: '15551234567@s.whatsapp.net',
+        participant: '15550001111@s.whatsapp.net',
+        fromMe: false,
+      },
+      messageTimestamp: 123,
+      message: {
+        extendedTextMessage: {
+          text: 'replying to the bot',
+          contextInfo: {
+            stanzaId: 'outbound-2',
+            participant: '15559998888:46@s.whatsapp.net',
+            remoteJid: '15551234567@s.whatsapp.net',
+            quotedMessage: { conversation: 'a message from the bot' },
+          },
+        },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15550001111@s.whatsapp.net',
+    senderNumber: '15550001111',
+    botIds: ['15559998888@s.whatsapp.net'],
+    downloadMedia: async () => Buffer.from(''),
+  });
+
+  assert.equal(
+    event.quotedParticipant,
+    '15559998888@s.whatsapp.net',
+    'device-suffixed quotedParticipant must normalize to the same bare id as botIds',
+  );
+  console.log('  ✓ device-suffixed quotedParticipant normalizes to match bare botIds');
+}
+
 {
   const cacheDir = mkdtempSync(path.join(tmpdir(), 'hermes-wa-doc-'));
   const event = await extractBridgeEvent({

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -15,7 +15,12 @@ export const MIME_MAP = {
 
 export function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  // Keep in sync with bridge.js's normalizeWhatsAppId — strip the whole
+  // ":<device>" segment rather than swapping the colon for "@", which
+  // otherwise mangles ids like "447397235771:12@s.whatsapp.net" into
+  // "447397235771@12@s.whatsapp.net" and breaks id equality checks
+  // (quotedParticipant vs botIds) used for reply-to-bot detection.
+  return String(value).replace(/:[^@]*@/, '@');
 }
 
 export function getMessageContent(msg) {

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -137,6 +137,32 @@ def test_mention_stripping_removes_bot_phone_from_body():
     assert "weather" in cleaned
 
 
+def test_reply_to_bot_matches_device_suffixed_quoted_participant():
+    # Baileys can report the quoting participant with a device suffix
+    # (e.g. "15551230000:46@s.whatsapp.net") while botIds are bare. Both
+    # must normalize to the same id or swipe-replies to the bot are
+    # silently dropped before the agent ever sees them.
+    adapter = _make_adapter(require_mention=True, group_policy="open")
+
+    assert adapter._should_process_message(
+        _group_message(
+            "In 10 mins",
+            quotedParticipant="15551230000:46@s.whatsapp.net",
+        )
+    ) is True
+
+
+def test_mentions_bot_matches_device_suffixed_mentioned_id():
+    adapter = _make_adapter(require_mention=True, group_policy="open")
+
+    assert adapter._should_process_message(
+        _group_message(
+            "hi there",
+            mentionedIds=["15551230000:46@s.whatsapp.net"],
+        )
+    ) is True
+
+
 # --- New dm_policy tests ---
 
 


### PR DESCRIPTION
## Summary

WhatsApp swipe-to-reply (and structured @-mention) detection silently failed when Baileys returned a device-suffixed JID, e.g. `447397235771:12@s.whatsapp.net`. `normalizeWhatsAppId`/`_normalize_whatsapp_id` did a naive first-colon-to-`@` swap, producing a malformed id like `447397235771@12@s.whatsapp.net` that never matched the plain `447397235771@s.whatsapp.net` form used elsewhere (`quotedParticipant`, `botIds`), so reply-to-bot and mention detection missed with no error or log trace — the message was simply never handed to the agent.

Fix strips the whole `:<device>` segment via regex instead of swapping the colon, matching the pattern already used correctly by `allowlist.js`'s `expandWhatsAppIdentifiers`. Applied consistently across the three places that implement this normalization: `scripts/whatsapp-bridge/bridge.js`, `scripts/whatsapp-bridge/bridge_helpers.js`, and `gateway/platforms/whatsapp_common.py`.

Fixes #29023.

## Test plan

- Added regression coverage for the exact case this changes: a device-suffixed `quotedParticipant`/`mentionedIds` entry must normalize to the same id as a bare `botIds` entry.
  - `node --test scripts/whatsapp-bridge/bridge.native.test.mjs` — new case asserts `extractBridgeEvent` normalizes a device-suffixed `contextInfo.participant` to match a bare `botIds` entry.
  - `uv run pytest tests/gateway/test_whatsapp_group_gating.py` — two new cases cover `_message_is_reply_to_bot` and `_message_mentions_bot` against a device-suffixed `quotedParticipant`/`mentionedIds` value.
- Confirmed both new tests fail against the pre-fix `normalizeWhatsAppId`/`_normalize_whatsapp_id` (checked out `HEAD~1` for just the three changed source files, reran) and pass with the fix restored.
- Full targeted suites green: `pytest tests/gateway/test_whatsapp_group_gating.py` (12 passed), `node --test scripts/whatsapp-bridge/bridge.native.test.mjs` and `allowlist.test.mjs` (unaffected, still 5/5 passed).