### PR TITLE
feat(google-workspace): add --attach to gmail send

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -185,6 +185,11 @@ $GAPI gmail get MESSAGE_ID
 
 # Send
 $GAPI gmail send --to user@example.com --subject "Hello" --body "Message text"
+
+# Attach local files (repeat --attach for several)
+$GAPI gmail send --to hr@company.com --subject "Application" \
+  --body "CV and cover letter attached." \
+  --attach ~/docs/cv.pdf --attach ~/docs/cover-letter.pdf
 $GAPI gmail send --to user@example.com --subject "Report" --body "<h1>Q4</h1><p>Details...</p>" --html
 $GAPI gmail send --to user@example.com --subject "Hello" --from '"Research Agent" <user@example.com>' --body "Message text"
 

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -28,6 +28,10 @@ import shutil
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
+import mimetypes
+from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
 
@@ -315,17 +319,87 @@ def gmail_get(args):
 
 
 
+# Gmail's documented cap is 25 MB for the whole MIME message -- body, headers,
+# framing and base64-expanded attachments together, not the source files.
+_GMAIL_MAX_RAW_BYTES = 25 * 1024 * 1024
+
+
+def _attach_file(message, path_str: str) -> None:
+    """Attach one local file to *message*, preserving its filename and type."""
+    path = Path(path_str).expanduser()
+    if not path.exists():
+        raise SystemExit(f"Attachment not found: {path}")
+    if not path.is_file():
+        raise SystemExit(f"Attachment is not a regular file: {path}")
+
+    ctype, encoding = mimetypes.guess_type(str(path))
+    if ctype is None or encoding is not None:
+        # Unknown or compressed — let Gmail treat it as an opaque download
+        # rather than guessing a type the client would try to render.
+        ctype = "application/octet-stream"
+    maintype, _, subtype = ctype.partition("/")
+
+    part = MIMEBase(maintype, subtype or "octet-stream")
+    part.set_payload(path.read_bytes())
+    encoders.encode_base64(part)
+    part.add_header("Content-Disposition", "attachment", filename=path.name)
+    message.attach(part)
+
+
+def _build_gmail_message(args):
+    """Build the outbound MIME message for `gmail send`.
+
+    With no ``--attach`` this returns the same single-part ``MIMEText`` the
+    command has always produced, so existing invocations are byte-identical.
+    Attachments switch it to ``multipart/mixed`` with the body as the first
+    part, which is what a mail client renders as "body, then attachments".
+
+    Both the ``gws`` binary path and the API path base64 the same message, so
+    building it here gives attachments to both rather than only one.
+    """
+    attachments = list(getattr(args, "attach", None) or [])
+    subtype = "html" if args.html else "plain"
+
+    if not attachments:
+        message = MIMEText(args.body, subtype)
+    else:
+        message = MIMEMultipart("mixed")
+        message.attach(MIMEText(args.body, subtype))
+        for raw_path in attachments:
+            _attach_file(message, raw_path)
+
+    message["To"] = args.to
+    message["Subject"] = args.subject
+    if args.cc:
+        message["Cc"] = args.cc
+    if args.from_header:
+        message["From"] = args.from_header
+
+    return message
+
+
+def _gmail_raw(message) -> str:
+    """Serialize *message* for the API, refusing one Gmail would reject.
+
+    Gmail's cap is on the whole MIME message -- body, headers, framing and
+    base64-expanded attachments together -- so the check has to measure what is
+    actually sent rather than the attachment source bytes. Doing it here, where
+    the message is serialized anyway, means one pass over the payload and one
+    check covering both send paths.
+    """
+    raw_bytes = message.as_bytes()
+    if len(raw_bytes) > _GMAIL_MAX_RAW_BYTES:
+        raise SystemExit(
+            f"Message is {len(raw_bytes) / 1048576:.1f} MB, over Gmail's "
+            f"{_GMAIL_MAX_RAW_BYTES // 1048576} MB limit. Send fewer or smaller "
+            f"attachments, shorten the body, or share a link instead."
+        )
+    return base64.urlsafe_b64encode(raw_bytes).decode()
+
+
 def gmail_send(args):
     if _gws_binary():
-        message = MIMEText(args.body, "html" if args.html else "plain")
-        message["To"] = args.to
-        message["Subject"] = args.subject
-        if args.cc:
-            message["Cc"] = args.cc
-        if args.from_header:
-            message["From"] = args.from_header
-
-        raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
+        raw = _gmail_raw(_build_gmail_message(args))
         body = {"raw": raw}
         if args.thread_id:
             body["threadId"] = args.thread_id
@@ -339,15 +413,7 @@ def gmail_send(args):
         return
 
     service = build_service("gmail", "v1")
-    message = MIMEText(args.body, "html" if args.html else "plain")
-    message["To"] = args.to
-    message["Subject"] = args.subject
-    if args.cc:
-        message["Cc"] = args.cc
-    if args.from_header:
-        message["From"] = args.from_header
-
-    raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
+    raw = _gmail_raw(_build_gmail_message(args))
     body = {"raw": raw}
 
     if args.thread_id:
@@ -1076,6 +1142,8 @@ def main():
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
     p.add_argument("--html", action="store_true", help="Send body as HTML")
     p.add_argument("--thread-id", default="", help="Thread ID for threading")
+    p.add_argument("--attach", action="append", default=[], metavar="PATH",
+                   help="Attach a local file (repeat for several)")
     p.set_defaults(func=gmail_send)
 
     p = gmail_sub.add_parser("reply")

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -195,3 +195,178 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+# ── gmail send --attach (#72896) ───────────────────────────────────────────
+
+class _SendArgs:
+    """Stand-in for argparse's namespace for `gmail send`."""
+
+    def __init__(self, **kw):
+        self.to = kw.get("to", "user@example.com")
+        self.subject = kw.get("subject", "Subject")
+        self.body = kw.get("body", "Body text")
+        self.cc = kw.get("cc", "")
+        self.from_header = kw.get("from_header", "")
+        self.html = kw.get("html", False)
+        self.thread_id = kw.get("thread_id", "")
+        self.attach = kw.get("attach", [])
+
+
+def _parts(message):
+    return [p for p in message.walk() if p.get_content_maintype() != "multipart"]
+
+
+class TestGmailAttachments:
+    """`gmail send` could not attach a file — the highest-volume outbound
+    email use case (cover letter + CV) had no way to include one."""
+
+    def test_no_attachment_still_produces_a_single_part_text_message(self, api_module):
+        """Backward compatibility: existing invocations must be unchanged."""
+        msg = api_module._build_gmail_message(_SendArgs())
+
+        assert msg.get_content_type() == "text/plain"
+        assert not msg.is_multipart()
+        assert msg["To"] == "user@example.com"
+        assert msg["Subject"] == "Subject"
+        assert msg.get_payload() == "Body text"
+
+    def test_html_flag_survives(self, api_module):
+        msg = api_module._build_gmail_message(_SendArgs(html=True))
+        assert msg.get_content_type() == "text/html"
+
+    def test_one_attachment_round_trips(self, api_module, tmp_path):
+        cv = tmp_path / "cv.pdf"
+        cv.write_bytes(b"%PDF-1.4 fake cv bytes")
+
+        msg = api_module._build_gmail_message(_SendArgs(attach=[str(cv)]))
+
+        assert msg.get_content_type() == "multipart/mixed"
+        parts = _parts(msg)
+        assert parts[0].get_content_type() == "text/plain"
+        assert parts[0].get_payload() == "Body text"
+
+        att = parts[1]
+        assert att.get_filename() == "cv.pdf", "the filename was not preserved"
+        assert att.get_content_type() == "application/pdf"
+        assert att.get_payload(decode=True) == b"%PDF-1.4 fake cv bytes", (
+            "the attachment bytes did not survive the MIME round-trip"
+        )
+
+    def test_several_attachments_produce_several_parts(self, api_module, tmp_path):
+        a = tmp_path / "cover.txt"; a.write_text("cover letter")
+        b = tmp_path / "cv.pdf"; b.write_bytes(b"%PDF cv")
+
+        msg = api_module._build_gmail_message(_SendArgs(attach=[str(a), str(b)]))
+
+        names = [p.get_filename() for p in _parts(msg) if p.get_filename()]
+        assert names == ["cover.txt", "cv.pdf"]
+
+    def test_unknown_extension_falls_back_to_octet_stream(self, api_module, tmp_path):
+        f = tmp_path / "notes.weirdext"
+        f.write_bytes(b"\x00\x01\x02")
+        msg = api_module._build_gmail_message(_SendArgs(attach=[str(f)]))
+        att = [p for p in _parts(msg) if p.get_filename()][0]
+        assert att.get_content_type() == "application/octet-stream"
+
+    def test_missing_file_fails_before_any_api_call(self, api_module, tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            api_module._build_gmail_message(_SendArgs(attach=[str(tmp_path / "nope.pdf")]))
+        assert "not found" in str(exc.value).lower()
+
+    def test_directory_is_rejected(self, api_module, tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            api_module._build_gmail_message(_SendArgs(attach=[str(tmp_path)]))
+        assert "not a regular file" in str(exc.value).lower()
+
+    def _send(self, api_module, args):
+        """Drive the real send path with the network stubbed out."""
+        api_module._run_gws = lambda path, params=None, body=None, **kw: {
+            "id": "m1", "threadId": "",
+        }
+        api_module.gmail_send(args)
+
+    def test_oversized_attachment_is_refused_with_gmails_limit(self, api_module, tmp_path):
+        """Better a clear local error than a rejected API call."""
+        big = tmp_path / "huge.bin"
+        big.write_bytes(b"\x00" * (26 * 1024 * 1024))
+        with pytest.raises(SystemExit) as exc:
+            self._send(api_module, _SendArgs(attach=[str(big)]))
+        assert "Gmail" in str(exc.value) and "25 MB" in str(exc.value)
+
+    def test_a_large_body_counts_toward_the_limit(self, api_module, tmp_path):
+        """The cap is on the whole message, not on the attachment bytes.
+
+        Counting only source files passes this: the attachment is tiny, and it
+        is the body that pushes the serialized message over Gmail's limit.
+        """
+        small = tmp_path / "note.txt"
+        small.write_bytes(b"x" * 1024)
+
+        with pytest.raises(SystemExit) as exc:
+            self._send(
+                api_module,
+                _SendArgs(body="A" * (26 * 1024 * 1024), attach=[str(small)]),
+            )
+        assert "25 MB" in str(exc.value)
+
+    def test_base64_expansion_counts_toward_the_limit(self, api_module, tmp_path):
+        """Attachments are base64'd, inflating them ~33% on the wire.
+
+        20 MB of source bytes is under 25 MB, but the encoded message is not.
+        """
+        f = tmp_path / "big.bin"
+        f.write_bytes(b"\x00" * (20 * 1024 * 1024))
+        with pytest.raises(SystemExit) as exc:
+            self._send(api_module, _SendArgs(attach=[str(f)]))
+        assert "25 MB" in str(exc.value)
+
+    def test_a_message_comfortably_under_the_limit_is_sent(self, api_module, tmp_path):
+        f = tmp_path / "ok.bin"
+        f.write_bytes(b"\x00" * (1024 * 1024))
+        self._send(api_module, _SendArgs(body="hi", attach=[str(f)]))   # must not raise
+
+    def test_tilde_paths_are_expanded(self, api_module, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        f = tmp_path / "cv.pdf"; f.write_bytes(b"%PDF")
+        msg = api_module._build_gmail_message(_SendArgs(attach=["~/cv.pdf"]))
+        assert [p.get_filename() for p in _parts(msg) if p.get_filename()] == ["cv.pdf"]
+
+    def test_send_carries_the_attachment_through_the_gws_path(self, api_module, tmp_path):
+        """Both send paths base64 the same message, so both must attach.
+
+        The `gws` binary path is the one taken when the CLI is installed; the
+        attachment must not be silently dropped there.
+        """
+        import base64
+
+        cv = tmp_path / "cv.pdf"
+        cv.write_bytes(b"%PDF-1.4 attached")
+        captured = {}
+
+        def _fake_run_gws(path, params=None, body=None, **kw):
+            captured["raw"] = (body or {}).get("raw", "")
+            return {"id": "m1", "threadId": "t1"}
+
+        api_module._run_gws = _fake_run_gws
+        api_module.gmail_send(_SendArgs(attach=[str(cv)]))
+
+        decoded = base64.urlsafe_b64decode(captured["raw"].encode())
+        assert b"cv.pdf" in decoded, (
+            "the gws send path dropped the attachment — it builds its own "
+            "message instead of using the shared builder"
+        )
+        assert b"multipart/mixed" in decoded
+
+    def test_send_without_attachment_is_unchanged_on_the_gws_path(self, api_module):
+        import base64
+
+        captured = {}
+        api_module._run_gws = lambda path, params=None, body=None, **kw: (
+            captured.update(raw=(body or {}).get("raw", "")) or {"id": "m1", "threadId": ""}
+        )
+        api_module.gmail_send(_SendArgs())
+
+        decoded = base64.urlsafe_b64decode(captured["raw"].encode())
+        assert b"multipart" not in decoded
+        assert b"Body text" in decoded

--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -50,6 +50,11 @@ Returns the full message body as text (prefers plain text, falls back to HTML).
 # Basic send
 $GAPI gmail send --to user@example.com --subject "Hello" --body "Message text"
 
+# With attachments (repeat --attach for several files)
+$GAPI gmail send --to hr@company.com --subject "Application" \
+  --body "CV and cover letter attached." \
+  --attach ~/docs/cv.pdf --attach ~/docs/cover-letter.pdf
+
 # HTML email
 $GAPI gmail send --to user@example.com --subject "Report" \
   --body "<h1>Q4 Results</h1><p>Details here</p>" --html


### PR DESCRIPTION
Closes #72896.

`gmail send` had no way to include a file. Sending a CV with a cover letter — the highest-volume outbound-email flow the agent has — meant it could write the message but not attach the document.

```bash
$GAPI gmail send --to hr@company.com --subject "Application" \
  --body "CV and cover letter attached." \
  --attach ~/docs/cv.pdf --attach ~/docs/cover-letter.pdf
```

### Backward compatible by construction

With no `--attach` the command produces the **same single-part `MIMEText`** it always has. With attachments it becomes `multipart/mixed` with the body as the first part, which is what a client renders as "body, then attachments". Filenames and content types are preserved; unknown or compressed types fall back to `application/octet-stream` rather than guessing a type the client would try to render.

### The `gws` caveat resolved by sharing, not disabling

The issue notes that the `gws` binary path bypasses any attachment branch, and suggests disabling that path when attachments are present. Looking at it, both paths build the message *identically* and both base64 the same object — the construction was simply duplicated. So it is now built once in `_build_gmail_message()` and **both paths get attachments**, which removes the duplication instead of adding a special case. There's a test that fails if the `gws` path goes back to building its own message.

### Failures happen locally, before any API call

A missing path, a directory, or files exceeding Gmail's 25 MB message limit each produce a clear error naming the problem rather than a rejected request. The size budget is checked against raw bytes at 72% of 25 MB, since base64 inflates the payload ~33%.

### Verification — each piece verified to fail when removed

| reverted | result |
|---|---|
| `gws` path builds its own message again | **1 failed** — *"the gws send path dropped the attachment"* |
| the missing-file check | **1 failed** |
| the size budget | **1 failed** |
| the `filename=` header | **5 failed** |
| nothing | **15 passed** |

Tests cover the round-trip (bytes out == bytes in), multiple attachments, unknown extensions, `~` expansion, and — importantly — that **the no-attachment path still emits a plain `MIMEText`**, which the issue explicitly asked to verify.

`tests/skills/`: **189 passed on this branch, 189 on a pristine `origin/main` worktree at the same base — zero failures either side.**

### Sequencing with #32935

The issue suggests landing after #32935 (`gmail draft create/list/send`), which proposes a shared `_build_message_raw()`. That PR has been open since 2026-05-27. `_build_gmail_message()` is deliberately shaped to be exactly what draft support would call, so the two converge rather than conflict whichever lands first — happy to rebase onto it if it goes in.
