### PR TITLE
fix(model_switch): typed provider-slug prefix switches providers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9250,6 +9250,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _cprint(f"  ✗ {result.error_message}")
             return
 
+        # A typed "provider/model" prefix is a provider switch — give it the
+        # same session-only default as --provider (resolve_persist_behavior
+        # rule 4) now that the typed prefix has been resolved. --global still
+        # forces persistence.
+        if result.typed_provider_hop:
+            persist_global = resolve_persist_behavior(
+                is_global_flag,
+                is_session,
+                is_once=one_turn,
+                explicit_provider=explicit_provider,
+                typed_provider_hop=True,
+            )
+
         if self.agent is not None:
             try:
                 from hermes_cli.context_switch_guard import merge_preflight_compression_warning

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2140,6 +2140,19 @@ class GatewaySlashCommandsMixin:
         if not result.success:
             return t("gateway.model.error_prefix", error=result.error_message)
 
+        # A typed "provider/model" prefix is a provider switch — give it the
+        # same session-only default as --provider (resolve_persist_behavior
+        # rule 4) now that the typed prefix has been resolved. --global still
+        # forces persistence.
+        if result.typed_provider_hop:
+            persist_global = resolve_persist_behavior(
+                is_global_flag,
+                is_session,
+                is_once=one_turn,
+                explicit_provider=explicit_provider,
+                typed_provider_hop=True,
+            )
+
         try:
             from hermes_cli.context_switch_guard import (
                 enrich_model_switch_warnings_for_gateway,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1224,6 +1224,67 @@ def switch_model(
     resolved_moa_preset = False
 
     # =================================================================
+    # PATH A0: Provider-slug prefix in the model target
+    # (/model <provider>/<model>)
+    # =================================================================
+    # A typed "provider/model" string (e.g. `/model opencode-zen/gpt-5.5`
+    # while on opencode-go) is an explicit provider switch when the leading
+    # segment resolves to a known provider.  Without this the whole string
+    # is treated as a model name on the CURRENT provider: the leading slug
+    # is stripped by per-provider normalization and the bare model is
+    # searched in the wrong catalog — an error when it's missing there
+    # ("Model `gpt-5.5` was not found in this provider's model listing"),
+    # or a silent no-op stay on the current provider when a same-named
+    # model happens to exist (e.g. kimi-k2.5 on both opencode-zen and
+    # opencode-go).  Routing through PATH A makes the typed form behave
+    # exactly like the picker (model + explicit provider).
+    #
+    # Two exceptions preserve aggregator-vendor slugs, which legitimately
+    # contain "/":
+    #   1. The CURRENT provider's catalog natively contains the full
+    #      "prefix/model" string (e.g. "openai/gpt-5.5" or
+    #      "anthropic/claude-sonnet-4.6" on OpenRouter) — that is a model
+    #      on the current aggregator, not a provider hop.
+    #   2. The prefix resolves to the current provider itself (or its
+    #      group id) — a same-provider switch that must keep the normal
+    #      path (e.g. "opencode-zen/gpt-5.5" while already on the
+    #      "opencode" group).
+    if (
+        not explicit_provider
+        and "/" in new_model
+        and not new_model.startswith("/")
+    ):
+        _pfx, _rest = new_model.split("/", 1)
+        _pfx_norm = _pfx.strip().lower()
+        _rest = _rest.strip()
+        _cur_norm = str(current_provider or "").strip().lower()
+        if _pfx_norm and _rest and _pfx_norm != _cur_norm:
+            _native_slug = False
+            if is_aggregator(current_provider):
+                try:
+                    _cat = list_provider_models(current_provider)
+                    _native_slug = any(
+                        str(m).lower() == new_model.lower() for m in _cat
+                    )
+                except Exception:
+                    _native_slug = False
+            if not _native_slug:
+                _pfx_pdef = resolve_provider_full(
+                    _pfx_norm, user_providers, custom_providers
+                )
+                if (
+                    _pfx_pdef is not None
+                    and str(_pfx_pdef.id or "").strip().lower() != _cur_norm
+                ):
+                    logger.debug(
+                        "Provider-slug prefix %r in /model %s -> explicit "
+                        "provider switch to %s with model %s",
+                        _pfx_norm, raw_input, _pfx_pdef.id, _rest,
+                    )
+                    explicit_provider = _pfx_norm
+                    new_model = _rest
+
+    # =================================================================
     # PATH A: Explicit --provider given
     # =================================================================
     if explicit_provider:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -32,6 +32,7 @@ from hermes_cli.providers import (
     get_label,
     host_mandated_api_mode,
     is_aggregator,
+    is_routing_aggregator,
     resolve_provider_full,
 )
 from hermes_cli.model_normalize import (
@@ -450,6 +451,12 @@ class ModelSwitchResult:
     capabilities: Optional[ModelCapabilities] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
+    # True when the provider hop came from a typed ``provider/model``
+    # prefix (e.g. ``/model opencode-zen/gpt-5.5``) rather than an
+    # explicit ``--provider`` flag.  Callers use this to apply the same
+    # session-only persistence default as ``--provider`` (rule 4 in
+    # :func:`resolve_persist_behavior`).
+    typed_provider_hop: bool = False
 
 
 @dataclass(frozen=True)
@@ -557,6 +564,7 @@ def resolve_persist_behavior(
     is_session: bool,
     is_once: bool = False,
     explicit_provider: str = "",
+    typed_provider_hop: bool = False,
 ) -> bool:
     """Decide whether a ``/model`` switch should persist to ``config.yaml``.
 
@@ -569,6 +577,9 @@ def resolve_persist_behavior(
        (session only).  Provider switches are typically exploratory — the
        user is trying a different backend for this conversation, not
        reconfiguring the default.  ``--global`` can still force persist.
+       ``typed_provider_hop`` (a ``provider/model`` prefix in the model
+       input, e.g. ``/model opencode-zen/gpt-5.5``) is the same signal and
+       gets the same session-only default.
     5. Otherwise defer to ``model.persist_switch_by_default`` in
        ``config.yaml`` (defaults to ``False``: a plain ``/model <name>``
        affects only the current session).  Users who want the old
@@ -585,7 +596,7 @@ def resolve_persist_behavior(
         return False
     if is_global:
         return True
-    if explicit_provider:
+    if explicit_provider or typed_provider_hop:
         return False
     try:
         from hermes_cli.config import load_config
@@ -1222,6 +1233,8 @@ def switch_model(
     new_model = raw_input.strip()
     target_provider = current_provider
     resolved_moa_preset = False
+    _typed_provider_hop = False
+    _native_aggregator_slug = False
 
     # =================================================================
     # PATH A0: Provider-slug prefix in the model target
@@ -1260,14 +1273,29 @@ def switch_model(
         _cur_norm = str(current_provider or "").strip().lower()
         if _pfx_norm and _rest and _pfx_norm != _cur_norm:
             _native_slug = False
-            if is_aggregator(current_provider):
+            if is_routing_aggregator(current_provider):
+                # A slash-bearing name on a TRUE routing aggregator (e.g.
+                # "anthropic/claude-sonnet-4.6" on OpenRouter) is native by
+                # default.  Only a *confirmed* non-match in the live catalog
+                # allows the provider-hop interpretation; when models.dev has
+                # no catalog data (empty list / lookup failure) preserve the
+                # native slug rather than guessing it is a provider hop.
+                # Flat-namespace resellers (opencode-zen/go) never match here
+                # — their catalogs are bare IDs, so their typed "provider/model"
+                # strings always route as hops.
                 try:
                     _cat = list_provider_models(current_provider)
-                    _native_slug = any(
+                    _native_slug = not _cat or any(
                         str(m).lower() == new_model.lower() for m in _cat
                     )
                 except Exception:
-                    _native_slug = False
+                    _native_slug = True
+                if _native_slug:
+                    # Preserve the native slug end-to-end: also suppress the
+                    # PATH B step-e provider guesser, which would otherwise
+                    # re-route the unconfirmed name via static catalogs when
+                    # models.dev had no data (e.g. anthropic/... -> gmi).
+                    _native_aggregator_slug = True
             if not _native_slug:
                 _pfx_pdef = resolve_provider_full(
                     _pfx_norm, user_providers, custom_providers
@@ -1283,6 +1311,7 @@ def switch_model(
                     )
                     explicit_provider = _pfx_norm
                     new_model = _rest
+                    _typed_provider_hop = True
 
     # =================================================================
     # PATH A: Explicit --provider given
@@ -1571,6 +1600,7 @@ def switch_model(
             and not resolved_alias
             and not resolved_in_current_catalog
             and not config_routed
+            and not _native_aggregator_slug
         ):
             detected = detect_provider_for_model(new_model, current_provider)
             if detected:
@@ -1842,6 +1872,7 @@ def switch_model(
         capabilities=capabilities,
         model_info=model_info,
         is_global=is_global,
+        typed_provider_hop=_typed_provider_hop,
     )
 
 

--- a/tests/hermes_cli/test_model_switch_provider_slug_prefix.py
+++ b/tests/hermes_cli/test_model_switch_provider_slug_prefix.py
@@ -1,0 +1,213 @@
+"""Regression tests: typed ``/model <provider>/<model>`` must switch provider.
+
+Before the PATH A0 fix in ``switch_model``, a typed ``provider/model`` string
+was treated as a model name on the CURRENT provider. The leading provider
+slug was stripped by per-provider normalization and the bare model was
+searched in the wrong catalog — an error when it was missing there, or a
+silent no-op stay on the current provider when a same-named model existed on
+both (e.g. ``kimi-k2.5`` on opencode-zen and opencode-go).
+
+The fix routes ``/model opencode-zen/gpt-5.5``-style input through the same
+explicit-provider path the picker uses, so the typed form and the picker
+behave identically. These tests pin the resolution contract:
+
+* A resolvable provider-slug prefix switches providers.
+* Aggregator-vendor slugs native to the current catalog (e.g.
+  ``openai/gpt-5.5`` on OpenRouter) are NOT hijacked as provider hops.
+* A prefix that resolves to the current provider (or its group) keeps the
+  normal same-provider path.
+"""
+
+import pytest
+
+import hermes_cli.model_switch as ms
+from hermes_cli.model_switch import switch_model
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+@pytest.fixture(autouse=True)
+def _fast_path(monkeypatch):
+    """Keep switch_model off the network and credential machinery.
+
+    The resolution steps under test are: provider-slug detection, PATH A
+    provider resolution, and the final target_provider/new_model. Live
+    catalog fetches, credential lookup, and metadata calls are stubbed.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test-key",
+            "base_url": "https://example.test/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: dict(_MOCK_VALIDATION),
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None
+    )
+
+
+@pytest.fixture
+def fake_catalogs(monkeypatch):
+    """Pin each provider's model catalog for the native-slug guard."""
+
+    def _catalog(provider: str, **kwargs):
+        return {
+            "openrouter": ["openai/gpt-5.5", "anthropic/claude-sonnet-4.6"],
+            "opencode-go": ["kimi-k2.5", "deepseek-v4-flash"],
+            "opencode-zen": ["kimi-k2.5", "gpt-5.5"],
+        }.get(provider, [])
+
+    monkeypatch.setattr(ms, "list_provider_models", _catalog)
+
+
+def test_go_to_zen_typed_provider_slug_switches_provider(fake_catalogs):
+    """/model opencode-zen/gpt-5.5 while on opencode-go moves to Zen."""
+    result = switch_model(
+        raw_input="opencode-zen/gpt-5.5",
+        current_provider="opencode-go",
+        current_model="deepseek-v4-flash",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    # opencode-zen resolves to the "opencode" group; the runtime endpoint is
+    # Zen (https://opencode.ai/zen/v1), and the model is the bare Zen model.
+    assert result.target_provider == "opencode"
+    assert result.provider_changed is True
+    assert result.new_model == "gpt-5.5"
+
+
+def test_zen_to_go_typed_provider_slug_switches_provider(fake_catalogs):
+    """/model opencode-go/kimi-k3 while on opencode-zen moves to Go."""
+    result = switch_model(
+        raw_input="opencode-go/kimi-k3",
+        current_provider="opencode-zen",
+        current_model="gpt-5.5",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.target_provider == "opencode-go"
+    assert result.provider_changed is True
+    assert result.new_model == "kimi-k3"
+
+
+def test_typed_slug_model_present_on_both_catalogs_still_switches(fake_catalogs):
+    """kimi-k2.5 exists on both providers; the typed slug must still switch.
+
+    This is the silent no-op regression: before the fix the bare model was
+    found in the current catalog and the switch "succeeded" without ever
+    leaving the current provider.
+    """
+    result = switch_model(
+        raw_input="opencode-zen/kimi-k2.5",
+        current_provider="opencode-go",
+        current_model="deepseek-v4-flash",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.target_provider == "opencode"
+    assert result.provider_changed is True
+    assert result.new_model == "kimi-k2.5"
+
+
+def test_openrouter_native_vendor_slug_is_not_hijacked(fake_catalogs):
+    """openai/gpt-5.5 is a native OpenRouter model, not a provider hop."""
+    result = switch_model(
+        raw_input="openai/gpt-5.5",
+        current_provider="openrouter",
+        current_model="nvidia/nemotron-3-ultra-550b-a55b:free",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.target_provider == "openrouter"
+    assert result.provider_changed is False
+    assert result.new_model == "openai/gpt-5.5"
+
+
+def test_openrouter_anthropic_vendor_slug_is_not_hijacked(fake_catalogs):
+    """anthropic/... on OpenRouter is a vendor slug (anthropic is also a
+    real Hermes provider id — the native-catalog guard must win)."""
+    result = switch_model(
+        raw_input="anthropic/claude-sonnet-4.6",
+        current_provider="openrouter",
+        current_model="nvidia/nemotron-3-ultra-550b-a55b:free",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.target_provider == "openrouter"
+    assert result.provider_changed is False
+    assert result.new_model == "anthropic/claude-sonnet-4.6"
+
+
+def test_same_provider_prefix_keeps_normal_path(fake_catalogs):
+    """/model opencode-go/kimi-k3 while already on opencode-go stays."""
+    result = switch_model(
+        raw_input="opencode-go/kimi-k3",
+        current_provider="opencode-go",
+        current_model="deepseek-v4-flash",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.target_provider == "opencode-go"
+    assert result.provider_changed is False
+    assert result.new_model == "kimi-k3"
+
+
+def test_group_id_prefix_keeps_normal_path(fake_catalogs):
+    """opencode/<model> while on the opencode group (Zen) is same-provider."""
+    result = switch_model(
+        raw_input="opencode/kimi-k2.5",
+        current_provider="opencode",
+        current_model="gpt-5.5",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.target_provider == "opencode"
+    assert result.provider_changed is False
+    assert result.new_model == "kimi-k2.5"
+
+
+def test_unresolvable_prefix_falls_through_to_normal_path(fake_catalogs):
+    """A prefix that is not a known provider keeps the old model-name path."""
+    result = switch_model(
+        raw_input="notaprovider/foo",
+        current_provider="opencode-go",
+        current_model="deepseek-v4-flash",
+        user_providers={},
+        custom_providers=[],
+    )
+    # Falls through: the provider never changes, the string is handled as a
+    # model name on the current provider (and ultimately rejected there).
+    assert result.target_provider == "opencode-go"
+    assert result.provider_changed is False
+
+
+def test_bare_provider_slug_still_switches_to_default_model(fake_catalogs):
+    """/model opencode-go (no model part) remains a provider-only switch."""
+    result = switch_model(
+        raw_input="opencode-go",
+        current_provider="opencode-zen",
+        current_model="gpt-5.5",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.target_provider == "opencode-go"
+    assert result.provider_changed is True

--- a/tests/hermes_cli/test_model_switch_provider_slug_prefix.py
+++ b/tests/hermes_cli/test_model_switch_provider_slug_prefix.py
@@ -211,3 +211,91 @@ def test_bare_provider_slug_still_switches_to_default_model(fake_catalogs):
     assert result.success
     assert result.target_provider == "opencode-go"
     assert result.provider_changed is True
+
+
+def test_empty_catalog_routing_aggregator_slug_preserved(monkeypatch):
+    """On a routing aggregator, an empty models.dev catalog must not turn a
+    native vendor slug into a provider hop (hermes-sweeper #75777 review)."""
+    monkeypatch.setattr(ms, "list_provider_models", lambda *a, **k: [])
+    result = switch_model(
+        raw_input="anthropic/claude-sonnet-4.6",
+        current_provider="openrouter",
+        current_model="nvidia/nemotron-3-ultra-550b-a55b:free",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.target_provider == "openrouter"
+    assert result.provider_changed is False
+    assert result.new_model == "anthropic/claude-sonnet-4.6"
+    assert result.typed_provider_hop is False
+
+
+def test_empty_catalog_flat_reseller_still_hops(monkeypatch):
+    """Flat-namespace resellers (opencode-go/zen) never consult the catalog:
+    a typed provider/model string still switches even when models.dev is
+    empty."""
+    monkeypatch.setattr(ms, "list_provider_models", lambda *a, **k: [])
+    result = switch_model(
+        raw_input="opencode-zen/gpt-5.5",
+        current_provider="opencode-go",
+        current_model="deepseek-v4-flash",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.target_provider == "opencode"
+    assert result.provider_changed is True
+    assert result.new_model == "gpt-5.5"
+    assert result.typed_provider_hop is True
+
+
+def test_typed_provider_hop_signal_set_for_typed_hop(fake_catalogs):
+    """result.typed_provider_hop must be True for a typed provider hop."""
+    result = switch_model(
+        raw_input="opencode-zen/gpt-5.5",
+        current_provider="opencode-go",
+        current_model="deepseek-v4-flash",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.provider_changed is True
+    assert result.typed_provider_hop is True
+
+
+def test_typed_provider_hop_signal_not_set_for_native_slug(fake_catalogs):
+    """Native aggregator slugs (openai/gpt-5.5 on OpenRouter) are NOT hops."""
+    result = switch_model(
+        raw_input="openai/gpt-5.5",
+        current_provider="openrouter",
+        current_model="nvidia/nemotron-3-ultra-550b-a55b:free",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.provider_changed is False
+    assert result.typed_provider_hop is False
+
+
+def test_typed_provider_hop_signal_not_set_for_plain_model(fake_catalogs):
+    """Plain model names never set the typed-hop signal."""
+    result = switch_model(
+        raw_input="deepseek-v4-flash",
+        current_provider="opencode-go",
+        current_model="kimi-k2.5",
+        user_providers={},
+        custom_providers=[],
+    )
+    assert result.success
+    assert result.typed_provider_hop is False
+
+
+def test_resolve_persist_behavior_typed_hop_is_session_only():
+    """A typed provider hop follows the --provider session-only rule unless
+    --global forces persistence (resolve_persist_behavior rule 4)."""
+    assert ms.resolve_persist_behavior(False, False, typed_provider_hop=True) is False
+    assert ms.resolve_persist_behavior(False, False, typed_provider_hop=False) is False
+    assert ms.resolve_persist_behavior(True, False, typed_provider_hop=True) is True
+    assert ms.resolve_persist_behavior(False, True, typed_provider_hop=True) is False
+    assert ms.resolve_persist_behavior(False, False, is_once=True, typed_provider_hop=True) is False

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4137,6 +4137,19 @@ def _apply_model_switch(
     if not result.success:
         raise ValueError(result.error_message or "model switch failed")
 
+    # A typed "provider/model" prefix is a provider switch — give it the
+    # same session-only default as --provider (resolve_persist_behavior
+    # rule 4) now that the typed prefix has been resolved, unless the
+    # caller explicitly overrode persistence. --global still forces it.
+    if getattr(result, "typed_provider_hop", False) and persist_override is None:
+        persist_global = resolve_persist_behavior(
+            is_global_flag,
+            is_session,
+            is_once=one_turn,
+            explicit_provider=explicit_provider,
+            typed_provider_hop=True,
+        )
+
     restore_snapshot = _snapshot_agent_model_runtime(agent) if (one_turn and agent) else None
 
     if agent:


### PR DESCRIPTION
## What does this PR do?

Typed `/model <provider>/<model>` switches are broken when the target provider differs from the current one. `/model opencode-zen/gpt-5.5` while on `opencode-go` fails with `Model `gpt-5.5` was not found in this provider's model listing.`, and when a same-named model exists on both providers (e.g. `kimi-k2.5`), the switch is a **silent no-op** — you stay on the current provider.

**Root cause**: the typed path never sets an explicit provider, so `switch_model()` treats the whole string as a bare model name on the *current* provider. Per-provider normalization strips the leading `provider/` slug, then the bare model is searched in the wrong catalog.

**Fix**: new PATH A0 in `switch_model()` detects a resolvable provider-slug prefix before normal lookup and routes through the explicit-provider path — exactly what the picker does (model + explicit provider). Two guards preserve legitimate slash-bearing model names:
1. Aggregator-native vendor slugs — `openai/gpt-5.5` on OpenRouter is a model on the current aggregator, not a provider hop.
2. Same-provider prefixes — `opencode-zen/gpt-5.5` while already on the `opencode` group keeps the normal path.

## Related Issue

No issue filed — reproduced on current `main` (see How to Test). Searched existing PRs; this is not a duplicate of:
- #67566 — picker path away from custom/local endpoints (`resolve_alias` vendor fallback). This is the typed path between aggregator providers.
- #72559 — same-aggregator prefix (`openrouter/deepseek-v4-pro` on OpenRouter) at request-time normalization. This is a cross-provider switch at switch-time.
- #71558 — matching-provider prefix stripping in `_strip_matching_provider_prefix`. This covers different-provider routing in `switch_model()`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_switch.py` — PATH A0: typed `provider/model` prefix routes through the explicit-provider path (61 insertions)
- `tests/hermes_cli/test_model_switch_provider_slug_prefix.py` — regression tests: GO→ZEN and ZEN→GO typed switches, same-provider retention, OpenRouter native slug preservation, colon-form and no-prefix behavior

## How to Test

1. Reproduce on current `main`: `/model opencode-zen/gpt-5.5` while on `opencode-go` → `Model `gpt-5.5` was not found in this provider's model listing.`
2. Apply this branch: the same command switches to `opencode-zen` with model `gpt-5.5` (`provider_changed=True`).
3. Run the regression suite:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_model_switch_provider_slug_prefix.py tests/hermes_cli/test_model_switch_custom_providers.py
   ```
   All pass. (Full `pytest tests/ -q` runs in CI; targeted model-switch suites verified locally.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Repro on current `main` (before this fix), typed `provider/model` against the current provider. In every case `provider_changed=False` — the switch never happens:

```
GO->ZEN gpt-5.5  (only on zen): success=True  target=opencode-go  changed=False  model=gpt-5.5
GO->ZEN kimi-k2.5 (on BOTH):    success=True  target=opencode-go  changed=False  model=kimi-k2.5
ZEN->GO kimi-k2.5 (on BOTH):    success=True  target=opencode-zen changed=False  model=kimi-k2.5
```

With live validation, the `gpt-5.5` case surfaces as `Model `gpt-5.5` was not found in this provider's model listing.` — loud but confusing (you asked for Zen). The `kimi-k2.5` case is the dangerous one: the bare model exists on the current provider, so it **succeeds silently** and you stay on the wrong provider — tokens spent against the wrong account/endpoint with no error.
