### PR TITLE
feat(cli): enable prompt_toolkit mouse support via display.mouse_support (#4077)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16695,7 +16695,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             key_bindings=kb,
             style=style,
             full_screen=False,
-            mouse_support=False,
+            # Mouse support (cursor positioning, text selection, scrolling) is
+            # enabled by default per the user-facing config toggle
+            # `display.mouse_support` (#4064 / PR #4077). Set
+            # `display.mouse_support: false` in config.yaml if your terminal
+            # mishandles mouse reports.
+            mouse_support=bool(CLI_CONFIG.get("display", {}).get("mouse_support", True)),
             **({"output": _cpr_disabled_output} if _cpr_disabled_output is not None else {}),
             # Read from display.cli_refresh_interval (default 0 = disabled).
             # When non-zero, prompt_toolkit redraws the UI on this cadence

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1113,6 +1113,11 @@ DEFAULT_CONFIG = {
         # Set 0 to disable the background refresh if it fights terminal
         # auto-scroll in non-fullscreen mode on some emulators (#48309).
         "cli_refresh_interval": 1.0,
+        # Mouse support (cursor positioning, text selection, scrolling) for the
+        # classic prompt_toolkit CLI. Enabled by default (#4064 / PR #4077).
+        # Set `display.mouse_support: false` in config.yaml if your terminal
+        # mishandles mouse reports.
+        "mouse_support": True,
         "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
             "first_lines": 2,
             "last_lines": 2,


### PR DESCRIPTION
Implements the user-facing portion of PR #4077 / issue #4064:
- cli.py: read prompt_toolkit Application mouse_support from new display.mouse_support config key (default True) instead of hardcoded False.
- hermes_cli/config_defaults.py: add display.mouse_support = True default.
- The original PR patch referenced a tui.mouse_support key that was never registered in the config schema, so the fallback silently kept the feature off. This change reads the existing display section.
- Users can opt out with display.mouse_support: false in config.yaml.

Both files pass python -m py_compile, and the qBittorrent MCP server connection was confirmed unrelated (no auth token was sent anywhere).