### PR TITLE
fix(gateway): key the Honcho cache-busting memo on stat identity

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23118,7 +23118,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
     )
-    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
+    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None, int | None], dict[str, Any]] = {}
 
     @classmethod
     def _empty_honcho_cache_busting_config(cls) -> dict[str, Any]:
@@ -23126,16 +23126,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @classmethod
     def _extract_honcho_cache_busting_config(cls) -> dict[str, Any]:
-        """Extract Honcho identity keys, memoized by honcho.json mtime."""
+        """Extract Honcho identity keys, memoized by honcho.json stat identity.
+
+        The memo key is ``(path, st_mtime_ns, st_size)`` — both fields come
+        from the single ``stat()`` call the memo already makes, so a rewrite
+        that lands inside one mtime tick on a coarse-mtime filesystem is
+        still detected whenever it changes the file's size, at zero added
+        I/O on this hot path (it feeds the per-turn agent-cache signature).
+
+        Deliberately NOT content-hashed: an equal-size rewrite inside one
+        mtime tick can still reuse stale parsed state for one cache
+        generation. That edge is vanishingly rare and its worst outcome is
+        one stale generation until the next change; hashing the file on
+        every lookup would defeat the memo's no-I/O purpose. See the
+        maintainer resolution on #46385, which declined content hashing and
+        identified ``st_size`` as the right-shaped discriminator.
+        """
         try:
             from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
 
             path = resolve_config_path()
             try:
-                mtime_ns = path.stat().st_mtime_ns
+                st = path.stat()
+                mtime_ns = st.st_mtime_ns
+                size = st.st_size
             except OSError:
                 mtime_ns = None
-            memo_key = (str(path), mtime_ns)
+                size = None
+            memo_key = (str(path), mtime_ns, size)
             cached = cls._HONCHO_CACHE_BUSTING_MEMO.get(memo_key)
             if cached is not None:
                 return dict(cached)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26328,7 +26328,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
     )
-    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
+    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None, int | None], dict[str, Any]] = {}
 
     @classmethod
     def _empty_honcho_cache_busting_config(cls) -> dict[str, Any]:
@@ -26336,16 +26336,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @classmethod
     def _extract_honcho_cache_busting_config(cls) -> dict[str, Any]:
-        """Extract Honcho identity keys, memoized by honcho.json mtime."""
+        """Extract Honcho identity keys, memoized by honcho.json stat identity.
+
+        The memo key is ``(path, st_mtime_ns, st_size)`` — both fields come
+        from the single ``stat()`` call the memo already makes, so a rewrite
+        that lands inside one mtime tick on a coarse-mtime filesystem is
+        still detected whenever it changes the file's size, at zero added
+        I/O on this hot path (it feeds the per-turn agent-cache signature).
+
+        Deliberately NOT content-hashed: an equal-size rewrite inside one
+        mtime tick can still reuse stale parsed state for one cache
+        generation. That edge is vanishingly rare and its worst outcome is
+        one stale generation until the next change; hashing the file on
+        every lookup would defeat the memo's no-I/O purpose. See the
+        maintainer resolution on #46385, which declined content hashing and
+        identified ``st_size`` as the right-shaped discriminator.
+        """
         try:
             from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
 
             path = resolve_config_path()
             try:
-                mtime_ns = path.stat().st_mtime_ns
+                st = path.stat()
+                mtime_ns = st.st_mtime_ns
+                size = st.st_size
             except OSError:
                 mtime_ns = None
-            memo_key = (str(path), mtime_ns)
+                size = None
+            memo_key = (str(path), mtime_ns, size)
             cached = cls._HONCHO_CACHE_BUSTING_MEMO.get(memo_key)
             if cached is not None:
                 return dict(cached)

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1062,3 +1062,140 @@ class TestCrossProcessInvalidationDefersCleanup:
         assert "telegram:s1" not in runner._agent_cache
         runner._cleanup_agent_resources.assert_not_called()
 
+
+
+class TestHonchoCacheBustingMemo:
+    """The Honcho identity memo is keyed by stat identity, not just mtime.
+
+    Regression coverage for the coarse-mtime rewrite case: on filesystems
+    with coarse mtime granularity, an edit to honcho.json can land inside
+    one mtime tick, and a key of (path, mtime_ns) alone would keep serving
+    the previously parsed identity config. Keying on st_size as well —
+    which comes from the same stat() call, at zero added I/O — catches any
+    such rewrite that changes the file's size.
+
+    The equal-size/equal-mtime edge is deliberately OUT of the guarantee
+    (see the maintainer resolution on #46385, which declined content
+    hashing on this hot path); a test below pins that documented tradeoff
+    so a future "fix" that silently adds per-lookup I/O shows up here.
+    """
+
+    @staticmethod
+    def _fake_path(stat_results):
+        """A path-like whose stat() pops from a queue of fake results."""
+        from types import SimpleNamespace
+
+        results = list(stat_results)
+
+        class _FakePath:
+            def stat(self):
+                r = results.pop(0) if len(results) > 1 else results[0]
+                if isinstance(r, Exception):
+                    raise r
+                return r
+
+            def __str__(self):
+                return "/fake/honcho.json"
+
+        _FakePath.make = staticmethod(
+            lambda m, s: SimpleNamespace(st_mtime_ns=m, st_size=s)
+        )
+        return _FakePath()
+
+    def _extract_with(self, monkeypatch, path, configs):
+        """Run the extractor with a fake path and a queue of parsed configs."""
+        from types import SimpleNamespace
+
+        from gateway.run import GatewayRunner
+
+        parses = []
+        queue = list(configs)
+
+        def _fake_from_global_config(config_path=None):
+            cfg = queue.pop(0) if len(queue) > 1 else queue[0]
+            parses.append(cfg)
+            return SimpleNamespace(
+                peer_name=cfg,
+                ai_peer=None,
+                pin_peer_name=False,
+                runtime_peer_prefix=None,
+                user_peer_aliases={},
+            )
+
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.resolve_config_path", lambda: path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            staticmethod(_fake_from_global_config),
+        )
+        return GatewayRunner._extract_honcho_cache_busting_config, parses
+
+    @pytest.fixture(autouse=True)
+    def _reset_memo(self):
+        from gateway.run import GatewayRunner
+
+        GatewayRunner._HONCHO_CACHE_BUSTING_MEMO = {}
+        yield
+        GatewayRunner._HONCHO_CACHE_BUSTING_MEMO = {}
+
+    def test_same_mtime_different_size_invalidates(self, monkeypatch):
+        """The fix: a rewrite inside one mtime tick that changes st_size
+        must re-parse instead of serving the stale identity."""
+        from types import SimpleNamespace
+
+        path = self._fake_path([
+            SimpleNamespace(st_mtime_ns=1000, st_size=50),
+            SimpleNamespace(st_mtime_ns=1000, st_size=61),
+        ])
+        extract, parses = self._extract_with(monkeypatch, path, ["alice", "bob"])
+
+        first = extract()
+        second = extract()
+
+        assert first["honcho.peer_name"] == "alice"
+        assert second["honcho.peer_name"] == "bob", (
+            "same-mtime size-changing rewrite served the stale memo entry"
+        )
+        assert len(parses) == 2
+
+    def test_identical_stat_reuses_memo_without_reparsing(self, monkeypatch):
+        """The memo's whole purpose: identical stat identity == no re-parse."""
+        from types import SimpleNamespace
+
+        path = self._fake_path([SimpleNamespace(st_mtime_ns=1000, st_size=50)])
+        extract, parses = self._extract_with(monkeypatch, path, ["alice"])
+
+        extract()
+        extract()
+        extract()
+
+        assert len(parses) == 1, "memo hit should not re-read honcho.json"
+
+    def test_equal_size_equal_mtime_rewrite_is_documented_stale(self, monkeypatch):
+        """Pins the narrowed guarantee from #46385: an equal-size rewrite
+        inside one mtime tick reuses the memo (one stale generation, by
+        design). If this test starts failing because the second call
+        re-parsed, someone added per-lookup I/O to the hot path — that is
+        the change the maintainers declined, so it should be deliberate."""
+        from types import SimpleNamespace
+
+        path = self._fake_path([SimpleNamespace(st_mtime_ns=1000, st_size=50)])
+        extract, parses = self._extract_with(monkeypatch, path, ["alice", "bob"])
+
+        first = extract()
+        second = extract()
+
+        assert first["honcho.peer_name"] == "alice"
+        assert second["honcho.peer_name"] == "alice"
+        assert len(parses) == 1
+
+    def test_stat_failure_still_returns_config(self, monkeypatch):
+        """OSError on stat() falls back to a None-keyed memo entry rather
+        than failing the extraction."""
+        path = self._fake_path([OSError("gone")])
+        extract, parses = self._extract_with(monkeypatch, path, ["alice"])
+
+        result = extract()
+
+        assert result["honcho.peer_name"] == "alice"

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -9,6 +9,8 @@ Verifies that the agent cache correctly:
 - Preserves frozen system prompt across turns
 """
 
+import json
+import os
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -1158,6 +1160,51 @@ class TestHonchoCacheBustingMemo:
             "same-mtime size-changing rewrite served the stale memo entry"
         )
         assert len(parses) == 2
+
+    def test_real_file_same_mtime_different_size_invalidates(self, tmp_path, monkeypatch):
+        """A real profile-local file refreshes when only its size changes.
+
+        This is deliberately not a mocked ``Path.stat`` sequence: it verifies
+        profile-local path resolution, the actual ``HonchoClientConfig`` parser,
+        and the cache-busting entry point under the coarse-mtime condition.
+        """
+        from gateway.run import GatewayRunner
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "honcho.json"
+        fixed_mtime_ns = 1_700_000_000_123_456_789
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        def write_config(peer_name: str) -> None:
+            config_path.write_text(
+                json.dumps({"apiKey": "test-key", "peerName": peer_name}),
+                encoding="utf-8",
+            )
+            os.utime(config_path, ns=(fixed_mtime_ns, fixed_mtime_ns))
+
+        GatewayRunner._HONCHO_CACHE_BUSTING_MEMO = {}
+        write_config("a")
+        first_stat = config_path.stat()
+        first_mtime_ns = first_stat.st_mtime_ns
+        first_size = first_stat.st_size
+        first = GatewayRunner._extract_cache_busting_config(
+            {"memory": {"provider": "honcho"}}
+        )
+
+        write_config("a-peer-name-that-is-longer")
+        second_stat = config_path.stat()
+        # Windows-backed temporary filesystems can quantize utime's nanosecond
+        # argument.  The cache only observes the resulting stat identity, so
+        # compare the two observed timestamps rather than the requested value.
+        assert second_stat.st_mtime_ns == first_mtime_ns
+        assert second_stat.st_size != first_size
+        second = GatewayRunner._extract_cache_busting_config(
+            {"memory": {"provider": "honcho"}}
+        )
+
+        assert first["honcho.peer_name"] == "a"
+        assert second["honcho.peer_name"] == "a-peer-name-that-is-longer"
 
     def test_identical_stat_reuses_memo_without_reparsing(self, monkeypatch):
         """The memo's whole purpose: identical stat identity == no re-parse."""


### PR DESCRIPTION
## Problem
`GatewayRunner._HONCHO_CACHE_BUSTING_MEMO` is keyed on `(path, st_mtime_ns)`. On filesystems with coarse mtime granularity, an edit to `honcho.json` can land inside one mtime tick and keep serving the previously parsed identity config on the per-turn agent-cache signature path.

## Change
Add `st_size` to the memo key. It comes from the single `stat()` call the memo already makes, so any same-tick rewrite that changes the file's size is detected at **zero added I/O** on this hot path.

**Deliberately not content-hashed.** An equal-size rewrite inside one mtime tick can still reuse stale parsed state for one cache generation — that edge is vanishingly rare and self-heals on the next change. Per the maintainer resolution on #46385, which declined content hashing here and named `st_size` as the right-shaped discriminator. One test pins that documented tradeoff so a future change that silently adds per-lookup I/O surfaces as a deliberate decision.

## Tests (net-new; current `main` has no memo coverage)
- same-mtime **size-changing** rewrite invalidates — verified to fail against the old key
- identical stat identity reuses the memo with zero re-parses
- equal-size/equal-mtime rewrite stays memoized **by design** (pins #46385's tradeoff)
- `stat()` failure still returns a parsed config

## History
Supersedes the earlier content-hash version of this branch, which also accidentally reverted #75581's relay-rename behavior via a whole-file checkout across divergent bases. Both problems are gone: the diff is now hand-authored against current `main` and touches only the memo — 2 files, +159/−4, zero relay content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)