### PR TITLE
fix(honcho): normalize config path display and resolution on Windows

### DIFF
--- a/plugins/memory/honcho/oauth_flow.py
+++ b/plugins/memory/honcho/oauth_flow.py
@@ -49,7 +49,7 @@ def _display_config_path(path: object) -> str:
 
     p = _Path(str(path))
     try:
-        return "~/" + str(p.relative_to(_Path.home()))
+        return "~/" + p.relative_to(_Path.home()).as_posix()
     except ValueError:
         return p.name
 

--- a/plugins/memory/honcho/oauth_flow.py
+++ b/plugins/memory/honcho/oauth_flow.py
@@ -45,10 +45,16 @@ _LOCAL_TOKEN_URL = "http://localhost:8000/oauth/token"
 _DEFAULT_CLIENT_ID = "hermes-agent"
 
 def _display_config_path(path: object) -> str:
-    """Home-relative display string for the consent screen (never the write path); outside ``$HOME``, the bare name."""
+    """Home-relative display string for the consent screen (never the write path); outside ``$HOME``, the bare name.
+
+    Imported at call time so tests can patch ``pathlib.Path`` and exercise
+    genuine Windows separator semantics on POSIX hosts.
+    """
+    from pathlib import Path
+
     p = Path(str(path))
     try:
-        return "~/" + str(p.relative_to(Path.home()))
+        return "~/" + p.relative_to(Path.home()).as_posix()
     except ValueError:
         return p.name
 

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -177,6 +177,72 @@ class TestResolveConfigPath:
         assert _get_default_hermes_home() == default_home
         assert result == default_cfg
 
+    def test_falls_back_to_global_without_hermes_home_env(self, tmp_path):
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+
+        with patch.dict(os.environ, {}, clear=False), \
+             patch.object(Path, "home", return_value=fake_home), \
+             patch(
+                 "plugins.memory.honcho.client.get_hermes_home",
+                 return_value=fake_home / ".hermes",
+             ), \
+             patch(
+                 "plugins.memory.honcho.client._get_default_hermes_home",
+                 return_value=fake_home / ".hermes",
+             ):
+            os.environ.pop("HERMES_HOME", None)
+            result = resolve_config_path()
+        assert result == fake_home / ".honcho" / "config.json"
+
+    def test_global_fallback_uses_home_at_call_time(self, tmp_path):
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch.object(Path, "home", return_value=fake_home):
+            assert resolve_global_config_path() == fake_home / ".honcho" / "config.json"
+            assert resolve_config_path() == fake_home / ".honcho" / "config.json"
+
+    def test_from_global_config_uses_default_profile_fallback(self, tmp_path, monkeypatch):
+        # Profile mode: from_global_config() reads the default-profile honcho.json
+        # via the HOME-anchored helper, not Path.home() / ".hermes".
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        default_home = fake_home / ".hermes"
+        profile_home = default_home / "profiles" / "work"
+        profile_home.mkdir(parents=True)
+        default_cfg = default_home / "honcho.json"
+        default_cfg.write_text(json.dumps({
+            "apiKey": "default-key",
+            "workspace": "default-ws",
+        }))
+
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        config = HonchoClientConfig.from_global_config()
+
+        assert config.api_key == "default-key"
+        assert config.workspace_id == "default-ws"
+
+    def test_from_global_config_uses_local_path(self, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        local_cfg = hermes_home / "honcho.json"
+        local_cfg.write_text(json.dumps({
+            "apiKey": "***",
+            "workspace": "local-ws",
+        }))
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch.object(Path, "home", return_value=tmp_path):
+            config = HonchoClientConfig.from_global_config()
+        assert config.api_key == "***"
+        assert config.workspace_id == "local-ws"
+
 
 class TestResolveActiveHost:
     def test_profile_host_key_uses_honcho_safe_separator(self):

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -301,6 +301,72 @@ class TestResolveConfigPath:
         assert _get_default_hermes_home() == default_home
         assert result == default_cfg
 
+    def test_falls_back_to_global_without_hermes_home_env(self, tmp_path):
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+
+        with patch.dict(os.environ, {}, clear=False), \
+             patch.object(Path, "home", return_value=fake_home), \
+             patch(
+                 "plugins.memory.honcho.client.get_hermes_home",
+                 return_value=fake_home / ".hermes",
+             ), \
+             patch(
+                 "plugins.memory.honcho.client._get_default_hermes_home",
+                 return_value=fake_home / ".hermes",
+             ):
+            os.environ.pop("HERMES_HOME", None)
+            result = resolve_config_path()
+        assert result == fake_home / ".honcho" / "config.json"
+
+    def test_global_fallback_uses_home_at_call_time(self, tmp_path):
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch.object(Path, "home", return_value=fake_home):
+            assert resolve_global_config_path() == fake_home / ".honcho" / "config.json"
+            assert resolve_config_path() == fake_home / ".honcho" / "config.json"
+
+    def test_from_global_config_uses_default_profile_fallback(self, tmp_path, monkeypatch):
+        # Profile mode: from_global_config() reads the default-profile honcho.json
+        # via the HOME-anchored helper, not Path.home() / ".hermes".
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        default_home = fake_home / ".hermes"
+        profile_home = default_home / "profiles" / "work"
+        profile_home.mkdir(parents=True)
+        default_cfg = default_home / "honcho.json"
+        default_cfg.write_text(json.dumps({
+            "apiKey": "default-key",
+            "workspace": "default-ws",
+        }))
+
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        config = HonchoClientConfig.from_global_config()
+
+        assert config.api_key == "default-key"
+        assert config.workspace_id == "default-ws"
+
+    def test_from_global_config_uses_local_path(self, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        local_cfg = hermes_home / "honcho.json"
+        local_cfg.write_text(json.dumps({
+            "apiKey": "***",
+            "workspace": "local-ws",
+        }))
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch.object(Path, "home", return_value=tmp_path):
+            config = HonchoClientConfig.from_global_config()
+        assert config.api_key == "***"
+        assert config.workspace_id == "local-ws"
+
 
 class TestResolveActiveHost:
     def test_profile_host_key_uses_honcho_safe_separator(self):

--- a/tests/honcho_plugin/test_oauth_flow.py
+++ b/tests/honcho_plugin/test_oauth_flow.py
@@ -275,6 +275,40 @@ def test_display_config_path_never_leaks_absolute_path():
     assert oauth_flow._display_config_path("/var/folders/tmp/honcho.json") == "honcho.json"
 
 
+def test_display_config_path_uses_forward_slashes_on_windows():
+    """The ~/-relative form must use forward slashes even when the underlying
+    Path type separates with backslashes.
+
+    Platform-independent by construction: _display_config_path does a
+    call-time ``from pathlib import Path``, so patching ``pathlib.Path`` with
+    a PureWindowsPath-based shim exercises real Windows path semantics on any
+    host. The old ``"~/" + str(p.relative_to(home))`` implementation returns
+    a backslash-separated ``~/AppData/Local/...`` (with backslashes) here —
+    mixed separators on the consent screen — so unlike the native-Path test
+    above, this one fails on the pre-fix code on POSIX CI too.
+
+    The patch is scoped and released BEFORE the asserts: pytest's own failure
+    reporting uses pathlib.Path, so asserting inside the patch would turn a
+    clean failure into an INTERNALERROR.
+    """
+    import pathlib
+    from unittest.mock import patch as _patch
+
+    class _WinPath(pathlib.PureWindowsPath):
+        @classmethod
+        def home(cls):
+            return cls("C:/Users/test")
+
+    with _patch.object(pathlib, "Path", _WinPath):
+        shown = oauth_flow._display_config_path(
+            "C:\\Users\\test\\AppData\\Local\\hermes\\honcho.json"
+        )
+        outside = oauth_flow._display_config_path("D:\\scratch\\honcho.json")
+
+    assert shown == "~/AppData/Local/hermes/honcho.json"
+    assert "\\" not in shown
+    # Outside home still degrades to the bare filename.
+    assert outside == "honcho.json"
 def test_cli_flow_stores_tokens_without_applying_config(tmp_path, fake_as):
     # apply_config=False (the CLI path): grant config must NOT touch settings.
     config_path = tmp_path / "honcho.json"


### PR DESCRIPTION
Split out of #66831, which had picked this up unrelated to its own topic. Unchanged content, rebased onto current `main`.

## Problem
`_display_config_path` built the `~/...` form with `str(Path.relative_to(...))`, which emits backslashes on Windows — so onboarding printed `~/AppData\Local\hermes\...`, mixing separators against the forward-slash convention the surrounding copy uses.

## Change
Use `.as_posix()` for the tilde form. One-line fix, plus coverage for the global/local config-path fallbacks that feed this display path (including resolving `HOME` at call time rather than import time).

## Verification
- `py_compile` clean.
- `tests/honcho_plugin/test_client.py`: 45 passed.
- Based on current `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)