### PR TITLE
fix(desktop): unwrap URL references when copying code blocks

### DIFF
--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -15,7 +15,7 @@ import {
   type SlashChipKind,
   slashIconElement
 } from '@/components/assistant-ui/directive-text'
-import { referenceKind, referenceRe } from '@/components/assistant-ui/reference-kinds'
+import { referenceKind, referenceRe, unwrapReferenceValue } from '@/components/assistant-ui/reference-kinds'
 
 import { slashCommandMatches, type SlashCommandScanOptions } from './slash-refs'
 
@@ -93,11 +93,7 @@ export function escapeHtml(value: string) {
 }
 
 export function unquoteRef(raw: string) {
-  const head = raw[0]
-  const tail = raw[raw.length - 1]
-  const quoted = (head === '`' && tail === '`') || (head === '"' && tail === '"') || (head === "'" && tail === "'")
-
-  return quoted ? raw.slice(1, -1) : raw.replace(/[,.;!?]+$/, '')
+  return unwrapReferenceValue(raw)
 }
 
 /** Always-quote variant of formatRefValue — chips need a fence even for safe values. */

--- a/apps/desktop/src/app/chat/composer/url-refs.ts
+++ b/apps/desktop/src/app/chat/composer/url-refs.ts
@@ -26,8 +26,16 @@ function splitUrlTail(raw: string) {
   return { trailing: raw.slice(url.length), url }
 }
 
-/** A URL needs a host past the scheme to be worth treating as a URL reference. */
-export const hasHttpUrlHost = (url: string) => /^https?:\/\/[^/\s]/i.test(splitUrlTail(url).url)
+/** A URL needs a valid HTTP(S) authority and host to be worth treating as a URL reference. */
+export const hasHttpUrlHost = (url: string) => {
+  try {
+    const parsed = new URL(splitUrlTail(url).url)
+
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && Boolean(parsed.hostname)
+  } catch {
+    return false
+  }
+}
 
 /** Rewrite bare links in `text` as `@url:` directives, leaving links that are
  *  already part of a directive alone. Returns `text` unchanged when there are

--- a/apps/desktop/src/app/chat/composer/url-refs.ts
+++ b/apps/desktop/src/app/chat/composer/url-refs.ts
@@ -26,8 +26,8 @@ function splitUrlTail(raw: string) {
   return { trailing: raw.slice(url.length), url }
 }
 
-/** A URL needs a host past the scheme to be worth chipping. */
-const hasHost = (url: string) => /^https?:\/\/[^/\s]/i.test(url)
+/** A URL needs a host past the scheme to be worth treating as a URL reference. */
+export const hasHttpUrlHost = (url: string) => /^https?:\/\/[^/\s]/i.test(splitUrlTail(url).url)
 
 /** Rewrite bare links in `text` as `@url:` directives, leaving links that are
  *  already part of a directive alone. Returns `text` unchanged when there are
@@ -48,7 +48,7 @@ export function linkifyUrls(text: string) {
     const start = match.index ?? 0
     const { url } = splitUrlTail(match[0])
 
-    if (!hasHost(url) || fenced.some(span => start >= span.start && start < span.end)) {
+    if (!hasHttpUrlHost(url) || fenced.some(span => start >= span.start && start < span.end)) {
       continue
     }
 
@@ -85,7 +85,7 @@ export function chipTypedUrlOnSpace(event: KeyboardEvent<HTMLDivElement>) {
 
   const { trailing, url } = splitUrlTail(token)
 
-  if (!hasHost(url)) {
+  if (!hasHttpUrlHost(url)) {
     return false
   }
 

--- a/apps/desktop/src/components/assistant-ui/directive-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/directive-text.test.ts
@@ -39,6 +39,22 @@ describe('hermesDirectiveFormatter.parse', () => {
     ])
   })
 
+  it('preserves punctuation inside quoted values but trims bare sentence punctuation', () => {
+    const quoted = hermesDirectiveFormatter.parse('see @file:`report!` now')
+    const bare = hermesDirectiveFormatter.parse('see @file:report! now')
+
+    expect(quoted).toEqual([
+      { kind: 'text', text: 'see ' },
+      { kind: 'mention', type: 'file', label: 'report!', id: 'report!' },
+      { kind: 'text', text: ' now' }
+    ])
+    expect(bare).toEqual([
+      { kind: 'text', text: 'see ' },
+      { kind: 'mention', type: 'file', label: 'report', id: 'report' },
+      { kind: 'text', text: ' now' }
+    ])
+  })
+
   it('parses session links with profile/id values', () => {
     const segments = hermesDirectiveFormatter.parse('see @session:work/20260101_abc123 next')
 

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -15,7 +15,7 @@ import { useSessionLinkTitle } from '@/lib/session-link-title'
 import { parseSessionRefValue, sessionRefFallbackLabel } from '@/lib/session-refs'
 import { cn } from '@/lib/utils'
 
-import { referenceKind, referenceRe, referenceStyle, WIRE_REFERENCE_KINDS } from './reference-kinds'
+import { referenceKind, referenceRe, referenceStyle, unwrapReferenceValue, WIRE_REFERENCE_KINDS } from './reference-kinds'
 
 const HERMES_REF_TYPES = WIRE_REFERENCE_KINDS
 type HermesRefType = (typeof HERMES_REF_TYPES)[number]
@@ -137,23 +137,6 @@ const HERMES_DIRECTIVE_RE = referenceRe()
 // something other than another slash.
 const SLASH_SKILL_RE = /(?<=^|\s)\/([a-zA-Z][\w-]*)(?![\w-]*\/)/g
 
-const TRAILING_PUNCTUATION_RE = /[,.;!?]+$/
-
-function unwrapRefValue(raw: string): string {
-  if (raw.length < 2) {
-    return raw
-  }
-
-  const head = raw[0]
-  const tail = raw[raw.length - 1]
-
-  if ((head === '`' && tail === '`') || (head === '"' && tail === '"') || (head === "'" && tail === "'")) {
-    return raw.slice(1, -1)
-  }
-
-  return raw.replace(TRAILING_PUNCTUATION_RE, '')
-}
-
 function needsQuoting(value: string): boolean {
   return /[\s()[\]{}<>"'`]/.test(value)
 }
@@ -235,7 +218,7 @@ function parseDirectiveText(text: string): Unstable_DirectiveSegment[] {
       id: match[3] || match[2] || ''
     })),
     ...Array.from(text.matchAll(HERMES_DIRECTIVE_RE)).map(match => {
-      const id = unwrapRefValue(match[2] || '')
+      const id = unwrapReferenceValue(match[2] || '')
 
       return {
         start: match.index ?? 0,

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -15,7 +15,7 @@ import { useSessionLinkTitle } from '@/lib/session-link-title'
 import { parseSessionRefValue, sessionRefFallbackLabel } from '@/lib/session-refs'
 import { cn } from '@/lib/utils'
 
-import { referenceKind, referenceRe, referenceStyle, WIRE_REFERENCE_KINDS } from './reference-kinds'
+import { referenceKind, referenceRe, referenceStyle, unwrapReferenceValue, WIRE_REFERENCE_KINDS } from './reference-kinds'
 
 const HERMES_REF_TYPES = WIRE_REFERENCE_KINDS
 type HermesRefType = (typeof HERMES_REF_TYPES)[number]
@@ -137,23 +137,6 @@ const HERMES_DIRECTIVE_RE = referenceRe()
 // something other than another slash.
 const SLASH_SKILL_RE = /(?<=^|\s)\/([a-zA-Z][\w-]*)(?![\w-]*\/)/g
 
-const TRAILING_PUNCTUATION_RE = /[,.;!?]+$/
-
-function unwrapRefValue(raw: string): string {
-  if (raw.length < 2) {
-    return raw
-  }
-
-  const head = raw[0]
-  const tail = raw[raw.length - 1]
-
-  if ((head === '`' && tail === '`') || (head === '"' && tail === '"') || (head === "'" && tail === "'")) {
-    return raw.slice(1, -1)
-  }
-
-  return raw.replace(TRAILING_PUNCTUATION_RE, '')
-}
-
 function needsQuoting(value: string): boolean {
   return /[\s()[\]{}<>"'`]/.test(value)
 }
@@ -226,7 +209,7 @@ function parseDirectiveText(text: string): Unstable_DirectiveSegment[] {
       id: match[3] || match[2] || ''
     })),
     ...Array.from(text.matchAll(HERMES_DIRECTIVE_RE)).map(match => {
-      const id = unwrapRefValue(match[2] || '')
+      const id = unwrapReferenceValue(match[2] || '')
 
       return {
         start: match.index ?? 0,

--- a/apps/desktop/src/components/assistant-ui/reference-kinds.ts
+++ b/apps/desktop/src/components/assistant-ui/reference-kinds.ts
@@ -171,3 +171,19 @@ export function textWithoutReferenceLines(text: string): string {
     .join('\n')
     .trim()
 }
+
+/** Remove optional wire-format quotes and terminal prose punctuation from a reference value. */
+export function unwrapReferenceValue(raw: string): string {
+  if (raw.length < 2) {
+    return raw
+  }
+
+  const head = raw[0]
+  const tail = raw[raw.length - 1]
+
+  if ((head === '`' && tail === '`') || (head === '"' && tail === '"') || (head === "'" && tail === "'")) {
+    return raw.slice(1, -1)
+  }
+
+  return raw.replace(/[,.;!?]+$/, '')
+}

--- a/apps/desktop/src/components/assistant-ui/reference-kinds.ts
+++ b/apps/desktop/src/components/assistant-ui/reference-kinds.ts
@@ -186,7 +186,14 @@ export function unquoteReferenceValue(raw: string): string {
     : raw
 }
 
-/** Remove optional wire-format quotes and terminal prose punctuation from a reference value. */
+/**
+ * Remove wire-format quotes; bare directives also shed terminal prose punctuation.
+ *
+ * Punctuation inside a quoted value is part of that value, while a bare
+ * `@file:report!` retains the historical sentence-boundary behavior.
+ */
 export function unwrapReferenceValue(raw: string): string {
-  return unquoteReferenceValue(raw).replace(/[,.;!?]+$/, '')
+  const value = unquoteReferenceValue(raw)
+
+  return value === raw ? value.replace(/[,.;!?]+$/, '') : value
 }

--- a/apps/desktop/src/components/assistant-ui/reference-kinds.ts
+++ b/apps/desktop/src/components/assistant-ui/reference-kinds.ts
@@ -172,8 +172,8 @@ export function textWithoutReferenceLines(text: string): string {
     .trim()
 }
 
-/** Remove optional wire-format quotes and terminal prose punctuation from a reference value. */
-export function unwrapReferenceValue(raw: string): string {
+/** Remove optional wire-format quotes while preserving every character in the value. */
+export function unquoteReferenceValue(raw: string): string {
   if (raw.length < 2) {
     return raw
   }
@@ -181,9 +181,12 @@ export function unwrapReferenceValue(raw: string): string {
   const head = raw[0]
   const tail = raw[raw.length - 1]
 
-  if ((head === '`' && tail === '`') || (head === '"' && tail === '"') || (head === "'" && tail === "'")) {
-    return raw.slice(1, -1)
-  }
+  return (head === '`' && tail === '`') || (head === '"' && tail === '"') || (head === "'" && tail === "'")
+    ? raw.slice(1, -1)
+    : raw
+}
 
-  return raw.replace(/[,.;!?]+$/, '')
+/** Remove optional wire-format quotes and terminal prose punctuation from a reference value. */
+export function unwrapReferenceValue(raw: string): string {
+  return unquoteReferenceValue(raw).replace(/[,.;!?]+$/, '')
 }

--- a/apps/desktop/src/components/chat/shiki-highlighter.test.ts
+++ b/apps/desktop/src/components/chat/shiki-highlighter.test.ts
@@ -57,8 +57,15 @@ second @url:"https://two.example" @file:\`src/app.ts\``
     expect(copyableCodeText(code)).toBe('first https://one.example\nsecond https://two.example @file:`src/app.ts`')
   })
 
-  it('keeps hostless HTTP(S) URL directives raw', () => {
-    for (const code of ['@url:http://', '@url:https://', '@url:http://?', '@url:https://?']) {
+  it('keeps hostless or malformed HTTP(S) URL directives raw', () => {
+    for (const code of [
+      '@url:http://',
+      '@url:https://',
+      '@url:http://?',
+      '@url:https://?',
+      '@url:http://:80',
+      '@url:https://#fragment',
+    ]) {
       expect(copyableCodeText(code)).toBe(code)
     }
   })

--- a/apps/desktop/src/components/chat/shiki-highlighter.test.ts
+++ b/apps/desktop/src/components/chat/shiki-highlighter.test.ts
@@ -57,6 +57,14 @@ second @url:"https://two.example" @file:\`src/app.ts\``
     expect(copyableCodeText(code)).toBe('first https://one.example\nsecond https://two.example @file:`src/app.ts`')
   })
 
+  it('keeps hostless HTTP(S) URL directives raw', () => {
+    const http = '@url:http://'
+    const https = '@url:https://'
+
+    expect(copyableCodeText(http)).toBe(http)
+    expect(copyableCodeText(https)).toBe(https)
+  })
+
   it('leaves invalid URL directives and other reference kinds unchanged', () => {
     const code = '@url:ftp://example.com @url:example.com @image:https://example.com/image.png'
 

--- a/apps/desktop/src/components/chat/shiki-highlighter.test.ts
+++ b/apps/desktop/src/components/chat/shiki-highlighter.test.ts
@@ -38,9 +38,19 @@ describe('chunkByLines', () => {
 
 
 describe('copyableCodeText', () => {
-  it('unwraps URL reference directives before copying a code block', () => {
-    expect(copyableCodeText('curl @url:https://example.com/image.png -o image.png')).toBe(
+  it('unwraps quoted URL reference directives before copying a code block', () => {
+    expect(copyableCodeText('curl @url:`https://example.com/image.png` -o image.png')).toBe(
       'curl https://example.com/image.png -o image.png'
     )
+  })
+
+  it('unwraps each supported URL quote style without changing other references', () => {
+    expect(copyableCodeText(`first @url:'https://one.example'\nsecond @url:"https://two.example" @file:\`src/app.ts\``)).toBe(
+      'first https://one.example\nsecond https://two.example @file:`src/app.ts`'
+    )
+  })
+
+  it('leaves text that is not a wire reference unchanged', () => {
+    expect(copyableCodeText("const directive = '@url:'")).toBe("const directive = '@url:'")
   })
 })

--- a/apps/desktop/src/components/chat/shiki-highlighter.test.ts
+++ b/apps/desktop/src/components/chat/shiki-highlighter.test.ts
@@ -57,12 +57,10 @@ second @url:"https://two.example" @file:\`src/app.ts\``
     expect(copyableCodeText(code)).toBe('first https://one.example\nsecond https://two.example @file:`src/app.ts`')
   })
 
-  it('keeps hostless HTTP(S) URL directives raw', () => {
-    const http = '@url:http://'
-    const https = '@url:https://'
-
-    expect(copyableCodeText(http)).toBe(http)
-    expect(copyableCodeText(https)).toBe(https)
+  it('keeps hostless and malformed-host HTTP(S) URL directives raw', () => {
+    for (const code of ['@url:http://', '@url:https://', '@url:http://?', '@url:https://#fragment', '@url:http://:80']) {
+      expect(copyableCodeText(code)).toBe(code)
+    }
   })
 
   it('leaves invalid URL directives and other reference kinds unchanged', () => {

--- a/apps/desktop/src/components/chat/shiki-highlighter.test.ts
+++ b/apps/desktop/src/components/chat/shiki-highlighter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { chunkByLines, exceedsHighlightBudget } from '@/components/chat/shiki-highlighter'
+import { chunkByLines, copyableCodeText, exceedsHighlightBudget } from '@/components/chat/shiki-highlighter'
 
 describe('exceedsHighlightBudget', () => {
   it('highlights normal-sized blocks', () => {
@@ -33,5 +33,14 @@ describe('chunkByLines', () => {
     expect(chunks).toHaveLength(5)
     expect(chunks.map(chunk => chunk.text).join('\n')).toBe(code)
     expect(chunks.reduce((sum, chunk) => sum + chunk.lines, 0)).toBe(1000)
+  })
+})
+
+
+describe('copyableCodeText', () => {
+  it('unwraps URL reference directives before copying a code block', () => {
+    expect(copyableCodeText('curl @url:https://example.com/image.png -o image.png')).toBe(
+      'curl https://example.com/image.png -o image.png'
+    )
   })
 })

--- a/apps/desktop/src/components/chat/shiki-highlighter.test.ts
+++ b/apps/desktop/src/components/chat/shiki-highlighter.test.ts
@@ -57,8 +57,8 @@ second @url:"https://two.example" @file:\`src/app.ts\``
     expect(copyableCodeText(code)).toBe('first https://one.example\nsecond https://two.example @file:`src/app.ts`')
   })
 
-  it('keeps hostless and malformed-host HTTP(S) URL directives raw', () => {
-    for (const code of ['@url:http://', '@url:https://', '@url:http://?', '@url:https://#fragment', '@url:http://:80']) {
+  it('keeps hostless HTTP(S) URL directives raw', () => {
+    for (const code of ['@url:http://', '@url:https://', '@url:http://?', '@url:https://?']) {
       expect(copyableCodeText(code)).toBe(code)
     }
   })

--- a/apps/desktop/src/components/chat/shiki-highlighter.test.ts
+++ b/apps/desktop/src/components/chat/shiki-highlighter.test.ts
@@ -44,13 +44,22 @@ describe('copyableCodeText', () => {
     )
   })
 
-  it('unwraps each supported URL quote style without changing other references', () => {
-    expect(copyableCodeText(`first @url:'https://one.example'\nsecond @url:"https://two.example" @file:\`src/app.ts\``)).toBe(
-      'first https://one.example\nsecond https://two.example @file:`src/app.ts`'
+  it('unwraps bare URL reference directives without losing code punctuation', () => {
+    expect(copyableCodeText('curl @url:https://example.com/image.png; echo done')).toBe(
+      'curl https://example.com/image.png; echo done'
     )
   })
 
-  it('leaves text that is not a wire reference unchanged', () => {
-    expect(copyableCodeText("const directive = '@url:'")).toBe("const directive = '@url:'")
+  it('unwraps each supported URL quote style without changing other references', () => {
+    const code = `first @url:'https://one.example'
+second @url:"https://two.example" @file:\`src/app.ts\``
+
+    expect(copyableCodeText(code)).toBe('first https://one.example\nsecond https://two.example @file:`src/app.ts`')
+  })
+
+  it('leaves invalid URL directives and other reference kinds unchanged', () => {
+    const code = '@url:ftp://example.com @url:example.com @image:https://example.com/image.png'
+
+    expect(copyableCodeText(code)).toBe(code)
   })
 })

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -124,7 +124,8 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   )
 }
 
-const URL_REFERENCE_VALUE_RE = /^https?:\/\/\S+$/i
+// Keep code literals such as `@url:http://` raw: a copyable URL needs a host.
+const URL_REFERENCE_VALUE_RE = /^https?:\/\/[^/\s]\S*$/i
 
 /** Convert URL references back to literal URLs for code-block clipboard text. */
 export function copyableCodeText(code: string): string {

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -123,6 +123,11 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   )
 }
 
+/** Convert URL references back to the literal URL for code-block clipboard text. */
+export function copyableCodeText(code: string): string {
+  return code.replaceAll('@url:', '')
+}
+
 export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
   components: { Pre },
   language,
@@ -152,7 +157,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
         iconClassName="size-2.5"
         label={t.assistant.tool.copyCode}
         showLabel={false}
-        text={trimmed}
+        text={copyableCodeText(trimmed)}
       />
       <CodeCardBody className="[&_pre]:px-3 [&_pre]:py-2.5">
         <ExpandableBlock>

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -124,15 +124,23 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   )
 }
 
-// Keep code literals such as `@url:http://` raw: a copyable URL needs a host.
-const URL_REFERENCE_VALUE_RE = /^https?:\/\/[^/\s]\S*$/i
+/** Match the composer's contract: only HTTP(S) URLs with a parsed host become URL references. */
+function isHttpUrlWithHost(value: string): boolean {
+  try {
+    const url = new URL(value)
+
+    return (url.protocol === 'http:' || url.protocol === 'https:') && Boolean(url.hostname)
+  } catch {
+    return false
+  }
+}
 
 /** Convert URL references back to literal URLs for code-block clipboard text. */
 export function copyableCodeText(code: string): string {
   return code.replace(referenceRe(), (directive, kind: string, value: string) => {
     const url = unquoteReferenceValue(value)
 
-    return kind === 'url' && URL_REFERENCE_VALUE_RE.test(url) ? url : directive
+    return kind === 'url' && isHttpUrlWithHost(url) ? url : directive
   })
 }
 

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -4,7 +4,7 @@ import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
 import { type ComponentProps, type FC, lazy, Suspense, useMemo } from 'react'
 import type ShikiHighlighter from 'react-shiki'
 
-import { referenceRe, unwrapReferenceValue } from '@/components/assistant-ui/reference-kinds'
+import { referenceRe, unquoteReferenceValue } from '@/components/assistant-ui/reference-kinds'
 import { CodeCard, CodeCardBody } from '@/components/chat/code-card'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { CopyButton } from '@/components/ui/copy-button'
@@ -129,7 +129,7 @@ const URL_REFERENCE_VALUE_RE = /^https?:\/\/\S+$/i
 /** Convert URL references back to literal URLs for code-block clipboard text. */
 export function copyableCodeText(code: string): string {
   return code.replace(referenceRe(), (directive, kind: string, value: string) => {
-    const url = unwrapReferenceValue(value)
+    const url = unquoteReferenceValue(value)
 
     return kind === 'url' && URL_REFERENCE_VALUE_RE.test(url) ? url : directive
   })
@@ -164,7 +164,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
         iconClassName="size-2.5"
         label={t.assistant.tool.copyCode}
         showLabel={false}
-        text={copyableCodeText(trimmed)}
+        text={() => copyableCodeText(trimmed)}
       />
       <CodeCardBody className="[&_pre]:px-3 [&_pre]:py-2.5">
         <ExpandableBlock>

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -4,6 +4,7 @@ import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
 import { type ComponentProps, type FC, lazy, Suspense, useMemo } from 'react'
 import type ShikiHighlighter from 'react-shiki'
 
+import { referenceRe, unwrapReferenceValue } from '@/components/assistant-ui/reference-kinds'
 import { CodeCard, CodeCardBody } from '@/components/chat/code-card'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { CopyButton } from '@/components/ui/copy-button'
@@ -123,9 +124,15 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   )
 }
 
-/** Convert URL references back to the literal URL for code-block clipboard text. */
+const URL_REFERENCE_VALUE_RE = /^https?:\/\/\S+$/i
+
+/** Convert URL references back to literal URLs for code-block clipboard text. */
 export function copyableCodeText(code: string): string {
-  return code.replaceAll('@url:', '')
+  return code.replace(referenceRe(), (directive, kind: string, value: string) => {
+    const url = unwrapReferenceValue(value)
+
+    return kind === 'url' && URL_REFERENCE_VALUE_RE.test(url) ? url : directive
+  })
 }
 
 export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -3,7 +3,7 @@
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
 import { type FC, lazy, Suspense, useMemo } from 'react'
 
-import { referenceRe, unwrapReferenceValue } from '@/components/assistant-ui/reference-kinds'
+import { referenceRe, unquoteReferenceValue } from '@/components/assistant-ui/reference-kinds'
 import { CodeCard, CodeCardBody } from '@/components/chat/code-card'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 // Theme constants live in shiki-config (dependency-free) so the lazy shiki
@@ -122,7 +122,7 @@ const URL_REFERENCE_VALUE_RE = /^https?:\/\/\S+$/i
 /** Convert URL references back to literal URLs for code-block clipboard text. */
 export function copyableCodeText(code: string): string {
   return code.replace(referenceRe(), (directive, kind: string, value: string) => {
-    const url = unwrapReferenceValue(value)
+    const url = unquoteReferenceValue(value)
 
     return kind === 'url' && URL_REFERENCE_VALUE_RE.test(url) ? url : directive
   })
@@ -158,7 +158,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
         iconClassName="size-2.5"
         label={t.assistant.tool.copyCode}
         showLabel={false}
-        text={copyableCodeText(content)}
+        text={() => copyableCodeText(content)}
       />
       <CodeCardBody className="[&_pre]:px-3 [&_pre]:py-2.5">
         <ExpandableBlock>

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -116,6 +116,11 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   )
 }
 
+/** Convert URL references back to the literal URL for code-block clipboard text. */
+export function copyableCodeText(code: string): string {
+  return code.replaceAll('@url:', '')
+}
+
 export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
   components: { Pre },
   language,
@@ -146,7 +151,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
         iconClassName="size-2.5"
         label={t.assistant.tool.copyCode}
         showLabel={false}
-        text={content}
+        text={copyableCodeText(content)}
       />
       <CodeCardBody className="[&_pre]:px-3 [&_pre]:py-2.5">
         <ExpandableBlock>

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -117,15 +117,23 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   )
 }
 
-// Keep code literals such as `@url:http://` raw: a copyable URL needs a host.
-const URL_REFERENCE_VALUE_RE = /^https?:\/\/[^/\s]\S*$/i
+/** Match the composer's contract: only HTTP(S) URLs with a parsed host become URL references. */
+function isHttpUrlWithHost(value: string): boolean {
+  try {
+    const url = new URL(value)
+
+    return (url.protocol === 'http:' || url.protocol === 'https:') && Boolean(url.hostname)
+  } catch {
+    return false
+  }
+}
 
 /** Convert URL references back to literal URLs for code-block clipboard text. */
 export function copyableCodeText(code: string): string {
   return code.replace(referenceRe(), (directive, kind: string, value: string) => {
     const url = unquoteReferenceValue(value)
 
-    return kind === 'url' && URL_REFERENCE_VALUE_RE.test(url) ? url : directive
+    return kind === 'url' && isHttpUrlWithHost(url) ? url : directive
   })
 }
 

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -3,6 +3,7 @@
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
 import { type FC, lazy, Suspense, useMemo } from 'react'
 
+import { hasHttpUrlHost } from '@/app/chat/composer/url-refs'
 import { referenceRe, unquoteReferenceValue } from '@/components/assistant-ui/reference-kinds'
 import { CodeCard, CodeCardBody } from '@/components/chat/code-card'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
@@ -117,23 +118,12 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   )
 }
 
-/** Match the composer's contract: only HTTP(S) URLs with a parsed host become URL references. */
-function isHttpUrlWithHost(value: string): boolean {
-  try {
-    const url = new URL(value)
-
-    return (url.protocol === 'http:' || url.protocol === 'https:') && Boolean(url.hostname)
-  } catch {
-    return false
-  }
-}
-
 /** Convert URL references back to literal URLs for code-block clipboard text. */
 export function copyableCodeText(code: string): string {
   return code.replace(referenceRe(), (directive, kind: string, value: string) => {
     const url = unquoteReferenceValue(value)
 
-    return kind === 'url' && isHttpUrlWithHost(url) ? url : directive
+    return kind === 'url' && hasHttpUrlHost(url) ? url : directive
   })
 }
 

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -3,6 +3,7 @@
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
 import { type FC, lazy, Suspense, useMemo } from 'react'
 
+import { referenceRe, unwrapReferenceValue } from '@/components/assistant-ui/reference-kinds'
 import { CodeCard, CodeCardBody } from '@/components/chat/code-card'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 // Theme constants live in shiki-config (dependency-free) so the lazy shiki
@@ -116,9 +117,15 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   )
 }
 
-/** Convert URL references back to the literal URL for code-block clipboard text. */
+const URL_REFERENCE_VALUE_RE = /^https?:\/\/\S+$/i
+
+/** Convert URL references back to literal URLs for code-block clipboard text. */
 export function copyableCodeText(code: string): string {
-  return code.replaceAll('@url:', '')
+  return code.replace(referenceRe(), (directive, kind: string, value: string) => {
+    const url = unwrapReferenceValue(value)
+
+    return kind === 'url' && URL_REFERENCE_VALUE_RE.test(url) ? url : directive
+  })
 }
 
 export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -117,7 +117,8 @@ const PlainCode: FC<{ code: string }> = ({ code }) => {
   )
 }
 
-const URL_REFERENCE_VALUE_RE = /^https?:\/\/\S+$/i
+// Keep code literals such as `@url:http://` raw: a copyable URL needs a host.
+const URL_REFERENCE_VALUE_RE = /^https?:\/\/[^/\s]\S*$/i
 
 /** Convert URL references back to literal URLs for code-block clipboard text. */
 export function copyableCodeText(code: string): string {


### PR DESCRIPTION
Fixes #75796.

## Scope
Code-block copy only: rendered code remains unchanged. The copy callback unwraps valid `http(s)` `@url:` wire references, including the composer’s quoted forms, while preserving bare-reference punctuation and leaving invalid URLs and other reference kinds untouched.

## Verification
- Red proof on the first commit: the focused highlighter test failed before the implementation (`copyableCodeText is not a function`).
- `npm --workspace apps/desktop exec vitest run src/components/chat/shiki-highlighter.test.ts src/components/assistant-ui/directive-text.test.ts` — 21 passed.
- Focused ESLint for all changed TypeScript/TSX files — passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh Claude review found quoted-wire parsing and fidelity issues; the follow-up commits address them and add coverage for quoted and bare URL directives, punctuation preservation, invalid directives, and other reference kinds.

The broader message-level copy action is intentionally out of scope; this PR fixes the reported code-block copy path.