### PR TITLE
feat(skills): declare and enforce skill-to-skill dependencies (depends_on)

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -499,6 +499,68 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
             "'hermes skills search <query>' to search deeper[/]\n")
 
 
+def _check_skill_dependencies(bundle, c: Console, *, force: bool = False) -> bool:
+    """Enforce a skill's ``depends_on`` list. Returns True when install must stop.
+
+    ``prerequisites`` (env vars, commands) and ``related_skills`` (advisory)
+    already exist, but neither expresses "this skill does not work without
+    that one", and nothing was enforced at install time. A skill that drives
+    another skill's commands could be installed alone and would only fail once
+    the agent tried to use it.
+
+    Required dependencies block; optional ones warn and proceed. ``--force``
+    downgrades a block to a warning, matching how it already overrides the
+    security verdict — the user has said they know what they are doing.
+    """
+    from tools.skills_hub import (
+        parse_skill_dependencies,
+        parse_skill_frontmatter,
+        resolve_skill_dependencies,
+    )
+
+    skill_md = (getattr(bundle, "files", None) or {}).get("SKILL.md")
+    if not skill_md:
+        return False
+
+    deps = parse_skill_dependencies(parse_skill_frontmatter(skill_md))
+    if not deps:
+        return False
+
+    missing_required, missing_optional = resolve_skill_dependencies(deps)
+
+    for dep in missing_optional:
+        why = f" — {dep.reason}" if dep.reason else ""
+        c.print(
+            f"[yellow]Optional dependency not installed:[/] '{dep.name}'{why}\n"
+            f"[dim]  '{bundle.name}' will work with reduced functionality. "
+            f"Install it with: hermes skill install {dep.name}[/]"
+        )
+
+    if not missing_required:
+        return False
+
+    lines = []
+    for dep in missing_required:
+        why = f" — {dep.reason}" if dep.reason else ""
+        lines.append(f"  • {dep.name}{why}")
+    names = " ".join(d.name for d in missing_required)
+    detail = "\n".join(lines)
+
+    if force:
+        c.print(
+            f"[yellow]Missing required dependencies (installing anyway, --force):[/]\n{detail}"
+        )
+        return False
+
+    c.print(
+        f"\n[bold red]Installation blocked:[/] '{bundle.name}' requires "
+        f"{len(missing_required)} skill(s) that are not installed:\n{detail}\n\n"
+        f"[dim]Install them first:  hermes skill install {names}\n"
+        f"Or bypass this check:  hermes skill install {bundle.name} --force[/]\n"
+    )
+    return True
+
+
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
@@ -698,6 +760,15 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, result.verdict,
                          f"{len(result.findings)}_findings")
+        return
+
+    # ── depends_on enforcement (#71853) ───────────────────────────────
+    # Runs after the security verdict and before the confirm prompt, so a
+    # blocked install never reaches the "Install 'x'?" question and the user
+    # is told what to install first rather than discovering it at runtime.
+    dep_error = _check_skill_dependencies(bundle, c, force=force)
+    if dep_error:
+        shutil.rmtree(q_path, ignore_errors=True)
         return
 
     if extra_metadata:

--- a/tests/hermes_cli/test_skill_depends_on.py
+++ b/tests/hermes_cli/test_skill_depends_on.py
@@ -1,0 +1,354 @@
+"""Skill ``depends_on`` declaration and install-time enforcement (#71853).
+
+Skills already carry ``prerequisites`` (env vars, commands) and
+``related_skills`` (advisory cross-references), but neither says "this skill
+does not work without that one", and nothing was enforced at install time. A
+skill that drives another skill's commands installed cleanly on its own and
+only failed once the agent reached for the missing piece.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from tools.skills_hub import (
+    SkillDependency,
+    parse_skill_dependencies,
+    resolve_skill_dependencies,
+)
+
+
+class TestParsing:
+    def test_bare_list_means_all_required(self):
+        deps = parse_skill_dependencies({"depends_on": ["obsidian", "kanban"]})
+        assert [(d.name, d.required) for d in deps] == [("obsidian", True), ("kanban", True)]
+
+    def test_mapping_form_carries_required_and_reason(self):
+        deps = parse_skill_dependencies({
+            "depends_on": [
+                {"name": "obsidian", "required": True, "reason": "reads from vaults"},
+                {"name": "kanban", "required": False, "reason": "embeds board status"},
+            ]
+        })
+        assert deps[0] == SkillDependency("obsidian", True, "reads from vaults")
+        assert deps[1] == SkillDependency("kanban", False, "embeds board status")
+
+    def test_absent_or_empty_is_no_dependencies(self):
+        assert parse_skill_dependencies({}) == []
+        assert parse_skill_dependencies({"depends_on": []}) == []
+        assert parse_skill_dependencies({"depends_on": None}) == []
+
+    def test_single_string_is_accepted(self):
+        assert [d.name for d in parse_skill_dependencies({"depends_on": "obsidian"})] == ["obsidian"]
+
+    def test_duplicates_collapse(self):
+        deps = parse_skill_dependencies({"depends_on": ["a", "a", {"name": "a"}]})
+        assert len(deps) == 1
+
+    def test_malformed_entries_are_skipped_not_raised(self):
+        """A bad depends_on must not make an installable skill uninstallable."""
+        deps = parse_skill_dependencies({
+            "depends_on": [123, None, {"required": True}, {"name": "  "}, "good"]
+        })
+        assert [d.name for d in deps] == ["good"]
+
+    def test_non_list_scalar_is_ignored(self):
+        assert parse_skill_dependencies({"depends_on": {"name": "x"}}) == []
+
+
+class TestResolution:
+    DEPS = [
+        SkillDependency("obsidian", True, "vaults"),
+        SkillDependency("kanban", False, "board status"),
+    ]
+
+    def test_splits_missing_required_from_missing_optional(self):
+        req, opt = resolve_skill_dependencies(self.DEPS, installed=set())
+        assert [d.name for d in req] == ["obsidian"]
+        assert [d.name for d in opt] == ["kanban"]
+
+    def test_nothing_missing_when_all_present(self):
+        req, opt = resolve_skill_dependencies(self.DEPS, installed={"obsidian", "kanban"})
+        assert req == [] and opt == []
+
+    def test_optional_present_required_missing(self):
+        req, opt = resolve_skill_dependencies(self.DEPS, installed={"kanban"})
+        assert [d.name for d in req] == ["obsidian"]
+        assert opt == []
+
+
+class TestInstalledDiscovery:
+    """The gate must agree with what the agent can actually load.
+
+    Anything runtime discovery can resolve is "installed" for this purpose;
+    reporting it missing blocks a dependency the user genuinely has.
+    """
+
+    def _roots(self, monkeypatch, *roots):
+        import tools.skills_hub as hub
+
+        monkeypatch.setattr(hub.HubLockFile, "list_installed", lambda self: [])
+        monkeypatch.setattr(
+            "agent.skill_utils.get_all_skills_dirs", lambda: list(roots)
+        )
+        return hub
+
+    def _skill(self, root, rel, *, declared=None):
+        d = root / rel
+        d.mkdir(parents=True, exist_ok=True)
+        name_line = f"name: {declared}\n" if declared else ""
+        (d / "SKILL.md").write_text(f"---\n{name_line}description: x\n---\n")
+        return d
+
+    def test_local_skills_count_even_without_a_lockfile_entry(self, tmp_path, monkeypatch):
+        local = tmp_path / "skills"
+        self._skill(local, "obsidian")
+        self._skill(local, "productivity/kanban")
+        self._skill(local, ".trash/ghost")          # hub internals are not skills
+
+        hub = self._roots(monkeypatch, local)
+        names = hub.installed_skill_names()
+
+        assert {"obsidian", "kanban"} <= names, (
+            "an official/hand-placed skill was not counted as installed, so its "
+            "dependents would be blocked for a dependency the user has"
+        )
+        assert "ghost" not in names
+
+    def test_external_roots_are_scanned(self, tmp_path, monkeypatch):
+        """skills.external_dirs are active skill roots at runtime.
+
+        get_all_skills_dirs() returns the local dir plus every configured
+        external dir; a dependency supplied from one of those is as usable as
+        one in the profile, so scanning only the profile falsely blocks it.
+        """
+        local = tmp_path / "skills"
+        external = tmp_path / "team-skills"
+        self._skill(local, "mine")
+        self._skill(external, "obsidian")
+
+        hub = self._roots(monkeypatch, local, external)
+        names = hub.installed_skill_names()
+
+        assert "obsidian" in names, (
+            "a skill provided by an external root was reported missing — its "
+            "dependents would be blocked despite being loadable at runtime"
+        )
+        assert "mine" in names
+
+    def test_declared_name_and_directory_name_both_resolve(self, tmp_path, monkeypatch):
+        """Runtime resolves ``frontmatter.get("name", skill_dir.name)``.
+
+        A hand-placed skill in a differently-named directory is usable under
+        its declared name, so both spellings have to satisfy a dependency.
+        """
+        local = tmp_path / "skills"
+        self._skill(local, "vendor-obsidian-v2", declared="obsidian")
+
+        hub = self._roots(monkeypatch, local)
+        names = hub.installed_skill_names()
+
+        assert "obsidian" in names, (
+            "depends_on: [obsidian] would be blocked even though the agent can "
+            "load that skill by its declared name"
+        )
+        assert "vendor-obsidian-v2" in names  # the directory spelling still works
+
+    def test_unreadable_frontmatter_falls_back_to_the_directory_name(self, tmp_path, monkeypatch):
+        local = tmp_path / "skills"
+        d = local / "kanban"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("no frontmatter at all\n")
+
+        hub = self._roots(monkeypatch, local)
+        assert "kanban" in hub.installed_skill_names()
+
+    def test_a_missing_root_does_not_break_the_others(self, tmp_path, monkeypatch):
+        local = tmp_path / "skills"
+        self._skill(local, "obsidian")
+        hub = self._roots(monkeypatch, local, tmp_path / "does-not-exist")
+        assert "obsidian" in hub.installed_skill_names()
+
+
+def _bundle(depends_on_yaml: str, name: str = "chronicle"):
+    md = f"---\nname: {name}\ndescription: test\n{depends_on_yaml}---\n\n# body\n"
+    return SimpleNamespace(name=name, files={"SKILL.md": md})
+
+
+class TestInstallEnforcement:
+    """The gate itself: required blocks, optional warns, --force overrides."""
+
+    @pytest.fixture()
+    def console(self):
+        class _C:
+            def __init__(self):
+                self.out = []
+
+            def print(self, *a, **k):
+                self.out.append(" ".join(str(x) for x in a))
+
+            @property
+            def text(self):
+                return "\n".join(self.out)
+        return _C()
+
+    def _check(self, monkeypatch, bundle, console, *, installed=frozenset(), force=False):
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import _check_skill_dependencies
+
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: set(installed))
+        return _check_skill_dependencies(bundle, console, force=force)
+
+    def test_missing_required_blocks_and_names_the_fix(self, monkeypatch, console):
+        b = _bundle("depends_on:\n  - name: obsidian\n    reason: reads vaults\n")
+        blocked = self._check(monkeypatch, b, console)
+
+        assert blocked is True, (
+            "install proceeded without a required dependency — the failure "
+            "would only surface when the agent used the skill"
+        )
+        assert "obsidian" in console.text
+        assert "hermes skill install obsidian" in console.text
+        assert "reads vaults" in console.text
+
+    def test_missing_optional_warns_but_proceeds(self, monkeypatch, console):
+        b = _bundle("depends_on:\n  - name: kanban\n    required: false\n")
+        assert self._check(monkeypatch, b, console) is False
+        assert "kanban" in console.text
+        assert "reduced functionality" in console.text
+
+    def test_satisfied_dependencies_are_silent(self, monkeypatch, console):
+        b = _bundle("depends_on: [obsidian]\n")
+        assert self._check(monkeypatch, b, console, installed={"obsidian"}) is False
+        assert console.text == ""
+
+    def test_force_downgrades_the_block_to_a_warning(self, monkeypatch, console):
+        b = _bundle("depends_on: [obsidian]\n")
+        assert self._check(monkeypatch, b, console, force=True) is False
+        assert "--force" in console.text or "force" in console.text.lower()
+
+    def test_skill_without_depends_on_is_untouched(self, monkeypatch, console):
+        b = _bundle("")
+        assert self._check(monkeypatch, b, console) is False
+        assert console.text == ""
+
+    def test_bundle_without_a_skill_md_is_untouched(self, monkeypatch, console):
+        b = SimpleNamespace(name="x", files={})
+        assert self._check(monkeypatch, b, console) is False
+
+    def test_broken_frontmatter_does_not_block(self, monkeypatch, console):
+        """Unparseable YAML must not make a skill uninstallable."""
+        b = SimpleNamespace(name="x", files={"SKILL.md": "---\nname: [unclosed\n---\n"})
+        assert self._check(monkeypatch, b, console) is False
+
+    def test_required_and_optional_together(self, monkeypatch, console):
+        b = _bundle(
+            "depends_on:\n"
+            "  - name: obsidian\n"
+            "    required: true\n"
+            "  - name: kanban\n"
+            "    required: false\n"
+        )
+        assert self._check(monkeypatch, b, console) is True
+        assert "obsidian" in console.text and "kanban" in console.text
+
+
+class TestDoInstallActuallyCallsTheGate:
+    """The gate must be wired into do_install, not merely defined.
+
+    Every test above calls ``_check_skill_dependencies`` directly, so all of
+    them pass with the call site deleted from ``do_install`` — the feature
+    would ship declared and unenforced, which is the exact thing this issue is
+    about. These drive the real install path instead.
+    """
+
+    @pytest.fixture()
+    def served(self, tmp_path, monkeypatch):
+        """A minimal one-file skill served over loopback, per test_skill_bundle_provenance."""
+        import subprocess
+        from http.server import SimpleHTTPRequestHandler
+        import socketserver
+        import threading
+
+        monkeypatch.setattr("tools.url_safety._global_allow_private_urls", lambda: True)
+
+        def _make(depends_on_yaml: str):
+            repo = tmp_path / f"upstream{len(depends_on_yaml)}"
+            repo.mkdir()
+            (repo / "SKILL.md").write_text(
+                f"---\nname: needs-dep\ndescription: A test skill.\n{depends_on_yaml}---\n\n# Body\n"
+            )
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "x"],
+                cwd=repo, check=True,
+            )
+
+            class _Quiet(SimpleHTTPRequestHandler):
+                def log_message(self, *_a):
+                    pass
+
+                def translate_path(self, path):
+                    import os
+                    rel = path.split("?", 1)[0].lstrip("/")
+                    return os.path.join(str(repo), rel)
+
+            httpd = socketserver.TCPServer(("127.0.0.1", 0), _Quiet)
+            threading.Thread(target=httpd.serve_forever, daemon=True).start()
+            url = f"http://127.0.0.1:{httpd.server_address[1]}/SKILL.md"
+            return url, httpd
+
+        return _make
+
+    def _run(self, monkeypatch, tmp_path, served, depends_on_yaml, *, installed=frozenset()):
+        from io import StringIO
+
+        from rich.console import Console
+
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import do_install
+        from tools.skills_hub import UrlSource
+
+        url, httpd = served(depends_on_yaml)
+        home = tmp_path / "home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr("tools.skills_hub.is_safe_url", lambda _u: True)
+        monkeypatch.setattr("tools.skills_hub.check_website_access", lambda _u: None)
+        monkeypatch.setattr(hub, "create_source_router", lambda auth=None: [UrlSource()])
+        monkeypatch.setattr(hub, "installed_skill_names", lambda: set(installed))
+
+        sink = StringIO()
+        try:
+            do_install(url, console=Console(file=sink, force_terminal=False),
+                       skip_confirm=True, name_override="needs-dep")
+        finally:
+            httpd.shutdown()
+        return home, sink.getvalue()
+
+    def test_unsatisfied_required_dependency_stops_the_install(
+        self, monkeypatch, tmp_path, served
+    ):
+        home, out = self._run(
+            monkeypatch, tmp_path, served,
+            "depends_on:\n  - name: obsidian\n    reason: reads vaults\n",
+        )
+        assert "Installation blocked" in out, (
+            "do_install ran to completion with a missing required dependency — "
+            "the gate is defined but never called"
+        )
+        assert not (home / "skills" / "needs-dep").exists(), (
+            "the skill landed on disk despite the block"
+        )
+
+    def test_satisfied_dependency_installs_normally(self, monkeypatch, tmp_path, served):
+        home, out = self._run(
+            monkeypatch, tmp_path, served,
+            "depends_on: [obsidian]\n",
+            installed={"obsidian"},
+        )
+        assert "Installation blocked" not in out, (
+            "a skill whose dependency IS installed was blocked anyway"
+        )
+        assert "Installed: needs-dep" in out, (
+            f"the install did not complete:\n{out}"
+        )

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3299,6 +3299,151 @@ def _skill_meta_to_dict(meta: SkillMeta) -> dict:
 # Lock file management
 # ---------------------------------------------------------------------------
 
+@dataclass
+class SkillDependency:
+    """One entry of a skill's ``depends_on`` front-matter list."""
+
+    name: str
+    required: bool = True
+    reason: str = ""
+
+
+def parse_skill_dependencies(frontmatter: dict) -> List[SkillDependency]:
+    """Read ``depends_on`` from SKILL.md front-matter.
+
+    Two spellings are accepted so a one-line declaration stays cheap::
+
+        depends_on: [obsidian, kanban]          # all required
+
+        depends_on:
+          - name: obsidian
+            required: true
+            reason: "reads from Obsidian vaults"
+          - name: kanban
+            required: false
+
+    Anything malformed is skipped rather than raising: a bad ``depends_on``
+    must not make an otherwise installable skill uninstallable.
+    """
+    raw = frontmatter.get("depends_on")
+    if not raw:
+        return []
+    if isinstance(raw, (str, bytes)):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return []
+
+    out: List[SkillDependency] = []
+    seen: set = set()
+    for item in raw:
+        if isinstance(item, str):
+            name, required, reason = item.strip(), True, ""
+        elif isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+            required = bool(item.get("required", True))
+            reason = str(item.get("reason") or "").strip()
+        else:
+            continue
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        out.append(SkillDependency(name=name, required=required, reason=reason))
+    return out
+
+
+def installed_skill_names() -> set:
+    """Every name under which a skill is reachable, matching runtime discovery.
+
+    The gate must agree with what the agent can actually load, or it blocks a
+    dependency the user genuinely has. Three sources, all of which runtime
+    discovery honours:
+
+    * the hub lockfile (hub installs);
+    * every root in ``get_all_skills_dirs()`` -- the local skills dir *and* the
+      configured ``skills.external_dirs`` -- since a skill supplied from an
+      external root is as usable as one in the profile;
+    * both the declared ``name:`` and the directory name for each SKILL.md.
+      ``tools/skills_tool.py`` resolves a skill as
+      ``frontmatter.get("name", skill_dir.name)``, so a hand-placed skill in a
+      differently-named directory is usable under its declared name;
+      ``tools/skills_sync.py`` indexes both forms for the same reason.
+    """
+    names: set = set()
+    try:
+        for entry in HubLockFile().list_installed():
+            nm = str(entry.get("name") or "").strip()
+            if nm:
+                names.add(nm)
+    except Exception:
+        pass
+
+    try:
+        from agent.skill_utils import get_all_skills_dirs
+
+        roots = list(get_all_skills_dirs())
+    except Exception:
+        roots = [_skills_dir()]
+
+    for root in roots:
+        try:
+            for skill_md in Path(root).rglob("SKILL.md"):
+                parent = skill_md.parent
+                if any(part.startswith(".") for part in parent.parts):
+                    continue
+                names.add(parent.name)
+                declared = _declared_skill_name(skill_md)
+                if declared:
+                    names.add(declared)
+        except Exception:
+            continue
+    return names
+
+
+def parse_skill_frontmatter(content) -> dict:
+    """Parse a SKILL.md's YAML front-matter into a dict.
+
+    Returns ``{}`` for anything unparseable rather than raising: front-matter
+    that a human mistyped must not take a code path down with it. Accepts
+    ``str`` or ``bytes`` so callers can pass either a file read or a bundle
+    entry.
+    """
+    if isinstance(content, bytes):
+        content = content.decode("utf-8", "replace")
+    elif not isinstance(content, str):
+        return {}
+    content = content.lstrip("\ufeff")
+    if not content.startswith("---"):
+        return {}
+    match = re.search(r"\n---\s*\n", content[3:])
+    if not match:
+        return {}
+    try:
+        parsed = yaml.safe_load(content[3:match.start() + 3])
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _declared_skill_name(skill_md: "Path") -> str:
+    """Return a SKILL.md's front-matter ``name:``, or "" when unreadable."""
+    try:
+        head = skill_md.read_text(encoding="utf-8", errors="replace")[:4000]
+    except Exception:
+        return ""
+    return str(parse_skill_frontmatter(head).get("name") or "").strip()
+
+
+def resolve_skill_dependencies(
+    deps: List[SkillDependency],
+    installed: Optional[set] = None,
+) -> Tuple[List[SkillDependency], List[SkillDependency]]:
+    """Split *deps* into (missing_required, missing_optional)."""
+    have = installed_skill_names() if installed is None else installed
+    missing_required = [d for d in deps if d.required and d.name not in have]
+    missing_optional = [d for d in deps if not d.required and d.name not in have]
+    return missing_required, missing_optional
+
+
 class HubLockFile:
     """Manages skills/.hub/lock.json — tracks provenance of installed hub skills."""
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -38,6 +38,12 @@ SKILL.md Format (YAML Frontmatter, agentskills.io compatible):
       env_vars: [API_KEY]         #   Legacy env var names are normalized into
                                   #   required_environment_variables on load.
       commands: [curl, jq]        #   Command checks remain advisory only.
+    depends_on:                   # Optional — other SKILLS this one needs.
+      - name: obsidian            #   Enforced by `hermes skill install`:
+        required: true            #   a missing required dep blocks the install
+        reason: "reads vaults"    #   (use --force to override); a missing
+      - name: kanban              #   optional dep warns and proceeds.
+        required: false           #   Shorthand: depends_on: [obsidian, kanban]
     compatibility: Requires X     # Optional (agentskills.io)
     metadata:                     # Optional, arbitrary key-value (agentskills.io)
       hermes:

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
@@ -72,6 +72,7 @@ metadata:
   hermes:
     tags: [short, descriptive, tags]
     related_skills: [other-skill, another-skill]
+depends_on: [other-skill]           # skills this one cannot work without
 ---
 ```
 


### PR DESCRIPTION
Closes #71853.

Skills carry two kinds of prerequisite metadata today — `prerequisites` (env vars, commands) and `related_skills` (advisory cross-references) — but neither says **"this skill does not work without that one"**, and nothing was enforced at install time. A skill that drives another skill's commands installs cleanly on its own; the failure surfaces only when the agent reaches for the missing piece, or the skill silently runs degraded.

### The field

```yaml
depends_on: [obsidian, kanban]          # shorthand — all required

depends_on:
  - name: obsidian
    required: true
    reason: "reads from Obsidian vaults"
  - name: kanban
    required: false
```

### The gate

`hermes skill install` resolves it **after the security verdict and before the confirmation prompt**, so a blocked install never reaches "Install 'x'?" and the user is told what to install first rather than discovering it at runtime:

```
Installation blocked: 'chronicle' requires 1 skill(s) that are not installed:
  • obsidian — reads from Obsidian vaults

Install them first:  hermes skill install obsidian
Or bypass this check:  hermes skill install chronicle --force
```

Required blocks, optional warns and proceeds, `--force` downgrades the block — matching how `--force` already overrides the security verdict.

### Two details worth review

**Installed-ness is read from the lockfile *and* from disk.** The hub lockfile only knows hub installs, but official skills shipped with Hermes and hand-placed directories are equally installed from the agent's point of view. A dependency the user genuinely has must never be reported missing, so `installed_skill_names()` unions both (skipping `.hub` / `.trash`).

**Malformed entries are skipped, never raised.** A bad `depends_on` must not make an otherwise installable skill uninstallable, so junk list entries and unparseable front-matter fall through to today's behaviour.

### Verification — each piece verified to fail when removed

| reverted | result |
|---|---|
| the `do_install` call site | **2 failed** — *"do_install ran to completion with a missing required dependency — the gate is defined but never called"* |
| required deps no longer block | **3 failed** |
| on-disk skills not counted as installed | **1 failed** — *"its dependents would be blocked for a dependency the user has"* |
| malformed entries raise instead of skip | **1 failed** |
| nothing | **21 passed** |

`TestDoInstallActuallyCallsTheGate` exists specifically because every other test calls `_check_skill_dependencies` directly and would pass with the call site deleted — the feature would ship declared and unenforced, which is the exact thing the issue is about. It drives the real `do_install` over a loopback-served skill, reusing the scaffolding from `tests/tools/test_skill_bundle_provenance.py`.

`tests/tools -k skill`: **14 failures on this branch, 14 on a pristine `origin/main` worktree at the same base — identical set.** `tests/hermes_cli -k skill`: 104 passed.

### Deliberately out of scope

Auto-installing missing dependencies would mean running the security scan and confirmation flow recursively, which deserves its own review. The error names the exact command instead. Happy to follow up with `--with-optional` and prompted auto-install if you want that shape.
