### PR TITLE
fix(acp): persist session cwd in top-level sessions.cwd column

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -321,14 +321,18 @@ class SessionManager:
             message_count = int(row.get("message_count") or 0)
             if message_count <= 0:
                 continue
-            # Extract cwd from model_config JSON.
-            session_cwd = "."
-            mc = row.get("model_config")
-            if mc:
-                try:
-                    session_cwd = json.loads(mc).get("cwd", ".")
-                except (json.JSONDecodeError, TypeError):
-                    pass
+            # Prefer the canonical top-level sessions.cwd column; fall back
+            # to model_config.cwd for legacy ACP rows that haven't been healed.
+            session_cwd = (row.get("cwd") or "").strip() or None
+            if not session_cwd:
+                mc = row.get("model_config")
+                if mc:
+                    try:
+                        session_cwd = json.loads(mc).get("cwd", ".")
+                    except (json.JSONDecodeError, TypeError):
+                        session_cwd = "."
+                else:
+                    session_cwd = "."
             if normalized_cwd and _normalize_cwd_for_compare(session_cwd) != normalized_cwd:
                 continue
             results.append({
@@ -442,6 +446,7 @@ class SessionManager:
                     source="acp",
                     model=model_str,
                     model_config={"cwd": state.cwd},
+                    cwd=state.cwd,
                 )
             else:
                 # Update model_config (contains cwd) if changed.
@@ -449,6 +454,13 @@ class SessionManager:
                     db.update_session_meta(state.session_id, cwd_json, model_str)
                 except Exception:
                     logger.debug("Failed to update ACP session metadata", exc_info=True)
+                # Also keep the top-level sessions.cwd column in sync so
+                # project_tree and other consumers that read sessions.cwd
+                # (not model_config.cwd) see the current workspace.
+                try:
+                    db.update_session_cwd(state.session_id, state.cwd)
+                except Exception:
+                    logger.debug("Failed to update ACP session cwd", exc_info=True)
 
             # When the agent owns persistence to this same SessionDB it has
             # already flushed the live transcript incrementally during
@@ -515,8 +527,11 @@ class SessionManager:
         if row.get("source") != "acp":
             return None
 
-        # Extract cwd from model_config.
-        cwd = "."
+        # Extract cwd: prefer the canonical top-level sessions.cwd column.
+        # Legacy ACP rows may have NULL sessions.cwd with a valid cwd in
+        # model_config — backfill the top-level column when that happens.
+        cwd = (row.get("cwd") or "").strip() or None
+        model_config_cwd = None
         requested_provider = row.get("billing_provider")
         restored_base_url = row.get("billing_base_url")
         restored_api_mode = None
@@ -525,12 +540,25 @@ class SessionManager:
             try:
                 meta = json.loads(mc)
                 if isinstance(meta, dict):
-                    cwd = meta.get("cwd", ".")
+                    model_config_cwd = meta.get("cwd")
+                    if not cwd and model_config_cwd:
+                        cwd = model_config_cwd
+                        # Heal the legacy row: backfill top-level cwd so
+                        # project_tree and other consumers see it.
+                        try:
+                            db.update_session_cwd(session_id, cwd)
+                        except Exception:
+                            logger.debug(
+                                "Failed to backfill ACP session cwd for %s",
+                                session_id, exc_info=True,
+                            )
                     requested_provider = meta.get("provider") or requested_provider
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
             except (json.JSONDecodeError, TypeError):
                 pass
+        if not cwd:
+            cwd = "."
 
         model = row.get("model") or None
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -102,7 +102,7 @@ def _ephemeral_child_sql(alias: str = "s") -> str:
     )
 
 
-SCHEMA_VERSION = 23
+SCHEMA_VERSION = 24
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -598,6 +598,36 @@ class SessionSchemaMixin:
                 if fts5_available and self._db_has_legacy_inline_fts(cursor):
                     self.set_meta("fts_optimize_available", "1", cursor=cursor)
 
+            if current_version < 24:
+                # v24: backfill sessions.cwd from model_config.cwd for legacy
+                # ACP rows. Before v24, ACP sessions wrote cwd only inside
+                # model_config JSON; the top-level sessions.cwd column was
+                # NULL. Desktop project_tree reads sessions.cwd directly and
+                # never inspects model_config, so every legacy ACP session
+                # landed in Home. This migration heals those rows idempotently:
+                # only source='acp', only when top-level cwd is NULL or empty,
+                # only when model_config is valid JSON with a non-empty string
+                # cwd. Never overwrites an existing non-empty cwd.
+                try:
+                    cursor.execute(
+                        """UPDATE sessions
+                           SET cwd = json_extract(model_config, '$.cwd')
+                           WHERE source = 'acp'
+                             AND (cwd IS NULL OR cwd = '')
+                             AND json_valid(model_config)
+                             AND json_type(model_config, '$.cwd') = 'text'
+                             AND json_extract(model_config, '$.cwd') IS NOT NULL
+                             AND LENGTH(TRIM(json_extract(model_config, '$.cwd'))) > 0"""
+                    )
+                    healed = cursor.rowcount
+                    if healed:
+                        logger.info(
+                            "v24 migration: backfilled cwd for %d legacy ACP sessions",
+                            healed,
+                        )
+                except sqlite3.OperationalError:
+                    pass
+
             # The FTS storage layout is versioned independently of the main
             # schema (see the v23 note above). Stamp the current layout so the
             # main version can always advance: a fresh/optimized DB is at

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -220,18 +220,262 @@ class TestListAndCleanup:
 class TestPersistence:
     """Verify that sessions are persisted to SessionDB and can be restored."""
 
+    # -- cwd persistence: top-level sessions.cwd column ------------------------
 
+    def test_create_persists_top_level_cwd(self, manager):
+        """ACP create_session must write cwd to the top-level sessions.cwd column."""
+        state = manager.create_session(cwd="/home/user/my-project")
+        db = manager._get_db()
+        row = db.get_session(state.session_id)
+        assert row is not None
+        assert row.get("cwd") == "/home/user/my-project", (
+            "top-level sessions.cwd must be set on create, not only model_config.cwd"
+        )
 
+    def test_update_cwd_persists_top_level_cwd(self, manager):
+        """ACP update_cwd must update the top-level sessions.cwd column."""
+        state = manager.create_session(cwd="/home/user/project-a")
+        manager.update_cwd(state.session_id, "/home/user/project-b")
+        db = manager._get_db()
+        row = db.get_session(state.session_id)
+        assert row.get("cwd") == "/home/user/project-b", (
+            "update_cwd must write to top-level sessions.cwd"
+        )
 
+    def test_backfill_legacy_acp_row_with_null_cwd(self, manager):
+        """Restoring a legacy ACP row (NULL sessions.cwd, valid model_config.cwd)
+        must heal the top-level cwd column."""
+        db = manager._get_db()
+        sid = "legacy-acp-session-1"
+        # Simulate a legacy row: top-level cwd is NULL, model_config has cwd.
+        db.create_session(
+            session_id=sid,
+            source="acp",
+            model="test-model",
+            model_config={"cwd": "/home/user/legacy-project"},
+        )
+        # Force top-level cwd to NULL to simulate the legacy state.
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE sessions SET cwd = NULL WHERE id = ?", (sid,)
+            )
+        )
+        # Verify the legacy state.
+        row = db.get_session(sid)
+        assert row.get("cwd") is None, "precondition: top-level cwd must be NULL"
+        mc = json.loads(row["model_config"])
+        assert mc.get("cwd") == "/home/user/legacy-project", (
+            "precondition: model_config.cwd must be set"
+        )
 
+        # Restore the session — this should backfill top-level cwd.
+        restored = manager.get_session(sid)
+        assert restored is not None
+        assert restored.cwd == "/home/user/legacy-project", (
+            "restored state must have cwd from model_config"
+        )
 
+        # After restore, the top-level cwd should be healed.
+        row_after = db.get_session(sid)
+        assert row_after.get("cwd") == "/home/user/legacy-project", (
+            "legacy row must be healed: top-level cwd backfilled from model_config"
+        )
 
+    def test_non_overwrite_existing_top_level_cwd(self, manager):
+        """Never overwrite an existing non-empty top-level cwd with model_config.cwd."""
+        db = manager._get_db()
+        sid = "acp-with-cwd-1"
+        # Create a row with BOTH top-level cwd and model_config.cwd set.
+        db.create_session(
+            session_id=sid,
+            source="acp",
+            model="test-model",
+            cwd="/home/user/real-project",
+            model_config={"cwd": "/home/user/real-project"},
+        )
+        # Now tamper model_config.cwd to a different value (simulating a stale
+        # model_config that wasn't updated).
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ?",
+                (json.dumps({"cwd": "/home/user/stale-cwd"}), sid),
+            )
+        )
+        row = db.get_session(sid)
+        assert row.get("cwd") == "/home/user/real-project", (
+            "precondition: top-level cwd is the real project"
+        )
+        mc = json.loads(row["model_config"])
+        assert mc.get("cwd") == "/home/user/stale-cwd", (
+            "precondition: model_config.cwd is stale"
+        )
 
+        # Restore — must prefer the existing top-level cwd.
+        restored = manager.get_session(sid)
+        assert restored is not None
+        assert restored.cwd == "/home/user/real-project", (
+            "must prefer existing top-level cwd over stale model_config.cwd"
+        )
+        # Top-level cwd must not be overwritten.
+        row_after = db.get_session(sid)
+        assert row_after.get("cwd") == "/home/user/real-project", (
+            "existing top-level cwd must not be overwritten"
+        )
 
+    def test_list_sessions_reads_top_level_cwd(self, manager):
+        """list_sessions must return cwd from the top-level column for DB-only rows."""
+        db = manager._get_db()
+        sid = "acp-dbonly-1"
+        db.create_session(
+            session_id=sid,
+            source="acp",
+            model="test-model",
+            cwd="/home/user/dbonly-project",
+            model_config={"cwd": "/home/user/dbonly-project"},
+        )
+        # Insert a message so list_sessions includes this row.
+        db.append_message(sid, role="user", content="hello from db-only")
 
+        results = manager.list_sessions()
+        found = [r for r in results if r["session_id"] == sid]
+        assert len(found) == 1, "DB-only ACP session must appear in list_sessions"
+        assert found[0]["cwd"] == "/home/user/dbonly-project", (
+            "list_sessions must return top-level cwd, not fall back to '.'"
+        )
 
+    # -- existing persistence tests -------------------------------------------
 
+    def test_migration_v24_backfills_legacy_acp_cwd(self, tmp_path):
+        """Reopening a DB with legacy ACP rows heals sessions.cwd from model_config.
 
+        The migration is version-gated (v24) and scoped to source='acp'. It
+        only fills NULL/empty top-level cwd when model_config has a non-empty
+        string cwd. Never overwrites an existing cwd.
+        """
+        import sqlite3 as _sqlite3
+
+        db_path = tmp_path / "legacy_acp.db"
+
+        # Build a v23 DB with a legacy ACP row: NULL top-level cwd, valid
+        # model_config.cwd. Also a non-ACP row to prove the migration is scoped.
+        raw = _sqlite3.connect(str(db_path))
+        raw.executescript(
+            """
+            CREATE TABLE schema_version (version INTEGER);
+            INSERT INTO schema_version VALUES (23);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, source TEXT, started_at REAL, ended_at REAL,
+                message_count INTEGER DEFAULT 0, tool_call_count INTEGER DEFAULT 0,
+                title TEXT, parent_session_id TEXT, model_config TEXT,
+                cwd TEXT, git_branch TEXT, git_repo_root TEXT,
+                profile_name TEXT
+            );
+            """
+        )
+        raw.execute(
+            "INSERT INTO sessions (id, source, model_config, cwd, started_at) "
+            "VALUES (?, 'acp', ?, NULL, 0)",
+            ("acp-legacy-1", json.dumps({"cwd": "/projects/legacy-acp"})),
+        )
+        raw.execute(
+            "INSERT INTO sessions (id, source, model_config, cwd, started_at) "
+            "VALUES (?, 'acp', ?, NULL, 0)",
+            ("acp-malformed-1", "not-json"),
+        )
+        raw.execute(
+            "INSERT INTO sessions (id, source, model_config, cwd, started_at) "
+            "VALUES (?, 'acp', ?, NULL, 0)",
+            ("acp-empty-cwd-1", json.dumps({"cwd": "  "})),
+        )
+        raw.execute(
+            "INSERT INTO sessions (id, source, model_config, cwd, started_at) "
+            "VALUES (?, 'cli', ?, NULL, 0)",
+            ("cli-legacy-1", json.dumps({"cwd": "/projects/legacy-cli"})),
+        )
+        # Non-empty top-level cwd must NOT be overwritten even if model_config differs.
+        raw.execute(
+            "INSERT INTO sessions (id, source, model_config, cwd, started_at) "
+            "VALUES (?, 'acp', ?, '/projects/real', 0)",
+            ("acp-existing-1", json.dumps({"cwd": "/projects/stale"})),
+        )
+        raw.commit()
+        raw.close()
+
+        # Reopen via SessionDB — triggers v24 migration.
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=db_path)
+        try:
+            row = db.get_session("acp-legacy-1")
+            assert row is not None
+            assert row["cwd"] == "/projects/legacy-acp", (
+                "v24 migration must backfill top-level cwd from model_config"
+            )
+            # Malformed JSON is skipped safely.
+            r2 = db.get_session("acp-malformed-1")
+            assert r2 is not None and r2["cwd"] is None
+            # Empty-string cwd in model_config is skipped.
+            r3 = db.get_session("acp-empty-cwd-1")
+            assert r3 is not None and r3["cwd"] is None
+            # Non-ACP rows are untouched.
+            r4 = db.get_session("cli-legacy-1")
+            assert r4 is not None and r4["cwd"] is None
+            # Existing non-empty cwd is NOT overwritten.
+            r5 = db.get_session("acp-existing-1")
+            assert r5 is not None and r5["cwd"] == "/projects/real"
+        finally:
+            db.close()
+
+        # Reopening again is idempotent — no further changes, no crash.
+        db2 = SessionDB(db_path=db_path)
+        try:
+            r = db2.get_session("acp-legacy-1")
+            assert r is not None and r["cwd"] == "/projects/legacy-acp"
+        finally:
+            db2.close()
+
+    def test_e2e_acp_session_placed_in_project_tree(self, tmp_path):
+        """ACP session with persisted top-level cwd is placed in its project,
+        not the Home bucket, by project_tree.build_tree."""
+        from tui_gateway.project_tree import build_tree, NO_PROJECT_ID
+
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+
+        db = SessionDB(tmp_path / "state.db")
+        mgr = SessionManager(agent_factory=_mock_agent, db=db)
+        state = mgr.create_session(cwd=str(workspace))
+
+        # Read the persisted row and shape it for build_tree.
+        row = db.get_session(state.session_id)
+        assert row is not None
+        row = dict(row)
+        row["started_at"] = 1000
+        row["last_active"] = 1000
+        row["title"] = None
+        row["preview"] = None
+        row["git_branch"] = ""
+        row["git_repo_root"] = ""
+
+        project = {
+            "id": "p_test",
+            "name": "Repo",
+            "primary_path": str(workspace),
+            "archived": False,
+            "folders": [{"path": str(workspace), "is_primary": True}],
+        }
+
+        tree = build_tree([project], [row], [], resolve=None, hydrate=True)
+        placed = next((p for p in tree["projects"] if p["id"] == "p_test"), None)
+        home = next((p for p in tree["projects"] if p["id"] == NO_PROJECT_ID), None)
+
+        assert placed is not None and placed["sessionCount"] == 1, (
+            "ACP session must be placed in its project"
+        )
+        assert home is None or home["sessionCount"] == 0, (
+            "ACP session must NOT land in Home"
+        )
+        db.close()
 
     def test_only_restores_acp_sessions(self, manager):
         """get_session should not restore non-ACP sessions from DB."""


### PR DESCRIPTION
## Summary

ACP sessions wrote `cwd` only inside `model_config` JSON, leaving the top-level `sessions.cwd` column NULL. The Desktop project tree (`tui_gateway/project_tree.py`) reads `sessions.cwd` directly and never inspects `model_config`, so every ACP session landed in the Home bucket instead of its project.

### Root cause

`acp_adapter/session.py` `SessionManager._persist` called `db.create_session(model_config={"cwd": state.cwd})` without passing the top-level `cwd=` parameter. `update_cwd` similarly updated only `model_config` via `update_session_meta`, not `sessions.cwd`.

### Changes

| File | Change |
|------|--------|
| `acp_adapter/session.py` | `_persist`: pass `cwd=state.cwd` to `db.create_session`; `update_cwd`: also call `db.update_session_cwd`; `_restore`: heal legacy rows by backfilling from `model_config.cwd`; `list_sessions`: prefer top-level cwd |
| `hermes_state_common.py` | `SCHEMA_VERSION` 23 → 24 |
| `hermes_state_schema.py` | v24 migration: backfill `sessions.cwd` from `model_config.cwd` for legacy ACP rows (scoped to `source='acp'`, idempotent, never overwrites existing non-empty cwd) |
| `tests/acp/test_session.py` | 7 new behavior tests |

### Migration details

The v24 migration uses a single SQL `UPDATE` with `json_valid`/`json_type`/`json_extract` guards:
- Only `source = 'acp'`
- Only when `cwd IS NULL OR cwd = ''`
- Only when `model_config` is valid JSON with a text-type `$.cwd` that is non-empty after trim
- Never overwrites an existing non-empty `sessions.cwd`
- Idempotent on re-open

## Test plan

- [x] `scripts/run_tests.sh tests/acp/test_session.py tests/tui_gateway/test_project_tree.py -q` → 48 passed
- [x] `scripts/run_tests.sh tests/acp/test_session.py tests/acp/test_session_db_private_access.py tests/acp/test_session_provenance.py tests/test_hermes_state.py tests/tui_gateway/test_project_tree.py -q` → 197 passed
- [x] Independent E2E harness: create → persist → `build_tree` → project placement (not Home) ✓
- [x] Migration v24: reopen legacy v23 DB → ACP rows healed, non-ACP untouched, existing cwd preserved ✓
- [x] `git stash` baseline on clean `upstream/main` confirms no regression