### PR TITLE
fix(agent): preserve MiniMax-M3 thinking blocks on /anthropic replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2455,13 +2455,24 @@ def _manage_thinking_signatures(
     stripping, message merging) invalidates the signature, causing HTTP 400
     "Invalid signature in thinking block".
 
-    Signatures are Anthropic-proprietary.  Third-party endpoints (MiniMax,
-    Azure AI Foundry, AWS Bedrock, self-hosted proxies) cannot validate them
-    and will reject them outright.  Kimi's /coding and DeepSeek's /anthropic
-    endpoints speak the Anthropic protocol upstream but require unsigned
-    thinking blocks (synthesised from ``reasoning_content``) to round-trip on
-    replayed assistant tool-call messages.  See hermes-agent#13848 (Kimi) and
+    Signatures are Anthropic-proprietary.  Third-party endpoints (Azure AI
+    Foundry, AWS Bedrock, self-hosted proxies) cannot validate them and will
+    reject them outright.  Kimi's /coding and DeepSeek's /anthropic endpoints
+    speak the Anthropic protocol upstream but require unsigned thinking
+    blocks (synthesised from ``reasoning_content``) to round-trip on replayed
+    assistant tool-call messages.  See hermes-agent#13848 (Kimi) and
     hermes-agent#16748 (DeepSeek).
+
+    MiniMax-M3 on ``api.minimax.io/anthropic`` (and the China mirror
+    ``api.minimaxi.com/anthropic``) returns signed thinking blocks that the
+    upstream accepts only in the same turn context — a cross-context signed
+    block 400s ("thinking blocks in the latest assistant message cannot be
+    modified").  MiniMax accepts UNSIGNED thinking blocks on replay and
+    continues the chain-of-thought, so Hermes downgrades signed blocks to
+    unsigned (keeping the text) instead of stripping them — stripping the
+    thinking block from a replayed assistant tool-call turn leaves the model
+    without its chain context and interleaved reasoning dies after the first
+    tool-call turn (verified live 2026-07-31, hermes-agent#75725).
 
     Nous Portal's ``/v1/messages`` route is the exception among third-party
     hosts: it proxies Claude to Anthropic/Vertex/Bedrock and validates the
@@ -2505,6 +2516,32 @@ def _manage_thinking_signatures(
                     # Signed (or redacted-with-data) — upstream can't validate, strip.
                     continue
                 new_content.append(b)
+            m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
+        elif _is_minimax_anthropic_endpoint(base_url):
+            # MiniMax-M3 /anthropic: preserve unsigned thinking blocks and
+            # DOWNGRADE signed ones to unsigned (drop the signature, keep the
+            # text) instead of stripping them. MiniMax cannot validate the
+            # Anthropic signature on a cross-context replay (HTTP 400), but it
+            # accepts unsigned blocks and continues the chain-of-thought.
+            # Dropping the block entirely leaves the model without chain
+            # context — interleaved reasoning dies after the first tool-call
+            # turn (live-verified 2026-07-31: replay WITH the unsigned block
+            # present continues thinking; replay WITHOUT it produces no
+            # thinking on the follow-up turn).
+            new_content = []
+            for b in m["content"]:
+                if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
+                    new_content.append(b)
+                    continue
+                if b.get("type") == "redacted_thinking" or b.get("data"):
+                    # Redacted-with-data — no recoverable text, drop.
+                    continue
+                if b.get("signature"):
+                    # Signed — downgrade to unsigned so the upstream accepts
+                    # it and the chain-of-thought survives.
+                    new_content.append({"type": "thinking", "thinking": b.get("thinking", "")})
+                else:
+                    new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
         elif _is_third_party or idx != last_assistant_idx:
             # Third-party: strip ALL thinking blocks (signatures are proprietary).

--- a/tests/agent/test_minimax_anthropic_thinking.py
+++ b/tests/agent/test_minimax_anthropic_thinking.py
@@ -1,0 +1,103 @@
+"""MiniMax-M3 /anthropic thinking blocks must survive replay (downgraded to unsigned).
+
+MiniMax-M3 on ``api.minimax.io/anthropic`` returns SIGNED thinking blocks.
+Hermes previously routed MiniMax into the generic third-party branch of
+``_manage_thinking_signatures``, which stripped ALL thinking blocks on
+replay — the replayed assistant tool-call turn carried no chain-of-thought,
+and interleaved reasoning died after the first tool-call turn
+(hermes-agent#75725).
+
+MiniMax accepts UNSIGNED thinking blocks on replay and continues the
+chain-of-thought; a cross-context SIGNED block 400s. So the fix downgrades
+signed blocks to unsigned (drop the signature, keep the text) instead of
+stripping them.
+"""
+
+from types import SimpleNamespace
+
+from agent.transports import get_transport
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+SIG = "sig-minimax"
+
+MINIMAX = "https://api.minimax.io/anthropic"
+MINIMAX_V1 = "https://api.minimax.io/anthropic/v1"
+MINIMAX_CN = "https://api.minimaxi.com/anthropic"
+MINIMAX_CN_V1 = "https://api.minimaxi.com/anthropic/v1"
+DEEPSEEK = "https://api.deepseek.com/anthropic"
+OPENAI_COMPAT = "https://api.minimax.io/v1"
+
+
+def _thinking_on_replay(base_url, signature: str | None = SIG, model="MiniMax-M3"):
+    """Normalize a thinking+tool_use turn, store it, convert to the next-turn
+    request, and return its thinking + tool_use blocks."""
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="thinking", thinking="Let me think about this carefully", signature=signature),
+            SimpleNamespace(
+                type="tool_use",
+                id="toolu_01",
+                name="get_weather",
+                input={"location": "San Francisco"},
+            ),
+        ],
+        stop_reason="tool_use",
+        usage=None,
+    )
+    normalized = get_transport("anthropic_messages").normalize_response(response)
+    stored = {
+        "role": "assistant",
+        "content": normalized.content or "",
+        "reasoning_details": (normalized.provider_data or {}).get("reasoning_details"),
+        "anthropic_content_blocks": (normalized.provider_data or {}).get("anthropic_content_blocks"),
+        "tool_calls": [
+            {
+                "id": "toolu_01",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"location": "San Francisco"}',
+                },
+            }
+        ],
+    }
+    messages = [
+        {"role": "user", "content": "q1"},
+        stored,
+        {"role": "tool", "tool_call_id": "toolu_01", "content": "ok"},
+    ]
+    _sys, out = convert_messages_to_anthropic(messages, base_url=base_url, model=model)
+    assistant = [m for m in out if m.get("role") == "assistant"][0]
+    thinking = [b for b in assistant["content"] if isinstance(b, dict) and b.get("type") == "thinking"]
+    tool_use = [b for b in assistant["content"] if isinstance(b, dict) and b.get("type") == "tool_use"]
+    return thinking, tool_use
+
+
+def test_minimax_downgrades_signed_thinking_to_unsigned():
+    """Signed thinking blocks on a replayed MiniMax tool-call turn must survive
+    as UNSIGNED blocks (text preserved, signature dropped)."""
+    for base_url in (MINIMAX, MINIMAX_V1, MINIMAX_CN, MINIMAX_CN_V1):
+        thinking, tool_use = _thinking_on_replay(base_url)
+        assert thinking, f"{base_url}: thinking block must survive replay"
+        assert thinking[0]["thinking"] == "Let me think about this carefully"
+        assert "signature" not in thinking[0], (
+            f"{base_url}: downgraded block must not carry the Anthropic signature"
+        )
+        assert len(tool_use) == 1, f"{base_url}: tool_use block must survive"
+
+
+def test_minimax_keeps_unsigned_thinking_verbatim():
+    """Already-unsigned thinking blocks pass through unchanged."""
+    thinking, _ = _thinking_on_replay(MINIMAX, signature=None)
+    assert thinking, "unsigned thinking block must survive replay"
+    assert thinking[0]["thinking"] == "Let me think about this carefully"
+    assert "signature" not in thinking[0]
+
+
+def test_other_third_party_still_strips_signed():
+    """Non-MiniMax third-party endpoints keep the strip-ALL behavior — the
+    MiniMax branch must not change how other hosts are treated."""
+    thinking, _ = _thinking_on_replay(DEEPSEEK)
+    # DeepSeek keeps its own strip-signed/preserve-unsigned branch upstream;
+    # with a signed block it strips. Assert we did not break that.
+    assert not any(b.get("signature") for b in thinking)


### PR DESCRIPTION
## What

Fixes interleaved thinking dying after the first tool-call turn when using **MiniMax-M3 via the Anthropic-compatible endpoint** (`api.minimax.io/anthropic`), the default `minimax` provider path. Closes #75725.

## Root cause

MiniMax-M3 returns **signed** thinking blocks. `_manage_thinking_signatures` routed MiniMax into the generic third-party branch, which strips **ALL** thinking blocks on replay — so the replayed assistant tool-call turn carried zero chain-of-thought, and the model stopped thinking on follow-up turns.

Live API verification (2026-07-31, direct curl against `/anthropic/v1/messages`):
- MiniMax rejects a cross-context **signed** block with HTTP 400 (signature validated against exact turn content).
- MiniMax **accepts unsigned** thinking blocks on replay and continues the chain-of-thought.
- Replaying a tool-call turn with **no** thinking block → the follow-up turn reliably produces no thinking.

## Fix

Add a MiniMax branch to `_manage_thinking_signatures`:
- **unsigned** thinking blocks pass through unchanged;
- **signed** blocks are downgraded to unsigned (signature dropped, text kept) — MiniMax can't validate the signature but needs the text to continue reasoning;
- all other third-party endpoints keep the existing strip-ALL behavior.

## Tests

`tests/agent/test_minimax_anthropic_thinking.py` (new, in the existing test idiom from `test_anthropic_kimi_signed_thinking_replay.py`):
- signed → unsigned downgrade across all MiniMax `/anthropic` hosts (`.io`, `.com` mirror, `/v1` suffix)
- unsigned pass-through
- DeepSeek strip-signed behavior unchanged (guard)

94 tests pass across the MiniMax + Anthropic thinking/adapter suites.

## Verification (beyond unit tests)

End-to-end on the fork: wire dumps confirm the preserved (unsigned) thinking block reaches the `/anthropic` request on turn 2, and live agent sessions produce real step-by-step thinking on **both** the tool-call turn and the follow-up turn.

Remaining known variable (MiniMax-side, not this PR): MiniMax's server can still *skip* visible thinking when it judges a turn trivial (adaptive semantics) — the docs state `thinking: {"type": "enabled"}` means "always enabled", but live behavior is judgment-based and time-varying. That gap is a separate MiniMax report.