### PR TITLE
fix(matrix): enable progressive response edits

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22710,7 +22710,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _buffer_only = False
         if source.platform == Platform.MATRIX:
             _effective_cursor = ""
-            _buffer_only = True
         # Fresh-final applies to Telegram only — other
         # platforms either edit in place cheaply (Discord,
         # Slack) or don't have the timestamp-on-edit /

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
@@ -112,6 +113,33 @@ class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
                 "metadata": metadata,
             }
         )
+        return SendResult(success=True, message_id=message_id)
+
+
+class MatrixStreamingProgressCaptureAdapter(ProgressCaptureAdapter):
+    """Records whether Matrix edits are progressive or finalizing."""
+
+    initial_send_seen = threading.Event()
+    progressive_edit_seen = threading.Event()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        result = await super().send(chat_id, content, reply_to=reply_to, metadata=metadata)
+        self.initial_send_seen.set()
+        return result
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False
+    ) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "finalize": finalize,
+            }
+        )
+        if not finalize:
+            self.progressive_edit_seen.set()
         return SendResult(success=True, message_id=message_id)
 
 
@@ -555,9 +583,10 @@ class StreamingRefineAgent:
     def run_conversation(self, message, conversation_history=None, task_id=None):
         if self.stream_delta_callback:
             self.stream_delta_callback("Continuing to refine:")
-        time.sleep(0.1)
+        MatrixStreamingProgressCaptureAdapter.initial_send_seen.wait(timeout=2.0)
         if self.stream_delta_callback:
             self.stream_delta_callback(" Final answer.")
+        MatrixStreamingProgressCaptureAdapter.progressive_edit_seen.wait(timeout=2.0)
         return {
             "final_response": "Continuing to refine: Final answer.",
             "response_previewed": True,
@@ -774,6 +803,36 @@ async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, 
     assert result.get("already_sent") is not True
     assert adapter.edits == []
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_matrix_streaming_omits_cursor(monkeypatch, tmp_path):
+    MatrixStreamingProgressCaptureAdapter.initial_send_seen.clear()
+    MatrixStreamingProgressCaptureAdapter.progressive_edit_seen.clear()
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingRefineAgent,
+        session_id="sess-matrix-streaming",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+        adapter_cls=MatrixStreamingProgressCaptureAdapter,
+    )
+
+    assert result.get("already_sent") is True
+    all_text = [call["content"] for call in adapter.sent] + [call["content"] for call in adapter.edits]
+    assert all_text, "expected streamed Matrix content to be sent or edited"
+    assert any(not call["finalize"] for call in adapter.edits), (
+        "Matrix should progressively edit the active message before finalization"
+    )
+    assert all("▉" not in text for text in all_text)
+    assert any("Continuing to refine:" in text for text in all_text)
 
 
 class TransformedStreamAgent:


### PR DESCRIPTION
## Summary

Enable progressive Matrix response edits by removing the Matrix-only `buffer_only=True` override from the shared stream-consumer configuration.

This is a current-`main` adaptation of the runtime fix originally proposed by @Kewe63 in #58787 for #58728. Since that PR was opened, the two stream-consumer construction sites have been centralized in `_build_stream_consumer_config()`, so the runtime fix is now a single-line removal in the shared path.

The Matrix cursor suppression remains unchanged (`_effective_cursor = ""`) to avoid the tofu/white-box cursor artifact in affected clients.

## Why

`GatewayStreamConsumer` only performs interval/threshold progressive updates when `buffer_only` is false. Matrix supports message editing through `m.replace`, but the platform-specific override forced final/split-only delivery even when streaming was enabled.

## Regression coverage

Add an end-to-end gateway-path regression test that:

- records Matrix edits including the `finalize` flag;
- requires at least one `finalize=False` edit before completion;
- preserves cursor suppression;
- uses deterministic `threading.Event` synchronization instead of timing-only sleeps.

Because both proxy/SSE and in-process agent paths now call the same `_build_stream_consumer_config()` helper, removing the override in that shared helper fixes both paths.

## Verification

Focused suites on current `main`:

```text
184 passed in 15.64s
```

Suites:

```text
tests/gateway/test_run_progress_topics.py
tests/gateway/test_stream_consumer.py
tests/gateway/test_matrix.py
tests/gateway/test_matrix_message_length.py
```

Real Matrix/Element E2E was exercised with a deterministic local producer (no LLM generation):

- 1 initial Matrix message;
- 4 successful non-finalizing progressive `m.replace` edits;
- 1 successful finalizing edit;
- every replacement targeted the same original event;
- replacement content grew from 112 to 311 characters;
- the final 412-character edit contained both start and end markers.

## Credit and relationship to existing work

The root cause and original runtime fix were identified by @Kewe63 in #58787. This PR rebases that fix onto the current centralized implementation and adds the behavioral regression coverage requested in the review on that PR.

Fixes #58728.
Supersedes #58787 on current `main` while preserving credit to its author.
