### PR TITLE
fix(relay): isolate shared metric scope stacks

### DIFF
--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -57,6 +57,7 @@ def _retry_ordinal(event: dict[str, Any]) -> int | None:
 @dataclass
 class _ModelCall:
     handle: Any
+    context: contextvars.Context
     task_id: str
     fields: dict[str, str]
     retry_ordinal: int | None = None
@@ -171,7 +172,13 @@ class _Runtime:
             with session.lock:
                 if session.closing or session.relay_session.context is None:
                     return None
-                task_context = session.relay_session.context.copy()
+                # A Context copy retains the same mutable NeMo Relay scope-stack
+                # object.  The core turn/logical-call scopes and shared-metrics
+                # task/model-call scopes have independent lifetimes, so sharing
+                # that stack makes one layer's close depend on the other layer's
+                # LIFO order.  Give metrics its own stack and preserve trace
+                # topology through the explicit parent handle below.
+                task_context = contextvars.Context()
                 start_fields = task_start_fields(event)
                 active_turn = relay_runtime.active_turn(session.session_id)
                 parent_handle = session.relay_session.handle
@@ -213,11 +220,20 @@ class _Runtime:
         *args: Any,
         **kwargs: Any,
     ) -> Any:
+        return self._run_in_context(task.context, callback, *args, **kwargs)
+
+    def _run_in_context(
+        self,
+        context: contextvars.Context,
+        callback: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
         def invoke() -> Any:
             self.relay.get_scope_stack()
             return callback(*args, **kwargs)
 
-        return task.context.copy().run(invoke)
+        return context.copy().run(invoke)
 
     def start_model_call(self, event: dict[str, Any]) -> None:
         task_id = str(event.get("task_id") or "")
@@ -255,33 +271,28 @@ class _Runtime:
                         retry_ordinal,
                     )
                 return
+            model_context = contextvars.Context()
             if task is not None:
                 task.model_call_ids.add(request_id)
                 if retry_ordinal is not None and retry_ordinal > 0:
                     # A real Hermes retry can advance api_request_id while
                     # carrying the retry ordinal. Count that physical attempt.
                     task.retry_count += 1
-                handle = self._run_in_task(
-                    task,
-                    self.relay.llm.call,
-                    MODEL_CALL_SCOPE,
-                    self.relay.LLMRequest({}, {}),
-                    handle=task.handle,
-                    metadata=self._event_metadata(),
-                    model_name=model_family,
-                )
+                parent_handle = task.handle
             else:
-                handle = self._run_in_session(
-                    session,
-                    self.relay.llm.call,
-                    MODEL_CALL_SCOPE,
-                    self.relay.LLMRequest({}, {}),
-                    handle=session.relay_session.handle,
-                    metadata=self._event_metadata(),
-                    model_name=model_family,
-                )
+                parent_handle = session.relay_session.handle
+            handle = self._run_in_context(
+                model_context,
+                self.relay.llm.call,
+                MODEL_CALL_SCOPE,
+                self.relay.LLMRequest({}, {}),
+                handle=parent_handle,
+                metadata=self._event_metadata(),
+                model_name=model_family,
+            )
             session.model_calls[request_id] = _ModelCall(
                 handle=handle,
+                context=model_context,
                 task_id=str(event.get("task_id") or ""),
                 fields=fields,
                 retry_ordinal=retry_ordinal,
@@ -536,23 +547,13 @@ class _Runtime:
         if model_call is None:
             return
         try:
-            task = session.tasks.get(model_call.task_id)
-            if task is not None:
-                self._run_in_task(
-                    task,
-                    self.relay.llm.call_end,
-                    model_call.handle,
-                    {**model_call.fields, "outcome": outcome},
-                    metadata=self._event_metadata(),
-                )
-            else:
-                self._run_in_session(
-                    session,
-                    self.relay.llm.call_end,
-                    model_call.handle,
-                    {**model_call.fields, "outcome": outcome},
-                    metadata=self._event_metadata(),
-                )
+            self._run_in_context(
+                model_call.context,
+                self.relay.llm.call_end,
+                model_call.handle,
+                {**model_call.fields, "outcome": outcome},
+                metadata=self._event_metadata(),
+            )
         except Exception:
             logger.warning(
                 "Hermes shared-metrics model call close failed", exc_info=True

--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -281,6 +281,13 @@ class _Runtime:
                 parent_handle = task.handle
             else:
                 parent_handle = session.relay_session.handle
+            # Seed the stored context itself before executing through a copy.
+            # NeMo Relay keeps its mutable scope stack in a ContextVar; if the
+            # first get_scope_stack() happens only inside _run_in_context(),
+            # that stack belongs to the temporary copy and a later copy cannot
+            # inherit it. Initializing here makes start and end copies share
+            # one per-model stack while preserving task/session isolation.
+            model_context.run(self.relay.get_scope_stack)
             handle = self._run_in_context(
                 model_context,
                 self.relay.llm.call,

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -488,6 +488,117 @@ def test_real_binding_drives_lifecycle_aggregation_export_and_snapshot(
         assert canary not in serialized_analytics
 
 
+def test_real_binding_keeps_metrics_scopes_off_the_core_turn_stack(
+    real_binding_runtime,
+):
+    from agent import relay_llm
+
+    lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
+        profile_key=relay_runtime.current_profile_key(),
+        session_id="scope-isolation-session",
+        platform="telegram",
+    )
+    turn = relay_runtime.SESSION_COORDINATOR.begin_turn(
+        lease,
+        turn_id="scope-isolation-turn",
+        task_id="scope-isolation-task",
+    )
+    metrics = relay_shared_metrics._get_runtime(host=lease.host)
+    assert metrics is not None
+    event = {
+        "session_id": lease.session_id,
+        "turn_id": turn.turn_id,
+        "task_id": turn.task_id,
+        "api_request_id": "scope-isolation-request",
+        "platform": lease.platform,
+        "provider": "custom",
+        "model": "test-model",
+        "api_mode": "custom",
+        "completed": True,
+    }
+
+    try:
+        metrics.start_task(event)
+        metrics.start_model_call(event)
+        result = relay_llm.execute(
+            {"model": "test-model", "messages": []},
+            lambda _request: {"content": "ok"},
+            session_id=lease.session_id,
+            name="test-provider",
+            model_name="test-model",
+            metadata=event,
+            defer_logical_completion=True,
+        )
+        metrics.end_model_call(event, "success")
+        relay_llm.complete_logical_call(
+            event["api_request_id"],
+            outcome="success",
+        )
+        metrics.finish_task(event)
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="success")
+
+        current_handle = lease.host.run_in_session(
+            lease.session,
+            lease.host.relay.scope.get_handle,
+        )
+
+        assert result == {"content": "ok"}
+        assert current_handle.uuid == lease.session.handle.uuid
+    finally:
+        metrics.shutdown()
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="failed")
+        relay_runtime.SESSION_COORDINATOR.release_conversation(lease)
+
+
+def test_real_binding_closes_overlapping_metric_calls_out_of_order(
+    real_binding_runtime,
+):
+    lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
+        profile_key=relay_runtime.current_profile_key(),
+        session_id="overlapping-metrics-session",
+        platform="telegram",
+    )
+    turn = relay_runtime.SESSION_COORDINATOR.begin_turn(
+        lease,
+        turn_id="overlapping-metrics-turn",
+        task_id="overlapping-metrics-task",
+    )
+    metrics = relay_shared_metrics._get_runtime(host=lease.host)
+    assert metrics is not None
+    base_event = {
+        "session_id": lease.session_id,
+        "turn_id": turn.turn_id,
+        "task_id": turn.task_id,
+        "platform": lease.platform,
+        "provider": "custom",
+        "model": "test-model",
+        "api_mode": "custom",
+        "completed": True,
+    }
+    first = {**base_event, "api_request_id": "overlapping-request-1"}
+    second = {**base_event, "api_request_id": "overlapping-request-2"}
+
+    try:
+        metrics.start_task(base_event)
+        metrics.start_model_call(first)
+        metrics.start_model_call(second)
+        metrics.end_model_call(first, "success")
+        metrics.end_model_call(second, "success")
+        metrics.finish_task(base_event)
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="success")
+
+        current_handle = lease.host.run_in_session(
+            lease.session,
+            lease.host.relay.scope.get_handle,
+        )
+
+        assert current_handle.uuid == lease.session.handle.uuid
+    finally:
+        metrics.shutdown()
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="failed")
+        relay_runtime.SESSION_COORDINATOR.release_conversation(lease)
+
+
 
 
 
@@ -967,7 +1078,6 @@ def test_failed_flush_keeps_daily_export_open_for_later_task(
     assert metrics["hermes.task_run.finished"]["value"] == 2
     assert flush_attempts == 2
     assert "Hermes shared-metrics task flush failed" in caplog.text
-
 
 
 

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -584,6 +584,18 @@ def test_real_binding_closes_overlapping_metric_calls_out_of_order(
         metrics.start_model_call(second)
         metrics.end_model_call(first, "success")
         metrics.end_model_call(second, "success")
+        metrics.relay.subscribers.flush()
+
+        model_counters = [
+            counter
+            for counter in metrics.subscriber.store.counter_snapshot()
+            if counter["metric_name"] == "hermes.model_call.count"
+        ]
+        assert sum(counter["value"] for counter in model_counters) == 2
+        assert {
+            counter["dimensions"]["outcome"] for counter in model_counters
+        } == {"success"}
+
         metrics.finish_task(base_event)
         relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="success")
 
@@ -1078,8 +1090,6 @@ def test_failed_flush_keeps_daily_export_open_for_later_task(
     assert metrics["hermes.task_run.finished"]["value"] == 2
     assert flush_attempts == 2
     assert "Hermes shared-metrics task flush failed" in caplog.text
-
-
 
 
 


### PR DESCRIPTION
## Summary

- give shared-metrics task scopes an independent NeMo Relay context
- give every physical model-call metric its own stored scope stack
- initialize that stored stack before copied start/end executions inherit it
- retain parent/child trace topology through explicit Relay handles
- close overlapping model-call metrics safely regardless of completion order

## Root cause

`contextvars.Context.copy()` preserves ContextVar bindings, including mutable native Relay scope stacks. Core conversation/turn scopes and observability task/model scopes have independent lifetimes, so sharing a stack can violate native LIFO ordering. Conversely, creating a blank stored model context but initializing its stack only in a temporary copy means later copies do not inherit that stored binding.

## Impact

Concurrent tool and model activity no longer shares the core conversation scope stack. Each model metric has a stable stored stack inherited by both its start and end operations, while trace parenting and aggregation remain intact.

## Validation

- `scripts/run_tests.sh tests/agent/test_relay_llm.py tests/agent/test_relay_tools.py tests/agent/test_auxiliary_relay.py tests/hermes_cli/test_relay_shared_metrics.py tests/hermes_cli/test_relay_shared_metrics_runtime.py tests/plugins/test_nemo_relay_plugin.py -k relay` (49 passed)
- real native-binding regression verifies two overlapping metric calls close successfully out of order
- `ruff check hermes_cli/observability/relay_shared_metrics.py tests/hermes_cli/test_relay_shared_metrics_runtime.py tests/agent/test_relay_tools.py`
- `git diff --check`