### PR TITLE
fix(voice): drop playback-phase barge transcripts that echo Hermes' own TTS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4691,6 +4691,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_tts_done.set()
         self._voice_tts_stop = None  # active streaming pipeline's stop event
         self._voice_barge_capture = threading.Event()  # barge monitor is capturing the interruption
+        self._voice_last_tts_text = ""  # most recently spoken TTS text (echo guard, #75780)
+        self._voice_barge_phase = None  # "generation" or "playback" phase of the last barge trip
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
@@ -12183,6 +12185,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 tts_text = tts_text.strip()
             if not tts_text:
                 return
+            self._voice_last_tts_text = tts_text
 
             # Use MP3 output for CLI playback (afplay doesn't handle OGG well).
             # The TTS tool may auto-convert MP3->OGG, but the original MP3 remains.
@@ -12293,6 +12296,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # Latch BEFORE cutting anything: suppresses process_loop's
                 # auto-restart until the capture is submitted.
                 self._voice_barge_capture.set()
+                self._voice_barge_phase = phase
                 if phase == "playback":
                     logger.debug(
                         "TTS CUT: full-duplex listener tripped during playback"
@@ -12350,6 +12354,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     _cprint(f"\n{_DIM}Stop phrase detected — ending voice chat.{_RST}")
                     self._disable_voice_mode()
                     return
+                # Fail-closed echo guard (#75780): a playback-phase capture
+                # has no acoustic echo cancellation, so speaker bleed alone
+                # can trip the barge trigger. If the transcript is a close
+                # match for what Hermes just spoke, treat it as self-capture
+                # instead of queuing it as a user turn.
+                if getattr(self, "_voice_barge_phase", None) == "playback":
+                    from tools.voice_mode import is_tts_echo
+                    if is_tts_echo(transcript, getattr(self, "_voice_last_tts_text", "")):
+                        logger.debug(
+                            "Dropping playback-phase barge transcript as TTS echo: %r",
+                            transcript,
+                        )
+                        _cprint(f"\n{_DIM}Ignored likely TTS echo (not queued).{_RST}")
+                        return
                 self._pending_input.put(_VoiceInputMessage(transcript))
                 submitted = True
             elif not result.get("success"):
@@ -13505,6 +13523,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # playback (speech cuts TTS), and disarms itself when the turn
             # is fully done. See _voice_full_duplex_listener.
             if self._voice_mode and self._voice_continuous:
+                self._voice_last_tts_text = ""
                 threading.Thread(
                     target=self._voice_full_duplex_listener, daemon=True
                 ).start()
@@ -13576,6 +13595,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 def stream_callback(delta: str):
                     if text_queue is not None:
                         text_queue.put(delta)
+                    # Track what's actually being spoken so a playback-phase
+                    # barge capture can be checked against it (echo guard,
+                    # #75780).
+                    self._voice_last_tts_text = (self._voice_last_tts_text or "") + delta
 
             # When voice mode is active, prepend a brief instruction so the
             # model responds concisely. The prefix is API-call-local only —
@@ -14830,6 +14853,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_tts_done.set()  # Initially "done" (no TTS pending)
         self._voice_tts_stop = None  # active streaming pipeline's stop event
         self._voice_barge_capture = threading.Event()  # barge monitor is capturing the interruption
+        self._voice_last_tts_text = ""  # most recently spoken TTS text (echo guard, #75780)
+        self._voice_barge_phase = None  # "generation" or "playback" phase of the last barge trip
 
         if os.environ.get("HERMES_DEFER_AGENT_STARTUP") != "1":
             self._install_tool_callbacks()

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -413,6 +413,79 @@ class TestVoiceBargeCaptureSubmit:
         assert not cli._voice_barge_capture.is_set()
         assert restarted.wait(2.0)  # continuous mode resumes listening
 
+    def test_playback_phase_echo_of_own_tts_is_dropped(self, tmp_path, monkeypatch):
+        """#75780: a playback-phase capture that closely matches the TTS
+        text Hermes just spoke is speaker bleed, not real user speech --
+        it must be dropped instead of queued as the next turn, and the mic
+        handed back so continuous mode keeps listening."""
+        cli = _make_voice_cli(_voice_mode=True, _voice_continuous=True)
+        cli._voice_barge_capture.set()
+        cli._voice_barge_phase = "playback"
+        cli._voice_last_tts_text = "네, 방금도 제 답변이 그대로 다시 입력됐어요."
+        wav = tmp_path / "barge.wav"
+        wav.write_bytes(b"RIFF")
+        restarted = threading.Event()
+        cli._voice_start_recording = lambda: restarted.set()
+
+        monkeypatch.setattr(
+            "tools.voice_mode.transcribe_recording",
+            lambda path, model=None: {
+                "success": True,
+                "transcript": "네 방금 네 방금도 제 답변이 그대로 다시 입력됐어요.",
+            },
+        )
+
+        cli._voice_submit_barge_utterance(str(wav))
+
+        assert cli._pending_input.empty()  # not queued as a user turn
+        assert not cli._voice_barge_capture.is_set()
+        assert restarted.wait(2.0)  # mic handed back instead of self-triggering another turn
+
+    def test_playback_phase_genuine_interjection_is_still_queued(self, tmp_path, monkeypatch):
+        """A real user interjection during playback -- unrelated to the TTS
+        text -- must still reach the agent."""
+        cli = _make_voice_cli()
+        cli._voice_barge_capture.set()
+        cli._voice_barge_phase = "playback"
+        cli._voice_last_tts_text = "The weather today is sunny with a light breeze."
+        wav = tmp_path / "barge.wav"
+        wav.write_bytes(b"RIFF")
+
+        monkeypatch.setattr(
+            "tools.voice_mode.transcribe_recording",
+            lambda path, model=None: {
+                "success": True,
+                "transcript": "actually can you check my calendar for tomorrow",
+            },
+        )
+
+        cli._voice_submit_barge_utterance(str(wav))
+
+        queued = cli._pending_input.get_nowait()
+        from cli import _VoiceInputMessage
+        assert str(queued) == "actually can you check my calendar for tomorrow"
+
+    def test_generation_phase_transcript_not_echo_checked(self, tmp_path, monkeypatch):
+        """Generation-phase barges (no TTS playing) are never treated as
+        echo, even if the transcript happens to match old TTS text."""
+        cli = _make_voice_cli()
+        cli._voice_barge_capture.set()
+        cli._voice_barge_phase = "generation"
+        cli._voice_last_tts_text = "stop, do it differently"
+        wav = tmp_path / "barge.wav"
+        wav.write_bytes(b"RIFF")
+
+        monkeypatch.setattr(
+            "tools.voice_mode.transcribe_recording",
+            lambda path, model=None: {"success": True, "transcript": "stop, do it differently"},
+        )
+
+        cli._voice_submit_barge_utterance(str(wav))
+
+        queued = cli._pending_input.get_nowait()
+        from cli import _VoiceInputMessage
+        assert str(queued) == "stop, do it differently"
+
 
 # ============================================================================
 # Full-duplex agent-turn listener — CLI phase behaviour

--- a/tests/tools/test_voice_tts_echo_guard.py
+++ b/tests/tools/test_voice_tts_echo_guard.py
@@ -66,6 +66,25 @@ class TestIsTtsEcho:
         transcript = "the smoke tests passed without any errors"
         assert is_tts_echo(transcript, spoken) is True
 
+    def test_short_genuine_acknowledgement_is_not_echo(self):
+        # A one-word barge-in that happens to also appear as a word inside
+        # a longer spoken reply must NOT be treated as a self-capture: the
+        # fragment fallback's same-length window would otherwise match it
+        # at ratio 1.0 and drop a real "yes" (#75792 review).
+        spoken = "Yes, I can help with that -- let me pull up the details for you."
+        transcript = "yes"
+        assert is_tts_echo(transcript, spoken) is False
+
+    def test_short_fragment_of_longer_reply_in_no_whitespace_language_is_echo(self):
+        # The fragment fallback must work without relying on whitespace
+        # word-splitting, since some languages (e.g. Chinese, Japanese)
+        # don't delimit words with spaces (#75792 review).
+        spoken = (
+            "部署已经成功完成。所有三个服务都正常运行状态良好,冒烟测试也全部通过,没有发现任何错误。"
+        )
+        transcript = "所有三个服务都正常运行状态良好"
+        assert is_tts_echo(transcript, spoken) is True
+
     def test_empty_inputs_are_not_echo(self):
         assert is_tts_echo("", "hello") is False
         assert is_tts_echo("hello", "") is False

--- a/tests/tools/test_voice_tts_echo_guard.py
+++ b/tests/tools/test_voice_tts_echo_guard.py
@@ -1,0 +1,57 @@
+"""Tests for the playback-phase TTS-echo guard (#75780).
+
+Contract:
+  - `is_tts_echo` flags a barge-in transcript as a likely self-capture of
+    Hermes' own TTS output when it is a close character-level match for the
+    text that was just spoken, regardless of language/tokenization.
+  - A genuine, unrelated user interjection captured during playback must
+    NOT be flagged, even though it happens to share some words.
+  - `HermesCLI._voice_submit_barge_utterance` uses this guard ONLY for
+    playback-phase barge captures (generation-phase speech can't be TTS
+    bleed, since nothing is playing) and drops the echoed transcript
+    instead of queuing it as the next user turn.
+"""
+
+from tools.voice_mode import is_tts_echo
+
+
+class TestIsTtsEcho:
+    def test_near_verbatim_repeat_is_echo(self):
+        spoken = (
+            "맞아요. 사용자가 마이크를 끄는 게 아니라 앱이 제 음성은 "
+            "에코 제거로 걸러내고 실제 사용자 음성만 끼어들기로 받아야 해요."
+        )
+        transcript = spoken
+        assert is_tts_echo(transcript, spoken) is True
+
+    def test_repeat_with_leading_stutter_is_echo(self):
+        spoken = "네, 방금도 제 답변이 그대로 다시 입력됐어요."
+        transcript = "네 방금 네 방금도 제 답변이 그대로 다시 입력됐어요."
+        assert is_tts_echo(transcript, spoken) is True
+
+    def test_unrelated_interjection_is_not_echo(self):
+        spoken = "The weather today is sunny with a light breeze from the west."
+        transcript = "actually can you also check my calendar for tomorrow"
+        assert is_tts_echo(transcript, spoken) is False
+
+    def test_short_unrelated_reply_is_not_echo(self):
+        spoken = "I've finished summarizing the document you shared earlier."
+        transcript = "stop"
+        assert is_tts_echo(transcript, spoken) is False
+
+    def test_empty_inputs_are_not_echo(self):
+        assert is_tts_echo("", "hello") is False
+        assert is_tts_echo("hello", "") is False
+        assert is_tts_echo("", "") is False
+
+    def test_case_and_whitespace_insensitive(self):
+        spoken = "Sure, I can help with that right away."
+        transcript = "  SURE,   I can help with that   right away.  "
+        assert is_tts_echo(transcript, spoken) is True
+
+    def test_custom_threshold_is_honored(self):
+        spoken = "This is a moderately similar sentence about testing."
+        transcript = "This is a rather different sentence about coding."
+        # Lenient threshold treats it as an echo, strict threshold does not.
+        assert is_tts_echo(transcript, spoken, threshold=0.5) is True
+        assert is_tts_echo(transcript, spoken, threshold=0.95) is False

--- a/tests/tools/test_voice_tts_echo_guard.py
+++ b/tests/tools/test_voice_tts_echo_guard.py
@@ -39,6 +39,33 @@ class TestIsTtsEcho:
         transcript = "stop"
         assert is_tts_echo(transcript, spoken) is False
 
+    def test_short_fragment_of_longer_multi_sentence_reply_is_echo(self):
+        # Playback-phase captures are cut immediately on trigger and only
+        # span pre-roll + time-to-silence, so a real self-capture is
+        # typically a short fragment of a much longer spoken reply, not a
+        # near-verbatim repeat of the whole thing. A whole-string ratio
+        # dilutes with the length mismatch and misses this case (#75780
+        # review).
+        spoken = (
+            "Sure, here's a summary of what we found. The build failed "
+            "because of a missing dependency in the lockfile. I've already "
+            "gone ahead and regenerated it, and the tests are passing "
+            "again locally. Let me know if you'd like me to open a PR for "
+            "this or if you want to review the diff first before I do "
+            "anything else."
+        )
+        transcript = "Sure, here's a summary of what we found."
+        assert is_tts_echo(transcript, spoken) is True
+
+    def test_short_fragment_from_middle_of_reply_is_echo(self):
+        spoken = (
+            "The deployment finished successfully. All three services "
+            "came up healthy, and the smoke tests passed without any "
+            "errors."
+        )
+        transcript = "the smoke tests passed without any errors"
+        assert is_tts_echo(transcript, spoken) is True
+
     def test_empty_inputs_are_not_echo(self):
         assert is_tts_echo("", "hello") is False
         assert is_tts_echo("hello", "") is False

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1338,6 +1338,16 @@ def is_tts_echo(
     a strong signal of speaker-bleed self-capture (fail-closed guard for the
     playback-phase full-duplex listener, which has no acoustic echo
     cancellation; see #75780).
+
+    The playback-phase capture is cut immediately when the barge trigger
+    fires and only spans the pre-roll buffer plus time-to-silence, so for
+    any spoken reply longer than a clause the transcript is a short
+    FRAGMENT of `spoken_text`, not a near-verbatim repeat of the whole
+    thing. A whole-string ratio dilutes towards 0 as `spoken_text` grows
+    past the fragment's length, so when the whole-string check misses, we
+    also slide a window sized to the transcript's word count across
+    `spoken_text` and compare against each window, catching a short
+    fragment echoed from within a much longer multi-sentence reply.
     """
     if not transcript or not spoken_text:
         return False
@@ -1345,7 +1355,19 @@ def is_tts_echo(
     b = _normalize_for_echo_compare(spoken_text)
     if not a or not b:
         return False
-    return difflib.SequenceMatcher(None, a, b).ratio() >= threshold
+    if difflib.SequenceMatcher(None, a, b).ratio() >= threshold:
+        return True
+    b_words = b.split(" ")
+    a_word_count = len(a.split(" "))
+    if a_word_count >= len(b_words):
+        return False
+    best_ratio = 0.0
+    for start in range(0, len(b_words) - a_word_count + 1):
+        window = " ".join(b_words[start : start + a_word_count])
+        ratio = difflib.SequenceMatcher(None, a, window).ratio()
+        if ratio > best_ratio:
+            best_ratio = ratio
+    return best_ratio >= threshold
 
 
 def voice_stop_hint() -> str:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1319,6 +1319,16 @@ def is_voice_stop_phrase(transcript: str, stop_phrases: Optional[tuple] = None) 
 # verbatim from the TTS text, creating a TTS -> STT -> TTS feedback loop.
 DEFAULT_TTS_ECHO_SIMILARITY_THRESHOLD = 0.6
 
+# Minimum normalized-transcript length (in characters) required before the
+# fragment sliding-window fallback runs. Below this, any same-length window
+# of `spoken_text` that happens to contain the transcript verbatim (e.g. a
+# genuine one-word barge-in like "yes" landing inside a longer reply that
+# also says "yes") scores a trivial 1.0 ratio and would otherwise be
+# misread as a self-capture. A real self-capture fragment spans at least
+# the pre-roll buffer plus time-to-silence, so it is normally well above
+# this length; a short genuine interjection is not (#75792 review).
+MIN_FRAGMENT_LENGTH_FOR_ECHO = 10
+
 
 def _normalize_for_echo_compare(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip().lower()
@@ -1345,9 +1355,14 @@ def is_tts_echo(
     FRAGMENT of `spoken_text`, not a near-verbatim repeat of the whole
     thing. A whole-string ratio dilutes towards 0 as `spoken_text` grows
     past the fragment's length, so when the whole-string check misses, we
-    also slide a window sized to the transcript's word count across
+    also slide a window sized to the transcript's character length across
     `spoken_text` and compare against each window, catching a short
-    fragment echoed from within a much longer multi-sentence reply.
+    fragment echoed from within a much longer multi-sentence reply. This
+    windowing is character-based (not word-split), so it also works for
+    languages without whitespace between words. Transcripts shorter than
+    `MIN_FRAGMENT_LENGTH_FOR_ECHO` skip this fallback entirely, since a
+    short genuine interjection can trivially match an equally short window
+    of unrelated spoken text.
     """
     if not transcript or not spoken_text:
         return False
@@ -1357,13 +1372,11 @@ def is_tts_echo(
         return False
     if difflib.SequenceMatcher(None, a, b).ratio() >= threshold:
         return True
-    b_words = b.split(" ")
-    a_word_count = len(a.split(" "))
-    if a_word_count >= len(b_words):
+    if len(a) < MIN_FRAGMENT_LENGTH_FOR_ECHO or len(a) >= len(b):
         return False
     best_ratio = 0.0
-    for start in range(0, len(b_words) - a_word_count + 1):
-        window = " ".join(b_words[start : start + a_word_count])
+    for start in range(0, len(b) - len(a) + 1):
+        window = b[start : start + len(a)]
         ratio = difflib.SequenceMatcher(None, a, window).ratio()
         if ratio > best_ratio:
             best_ratio = ratio

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -9,6 +9,7 @@ Dependencies (optional):
     or: uv sync --extra voice
 """
 
+import difflib
 import logging
 import math
 import os
@@ -1308,6 +1309,43 @@ def is_voice_stop_phrase(transcript: str, stop_phrases: Optional[tuple] = None) 
     if stop_phrases is None:
         stop_phrases = _load_voice_stop_phrases()
     return cleaned in stop_phrases
+
+
+# Similarity ratio (difflib.SequenceMatcher, 0..1) above which a
+# playback-phase barge transcript is treated as a self-capture of Hermes'
+# own just-spoken TTS rather than genuine user speech. See #75780: the
+# full-duplex listener has no acoustic echo cancellation, so speaker bleed
+# on the mic can trip the barge trigger and get transcribed nearly
+# verbatim from the TTS text, creating a TTS -> STT -> TTS feedback loop.
+DEFAULT_TTS_ECHO_SIMILARITY_THRESHOLD = 0.6
+
+
+def _normalize_for_echo_compare(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def is_tts_echo(
+    transcript: str,
+    spoken_text: str,
+    threshold: float = DEFAULT_TTS_ECHO_SIMILARITY_THRESHOLD,
+) -> bool:
+    """Return True when *transcript* looks like a self-capture of *spoken_text*.
+
+    Compares a playback-phase barge-in transcript against the TTS text
+    Hermes just spoke using a character-level similarity ratio, which works
+    across languages without word-tokenization. A genuine user interjection
+    is very unlikely to closely match Hermes' own words, so a high ratio is
+    a strong signal of speaker-bleed self-capture (fail-closed guard for the
+    playback-phase full-duplex listener, which has no acoustic echo
+    cancellation; see #75780).
+    """
+    if not transcript or not spoken_text:
+        return False
+    a = _normalize_for_echo_compare(transcript)
+    b = _normalize_for_echo_compare(spoken_text)
+    if not a or not b:
+        return False
+    return difflib.SequenceMatcher(None, a, b).ratio() >= threshold
 
 
 def voice_stop_hint() -> str:


### PR DESCRIPTION
## What does this PR do?

Adds a fail-closed transcript-level guard so the CLI's continuous-voice
playback-phase barge-in listener can no longer transcribe Hermes' own TTS
output and re-submit it as a user turn.

`tools.voice_mode.full_duplex_listen()` keeps the mic open during TTS
playback with no acoustic echo cancellation (`5081551f0`). On some
speaker/mic combinations (e.g. built-in MacBook speakers + mic), TTS bleed
alone crosses the playback-phase RMS trigger, gets cut/captured/
transcribed, and `_voice_submit_barge_utterance()` unconditionally queues
the transcript as the next user turn. The assistant then replies, that
reply is captured again, and the loop repeats indefinitely, burning
STT/LLM/TTS calls until the user manually stops it (`Ctrl+B` / `/voice
off`).

This lands option 2 from the issue's proposed fix (the smallest,
hardware-independent piece): `tools.voice_mode.is_tts_echo()` compares a
playback-phase barge transcript against the TTS text Hermes just spoke,
using a character-level similarity ratio (language-agnostic — works for
the Korean example in the issue without word tokenization). When a
playback-phase capture is a close match, it's dropped instead of queued
and the mic is handed back to the normal continuous-listening loop.
Generation-phase trips (no TTS playing, so no bleed is possible) are
untouched.

**Update:** review caught that the whole-string similarity ratio only
scores high when the transcript and the full spoken text are close in
*length*. Since a playback-phase capture is cut immediately on trigger
and only spans the pre-roll buffer plus time-to-silence, a genuine echo
is normally a short *fragment* of a longer, multi-sentence reply — for
any response longer than a clause, the length mismatch diluted the ratio
below threshold and let the echo through ungated. `is_tts_echo()` now
falls back to sliding a window sized to the transcript's word count
across the spoken text and comparing against each window, so a short
fragment echoed from within a much longer reply is still caught. Added
tests for a fragment matched at the start and in the middle of a longer
reply (`test_short_fragment_of_longer_multi_sentence_reply_is_echo`,
`test_short_fragment_from_middle_of_reply_is_echo`).

True acoustic echo cancellation (item 1) and a repeated-high-similarity
circuit breaker (item 4) from the issue's proposal are larger, hardware-
or platform-dependent follow-ups; this PR focuses on the minimal guard
that directly stops the reported feedback loop.

## Related Issue

Fixes #75780

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/voice_mode.py`: add `is_tts_echo()` (+ `_normalize_for_echo_compare`
  helper and `DEFAULT_TTS_ECHO_SIMILARITY_THRESHOLD` constant) — a
  language-agnostic character-level similarity check between a captured
  transcript and recently-spoken TTS text. Checks a whole-string ratio
  first, then falls back to sliding a window sized to the transcript's
  word count across the spoken text, so a short captured fragment of a
  much longer multi-sentence reply is still recognized as an echo.
- `cli.py`:
  - Track the text currently being spoken in `self._voice_last_tts_text`
    (set from the whole-file `_voice_speak_response` path and accumulated
    from the streaming-TTS `stream_callback` deltas; reset at the start of
    each continuous-voice turn).
  - Record the barge phase (`generation`/`playback`) that tripped in
    `self._voice_barge_phase` from `_voice_full_duplex_listener`'s
    `_on_trigger`.
  - In `_voice_submit_barge_utterance`, when the phase is `playback`, drop
    the transcript via `is_tts_echo()` instead of queuing it, and let the
    existing "no usable transcript" path hand the mic back.
- Tests: `tests/tools/test_voice_tts_echo_guard.py` (new — unit coverage
  for `is_tts_echo`, including the issue's own Korean repro transcripts)
  and three new cases in `tests/tools/test_voice_cli_integration.py`
  covering the CLI-level drop/keep/generation-phase-unaffected behavior.

## How to Test

1. `source .venv/bin/activate && ruff check cli.py tools/voice_mode.py tests/tools/test_voice_tts_echo_guard.py tests/tools/test_voice_cli_integration.py` → `All checks passed!`
2. `bash scripts/run_tests.sh tests/tools/test_voice_tts_echo_guard.py tests/tools/test_voice_cli_integration.py tests/tools/test_voice_mode.py tests/tools/test_voice_stop_phrase.py -q`:
   ```
   === Summary: 4 files, 100 tests passed, 0 failed (100% complete) ===
   ```
3. Proved the new tests fail without the fix: reverted `cli.py` and
   `tools/voice_mode.py` to the pre-fix state (tests kept) and reran —
   `test_voice_tts_echo_guard.py` fails to import (`is_tts_echo` doesn't
   exist yet) and
   `TestVoiceBargeCaptureSubmit::test_playback_phase_echo_of_own_tts_is_dropped`
   fails because the echoed transcript is queued as a real user turn:
   ```
   FAILED tests/tools/test_voice_cli_integration.py::TestVoiceBargeCaptureSubmit::test_playback_phase_echo_of_own_tts_is_dropped
   ERROR tests/tools/test_voice_tts_echo_guard.py (ImportError: cannot import name 'is_tts_echo')
   ```
   Restoring the fix makes both green again (step 2's output above).
4. Ran the full `tests/tools/` suite: all voice-related files pass
   (`test_voice_cli_integration.py`, `test_voice_mode.py`,
   `test_voice_stop_phrase.py`, `test_voice_tts_echo_guard.py`,
   `test_voice_credential_pool_resolution.py`,
   `test_voice_mode_playback_env_scrub.py`, `test_voice_thinking_sound.py`,
   `test_voice_wsl_pipewire.py`). The only 20 failing tests in that broader
   run are unrelated to this change (parallel-search SDK, Daytona sandbox,
   image/video generation, Modal snapshot tests — all failing on lazy
   third-party SDK installs disabled in this sandboxed environment, not on
   anything touched here).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(voice):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the test suite and all relevant tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — not verified against real hardware
  (built-in MacBook mic/speakers); this PR is a deterministic,
  hardware-independent transcript-level guard validated with unit +
  integration tests reproducing the issue's own transcripts, not a live
  audio session.

### Documentation & Housekeeping

- [x] N/A — no user-facing docs/config keys changed (no new
  `voice.*` config surface; the guard runs unconditionally within the
  existing barge-in path)
- [x] N/A — no config keys added
- [x] N/A — no architecture/workflow changes
- [x] N/A — CLI-only change, no platform-specific code paths
- [x] N/A — no tool schemas changed

---

*This PR was prepared with AI assistance (Claude), with the diff, tests,
and pre/post-fix verification reviewed as described above.*
