### PR TITLE
fix(terminal): report real failure when a background spawn never starts

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -586,6 +586,72 @@ class TestSpawnEnvSanitization:
 
 
 # =========================================================================
+# Local-startup observation window (#75675, local-spawn follow-up)
+# =========================================================================
+
+class TestObserveLocalStartup:
+    """``spawn_local`` always succeeds at the Popen level (the login shell
+    launches fine) even when the wrapped command itself fails almost
+    instantly. ``observe_local_startup`` gives the caller a brief chance to
+    see that before reporting blanket "started" success.
+
+    Real subprocesses are used here (not mocked) since the whole point is to
+    exercise actual shell-startup timing. A generous ``timeout`` is passed
+    explicitly (rather than relying on the short production default) so the
+    test is not flaky on slower CI/dev hosts where a login shell can take a
+    few hundred ms to spawn and exit.
+    """
+
+    def test_observes_immediate_failure(self, registry, tmp_path):
+        session = registry.spawn_local("false", cwd=str(tmp_path))
+        try:
+            registry.observe_local_startup(session, timeout=5.0, interval=0.02)
+            assert session.exited is True
+            assert session.exit_code == 1
+            # A real launch that ran and failed is NOT a "failed_start" --
+            # the shell/process genuinely started.
+            assert session.completion_reason != "failed_start"
+        finally:
+            registry.kill_process(session.id)
+
+    def test_observes_immediate_success(self, registry, tmp_path):
+        session = registry.spawn_local("true", cwd=str(tmp_path))
+        try:
+            registry.observe_local_startup(session, timeout=5.0, interval=0.02)
+            assert session.exited is True
+            assert session.exit_code == 0
+        finally:
+            registry.kill_process(session.id)
+
+    def test_does_not_block_a_long_lived_process(self, registry, tmp_path):
+        """A genuinely long-lived process must not be misclassified as exited
+        just because the observation window elapsed -- it simply outlives it
+        and falls through to the normal "running" path unaffected."""
+        session = registry.spawn_local("sleep 30", cwd=str(tmp_path))
+        try:
+            registry.observe_local_startup(session, timeout=0.2, interval=0.02)
+            assert session.exited is False
+        finally:
+            registry.kill_process(session.id)
+
+    def test_noop_on_already_exited_session(self, registry):
+        session = _make_session(exited=True, exit_code=0)
+        # Should return immediately without touching a (nonexistent) process.
+        registry.observe_local_startup(session, timeout=5.0, interval=0.02)
+        assert session.exited is True
+
+    def test_noop_without_a_popen_handle(self, registry):
+        """PTY sessions (and anything else without ``session.process``) must
+        not pay the observation window at all -- there's nothing to poll."""
+        session = _make_session(exited=False)
+        assert session.process is None
+        start = time.monotonic()
+        registry.observe_local_startup(session, timeout=5.0, interval=0.02)
+        assert time.monotonic() - start < 0.5
+        assert session.exited is False
+
+
+# =========================================================================
 # Popen leak prevention
 # =========================================================================
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -526,8 +526,30 @@ class TestSpawnEnvSanitization:
         assert session.pid is None
         assert session.output_buffer == "syntax error"
         fake_thread.start.assert_not_called()
-        # A failed launch must not be exposed as a running/tracked session.
+        # A failed launch must not be exposed as a running/tracked session...
         assert session.id not in registry._running
+        # ...but it must still be discoverable as a finished/failed record
+        # (#75675): otherwise the session id handed back to the caller is a
+        # dead end for any later process(action='list'/'poll') lookup, and
+        # the only failure signal is whatever the immediate caller does with
+        # the return value in-process.
+        assert registry._finished.get(session.id) is session
+
+    def test_spawn_via_env_exception_registers_finished_session(self, registry):
+        class RaisingEnv:
+            def execute(self, command, **kwargs):
+                raise RuntimeError("sandbox unreachable")
+
+        fake_thread = MagicMock()
+        with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(RaisingEnv(), "echo hello")
+
+        assert session.exited is True
+        assert session.completion_reason == "failed_start"
+        assert "sandbox unreachable" in session.output_buffer
+        assert session.id not in registry._running
+        assert registry._finished.get(session.id) is session
 
     def test_env_poller_quotes_temp_paths_with_spaces(self, registry):
         session = _make_session(sid="proc_space")

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -770,8 +770,10 @@ class TestSpawnEnvSanitization:
         assert session.pid is None
         assert session.output_buffer == "syntax error"
         fake_thread.start.assert_not_called()
-        # A failed launch must not be exposed as a running/tracked session.
+        # A failed launch must not be exposed as a running session, but it
+        # must remain discoverable as a finished record for list/poll.
         assert session.id not in registry._running
+        assert registry._finished.get(session.id) is session
 
     def test_env_poller_quotes_temp_paths_with_spaces(self, registry):
         session = _make_session(sid="proc_space")

--- a/tests/tools/test_terminal_background_spawn_failure.py
+++ b/tests/tools/test_terminal_background_spawn_failure.py
@@ -1,0 +1,101 @@
+"""Regression tests for #75675: TUI background terminal processes silently
+fail to start.
+
+``terminal(background=true)`` used to report the generic "Background process
+started" success unconditionally, even when the underlying process registry
+spawn immediately failed (``ProcessSession.exited is True``, e.g. a sandbox
+``env.execute()`` launch error via ``spawn_via_env``). The caller had no way
+to learn the process never actually ran, and — because ``spawn_via_env``
+also never registered the dead-on-arrival session anywhere — a later
+``process(action='list'/'poll')`` came back completely empty too.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import tools.terminal_tool as terminal_tool_module
+from tools.process_registry import ProcessSession
+
+
+def _make_env_config(tmp_path, **overrides):
+    config = {
+        "env_type": "local",
+        "timeout": 30,
+        "cwd": str(tmp_path),
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }
+    config.update(overrides)
+    return config
+
+
+def _run_background(monkeypatch, tmp_path, *, spawn_session):
+    mock_env = MagicMock()
+    mock_env.env = {}
+
+    monkeypatch.setattr(
+        terminal_tool_module, "_get_env_config", lambda: _make_env_config(tmp_path)
+    )
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", mock_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    from tools import process_registry as process_registry_module
+
+    monkeypatch.setattr(
+        process_registry_module.process_registry,
+        "spawn_local",
+        lambda **_kwargs: spawn_session,
+    )
+
+    return json.loads(
+        terminal_tool_module.terminal_tool(command="azcopy sync foo bar", background=True)
+    )
+
+
+def test_background_reports_failure_instead_of_fake_success(monkeypatch, tmp_path):
+    failed_session = ProcessSession(
+        id="proc_deadonarrival",
+        command="azcopy sync foo bar",
+        started_at=0.0,
+        pid=None,
+        exited=True,
+        exit_code=127,
+        completion_reason="failed_start",
+        termination_source="failed_start",
+        output_buffer="bash: azcopy: command not found",
+    )
+
+    result = _run_background(monkeypatch, tmp_path, spawn_session=failed_session)
+
+    assert result["error"], "a dead-on-arrival spawn must report an error"
+    assert result["exit_code"] == 127
+    assert result["output"] != "Background process started"
+    assert "azcopy" in result["error"] or "command not found" in result["error"]
+
+
+def test_background_still_reports_success_for_a_live_process(monkeypatch, tmp_path):
+    live_session = ProcessSession(
+        id="proc_alive",
+        command="sleep 30",
+        started_at=0.0,
+        pid=4242,
+        exited=False,
+    )
+
+    result = _run_background(monkeypatch, tmp_path, spawn_session=live_session)
+
+    assert result["error"] is None
+    assert result["exit_code"] == 0
+    assert result["session_id"] == "proc_alive"
+    assert result["pid"] == 4242
+    assert result["output"] == "Background process started"

--- a/tests/tools/test_terminal_background_spawn_failure.py
+++ b/tests/tools/test_terminal_background_spawn_failure.py
@@ -8,6 +8,18 @@ spawn immediately failed (``ProcessSession.exited is True``, e.g. a sandbox
 to learn the process never actually ran, and — because ``spawn_via_env``
 also never registered the dead-on-arrival session anywhere — a later
 ``process(action='list'/'poll')`` came back completely empty too.
+
+This also covers the local-spawn analog: ``spawn_local`` always succeeds at
+the ``Popen`` level (the login shell launches fine) even when the wrapped
+command itself fails almost instantly, so ``terminal_tool`` gives it a brief
+observation window (``process_registry.observe_local_startup``) before
+reporting blanket success, and classifies the outcome instead of blindly
+returning ``failed_start`` for anything that has already exited:
+  - never launched at all (``completion_reason == "failed_start"``)
+  - launched but failed immediately (real exit code != 0 -- a command error,
+    not a launch failure)
+  - launched and completed successfully before the window closed (exit code
+    0 -- a real success, not a failure and not "still starting")
 """
 
 import json
@@ -33,12 +45,11 @@ def _make_env_config(tmp_path, **overrides):
     return config
 
 
-def _run_background(monkeypatch, tmp_path, *, spawn_session):
-    mock_env = MagicMock()
-    mock_env.env = {}
-
+def _patch_common(monkeypatch, tmp_path, mock_env, **config_overrides):
     monkeypatch.setattr(
-        terminal_tool_module, "_get_env_config", lambda: _make_env_config(tmp_path)
+        terminal_tool_module,
+        "_get_env_config",
+        lambda: _make_env_config(tmp_path, **config_overrides),
     )
     monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
     monkeypatch.setattr(
@@ -48,6 +59,13 @@ def _run_background(monkeypatch, tmp_path, *, spawn_session):
     )
     monkeypatch.setitem(terminal_tool_module._active_environments, "default", mock_env)
     monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+
+def _run_background(monkeypatch, tmp_path, *, spawn_session):
+    """Local path, with ``spawn_local`` mocked to return a canned session."""
+    mock_env = MagicMock()
+    mock_env.env = {}
+    _patch_common(monkeypatch, tmp_path, mock_env)
 
     from tools import process_registry as process_registry_module
 
@@ -60,6 +78,37 @@ def _run_background(monkeypatch, tmp_path, *, spawn_session):
     return json.loads(
         terminal_tool_module.terminal_tool(command="azcopy sync foo bar", background=True)
     )
+
+
+def _run_background_non_local(monkeypatch, tmp_path, *, spawn_session, register_finished=True):
+    """Non-local path, with ``spawn_via_env`` mocked to return a canned
+    session. Mirrors what the real ``spawn_via_env`` does for a
+    dead-on-arrival session: register it into ``_finished`` so it stays
+    discoverable via ``process(action='list'/'poll')`` after the call
+    returns -- Teknium's review on PR #75753 flagged that the original test
+    only exercised the local/``spawn_local`` path.
+    """
+    mock_env = MagicMock()
+    mock_env.env = {}
+    _patch_common(monkeypatch, tmp_path, mock_env, env_type="docker", docker_image="test-image")
+
+    from tools import process_registry as process_registry_module
+
+    def fake_spawn_via_env(**_kwargs):
+        if register_finished and spawn_session.exited:
+            process_registry_module.process_registry._finished[spawn_session.id] = spawn_session
+        return spawn_session
+
+    monkeypatch.setattr(
+        process_registry_module.process_registry,
+        "spawn_via_env",
+        fake_spawn_via_env,
+    )
+
+    result = json.loads(
+        terminal_tool_module.terminal_tool(command="azcopy sync foo bar", background=True)
+    )
+    return result, process_registry_module.process_registry
 
 
 def test_background_reports_failure_instead_of_fake_success(monkeypatch, tmp_path):
@@ -80,6 +129,7 @@ def test_background_reports_failure_instead_of_fake_success(monkeypatch, tmp_pat
     assert result["error"], "a dead-on-arrival spawn must report an error"
     assert result["exit_code"] == 127
     assert result["output"] != "Background process started"
+    assert result["status"] == "failed_start"
     assert "azcopy" in result["error"] or "command not found" in result["error"]
 
 
@@ -99,3 +149,113 @@ def test_background_still_reports_success_for_a_live_process(monkeypatch, tmp_pa
     assert result["session_id"] == "proc_alive"
     assert result["pid"] == 4242
     assert result["output"] == "Background process started"
+
+
+def test_background_non_local_failure_is_discoverable_via_list_and_poll(monkeypatch, tmp_path):
+    """Teknium (PR #75753 review): the original test forced env_type='local'
+    and only patched ``spawn_local``, never exercising ``spawn_via_env`` --
+    the path actually named in the #75675 regression. This drives a non-local
+    env_type through ``spawn_via_env`` and confirms the failed session
+    remains observable through the public process list/poll surface
+    afterward, not just in the immediate tool return value.
+    """
+    failed_session = ProcessSession(
+        id="proc_sandbox_deadonarrival",
+        command="azcopy sync foo bar",
+        started_at=0.0,
+        pid=None,
+        exited=True,
+        exit_code=-1,
+        completion_reason="failed_start",
+        termination_source="failed_start",
+        output_buffer="Failed to start: sandbox unreachable",
+    )
+
+    result, registry = _run_background_non_local(
+        monkeypatch, tmp_path, spawn_session=failed_session
+    )
+
+    assert result["error"], "a dead-on-arrival spawn must report an error"
+    assert result["status"] == "failed_start"
+    assert result["session_id"] == "proc_sandbox_deadonarrival"
+    assert result["output"] != "Background process started"
+
+    # Discoverable via process(action='list') ...
+    listed = {s["session_id"]: s for s in registry.list_sessions()}
+    assert "proc_sandbox_deadonarrival" in listed
+    assert listed["proc_sandbox_deadonarrival"]["status"] == "exited"
+
+    # ... and via process(action='poll').
+    polled = registry.poll("proc_sandbox_deadonarrival")
+    assert polled["status"] == "exited"
+    assert polled["exit_code"] == -1
+    assert polled["completion_reason"] == "failed_start"
+
+
+# =========================================================================
+# Real local spawns (no mocking of spawn_local/observe_local_startup) --
+# exercise the actual startup-observation + classification path end to end.
+# =========================================================================
+
+def _run_real_local_background(monkeypatch, tmp_path, command, *, observe_timeout=5.0):
+    """Runs terminal_tool(background=True) against a REAL local subprocess.
+
+    ``observe_local_startup`` is NOT mocked away, but its effective timeout
+    is widened for the test: the production default is deliberately brief
+    (so healthy long-lived processes never feel a startup delay), which
+    makes CI/dev-host shell-startup jitter (a login shell can take a few
+    hundred ms end-to-end depending on host/profile) a source of flakiness
+    if we rely on it. Calling the *real* implementation with a longer
+    ``timeout`` keeps this an end-to-end test of the real code path while
+    removing that timing sensitivity.
+    """
+    mock_env = MagicMock()
+    mock_env.env = {}
+    _patch_common(monkeypatch, tmp_path, mock_env)
+
+    from tools import process_registry as process_registry_module
+
+    real_observe = process_registry_module.process_registry.observe_local_startup
+    monkeypatch.setattr(
+        process_registry_module.process_registry,
+        "observe_local_startup",
+        lambda session, timeout=observe_timeout, interval=0.02: real_observe(
+            session, timeout=timeout, interval=interval
+        ),
+    )
+
+    result = None
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(command=command, background=True)
+        )
+        return result
+    finally:
+        # Best-effort cleanup: don't leak a real subprocess out of the test
+        # (harmless no-op if the session already exited on its own).
+        session_id = (result or {}).get("session_id")
+        if session_id:
+            process_registry_module.process_registry.kill_process(session_id)
+
+
+def test_real_local_command_that_fails_immediately_is_not_reported_as_started(monkeypatch, tmp_path):
+    """A real local command that exits nonzero almost instantly must be
+    reported as a genuine command failure -- not a fake "Background process
+    started" success, and not mislabeled "failed_start" (the shell/process
+    genuinely launched; the command it ran just failed)."""
+    result = _run_real_local_background(monkeypatch, tmp_path, "false")
+
+    assert result["output"] != "Background process started"
+    assert result["error"], "an immediately-failing command must report an error"
+    assert result["exit_code"] not in (0, None)
+    assert result["status"] != "failed_start"
+
+
+def test_real_local_fast_success_is_not_reported_as_failed_start(monkeypatch, tmp_path):
+    """A real local command that succeeds almost instantly (`true`) must be
+    reported as a success -- never as failed_start, and never with an error."""
+    result = _run_real_local_background(monkeypatch, tmp_path, "true")
+
+    assert result["status"] != "failed_start"
+    assert result["error"] is None
+    assert result["exit_code"] == 0

--- a/tests/tools/test_terminal_background_spawn_failure.py
+++ b/tests/tools/test_terminal_background_spawn_failure.py
@@ -1,0 +1,247 @@
+"""Background spawn failure reporting and failed-session observability.
+
+``terminal(background=true)`` used to return a fake ``Background process
+started`` payload when ``spawn_via_env`` produced a dead-on-arrival session
+(no PID, ``completion_reason == "failed_start"``). The session was also
+never registered, so ``process(action='list'/'poll')`` answered empty /
+``not_found``.
+
+These tests drive the public ``terminal_tool`` + ``process`` surfaces against
+a fake non-local environment so they exercise ``spawn_via_env``, not the
+local ``Popen`` path. They do not claim that a long-running command that
+fails to launch inside a real sandbox is made to start.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+from tools.process_registry import (
+    MAX_PROCESSES,
+    ProcessSession,
+    _handle_process,
+    process_registry,
+)
+
+
+def _non_local_config(**overrides):
+    config = {
+        "env_type": "ssh",
+        "timeout": 60,
+        "cwd": "/tmp",
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+        "lifetime_seconds": 3600,
+    }
+    config.update(overrides)
+    return config
+
+
+class _BrokenSpawnEnvironment:
+    """Non-local backend whose background wrapper never emits a PID."""
+
+    env: dict = {}
+
+    def execute(self, command, timeout=None, rewrite_compound_background=False, **kwargs):
+        return {
+            "output": "bash: /sandbox/tmp/hermes_bg.pid: Read-only file system",
+            "returncode": 1,
+        }
+
+
+class _HealthySpawnEnvironment:
+    """Non-local backend whose wrapper prints a PID — a real launch."""
+
+    env: dict = {}
+
+    def execute(self, command, timeout=None, rewrite_compound_background=False, **kwargs):
+        return {"output": "4242", "returncode": 0}
+
+
+@pytest.fixture
+def background_env(monkeypatch):
+    """Route terminal_tool at a caller-supplied fake non-local environment."""
+
+    def _install(environment, task_id="default"):
+        monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _non_local_config())
+        monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+        monkeypatch.setattr(
+            terminal_tool,
+            "_check_all_guards",
+            lambda command, env_type, **kwargs: {"approved": True},
+        )
+        monkeypatch.setitem(terminal_tool._active_environments, task_id, environment)
+        monkeypatch.setitem(terminal_tool._last_activity, task_id, 0.0)
+        return task_id
+
+    with process_registry._lock:
+        pre_running = set(process_registry._running)
+        pre_finished = set(process_registry._finished)
+
+    yield _install
+
+    with process_registry._lock:
+        leaked_running = [
+            process_registry._running.pop(session_id)
+            for session_id in list(process_registry._running)
+            if session_id not in pre_running
+        ]
+        for session_id in list(process_registry._finished):
+            if session_id not in pre_finished:
+                process_registry._finished.pop(session_id, None)
+    for session in leaked_running:
+        session.exited = True
+        thread = getattr(session, "_reader_thread", None)
+        if thread is not None:
+            thread.join(timeout=10)
+            assert not thread.is_alive(), f"poller thread {thread.name} outlived the test"
+
+
+def test_non_local_no_pid_failed_start_returns_failure(background_env):
+    task_id = background_env(_BrokenSpawnEnvironment())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            command="azcopy sync foo bar", background=True, task_id=task_id
+        )
+    )
+
+    assert result.get("error")
+    assert result.get("exit_code") not in (0, None)
+    assert result.get("output") != "Background process started"
+    assert result.get("status") == "failed_start"
+
+
+def test_failure_output_and_exit_status_are_preserved(background_env):
+    task_id = background_env(_BrokenSpawnEnvironment())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            command="azcopy sync foo bar", background=True, task_id=task_id
+        )
+    )
+
+    assert result["exit_code"] == 1
+    combined = f"{result.get('output') or ''} {result.get('error') or ''}"
+    assert "Read-only file system" in combined
+
+
+def test_failed_session_visible_in_process_list(background_env):
+    task_id = background_env(_BrokenSpawnEnvironment())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            command="azcopy sync foo bar", background=True, task_id=task_id
+        )
+    )
+    session_id = result["session_id"]
+
+    listed = json.loads(_handle_process({"action": "list"}, task_id=task_id))
+    by_id = {row["session_id"]: row for row in listed["processes"]}
+    assert session_id in by_id
+    assert by_id[session_id]["status"] == "exited"
+
+
+def test_failed_session_is_pollable(background_env):
+    task_id = background_env(_BrokenSpawnEnvironment())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            command="azcopy sync foo bar", background=True, task_id=task_id
+        )
+    )
+    session_id = result["session_id"]
+
+    polled = json.loads(_handle_process({"action": "poll", "session_id": session_id}))
+    assert polled.get("status") != "not_found"
+    assert polled["status"] == "exited"
+    assert polled["completion_reason"] == "failed_start"
+    assert polled["exit_code"] == 1
+
+
+def test_successful_background_launch_unchanged(background_env):
+    task_id = background_env(_HealthySpawnEnvironment())
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            command="./run-server.sh", background=True, task_id=task_id
+        )
+    )
+
+    assert result.get("error") is None
+    assert result.get("exit_code") == 0
+    assert result["output"] == "Background process started"
+    assert result["session_id"]
+    assert result["pid"] == 4242
+
+    polled = process_registry.poll(result["session_id"])
+    assert polled.get("status") != "not_found"
+    assert polled["status"] == "running"
+
+
+def test_immediately_completed_success_is_not_failed_start(background_env, monkeypatch):
+    """A spawn that already finished with exit 0 is not a launch failure."""
+    task_id = background_env(_HealthySpawnEnvironment())
+    completed = ProcessSession(
+        id="proc_fast_ok",
+        command="true",
+        task_id=task_id,
+        started_at=0.0,
+        pid=4242,
+        exited=True,
+        exit_code=0,
+        completion_reason="exited",
+        output_buffer="ok\n",
+    )
+    process_registry._finished[completed.id] = completed
+
+    monkeypatch.setattr(
+        process_registry,
+        "spawn_via_env",
+        lambda **_kwargs: completed,
+    )
+
+    result = json.loads(
+        terminal_tool.terminal_tool(command="true", background=True, task_id=task_id)
+    )
+
+    assert result.get("status") != "failed_start"
+    assert result.get("error") is None
+    assert result.get("exit_code") == 0
+    assert result.get("session_id") == "proc_fast_ok"
+    assert result.get("output") != "Background process started"
+
+
+def test_registry_lifecycle_stays_bounded_after_failed_starts():
+    from tools.process_registry import ProcessRegistry
+
+    registry = ProcessRegistry()
+    now = time.time()
+    for i in range(MAX_PROCESSES):
+        session = ProcessSession(
+            id=f"proc_old_{i}",
+            command="sleep 1",
+            started_at=now - i,
+            exited=True,
+            exit_code=0,
+        )
+        registry._finished[session.id] = session
+
+    class RaisingEnv:
+        def execute(self, command, **kwargs):
+            raise RuntimeError("sandbox unreachable")
+
+    failed = registry.spawn_via_env(RaisingEnv(), "azcopy sync foo bar")
+    total = len(registry._running) + len(registry._finished)
+    assert total <= MAX_PROCESSES
+    assert failed.id in registry._finished
+    assert failed.id not in registry._running
+    assert len(registry._finished) == MAX_PROCESSES

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -928,9 +928,18 @@ class ProcessRegistry:
             self._prune_if_needed()
             if not session.exited:
                 self._running[session.id] = session
+            else:
+                # A launch failure still gets a durable record: without this,
+                # the session vanishes the moment this call returns and is
+                # invisible to a later process(action='list'/'poll'), even
+                # though the caller was handed this session's id (#75675 —
+                # "TUI: background terminal processes silently fail to
+                # start"). Registering it as already-finished lets any
+                # caller confirm the failure and read the captured output
+                # after the fact, not just the immediate return value.
+                self._finished[session.id] = session
 
-        if not session.exited:
-            self._write_checkpoint()
+        self._write_checkpoint()
 
         return session
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -834,6 +834,47 @@ class ProcessRegistry:
 
         return session
 
+    # Bounded local-startup observation window (seconds). Long enough to
+    # catch "command not found" / permission-denied class failures (the
+    # login shell launches instantly and a missing binary fails within a
+    # few milliseconds), short enough that healthy long-lived processes
+    # (servers, watchers) never feel a startup delay -- they simply outlive
+    # the window and fall through unaffected.
+    _LOCAL_STARTUP_OBSERVATION_SECONDS = 0.2
+    _LOCAL_STARTUP_POLL_INTERVAL_SECONDS = 0.02
+
+    def observe_local_startup(
+        self,
+        session: "ProcessSession",
+        timeout: float = _LOCAL_STARTUP_OBSERVATION_SECONDS,
+        interval: float = _LOCAL_STARTUP_POLL_INTERVAL_SECONDS,
+    ) -> None:
+        """Give a freshly spawned local background process a brief window to
+        fail immediately before the caller reports blanket "started" success.
+
+        ``spawn_local`` always succeeds at the ``Popen`` level -- the user's
+        login shell launches fine -- even when the *command inside* the shell
+        is bogus (``command not found`` exits the shell with rc 127 almost
+        instantly). Nothing observes that until the async reader thread's
+        ``finally`` block runs, or a later ``process(action='poll')`` call
+        happens to reconcile it. Without this, a dead-on-arrival local
+        command is reported as a live, successfully-started background
+        process (the same silent-failure symptom as #75675, on the local
+        path instead of ``spawn_via_env``).
+
+        Safe no-op for PTY sessions and anything without a real ``Popen``
+        handle (``_reconcile_local_exit`` already guards that); such
+        sessions return immediately without waiting out the window.
+        """
+        if session is None or session.exited or session.process is None:
+            return
+        deadline = time.monotonic() + max(timeout, 0.0)
+        while True:
+            self._reconcile_local_exit(session)
+            if session.exited or time.monotonic() >= deadline:
+                return
+            time.sleep(interval)
+
     def spawn_via_env(
         self,
         env: Any,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1304,7 +1304,13 @@ class ProcessRegistry:
             if not session.exited:
                 self._running[session.id] = session
 
-        if not session.exited:
+        if session.exited:
+            # Keep dead-on-arrival launches discoverable. Skipping
+            # ``_running`` is deliberate (this is not a live process), but
+            # dropping the session entirely made process(list/poll) return
+            # empty/not_found for an id the caller just received.
+            self._move_to_finished(session)
+        else:
             self._write_checkpoint()
 
         return session

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2557,6 +2557,12 @@ def terminal_tool(
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
                     )
+                    # Local spawns always succeed at the Popen level (the
+                    # login shell launches fine) even when the command
+                    # *inside* the shell is bogus -- give it a brief window
+                    # to fail immediately (command-not-found, permission
+                    # denied) before we report blanket success below.
+                    process_registry.observe_local_startup(proc_session)
                 else:
                     proc_session = process_registry.spawn_via_env(
                         env=env,
@@ -2566,31 +2572,73 @@ def terminal_tool(
                         session_key=session_key,
                     )
 
-                # Non-local backends (spawn_via_env) can fail to launch the
-                # command (no PID captured, e.g. sandbox exec error) without
-                # raising -- they return a session with exited=True instead
-                # of a live one, and that session is never registered in the
-                # process registry's tracking tables. Reporting the generic
-                # "Background process started" success here would tell the
-                # agent (and the user) a process is running when nothing
-                # ever started, with no way to discover the failure via
+                # Both spawn paths can produce an already-exited session by
+                # the time we get here:
+                #   - spawn_via_env can fail to launch the command at all
+                #     (no PID captured, e.g. sandbox exec error) -- always
+                #     completion_reason == "failed_start".
+                #   - spawn_local + observe_local_startup can observe a real
+                #     launch that exited almost instantly, either with an
+                #     error (command not found, bad args) or genuine fast
+                #     success (`echo hi`, `true`).
+                # Reporting the generic "Background process started" success
+                # for any of these would tell the agent (and the user) a
+                # process is running when it never did (or already finished),
+                # with no way to discover the truth via
                 # process(action='list'/'poll') afterward (#75675: "TUI:
                 # background terminal processes silently fail to start").
-                # Surface the real failure immediately instead.
+                # Classify and surface the real outcome instead of a blunt
+                # "exited implies failed_start".
                 if proc_session.exited:
                     failure_detail = (
                         proc_session.output_buffer.strip()
                         or f"process exited immediately (reason: {proc_session.completion_reason})"
                     )
+                    exit_code = (
+                        proc_session.exit_code
+                        if proc_session.exit_code is not None else -1
+                    )
+                    if proc_session.completion_reason == "failed_start":
+                        # The command never actually launched -- nothing to
+                        # point process(action='poll'/'log') at except this
+                        # payload.
+                        return json.dumps({
+                            "output": "",
+                            "session_id": proc_session.id,
+                            "exit_code": exit_code,
+                            "error": f"Failed to start background process: {failure_detail}",
+                            "status": "failed_start",
+                        }, ensure_ascii=False)
+                    if exit_code != 0:
+                        # The process DID launch (real PID, real tracked
+                        # session) but the command itself failed and exited
+                        # before we could observe it "running". This is a
+                        # command error, not a launch failure -- report the
+                        # real exit code/output instead of a misleading
+                        # "couldn't start" message.
+                        return json.dumps({
+                            "output": proc_session.output_buffer,
+                            "session_id": proc_session.id,
+                            "pid": proc_session.pid,
+                            "exit_code": exit_code,
+                            "error": (
+                                f"Background process exited immediately with "
+                                f"exit code {exit_code}: {failure_detail}"
+                            ),
+                            "status": "exited",
+                        }, ensure_ascii=False)
+                    # exit_code == 0: the command started, ran, and finished
+                    # successfully within the brief startup observation
+                    # window (e.g. `echo hi`, `true`). Report it as a real
+                    # completed run -- it is neither "still starting" nor a
+                    # failure.
                     return json.dumps({
-                        "output": "",
+                        "output": proc_session.output_buffer or "Background process completed successfully",
                         "session_id": proc_session.id,
-                        "exit_code": (
-                            proc_session.exit_code
-                            if proc_session.exit_code is not None else -1
-                        ),
-                        "error": f"Failed to start background process: {failure_detail}",
-                        "status": "failed_start",
+                        "pid": proc_session.pid,
+                        "exit_code": 0,
+                        "error": None,
+                        "status": "completed",
                     }, ensure_ascii=False)
 
                 result_data = {

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2566,6 +2566,33 @@ def terminal_tool(
                         session_key=session_key,
                     )
 
+                # Non-local backends (spawn_via_env) can fail to launch the
+                # command (no PID captured, e.g. sandbox exec error) without
+                # raising -- they return a session with exited=True instead
+                # of a live one, and that session is never registered in the
+                # process registry's tracking tables. Reporting the generic
+                # "Background process started" success here would tell the
+                # agent (and the user) a process is running when nothing
+                # ever started, with no way to discover the failure via
+                # process(action='list'/'poll') afterward (#75675: "TUI:
+                # background terminal processes silently fail to start").
+                # Surface the real failure immediately instead.
+                if proc_session.exited:
+                    failure_detail = (
+                        proc_session.output_buffer.strip()
+                        or f"process exited immediately (reason: {proc_session.completion_reason})"
+                    )
+                    return json.dumps({
+                        "output": "",
+                        "session_id": proc_session.id,
+                        "exit_code": (
+                            proc_session.exit_code
+                            if proc_session.exit_code is not None else -1
+                        ),
+                        "error": f"Failed to start background process: {failure_detail}",
+                        "status": "failed_start",
+                    }, ensure_ascii=False)
+
                 result_data = {
                     "output": "Background process started",
                     "session_id": proc_session.id,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3092,6 +3092,58 @@ def terminal_tool(
                         session_key=session_key,
                     )
 
+                if getattr(proc_session, "exited", False):
+                    # spawn_via_env can return already-exited (no PID /
+                    # execute exception). Classify instead of reporting
+                    # fake "Background process started" success. Do not
+                    # treat every immediate exit as failed_start: exit 0
+                    # is a completed command; nonzero without failed_start
+                    # is a command error.
+                    from agent.redact import redact_terminal_output
+
+                    captured = redact_terminal_output(
+                        getattr(proc_session, "output_buffer", "") or "",
+                        command,
+                        force=True,
+                    )
+                    exit_code = getattr(proc_session, "exit_code", None)
+                    if exit_code is None:
+                        exit_code = -1
+                    reason = getattr(proc_session, "completion_reason", "") or ""
+                    if reason == "failed_start":
+                        detail = captured or "process never produced a PID"
+                        return json.dumps({
+                            "output": captured,
+                            "session_id": proc_session.id,
+                            "pid": proc_session.pid,
+                            "exit_code": exit_code,
+                            "error": _redact_terminal_error_text(
+                                f"Failed to start background process: {detail}"
+                            ),
+                            "status": "failed_start",
+                        }, ensure_ascii=False)
+                    if exit_code != 0:
+                        detail = captured or f"process exited immediately (reason: {reason})"
+                        return json.dumps({
+                            "output": captured,
+                            "session_id": proc_session.id,
+                            "pid": proc_session.pid,
+                            "exit_code": exit_code,
+                            "error": _redact_terminal_error_text(
+                                f"Background process exited immediately with "
+                                f"exit code {exit_code}: {detail}"
+                            ),
+                            "status": "exited",
+                        }, ensure_ascii=False)
+                    return json.dumps({
+                        "output": captured or "Background process completed successfully",
+                        "session_id": proc_session.id,
+                        "pid": proc_session.pid,
+                        "exit_code": 0,
+                        "error": None,
+                        "status": "exited",
+                    }, ensure_ascii=False)
+
                 result_data = {
                     "output": "Background process started",
                     "session_id": proc_session.id,


### PR DESCRIPTION
## What does this PR do?

`terminal(background=true)` used to return a fake `"Background process started"`
payload when the non-local `spawn_via_env` path produced a dead-on-arrival session
(no PID, `completion_reason == "failed_start"`). The session was also dropped from
the process registry, so later `process(action='list'/'poll')` answered empty /
`not_found`.

This PR:

- returns a truthful `status=failed_start` error payload (output + exit preserved,
  secrets redacted with `force=True`)
- registers the failed session via `_move_to_finished` so it stays listable and
  pollable
- distinguishes an immediately successful exit (`exit_code == 0`) from a failed
  start
- keeps a healthy in-flight background launch on the existing started + running
  contract
- keeps the finished-registry lifecycle bounded (`MAX_PROCESSES`)

This is **failure reporting + observability only**. The underlying sandbox launch
failure is **not** repaired. This PR does **not** claim that a long-running
process is made to start. Local long-running spawn already works on current
main; the remaining hole is non-local no-PID `spawn_via_env`.

## Related

Related to issue 75675 (observability slice). This PR does **not** close that issue.

Salvage of this PR's keep_open path (Teknium: cover `spawn_via_env` and public
list/poll discoverability). Competing open PR #78199 reports the same failed start
but omits the session id instead of retaining `_finished`. This PR keeps the
discoverable-id contract from the keep_open review and does not adopt hide-id.

Rebased onto `upstream/main` `74f99af470ae8ce47f0903cf431d106cecbd37f2`.
Tip: `fdb16f69c671ca87ac347bca988d3b7b41c3022d`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/process_registry.py` — dead-on-arrival `spawn_via_env` sessions go through `_move_to_finished`
- `tools/terminal_tool.py` — classify already-exited background spawns; redact captured output
- `tests/tools/test_terminal_background_spawn_failure.py` — public-surface spawn-failure + list/poll tests
- `tests/tools/test_process_registry.py` — failed launch remains listable in `_finished`

Dropped from the earlier head of this PR: `observe_local_startup` (that was an
expansion, not the observability salvage).

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_terminal_background_spawn_failure.py tests/tools/test_process_registry.py -k "test_non_local_no_pid or test_failure_output or test_failed_session or test_successful_background or test_immediately_completed or test_registry_lifecycle or test_spawn_via_env_checks_returncode" -q
```

Expect 8 passed. Confirm:

- no-PID `spawn_via_env` returns `status=failed_start` with an error (not fake start)
- `process(list)` and `process(poll)` can find that session id
- exit-0 already-completed is **not** `failed_start` and **not** `"Background process started"`
- healthy background launch still returns started + pollable `running`
- registry stays at `MAX_PROCESSES` after a failed start

No live Docker/SSH E2E; tests drive a fake `env.execute()` that returns no PID.

## Checklist

- [x] Conventional Commits
- [x] Tests added
- [x] Does **not** claim to close issue 75675
- [x] Does **not** hide the session id (#78199 contract is a human choice, not this PR)
