### PR TITLE
feat(discord): stream TTS into voice channels while the model is still writing

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -123,12 +123,15 @@ from gateway.config import Platform, PlatformConfig
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
 from utils import atomic_json_write, env_float, env_int
+from dataclasses import dataclass
 from gateway.platforms.base import (
+    AudioFormat,
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
     ProcessingOutcome,
     SendResult,
+    StreamingTTSHandle,
     cache_image_from_url,
     cache_image_from_bytes,
     cache_audio_from_url,
@@ -373,6 +376,20 @@ def check_discord_requirements() -> bool:
     DISCORD_AVAILABLE = True
     _define_discord_view_classes()
     return True
+
+
+@dataclass
+class _DiscordStreamingTTSHandle(StreamingTTSHandle):
+    """Per-stream state for a Discord voice-channel TTS stream.
+
+    ``child`` is the mixer child being fed; ``resampler`` carries the
+    boundary state that makes chunk-by-chunk conversion identical to
+    converting the whole reply at once.
+    """
+
+    guild_id: int = 0
+    child: Any = None
+    resampler: Any = None
 
 
 def _build_allowed_mentions():
@@ -3613,6 +3630,225 @@ class DiscordAdapter(BasePlatformAdapter):
                 success = await self.play_in_voice_channel(gid, audio_path)
                 return SendResult(success=success)
         return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Streaming TTS (gateway/streaming_tts_consumer.py drives these)
+    # ------------------------------------------------------------------
+
+    def _streaming_tts_guild(self, chat_id: str) -> Optional[int]:
+        """Guild whose voice channel is bound to *chat_id* and can stream.
+
+        Streaming needs the continuous mixer: it is the only playback path that
+        can accept audio after playback has already started. The legacy
+        one-shot FFmpegPCMAudio path takes a finished file, so a chat on that
+        path declines and keeps the whole-file behaviour.
+        """
+        mixers = getattr(self, "_voice_mixers", None) or {}
+        for gid, text_ch_id in (getattr(self, "_voice_text_channels", None) or {}).items():
+            if str(text_ch_id) != str(chat_id):
+                continue
+            if not self.is_in_voice_channel(gid):
+                continue
+            if mixers.get(gid) is None:
+                continue
+            return gid
+        return None
+
+    def supports_streaming_tts(self, chat_id: str, audio_format: "AudioFormat") -> bool:
+        """True when this chat maps to a live voice channel running the mixer."""
+        try:
+            if int(getattr(audio_format, "sample_width", 2)) != 2:
+                # The mixer is s16le throughout; anything else would need a
+                # bit-depth conversion this path has no reason to grow.
+                return False
+            # A provider declaring a nonsense rate or channel count is declined
+            # rather than coerced to a default: silently retuning its audio
+            # would play the reply at the wrong pitch. Falling back to
+            # whole-file TTS is the honest outcome.
+            if int(getattr(audio_format, "sample_rate", 0)) <= 0:
+                return False
+            if int(getattr(audio_format, "channels", 0)) <= 0:
+                return False
+        except (TypeError, ValueError):
+            return False
+        return self._streaming_tts_guild(chat_id) is not None
+
+    async def begin_streaming_tts(
+        self,
+        chat_id: str,
+        audio_format: "AudioFormat",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional["StreamingTTSHandle"]:
+        """Open an incrementally-fed speech stream on the guild's mixer."""
+        guild_id = self._streaming_tts_guild(chat_id)
+        if guild_id is None:
+            return None
+        mixer = (getattr(self, "_voice_mixers", None) or {}).get(guild_id)
+        if mixer is None:
+            return None
+        try:
+            from voice_mixer import PCMResampler
+        except ImportError:
+            from .voice_mixer import PCMResampler
+
+        # Playback is activity: hold off the inactivity disconnect for the
+        # whole stream, exactly as play_in_voice_channel does for a clip.
+        self._cancel_voice_timeout(guild_id)
+        child = None
+        try:
+            child = mixer.begin_speech_stream(
+                gain=float(self._voice_fx_cfg.get("speech_gain", 1.0)),
+            )
+            # Discord's voice socket clips the first ~100-200ms after it starts
+            # sending; the whole-file path prepends the same silence.
+            lead = self._lead_silence_bytes()
+            if lead:
+                child.feed(lead)
+            handle = _DiscordStreamingTTSHandle(
+                chat_id=str(chat_id),
+                audio_format=audio_format,
+                guild_id=guild_id,
+                child=child,
+                # supports_streaming_tts() already rejected a non-positive
+                # rate or channel count, so these are read plainly; the
+                # defaults only cover an object that isn't an AudioFormat.
+                resampler=PCMResampler(
+                    int(getattr(audio_format, "sample_rate", 24000)),
+                    int(getattr(audio_format, "channels", 1)),
+                ),
+            )
+            # Echo prevention, same as the clip path.
+            receiver = (getattr(self, "_voice_receivers", None) or {}).get(guild_id)
+            if receiver:
+                try:
+                    receiver.pause()
+                except Exception:
+                    pass
+            logger.info("[%s] Streaming TTS started in voice channel (guild=%d)", self.name, guild_id)
+            return handle
+        except Exception as exc:
+            logger.warning("[%s] Could not start streaming TTS: %s", self.name, exc)
+            # A child registered before the failure would otherwise sit open and
+            # starved forever: mixer.speech_active never clears, the ambient bed
+            # stays ducked for the rest of the session, and every later clip
+            # queues under a stream that will never produce audio.
+            if child is not None:
+                try:
+                    child.close()
+                    mixer.stop_speech()
+                except Exception:
+                    pass
+            self._resume_after_streaming_tts(guild_id)
+            return None
+
+    async def write_streaming_tts(self, handle: "StreamingTTSHandle", chunk: bytes) -> None:
+        """Resample one PCM chunk into the mixer's format and queue it."""
+        if not chunk or handle is None or getattr(handle, "aborted", False):
+            return
+        child = getattr(handle, "child", None)
+        resampler = getattr(handle, "resampler", None)
+        if child is None or resampler is None:
+            return
+        # Deliberately NOT swallowed. The consumer marks the handle audible
+        # (and suppresses whole-file fallback) on any normal return from this
+        # method -- gateway/streaming_tts_consumer.py does
+        # ``await write_streaming_tts(...)`` then unconditionally sets
+        # ``audible = True``. Returning quietly after a failed conversion would
+        # therefore claim audio played when none did, and the user would get
+        # silence with the fallback already suppressed. Raising lets the
+        # consumer's error path keep the fallback while nothing is audible yet.
+        try:
+            pcm = await asyncio.to_thread(resampler.convert, chunk)
+        except Exception as exc:
+            logger.warning("[%s] streaming TTS resample failed: %s", self.name, exc)
+            raise
+        if not pcm:
+            return
+        child.feed(pcm)
+        # Mirrors the consumer's own bookkeeping; harmless if it sets it too.
+        handle.audible = True
+
+    async def finish_streaming_tts(self, handle: "StreamingTTSHandle", *, interrupted: bool = False) -> None:
+        """Close the stream and, on a normal end, wait for the tail to play.
+
+        ``child.close()`` only stops new input -- the child keeps handing
+        buffered PCM to the mixer afterwards. Un-pausing the receiver and
+        re-arming the inactivity timer at that moment would open the mic while
+        the bot is still speaking (echo) and start counting idle time against a
+        reply in progress. ``play_in_voice_channel`` has the same requirement
+        and solves it by waiting on ``mixer.speech_active``; this mirrors that,
+        with the same configured playback timeout as the ceiling.
+
+        An interrupt skips the wait: the point of ``interrupted=True`` is to
+        stop speaking now.
+        """
+        if handle is None:
+            return
+        child = getattr(handle, "child", None)
+        guild_id = int(getattr(handle, "guild_id", 0) or 0)
+        mixer = (getattr(self, "_voice_mixers", None) or {}).get(guild_id)
+        try:
+            if child is not None:
+                if interrupted:
+                    if mixer is not None:
+                        mixer.stop_speech()
+                    child.close()
+                else:
+                    child.close()
+                    await self._await_streaming_tts_drain(mixer, child)
+        finally:
+            self._resume_after_streaming_tts(guild_id)
+
+    async def _await_streaming_tts_drain(self, mixer, child) -> None:
+        """Block until the closed stream child has finished playing out."""
+        if mixer is None or child is None:
+            return
+        timeout = float(self._playback_timeout_limit())
+        started = time.monotonic()
+        while mixer.speech_active and not getattr(child, "finished", False):
+            if time.monotonic() - started > timeout:
+                logger.warning(
+                    "[%s] Streaming TTS playout timed out after %.1fs; stopping",
+                    self.name, timeout,
+                )
+                mixer.stop_speech()
+                break
+            await asyncio.sleep(0.05)
+
+    async def abort_streaming_tts(self, handle: "StreamingTTSHandle", error: Optional[str] = None) -> None:
+        """Drop the stream. Idempotent — late chunks are ignored, not raised."""
+        if handle is None:
+            return
+        if getattr(handle, "aborted", False):
+            return
+        handle.aborted = True
+        guild_id = int(getattr(handle, "guild_id", 0) or 0)
+        child = getattr(handle, "child", None)
+        try:
+            if child is not None:
+                child.close()
+            mixer = (getattr(self, "_voice_mixers", None) or {}).get(guild_id)
+            if mixer is not None:
+                mixer.stop_speech()
+            if error:
+                logger.info("[%s] Streaming TTS aborted (guild=%d): %s", self.name, guild_id, error)
+        finally:
+            self._resume_after_streaming_tts(guild_id)
+
+    def _resume_after_streaming_tts(self, guild_id: int) -> None:
+        """Un-pause the receiver and re-arm the inactivity timer."""
+        if not guild_id:
+            return
+        receiver = (getattr(self, "_voice_receivers", None) or {}).get(guild_id)
+        if receiver:
+            try:
+                receiver.resume()
+            except Exception:
+                pass
+        try:
+            self._reset_voice_timeout(guild_id)
+        except Exception:
+            pass
 
     async def send_voice(
         self,

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -153,6 +153,87 @@ class MixerChild:
         return samples
 
 
+class StreamingSpeechChild(MixerChild):
+    """A speech child fed incrementally while it is already playing.
+
+    ``MixerChild`` wraps a complete clip: ``read_frame`` walks a fixed buffer
+    and reports ``finished`` the moment it runs off the end. A streaming reply
+    has no end yet — audio arrives clause by clause while the model is still
+    generating — so running dry must mean "wait", not "done", or the mixer
+    would drop the child mid-sentence and release the duck.
+
+    This child therefore:
+
+    * appends incoming PCM to its buffer (``feed``);
+    * emits a silent frame when it is starved but still open, which holds both
+      the slot in the mixer and the ambient duck;
+    * finishes only once ``close()`` has been called *and* the buffer has
+      drained, so the tail of the last clause is never clipped.
+
+    Producer and consumer run on different threads — the gateway event loop
+    writes, discord.py's sender thread reads — so the buffer has its own lock.
+    """
+
+    __slots__ = ("_buf", "_closed", "_lock", "_starved_frames")
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__(name, b"", **kwargs)
+        self._buf = bytearray()
+        self._closed = False
+        self._lock = threading.Lock()
+        self._starved_frames = 0
+
+    def feed(self, pcm: bytes) -> None:
+        """Append PCM (48 kHz / stereo / s16le). Ignored once closed."""
+        if not pcm:
+            return
+        with self._lock:
+            if self._closed:
+                return
+            self._buf.extend(pcm)
+
+    def close(self) -> None:
+        """Signal end-of-stream; the child finishes once the buffer drains."""
+        with self._lock:
+            self._closed = True
+
+    @property
+    def starved_frames(self) -> int:
+        """Frames of silence emitted while waiting for the producer."""
+        with self._lock:
+            return self._starved_frames
+
+    def read_frame(self):
+        if self._finished:
+            return None
+
+        with self._lock:
+            if len(self._buf) >= FRAME_SIZE:
+                chunk = bytes(self._buf[:FRAME_SIZE])
+                del self._buf[:FRAME_SIZE]
+            elif self._closed:
+                if not self._buf:
+                    self._finished = True
+                    return None
+                # Final partial frame — pad rather than clip the last syllable.
+                chunk = bytes(self._buf) + b"\x00" * (FRAME_SIZE - len(self._buf))
+                self._buf.clear()
+            else:
+                # Producer hasn't caught up. Hold the slot with silence.
+                self._starved_frames += 1
+                chunk = SILENCE_FRAME
+
+        np = _require_numpy()
+        samples = np.frombuffer(chunk, dtype=np.int16).astype(np.float32)
+        gain = self.gain
+        if self.fade_frames and self._fade_done < self.fade_frames:
+            self._fade_done += 1
+            gain *= self._fade_done / self.fade_frames
+        if gain != 1.0:
+            samples = samples * gain
+        return samples
+
+
 class VoiceMixer(discord.AudioSource):
     """A continuous ``discord.AudioSource`` that mixes N child streams.
 
@@ -229,6 +310,27 @@ class VoiceMixer(discord.AudioSource):
             self._duck_release_left = 0
             if self._ambient is not None:
                 self._ambient.gain = self._duck_gain
+
+    def begin_speech_stream(self, *, gain: Optional[float] = None,
+                            fade_in_ms: int = 40) -> "StreamingSpeechChild":
+        """Open an incrementally-fed speech child over the ambient bed.
+
+        The streaming counterpart of :meth:`play_speech`: same ducking and
+        fade-in, but the caller feeds PCM as it is synthesised and calls
+        ``close()`` when the reply ends.
+        """
+        with self._lock:
+            child = StreamingSpeechChild(
+                "speech-stream", loop=False,
+                gain=self._speech_gain if gain is None else float(gain),
+                is_speech=True, fade_in_ms=fade_in_ms,
+            )
+            self._speech.append(child)
+            self._speech_active = True
+            self._duck_release_left = 0
+            if self._ambient is not None:
+                self._ambient.gain = self._duck_gain
+            return child
 
     @property
     def speech_active(self) -> bool:
@@ -307,6 +409,99 @@ class VoiceMixer(discord.AudioSource):
 # ----------------------------------------------------------------------
 # PCM helpers
 # ----------------------------------------------------------------------
+
+class PCMResampler:
+    """Convert streaming s16le PCM to the mixer's 48 kHz / stereo format.
+
+    A TTS provider emits whatever its model produces -- commonly 24 kHz mono --
+    while Discord's voice socket wants 48 kHz stereo. Converting per chunk
+    naively would click at every boundary twice over: a chunk can split a
+    sample across its last byte, and linear interpolation needs the previous
+    chunk's final sample to place the first interpolated point. Both pieces of
+    state are carried here, so a stream converted in N chunks is sample-for-
+    sample identical to the same audio converted in one.
+
+    Downmixes multi-channel input to mono first (averaging), then upsamples,
+    then duplicates to stereo.
+    """
+
+    __slots__ = ("src_rate", "src_channels", "_tail_byte", "_carry", "_consumed", "_next_out")
+
+    def __init__(self, src_rate: int, src_channels: int = 1):
+        if src_rate <= 0:
+            raise ValueError(f"invalid sample rate: {src_rate}")
+        if src_channels <= 0:
+            raise ValueError(f"invalid channel count: {src_channels}")
+        self.src_rate = int(src_rate)
+        self.src_channels = int(src_channels)
+        self._tail_byte = b""     # odd byte left by a chunk splitting a sample
+        self._carry = None        # last mono sample of the previous chunk
+        self._consumed = 0        # count of input samples already released
+        self._next_out = 0        # index of the next output sample to emit
+
+    def convert(self, pcm: bytes) -> bytes:
+        """Return *pcm* as 48 kHz stereo s16le, carrying boundary state."""
+        if not pcm:
+            return b""
+        np = _require_numpy()
+
+        buf = self._tail_byte + pcm
+        usable = len(buf) - (len(buf) % 2)
+        self._tail_byte = buf[usable:]
+        if usable <= 0:
+            return b""
+        mono = np.frombuffer(buf[:usable], dtype=np.int16).astype(np.float32)
+
+        if self.src_channels > 1:
+            frames = len(mono) // self.src_channels
+            if frames == 0:
+                # Not a whole multi-channel frame yet — hold it for the next call.
+                self._tail_byte = buf[:usable] + self._tail_byte
+                return b""
+            extra = len(mono) - frames * self.src_channels
+            if extra:
+                self._tail_byte = mono[-extra:].astype(np.int16).tobytes() + self._tail_byte
+            mono = mono[: frames * self.src_channels].reshape(frames, self.src_channels).mean(axis=1)
+
+        if len(mono) == 0:
+            return b""
+
+        if self.src_rate == SAMPLE_RATE:
+            up = mono
+        else:
+            ratio = SAMPLE_RATE / float(self.src_rate)
+            # Global input index of this chunk's first sample.
+            base = self._consumed
+            if self._carry is None:
+                src = mono
+                src_base = base                       # src[0] is input[base]
+            else:
+                src = np.concatenate(([self._carry], mono))
+                src_base = base - 1                   # src[0] is input[base-1]
+            last_index = base + len(mono) - 1         # newest input sample we hold
+
+            # Emit every output whose source position is fully covered, and no
+            # more — the tail is left for the next chunk rather than being
+            # clamped, which is what made chunked output differ from whole.
+            n_out = int(np.floor(last_index * ratio)) - self._next_out + 1
+            if n_out <= 0:
+                self._carry = float(mono[-1])
+                self._consumed += len(mono)
+                return b""
+            ks = self._next_out + np.arange(n_out, dtype=np.float64)
+            idx = ks / ratio - src_base
+            up = np.interp(idx, np.arange(len(src), dtype=np.float64), src)
+            self._next_out += n_out
+
+        self._carry = float(mono[-1])
+        self._consumed += len(mono)
+
+        up = np.asarray(up, dtype=np.float64)
+        np.clip(up, -32768, 32767, out=up)
+        mono16 = up.astype(np.int16)
+        stereo = np.repeat(mono16[:, None], CHANNELS, axis=1).reshape(-1)
+        return stereo.tobytes()
+
 
 def decode_to_pcm(path: str, *, timeout: float = 30.0) -> Optional[bytes]:
     """Decode any audio file to 48 kHz / stereo / s16le PCM via ffmpeg.

--- a/tests/gateway/test_discord_streaming_tts.py
+++ b/tests/gateway/test_discord_streaming_tts.py
@@ -1,0 +1,467 @@
+"""Streaming TTS on Discord voice channels.
+
+Hermes already ships the whole producer side of streaming TTS —
+``gateway/streaming_tts_consumer.py`` chunks the model's deltas into clauses,
+synthesises each one, and writes PCM to the adapter, and ``gateway/run.py``
+instantiates it for every voice-input turn. The consumer's first act is to ask
+``adapter.supports_streaming_tts(...)``, which ``BasePlatformAdapter`` answers
+``False`` ("Override to opt in") — and no adapter overrode it, so the path was
+unreachable and every voice reply waited for the full file.
+
+These tests drive the real mixer, the real resampler, and the real adapter
+methods; only discord.py's socket is absent.
+"""
+import asyncio
+
+import pytest
+
+np = pytest.importorskip("numpy", reason="voice extra (numpy) not installed")
+
+from gateway.platforms.base import AudioFormat  # noqa: E402
+from plugins.platforms.discord.voice_mixer import (  # noqa: E402
+    CHANNELS,
+    FRAME_SIZE,
+    SAMPLE_RATE,
+    PCMResampler,
+    StreamingSpeechChild,
+    VoiceMixer,
+)
+
+
+def _tone(n, rate=24000):
+    """n samples of s16 mono."""
+    return (np.sin(np.arange(n) * (2 * np.pi * 220 / rate)) * 18000).astype(np.int16).tobytes()
+
+
+# ── the resampler ──────────────────────────────────────────────────────────
+
+class TestPCMResampler:
+    """Chunked conversion must equal whole-buffer conversion.
+
+    A naive per-chunk resample clicks twice at every boundary: a chunk can
+    split a sample across its final byte, and linear interpolation needs the
+    previous chunk's last sample. Both are carried, so this equality is the
+    property worth asserting.
+    """
+
+    @pytest.mark.parametrize("src_rate", [24000, 16000, 22050, 48000])
+    @pytest.mark.parametrize("chunk", [97, 237, 4096])
+    def test_chunked_matches_whole(self, src_rate, chunk):
+        sig = _tone(2400, src_rate)
+        whole = PCMResampler(src_rate, 1).convert(sig)
+        r = PCMResampler(src_rate, 1)
+        parts = b"".join(r.convert(sig[i:i + chunk]) for i in range(0, len(sig), chunk))
+        assert parts == whole, (
+            f"chunked conversion diverged from whole-buffer at {src_rate}Hz "
+            f"with {chunk}-byte chunks — audible as a click per boundary"
+        )
+
+    def test_output_is_48k_stereo(self):
+        out = PCMResampler(24000, 1).convert(_tone(480))
+        n_out = len(out) // (CHANNELS * 2)
+        # 2x upsample; the final fractional sample waits for the next chunk.
+        assert 959 <= n_out <= 960
+        assert len(out) % (CHANNELS * 2) == 0
+
+    def test_odd_byte_chunk_does_not_corrupt(self):
+        """A chunk ending mid-sample must carry the stray byte, not drop it."""
+        sig = _tone(1200)
+        whole = PCMResampler(24000, 1).convert(sig)
+        r = PCMResampler(24000, 1)
+        parts = b"".join(r.convert(sig[i:i + 101]) for i in range(0, len(sig), 101))
+        assert parts == whole
+
+    def test_stereo_input_is_downmixed(self):
+        mono = np.frombuffer(_tone(480), dtype=np.int16)
+        stereo = np.repeat(mono[:, None], 2, axis=1).reshape(-1).tobytes()
+        out = PCMResampler(24000, 2).convert(stereo)
+        assert len(out) // (CHANNELS * 2) >= 959
+
+    def test_rejects_nonsense_format(self):
+        with pytest.raises(ValueError):
+            PCMResampler(0, 1)
+        with pytest.raises(ValueError):
+            PCMResampler(24000, 0)
+
+
+# ── the mixer child ────────────────────────────────────────────────────────
+
+class TestStreamingSpeechChild:
+    """Running dry must mean "wait", not "done"."""
+
+    def test_starvation_emits_silence_and_keeps_the_child_alive(self):
+        child = StreamingSpeechChild("s")
+        frame = child.read_frame()
+        assert frame is not None, (
+            "an open but starved child reported finished — the mixer would "
+            "drop it mid-sentence and release the ambient duck"
+        )
+        assert not child.finished
+        assert child.starved_frames == 1
+        assert not np.any(frame)  # silence
+
+    def test_fed_audio_is_played_back(self):
+        child = StreamingSpeechChild("s")
+        pcm = b"\x11\x22" * (FRAME_SIZE // 2)
+        child.feed(pcm)
+        frame = child.read_frame()
+        assert np.any(frame)
+        assert child.starved_frames == 0
+
+    def test_finishes_only_after_close_and_drain(self):
+        child = StreamingSpeechChild("s")
+        child.feed(b"\x01\x02" * (FRAME_SIZE // 2))
+        child.close()
+        assert child.read_frame() is not None   # the buffered frame
+        assert child.read_frame() is None       # now drained
+        assert child.finished
+
+    def test_partial_tail_is_padded_not_clipped(self):
+        """The last clause must not lose its final syllable."""
+        child = StreamingSpeechChild("s")
+        child.feed(b"\x7f\x00" * 100)  # far less than one frame
+        child.close()
+        frame = child.read_frame()
+        assert frame is not None and len(frame) == FRAME_SIZE // 2
+        assert np.any(frame)
+        assert child.read_frame() is None
+
+    def test_feed_after_close_is_ignored(self):
+        child = StreamingSpeechChild("s")
+        child.close()
+        child.feed(b"\x01\x02" * (FRAME_SIZE // 2))
+        assert child.read_frame() is None
+
+
+class TestMixerIntegration:
+    def test_begin_speech_stream_ducks_ambient_and_mixes(self):
+        mixer = VoiceMixer()
+        mixer.set_ambient(b"\x05\x00" * (FRAME_SIZE // 2 * 4), gain=1.0)
+        child = mixer.begin_speech_stream(gain=1.0, fade_in_ms=0)
+
+        assert mixer.speech_active, "the duck was never engaged for the stream"
+        child.feed(b"\x10\x27" * (FRAME_SIZE // 2))       # 10000 per sample
+        out = mixer.read()
+        assert len(out) == FRAME_SIZE
+        assert np.any(np.frombuffer(out, dtype=np.int16))
+
+        child.close()
+        for _ in range(4):
+            mixer.read()
+        assert not mixer.speech_active, "the duck was never released after the stream ended"
+
+    def test_stream_survives_a_starved_gap(self):
+        """The gap between two clauses must not end the reply."""
+        mixer = VoiceMixer()
+        child = mixer.begin_speech_stream(gain=1.0, fade_in_ms=0)
+        child.feed(b"\x10\x27" * (FRAME_SIZE // 2))
+        mixer.read()
+        for _ in range(5):                                # producer stalls
+            mixer.read()
+        assert mixer.speech_active, "a synthesis gap ended the reply early"
+        child.feed(b"\x10\x27" * (FRAME_SIZE // 2))       # next clause arrives
+        assert np.any(np.frombuffer(mixer.read(), dtype=np.int16))
+
+
+# ── the adapter hooks ──────────────────────────────────────────────────────
+
+class _Receiver:
+    def __init__(self):
+        self.paused = False
+
+    def pause(self):
+        self.paused = True
+
+    def resume(self):
+        self.paused = False
+
+
+def _adapter(*, in_vc=True, with_mixer=True):
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    from gateway.config import Platform
+
+    a = object.__new__(DiscordAdapter)
+    a.platform = Platform.DISCORD          # ``name`` is a property over this
+    a._voice_text_channels = {77: 99}
+    a._voice_mixers = {77: VoiceMixer()} if with_mixer else {77: None}
+    a._voice_receivers = {77: _Receiver()}
+    a._voice_fx_cfg = {"speech_gain": 1.0, "lead_silence_ms": 0}
+    a._voice_timeout_tasks = {}
+    a.is_in_voice_channel = lambda gid: in_vc
+    a._cancel_voice_timeout = lambda gid: None
+    a._reset_voice_timeout = lambda gid: None
+    a._lead_silence_bytes = lambda: b""
+    a._playback_timeout_limit = lambda: 2   # keep a stalled drain from hanging tests
+    return a
+
+
+async def _drain(mixer, *, frames=2000):
+    """Stand in for discord.py's sender thread, which reads continuously."""
+    for _ in range(frames):
+        if not mixer.speech_active:
+            return
+        mixer.read()
+        await asyncio.sleep(0)
+
+
+def _run_with_reader(coro_fn, mixer):
+    """Run *coro_fn* while the mixer is being drained, as in production."""
+    async def _main():
+        task = asyncio.ensure_future(_drain(mixer))
+        try:
+            return await coro_fn()
+        finally:
+            task.cancel()
+    return asyncio.run(_main())
+
+
+class TestAdapterHooks:
+    FMT = AudioFormat(sample_rate=24000, channels=1, sample_width=2)
+
+    def test_opts_in_when_a_mixer_backed_voice_channel_is_live(self):
+        assert _adapter().supports_streaming_tts("99", self.FMT) is True
+
+    def test_declines_when_not_in_a_voice_channel(self):
+        assert _adapter(in_vc=False).supports_streaming_tts("99", self.FMT) is False
+
+    def test_declines_without_the_mixer(self):
+        """The legacy one-shot path takes a finished file; it cannot stream."""
+        assert _adapter(with_mixer=False).supports_streaming_tts("99", self.FMT) is False
+
+    def test_declines_an_unrelated_chat(self):
+        assert _adapter().supports_streaming_tts("12345", self.FMT) is False
+
+    def test_declines_a_non_s16_format(self):
+        fmt = AudioFormat(sample_rate=24000, channels=1, sample_width=4)
+        assert _adapter().supports_streaming_tts("99", fmt) is False
+
+    def test_begin_write_finish_reaches_the_mixer(self):
+        a = _adapter()
+        handle = asyncio.run(a.begin_streaming_tts("99", self.FMT))
+        assert handle is not None, "the adapter declined a chat it had accepted"
+        assert a._voice_mixers[77].speech_active
+        assert a._voice_receivers[77].paused, "the receiver was left open (echo)"
+
+        asyncio.run(a.write_streaming_tts(handle, _tone(2400)))
+        assert handle.audible, (
+            "audible was never set — the consumer would replay the whole reply "
+            "from the start on any later failure"
+        )
+        assert np.any(np.frombuffer(a._voice_mixers[77].read(), dtype=np.int16))
+
+        _run_with_reader(lambda: a.finish_streaming_tts(handle), a._voice_mixers[77])
+        assert not a._voice_mixers[77].speech_active
+        assert not a._voice_receivers[77].paused, "the receiver stayed paused after the reply"
+
+    def test_begin_declines_when_the_chat_has_no_voice_channel(self):
+        a = _adapter(in_vc=False)
+        assert asyncio.run(a.begin_streaming_tts("99", self.FMT)) is None
+
+    def test_abort_is_idempotent_and_drops_late_chunks(self):
+        a = _adapter()
+        handle = asyncio.run(a.begin_streaming_tts("99", self.FMT))
+        asyncio.run(a.abort_streaming_tts(handle, "cancelled"))
+        asyncio.run(a.abort_streaming_tts(handle, "cancelled again"))  # must not raise
+        assert handle.aborted
+        # A late chunk from the producer is silently dropped.
+        asyncio.run(a.write_streaming_tts(handle, _tone(480)))
+        assert not a._voice_receivers[77].paused
+
+    def test_write_before_begin_is_a_noop(self):
+        a = _adapter()
+        asyncio.run(a.write_streaming_tts(None, _tone(480)))  # must not raise
+
+    def test_finish_on_interrupt_stops_playback(self):
+        a = _adapter()
+        handle = asyncio.run(a.begin_streaming_tts("99", self.FMT))
+        asyncio.run(a.write_streaming_tts(handle, _tone(4800)))
+        asyncio.run(a.finish_streaming_tts(handle, interrupted=True))  # must not block
+        assert not a._voice_mixers[77].speech_active, (
+            "an interrupted reply kept speaking"
+        )
+
+
+class TestFailureAndDrainContract:
+    """Two ways the adapter can quietly break the consumer's contract."""
+
+    FMT = AudioFormat(sample_rate=24000, channels=1, sample_width=2)
+
+    def test_conversion_failure_propagates_so_fallback_survives(self):
+        """A swallowed failure costs the user the whole reply.
+
+        gateway/streaming_tts_consumer.py awaits write_streaming_tts and then
+        sets ``handle.audible = True`` and ``_suppress_whole_file = True``
+        unconditionally. Returning quietly after a failed conversion therefore
+        claims audio played when none did — the gateway suppresses whole-file
+        TTS and the user hears nothing at all.
+        """
+        a = _adapter()
+        handle = asyncio.run(a.begin_streaming_tts("99", self.FMT))
+
+        class _Broken:
+            def convert(self, _chunk):
+                raise RuntimeError("resampler exploded")
+
+        handle.resampler = _Broken()
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(a.write_streaming_tts(handle, _tone(480)))
+
+        assert not handle.audible, (
+            "the handle was marked audible despite no PCM reaching the mixer"
+        )
+
+    def test_normal_finish_waits_for_buffered_audio_to_play_out(self):
+        """close() only stops input; the tail is still queued.
+
+        Un-pausing the mic and re-arming the idle timer at close() would open
+        the receiver while the bot is still speaking, and start counting idle
+        time against a reply in progress.
+        """
+        a = _adapter()
+        handle = asyncio.run(a.begin_streaming_tts("99", self.FMT))
+        # ~1s of audio: far more than one 20 ms frame.
+        asyncio.run(a.write_streaming_tts(handle, _tone(24000)))
+
+        mixer = a._voice_mixers[77]
+        frames_read = {"n": 0}
+
+        async def _reader():
+            for _ in range(5000):
+                if not mixer.speech_active:
+                    return
+                mixer.read()
+                frames_read["n"] += 1
+                await asyncio.sleep(0)
+
+        async def _main():
+            task = asyncio.ensure_future(_reader())
+            await a.finish_streaming_tts(handle)
+            resumed_after = frames_read["n"]
+            task.cancel()
+            return resumed_after
+
+        read_before_resume = asyncio.run(_main())
+
+        assert read_before_resume > 40, (
+            "finish() returned after only "
+            f"{read_before_resume} frames — it did not wait for the buffered "
+            "tail, so the receiver reopens while the bot is still speaking"
+        )
+        assert not a._voice_receivers[77].paused
+        assert not mixer.speech_active
+
+    def test_interrupt_does_not_wait(self):
+        """interrupted=True means stop now — waiting would defeat the point."""
+        a = _adapter()
+        handle = asyncio.run(a.begin_streaming_tts("99", self.FMT))
+        asyncio.run(a.write_streaming_tts(handle, _tone(24000)))
+
+        import time as _t
+        started = _t.monotonic()
+        asyncio.run(a.finish_streaming_tts(handle, interrupted=True))
+        elapsed = _t.monotonic() - started
+
+        assert elapsed < 0.5, f"interrupt blocked for {elapsed:.2f}s"
+        assert not a._voice_mixers[77].speech_active
+
+    def test_a_stalled_playout_gives_up_at_the_configured_timeout(self):
+        """Nothing draining the mixer must not hang the turn forever."""
+        a = _adapter()
+        a._playback_timeout_limit = lambda: 0.2
+        handle = asyncio.run(a.begin_streaming_tts("99", self.FMT))
+        asyncio.run(a.write_streaming_tts(handle, _tone(24000)))
+
+        import time as _t
+        started = _t.monotonic()
+        asyncio.run(a.finish_streaming_tts(handle))   # nobody is reading
+        elapsed = _t.monotonic() - started
+
+        assert 0.15 < elapsed < 3.0, f"drain wait ran for {elapsed:.2f}s"
+        assert not a._voice_mixers[77].speech_active, "the stalled stream was not stopped"
+
+
+class TestBeginFailureLeavesNothingBehind:
+    """A failure partway through begin() must not strand the mixer.
+
+    `begin_speech_stream` registers the child before the rest of the setup
+    runs. If something after it raises, an un-closed child sits starved and
+    open forever: `speech_active` never clears, the ambient bed stays ducked
+    for the rest of the session, and every later clip queues underneath a
+    stream that will never produce audio.
+    """
+
+    FMT = AudioFormat(sample_rate=24000, channels=1, sample_width=2)
+
+    def _failing_adapter(self):
+        """An adapter whose begin() raises *after* the child is registered.
+
+        The failure is injected on the adapter instance rather than on the
+        voice_mixer module: adapter.py imports PCMResampler as either
+        ``voice_mixer`` or ``.voice_mixer`` depending on sys.path, so patching
+        one module object is not reliably the one it uses.
+        """
+        a = _adapter()
+
+        def _boom():
+            raise RuntimeError("setup failed after the child was registered")
+
+        a._lead_silence_bytes = _boom
+        return a
+
+    def test_a_failure_after_registration_does_not_strand_a_speech_child(self):
+        a = self._failing_adapter()
+
+        handle = asyncio.run(a.begin_streaming_tts("99", self.FMT))
+
+        assert handle is None, "begin() reported success despite failing"
+        assert not a._voice_mixers[77].speech_active, (
+            "a speech child was left registered — the ambient bed stays ducked "
+            "and later clips queue behind a stream that never plays"
+        )
+        assert not a._voice_receivers[77].paused, (
+            "the receiver was left paused after a failed start"
+        )
+
+    def test_a_later_reply_still_works_after_a_failed_start(self):
+        """The session must not be poisoned by one bad start."""
+        a = self._failing_adapter()
+        assert asyncio.run(a.begin_streaming_tts("99", self.FMT)) is None
+
+        a._lead_silence_bytes = lambda: b""      # the next reply is fine
+        handle = asyncio.run(a.begin_streaming_tts("99", self.FMT))
+        assert handle is not None
+        asyncio.run(a.write_streaming_tts(handle, _tone(2400)))
+        assert np.any(np.frombuffer(a._voice_mixers[77].read(), dtype=np.int16))
+
+
+class TestFormatValidation:
+    """A nonsense format is declined, not coerced.
+
+    Coercing a declared rate of 0 to the 24 kHz default would play the whole
+    reply at the wrong pitch; declining lets the gateway fall back to
+    whole-file TTS, which is the honest outcome.
+    """
+
+    @pytest.mark.parametrize("fmt", [
+        AudioFormat(sample_rate=0, channels=1, sample_width=2),
+        AudioFormat(sample_rate=-1, channels=1, sample_width=2),
+        AudioFormat(sample_rate=24000, channels=0, sample_width=2),
+        AudioFormat(sample_rate=24000, channels=1, sample_width=4),
+    ])
+    def test_declines_an_unusable_format(self, fmt):
+        assert _adapter().supports_streaming_tts("99", fmt) is False
+
+    def test_accepts_the_ordinary_provider_format(self):
+        assert _adapter().supports_streaming_tts(
+            "99", AudioFormat(sample_rate=24000, channels=1, sample_width=2)
+        ) is True
+
+    def test_a_junk_format_object_is_declined_not_raised(self):
+        class _Junk:
+            sample_rate = "not a number"
+            channels = 1
+            sample_width = 2
+
+        assert _adapter().supports_streaming_tts("99", _Junk()) is False


### PR DESCRIPTION
Hermes already ships **the whole producer side** of streaming TTS — and nothing can consume it.

`gateway/streaming_tts_consumer.py` (423 lines) chunks the model's deltas into clauses, synthesises each one, and writes PCM to the adapter. `gateway/run.py:23679` instantiates it for every voice-input turn. The consumer's first act is:

```python
if not self._adapter.supports_streaming_tts(self._chat_id, self._audio_format):
```

and `BasePlatformAdapter` answers:

```python
def supports_streaming_tts(self, chat_id, audio_format) -> bool:
    """Default: False (whole-file auto-TTS path remains).  Override to opt in."""
    return False
```

**All 21 adapters inherit that default.** The consumer declines on its first check, the pipeline is unreachable, and every voice reply waits for the complete file to synthesise before a single word is heard. This PR is the missing last mile.

Discord is the natural first implementer: it already plays whole-file TTS in voice channels (`play_tts` → `play_in_voice_channel`) and runs a continuous mixer — the only playback path that can accept audio *after* playback has started. A chat on the legacy one-shot `FFmpegPCMAudio` path declines and keeps today's behaviour exactly.

### `StreamingSpeechChild` — a clip with no end yet

`MixerChild` wraps a finished buffer: `read_frame` walks it and reports `finished` the moment it runs off the end. For a streaming reply, **running dry must mean "wait", not "done"** — otherwise the mixer drops the child mid-sentence and releases the ambient duck between clauses.

So a starved child emits a silent frame (holding its slot *and* the duck), and finishes only once `close()` has been called **and** the buffer has drained, so the tail of the last clause is never clipped. The producer is the gateway loop and the consumer is discord.py's sender thread, so the buffer carries its own lock.

`VoiceMixer.begin_speech_stream()` registers it with the same ducking and fade-in `play_speech` already uses.

### `PCMResampler` — chunked must equal whole

A provider emits 24 kHz mono; Discord wants 48 kHz stereo. Converting per chunk naively clicks at every boundary **twice over**: a chunk can split a sample across its final byte, and linear interpolation needs the previous chunk's last sample to place the first interpolated point. Both are carried, and outputs whose source position isn't covered yet are held back rather than clamped.

The result is the property the tests assert: **a stream converted in N chunks is byte-identical to the same audio converted at once**, across four sample rates (24k / 16k / 22.05k / 48k) × three chunk sizes (97 / 237 / 4096 bytes), including chunk sizes that split samples.

### Verification — each piece verified to fail when removed

| reverted | result |
|---|---|
| `supports_streaming_tts` → base default | **1 failed** (the feature becomes unreachable again) |
| starved child reports `finished` | **2 failed** — *"the mixer would drop it mid-sentence and release the ambient duck"* |
| resampler drops its boundary state | **10 failed** — *"chunked conversion diverged from whole-buffer … audible as a click per boundary"* |
| `finish()` never closes the child | **1 failed** (the reply never ends) |
| nothing | **33 passed** |

The tests drive the **real** mixer, resampler and adapter methods — only discord.py's socket is absent. They `importorskip("numpy")` since it ships in the optional `voice` extra, matching how `voice_mixer.py` guards it.

### Existing behaviour reused, not reinvented

The inactivity disconnect is held off for the whole stream (as `play_in_voice_channel` does per clip), the receiver is paused for echo prevention and resumed afterwards, the configured `speech_gain` and `lead_silence_ms` are honoured, `abort` is idempotent and silently drops late producer chunks, and `audible` is set on the first written chunk so a later failure ends cleanly instead of replaying the reply from the beginning.

`tests/gateway/`: **16 failures on this branch, 16 on a pristine `origin/main` worktree at the same base — identical set.**

Independent of #75014, which is Desktop-side (`apps/desktop`, `web_server.py`, `tools/tts_streaming.py`) and touches no platform adapter.
