### PR TITLE
fix: use UUID for cross-session image upload filename uniqueness (#75761)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9837,15 +9837,14 @@ def _queue_attached_image(session: dict, img_bytes: bytes, ext: str, *, prefix: 
     ``session["attached_images"]`` so the next ``prompt.submit`` picks it up via
     the existing native-image-attach pipeline. Returns the written path.
     """
-    session["image_counter"] = session.get("image_counter", 0) + 1
     img_dir = _session_images_dir(session)
     img_dir.mkdir(parents=True, exist_ok=True)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    img_path = img_dir / f"{prefix}_{ts}_{session['image_counter']}{ext}"
+    unique = uuid.uuid4().hex[:12]
+    img_path = img_dir / f"{prefix}_{ts}_{unique}{ext}"
     try:
         img_path.write_bytes(img_bytes)
     except Exception:
-        session["image_counter"] = max(0, session["image_counter"] - 1)
         raise
     session.setdefault("attached_images", []).append(str(img_path))
     return img_path


### PR DESCRIPTION
## Summary

`_queue_attached_image()` generates filenames using a session-local counter + second-level timestamp. When multiple sessions share the same profile (the intended behavior after e444d165), they each start `image_counter` at 0, producing identical filenames within the same second. The second write silently overwrites the first, and both sessions retain references to the same final file — so one conversation gets the wrong image.

## Fix

Replace the session-local counter with a 12-character UUID hex suffix, giving process- and session-independent uniqueness while keeping the timestamp for readability. `uuid` is already imported in this file (line 16).

## Changes

- `tui_gateway/server.py:_queue_attached_image()`: Remove `image_counter` increment/decrement; generate filename with `uuid.uuid4().hex[:12]` instead.

## Test Plan

- [ ] Unit test: two sessions with same `profile_home` and frozen timestamp produce distinct paths and preserve their respective bytes
- [ ] Existing image-attach tests still pass

Fixes #75761