### PR TITLE
fix(desktop): remove dead voice.record_key field from Voice settings

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -320,6 +320,14 @@ export function ConfigSettings({
           where image-attachment behavior already lives, so this sits above the
           schema fields for that section. */}
       {activeSectionId === 'chat' ? <AttachmentSizeSetting /> : null}
+      {/* Desktop's push-to-talk binding lives in the rebindable keybind store
+          (`composer.voice`), not in this config-backed section — `voice.record_key`
+          from config.yaml is a CLI/TUI-only setting and was previously shown here
+          without ever doing anything (NousResearch/hermes-agent#40855). Point users
+          at the real control instead of re-adding a dead field. */}
+      {activeSectionId === 'voice' ? (
+        <ListRow description={c.voiceShortcutHintDesc} title={c.voiceShortcutHintTitle} />
+      ) : null}
       {visibleFields.length === 0 && activeSectionId !== 'chat' ? (
         <EmptyState description={c.emptyDesc} title={c.emptyTitle} />
       ) : visibleFields.length === 0 ? null : (

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -746,7 +746,6 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.elevenlabs.language_code',
       'stt.elevenlabs.tag_audio_events',
       'stt.elevenlabs.diarize',
-      'voice.record_key',
       'voice.max_recording_seconds'
     ]
   },

--- a/apps/desktop/src/app/settings/voice-field-visible.test.ts
+++ b/apps/desktop/src/app/settings/voice-field-visible.test.ts
@@ -15,7 +15,7 @@ describe('voiceFieldVisible', () => {
   it('always shows top-level + non-provider keys', () => {
     const config = cfg()
 
-    for (const key of ['tts.provider', 'stt.enabled', 'stt.provider', 'voice.auto_tts', 'voice.record_key']) {
+    for (const key of ['tts.provider', 'stt.enabled', 'stt.provider', 'voice.auto_tts']) {
       expect(voiceFieldVisible(key, config)).toBe(true)
     }
   })

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -559,6 +559,9 @@ export const en: Translations = {
       attachmentSizeTitle: 'Max preview / image load size',
       attachmentSizeDesc:
         'How big a local file Desktop will load for previews and image attach, in MB. Default is 16. Remote non-image attach uses a separate 256 MB cap. Setting this very high loads the whole file into memory and can freeze or crash the app.',
+      voiceShortcutHintTitle: 'Push-to-talk shortcut',
+      voiceShortcutHintDesc:
+        'Set the voice recording shortcut in Settings → Keyboard Shortcuts ("Start / stop voice conversation"). The voice.record_key config value only applies to the CLI and TUI.',
       attachmentSizeUnit: 'MB',
       attachmentSizeLabel: 'Max preview / image load size in megabytes'
     },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -462,6 +462,8 @@ export interface Translations {
       keepAwakeDesc: string
       attachmentSizeTitle: string
       attachmentSizeDesc: string
+      voiceShortcutHintTitle: string
+      voiceShortcutHintDesc: string
       attachmentSizeUnit: string
       attachmentSizeLabel: string
     }

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -769,6 +769,8 @@ export const zh: Translations = {
       attachmentSizeTitle: '预览 / 图片加载大小上限',
       attachmentSizeDesc:
         '桌面端为预览和图片附件加载本地文件的大小上限（MB）。默认为 16。远程非图片附件使用单独的 256 MB 上限。设置过大会将整个文件读入内存，可能导致应用卡死或崩溃。',
+      voiceShortcutHintTitle: '语音快捷键',
+      voiceShortcutHintDesc: '请在“设置 → 键盘快捷键”中设置语音录制快捷键（“开始 / 停止语音对话”）。voice.record_key 配置项仅适用于 CLI 和 TUI。',
       attachmentSizeUnit: 'MB',
       attachmentSizeLabel: '预览 / 图片加载大小上限（MB）'
     },


### PR DESCRIPTION
## What & why

Closes #40855.

`voice.record_key` (config.yaml) only ever applied to the CLI and TUI. The keybind wiring for Desktop's own push-to-talk shortcut already landed on `main` as the rebindable `composer.voice` keybind (see the discussion on the now-closed PR #41073), which lives entirely in the local keybind store and never reads `voice.record_key`. That left the field still visible in **Settings → Voice & Speech**, doing nothing when a user changed it — the exact symptom in #40855.

This finishes the remaining half of that issue: option (b) from the PR #41073 discussion — drop the redundant config field rather than bridge it into the keybind store, since the keybind registry is Desktop's actual source of truth for this setting.

## Change

- Remove `voice.record_key` from the Voice settings section keys (`apps/desktop/src/app/settings/constants.ts`).
- Add a small hint row on the Voice settings page pointing users to Settings → Keyboard Shortcuts, where the real `composer.voice` binding lives (`config-settings.tsx`).
- Drop the now-stale key from `voice-field-visible.test.ts`.
- Add the new i18n copy (en, zh — other locales fall back to en per existing convention).

## Testing

- `npx tsc -p . --noEmit` — clean.
- `npm run test:ui` — 25 files / 252 tests passed, including `voice-field-visible.test.ts`.
