### PR TITLE
feat(image-gen): add MiniMax image-01 and StepFun step-image-edit-2 backends

### DIFF
--- a/plugins/image_gen/minimax/__init__.py
+++ b/plugins/image_gen/minimax/__init__.py
@@ -1,0 +1,429 @@
+"""MiniMax image generation backend.
+
+Exposes MiniMax's ``image-01`` text-to-image model as an
+:class:`ImageGenProvider` implementation.
+
+Features:
+- Text-to-image generation
+- Eight aspect ratios (1:1, 16:9, 4:3, 3:2, 2:3, 3:4, 9:16, 21:9)
+- 1–9 images per request (we always send ``n=1`` to match the Hermes
+  single-image contract — callers wanting a grid should call repeatedly)
+- Optional prompt-optimizer pass
+- Reproducible generation via ``seed`` kwarg
+- URL or base64 output (we prefer base64 so the gateway has a stable
+  file path; URLs expire after 24h per the MiniMax API spec)
+
+Selection precedence (first hit wins):
+1. ``MINIMAX_IMAGE_MODEL`` env var
+2. ``image_gen.minimax.model`` in ``config.yaml``
+3. :data:`DEFAULT_MODEL`
+
+Docs: https://platform.minimax.io/docs/api-reference/image-generation-t2i
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    save_url_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+# Only one model currently supported by the T2I endpoint. Listed as a dict
+# (not a bare string) so the registry shape matches the multi-model providers
+# — the picker will show whatever's here, and adding a future model is a
+# one-line append.
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "image-01": {
+        "display": "MiniMax image-01",
+        "speed": "~8-15s",
+        "strengths": "Photorealistic, anime, illustration; up to 9 images/request.",
+        "price": "see https://platform.minimax.io/docs/pricing/overview",
+    },
+}
+
+DEFAULT_MODEL = "image-01"
+
+# MiniMax aspect ratio options per the public API spec. The three Hermes
+# canonical ratios are explicit; the rest map through unchanged.
+_MINIMAX_ASPECT_RATIOS = {
+    "landscape": "16:9",
+    "square": "1:1",
+    "portrait": "9:16",
+    "4:3": "4:3",
+    "3:4": "3:4",
+    "3:2": "3:2",
+    "2:3": "2:3",
+    "21:9": "21:9",
+}
+
+# Base URL — international endpoint, matches the LLM provider's MINIMAX_API_KEY
+# semantics (https://api.minimax.io). China users can override with
+# ``MINIMAX_IMAGE_BASE_URL=https://api.minimaxi.com/v1`` if/when the image
+# endpoint mirrors to the CN domain.
+DEFAULT_BASE_URL = "https://api.minimax.io/v1"
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def _load_minimax_config() -> Dict[str, Any]:
+    """Read ``image_gen.minimax`` from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        minimax_section = section.get("minimax") if isinstance(section, dict) else None
+        return minimax_section if isinstance(minimax_section, dict) else {}
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load image_gen.minimax config: %s", exc)
+        return {}
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    """Decide which model to use and return ``(model_id, meta)``."""
+    env_override = os.environ.get("MINIMAX_IMAGE_MODEL")
+    if env_override and env_override in _MODELS:
+        return env_override, _MODELS[env_override]
+
+    cfg = _load_minimax_config()
+    candidate = cfg.get("model") if isinstance(cfg.get("model"), str) else None
+    if candidate and candidate in _MODELS:
+        return candidate, _MODELS[candidate]
+
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_base_url() -> str:
+    """Pick the base URL, honoring ``MINIMAX_IMAGE_BASE_URL`` for China users."""
+    override = os.environ.get("MINIMAX_IMAGE_BASE_URL")
+    if override:
+        return override.rstrip("/")
+    cfg = _load_minimax_config()
+    candidate = cfg.get("base_url") if isinstance(cfg.get("base_url"), str) else None
+    if candidate:
+        return candidate.rstrip("/")
+    return DEFAULT_BASE_URL
+
+
+def _resolve_prompt_optimizer(kwargs: Dict[str, Any]) -> bool:
+    """Read ``prompt_optimizer`` kwarg / config, defaulting to False."""
+    if "prompt_optimizer" in kwargs:
+        return bool(kwargs["prompt_optimizer"])
+    cfg = _load_minimax_config()
+    if isinstance(cfg.get("prompt_optimizer"), bool):
+        return cfg["prompt_optimizer"]
+    return False
+
+
+def _resolve_seed(kwargs: Dict[str, Any]) -> Optional[int]:
+    """Read ``seed`` kwarg, falling back to config. None = random."""
+    if "seed" in kwargs:
+        value = kwargs["seed"]
+        if isinstance(value, int):
+            return value
+    cfg = _load_minimax_config()
+    if isinstance(cfg.get("seed"), int):
+        return cfg["seed"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class MiniMaxImageGenProvider(ImageGenProvider):
+    """MiniMax ``image-01`` backend."""
+
+    @property
+    def name(self) -> str:
+        return "minimax"
+
+    @property
+    def display_name(self) -> str:
+        return "MiniMax"
+
+    def is_available(self) -> bool:
+        return bool(os.environ.get("MINIMAX_API_KEY"))
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta["display"],
+                "speed": meta["speed"],
+                "strengths": meta["strengths"],
+                "price": meta["price"],
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "MiniMax (image-01)",
+            "badge": "paid",
+            "tag": (
+                "image-01 — text-to-image; 8 aspect ratios; "
+                "1–9 images/request; uses MINIMAX_API_KEY"
+            ),
+            "env_vars": [
+                {
+                    "key": "MINIMAX_API_KEY",
+                    "prompt": "MiniMax API key",
+                    "url": "https://platform.minimax.io/user-center/basic-information/interface-key",
+                },
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Generate an image using MiniMax's image-01 endpoint."""
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="minimax",
+                aspect_ratio=aspect,
+            )
+        # MiniMax caps prompts at 1500 chars — surface a clean error rather
+        # than letting the API return a generic 4xx.
+        if len(prompt) > 1500:
+            return error_response(
+                error=(
+                    f"Prompt is {len(prompt)} characters; MiniMax image-01 "
+                    "accepts at most 1500."
+                ),
+                error_type="invalid_argument",
+                provider="minimax",
+                aspect_ratio=aspect,
+            )
+
+        api_key = os.environ.get("MINIMAX_API_KEY", "").strip()
+        if not api_key:
+            return error_response(
+                error=(
+                    "MINIMAX_API_KEY not set. Run `hermes setup` → Image "
+                    "Generation → MiniMax to configure, or get a key at "
+                    "https://platform.minimax.io/."
+                ),
+                error_type="auth_required",
+                provider="minimax",
+                aspect_ratio=aspect,
+            )
+
+        model_id, _meta = _resolve_model()
+        minimax_ar = _MINIMAX_ASPECT_RATIOS.get(aspect, "1:1")
+        base_url = _resolve_base_url()
+        prompt_optimizer = _resolve_prompt_optimizer(kwargs)
+        seed = _resolve_seed(kwargs)
+
+        # Prefer base64 — URLs expire after 24h per MiniMax docs and that
+        # outlives the gateway's intent to ship the file around.
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "prompt": prompt,
+            "aspect_ratio": minimax_ar,
+            "response_format": "base64",
+            "n": 1,
+            "prompt_optimizer": prompt_optimizer,
+        }
+        if seed is not None:
+            payload["seed"] = seed
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            response = requests.post(
+                f"{base_url}/image_generation",
+                headers=headers,
+                json=payload,
+                timeout=120,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            resp = exc.response
+            status = resp.status_code if resp is not None else 0
+            err_msg = ""
+            if resp is not None:
+                try:
+                    body = resp.json()
+                    # MiniMax wraps status under base_resp / data.error.
+                    err_msg = (
+                        body.get("base_resp", {}).get("status_msg")
+                        or body.get("message")
+                        or resp.text[:300]
+                    )
+                except Exception:
+                    err_msg = resp.text[:300]
+            else:
+                err_msg = str(exc)
+            logger.error("MiniMax image gen failed (%d): %s", status, err_msg)
+            return error_response(
+                error=f"MiniMax image generation failed ({status}): {err_msg}",
+                error_type="api_error",
+                provider="minimax",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.Timeout:
+            return error_response(
+                error="MiniMax image generation timed out (120s)",
+                error_type="timeout",
+                provider="minimax",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.ConnectionError as exc:
+            return error_response(
+                error=f"MiniMax connection error: {exc}",
+                error_type="connection_error",
+                provider="minimax",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            result = response.json()
+        except Exception as exc:
+            return error_response(
+                error=f"MiniMax returned invalid JSON: {exc}",
+                error_type="invalid_response",
+                provider="minimax",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        # Per the spec, base_resp.status_code == 0 indicates success. Other
+        # values are MiniMax-specific error codes — surface them precisely
+        # rather than treating the whole response as a generic failure.
+        base_resp = result.get("base_resp") or {}
+        if isinstance(base_resp, dict) and base_resp.get("status_code") not in (None, 0):
+            err_msg = base_resp.get("status_msg") or "unknown MiniMax error"
+            return error_response(
+                error=f"MiniMax image generation failed: {err_msg}",
+                error_type="api_error",
+                provider="minimax",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        # Successful path — extract the first asset from data.image_urls
+        # (or fall through to a b64 field if MiniMax ever adds one).
+        data = result.get("data") or {}
+        image_url: Optional[str] = None
+        if isinstance(data, dict):
+            urls = data.get("image_urls")
+            if isinstance(urls, list) and urls:
+                first = urls[0]
+                if isinstance(first, str) and first.strip():
+                    image_url = first.strip()
+        b64 = data.get("image_base64") if isinstance(data, dict) else None
+        if not b64 and not image_url:
+            # Spec mentions ``data.image_urls`` — but also try the raw b64
+            # fallback ``data.image_base64`` since some MiniMax deployments
+            # use the latter naming. Only fail after exhausting both.
+            return error_response(
+                error="MiniMax returned no image_urls and no base64 data",
+                error_type="empty_response",
+                provider="minimax",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if b64:
+            try:
+                saved_path = save_b64_image(b64, prefix=f"minimax_{model_id}")
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not save image to cache: {exc}",
+                    error_type="io_error",
+                    provider="minimax",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            image_ref = str(saved_path)
+        else:
+            # URL fallback — URLs expire in 24h, so cache locally at
+            # tool-completion time, mirroring xAI's ephemeral-URL guard
+            # (see plugins/image_gen/xai/__init__.py).
+            assert image_url is not None
+            try:
+                saved_path = save_url_image(image_url, prefix=f"minimax_{model_id}")
+            except Exception as exc:
+                logger.warning(
+                    "MiniMax image URL %s could not be cached (%s); falling back to bare URL.",
+                    image_url,
+                    exc,
+                )
+                image_ref = image_url
+            else:
+                image_ref = str(saved_path)
+
+        extra: Dict[str, Any] = {
+            "aspect_ratio_native": minimax_ar,
+            "prompt_optimizer": prompt_optimizer,
+        }
+        if seed is not None:
+            extra["seed"] = seed
+        request_id = result.get("id")
+        if isinstance(request_id, str) and request_id:
+            extra["request_id"] = request_id
+
+        return success_response(
+            image=image_ref,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="minimax",
+            extra=extra,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+
+def register(ctx: Any) -> None:
+    """Register this provider with the image gen registry."""
+    ctx.register_image_gen_provider(MiniMaxImageGenProvider())

--- a/plugins/image_gen/minimax/plugin.yaml
+++ b/plugins/image_gen/minimax/plugin.yaml
@@ -1,0 +1,7 @@
+name: minimax
+version: 1.0.0
+description: "MiniMax image generation backend (image-01). Text-to-image via api.minimax.io."
+author: Hermes Agent
+kind: backend
+requires_env:
+  - MINIMAX_API_KEY

--- a/plugins/image_gen/stepfun/__init__.py
+++ b/plugins/image_gen/stepfun/__init__.py
@@ -1,0 +1,514 @@
+"""StepFun image generation backend.
+
+Exposes StepFun's ``step-image-edit-2`` text-to-image model as an
+:class:`ImageGenProvider` implementation. (The name retains the "-edit-"
+segment because that's what StepFun currently ships; the endpoint serves
+both text-to-image and image-to-image.)
+
+Features:
+- Text-to-image generation
+- Five sizes (1024x1024, 768x1360, 896x1184, 1360x768, 1184x896)
+- Adjustable ``steps`` (1–50, default 8) and ``cfg_scale`` (1.0–10.0,
+  default 1.0) — surfaced as kwargs
+- ``negative_prompt`` (up to 512 chars) — surfaced as kwarg
+- ``text_mode`` toggle for text-rendering optimization — surfaced as kwarg
+- Reproducible generation via ``seed``
+- Base64 or URL output (we prefer base64 so the gateway has a stable
+  file path; URLs expire after 2h per the StepFun API spec)
+
+Selection precedence (first hit wins):
+1. ``STEPFUN_IMAGE_MODEL`` env var
+2. ``image_gen.stepfun.model`` in ``config.yaml``
+3. :data:`DEFAULT_MODEL`
+
+Docs: https://platform.stepfun.ai/docs/en/api-reference/images/image
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    save_url_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+# Per the StepFun image API docs (June 2026), only step-image-edit-2 is
+# currently exposed for the v1/images/generations endpoint. Model dict shape
+# matches the multi-model providers so the picker UX is identical.
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "step-image-edit-2": {
+        "display": "StepFun step-image-edit-2",
+        "speed": "~5-15s",
+        "strengths": (
+            "Fast; configurable steps/cfg_scale; supports negative_prompt; "
+            "good for text rendering."
+        ),
+        "price": "see https://platform.stepfun.ai/docs/pricing/overview",
+    },
+}
+
+DEFAULT_MODEL = "step-image-edit-2"
+
+# Map Hermes's three abstract aspect ratios onto StepFun's size strings.
+# Note: StepFun uses ``{height}x{width}`` ordering for the size param,
+# which is the *opposite* of OpenAI's ``{width}x{height}`` convention.
+_STEPFUN_SIZES = {
+    "landscape": "1360x768",   # 16:9-ish — width > height
+    "square": "1024x1024",
+    "portrait": "768x1360",    # 9:16-ish — height > width
+}
+
+# StepFun default base URL — international endpoint. Override with
+# ``STEPFUN_IMAGE_BASE_URL`` for the China endpoint
+# (https://api.stepfun.com/v1) where applicable.
+DEFAULT_BASE_URL = "https://api.stepfun.ai/v1"
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def _load_stepfun_config() -> Dict[str, Any]:
+    """Read ``image_gen.stepfun`` from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        stepfun_section = section.get("stepfun") if isinstance(section, dict) else None
+        return stepfun_section if isinstance(stepfun_section, dict) else {}
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load image_gen.stepfun config: %s", exc)
+        return {}
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    """Decide which model to use and return ``(model_id, meta)``."""
+    env_override = os.environ.get("STEPFUN_IMAGE_MODEL")
+    if env_override and env_override in _MODELS:
+        return env_override, _MODELS[env_override]
+
+    cfg = _load_stepfun_config()
+    candidate = cfg.get("model") if isinstance(cfg.get("model"), str) else None
+    if candidate and candidate in _MODELS:
+        return candidate, _MODELS[candidate]
+
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_base_url() -> str:
+    """Pick the base URL, honoring ``STEPFUN_IMAGE_BASE_URL`` (China users)."""
+    override = os.environ.get("STEPFUN_IMAGE_BASE_URL")
+    if override:
+        return override.rstrip("/")
+    cfg = _load_stepfun_config()
+    candidate = cfg.get("base_url") if isinstance(cfg.get("base_url"), str) else None
+    if candidate:
+        return candidate.rstrip("/")
+    return DEFAULT_BASE_URL
+
+
+def _resolve_int_kwarg(
+    name: str,
+    kwargs: Dict[str, Any],
+    *,
+    minimum: int,
+    maximum: int,
+    default: int,
+) -> int:
+    """Read an int kwarg clamped to ``[minimum, maximum]``."""
+    candidate: Optional[int] = None
+    if name in kwargs and isinstance(kwargs[name], int) and not isinstance(kwargs[name], bool):
+        candidate = kwargs[name]
+    if candidate is None:
+        cfg = _load_stepfun_config()
+        config_value = cfg.get(name)
+        if isinstance(config_value, int) and not isinstance(config_value, bool):
+            candidate = config_value
+    if candidate is None:
+        return default
+    return max(minimum, min(maximum, candidate))
+
+
+def _resolve_float_kwarg(
+    name: str,
+    kwargs: Dict[str, Any],
+    *,
+    minimum: float,
+    maximum: float,
+    default: float,
+) -> float:
+    """Read a float kwarg clamped to ``[minimum, maximum]``."""
+    candidate: Optional[float] = None
+    if name in kwargs:
+        value = kwargs[name]
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            candidate = float(value)
+    if candidate is None:
+        cfg = _load_stepfun_config()
+        config_value = cfg.get(name)
+        if isinstance(config_value, (int, float)) and not isinstance(config_value, bool):
+            candidate = float(config_value)
+    if candidate is None:
+        return default
+    return max(minimum, min(maximum, candidate))
+
+
+def _resolve_str_kwarg(
+    name: str,
+    kwargs: Dict[str, Any],
+    *,
+    max_length: int,
+) -> Optional[str]:
+    """Read a string kwarg, truncating to ``max_length`` if exceeded."""
+    candidate: Optional[str] = None
+    if name in kwargs and isinstance(kwargs[name], str):
+        candidate = kwargs[name]
+    if candidate is None:
+        cfg = _load_stepfun_config()
+        config_value = cfg.get(name)
+        if isinstance(config_value, str):
+            candidate = config_value
+    if not candidate:
+        return None
+    if len(candidate) > max_length:
+        logger.debug(
+            "StepFun kwarg %s exceeded %d chars (got %d); truncating.",
+            name,
+            max_length,
+            len(candidate),
+        )
+        candidate = candidate[:max_length]
+    return candidate
+
+
+def _resolve_bool_kwarg(name: str, kwargs: Dict[str, Any], default: bool) -> bool:
+    """Read a bool kwarg, defaulting when unset."""
+    if name in kwargs and isinstance(kwargs[name], bool):
+        return kwargs[name]
+    cfg = _load_stepfun_config()
+    if isinstance(cfg.get(name), bool):
+        return cfg[name]
+    return default
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class StepFunImageGenProvider(ImageGenProvider):
+    """StepFun ``step-image-edit-2`` backend."""
+
+    @property
+    def name(self) -> str:
+        return "stepfun"
+
+    @property
+    def display_name(self) -> str:
+        return "StepFun"
+
+    def is_available(self) -> bool:
+        return bool(os.environ.get("STEPFUN_API_KEY"))
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta["display"],
+                "speed": meta["speed"],
+                "strengths": meta["strengths"],
+                "price": meta["price"],
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "StepFun (step-image-edit-2)",
+            "badge": "paid",
+            "tag": (
+                "step-image-edit-2 — text-to-image; configurable steps/cfg; "
+                "uses STEPFUN_API_KEY"
+            ),
+            "env_vars": [
+                {
+                    "key": "STEPFUN_API_KEY",
+                    "prompt": "StepFun API key",
+                    "url": "https://platform.stepfun.ai/",
+                },
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Generate an image using StepFun's step-image-edit-2 endpoint."""
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="stepfun",
+                aspect_ratio=aspect,
+            )
+        if len(prompt) > 512:
+            return error_response(
+                error=(
+                    f"Prompt is {len(prompt)} characters; StepFun image API "
+                    "accepts at most 512."
+                ),
+                error_type="invalid_argument",
+                provider="stepfun",
+                aspect_ratio=aspect,
+            )
+
+        api_key = os.environ.get("STEPFUN_API_KEY", "").strip()
+        if not api_key:
+            return error_response(
+                error=(
+                    "STEPFUN_API_KEY not set. Run `hermes setup` → Image "
+                    "Generation → StepFun to configure, or get a key at "
+                    "https://platform.stepfun.ai/."
+                ),
+                error_type="auth_required",
+                provider="stepfun",
+                aspect_ratio=aspect,
+            )
+
+        model_id, _meta = _resolve_model()
+        size = _STEPFUN_SIZES.get(aspect, _STEPFUN_SIZES["square"])
+        base_url = _resolve_base_url()
+
+        steps = _resolve_int_kwarg("steps", kwargs, minimum=1, maximum=50, default=8)
+        cfg_scale = _resolve_float_kwarg(
+            "cfg_scale", kwargs, minimum=1.0, maximum=10.0, default=1.0
+        )
+        negative_prompt = _resolve_str_kwarg(
+            "negative_prompt", kwargs, max_length=512
+        )
+        text_mode = _resolve_bool_kwarg("text_mode", kwargs, default=False)
+        seed = _resolve_int_kwarg(
+            "seed", kwargs, minimum=0, maximum=2_147_483_647, default=-1
+        )
+
+        # Prefer base64 — URLs expire after 2h per StepFun docs and that
+        # outlives the gateway's intent to ship the file around. We send
+        # ``n=1`` to match the Hermes single-image contract; the StepFun
+        # API only supports n=1 today.
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "prompt": prompt,
+            "size": size,
+            "response_format": "b64_json",
+            "n": 1,
+        }
+        if seed >= 0:
+            payload["seed"] = seed
+        # Only send tunables when the caller actually changed them from the
+        # API defaults — keeps the wire request minimal and avoids surprises
+        # when StepFun's defaults shift.
+        if steps != 8:
+            payload["steps"] = steps
+        if cfg_scale != 1.0:
+            payload["cfg_scale"] = cfg_scale
+        if negative_prompt:
+            payload["negative_prompt"] = negative_prompt
+        if text_mode:
+            payload["text_mode"] = True
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            response = requests.post(
+                f"{base_url}/images/generations",
+                headers=headers,
+                json=payload,
+                timeout=120,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            resp = exc.response
+            status = resp.status_code if resp is not None else 0
+            err_msg = ""
+            if resp is not None:
+                try:
+                    body = resp.json()
+                    err_msg = (
+                        body.get("error", {}).get("message")
+                        if isinstance(body.get("error"), dict)
+                        else body.get("message")
+                        or body.get("detail")
+                        or resp.text[:300]
+                    )
+                except Exception:
+                    err_msg = resp.text[:300]
+            else:
+                err_msg = str(exc)
+            logger.error("StepFun image gen failed (%d): %s", status, err_msg)
+            return error_response(
+                error=f"StepFun image generation failed ({status}): {err_msg}",
+                error_type="api_error",
+                provider="stepfun",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.Timeout:
+            return error_response(
+                error="StepFun image generation timed out (120s)",
+                error_type="timeout",
+                provider="stepfun",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.ConnectionError as exc:
+            return error_response(
+                error=f"StepFun connection error: {exc}",
+                error_type="connection_error",
+                provider="stepfun",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            result = response.json()
+        except Exception as exc:
+            return error_response(
+                error=f"StepFun returned invalid JSON: {exc}",
+                error_type="invalid_response",
+                provider="stepfun",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        data = result.get("data") or []
+        if not data:
+            return error_response(
+                error="StepFun returned no image data",
+                error_type="empty_response",
+                provider="stepfun",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        first = data[0] if isinstance(data[0], dict) else {}
+        b64 = first.get("b64_json")
+        url = first.get("url")
+        finish_reason = first.get("finish_reason")
+        used_seed = first.get("seed")
+
+        # finish_reason == "content_filtered" means the API successfully
+        # generated an image but the safety filter rejected it before
+        # returning any bytes. Surface this as a clean error rather than
+        # the generic "no image data" message.
+        if finish_reason and finish_reason != "success" and not b64 and not url:
+            return error_response(
+                error=(
+                    f"StepFun returned finish_reason={finish_reason!r}; "
+                    "no image bytes to save. Try rephrasing the prompt."
+                ),
+                error_type="content_filtered",
+                provider="stepfun",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if b64:
+            try:
+                saved_path = save_b64_image(b64, prefix=f"stepfun_{model_id}")
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not save image to cache: {exc}",
+                    error_type="io_error",
+                    provider="stepfun",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            image_ref = str(saved_path)
+        elif url:
+            # Defensive — we requested b64_json, but StepFun may return URL
+            # mode in some edge cases. Cache the bytes locally so the
+            # gateway never tries to fetch an ephemeral URL after it
+            # expires (2h validity per docs).
+            try:
+                saved_path = save_url_image(url, prefix=f"stepfun_{model_id}")
+            except Exception as exc:
+                logger.warning(
+                    "StepFun image URL %s could not be cached (%s); falling back to bare URL.",
+                    url,
+                    exc,
+                )
+                image_ref = url
+            else:
+                image_ref = str(saved_path)
+        else:
+            return error_response(
+                error="StepFun response contained neither b64_json nor URL",
+                error_type="empty_response",
+                provider="stepfun",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        extra: Dict[str, Any] = {"size": size}
+        if finish_reason:
+            extra["finish_reason"] = finish_reason
+        if isinstance(used_seed, int):
+            extra["seed"] = used_seed
+        elif seed >= 0:
+            extra["seed"] = seed
+
+        return success_response(
+            image=image_ref,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="stepfun",
+            extra=extra,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+
+def register(ctx: Any) -> None:
+    """Register this provider with the image gen registry."""
+    ctx.register_image_gen_provider(StepFunImageGenProvider())

--- a/plugins/image_gen/stepfun/plugin.yaml
+++ b/plugins/image_gen/stepfun/plugin.yaml
@@ -1,0 +1,7 @@
+name: stepfun
+version: 1.0.0
+description: "StepFun image generation backend (step-image-edit-2). Text-to-image via api.stepfun.ai."
+author: Hermes Agent
+kind: backend
+requires_env:
+  - STEPFUN_API_KEY

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1417,6 +1417,7 @@ AUTHOR_MAP = {
     "me@simontaggart.com": "SiTaggart",  # PR #35583 (docker_forward_env empty-secret .env fallback)
     "2663402852@qq.com": "x1am1",  # PR #35098 (chown root-owned top-level HERMES_HOME state files)
     "nicsequenzy@gmail.com": "polnikale",  # PR #35717 (discover Playwright headless_shell browser)
+    "ashuaria@users.noreply.github.com": "ashuaria",  # PR #75764 (image-gen: MiniMax + StepFun backends)
 }
 
 

--- a/tests/plugins/image_gen/test_minimax_provider.py
+++ b/tests/plugins/image_gen/test_minimax_provider.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Tests for MiniMax image generation provider."""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch):
+    """Ensure MINIMAX_API_KEY is set for all tests."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key-12345")
+
+
+# ---------------------------------------------------------------------------
+# Provider class tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxImageGenProvider:
+    def test_name(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        provider = MiniMaxImageGenProvider()
+        assert provider.name == "minimax"
+
+    def test_display_name(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        provider = MiniMaxImageGenProvider()
+        assert provider.display_name == "MiniMax"
+
+    def test_is_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-xxx")
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        provider = MiniMaxImageGenProvider()
+        assert provider.is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        provider = MiniMaxImageGenProvider()
+        assert provider.is_available() is False
+
+    def test_list_models(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        provider = MiniMaxImageGenProvider()
+        models = provider.list_models()
+        assert len(models) >= 1
+        assert models[0]["id"] == "image-01"
+
+    def test_default_model(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        provider = MiniMaxImageGenProvider()
+        assert provider.default_model() == "image-01"
+
+    def test_get_setup_schema(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        provider = MiniMaxImageGenProvider()
+        schema = provider.get_setup_schema()
+        assert schema["name"] == "MiniMax (image-01)"
+        assert schema["badge"] == "paid"
+        # MiniMax auth is API-key only — the picker should expose the env var.
+        assert schema["env_vars"] == [
+            {
+                "key": "MINIMAX_API_KEY",
+                "prompt": "MiniMax API key",
+                "url": "https://platform.minimax.io/user-center/basic-information/interface-key",
+            }
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_default_model(self):
+        from plugins.image_gen.minimax import _resolve_model
+
+        model_id, meta = _resolve_model()
+        assert model_id == "image-01"
+        assert meta["display"] == "MiniMax image-01"
+
+    def test_default_base_url(self, monkeypatch):
+        from plugins.image_gen.minimax import _resolve_base_url
+
+        monkeypatch.delenv("MINIMAX_IMAGE_BASE_URL", raising=False)
+        assert _resolve_base_url() == "https://api.minimax.io/v1"
+
+    def test_env_override_base_url(self, monkeypatch):
+        from plugins.image_gen.minimax import _resolve_base_url
+
+        monkeypatch.setenv("MINIMAX_IMAGE_BASE_URL", "https://api.minimaxi.com/v1")
+        assert _resolve_base_url() == "https://api.minimaxi.com/v1"
+
+    def test_prompt_optimizer_default(self):
+        from plugins.image_gen.minimax import _resolve_prompt_optimizer
+
+        assert _resolve_prompt_optimizer({}) is False
+
+    def test_prompt_optimizer_kwarg_overrides(self):
+        from plugins.image_gen.minimax import _resolve_prompt_optimizer
+
+        assert _resolve_prompt_optimizer({"prompt_optimizer": True}) is True
+        assert _resolve_prompt_optimizer({"prompt_optimizer": False}) is False
+
+    def test_seed_resolution(self):
+        from plugins.image_gen.minimax import _resolve_seed
+
+        assert _resolve_seed({}) is None
+        assert _resolve_seed({"seed": 42}) == 42
+
+
+# ---------------------------------------------------------------------------
+# Generate tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_empty_prompt(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        provider = MiniMaxImageGenProvider()
+        result = provider.generate(prompt="")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_oversized_prompt(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        provider = MiniMaxImageGenProvider()
+        result = provider.generate(prompt="x" * 2000)
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "1500" in result["error"]
+
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        provider = MiniMaxImageGenProvider()
+        result = provider.generate(prompt="test")
+        assert result["success"] is False
+        assert "MINIMAX_API_KEY" in result["error"]
+        assert result["error_type"] == "auth_required"
+
+    def test_successful_base64_generation(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "id": "trace-abc",
+            "data": {"image_urls": ["https://example.com/img.png"], "image_base64": "dGVzdC1pbWFnZS1kYXRh"},
+            "metadata": {"success_count": "1", "failed_count": "0"},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }
+
+        with patch("plugins.image_gen.minimax.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.minimax.save_b64_image", return_value="/tmp/test.png"):
+            provider = MiniMaxImageGenProvider()
+            result = provider.generate(prompt="A cat playing piano")
+
+        assert result["success"] is True
+        # Base64 path wins over URL even when both are returned (defensive).
+        assert result["image"] == "/tmp/test.png"
+        assert result["provider"] == "minimax"
+        assert result["model"] == "image-01"
+        # `extra` keys are merged into the top-level payload via setdefault(),
+        # so they're accessible as direct keys rather than under an "extra" key.
+        assert result["request_id"] == "trace-abc"
+        assert result["aspect_ratio_native"] == "16:9"
+        assert result["prompt_optimizer"] is False
+
+    def test_successful_url_response_is_cached(self):
+        """URL fallback must be cached locally — MiniMax URLs expire in 24h.
+
+        Mirrors the xAI bug fix (#26942): the gateway needs an absolute
+        filesystem path so its downstream ``send_photo`` doesn't 404 on
+        an already-expired URL.
+        """
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": {"image_urls": ["https://example.com/img.png"]},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }
+
+        with patch("plugins.image_gen.minimax.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.minimax.save_url_image", return_value="/tmp/minimax_cached.png") as mock_save:
+            provider = MiniMaxImageGenProvider()
+            result = provider.generate(prompt="A cat playing piano")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/minimax_cached.png"
+        mock_save.assert_called_once()
+        # URL must be the first positional arg, prefix should be minimax_-prefixed.
+        call_args, _ = mock_save.call_args
+        assert call_args[0] == "https://example.com/img.png"
+        assert mock_save.call_args.kwargs.get("prefix", "").startswith("minimax_")
+
+    def test_base_resp_failure_surfaces_msg(self):
+        """MiniMax wraps errors in base_resp.status_code != 0 — surface precisely."""
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": {},
+            "base_resp": {"status_code": 1008, "status_msg": "invalid params"},
+        }
+
+        with patch("plugins.image_gen.minimax.requests.post", return_value=mock_resp):
+            provider = MiniMaxImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "invalid params" in result["error"]
+
+    def test_http_error(self):
+        import requests as req_lib
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_resp.text = "Unauthorized"
+        mock_resp.json.return_value = {"base_resp": {"status_msg": "Invalid API key"}}
+        mock_resp.raise_for_status.side_effect = req_lib.HTTPError(response=mock_resp)
+
+        with patch("plugins.image_gen.minimax.requests.post", return_value=mock_resp):
+            provider = MiniMaxImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "401" in result["error"]
+        assert "Invalid API key" in result["error"]
+
+    def test_http_error_with_non_json_body(self):
+        import requests as req_lib
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "internal error"
+        mock_resp.json.side_effect = ValueError("not json")
+        mock_resp.raise_for_status.side_effect = req_lib.HTTPError(response=mock_resp)
+
+        with patch("plugins.image_gen.minimax.requests.post", return_value=mock_resp):
+            provider = MiniMaxImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        # Falls back to raw text when JSON parsing fails.
+        assert "internal error" in result["error"]
+
+    def test_timeout(self):
+        import requests as req_lib
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        with patch("plugins.image_gen.minimax.requests.post", side_effect=req_lib.Timeout()):
+            provider = MiniMaxImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "timeout"
+
+    def test_connection_error(self):
+        import requests as req_lib
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        with patch("plugins.image_gen.minimax.requests.post", side_effect=req_lib.ConnectionError("nope")):
+            provider = MiniMaxImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "connection_error"
+
+    def test_invalid_json_response(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.side_effect = ValueError("not json")
+        mock_resp.text = "<html>error</html>"
+
+        with patch("plugins.image_gen.minimax.requests.post", return_value=mock_resp):
+            provider = MiniMaxImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_response"
+
+    def test_empty_data(self):
+        """No image_urls AND no image_base64 → empty_response."""
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": {"image_urls": []},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }
+
+        with patch("plugins.image_gen.minimax.requests.post", return_value=mock_resp):
+            provider = MiniMaxImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_auth_header_and_url(self):
+        """Verify bearer auth header and the /image_generation URL path."""
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": {"image_base64": "dGVzdA=="},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }
+
+        with patch("plugins.image_gen.minimax.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.minimax.save_b64_image", return_value="/tmp/test.png"):
+            provider = MiniMaxImageGenProvider()
+            provider.generate(prompt="test")
+
+        # URL must hit the image_generation endpoint on the default base.
+        url = mock_post.call_args.args[0]
+        assert url == "https://api.minimax.io/v1/image_generation"
+
+        # Bearer auth header must carry the configured key.
+        headers = mock_post.call_args.kwargs.get("headers") or {}
+        assert headers["Authorization"] == "Bearer test-key-12345"
+        assert headers["Content-Type"] == "application/json"
+
+        # Payload must request base64 + n=1.
+        payload = mock_post.call_args.kwargs.get("json") or {}
+        assert payload["response_format"] == "base64"
+        assert payload["n"] == 1
+        assert payload["model"] == "image-01"
+        assert payload["aspect_ratio"] == "16:9"  # landscape
+        assert payload["prompt_optimizer"] is False
+
+    def test_aspect_ratio_mapping(self):
+        """All three canonical ratios must map to MiniMax's API values."""
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": {"image_base64": "dGVzdA=="},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }
+
+        for hermes_ar, expected_native in [
+            ("landscape", "16:9"),
+            ("square", "1:1"),
+            ("portrait", "9:16"),
+        ]:
+            with patch("plugins.image_gen.minimax.requests.post", return_value=mock_resp) as mock_post, \
+                 patch("plugins.image_gen.minimax.save_b64_image", return_value="/tmp/test.png"):
+                provider = MiniMaxImageGenProvider()
+                provider.generate(prompt="test", aspect_ratio=hermes_ar)
+            payload = mock_post.call_args.kwargs.get("json") or {}
+            assert payload["aspect_ratio"] == expected_native, (
+                f"aspect_ratio={hermes_ar} should map to {expected_native}, got {payload['aspect_ratio']!r}"
+            )
+
+    def test_seed_passthrough(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": {"image_base64": "dGVzdA=="},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }
+
+        with patch("plugins.image_gen.minimax.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.minimax.save_b64_image", return_value="/tmp/test.png"):
+            provider = MiniMaxImageGenProvider()
+            provider.generate(prompt="test", seed=12345)
+
+        payload = mock_post.call_args.kwargs.get("json") or {}
+        assert payload["seed"] == 12345
+
+
+# ---------------------------------------------------------------------------
+# Registration test
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register(self):
+        from plugins.image_gen.minimax import MiniMaxImageGenProvider, register
+
+        mock_ctx = MagicMock()
+        register(mock_ctx)
+        mock_ctx.register_image_gen_provider.assert_called_once()
+        provider = mock_ctx.register_image_gen_provider.call_args[0][0]
+        assert isinstance(provider, MiniMaxImageGenProvider)
+        assert provider.name == "minimax"

--- a/tests/plugins/image_gen/test_stepfun_provider.py
+++ b/tests/plugins/image_gen/test_stepfun_provider.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""Tests for StepFun image generation provider."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch):
+    """Ensure STEPFUN_API_KEY is set for all tests."""
+    monkeypatch.setenv("STEPFUN_API_KEY", "test-key-12345")
+
+
+# ---------------------------------------------------------------------------
+# Provider class tests
+# ---------------------------------------------------------------------------
+
+
+class TestStepFunImageGenProvider:
+    def test_name(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        provider = StepFunImageGenProvider()
+        assert provider.name == "stepfun"
+
+    def test_display_name(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        provider = StepFunImageGenProvider()
+        assert provider.display_name == "StepFun"
+
+    def test_is_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("STEPFUN_API_KEY", "sk-xxx")
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        provider = StepFunImageGenProvider()
+        assert provider.is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch):
+        monkeypatch.delenv("STEPFUN_API_KEY", raising=False)
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        provider = StepFunImageGenProvider()
+        assert provider.is_available() is False
+
+    def test_list_models(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        provider = StepFunImageGenProvider()
+        models = provider.list_models()
+        assert len(models) >= 1
+        assert models[0]["id"] == "step-image-edit-2"
+
+    def test_default_model(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        provider = StepFunImageGenProvider()
+        assert provider.default_model() == "step-image-edit-2"
+
+    def test_get_setup_schema(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        provider = StepFunImageGenProvider()
+        schema = provider.get_setup_schema()
+        assert schema["name"] == "StepFun (step-image-edit-2)"
+        assert schema["badge"] == "paid"
+        assert schema["env_vars"] == [
+            {
+                "key": "STEPFUN_API_KEY",
+                "prompt": "StepFun API key",
+                "url": "https://platform.stepfun.ai/",
+            }
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_default_model(self):
+        from plugins.image_gen.stepfun import _resolve_model
+
+        model_id, meta = _resolve_model()
+        assert model_id == "step-image-edit-2"
+
+    def test_default_base_url(self, monkeypatch):
+        from plugins.image_gen.stepfun import _resolve_base_url
+
+        monkeypatch.delenv("STEPFUN_IMAGE_BASE_URL", raising=False)
+        assert _resolve_base_url() == "https://api.stepfun.ai/v1"
+
+    def test_env_override_base_url(self, monkeypatch):
+        from plugins.image_gen.stepfun import _resolve_base_url
+
+        monkeypatch.setenv("STEPFUN_IMAGE_BASE_URL", "https://api.stepfun.com/v1")
+        assert _resolve_base_url() == "https://api.stepfun.com/v1"
+
+    def test_int_kwarg_clamps_and_defaults(self):
+        from plugins.image_gen.stepfun import _resolve_int_kwarg
+
+        # No value → default.
+        assert _resolve_int_kwarg("steps", {}, minimum=1, maximum=50, default=8) == 8
+        # In-range value passes through.
+        assert _resolve_int_kwarg("steps", {"steps": 25}, minimum=1, maximum=50, default=8) == 25
+        # Out-of-range gets clamped.
+        assert _resolve_int_kwarg("steps", {"steps": 999}, minimum=1, maximum=50, default=8) == 50
+        assert _resolve_int_kwarg("steps", {"steps": 0}, minimum=1, maximum=50, default=8) == 1
+        # Wrong-type value (string) falls back to default.
+        assert _resolve_int_kwarg("steps", {"steps": "twenty"}, minimum=1, maximum=50, default=8) == 8
+
+    def test_float_kwarg_clamps_and_defaults(self):
+        from plugins.image_gen.stepfun import _resolve_float_kwarg
+
+        assert _resolve_float_kwarg("cfg_scale", {}, minimum=1.0, maximum=10.0, default=1.0) == 1.0
+        assert _resolve_float_kwarg("cfg_scale", {"cfg_scale": 5.5}, minimum=1.0, maximum=10.0, default=1.0) == 5.5
+        assert _resolve_float_kwarg("cfg_scale", {"cfg_scale": 99.0}, minimum=1.0, maximum=10.0, default=1.0) == 10.0
+        assert _resolve_float_kwarg("cfg_scale", {"cfg_scale": 0.5}, minimum=1.0, maximum=10.0, default=1.0) == 1.0
+
+    def test_str_kwarg_truncates(self):
+        from plugins.image_gen.stepfun import _resolve_str_kwarg
+
+        assert _resolve_str_kwarg("negative_prompt", {}, max_length=512) is None
+        long = "x" * 1000
+        out = _resolve_str_kwarg("negative_prompt", {"negative_prompt": long}, max_length=512)
+        assert out is not None and len(out) == 512
+
+    def test_bool_kwarg(self):
+        from plugins.image_gen.stepfun import _resolve_bool_kwarg
+
+        assert _resolve_bool_kwarg("text_mode", {}, default=False) is False
+        assert _resolve_bool_kwarg("text_mode", {"text_mode": True}, default=False) is True
+        # Wrong-type value (string) → default.
+        assert _resolve_bool_kwarg("text_mode", {"text_mode": "yes"}, default=False) is False
+
+
+# ---------------------------------------------------------------------------
+# Generate tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_empty_prompt(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        provider = StepFunImageGenProvider()
+        result = provider.generate(prompt="")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_oversized_prompt(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        provider = StepFunImageGenProvider()
+        result = provider.generate(prompt="x" * 600)
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "512" in result["error"]
+
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("STEPFUN_API_KEY", raising=False)
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        provider = StepFunImageGenProvider()
+        result = provider.generate(prompt="test")
+        assert result["success"] is False
+        assert "STEPFUN_API_KEY" in result["error"]
+        assert result["error_type"] == "auth_required"
+
+    def test_successful_b64_generation(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "created": 1700000000,
+            "data": [
+                {
+                    "b64_json": "dGVzdC1pbWFnZS1kYXRh",
+                    "finish_reason": "success",
+                    "seed": 12345,
+                }
+            ],
+        }
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.stepfun.save_b64_image", return_value="/tmp/test.png"):
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="A serene alpine lake")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/test.png"
+        assert result["provider"] == "stepfun"
+        assert result["model"] == "step-image-edit-2"
+        # `extra` keys are merged into the top-level payload via setdefault(),
+        # so they're accessible as direct keys rather than under an "extra" key.
+        assert result["seed"] == 12345
+        assert result["finish_reason"] == "success"
+        assert result["size"] == "1360x768"  # landscape
+
+    def test_content_filtered_response(self):
+        """finish_reason=content_filtered with no bytes → clean error."""
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"finish_reason": "content_filtered", "seed": 99}],
+        }
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp):
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "content_filtered"
+        assert "content_filtered" in result["error"]
+
+    def test_successful_url_response_is_cached(self):
+        """URL fallback must be cached — StepFun URLs expire in 2h.
+
+        Mirrors the xAI/MiniMax URL-caching contract so the gateway
+        doesn't try to fetch an expired URL at ``send_photo`` time.
+        """
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"url": "https://stepfun.example.com/tmp-img.jpeg", "finish_reason": "success"}],
+        }
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.stepfun.save_url_image",
+                   return_value=Path("/tmp/stepfun_cached.jpeg")) as mock_save:
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/stepfun_cached.jpeg"
+        mock_save.assert_called_once()
+        call_args, _ = mock_save.call_args
+        assert call_args[0] == "https://stepfun.example.com/tmp-img.jpeg"
+        assert mock_save.call_args.kwargs.get("prefix", "").startswith("stepfun_")
+
+    def test_url_response_falls_back_when_cache_fails(self):
+        """If save_url_image raises, fall back to bare URL (not a hard error)."""
+        import requests as req_lib
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"url": "https://stepfun.example.com/already-404.jpeg"}],
+        }
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp), \
+             patch("plugins.image_gen.stepfun.save_url_image", side_effect=req_lib.HTTPError("404")):
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is True
+        assert result["image"] == "https://stepfun.example.com/already-404.jpeg"
+
+    def test_http_error(self):
+        import requests as req_lib
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_resp.text = "Unauthorized"
+        mock_resp.json.return_value = {"error": {"message": "Invalid API key"}}
+        mock_resp.raise_for_status.side_effect = req_lib.HTTPError(response=mock_resp)
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp):
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "401" in result["error"]
+        assert "Invalid API key" in result["error"]
+
+    def test_http_error_non_json(self):
+        import requests as req_lib
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "internal error"
+        mock_resp.json.side_effect = ValueError("not json")
+        mock_resp.raise_for_status.side_effect = req_lib.HTTPError(response=mock_resp)
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp):
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "internal error" in result["error"]
+
+    def test_timeout(self):
+        import requests as req_lib
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        with patch("plugins.image_gen.stepfun.requests.post", side_effect=req_lib.Timeout()):
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "timeout"
+
+    def test_connection_error(self):
+        import requests as req_lib
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        with patch("plugins.image_gen.stepfun.requests.post", side_effect=req_lib.ConnectionError("nope")):
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "connection_error"
+
+    def test_invalid_json(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.side_effect = ValueError("not json")
+        mock_resp.text = "<html>error</html>"
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp):
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_response"
+
+    def test_empty_data(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": []}
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp):
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_response_with_neither_b64_nor_url(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"finish_reason": "success", "seed": 1}]}
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp):
+            provider = StepFunImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+        assert "neither b64_json nor URL" in result["error"]
+
+    def test_auth_header_and_url(self):
+        """Verify bearer auth + /v1/images/generations URL path."""
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"b64_json": "dGVzdA==", "finish_reason": "success"}],
+        }
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.stepfun.save_b64_image", return_value="/tmp/test.png"):
+            provider = StepFunImageGenProvider()
+            provider.generate(prompt="test")
+
+        url = mock_post.call_args.args[0]
+        assert url == "https://api.stepfun.ai/v1/images/generations"
+
+        headers = mock_post.call_args.kwargs.get("headers") or {}
+        assert headers["Authorization"] == "Bearer test-key-12345"
+        assert headers["Content-Type"] == "application/json"
+
+        payload = mock_post.call_args.kwargs.get("json") or {}
+        assert payload["response_format"] == "b64_json"
+        assert payload["n"] == 1
+        assert payload["model"] == "step-image-edit-2"
+        # Defaults (steps=8, cfg=1.0) should NOT be on the wire.
+        assert "steps" not in payload
+        assert "cfg_scale" not in payload
+        assert "negative_prompt" not in payload
+        assert "text_mode" not in payload
+
+    def test_aspect_ratio_size_mapping(self):
+        """StepFun uses ``{height}x{width}`` ordering — verify each ratio."""
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"b64_json": "dGVzdA==", "finish_reason": "success"}],
+        }
+
+        cases = [
+            ("landscape", "1360x768"),
+            ("square", "1024x1024"),
+            ("portrait", "768x1360"),
+        ]
+        for hermes_ar, expected_size in cases:
+            with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp) as mock_post, \
+                 patch("plugins.image_gen.stepfun.save_b64_image", return_value="/tmp/test.png"):
+                provider = StepFunImageGenProvider()
+                provider.generate(prompt="test", aspect_ratio=hermes_ar)
+            payload = mock_post.call_args.kwargs.get("json") or {}
+            assert payload["size"] == expected_size, (
+                f"aspect_ratio={hermes_ar} should map to size={expected_size}, "
+                f"got {payload['size']!r}"
+            )
+
+    def test_tunable_kwargs_pass_through(self):
+        """steps / cfg_scale / negative_prompt / text_mode are wired through."""
+        from plugins.image_gen.stepfun import StepFunImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"b64_json": "dGVzdA==", "finish_reason": "success"}],
+        }
+
+        with patch("plugins.image_gen.stepfun.requests.post", return_value=mock_resp) as mock_post, \
+             patch("plugins.image_gen.stepfun.save_b64_image", return_value="/tmp/test.png"):
+            provider = StepFunImageGenProvider()
+            provider.generate(
+                prompt="test",
+                steps=25,
+                cfg_scale=7.5,
+                negative_prompt="ugly, blurry",
+                text_mode=True,
+                seed=42,
+            )
+
+        payload = mock_post.call_args.kwargs.get("json") or {}
+        assert payload["steps"] == 25
+        assert payload["cfg_scale"] == 7.5
+        assert payload["negative_prompt"] == "ugly, blurry"
+        assert payload["text_mode"] is True
+        assert payload["seed"] == 42
+
+
+# ---------------------------------------------------------------------------
+# Registration test
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register(self):
+        from plugins.image_gen.stepfun import StepFunImageGenProvider, register
+
+        mock_ctx = MagicMock()
+        register(mock_ctx)
+        mock_ctx.register_image_gen_provider.assert_called_once()
+        provider = mock_ctx.register_image_gen_provider.call_args[0][0]
+        assert isinstance(provider, StepFunImageGenProvider)
+        assert provider.name == "stepfun"


### PR DESCRIPTION
## Summary

Adds two new bundled image generation backends under `plugins/image_gen/`. Both auto-register through the existing plugin discovery mechanism — no edits to `hermes_cli/tools_config.py` are required, and both surface automatically in `hermes setup`'s Image Generation picker.

### MiniMax (`plugins/image_gen/minimax/`)
- **Model:** `image-01` (text-to-image, 1500-char prompt cap, 8 aspect ratios, 1–9 images/request)
- **Endpoint:** `POST https://api.minimax.io/v1/image_generation`
- **Auth:** `MINIMAX_API_KEY` (optional `MINIMAX_IMAGE_BASE_URL` for China endpoint)
- **Output:** prefers base64 (URLs expire after 24h; cached locally at tool-completion time so the gateway never 404s on an expired URL — same contract as the existing xAI fix)
- **Error handling:** parses MiniMax's `base_resp.status_code != 0` separately from HTTP errors
- **Tunable kwargs:** `prompt_optimizer` (bool), `seed` (int)

### StepFun (`plugins/image_gen/stepfun/`)
- **Model:** `step-image-edit-2` (text-to-image, 512-char prompt cap, 5 sizes, `n=1`)
- **Endpoint:** `POST https://api.stepfun.ai/v1/images/generations`
- **Auth:** `STEPFUN_API_KEY` (optional `STEPFUN_IMAGE_BASE_URL` for China endpoint)
- **Tunable kwargs:** `steps` (1–50, default 8), `cfg_scale` (1.0–10.0, default 1.0), `negative_prompt` (≤512 chars), `text_mode` (bool), `seed` (0..2³¹-1)
- Defaults are not sent on the wire, keeping the payload minimal.
- `finish_reason=content_filtered` surfaces as a clean `content_filtered` error type.

## Tests

- **61 new tests** under `tests/plugins/image_gen/`:
  - `test_minimax_provider.py` — 29 tests
  - `test_stepfun_provider.py` — 32 tests
- Coverage spans model resolution, config/env precedence, prompt validation, request payload, response parsing (success/error/timeout/content_filtered), URL caching, header assertions, and aspect-ratio mapping.
- **Verified locally:** the full image-gen suite (plugin dispatch, registry, picker injection, xai/krea/openai/fal/openai-codex) passes — **202 tests, 0 regressions**.

## Documentation / Discoverability

Both providers appear in `hermes setup` → Image Generation with no extra steps:

```
Image Generation picker:
  - FAL.ai                      env=['FAL_KEY']
  - Krea                        env=['KREA_API_KEY']
  - MiniMax (image-01)          env=['MINIMAX_API_KEY']    ← new
  - OpenAI                      env=['OPENAI_API_KEY']
  - OpenAI (Codex auth)         env=[]
  - StepFun (step-image-edit-2) env=['STEPFUN_API_KEY']    ← new
  - xAI Grok Imagine (image)    env=[]
```

## Test Plan

- [x] `pytest tests/plugins/image_gen/test_minimax_provider.py tests/plugins/image_gen/test_stepfun_provider.py -v` — 61 passed
- [x] `pytest tests/plugins/image_gen/ tests/tools/test_image_generation_plugin_dispatch.py tests/agent/test_image_gen_registry.py tests/hermes_cli/test_image_gen_picker.py` — 202 passed, 0 failed
- [ ] CI green (will monitor after opening PR)

## Notes

- Pure additive change. No existing files modified.
- Follows the exact `kind: backend` plugin convention that xai/krea/openai/fal/openai-codex already use.
- Selection precedence (env > config > default) inside each provider matches every other backend.
