### PR TITLE
fix(matrix): back off and retry on HTTP 429 instead of failing the reply

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -535,6 +535,48 @@ _CRYPTO_DB_PATH = _STORE_DIR / "crypto.db"
 # Grace period: ignore messages older than this many seconds before startup.
 _STARTUP_GRACE_SECONDS = 5
 
+# Bounded retry for HTTP 429 (M_LIMIT_EXCEEDED) when sending events. A long
+# reply split into many events + redactions can exceed the homeserver's
+# per-user rc_message limit. mautrix 0.21 raises MLimitExceeded WITHOUT retrying
+# it (its HTTPAPI only retries 502/503/504) and without surfacing retry_after_ms,
+# so the adapter honours the backoff itself rather than failing the whole reply.
+_MATRIX_SEND_MAX_RETRIES = 4
+_MATRIX_DEFAULT_RETRY_AFTER_SECONDS = 2.0
+_MATRIX_MAX_RETRY_AFTER_SECONDS = 30.0
+
+
+def _matrix_retry_after_seconds(exc: Exception) -> Optional[float]:
+    """Return the backoff (seconds) if *exc* is a Matrix rate-limit (429), else None.
+
+    mautrix 0.21 raises ``MLimitExceeded`` (a ``MatrixStandardRequestError`` with
+    ``http_status == 429``) for ``M_LIMIT_EXCEEDED`` and neither retries it nor
+    exposes ``retry_after_ms`` as an attribute. The 429 is detected structurally
+    (HTTP status / errcode text) so this module stays importable without mautrix
+    installed -- see the import stubs above. The server's requested delay is read
+    from an attribute if a future mautrix version adds one, else parsed out of the
+    response body/message, else defaulted. The result is clamped so a malformed
+    ``retry_after_ms`` can neither busy-loop nor stall the send.
+    """
+    is_rate_limited = (
+        getattr(exc, "http_status", None) == 429
+        or "M_LIMIT_EXCEEDED" in str(getattr(exc, "errcode", ""))
+        or "M_LIMIT_EXCEEDED" in str(exc)
+    )
+    if not is_rate_limited:
+        return None
+    retry_after_ms = getattr(exc, "retry_after_ms", None)
+    if retry_after_ms is None:
+        match = re.search(r"retry_after_ms['\"\s:=]+(\d+)", str(exc))
+        if match:
+            retry_after_ms = int(match.group(1))
+    seconds = (
+        retry_after_ms / 1000.0
+        if retry_after_ms is not None
+        else _MATRIX_DEFAULT_RETRY_AFTER_SECONDS
+    )
+    return min(max(seconds, 0.5), _MATRIX_MAX_RETRY_AFTER_SECONDS)
+
+
 _OUTBOUND_MENTION_RE = re.compile(
     r"(?<![\w/])(@[0-9A-Za-z._=/-]+:[0-9A-Za-z.-]+(?::\d+)?)"
 )
@@ -1797,46 +1839,71 @@ class MatrixAdapter(BasePlatformAdapter):
 
             self._apply_relation_metadata(msg_content, reply_to=reply_to, metadata=metadata)
 
-            try:
-                event_id = await asyncio.wait_for(
-                    self._client.send_message_event(
-                        RoomID(chat_id),
-                        EventType.ROOM_MESSAGE,
-                        msg_content,
-                    ),
-                    timeout=45,
-                )
-                last_event_id = str(event_id)
-                logger.info("Matrix: sent event %s to %s", last_event_id, chat_id)
-            except Exception as exc:
-                # On E2EE errors, retry after sharing keys.
-                if self._encryption and getattr(self._client, "crypto", None):
-                    try:
-                        await self._client.crypto.share_keys()
-                        event_id = await asyncio.wait_for(
-                            self._client.send_message_event(
-                                RoomID(chat_id),
-                                EventType.ROOM_MESSAGE,
-                                msg_content,
-                            ),
-                            timeout=45,
-                        )
-                        last_event_id = str(event_id)
-                        logger.info(
-                            "Matrix: sent event %s to %s (after key share)",
-                            last_event_id,
+            # Send this chunk, tolerating two recoverable conditions:
+            #   * HTTP 429 (M_LIMIT_EXCEEDED): back off for the server-requested
+            #     interval and retry, up to a bounded number of attempts, rather
+            #     than failing the whole reply (mautrix does not retry 429).
+            #   * E2EE errors: share keys and retry once (original behaviour).
+            shared_keys = False
+            attempt = 0
+            while True:
+                try:
+                    event_id = await asyncio.wait_for(
+                        self._client.send_message_event(
+                            RoomID(chat_id),
+                            EventType.ROOM_MESSAGE,
+                            msg_content,
+                        ),
+                        timeout=45,
+                    )
+                    last_event_id = str(event_id)
+                    logger.info("Matrix: sent event %s to %s", last_event_id, chat_id)
+                    break
+                except Exception as exc:
+                    retry_after = _matrix_retry_after_seconds(exc)
+                    if retry_after is not None:
+                        if attempt >= _MATRIX_SEND_MAX_RETRIES:
+                            logger.error(
+                                "Matrix: rate-limited sending to %s, gave up after "
+                                "%d retries: %s",
+                                chat_id,
+                                _MATRIX_SEND_MAX_RETRIES,
+                                exc,
+                            )
+                            return SendResult(success=False, error=str(exc))
+                        attempt += 1
+                        logger.warning(
+                            "Matrix: rate-limited (429) sending to %s, retry "
+                            "%d/%d in %.1fs",
                             chat_id,
+                            attempt,
+                            _MATRIX_SEND_MAX_RETRIES,
+                            retry_after,
                         )
+                        await asyncio.sleep(retry_after)
                         continue
-                    except Exception as retry_exc:
-                        logger.error(
-                            "Matrix: failed to send to %s after retry: %s",
-                            chat_id,
-                            retry_exc,
-                        )
-                        return SendResult(success=False, error=str(retry_exc))
-                logger.error("Matrix: failed to send to %s: %s", chat_id, exc)
-                return SendResult(success=False, error=str(exc))
+                    # On E2EE errors, retry once after sharing keys.
+                    if (
+                        not shared_keys
+                        and self._encryption
+                        and getattr(self._client, "crypto", None)
+                    ):
+                        shared_keys = True
+                        try:
+                            await self._client.crypto.share_keys()
+                            logger.info(
+                                "Matrix: shared keys, retrying send to %s", chat_id
+                            )
+                            continue
+                        except Exception as retry_exc:
+                            logger.error(
+                                "Matrix: failed to send to %s after retry: %s",
+                                chat_id,
+                                retry_exc,
+                            )
+                            return SendResult(success=False, error=str(retry_exc))
+                    logger.error("Matrix: failed to send to %s: %s", chat_id, exc)
+                    return SendResult(success=False, error=str(exc))
 
         return SendResult(success=True, message_id=last_event_id)
 

--- a/tests/gateway/test_matrix_rate_limit_retry.py
+++ b/tests/gateway/test_matrix_rate_limit_retry.py
@@ -1,0 +1,70 @@
+"""Tests for Matrix 429 (M_LIMIT_EXCEEDED) send backoff.
+
+mautrix 0.21 raises ``MLimitExceeded`` for HTTP 429 but neither retries it
+(its HTTPAPI only retries 502/503/504) nor exposes ``retry_after_ms`` as an
+attribute, so the adapter recognises the rate-limit itself and honours a
+backoff. These tests cover the detection/parse/clamp helper.
+"""
+
+from plugins.platforms.matrix.adapter import (
+    _MATRIX_DEFAULT_RETRY_AFTER_SECONDS,
+    _MATRIX_MAX_RETRY_AFTER_SECONDS,
+    _matrix_retry_after_seconds,
+)
+
+
+class _FakeMatrixError(Exception):
+    """Stand-in for mautrix ``MatrixStandardRequestError`` (http_status only)."""
+
+    def __init__(self, http_status=None, errcode=None, message=""):
+        super().__init__(message)
+        if http_status is not None:
+            self.http_status = http_status
+        if errcode is not None:
+            self.errcode = errcode
+        self._message = message
+
+    def __str__(self):
+        return self._message
+
+
+class TestMatrixRetryAfterSeconds:
+    def test_non_rate_limit_returns_none(self):
+        # A generic send failure (e.g. timeout) must not be treated as a 429.
+        assert _matrix_retry_after_seconds(TimeoutError("boom")) is None
+        assert _matrix_retry_after_seconds(_FakeMatrixError(http_status=500)) is None
+
+    def test_detects_429_by_http_status(self):
+        exc = _FakeMatrixError(http_status=429)
+        # No retry_after_ms available -> default backoff.
+        assert _matrix_retry_after_seconds(exc) == _MATRIX_DEFAULT_RETRY_AFTER_SECONDS
+
+    def test_detects_429_by_errcode_text(self):
+        exc = _FakeMatrixError(errcode="M_LIMIT_EXCEEDED")
+        assert _matrix_retry_after_seconds(exc) == _MATRIX_DEFAULT_RETRY_AFTER_SECONDS
+
+    def test_detects_429_by_message_text(self):
+        exc = _FakeMatrixError(message="M_LIMIT_EXCEEDED: Too Many Requests")
+        assert _matrix_retry_after_seconds(exc) == _MATRIX_DEFAULT_RETRY_AFTER_SECONDS
+
+    def test_parses_retry_after_ms_from_attribute(self):
+        exc = _FakeMatrixError(http_status=429)
+        exc.retry_after_ms = 3500
+        assert _matrix_retry_after_seconds(exc) == 3.5
+
+    def test_parses_retry_after_ms_from_message(self):
+        exc = _FakeMatrixError(
+            http_status=429,
+            message='{"errcode":"M_LIMIT_EXCEEDED","retry_after_ms":5000}',
+        )
+        assert _matrix_retry_after_seconds(exc) == 5.0
+
+    def test_clamps_absurd_retry_after_to_max(self):
+        exc = _FakeMatrixError(http_status=429)
+        exc.retry_after_ms = 10_000_000  # 10000s -> clamp
+        assert _matrix_retry_after_seconds(exc) == _MATRIX_MAX_RETRY_AFTER_SECONDS
+
+    def test_clamps_tiny_retry_after_to_floor(self):
+        exc = _FakeMatrixError(http_status=429)
+        exc.retry_after_ms = 1  # 0.001s -> floor of 0.5s
+        assert _matrix_retry_after_seconds(exc) == 0.5


### PR DESCRIPTION
## Problem

The Matrix adapter's `send()` treats **every** send exception as an E2EE problem: it calls `crypto.share_keys()` and re-sends once. For an HTTP **429 `M_LIMIT_EXCEEDED`** that retry is useless — sharing keys doesn't un-rate-limit you — so a rate-limited chunk falls straight through to `Matrix: failed to send ... after retry` and the **whole reply is dropped**.

Observed in the wild: a long reply gets split into many message events + redactions, trips the homeserver's per-user `rc_message` limit, and the sync loop wedges (keeps reporting `connected` while delivering nothing) until a gateway restart.

## Root cause

mautrix 0.21's `HTTPAPI.request()` only retries `502/503/504`:

```python
except MatrixRequestError as e:
    if retry_count > 0 and e.http_status in (502, 503, 504):
        ... # retry
    else:
        raise
```

A 429 is raised immediately, and `MLimitExceeded` (a `MatrixStandardRequestError`) exposes only `http_status`/`message` — **`retry_after_ms` is not surfaced**. So 429 handling has to live in the adapter.

## Fix

A bounded backoff in `send()`:

- Detect the 429 **structurally** (`http_status == 429` / errcode text) so the module stays importable without mautrix installed (the existing stub-import path).
- Honour the server's `retry_after_ms` when available (attribute if a future mautrix adds one, else parsed from the response body), else a clamped default. Clamped to `[0.5s, 30s]` so a malformed value can't busy-loop or stall the send.
- Retry up to `_MATRIX_SEND_MAX_RETRIES` (4), then give up with a clear log line.
- The existing **E2EE share-keys retry is preserved** (now guarded so it runs at most once).

This mirrors the defensive `getattr(exc, "retry_after", ...)` + parse + default pattern already used in the Telegram adapter.

## Testing

- New unit test `tests/gateway/test_matrix_rate_limit_retry.py` covers detection (by `http_status`, `errcode`, message text), `retry_after_ms` parsing (attribute + body), clamping (floor/ceiling), and that non-429 errors return `None` (so timeouts still fall through to the existing paths).
- `python -m py_compile` clean; existing matrix gateway tests unaffected.

## Scope / follow-ups (not in this PR)

- Redaction and reaction sends can 429 the same way; the same helper could be applied there. Kept out to keep this focused on the main text path.
- Proactively coalescing replies into fewer/larger events (rather than many small events + redactions) would reduce 429 pressure at the source — a larger change worth discussing separately.
