### PR TITLE
chore: remove deprecated Kimi K2 pre-2.5 models from provider lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -347,10 +347,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2.5",
         "kimi-for-coding",
         "kimi-for-coding-highspeed",
-        "kimi-k2-thinking",
-        "kimi-k2-thinking-turbo",
-        "kimi-k2-turbo-preview",
-        "kimi-k2-0905-preview",
     ],
     "kimi-coding-cn": [
         "kimi-k3",
@@ -358,9 +354,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2.7-code-highspeed",
         "kimi-k2.6",
         "kimi-k2.5",
-        "kimi-k2-thinking",
-        "kimi-k2-turbo-preview",
-        "kimi-k2-0905-preview",
     ],
     "stepfun": [
         "step-3.5-flash",
@@ -370,9 +363,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k3",
         "kimi-k2.6",
         "kimi-k2.5",
-        "kimi-k2-thinking",
-        "kimi-k2-turbo-preview",
-        "kimi-k2-0905-preview",
     ],
     "minimax": [
         "MiniMax-M3",
@@ -557,7 +547,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMaxAI/MiniMax-M2.5",
         "zai-org/GLM-5",
         "XiaomiMiMo/MiMo-V2-Flash",
-        "moonshotai/Kimi-K2-Thinking",
         "moonshotai/Kimi-K2.6",
     ],
     # AWS Bedrock — static fallback list used when dynamic discovery is


### PR DESCRIPTION
## Summary

Remove deprecated Kimi K2 models released before version 2.5 from the `_PROVIDER_MODELS` catalogue. These models have been deprecated by Kimi/Moonshot AI.

### Removed models

- `kimi-k2-thinking`
- `kimi-k2-thinking-turbo`
- `kimi-k2-turbo-preview`
- `kimi-k2-0905-preview`
- `moonshotai/Kimi-K2-Thinking`

### Retained (>= 2.5)

- `kimi-k2.5`
- `kimi-k2.6`
- `kimi-k2.7-code`
- `kimi-k2.7-code-highspeed`

### Affected providers

`kimi-coding`, `kimi-coding-cn`, `moonshot`, `huggingface`