### PR TITLE
feat: add HERMES_OFFLINE env for air-gapped deployments

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -24,6 +24,7 @@ rather than parsing the raw JSON themselves.
 
 import json
 import logging
+import os
 import threading
 import time
 from dataclasses import dataclass
@@ -387,6 +388,12 @@ def fetch_models_dev(
     that must never wait on the network.
     """
     global _models_dev_cache, _models_dev_cache_time, _models_dev_retry_after
+
+    # HERMES_OFFLINE=1 (air-gapped / intranet deployments): never open a
+    # socket. Behave as if allow_network=False for every caller, including
+    # force_refresh, so the process lives entirely off disk/memory caches.
+    if os.environ.get("HERMES_OFFLINE"):
+        allow_network = False
 
     if not allow_network:
         if _models_dev_cache:

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -283,7 +283,12 @@ def check_for_updates() -> Optional[int]:
     Returns the number of commits behind, ``UPDATE_AVAILABLE_NO_COUNT`` (-1)
     if behind but the count is unknown, ``0`` if up-to-date, or ``None`` if
     the check failed or doesn't apply. Cached for 6 hours.
+
+    ``HERMES_OFFLINE=1`` short-circuits the check entirely — intranet /
+    air-gapped deployments must never touch the network.
     """
+    if os.environ.get("HERMES_OFFLINE"):
+        return None
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -311,6 +311,25 @@ class TestFetchModelsDev:
         assert result == expected
         mock_get.assert_not_called()
 
+    @patch("agent.models_dev.requests.get")
+    def test_hermes_offline_env_never_fetches(self, mock_get, monkeypatch):
+        """HERMES_OFFLINE=1 must suppress all network access, even on
+        force_refresh, falling back to any disk cache regardless of age."""
+        import agent.models_dev as md
+
+        monkeypatch.setenv("HERMES_OFFLINE", "1")
+        with patch.object(md, "_load_disk_cache", return_value=SAMPLE_REGISTRY):
+            result = fetch_models_dev(force_refresh=True)
+
+        assert result == SAMPLE_REGISTRY
+        mock_get.assert_not_called()
+
+        # With no cache at all it returns empty rather than trying network.
+        md._models_dev_cache = {}
+        with patch.object(md, "_load_disk_cache", return_value={}):
+            assert fetch_models_dev() == {}
+        mock_get.assert_not_called()
+
 
 
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -9,6 +9,13 @@ import model_tools
 import tools.mcp_tool
 
 
+def test_check_for_updates_returns_none_under_hermes_offline(monkeypatch):
+    """HERMES_OFFLINE=1 must skip the update check's network path entirely."""
+    monkeypatch.setenv("HERMES_OFFLINE", "1")
+    with patch.object(banner.subprocess, "run", side_effect=AssertionError("no subprocess allowed")):
+        assert banner.check_for_updates() is None
+
+
 def test_cprint_falls_back_to_plain_print_when_prompt_toolkit_has_no_console(capsys):
     with patch(
         "prompt_toolkit.print_formatted_text",


### PR DESCRIPTION
## Summary

Setting `HERMES_OFFLINE=1` suppresses the two unconditional outbound network calls a cold Hermes process makes, so intranet / air-gapped deployments can run with zero external connectivity:

- `agent/models_dev.py` — `fetch_models_dev()` treats every caller as `allow_network=False` (including `force_refresh`), living entirely off in-memory / disk caches. This reuses the existing `allow_network` seam rather than adding a new code path.
- `hermes_cli/banner.py` — `check_for_updates()` returns `None` immediately, skipping the `git ls-remote` probe.

Motivation: on networks where models.dev is unreachable, the cold-start fetch blocks on a 15s connect timeout (twice on the startup path, ~31s stall). For fully air-gapped environments there is currently no switch to guarantee zero outbound traffic.

All other outbound behavior (skills hub, provider APIs, `/debug` upload) is already user-invoked only and out of scope here.

Relates to #17696 — this covers the runtime zero-egress half of that request (offline install packaging is out of scope).

## Test plan

- [x] `tests/agent/test_models_dev.py::TestFetchModelsDev::test_hermes_offline_env_never_fetches` — env set + `force_refresh=True` never touches `requests.get`, serves disk cache
- [x] `tests/hermes_cli/test_banner.py::test_check_for_updates_returns_none_under_hermes_offline` — env set short-circuits before any subprocess call
- [x] Existing `test_models_dev.py` / `test_banner*.py` suites pass (25 passed)
- [x] Manual: `HERMES_OFFLINE=1 hermes chat -q hi` cold start completes with no models.dev fetch attempt in verbose logs