### PR TITLE
fix(bootstrap): strip mismatched-Python-version site-packages from sys.path

### DIFF
--- a/hermes_bootstrap.py
+++ b/hermes_bootstrap.py
@@ -36,12 +36,21 @@ What this module does NOT do:
     an explicit ``encoding="utf-8"`` at the call site (lint rule
     ``PLW1514`` / ``PYI058``).  Ruff is the right tool for that sweep.
 
-What this module does on POSIX:
+What this module does on POSIX (for the UTF-8 shim specifically):
 
   - Nothing.  POSIX systems are already UTF-8 by default in 99% of cases,
     and we don't want to touch ``LANG``/``LC_*`` behavior that users may
     have configured intentionally.  If someone hits a C/POSIX locale on
     Linux, they can export ``PYTHONUTF8=1`` themselves — we won't override.
+
+This module also runs a platform-independent guard on import,
+``harden_user_site_version()``, which drops any ``pythonX.Y/site-packages``
+directory from ``sys.path`` that belongs to a *different* Python minor
+version than the running interpreter. A stray directory like that (typically
+a ``PYTHONPATH``/user-site leak from the launching environment) can only
+ever hold incompatible compiled extensions, and Python reports the failure
+as a confusing "cannot import name '_imaging' from 'PIL'" deep inside
+whatever backend touches it first rather than a clear version mismatch.
 
 Idempotent: safe to call multiple times.  ``_bootstrap_once`` guards
 against double-reconfigure.
@@ -50,10 +59,16 @@ against double-reconfigure.
 from __future__ import annotations
 
 import os
+import re
 import sys
 
 _IS_WINDOWS = sys.platform == "win32"
 _bootstrap_applied = False
+
+# Matches a versioned CPython directory segment, e.g. ".../lib/python3.12/
+# site-packages" — captures (major, minor) so it can be compared against the
+# running interpreter's own version.
+_PYVER_DIR_RE = re.compile(r"python(\d+)\.(\d+)(?=[\\/]|$)", re.IGNORECASE)
 
 
 def apply_windows_utf8_bootstrap() -> bool:
@@ -226,6 +241,48 @@ def activate_durable_lazy_target() -> None:
         pass
 
 
+def harden_user_site_version() -> None:
+    """Drop any ``pythonX.Y/site-packages`` dir for the *wrong* interpreter
+    version out of ``sys.path``.
+
+    A long-lived server process (the gateway, the dashboard's ``tui_gateway``
+    backend, ...) can end up with a stray site-packages directory belonging
+    to a different Python minor version on its ``sys.path`` — e.g. a
+    ``PYTHONPATH``/user-site leak from the launching environment (a systemd
+    unit that doesn't scrub the operator's shell env, a stale venv
+    activation). That directory can only ever contain compiled extension
+    modules the running interpreter cannot load (the ``.so`` ABI tag is
+    version-specific) — the import doesn't fail cleanly, it fails with a
+    confusing ``cannot import name '_imaging' from 'PIL'`` deep inside
+    whatever backend touched it first, because Python only reports the
+    missing submodule, not the version mismatch that caused it.
+
+    Removing any such directory up front means backend imports (PIL, etc.)
+    always resolve into the running interpreter's own, healthy
+    site-packages instead of silently shadowing into an incompatible one.
+    Never raises; a clean ``sys.path`` is a no-op.
+    """
+    current = (sys.version_info.major, sys.version_info.minor)
+    try:
+        cleaned = []
+        changed = False
+        for entry in sys.path:
+            match = _PYVER_DIR_RE.search(entry)
+            if (
+                match
+                and "site-packages" in entry.replace("\\", "/")
+                and (int(match.group(1)), int(match.group(2))) != current
+            ):
+                changed = True
+                continue
+            cleaned.append(entry)
+        if changed:
+            sys.path[:] = cleaned
+    except Exception:
+        # Bootstrap must never crash an entry point.
+        pass
+
+
 # Apply on import — entry points just need ``import hermes_bootstrap``
 # (or ``from hermes_bootstrap import apply_windows_utf8_bootstrap``) at
 # the very top of their module, before importing anything else.  The
@@ -237,3 +294,7 @@ suppress_platform_ver_console()
 # packages installed into the data volume on a previous run are importable
 # this run, before any backend module imports its SDK. No-op when unset.
 activate_durable_lazy_target()
+
+# Scrub any mismatched-Python-version site-packages dir off sys.path before
+# any backend module (PIL, etc.) can resolve an import into it.
+harden_user_site_version()

--- a/hermes_bootstrap.py
+++ b/hermes_bootstrap.py
@@ -65,10 +65,17 @@ import sys
 _IS_WINDOWS = sys.platform == "win32"
 _bootstrap_applied = False
 
-# Matches a versioned CPython directory segment, e.g. ".../lib/python3.12/
-# site-packages" — captures (major, minor) so it can be compared against the
-# running interpreter's own version.
-_PYVER_DIR_RE = re.compile(r"python(\d+)\.(\d+)(?=[\\/]|$)", re.IGNORECASE)
+# Matches a complete ".../pythonX.Y/site-packages" path — captures (major,
+# minor) so it can be compared against the running interpreter's own
+# version. The two path components must be adjacent: a "pythonX.Y" segment
+# immediately followed by a "site-packages" segment. Anchoring on the full
+# pair (rather than checking "pythonX.Y/" and "site-packages" as
+# independent substrings anywhere in the path) avoids misfiring on paths
+# where the two happen to appear separately, e.g.
+# ".../python3.12/config/site-packages-notes".
+_PYVER_DIR_RE = re.compile(
+    r"python(\d+)\.(\d+)[\\/]site-packages(?=[\\/]|$)", re.IGNORECASE
+)
 
 
 def apply_windows_utf8_bootstrap() -> bool:
@@ -229,6 +236,13 @@ def activate_durable_lazy_target() -> None:
     The activation appends to the END of ``sys.path`` so the core venv
     always wins name collisions (see ``tools.lazy_deps`` for the full
     security rationale). Never raises; a missing/empty target is a no-op.
+
+    Must run *after* :func:`harden_user_site_version` (see the module-level
+    call order below). A configured target is trusted, arbitrary path — it
+    can legitimately be named like a versioned site-packages dir (e.g.
+    ``/data/python3.12/site-packages``) even though it holds packages for
+    the *running* interpreter. Activating it before the version sanitizer
+    would let the sanitizer immediately strip it back off ``sys.path``.
     """
     if not os.environ.get("HERMES_LAZY_INSTALL_TARGET", "").strip():
         return
@@ -261,6 +275,9 @@ def harden_user_site_version() -> None:
     always resolve into the running interpreter's own, healthy
     site-packages instead of silently shadowing into an incompatible one.
     Never raises; a clean ``sys.path`` is a no-op.
+
+    Must run *before* :func:`activate_durable_lazy_target` — see that
+    function's docstring for why the ordering matters.
     """
     current = (sys.version_info.major, sys.version_info.minor)
     try:
@@ -268,11 +285,7 @@ def harden_user_site_version() -> None:
         changed = False
         for entry in sys.path:
             match = _PYVER_DIR_RE.search(entry)
-            if (
-                match
-                and "site-packages" in entry.replace("\\", "/")
-                and (int(match.group(1)), int(match.group(2))) != current
-            ):
+            if match and (int(match.group(1)), int(match.group(2))) != current:
                 changed = True
                 continue
             cleaned.append(entry)
@@ -290,11 +303,16 @@ def harden_user_site_version() -> None:
 apply_windows_utf8_bootstrap()
 suppress_platform_ver_console()
 
+# Scrub any mismatched-Python-version site-packages dir off sys.path before
+# any backend module (PIL, etc.) can resolve an import into it. Must run
+# BEFORE activate_durable_lazy_target(): a configured durable target is a
+# trusted, arbitrary path that can legitimately be named like a versioned
+# site-packages dir (e.g. "/data/python3.12/site-packages") for a different
+# reason than an actual leaked interpreter version — activating it first
+# would let this sanitizer immediately strip it back off sys.path.
+harden_user_site_version()
+
 # Activate the durable lazy-install target (immutable Docker images) so
 # packages installed into the data volume on a previous run are importable
 # this run, before any backend module imports its SDK. No-op when unset.
 activate_durable_lazy_target()
-
-# Scrub any mismatched-Python-version site-packages dir off sys.path before
-# any backend module (PIL, etc.) can resolve an import into it.
-harden_user_site_version()

--- a/tests/test_hermes_bootstrap.py
+++ b/tests/test_hermes_bootstrap.py
@@ -368,3 +368,67 @@ class TestSuppressPlatformVerConsole:
             if original is not None:
                 platform._syscmd_ver = original
 
+
+class _FakeVersionInfo:
+    """Minimal stand-in for sys.version_info (which can't be instantiated)."""
+
+    def __init__(self, major, minor):
+        self.major = major
+        self.minor = minor
+
+
+class TestHardenUserSiteVersion:
+    """harden_user_site_version() must strip a mismatched-Python-version
+    site-packages dir off sys.path — the cross-version user-site leak that
+    broke pet.generate's PIL import (cannot import name '_imaging' from
+    'PIL', resolved from a python3.12 user-site inside a python3.11 process)."""
+
+    def _run(self, hb, path_seed, major, minor):
+        original = sys.path[:]
+        try:
+            sys.path[:] = path_seed
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr(hb.sys, "version_info", _FakeVersionInfo(major, minor))
+                hb.harden_user_site_version()
+            return sys.path[:]
+        finally:
+            sys.path[:] = original
+
+    def test_mismatched_version_site_packages_removed(self):
+        hb = _fresh_import()
+        result = self._run(
+            hb,
+            [
+                "/opt/hermes",
+                "/home/user/.local/lib/python3.12/site-packages",
+                "/opt/hermes/venv/lib/python3.11/site-packages",
+            ],
+            3,
+            11,
+        )
+        assert "/home/user/.local/lib/python3.12/site-packages" not in result
+        assert "/opt/hermes/venv/lib/python3.11/site-packages" in result
+        assert "/opt/hermes" in result
+
+    def test_matching_version_site_packages_kept(self):
+        hb = _fresh_import()
+        seed = [
+            "/opt/hermes",
+            "/home/user/.local/lib/python3.11/site-packages",
+        ]
+        result = self._run(hb, seed, 3, 11)
+        assert result == seed
+
+    def test_non_site_packages_paths_untouched(self):
+        hb = _fresh_import()
+        seed = ["/opt/hermes", "/home/user/.local/lib/python3.12/scripts"]
+        result = self._run(hb, seed, 3, 11)
+        assert result == seed
+
+    def test_no_crash_on_unusual_path_entries(self):
+        hb = _fresh_import()
+        seed = ["", ".", "not-a-path::weird"]
+        # Should not raise even with odd/empty entries.
+        result = self._run(hb, seed, 3, 11)
+        assert isinstance(result, list)
+

--- a/tests/test_hermes_bootstrap.py
+++ b/tests/test_hermes_bootstrap.py
@@ -432,3 +432,43 @@ class TestHardenUserSiteVersion:
         result = self._run(hb, seed, 3, 11)
         assert isinstance(result, list)
 
+    def test_site_packages_substring_elsewhere_not_stripped(self):
+        """A path that independently contains "pythonX.Y/" and
+        "site-packages" as two *unrelated* components — rather than the
+        complete "pythonX.Y/site-packages" pair — must not be treated as a
+        mismatched-version site-packages dir."""
+        hb = _fresh_import()
+        seed = ["/opt/hermes", "/data/python3.12/config/site-packages-notes"]
+        result = self._run(hb, seed, 3, 11)
+        assert result == seed
+
+
+class TestBootstrapImportOrder:
+    """Regression test: harden_user_site_version() must run BEFORE
+    activate_durable_lazy_target() at module import time. A configured
+    HERMES_LAZY_INSTALL_TARGET is a trusted, arbitrary path that can
+    legitimately be named like a versioned site-packages dir (e.g.
+    "/data/python3.12/site-packages") for a reason unrelated to the
+    running interpreter's own version. If the durable target were
+    activated (appended to sys.path) before the version sanitizer ran,
+    the sanitizer would immediately strip it back off."""
+
+    def test_version_named_lazy_target_survives_bootstrap(self, tmp_path, monkeypatch):
+        # Name the target for a minor version that is guaranteed to differ
+        # from the *actual* running interpreter (no version_info faking —
+        # faking it would also make harden_user_site_version() misidentify
+        # this venv's own real site-packages dir as mismatched, which is a
+        # test artifact, not the scenario under test).
+        other_minor = 5 if sys.version_info.minor != 5 else 6
+        target = tmp_path / f"python3.{other_minor}" / "site-packages"
+        target.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_LAZY_INSTALL_TARGET", str(target))
+
+        original_path = sys.path[:]
+        try:
+            _fresh_import()
+            assert str(target) in sys.path
+        finally:
+            sys.path[:] = original_path
+            sys.modules.pop("hermes_bootstrap", None)
+


### PR DESCRIPTION
## What does this PR do?

Adds a defensive guard to `hermes_bootstrap.py` — the module imported at the
top of every Hermes entry point (CLI, gateway, `tui_gateway`, ACP adapter,
batch runner) — that strips any `pythonX.Y/site-packages` directory from
`sys.path` when `X.Y` doesn't match the running interpreter's own version.

## Related Issue

Fixes #75766

## Root cause

The reporter's `/hatch` (`pet.generate`) call fails with:

```
pet.generate failed: cannot import name '_imaging' from 'PIL'
(/home/linuxuser/.local/lib/python3.12/site-packages/PIL/__init__.py)
```

The Hermes backend runs on venv **python3.11**, but its `sys.path` had
picked up a **python3.12** user-site directory from the launch environment
(a `PYTHONPATH`/user-site leak — e.g. from a systemd user unit or shell env
that isn't scrubbed before spawning the long-lived server process). A
python3.11 interpreter can never load a python3.12-compiled extension
(`_imaging.cpython-312-*.so` has the wrong ABI tag for 3.11), so the import
fails — not with a clear version-mismatch error, but with a confusing
"missing submodule" error deep inside whatever backend (PIL, here) happens
to touch that directory first.

This is a class of bug, not specific to PIL: any compiled extension in a
mismatched-version site-packages dir will fail the same confusing way, and
every Hermes entry point that inherits a contaminated launch environment is
exposed to it.

## Changes Made

- `hermes_bootstrap.py`: added `harden_user_site_version()`, which scans
  `sys.path` for `.../pythonX.Y/site-packages` entries whose `X.Y` doesn't
  match `sys.version_info`, and drops them. Applied automatically on import
  (alongside the existing Windows UTF-8 shim and durable-lazy-target
  activation), so every entry point that imports `hermes_bootstrap` is
  covered — including `tui_gateway/entry.py`, the process that serves
  `pet.generate`. Never raises; a clean `sys.path` is a no-op.
- `tests/test_hermes_bootstrap.py`: added `TestHardenUserSiteVersion` —
  covers removing a mismatched-version site-packages dir, keeping a
  matching-version one, leaving non-site-packages paths untouched, and not
  crashing on odd `sys.path` entries.

## How to Test

1. `python -m pytest tests/test_hermes_bootstrap.py -q` → 19 passed, 4 skipped
   (4 Windows-only tests skip on Linux CI).
2. Proof the new tests fail without the fix — reverted only
   `hermes_bootstrap.py` to `HEAD~1` (keeping the new test file) and reran:
   ```
   FAILED ...::test_mismatched_version_site_packages_removed - AttributeError: module 'hermes_bootstrap' has no attribute 'harden_user_site_version'
   FAILED ...::test_matching_version_site_packages_kept - AttributeError: module 'hermes_bootstrap' has no attribute 'harden_user_site_version'
   FAILED ...::test_non_site_packages_paths_untouched - AttributeError: module 'hermes_bootstrap' has no attribute 'harden_user_site_version'
   FAILED ...::test_no_crash_on_unusual_path_entries - AttributeError: module 'hermes_bootstrap' has no attribute 'harden_user_site_version'
   4 failed, 15 passed, 4 skipped
   ```
   Restored the fix and reran — all 19 pass.
3. `ruff check hermes_bootstrap.py tests/test_hermes_bootstrap.py` → all checks passed.
4. Also ran the existing sys.path regression suites to confirm no
   interference: `tests/tui_gateway/test_entry_sys_path.py`,
   `tests/tui_gateway/test_slash_worker_sys_path.py` → all pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/test_hermes_bootstrap.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] Tested on Linux (Ubuntu, CI environment)

### Documentation & Housekeeping

- [x] N/A — no config keys, tool schemas, or CLI workflow changes
- [x] Updated the docstring in `hermes_bootstrap.py` to describe the new
      cross-platform guard (the old "does nothing on POSIX" line was scoped
      to the UTF-8 shim specifically; clarified)

## AI assistance disclosure

This PR was prepared with the assistance of an AI coding agent (Claude),
which investigated the issue, wrote the fix, and wrote/verified the tests
(including confirming they fail without the fix). A human reviews and is
responsible for this submission.
