### PR TITLE
fix(gateway): keep SIGUSR2 traceback dumps nonfatal

### DIFF
--- a/gateway/faulthandler_setup.py
+++ b/gateway/faulthandler_setup.py
@@ -1,0 +1,16 @@
+"""Safe signal-triggered Python traceback dumps for the gateway."""
+
+from __future__ import annotations
+
+import faulthandler
+from typing import IO, Any
+
+
+def register_traceback_signal(signum: int, *, file: IO[Any]) -> None:
+    """Register a diagnostic signal without replaying its fatal default action."""
+    faulthandler.register(
+        signum,
+        file=file,
+        all_threads=True,
+        chain=False,
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10238,12 +10238,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _faulthandler_path = os.path.join(_log_dir, "gateway_faulthandler.log")
                 os.makedirs(_log_dir, exist_ok=True)
                 _fh = open(_faulthandler_path, "a", encoding="utf-8")
-                faulthandler.register(
-                    _sigusr2,
-                    file=_fh,
-                    all_threads=True,
-                    chain=True,
-                )
+                from gateway.faulthandler_setup import register_traceback_signal
+
+                register_traceback_signal(_sigusr2, file=_fh)
             except Exception:
                 logger.debug("Could not set up faulthandler file logging", exc_info=True)
 

--- a/tests/gateway/test_faulthandler_signal.py
+++ b/tests/gateway/test_faulthandler_signal.py
@@ -1,0 +1,22 @@
+"""Regression tests for non-fatal gateway traceback signals."""
+
+from __future__ import annotations
+
+from gateway import faulthandler_setup
+
+
+def test_traceback_signal_does_not_chain_to_fatal_default(monkeypatch, tmp_path):
+    observed = {}
+
+    def register(signum, **kwargs):
+        observed["signum"] = signum
+        observed.update(kwargs)
+
+    monkeypatch.setattr(faulthandler_setup.faulthandler, "register", register)
+
+    with (tmp_path / "tracebacks.log").open("a") as output:
+        faulthandler_setup.register_traceback_signal(12, file=output)
+
+    assert observed["signum"] == 12
+    assert observed["all_threads"] is True
+    assert observed["chain"] is False


### PR DESCRIPTION
## Summary

- register the gateway's SIGUSR2 traceback dump without chaining the prior handler
- keep all-thread faulthandler output while preventing the signal's default termination action
- isolate the registration contract in a small testable helper

## Root cause

The gateway registered SIGUSR2 with `faulthandler.register(..., chain=True)`. After writing the requested traceback dump, Python invoked the previous/default SIGUSR2 action. On POSIX systems that default action terminates the process, so a diagnostic intended for a frozen gateway could itself kill the gateway.

## Impact

Operators can request an all-thread traceback dump from a live gateway without causing an unclean process exit and supervised restart.

## Validation

- `scripts/run_tests.sh tests/gateway/test_faulthandler_signal.py tests/gateway/test_71671_faulthandler_no_stderr.py` (2 passed)
- `ruff check gateway/faulthandler_setup.py gateway/run.py tests/gateway/test_faulthandler_signal.py`
- live signal probe confirmed the gateway PID remained unchanged after SIGUSR2
- `git diff --check`
