### PR TITLE
fix(clarify): let CLI honor agent.clarify_timeout

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -518,9 +518,9 @@ def load_cli_config() -> Dict[str, Any]:
 
             "skin": "default",
         },
-        "clarify": {
-            "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding
-        },
+        # Do not materialize the legacy ``clarify.timeout`` here. Its presence
+        # is the explicit-override signal used by resolve_clarify_timeout(); a
+        # default value would mask the canonical agent.clarify_timeout setting.
         "code_execution": {
             "timeout": 300,    # Max seconds a sandbox script can run before being killed (5 min)
             "max_tool_calls": 50,  # Max RPC tool calls per execution

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -364,6 +364,50 @@ class TestHistoryDisplay:
 
 
 
+class TestClarifyTimeoutConfig:
+    """The classic CLI must not turn its old default into an override."""
+
+    def test_canonical_timeout_reaches_cli_when_legacy_key_is_unset(
+        self, tmp_path, monkeypatch
+    ):
+        import yaml
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(yaml.safe_dump({
+            "agent": {"clarify_timeout": 5000},
+        }))
+
+        import cli
+        from tools.clarify_gateway import resolve_clarify_timeout
+
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        config = cli.load_cli_config()
+
+        assert "clarify" not in config
+        assert resolve_clarify_timeout(config) == 5000
+
+    def test_explicit_legacy_timeout_still_wins_in_cli_config(
+        self, tmp_path, monkeypatch
+    ):
+        import yaml
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(yaml.safe_dump({
+            "agent": {"clarify_timeout": 5000},
+            "clarify": {"timeout": 90},
+        }))
+
+        import cli
+        from tools.clarify_gateway import resolve_clarify_timeout
+
+        monkeypatch.setattr(cli, "_hermes_home", hermes_home)
+        config = cli.load_cli_config()
+
+        assert resolve_clarify_timeout(config) == 90
+
+
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""
 
@@ -521,7 +565,5 @@ class TestRootLevelProviderOverride:
         result = _normalize_root_model_keys({"model": {"model": "m-key", "name": "n-key"}})
         assert result["model"]["default"] == "m-key"
         assert "model" not in result["model"] and "name" not in result["model"]
-
-
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2214,12 +2214,14 @@ The delegation provider uses the same credential resolution as CLI/gateway start
 
 ## Clarify
 
-Configure how long the gateway waits for a response to a clarifying question. The canonical key is `agent.clarify_timeout` (default `3600` seconds); a legacy top-level `clarify.timeout` is still honored if explicitly set:
+Configure how long Hermes waits for a response to a clarifying question across the gateway, CLI, TUI, and desktop app. The canonical key is `agent.clarify_timeout` (default `3600` seconds); a legacy top-level `clarify.timeout` is still honored if explicitly set:
 
 ```yaml
 agent:
   clarify_timeout: 3600        # Seconds to wait for user clarification response (0 or less = unlimited)
 ```
+
+Restart an active CLI, TUI, or desktop session after changing this setting so it reloads the configuration.
 
 ## Context Files (SOUL.md, AGENTS.md)
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -716,7 +716,7 @@ When the agent calls the `clarify` tool — to ask which approach you prefer, ge
 
 Click a numbered button to answer, or click **Other** to type a free-form response (the next message you send in that channel becomes the answer). Open-ended `clarify` calls (no preset choices) skip the buttons and just capture your next message.
 
-The buttons disable themselves once a choice is made so duplicate clicks don't double-resolve the prompt. Configure the response timeout via `agent.clarify_timeout` in `~/.hermes/config.yaml` (default `600` seconds). If you don't respond within the timeout, the agent unblocks with a sentinel message and adapts rather than hanging.
+The buttons disable themselves once a choice is made so duplicate clicks don't double-resolve the prompt. Configure the response timeout via `agent.clarify_timeout` in `~/.hermes/config.yaml` (default `3600` seconds). If you don't respond within the timeout, the agent unblocks with a sentinel message and adapts rather than hanging.
 
 ## Home Channel
 
@@ -921,5 +921,4 @@ Leave `everyone` and `roles` at `false` unless you know exactly why you need the
 :::
 
 For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
-
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1277,7 +1277,7 @@ When the agent calls the `clarify` tool — to ask which approach you prefer, ge
 
 Tap a button to answer, or tap **Other** to type a free-form response (the next message you send becomes the answer). Open-ended `clarify` calls (no preset choices) skip the buttons and just capture your next message.
 
-Configure the response timeout via `agent.clarify_timeout` in `~/.hermes/config.yaml` (default `600` seconds). If you don't respond within the timeout, the agent unblocks with a sentinel message and adapts rather than hanging.
+Configure the response timeout via `agent.clarify_timeout` in `~/.hermes/config.yaml` (default `3600` seconds). If you don't respond within the timeout, the agent unblocks with a sentinel message and adapts rather than hanging.
 
 ## Push notification volume
 


### PR DESCRIPTION
## What changed and why

Per the reporter's July 31 clarification, the classic CLI still auto-decides after 120 seconds on current main when only `agent.clarify_timeout` is configured. `load_cli_config()` was materializing the deprecated `clarify.timeout: 120`, causing the shared resolver to mistake a CLI default for an explicit legacy override.

This removes that synthetic legacy default so the canonical setting reaches the CLI. An explicitly configured `clarify.timeout` continues to take precedence for backwards compatibility. The configuration reference now covers every surface, notes the session restart requirement, and the Discord and Telegram guides now report the correct 3600-second default.

## Addressing maintainer feedback

#69774 is merged and introduced the shared timeout resolver, but its intended explicit-legacy precedence could not work for the classic CLI while `load_cli_config()` always injected `clarify.timeout: 120`. This follow-up fixes that remaining current-main path without changing the precedence contract established by #69774.

## How to test

- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/cli/test_cli_init.py tests/tools/test_clarify_gateway.py -q -x --timeout=60 "$@"' sh` (passes: 51 tests)
- With only `agent.clarify_timeout: 5000` in `config.yaml`, verify classic CLI resolution is 5000; with explicit `clarify.timeout: 90`, verify the legacy setting remains 90.
- The requested full `pytest tests/` command was attempted, but collection is blocked in this environment because the system Python lacks FastAPI/uvicorn and cannot install them under PEP 668.

## What platforms tested on

- macOS (local worker environment)

Refs #25859

<!-- autocontrib:worker-id=issue-followup-a45402ed kind=pr-open -->