### PR TITLE
fix(update): detect stale Windows updater binary after update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9102,6 +9102,24 @@ def cmd_update(args):
     _update_lock = UpdateLock()
     if not _update_lock.acquire():
         print(describe_holder(_update_lock.holder))
+        # The single most common cause of this refusal on Windows is a stale
+        # staged hermes-setup.exe: the desktop pre-writes the update marker
+        # with the updater's own PID, the updater spawns `hermes update`, and
+        # a binary built before the HANDOFF_PID fix (8c76fe19f) cannot pass
+        # the lock to its child, so the child refuses its own parent's marker
+        # and leaves it behind. Diagnose that case right here -- on the exact
+        # path the deadlocked user lands -- instead of silently failing.
+        try:
+            from hermes_cli.update_cmd import _windows_updater_is_stale
+            from hermes_cli.update_cmd import _windows_updater_stale_notice_text
+
+            if _windows_updater_is_stale():
+                print(_windows_updater_stale_notice_text())
+        except Exception as _updater_probe_exc:
+            # Never let the probe break the refusal message.
+            logger.debug(
+                "Windows updater staleness notice failed: %s", _updater_probe_exc
+            )
         _finalize_update_output(_update_io_state)
         sys.exit(UPDATE_EXIT_CONCURRENT)
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3584,6 +3584,10 @@ def _windows_updater_is_stale() -> bool:
     the handoff marker string. Any error (missing file, unreadable binary,
     non-Windows) returns False so a healthy install is never nagged and a
     broken probe never blocks an update.
+
+    The marker may sit anywhere in the binary (the Rust compiler can place
+    string literals at any offset), so the file is scanned incrementally in
+    bounded chunks rather than truncated at an arbitrary head size.
     """
     if not _m()._is_windows():
         return False
@@ -3593,38 +3597,55 @@ def _windows_updater_is_stale() -> bool:
         updater = get_hermes_home() / _WINDOWS_UPDATER_BINARY_NAME
         if not updater.is_file():
             return False
+        marker = _WINDOWS_UPDATER_HANDOFF_MARKER
+        # 64 KiB scan window with a one-marker-length overlap so a marker
+        # split across a chunk boundary is still found. Bounded memory: only
+        # two windows are ever live, regardless of binary size.
+        window = 64 * 1024
+        overlap = len(marker) - 1
         with open(updater, "rb") as fh:
-            head = fh.read(16 * 1024 * 1024)
-        return _WINDOWS_UPDATER_HANDOFF_MARKER not in head
+            prev_tail = b""
+            while True:
+                chunk = fh.read(window)
+                if not chunk:
+                    break
+                if marker in prev_tail + chunk:
+                    return False
+                if len(chunk) < window:
+                    break
+                prev_tail = chunk[-overlap:] if overlap > 0 else b""
+        return True
     except Exception as exc:
         logger.debug("Windows updater staleness probe failed: %s", exc)
         return False
 
 
-def _print_windows_updater_stale_notice() -> None:
-    """Warn when the staged Windows updater binary is too old to complete
-    an in-app update, with the exact repair steps.
+def _windows_updater_stale_notice_text() -> str:
+    """Multi-line notice for a stale staged Windows updater binary.
 
-    Printed after a successful `hermes update` so the user learns about the
-    stale binary at the moment they are already thinking about their install.
-    Kept non-fatal: the code update itself succeeded; only the next desktop
-    in-app update would deadlock.
+    Returns (not prints) so callers can append it to their own output:
+    the lock-refusal path in ``cmd_update`` prints it after
+    ``describe_holder`` -- the exact spot a user stuck in the stale-updater
+    deadlock lands -- while the success tail of ``_cmd_update_impl`` prints
+    it proactively for the next update. Kept non-fatal: the code update
+    itself succeeded; only the next desktop in-app update would deadlock.
     """
-    print()
-    print(
+    return (
+        "\n"
         "⚠ Stale Windows updater detected: the installed Hermes-Setup.exe "
-        "was built before the lock-handoff fix (upstream commit 8c76fe19f)."
+        "was built before the lock-handoff fix (upstream commit 8c76fe19f).\n"
+        "  The desktop in-app Update fails with \"Another Hermes update is\n"
+        "  already running\" until this binary is replaced.\n"
+        "  Fix: download the latest installer from\n"
+        "  https://hermes-agent.nousresearch.com/ and run it, or re-run the\n"
+        "  installer you originally used. `hermes update` cannot replace this\n"
+        "  binary itself."
     )
-    print(
-        "  The desktop in-app Update will fail with \"Another Hermes update "
-        "is already running\" until this binary is replaced."
-    )
-    print(
-        "  Fix: download the latest installer from "
-        "https://hermes-agent.nousresearch.com/ and run it, or re-run the "
-        "installer you originally used. `hermes update` cannot replace this "
-        "binary itself."
-    )
+
+
+def _print_windows_updater_stale_notice() -> None:
+    """Print :func:`_windows_updater_stale_notice_text` (success-tail path)."""
+    print(_windows_updater_stale_notice_text())
 
 
 def _cmd_update_impl(args, gateway_mode: bool):

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3551,6 +3551,82 @@ def _normalize_managed_eol(git_cmd, repo_root):
         # Never let line-ending cleanup block an update.
         pass
 
+
+# Marker string embedded in the Windows Tauri updater binary by the
+# HANDOFF_PID fix (upstream commit 8c76fe19f, "fix(update): let the GUI
+# updater's hermes update child pass the lock it already holds"). A
+# Hermes-Setup.exe built BEFORE that commit does not contain it, and such a
+# stale updater deadlocks every in-app update on Windows: the desktop
+# pre-writes the update marker with the updater's own PID, the updater spawns
+# `hermes update`, and the child refuses because it cannot distinguish its
+# parent's marker from a foreign concurrent updater ("Another Hermes update
+# is already running" / "Hermes is still running"), leaving a stale marker
+# behind that poisons subsequent attempts.
+#
+# `hermes update` never rebuilds this installer (it rebuilds the desktop app
+# and web UI, not the Tauri bootstrap binary), so a stale staged updater
+# survives code updates silently. We detect it here -- on the only code path
+# that is guaranteed to run the FRESH checkout -- and tell the user exactly
+# how to repair it, instead of letting the next in-app update deadlock.
+_WINDOWS_UPDATER_HANDOFF_MARKER = b"HERMES_UPDATE_HANDOFF_PID"
+
+
+# Windows updater binary name under HERMES_HOME (mirrors
+# apps/bootstrap-installer/src-tauri/src/paths.rs `installer_dest()`).
+_WINDOWS_UPDATER_BINARY_NAME = "hermes-setup.exe"
+
+
+def _windows_updater_is_stale() -> bool:
+    """True when the staged Windows updater predates the HANDOFF_PID fix.
+
+    Read-only best-effort probe: locates HERMES_HOME/hermes-setup.exe (the
+    binary the desktop launches with `--update`) and checks whether it embeds
+    the handoff marker string. Any error (missing file, unreadable binary,
+    non-Windows) returns False so a healthy install is never nagged and a
+    broken probe never blocks an update.
+    """
+    if not _m()._is_windows():
+        return False
+    try:
+        from hermes_constants import get_hermes_home
+
+        updater = get_hermes_home() / _WINDOWS_UPDATER_BINARY_NAME
+        if not updater.is_file():
+            return False
+        with open(updater, "rb") as fh:
+            head = fh.read(16 * 1024 * 1024)
+        return _WINDOWS_UPDATER_HANDOFF_MARKER not in head
+    except Exception as exc:
+        logger.debug("Windows updater staleness probe failed: %s", exc)
+        return False
+
+
+def _print_windows_updater_stale_notice() -> None:
+    """Warn when the staged Windows updater binary is too old to complete
+    an in-app update, with the exact repair steps.
+
+    Printed after a successful `hermes update` so the user learns about the
+    stale binary at the moment they are already thinking about their install.
+    Kept non-fatal: the code update itself succeeded; only the next desktop
+    in-app update would deadlock.
+    """
+    print()
+    print(
+        "⚠ Stale Windows updater detected: the installed Hermes-Setup.exe "
+        "was built before the lock-handoff fix (upstream commit 8c76fe19f)."
+    )
+    print(
+        "  The desktop in-app Update will fail with \"Another Hermes update "
+        "is already running\" until this binary is replaced."
+    )
+    print(
+        "  Fix: download the latest installer from "
+        "https://hermes-agent.nousresearch.com/ and run it, or re-run the "
+        "installer you originally used. `hermes update` cannot replace this "
+        "binary itself."
+    )
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
@@ -4592,6 +4668,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("  be in a mixed state until the Node deps are rebuilt.")
         else:
             print("✓ Update complete!")
+
+        # Windows: the staged hermes-setup.exe is NOT rebuilt by `hermes
+        # update` (only the desktop app + web UI are). If it predates the
+        # HANDOFF_PID fix (8c76fe19f), the next desktop in-app update will
+        # deadlock with "Another Hermes update is already running". Surface
+        # the repair steps now, on the one path guaranteed to run fresh code.
+        try:
+            if _windows_updater_is_stale():
+                _print_windows_updater_stale_notice()
+        except Exception as _updater_probe_exc:
+            # Never let the probe break an otherwise-good update.
+            logger.debug(
+                "Windows updater staleness notice failed: %s", _updater_probe_exc
+            )
 
         # Search-index optimization notice (v23). Existing installs keep their
         # working search index untouched on update; the compact v23 layout —

--- a/tests/hermes_cli/test_update_stale_windows_updater.py
+++ b/tests/hermes_cli/test_update_stale_windows_updater.py
@@ -98,3 +98,49 @@ def test_notice_mentions_the_failure_signature(capsys):
     update_mod._print_windows_updater_stale_notice()
     out = capsys.readouterr().out
     assert "Another Hermes update" in out
+
+
+def test_marker_after_16mib_is_still_detected(monkeypatch, tmp_path):
+    """A handoff marker placed beyond the old 16 MiB head-cut must still be
+    found -- the probe scans the whole binary, not a fixed prefix."""
+    monkeypatch.setattr(update_mod._m(), "_is_windows", lambda: True)
+    updater = tmp_path / "hermes-setup.exe"
+    # 20 MiB of padding, marker past 16 MiB, then a non-marker tail.
+    payload = b"\x00" * (20 * 1024 * 1024)
+    payload += update_mod._WINDOWS_UPDATER_HANDOFF_MARKER
+    payload += b"\x00" * 1024
+    updater.write_bytes(payload)
+
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    assert update_mod._windows_updater_is_stale() is False
+
+
+def test_marker_split_across_chunk_boundary_is_found(monkeypatch, tmp_path):
+    """A marker straddling a 64 KiB scan-window boundary must still match
+    thanks to the overlap carried between chunks."""
+    monkeypatch.setattr(update_mod._m(), "_is_windows", lambda: True)
+    updater = tmp_path / "hermes-setup.exe"
+    marker = update_mod._WINDOWS_UPDATER_HANDOFF_MARKER
+    # Split the marker right in the middle, with the first half ending
+    # exactly at a 64 KiB window boundary.
+    window = 64 * 1024
+    half = len(marker) // 2
+    payload = b"\x00" * (window - half) + marker
+    updater.write_bytes(payload)
+
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    assert update_mod._windows_updater_is_stale() is False
+
+
+def test_stale_notice_text_is_returned_not_printed():
+    """The lock-refusal path needs the notice as text to append to the
+    describe_holder output; make sure the text helper exists and mentions
+    the fix URL and the failure signature."""
+    text = update_mod._windows_updater_stale_notice_text()
+    assert "Stale Windows updater" in text
+    assert "hermes-agent.nousresearch.com" in text
+    assert "Another Hermes update" in text

--- a/tests/hermes_cli/test_update_stale_windows_updater.py
+++ b/tests/hermes_cli/test_update_stale_windows_updater.py
@@ -1,0 +1,100 @@
+"""Guard: `hermes update` must detect a stale Windows updater binary.
+
+The Tauri-based ``Hermes-Setup.exe`` staged at ``HERMES_HOME`` is NOT rebuilt
+by ``hermes update`` (only the desktop app and web UI are). A binary built
+before the lock-handoff fix (upstream commit 8c76fe19f) deadlocks every
+desktop in-app update on Windows with "Another Hermes update is already
+running", because it cannot pass the update marker lock it already holds to
+its ``hermes update`` child.
+
+These tests pin the detection helpers in ``hermes_cli.update_cmd``: the
+staleness probe must be a read-only best-effort check (never raises, never
+nags a healthy install) and the notice must point at the repair path.
+"""
+
+import os
+import sys
+
+import hermes_cli.update_cmd as update_mod
+
+
+def _write_fake_updater(path, *, with_marker: bool) -> None:
+    """Create a fake Windows updater binary at ``path``."""
+    payload = b"\x00\x01MZfake-windows-updater\x00\x02"
+    if with_marker:
+        payload += update_mod._WINDOWS_UPDATER_HANDOFF_MARKER + b"\x00"
+    path.write_bytes(payload)
+
+
+def test_handoff_marker_string_is_present():
+    """The marker we probe for must be the one the fix embedded."""
+    assert update_mod._WINDOWS_UPDATER_HANDOFF_MARKER == b"HERMES_UPDATE_HANDOFF_PID"
+
+
+def test_stale_detected_when_marker_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(update_mod._m(), "_is_windows", lambda: True)
+    updater = tmp_path / "hermes-setup.exe"
+    _write_fake_updater(updater, with_marker=False)
+
+    def fake_home():
+        return tmp_path
+
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", fake_home)
+    assert update_mod._windows_updater_is_stale() is True
+
+
+def test_fresh_updater_not_stale(monkeypatch, tmp_path):
+    monkeypatch.setattr(update_mod._m(), "_is_windows", lambda: True)
+    updater = tmp_path / "hermes-setup.exe"
+    _write_fake_updater(updater, with_marker=True)
+
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    assert update_mod._windows_updater_is_stale() is False
+
+
+def test_missing_updater_not_stale(monkeypatch, tmp_path):
+    """No staged updater -> nothing to warn about (source/dev installs)."""
+    monkeypatch.setattr(update_mod._m(), "_is_windows", lambda: True)
+
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    assert update_mod._windows_updater_is_stale() is False
+
+
+def test_non_windows_never_stale(monkeypatch):
+    monkeypatch.setattr(update_mod._m(), "_is_windows", lambda: False)
+    assert update_mod._windows_updater_is_stale() is False
+
+
+def test_probe_never_raises_on_garbage(monkeypatch, tmp_path):
+    """Unreadable/garbage updater must not raise or block an update."""
+    monkeypatch.setattr(update_mod._m(), "_is_windows", lambda: True)
+    updater = tmp_path / "hermes-setup.exe"
+    updater.write_bytes(b"\xff\xfe\x00\x01")  # random binary, no marker
+
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    # No exception, and a marker-less binary is treated as stale.
+    assert update_mod._windows_updater_is_stale() is True
+
+
+def test_notice_points_at_repair_path(capsys):
+    """The stale-updater notice must tell the user how to fix it."""
+    update_mod._print_windows_updater_stale_notice()
+    out = capsys.readouterr().out
+    assert "Stale Windows updater" in out
+    assert "hermes-agent.nousresearch.com" in out
+    assert "8c76fe19f" in out
+
+
+def test_notice_mentions_the_failure_signature(capsys):
+    """Users hitting the deadlock must recognize it in the notice."""
+    update_mod._print_windows_updater_stale_notice()
+    out = capsys.readouterr().out
+    assert "Another Hermes update" in out


### PR DESCRIPTION
﻿## Summary

hermes update never refreshes the staged Windows updater binary (HERMES_HOME/hermes-setup.exe) that the desktop launches with --update. Combined with the release-process issue where the shipped installer was built from a stale commit, Windows users can be stuck with a hermes-setup.exe that predates the lock-handoff contract (8c76fe19f) with no way to know why their in-app Update fails — or to repair it via hermes update.

**Note on scope:** the deadlock half of this was fixed upstream by #75847 (merged): hermes update now recognizes a live marker held by any process ancestor (psutil.Process().parents()) as its own orchestrating updater, so a stale binary no longer deadlocks the in-app update. This PR covers the remaining half — **detecting and surfacing the stale binary**, since nothing refreshes it during updates (same root as #74836).

## Changes

- hermes_cli/update_cmd.py:
  - _windows_updater_is_stale() — scans the whole staged hermes-setup.exe incrementally (64 KiB windows with marker-length overlap) for the HERMES_UPDATE_HANDOFF_PID marker string; a marker at any offset is found (no 16 MiB head-cut false positives).
  - _windows_updater_stale_notice_text() / _print_windows_updater_stale_notice() — notice with exact repair steps (re-download the installer from hermes-agent.nousresearch.com); the text helper lets the refusal path append it.
- hermes_cli/main.py: the UpdateLock refusal branch of cmd_update() runs the probe and prints the notice after describe_holder() — the exact spot a user stuck in the stale-updater deadlock lands. Wrapped in try/except so a broken probe never breaks the refusal message.
- 	ests/hermes_cli/test_update_stale_windows_updater.py: 11 tests — marker present/absent, fresh vs stale, missing binary, non-Windows, garbage binary never raises, notice contents, marker past 16 MiB, marker split across a chunk boundary, text helper.

## Design notes

- Read-only detection only: never auto-downloads or replaces the binary (signature trust stays with the user).
- Never raises, never blocks an update; healthy installs are never nagged.
- Zero added latency on the happy path (the probe runs only when the refusal already happened, or after a successful update).

中文说明: 死锁部分已由上游 PR #75847（psutil 祖先链方案）修复合并；本 PR 覆盖剩余缺口——检测并提示陈旧的 Windows updater 二进制（更新流程从不刷新它，与 #74836 同根）。已 rebase 到最新 main，11 个测试全过，与 #75847 的 25 个 update_lock 测试无冲突。
