### PR TITLE
fix(desktop): recover from interrupted Windows update (missing hermes.exe + ENOTEMPTY)

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -904,29 +904,63 @@ impl HermesInvocation {
     }
 }
 
-/// How long the import-probe child gets before we give up on it. This runs
-/// synchronously inside `resolve_hermes`, ahead of the update's stage
-/// manifest — an unbounded probe can hang the whole updater (and hold the
-/// update-in-progress marker) on a wedged/antivirus-stalled interpreter.
-/// Mirrors the timeout/retry spirit of the Electron desktop's
-/// `canImportHermesCli()` probe (apps/desktop/electron/backend-probes.ts),
-/// which bounds its own child the same way.
-const IMPORT_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long each import-probe attempt gets. Runs inside `resolve_hermes`,
+/// ahead of the update's stage manifest — an unbounded probe can hang the
+/// whole updater (and hold the update-in-progress marker) on a wedged /
+/// antivirus-stalled interpreter.
+///
+/// Matches the Electron desktop's `canImportHermesCli()` budget
+/// (`apps/desktop/electron/backend-probes.ts`: 15s default; shorter budgets
+/// false-negatived healthy Windows cold starts / AV — issue #61764).
+const IMPORT_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// Wait for `child` up to `timeout`. On timeout, kill and reap it (never
-/// leave a zombie/hung process behind) and report `false` — the same value
-/// as a clean non-zero exit — so callers can treat "no answer in time" the
-/// same as "no". Extracted from `venv_python_can_import_hermes_cli` so the
-/// bounding behavior itself can be unit-tested against a real, controllable
-/// long-lived process instead of depending on the hardcoded `-c` probe args.
-async fn wait_for_child_success(mut child: tokio::process::Child, timeout: Duration) -> bool {
+/// Bound on the kill/reap wait after a timed-out probe. Without this, a
+/// `start_kill()` that fails to reap would leave `child.wait()` unbounded —
+/// recreating the hang the probe timeout exists to prevent.
+const IMPORT_PROBE_REAP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Distinct outcomes for the venv Python import probe. Collapsing timeout
+/// into a plain failure previously pushed a merely-slow target venv toward
+/// unsafe fallbacks; callers must treat TimedOut differently (retry once,
+/// then fail into repair — never select an unrelated CLI).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeResult {
+    Passed,
+    Failed,
+    TimedOut,
+}
+
+/// Wait for `child` up to `timeout`. On timeout, kill and reap it under
+/// `IMPORT_PROBE_REAP_TIMEOUT` so neither the probe nor the reap can hang
+/// forever. Extracted so timeout/kill behavior can be unit-tested against a
+/// controllable long-lived process instead of the hardcoded `-c` probe args.
+async fn wait_for_child_probe(
+    mut child: tokio::process::Child,
+    timeout: Duration,
+) -> ProbeResult {
     match tokio::time::timeout(timeout, child.wait()).await {
-        Ok(Ok(status)) => status.success(),
-        Ok(Err(_)) => false,
+        Ok(Ok(status)) => {
+            if status.success() {
+                ProbeResult::Passed
+            } else {
+                ProbeResult::Failed
+            }
+        }
+        Ok(Err(_)) => ProbeResult::Failed,
         Err(_timed_out) => {
             let _ = child.start_kill();
-            let _ = child.wait().await;
-            false
+            // Bound the reap: if start_kill failed or the OS is stuck, do not
+            // wait forever on child.wait() — that would reintroduce the hang.
+            match tokio::time::timeout(IMPORT_PROBE_REAP_TIMEOUT, child.wait()).await {
+                Ok(_) => {}
+                Err(_) => {
+                    tracing::warn!(
+                        "import-probe child did not exit within {:?} after kill; abandoning wait",
+                        IMPORT_PROBE_REAP_TIMEOUT
+                    );
+                }
+            }
+            ProbeResult::TimedOut
         }
     }
 }
@@ -939,15 +973,43 @@ async fn wait_for_child_success(mut child: tokio::process::Child, timeout: Durat
 /// `install_root` is added to `PYTHONPATH` so a source-tree checkout resolves
 /// `hermes_cli` even if the editable install's `.pth`/egg-link is stale.
 ///
-/// Bounded by `IMPORT_PROBE_TIMEOUT` (see `wait_for_child_success`): a wedged
-/// interpreter is killed and reaped rather than left to hang `resolve_hermes`
-/// (and therefore the whole update) indefinitely. A timeout is treated the
-/// same as "can't import" — resolution just continues to the next rung
-/// (PATH).
-async fn venv_python_can_import_hermes_cli(python: &Path, install_root: &Path) -> bool {
+/// Bounded by `IMPORT_PROBE_TIMEOUT` with one automatic retry on
+/// [`ProbeResult::TimedOut`] (same spirit as Electron's probe). A second
+/// timeout, or any Failed, means "this install's venv is not usable" —
+/// callers must fail into repair rather than picking a foreign CLI.
+async fn venv_python_can_import_hermes_cli(python: &Path, install_root: &Path) -> ProbeResult {
     if !python.exists() {
-        return false;
+        return ProbeResult::Failed;
     }
+    // Attempt 1 + one TimedOut retry (Electron probe: timeout → retry once).
+    for attempt in 1..=2 {
+        let result = spawn_and_probe_hermes_cli(python, install_root).await;
+        match result {
+            ProbeResult::Passed => return ProbeResult::Passed,
+            ProbeResult::Failed => {
+                tracing::debug!(
+                    python = %python.display(),
+                    attempt,
+                    "hermes_cli import probe failed"
+                );
+                return ProbeResult::Failed;
+            }
+            ProbeResult::TimedOut => {
+                tracing::debug!(
+                    python = %python.display(),
+                    attempt,
+                    "hermes_cli import probe timed out"
+                );
+                if attempt == 2 {
+                    return ProbeResult::TimedOut;
+                }
+            }
+        }
+    }
+    ProbeResult::TimedOut
+}
+
+async fn spawn_and_probe_hermes_cli(python: &Path, install_root: &Path) -> ProbeResult {
     let mut python_path = install_root.as_os_str().to_os_string();
     if let Some(existing) = env::var_os("PYTHONPATH") {
         python_path.push(if cfg!(target_os = "windows") { ";" } else { ":" });
@@ -967,25 +1029,27 @@ async fn venv_python_can_import_hermes_cli(python: &Path, install_root: &Path) -
     }
     let child = match cmd.spawn() {
         Ok(child) => child,
-        Err(_) => return false,
+        Err(_) => return ProbeResult::Failed,
     };
-    let passed = wait_for_child_success(child, IMPORT_PROBE_TIMEOUT).await;
-    if !passed {
-        tracing::debug!(python = %python.display(), "hermes_cli import probe did not succeed");
-    }
-    passed
+    wait_for_child_probe(child, IMPORT_PROBE_TIMEOUT).await
 }
 
 /// Ordered resolution decision. Pulled out of `resolve_hermes` so the
-/// ordering itself — the actual thing #75584's review flagged — can be unit
-/// tested without a real venv, a real python subprocess, or a mutated PATH.
-/// `resolve_hermes` gathers the real signals (shim presence, the bounded
-/// import probe, PATH) and hands them here.
+/// ladder can be unit-tested without a real venv or python subprocess.
+///
+/// Safe ladder for this *install-specific* updater:
+/// 1. target venv shim
+/// 2. target validated venv Python (`python -m hermes_cli.main`)
+/// 3. None → caller surfaces a repair/bootstrap error
+///
+/// Deliberately **no** generic PATH fallback: a `hermes.exe` from PATH can
+/// belong to another checkout; that CLI derives `PROJECT_ROOT` from its own
+/// package and would update/rebuild the wrong install while this one stays
+/// broken.
 fn resolve_hermes_from_signals(
     install_root: &Path,
     shim_exists: bool,
-    python_import_probe_passed: bool,
-    path_dirs: &[PathBuf],
+    python_import_probe: ProbeResult,
 ) -> Option<HermesInvocation> {
     // 1. Target install's own venv shim — the fast, common, already-correct
     //    path when the install isn't broken.
@@ -994,36 +1058,21 @@ fn resolve_hermes_from_signals(
     }
     // 2. Target install's own venv python, run as a module — the #75584
     //    recovery path for a shim deleted by an interrupted update, but
-    //    ONLY once validated (see venv_python_can_import_hermes_cli). This
-    //    must outrank PATH: it is still THIS install, just invoked
-    //    differently, whereas a PATH hermes.exe may belong to an entirely
-    //    unrelated install and would silently update the wrong checkout.
-    if python_import_probe_passed {
+    //    ONLY once the import probe Passed. TimedOut/Failed must not fall
+    //    through to any unrelated executable.
+    if python_import_probe == ProbeResult::Passed {
         return Some(HermesInvocation {
             program: venv_python(install_root),
             prefix_args: vec!["-m".to_string(), "hermes_cli.main".to_string()],
         });
     }
-    // 3. PATH fallback — last resort only. which-style probe via env, kept
-    //    dependency-free. We can't cheaply prove a PATH hermes.exe belongs to
-    //    `install_root` (a real one could be a symlink/shim into any venv),
-    //    so treat it as the least-trusted rung rather than rejecting it
-    //    outright: with no working shim and no importable venv python, it is
-    //    still better than failing the update entirely.
-    let exe = if cfg!(target_os = "windows") { "hermes.exe" } else { "hermes" };
-    for dir in path_dirs {
-        let cand = dir.join(exe);
-        if cand.exists() {
-            return Some(HermesInvocation::direct(cand));
-        }
-    }
     None
 }
 
-/// Resolve the hermes CLI to drive. Prefer the venv shim in the install we
-/// just updated; then the venv's own python run as `python -m
-/// hermes_cli.main` when the shim is missing but the venv is otherwise
-/// intact; finally fall back to `hermes` on PATH.
+/// Resolve the hermes CLI to drive for *this* install. Prefer the venv shim;
+/// then the venv's own python as `python -m hermes_cli.main` when the shim is
+/// missing but the venv is otherwise intact. If neither works, return `None`
+/// so the caller can emit a repair error — do **not** fall back to PATH.
 ///
 /// The shim-missing-but-venv-intact case is exactly issue #75584: an
 /// interrupted `hermes update` can leave `venv/Scripts/hermes.exe` deleted
@@ -1036,31 +1085,18 @@ fn resolve_hermes_from_signals(
 /// run at all. Mirrors `resolveVenvHermesCommand()` in
 /// apps/desktop/electron/windows-hermes-path.ts, which the Electron desktop
 /// backend launcher already uses for the same recovery.
-///
-/// PATH is deliberately the LAST rung, not the second one: a `hermes.exe`
-/// resolved from PATH can belong to a completely different install than
-/// `install_root` (another checkout, another profile, a stale global
-/// install). Trying it before the validated venv-python fallback would let a
-/// foreign hermes.exe silently update the wrong checkout while leaving this
-/// (actually recoverable) install broken — the bug this ordering fixes.
 async fn resolve_hermes(install_root: &Path) -> Option<HermesInvocation> {
     let shim = venv_hermes(install_root);
     let shim_exists = shim.exists();
     // Skip the subprocess probe entirely when the shim already resolves —
     // avoids paying its cost (even bounded) on the common healthy-install path.
-    let python_import_probe_passed = if shim_exists {
-        false
+    let python_import_probe = if shim_exists {
+        ProbeResult::Failed // unused when shim exists
     } else {
         let python = venv_python(install_root);
         venv_python_can_import_hermes_cli(&python, install_root).await
     };
-    let path_dirs: Vec<PathBuf> = std::env::var("PATH")
-        .map(|path| {
-            let sep = if cfg!(target_os = "windows") { ';' } else { ':' };
-            path.split(sep).map(PathBuf::from).collect()
-        })
-        .unwrap_or_default();
-    resolve_hermes_from_signals(install_root, shim_exists, python_import_probe_passed, &path_dirs)
+    resolve_hermes_from_signals(install_root, shim_exists, python_import_probe)
 }
 
 fn update_child_env(install_root: &Path, hermes: &HermesInvocation) -> Vec<(String, OsString)> {
@@ -1440,18 +1476,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn venv_python_can_import_hermes_cli_false_when_interpreter_missing() {
+    async fn venv_python_can_import_hermes_cli_failed_when_interpreter_missing() {
         let ghost = Path::new("/nonexistent/does/not/exist/python.exe");
-        assert!(!venv_python_can_import_hermes_cli(ghost, Path::new("/nonexistent")).await);
+        assert_eq!(
+            venv_python_can_import_hermes_cli(ghost, Path::new("/nonexistent")).await,
+            ProbeResult::Failed
+        );
     }
 
-    /// Spawn a real, long-lived (30s) sibling process, independent of the
-    /// hardcoded `-c "import ..."` probe args, so timeout tests can exercise
-    /// `wait_for_child_success` directly with a short test-local timeout.
+    /// Spawn a real, long-lived sibling process so timeout tests can exercise
+    /// `wait_for_child_probe` with a short test-local timeout. Prefer `ping`
+    /// over `timeout`/`sleep` on Windows: `timeout /T` often exits immediately
+    /// when detached (no console), which would yield Failed instead of TimedOut.
     fn spawn_long_lived_process() -> tokio::process::Child {
         let mut cmd = if cfg!(windows) {
-            let mut c = Command::new("timeout");
-            c.args(["/T", "30", "/nobreak"]);
+            let mut c = Command::new("ping");
+            c.args(["-n", "30", "127.0.0.1"]);
             c
         } else {
             let mut c = Command::new("sleep");
@@ -1465,19 +1505,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wait_for_child_success_kills_and_returns_false_on_timeout() {
-        // P2 regression: a wedged interpreter (e.g. antivirus-stalled, or a
-        // subprocess-startup deadlock) must not hang resolve_hermes forever.
-        // Use a short local timeout against a real 30s-lived process so the
-        // test itself stays fast while still proving the kill-on-timeout path.
+    async fn wait_for_child_probe_kills_and_returns_timed_out() {
+        // A wedged interpreter must not hang resolve_hermes forever, and the
+        // outcome must be TimedOut (not Failed) so callers can retry once.
         let child = spawn_long_lived_process();
         let pid = child.id();
 
         let started = Instant::now();
-        let result = wait_for_child_success(child, Duration::from_millis(200)).await;
+        let result = wait_for_child_probe(child, Duration::from_millis(200)).await;
         let elapsed = started.elapsed();
 
-        assert!(!result, "a wedged/slow child must resolve to false, not hang");
+        assert_eq!(result, ProbeResult::TimedOut);
         assert!(
             elapsed < Duration::from_secs(10),
             "must bail out at the local timeout, not wait for the 30s child; took {elapsed:?}"
@@ -1491,39 +1529,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wait_for_child_success_true_for_a_fast_clean_exit() {
+    async fn wait_for_child_probe_passed_for_a_fast_clean_exit() {
         let child = if cfg!(windows) {
             Command::new("cmd").args(["/C", "exit 0"]).spawn().unwrap()
         } else {
             Command::new("true").spawn().unwrap()
         };
-        assert!(wait_for_child_success(child, Duration::from_secs(10)).await);
+        assert_eq!(
+            wait_for_child_probe(child, Duration::from_secs(10)).await,
+            ProbeResult::Passed
+        );
     }
 
     #[tokio::test]
-    async fn wait_for_child_success_false_for_a_fast_nonzero_exit() {
+    async fn wait_for_child_probe_failed_for_a_fast_nonzero_exit() {
         let child = if cfg!(windows) {
             Command::new("cmd").args(["/C", "exit 1"]).spawn().unwrap()
         } else {
             Command::new("false").spawn().unwrap()
         };
-        assert!(!wait_for_child_success(child, Duration::from_secs(10)).await);
+        assert_eq!(
+            wait_for_child_probe(child, Duration::from_secs(10)).await,
+            ProbeResult::Failed
+        );
     }
 
     #[tokio::test]
-    async fn import_probe_timeout_is_a_small_bounded_duration() {
-        // Invariant, not a change-detector: the probe must actually be
-        // bounded (not zero, not accidentally huge) without pinning an exact
-        // literal that would break on a deliberate future retune.
-        assert!(IMPORT_PROBE_TIMEOUT >= Duration::from_secs(1));
-        assert!(IMPORT_PROBE_TIMEOUT <= Duration::from_secs(60));
+    async fn import_probe_timeout_matches_electron_budget() {
+        // Electron uses 15s (#61764); keep us in the same ballpark without
+        // freezing an exact literal that would break a deliberate retune.
+        assert!(IMPORT_PROBE_TIMEOUT >= Duration::from_secs(10));
+        assert!(IMPORT_PROBE_TIMEOUT <= Duration::from_secs(30));
+        assert!(IMPORT_PROBE_REAP_TIMEOUT <= IMPORT_PROBE_TIMEOUT);
     }
 
     #[tokio::test]
     async fn resolve_hermes_prefers_existing_shim_over_python_fallback() {
         // When the console-script shim is present, resolve_hermes must return
-        // it directly (no `-m hermes_cli.main` prefix) regardless of whether a
-        // venv python or a hermes on PATH would also resolve.
+        // it directly (no `-m hermes_cli.main` prefix).
         let dir = unique_tmp_dir("resolve-hermes-shim");
         let shim = venv_hermes(&dir);
         if let Some(parent) = shim.parent() {
@@ -1539,65 +1582,45 @@ mod tests {
     }
 
     #[test]
-    fn resolve_hermes_from_signals_prefers_venv_python_over_foreign_path_hermes() {
-        // P1 regression (#75584 review): target shim missing, target venv
-        // python passes the import probe, AND a foreign hermes.exe sits on
-        // PATH. The target's own validated venv python must win — a PATH
-        // hermes.exe can belong to a totally unrelated install and would
-        // silently update the wrong checkout while leaving this (recoverable)
-        // install broken.
+    fn resolve_hermes_from_signals_prefers_venv_python_when_probe_passed() {
+        // Target shim missing + probe Passed → module fallback.
         let install_root = unique_tmp_dir("resolve-signals-install-root");
-        let foreign_dir = unique_tmp_dir("resolve-signals-foreign-path");
-        let exe_name = if cfg!(target_os = "windows") { "hermes.exe" } else { "hermes" };
-        let foreign_hermes = foreign_dir.join(exe_name);
-        std::fs::write(&foreign_hermes, "").unwrap();
 
         let resolved = resolve_hermes_from_signals(
             &install_root,
-            false, // target shim missing
-            true,  // target venv python passed the import probe
-            &[foreign_dir.clone()],
+            false,
+            ProbeResult::Passed,
         )
         .expect("validated venv python fallback must resolve");
 
-        assert_eq!(
-            resolved.program,
-            venv_python(&install_root),
-            "target install's own venv python must win over a foreign PATH hermes.exe"
-        );
+        assert_eq!(resolved.program, venv_python(&install_root));
         assert_eq!(
             resolved.prefix_args,
             vec!["-m".to_string(), "hermes_cli.main".to_string()]
         );
 
         let _ = std::fs::remove_dir_all(&install_root);
-        let _ = std::fs::remove_dir_all(&foreign_dir);
     }
 
     #[test]
-    fn resolve_hermes_from_signals_falls_back_to_path_only_as_last_resort() {
-        // When neither the shim nor the venv python probe resolve, PATH
-        // remains the final rung (better than failing the update outright).
-        let install_root = unique_tmp_dir("resolve-signals-path-fallback");
-        let path_dir = unique_tmp_dir("resolve-signals-path-only");
-        let exe_name = if cfg!(target_os = "windows") { "hermes.exe" } else { "hermes" };
-        let path_hermes = path_dir.join(exe_name);
-        std::fs::write(&path_hermes, "").unwrap();
-
-        let resolved = resolve_hermes_from_signals(&install_root, false, false, &[path_dir.clone()])
-            .expect("PATH fallback must resolve when nothing else does");
-
-        assert_eq!(resolved.program, path_hermes);
-        assert!(resolved.prefix_args.is_empty());
-
+    fn resolve_hermes_from_signals_never_uses_foreign_path_hermes() {
+        // P1: even when a foreign hermes.exe exists on PATH and the target
+        // probe Failed/TimedOut, resolution must return None (repair error)
+        // — never the foreign CLI. PATH is not part of this install's ladder.
+        let install_root = unique_tmp_dir("resolve-signals-no-path");
+        for probe in [ProbeResult::Failed, ProbeResult::TimedOut] {
+            assert!(
+                resolve_hermes_from_signals(&install_root, false, probe).is_none(),
+                "probe {probe:?} must fail into repair, not PATH"
+            );
+        }
         let _ = std::fs::remove_dir_all(&install_root);
-        let _ = std::fs::remove_dir_all(&path_dir);
     }
 
     #[test]
     fn resolve_hermes_from_signals_none_when_nothing_resolves() {
         let install_root = unique_tmp_dir("resolve-signals-none");
-        assert!(resolve_hermes_from_signals(&install_root, false, false, &[]).is_none());
+        assert!(resolve_hermes_from_signals(&install_root, false, ProbeResult::Failed).is_none());
         let _ = std::fs::remove_dir_all(&install_root);
     }
 

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -386,10 +386,11 @@ async fn run_update(app: AppHandle) -> Result<()> {
 
     emit_stage(&app, "update", StageState::Running, None, None);
     let started = Instant::now();
+    let update_full_args = hermes.full_args(&update_args);
     let mut update = run_streamed(
         &app,
-        &hermes,
-        &update_args,
+        &hermes.program,
+        &update_full_args,
         &install_root,
         &child_env,
         Some("update"),
@@ -419,8 +420,8 @@ async fn run_update(app: AppHandle) -> Result<()> {
         );
         update = run_streamed(
             &app,
-            &hermes,
-            &update_args,
+            &hermes.program,
+            &update_full_args,
             &install_root,
             &child_env,
             Some("update"),
@@ -486,10 +487,11 @@ async fn run_update(app: AppHandle) -> Result<()> {
     emit_stage(&app, "rebuild", StageState::Running, None, None);
     let started = Instant::now();
     let rebuild_args: Vec<String> = vec!["desktop".into(), "--build-only".into()];
+    let rebuild_full_args = hermes.full_args(&rebuild_args);
     let mut rebuild = run_streamed(
         &app,
-        &hermes,
-        &rebuild_args,
+        &hermes.program,
+        &rebuild_full_args,
         &install_root,
         &child_env,
         Some("rebuild"),
@@ -514,8 +516,8 @@ async fn run_update(app: AppHandle) -> Result<()> {
         );
         rebuild = run_streamed(
             &app,
-            &hermes,
-            &rebuild_args,
+            &hermes.program,
+            &rebuild_full_args,
             &install_root,
             &child_env,
             Some("rebuild"),
@@ -874,12 +876,80 @@ fn venv_hermes(install_root: &Path) -> PathBuf {
     }
 }
 
+/// Path to the venv's python interpreter under an install root, regardless of
+/// existence.
+fn venv_python(install_root: &Path) -> PathBuf {
+    if cfg!(target_os = "windows") {
+        install_root.join("venv").join("Scripts").join("python.exe")
+    } else {
+        install_root.join("venv").join("bin").join("python")
+    }
+}
+
+/// How to invoke the resolved hermes CLI: either the console-script shim
+/// directly, or an interpreter plus the args needed to run it as a module.
+struct HermesInvocation {
+    program: PathBuf,
+    /// Prepended to the caller's own argv, e.g. `["-m", "hermes_cli.main"]`.
+    prefix_args: Vec<String>,
+}
+
+impl HermesInvocation {
+    fn direct(program: PathBuf) -> Self {
+        Self { program, prefix_args: Vec::new() }
+    }
+
+    fn full_args(&self, trailing: &[String]) -> Vec<String> {
+        self.prefix_args.iter().cloned().chain(trailing.iter().cloned()).collect()
+    }
+}
+
+/// Same probe as the Electron desktop's `canImportHermesCli()`
+/// (apps/desktop/electron/backend-probes.ts): a venv can have `python.exe` on
+/// disk but be dead (missing deps from an update that died mid-`pip
+/// install`), so importing `hermes_cli.config` (not just the top-level
+/// package) is required before trusting it as a fallback interpreter.
+/// `install_root` is added to `PYTHONPATH` so a source-tree checkout resolves
+/// `hermes_cli` even if the editable install's `.pth`/egg-link is stale.
+fn venv_python_can_import_hermes_cli(python: &Path, install_root: &Path) -> bool {
+    if !python.exists() {
+        return false;
+    }
+    let mut python_path = install_root.as_os_str().to_os_string();
+    if let Some(existing) = env::var_os("PYTHONPATH") {
+        python_path.push(if cfg!(target_os = "windows") { ";" } else { ":" });
+        python_path.push(existing);
+    }
+    std::process::Command::new(python)
+        .args(["-c", "import yaml; import dotenv; import hermes_cli.config"])
+        .env("PYTHONPATH", python_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
 /// Resolve the hermes CLI to drive. Prefer the venv shim in the install we
-/// just updated; fall back to `hermes` on PATH.
-fn resolve_hermes(install_root: &Path) -> Option<PathBuf> {
+/// just updated; fall back to `hermes` on PATH; finally fall back to the
+/// venv's own python run as `python -m hermes_cli.main` when the shim is
+/// missing but the venv is otherwise intact.
+///
+/// The shim-missing-but-venv-intact case is exactly issue #75584: an
+/// interrupted `hermes update` can leave `venv/Scripts/hermes.exe` deleted
+/// (uv/distlib skips the launcher write when the live shim was locked) while
+/// `hermes-agent.exe`/`hermes-acp.exe` and the rest of the venv remain. Without
+/// this fallback the updater dead-ends here with "Could not find the hermes
+/// CLI" and the user must manually run `pip install -e .` to recover — even
+/// though `hermes update` itself already self-heals this exact shim via
+/// `_verify_console_scripts_installed` (hermes_cli/main.py) once it manages to
+/// run at all. Mirrors `resolveVenvHermesCommand()` in
+/// apps/desktop/electron/windows-hermes-path.ts, which the Electron desktop
+/// backend launcher already uses for the same recovery.
+fn resolve_hermes(install_root: &Path) -> Option<HermesInvocation> {
     let shim = venv_hermes(install_root);
     if shim.exists() {
-        return Some(shim);
+        return Some(HermesInvocation::direct(shim));
     }
     // PATH fallback. which-style probe via env, kept dependency-free.
     let exe = if cfg!(target_os = "windows") { "hermes.exe" } else { "hermes" };
@@ -888,9 +958,16 @@ fn resolve_hermes(install_root: &Path) -> Option<PathBuf> {
         for dir in path.split(sep) {
             let cand = Path::new(dir).join(exe);
             if cand.exists() {
-                return Some(cand);
+                return Some(HermesInvocation::direct(cand));
             }
         }
+    }
+    let python = venv_python(install_root);
+    if venv_python_can_import_hermes_cli(&python, install_root) {
+        return Some(HermesInvocation {
+            program: python,
+            prefix_args: vec!["-m".to_string(), "hermes_cli.main".to_string()],
+        });
     }
     None
 }
@@ -1225,6 +1302,63 @@ mod tests {
         let shim = venv_hermes(root);
         assert!(shim.starts_with(root));
         assert!(shim.to_string_lossy().contains("venv"));
+    }
+
+    #[test]
+    fn venv_python_is_under_install_root() {
+        let root = Path::new("/x/hermes-agent");
+        let python = venv_python(root);
+        assert!(python.starts_with(root));
+        assert!(python.to_string_lossy().contains("venv"));
+    }
+
+    #[test]
+    fn hermes_invocation_direct_has_no_prefix_args() {
+        let invocation = HermesInvocation::direct(PathBuf::from("/x/hermes.exe"));
+        let trailing = vec!["update".to_string(), "--yes".to_string()];
+        assert_eq!(invocation.full_args(&trailing), trailing);
+    }
+
+    #[test]
+    fn hermes_invocation_module_fallback_prepends_prefix_args() {
+        // #75584: when the shim is missing, we drive the CLI as
+        // `python -m hermes_cli.main <trailing args>` — the module flag must
+        // come BEFORE the caller's own argv (e.g. `update --yes --gateway`),
+        // not after.
+        let invocation = HermesInvocation {
+            program: PathBuf::from("/x/venv/Scripts/python.exe"),
+            prefix_args: vec!["-m".to_string(), "hermes_cli.main".to_string()],
+        };
+        let trailing = vec!["update".to_string(), "--yes".to_string()];
+        assert_eq!(
+            invocation.full_args(&trailing),
+            vec!["-m", "hermes_cli.main", "update", "--yes"]
+        );
+    }
+
+    #[test]
+    fn venv_python_can_import_hermes_cli_false_when_interpreter_missing() {
+        let ghost = Path::new("/nonexistent/does/not/exist/python.exe");
+        assert!(!venv_python_can_import_hermes_cli(ghost, Path::new("/nonexistent")));
+    }
+
+    #[test]
+    fn resolve_hermes_prefers_existing_shim_over_python_fallback() {
+        // When the console-script shim is present, resolve_hermes must return
+        // it directly (no `-m hermes_cli.main` prefix) regardless of whether a
+        // venv python or a hermes on PATH would also resolve.
+        let dir = unique_tmp_dir("resolve-hermes-shim");
+        let shim = venv_hermes(&dir);
+        if let Some(parent) = shim.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&shim, "").unwrap();
+
+        let resolved = resolve_hermes(&dir).expect("shim on disk must resolve");
+        assert_eq!(resolved.program, shim);
+        assert!(resolved.prefix_args.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -363,7 +363,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
         LogStream::Stdout,
         &format!("[update] updating against branch {update_branch}"),
     );
-    let child_env = update_child_env(&install_root);
+    let child_env = update_child_env(&install_root, &hermes);
     let mut update_args: Vec<String> =
         vec!["update".into(), "--yes".into(), "--gateway".into()];
     // --force skips `hermes update`'s Windows running-exe guard (which would
@@ -972,7 +972,7 @@ fn resolve_hermes(install_root: &Path) -> Option<HermesInvocation> {
     None
 }
 
-fn update_child_env(install_root: &Path) -> Vec<(String, OsString)> {
+fn update_child_env(install_root: &Path, hermes: &HermesInvocation) -> Vec<(String, OsString)> {
     let hermes_home = crate::paths::hermes_home();
     let mut envs = vec![(
         "HERMES_HOME".to_string(),
@@ -985,6 +985,18 @@ fn update_child_env(install_root: &Path) -> Vec<(String, OsString)> {
     // a frozen stage, and users cancel a healthy update. Force line-by-line
     // output instead.
     envs.push(("PYTHONUNBUFFERED".to_string(), OsString::from("1")));
+    // When resolve_hermes() fell back to `python -m hermes_cli.main` (shim
+    // missing, issue #75584), pin PYTHONPATH to install_root so module
+    // resolution matches exactly what venv_python_can_import_hermes_cli()
+    // already probed — belt-and-suspenders alongside `-m`'s own cwd-first
+    // sys.path insertion, in case a stale editable-install .pth or an
+    // inherited PYTHONPATH shadows it in some environment we didn't probe.
+    if !hermes.prefix_args.is_empty() {
+        envs.push((
+            "PYTHONPATH".to_string(),
+            install_root.as_os_str().to_os_string(),
+        ));
+    }
     // We hold the update-in-progress marker for this whole run, and the
     // `hermes update` child claims that SAME lock (hermes_cli/update_lock.py).
     // Name our pid so the child recognizes the live holder as its own
@@ -1368,7 +1380,10 @@ mod tests {
 
     #[test]
     fn update_child_env_forces_unbuffered_python() {
-        let envs = update_child_env(Path::new("/x/hermes-agent"));
+        let envs = update_child_env(
+            Path::new("/x/hermes-agent"),
+            &HermesInvocation::direct(PathBuf::from("/x/hermes-agent/venv/bin/hermes")),
+        );
         assert!(
             envs.iter()
                 .any(|(k, v)| k == "PYTHONUNBUFFERED" && v.to_str() == Some("1")),
@@ -1378,12 +1393,38 @@ mod tests {
 
     #[test]
     fn update_child_env_names_our_pid_for_the_lock_handoff() {
-        let envs = update_child_env(Path::new("/x/hermes-agent"));
+        let envs = update_child_env(
+            Path::new("/x/hermes-agent"),
+            &HermesInvocation::direct(PathBuf::from("/x/hermes-agent/venv/bin/hermes")),
+        );
         assert!(
             envs.iter().any(|(k, v)| k == "HERMES_UPDATE_HANDOFF_PID"
                 && v.to_str() == Some(std::process::id().to_string().as_str())),
             "the hermes update child claims the same marker we hold; without our pid \
              it refuses its own parent's lock and every GUI update dead-ends on exit 2"
+        );
+    }
+
+    #[test]
+    fn update_child_env_sets_pythonpath_only_for_module_fallback() {
+        let direct = HermesInvocation::direct(PathBuf::from("/x/hermes-agent/venv/bin/hermes"));
+        let direct_envs = update_child_env(Path::new("/x/hermes-agent"), &direct);
+        assert!(
+            !direct_envs.iter().any(|(k, _)| k == "PYTHONPATH"),
+            "the direct shim invocation must not need a PYTHONPATH override"
+        );
+
+        let module_fallback = HermesInvocation {
+            program: PathBuf::from("/x/hermes-agent/venv/bin/python"),
+            prefix_args: vec!["-m".to_string(), "hermes_cli.main".to_string()],
+        };
+        let module_envs = update_child_env(Path::new("/x/hermes-agent"), &module_fallback);
+        assert!(
+            module_envs.iter().any(|(k, v)| k == "PYTHONPATH"
+                && v.to_str() == Some("/x/hermes-agent")),
+            "the python -m hermes_cli.main fallback (#75584) must pin PYTHONPATH to \
+             install_root so module resolution matches what the import probe already \
+             verified, even if a stale editable-install .pth would otherwise shadow it"
         );
     }
 

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -304,7 +304,7 @@ async fn run_update(app: AppHandle) -> Result<()> {
         None
     };
 
-    let hermes = resolve_hermes(&install_root).ok_or_else(|| {
+    let hermes = resolve_hermes(&install_root).await.ok_or_else(|| {
         let msg = format!(
             "Could not find the hermes CLI under {}. Is Hermes installed? \
              Re-run the installer to repair the install.",
@@ -904,6 +904,33 @@ impl HermesInvocation {
     }
 }
 
+/// How long the import-probe child gets before we give up on it. This runs
+/// synchronously inside `resolve_hermes`, ahead of the update's stage
+/// manifest — an unbounded probe can hang the whole updater (and hold the
+/// update-in-progress marker) on a wedged/antivirus-stalled interpreter.
+/// Mirrors the timeout/retry spirit of the Electron desktop's
+/// `canImportHermesCli()` probe (apps/desktop/electron/backend-probes.ts),
+/// which bounds its own child the same way.
+const IMPORT_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Wait for `child` up to `timeout`. On timeout, kill and reap it (never
+/// leave a zombie/hung process behind) and report `false` — the same value
+/// as a clean non-zero exit — so callers can treat "no answer in time" the
+/// same as "no". Extracted from `venv_python_can_import_hermes_cli` so the
+/// bounding behavior itself can be unit-tested against a real, controllable
+/// long-lived process instead of depending on the hardcoded `-c` probe args.
+async fn wait_for_child_success(mut child: tokio::process::Child, timeout: Duration) -> bool {
+    match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => status.success(),
+        Ok(Err(_)) => false,
+        Err(_timed_out) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            false
+        }
+    }
+}
+
 /// Same probe as the Electron desktop's `canImportHermesCli()`
 /// (apps/desktop/electron/backend-probes.ts): a venv can have `python.exe` on
 /// disk but be dead (missing deps from an update that died mid-`pip
@@ -911,7 +938,13 @@ impl HermesInvocation {
 /// package) is required before trusting it as a fallback interpreter.
 /// `install_root` is added to `PYTHONPATH` so a source-tree checkout resolves
 /// `hermes_cli` even if the editable install's `.pth`/egg-link is stale.
-fn venv_python_can_import_hermes_cli(python: &Path, install_root: &Path) -> bool {
+///
+/// Bounded by `IMPORT_PROBE_TIMEOUT` (see `wait_for_child_success`): a wedged
+/// interpreter is killed and reaped rather than left to hang `resolve_hermes`
+/// (and therefore the whole update) indefinitely. A timeout is treated the
+/// same as "can't import" — resolution just continues to the next rung
+/// (PATH).
+async fn venv_python_can_import_hermes_cli(python: &Path, install_root: &Path) -> bool {
     if !python.exists() {
         return false;
     }
@@ -920,20 +953,77 @@ fn venv_python_can_import_hermes_cli(python: &Path, install_root: &Path) -> bool
         python_path.push(if cfg!(target_os = "windows") { ";" } else { ":" });
         python_path.push(existing);
     }
-    std::process::Command::new(python)
-        .args(["-c", "import yaml; import dotenv; import hermes_cli.config"])
+    let mut cmd = Command::new(python);
+    cmd.args(["-c", "import yaml; import dotenv; import hermes_cli.config"])
         .env("PYTHONPATH", python_path)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(target_os = "windows")]
+    {
+        // CREATE_NO_WINDOW — same as run_streamed's child spawns, no flashing
+        // console behind the GUI for this probe either. tokio::process::Command
+        // exposes this natively on Windows (no CommandExt import needed).
+        cmd.creation_flags(0x0800_0000);
+    }
+    let child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(_) => return false,
+    };
+    let passed = wait_for_child_success(child, IMPORT_PROBE_TIMEOUT).await;
+    if !passed {
+        tracing::debug!(python = %python.display(), "hermes_cli import probe did not succeed");
+    }
+    passed
+}
+
+/// Ordered resolution decision. Pulled out of `resolve_hermes` so the
+/// ordering itself — the actual thing #75584's review flagged — can be unit
+/// tested without a real venv, a real python subprocess, or a mutated PATH.
+/// `resolve_hermes` gathers the real signals (shim presence, the bounded
+/// import probe, PATH) and hands them here.
+fn resolve_hermes_from_signals(
+    install_root: &Path,
+    shim_exists: bool,
+    python_import_probe_passed: bool,
+    path_dirs: &[PathBuf],
+) -> Option<HermesInvocation> {
+    // 1. Target install's own venv shim — the fast, common, already-correct
+    //    path when the install isn't broken.
+    if shim_exists {
+        return Some(HermesInvocation::direct(venv_hermes(install_root)));
+    }
+    // 2. Target install's own venv python, run as a module — the #75584
+    //    recovery path for a shim deleted by an interrupted update, but
+    //    ONLY once validated (see venv_python_can_import_hermes_cli). This
+    //    must outrank PATH: it is still THIS install, just invoked
+    //    differently, whereas a PATH hermes.exe may belong to an entirely
+    //    unrelated install and would silently update the wrong checkout.
+    if python_import_probe_passed {
+        return Some(HermesInvocation {
+            program: venv_python(install_root),
+            prefix_args: vec!["-m".to_string(), "hermes_cli.main".to_string()],
+        });
+    }
+    // 3. PATH fallback — last resort only. which-style probe via env, kept
+    //    dependency-free. We can't cheaply prove a PATH hermes.exe belongs to
+    //    `install_root` (a real one could be a symlink/shim into any venv),
+    //    so treat it as the least-trusted rung rather than rejecting it
+    //    outright: with no working shim and no importable venv python, it is
+    //    still better than failing the update entirely.
+    let exe = if cfg!(target_os = "windows") { "hermes.exe" } else { "hermes" };
+    for dir in path_dirs {
+        let cand = dir.join(exe);
+        if cand.exists() {
+            return Some(HermesInvocation::direct(cand));
+        }
+    }
+    None
 }
 
 /// Resolve the hermes CLI to drive. Prefer the venv shim in the install we
-/// just updated; fall back to `hermes` on PATH; finally fall back to the
-/// venv's own python run as `python -m hermes_cli.main` when the shim is
-/// missing but the venv is otherwise intact.
+/// just updated; then the venv's own python run as `python -m
+/// hermes_cli.main` when the shim is missing but the venv is otherwise
+/// intact; finally fall back to `hermes` on PATH.
 ///
 /// The shim-missing-but-venv-intact case is exactly issue #75584: an
 /// interrupted `hermes update` can leave `venv/Scripts/hermes.exe` deleted
@@ -946,30 +1036,31 @@ fn venv_python_can_import_hermes_cli(python: &Path, install_root: &Path) -> bool
 /// run at all. Mirrors `resolveVenvHermesCommand()` in
 /// apps/desktop/electron/windows-hermes-path.ts, which the Electron desktop
 /// backend launcher already uses for the same recovery.
-fn resolve_hermes(install_root: &Path) -> Option<HermesInvocation> {
+///
+/// PATH is deliberately the LAST rung, not the second one: a `hermes.exe`
+/// resolved from PATH can belong to a completely different install than
+/// `install_root` (another checkout, another profile, a stale global
+/// install). Trying it before the validated venv-python fallback would let a
+/// foreign hermes.exe silently update the wrong checkout while leaving this
+/// (actually recoverable) install broken — the bug this ordering fixes.
+async fn resolve_hermes(install_root: &Path) -> Option<HermesInvocation> {
     let shim = venv_hermes(install_root);
-    if shim.exists() {
-        return Some(HermesInvocation::direct(shim));
-    }
-    // PATH fallback. which-style probe via env, kept dependency-free.
-    let exe = if cfg!(target_os = "windows") { "hermes.exe" } else { "hermes" };
-    if let Ok(path) = std::env::var("PATH") {
-        let sep = if cfg!(target_os = "windows") { ';' } else { ':' };
-        for dir in path.split(sep) {
-            let cand = Path::new(dir).join(exe);
-            if cand.exists() {
-                return Some(HermesInvocation::direct(cand));
-            }
-        }
-    }
-    let python = venv_python(install_root);
-    if venv_python_can_import_hermes_cli(&python, install_root) {
-        return Some(HermesInvocation {
-            program: python,
-            prefix_args: vec!["-m".to_string(), "hermes_cli.main".to_string()],
-        });
-    }
-    None
+    let shim_exists = shim.exists();
+    // Skip the subprocess probe entirely when the shim already resolves —
+    // avoids paying its cost (even bounded) on the common healthy-install path.
+    let python_import_probe_passed = if shim_exists {
+        false
+    } else {
+        let python = venv_python(install_root);
+        venv_python_can_import_hermes_cli(&python, install_root).await
+    };
+    let path_dirs: Vec<PathBuf> = std::env::var("PATH")
+        .map(|path| {
+            let sep = if cfg!(target_os = "windows") { ';' } else { ':' };
+            path.split(sep).map(PathBuf::from).collect()
+        })
+        .unwrap_or_default();
+    resolve_hermes_from_signals(install_root, shim_exists, python_import_probe_passed, &path_dirs)
 }
 
 fn update_child_env(install_root: &Path, hermes: &HermesInvocation) -> Vec<(String, OsString)> {
@@ -1348,14 +1439,88 @@ mod tests {
         );
     }
 
-    #[test]
-    fn venv_python_can_import_hermes_cli_false_when_interpreter_missing() {
+    #[tokio::test]
+    async fn venv_python_can_import_hermes_cli_false_when_interpreter_missing() {
         let ghost = Path::new("/nonexistent/does/not/exist/python.exe");
-        assert!(!venv_python_can_import_hermes_cli(ghost, Path::new("/nonexistent")));
+        assert!(!venv_python_can_import_hermes_cli(ghost, Path::new("/nonexistent")).await);
     }
 
-    #[test]
-    fn resolve_hermes_prefers_existing_shim_over_python_fallback() {
+    /// Spawn a real, long-lived (30s) sibling process, independent of the
+    /// hardcoded `-c "import ..."` probe args, so timeout tests can exercise
+    /// `wait_for_child_success` directly with a short test-local timeout.
+    fn spawn_long_lived_process() -> tokio::process::Child {
+        let mut cmd = if cfg!(windows) {
+            let mut c = Command::new("timeout");
+            c.args(["/T", "30", "/nobreak"]);
+            c
+        } else {
+            let mut c = Command::new("sleep");
+            c.arg("30");
+            c
+        };
+        cmd.stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn long-lived helper process")
+    }
+
+    #[tokio::test]
+    async fn wait_for_child_success_kills_and_returns_false_on_timeout() {
+        // P2 regression: a wedged interpreter (e.g. antivirus-stalled, or a
+        // subprocess-startup deadlock) must not hang resolve_hermes forever.
+        // Use a short local timeout against a real 30s-lived process so the
+        // test itself stays fast while still proving the kill-on-timeout path.
+        let child = spawn_long_lived_process();
+        let pid = child.id();
+
+        let started = Instant::now();
+        let result = wait_for_child_success(child, Duration::from_millis(200)).await;
+        let elapsed = started.elapsed();
+
+        assert!(!result, "a wedged/slow child must resolve to false, not hang");
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "must bail out at the local timeout, not wait for the 30s child; took {elapsed:?}"
+        );
+        if let Some(pid) = pid {
+            assert!(
+                !pid_is_alive(pid),
+                "a timed-out child must be killed and reaped, not left running"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_for_child_success_true_for_a_fast_clean_exit() {
+        let child = if cfg!(windows) {
+            Command::new("cmd").args(["/C", "exit 0"]).spawn().unwrap()
+        } else {
+            Command::new("true").spawn().unwrap()
+        };
+        assert!(wait_for_child_success(child, Duration::from_secs(10)).await);
+    }
+
+    #[tokio::test]
+    async fn wait_for_child_success_false_for_a_fast_nonzero_exit() {
+        let child = if cfg!(windows) {
+            Command::new("cmd").args(["/C", "exit 1"]).spawn().unwrap()
+        } else {
+            Command::new("false").spawn().unwrap()
+        };
+        assert!(!wait_for_child_success(child, Duration::from_secs(10)).await);
+    }
+
+    #[tokio::test]
+    async fn import_probe_timeout_is_a_small_bounded_duration() {
+        // Invariant, not a change-detector: the probe must actually be
+        // bounded (not zero, not accidentally huge) without pinning an exact
+        // literal that would break on a deliberate future retune.
+        assert!(IMPORT_PROBE_TIMEOUT >= Duration::from_secs(1));
+        assert!(IMPORT_PROBE_TIMEOUT <= Duration::from_secs(60));
+    }
+
+    #[tokio::test]
+    async fn resolve_hermes_prefers_existing_shim_over_python_fallback() {
         // When the console-script shim is present, resolve_hermes must return
         // it directly (no `-m hermes_cli.main` prefix) regardless of whether a
         // venv python or a hermes on PATH would also resolve.
@@ -1366,11 +1531,74 @@ mod tests {
         }
         std::fs::write(&shim, "").unwrap();
 
-        let resolved = resolve_hermes(&dir).expect("shim on disk must resolve");
+        let resolved = resolve_hermes(&dir).await.expect("shim on disk must resolve");
         assert_eq!(resolved.program, shim);
         assert!(resolved.prefix_args.is_empty());
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn resolve_hermes_from_signals_prefers_venv_python_over_foreign_path_hermes() {
+        // P1 regression (#75584 review): target shim missing, target venv
+        // python passes the import probe, AND a foreign hermes.exe sits on
+        // PATH. The target's own validated venv python must win — a PATH
+        // hermes.exe can belong to a totally unrelated install and would
+        // silently update the wrong checkout while leaving this (recoverable)
+        // install broken.
+        let install_root = unique_tmp_dir("resolve-signals-install-root");
+        let foreign_dir = unique_tmp_dir("resolve-signals-foreign-path");
+        let exe_name = if cfg!(target_os = "windows") { "hermes.exe" } else { "hermes" };
+        let foreign_hermes = foreign_dir.join(exe_name);
+        std::fs::write(&foreign_hermes, "").unwrap();
+
+        let resolved = resolve_hermes_from_signals(
+            &install_root,
+            false, // target shim missing
+            true,  // target venv python passed the import probe
+            &[foreign_dir.clone()],
+        )
+        .expect("validated venv python fallback must resolve");
+
+        assert_eq!(
+            resolved.program,
+            venv_python(&install_root),
+            "target install's own venv python must win over a foreign PATH hermes.exe"
+        );
+        assert_eq!(
+            resolved.prefix_args,
+            vec!["-m".to_string(), "hermes_cli.main".to_string()]
+        );
+
+        let _ = std::fs::remove_dir_all(&install_root);
+        let _ = std::fs::remove_dir_all(&foreign_dir);
+    }
+
+    #[test]
+    fn resolve_hermes_from_signals_falls_back_to_path_only_as_last_resort() {
+        // When neither the shim nor the venv python probe resolve, PATH
+        // remains the final rung (better than failing the update outright).
+        let install_root = unique_tmp_dir("resolve-signals-path-fallback");
+        let path_dir = unique_tmp_dir("resolve-signals-path-only");
+        let exe_name = if cfg!(target_os = "windows") { "hermes.exe" } else { "hermes" };
+        let path_hermes = path_dir.join(exe_name);
+        std::fs::write(&path_hermes, "").unwrap();
+
+        let resolved = resolve_hermes_from_signals(&install_root, false, false, &[path_dir.clone()])
+            .expect("PATH fallback must resolve when nothing else does");
+
+        assert_eq!(resolved.program, path_hermes);
+        assert!(resolved.prefix_args.is_empty());
+
+        let _ = std::fs::remove_dir_all(&install_root);
+        let _ = std::fs::remove_dir_all(&path_dir);
+    }
+
+    #[test]
+    fn resolve_hermes_from_signals_none_when_nothing_resolves() {
+        let install_root = unique_tmp_dir("resolve-signals-none");
+        assert!(resolve_hermes_from_signals(&install_root, false, false, &[]).is_none());
+        let _ = std::fs::remove_dir_all(&install_root);
     }
 
     #[test]

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5486,6 +5486,16 @@ def _run_npm_install_deterministic(
     committed lockfile and makes every future ``npm ci`` fail — a
     self-reinforcing cycle where web devDeps never install and a stale dist
     is served on every update (PR #65595).
+
+    When ``npm ci`` fails, ``node_modules`` is removed before the ``npm
+    install`` fallback runs. An interrupted previous install (power loss,
+    Ctrl+C, a killed gateway holding a file open) can leave a half-written
+    tree that trips ``npm install`` over the exact same corruption ``npm ci``
+    just hit — most visibly ``ENOTEMPTY`` on Windows, where a stale nested
+    ``.bin`` directory blocks npm's rename-based package writes (issue
+    #75584). ``npm ci`` itself would have wiped and rebuilt ``node_modules``
+    from scratch had it succeeded, so this keeps the fallback's starting
+    point consistent with what a clean ``ci`` run would have produced.
     """
     # unicode-animations' postinstall animates to /dev/tty (bypasses
     # --silent/capture_output). It no-ops when CI is set — same as the TUI
@@ -5508,6 +5518,14 @@ def _run_npm_install_deterministic(
                 return ci_result
             # Fall through to `npm install` — lockfile may be out of sync on a
             # WIP fork/branch, or `npm ci` may not be available on very old npm.
+            # Clear a possibly half-written node_modules first (see docstring)
+            # so the fallback doesn't inherit the same corruption. Best-effort:
+            # a locked file (e.g. an antivirus scan, a straggler process) must
+            # not crash the updater — `npm install` still runs and surfaces its
+            # own, clearer error if the tree really can't be repaired.
+            node_modules = cwd / "node_modules"
+            if node_modules.exists():
+                shutil.rmtree(node_modules, ignore_errors=True)
         return _run([npm_exe, "install", "--no-save", "--include=dev", *extra_args])
 
     result = _attempt(npm)

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -368,3 +368,74 @@ class TestBuildRecoversFromMissingToolchain:
         assert mock_install.call_count == 1
         assert mock_build.call_count == 1
 
+
+class TestNpmCiFailureCleansNodeModules:
+    """``npm ci`` failure must wipe ``node_modules`` before the ``npm install``
+    fallback runs, so an interrupted-update corruption (issue #75584's
+    Windows ``ENOTEMPTY`` on a stale nested ``.bin`` dir) doesn't survive into
+    the fallback attempt.
+    """
+
+    def test_ci_failure_removes_node_modules_before_install_fallback(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+        node_modules = web_dir / "node_modules"
+        (node_modules / "@babel" / "core" / "node_modules" / ".bin").mkdir(parents=True)
+
+        Subprocess = __import__("subprocess")
+        ci_fail = Subprocess.CompletedProcess(
+            [], 1, stdout="", stderr="npm error code ENOTEMPTY\nnpm error syscall rmdir"
+        )
+        install_ok = Subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        node_modules_existed_at_install = None
+
+        def mock_run(cmd, **kwargs):
+            nonlocal node_modules_existed_at_install
+            if cmd[1] == "ci":
+                return ci_fail
+            if cmd[1] == "install":
+                node_modules_existed_at_install = node_modules.exists()
+            return install_ok
+
+        with patch("hermes_cli.main.subprocess.run", side_effect=mock_run):
+            result = _run_npm_install_deterministic("/usr/bin/npm", web_dir)
+
+        assert result.returncode == 0
+        assert not node_modules.exists(), "corrupted tree must be removed"
+        assert node_modules_existed_at_install is False, (
+            "cleanup must happen before the install fallback runs, not after"
+        )
+
+    def test_ci_success_leaves_node_modules_untouched(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+        node_modules = web_dir / "node_modules"
+        node_modules.mkdir()
+
+        Subprocess = __import__("subprocess")
+        ci_ok = Subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        with patch("hermes_cli.main.subprocess.run", return_value=ci_ok):
+            _run_npm_install_deterministic("/usr/bin/npm", web_dir)
+
+        assert node_modules.exists(), "a successful npm ci must not be touched"
+
+    def test_missing_node_modules_does_not_error_on_ci_failure(self, tmp_path):
+        """No node_modules to begin with (e.g. very first install attempt) —
+        the cleanup step must be a no-op, not raise."""
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        Subprocess = __import__("subprocess")
+        ci_fail = Subprocess.CompletedProcess([], 1, stdout="", stderr="ERESOLVE")
+        install_ok = Subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        def mock_run(cmd, **kwargs):
+            return ci_fail if cmd[1] == "ci" else install_ok
+
+        with patch("hermes_cli.main.subprocess.run", side_effect=mock_run):
+            result = _run_npm_install_deterministic("/usr/bin/npm", web_dir)
+
+        assert result.returncode == 0
+


### PR DESCRIPTION
## What does this PR do?

After an interrupted Windows update/install, Desktop recovery often fails in two ways:

1. `hermes.exe` is missing from the target venv, so the bootstrap updater hard-fails with "UPDATE DIDN'T FINISH / Could not find the hermes CLI"
2. Corrupt `node_modules` causes `npm ci` to fail with `ENOTEMPTY` and the install cascade never recovers

This PR:

- Falls back to `venv/Scripts/python.exe -m hermes_cli.main` when the target shim is missing (mirrors Electron's existing pattern)
- Prefers **target venv shim → target validated venv Python → repair error** (no generic PATH fallback — a foreign `hermes.exe` must not update the wrong checkout)
- Bounds the `hermes_cli` import probe (`Passed` / `Failed` / `TimedOut`), retries TimedOut once at 15s (Electron parity), and bounds the kill/reap wait
- Wipes `node_modules` (best-effort) after a failed `npm ci` before the `npm install` fallback

## Related Issue

Partially addresses #75584

(Covers missing-shim recovery + ENOTEMPTY `node_modules` cleanup. Broader updater lock/orphan races remain tracked by other open work.)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `apps/bootstrap-installer/src-tauri/src/update.rs` — safe resolve ladder, ProbeResult + retry, bounded reap; Rust unit tests
- `hermes_cli/main.py` — `_run_npm_install_deterministic` cleans `node_modules` after `npm ci` failure
- `tests/hermes_cli/test_web_ui_build.py` — coverage for the npm cleanup path

## How to Test

1. Rust: `cargo test --lib update::` in `apps/bootstrap-installer/src-tauri`
2. Python: `uv run --extra dev pytest tests/hermes_cli/test_web_ui_build.py -q`
3. Manual (Windows): remove `venv/Scripts/hermes.exe` but keep a healthy venv Python; ensure update resolves to `python -m hermes_cli.main`
4. Manual: with a foreign `hermes.exe` on PATH and a broken/slow target venv probe, confirm the updater fails into repair rather than updating the foreign install
5. Manual: corrupt `node_modules` so `npm ci` fails with ENOTEMPTY; confirm wipe + `npm install` fallback proceeds

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched for existing PRs (related: #34327 for ENOTEMPTY)
- [x] PR contains only related changes
- [x] Tests added/updated
- [x] Tested on: Windows 11

### Documentation & Housekeeping

- [x] Docs — N/A (code comments updated in `update.rs`)
- [x] Config / CONTRIBUTING / tool schemas — N/A
- [x] Cross-platform impact considered (Windows-focused recovery; helpers remain OS-aware)
